### PR TITLE
Fix published-image smoke and add GHCR preflight

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -138,6 +138,10 @@ hooks {
   // ==========================================================================
   ["pre-push"] {
     steps {
+      ["ghcr_publish_prereqs"] {
+        exclusive = true
+        check = "uv run --directory python dotfiles-setup ghcr-check"
+      }
       ["test"] {
         exclusive = true
         check = "uv run pytest tests/ -x -q"

--- a/python/src/dotfiles_setup/ghcr.py
+++ b/python/src/dotfiles_setup/ghcr.py
@@ -1,0 +1,163 @@
+"""GHCR publish prerequisite checks using GitHub CLI."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+from shutil import which
+from typing import Any
+
+
+class GhcrCheckError(RuntimeError):
+    """Raised when GHCR publish prerequisites are not satisfied."""
+
+
+def _run(
+    args: list[str],
+    *,
+    cwd: Path,
+) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess and capture text output."""
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _run_gh_json(
+    args: list[str],
+    *,
+    cwd: Path,
+) -> dict[str, Any]:
+    """Run a gh command that returns JSON."""
+    result = _run(["gh", *args], cwd=cwd)
+    if result.returncode != 0:
+        message = (result.stderr or result.stdout).strip()
+        raise GhcrCheckError(message or f"gh {' '.join(args)} failed")
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise GhcrCheckError(f"Unable to parse JSON from gh {' '.join(args)}") from exc
+    if not isinstance(data, dict):
+        raise GhcrCheckError(f"Unexpected JSON shape from gh {' '.join(args)}")
+    return data
+
+
+def _parse_scopes(auth_output: str) -> set[str]:
+    """Extract token scopes from `gh auth status` output."""
+    match = re.search(r"Token scopes:\s*(.+)", auth_output)
+    if not match:
+        return set()
+    raw_scopes = match.group(1).replace("'", "")
+    return {scope.strip() for scope in raw_scopes.split(",") if scope.strip()}
+
+
+def _require_workflow_permissions(ci_workflow_path: Path) -> None:
+    """Ensure the CI workflow explicitly requests package write access."""
+    if not ci_workflow_path.exists():
+        raise GhcrCheckError(f"Workflow file not found: {ci_workflow_path}")
+    text = ci_workflow_path.read_text()
+    if "packages: write" not in text:
+        raise GhcrCheckError(
+            f"{ci_workflow_path} must explicitly request packages: write",
+        )
+
+
+def validate_ghcr_prereqs(
+    *,
+    repo_root: Path,
+    owner: str,
+    repo: str,
+    package_name: str,
+) -> dict[str, Any]:
+    """Validate GHCR publish prerequisites that are observable via `gh`."""
+    if which("gh") is None:
+        raise GhcrCheckError("gh is not installed or not on PATH")
+
+    auth_result = _run(["gh", "auth", "status"], cwd=repo_root)
+    if auth_result.returncode != 0:
+        message = (auth_result.stderr or auth_result.stdout).strip()
+        raise GhcrCheckError(message or "gh auth status failed")
+
+    scopes = _parse_scopes("\n".join((auth_result.stdout, auth_result.stderr)))
+    required_scopes = {"repo", "read:org", "workflow", "write:packages"}
+    missing_scopes = sorted(required_scopes - scopes)
+    if missing_scopes:
+        raise GhcrCheckError(
+            "gh auth token is missing required scopes: "
+            + ", ".join(missing_scopes),
+        )
+
+    repo_info = _run_gh_json(
+        [
+            "repo",
+            "view",
+            f"{owner}/{repo}",
+            "--json",
+            "nameWithOwner,viewerPermission,isPrivate,defaultBranchRef",
+        ],
+        cwd=repo_root,
+    )
+    if repo_info.get("nameWithOwner") != f"{owner}/{repo}":
+        raise GhcrCheckError("Resolved GitHub repo does not match expected owner/repo")
+
+    actions_permissions = _run_gh_json(
+        ["api", f"repos/{owner}/{repo}/actions/permissions"],
+        cwd=repo_root,
+    )
+    if not actions_permissions.get("enabled", False):
+        raise GhcrCheckError("GitHub Actions is disabled for this repository")
+
+    workflow_permissions = _run_gh_json(
+        ["api", f"repos/{owner}/{repo}/actions/permissions/workflow"],
+        cwd=repo_root,
+    )
+
+    package_info = _run_gh_json(
+        ["api", f"/orgs/{owner}/packages/container/{package_name}"],
+        cwd=repo_root,
+    )
+    if package_info.get("name") != package_name:
+        raise GhcrCheckError(
+            "Resolved GHCR package does not match expected package name",
+        )
+    if package_info.get("owner", {}).get("login") != owner:
+        raise GhcrCheckError("GHCR package owner does not match expected organization")
+
+    _require_workflow_permissions(repo_root / ".github" / "workflows" / "ci.yml")
+
+    package_versions_result = _run(
+        [
+            "gh",
+            "api",
+            f"/orgs/{owner}/packages/container/{package_name}/versions?per_page=20",
+        ],
+        cwd=repo_root,
+    )
+    if package_versions_result.returncode != 0:
+        message = (package_versions_result.stderr or package_versions_result.stdout).strip()
+        raise GhcrCheckError(message or "Unable to inspect GHCR package versions")
+
+    return {
+        "status": "passed",
+        "repo": repo_info["nameWithOwner"],
+        "viewer_permission": repo_info.get("viewerPermission", ""),
+        "default_branch": repo_info.get("defaultBranchRef", {}).get("name", ""),
+        "workflow_default_permissions": workflow_permissions.get(
+            "default_workflow_permissions",
+            "",
+        ),
+        "package_visibility": package_info.get("visibility", ""),
+        "package_url": package_info.get("html_url", ""),
+        "note": (
+            "CLI validation covers auth scopes, repo Actions settings, workflow "
+            "package-write intent, and package existence. GitHub does not expose "
+            "the package's Actions repository allowlist cleanly through gh API, so "
+            "that setting still requires occasional UI confirmation."
+        ),
+    }

--- a/python/src/dotfiles_setup/image.py
+++ b/python/src/dotfiles_setup/image.py
@@ -39,7 +39,7 @@ set -euo pipefail
 echo "=== hk validate ==="
 cd /tmp/dotfiles
 mise trust .
-hk validate
+HK_FILE=hk.pkl hk validate
 echo "=== mise ls (check no missing) ==="
 mise_output=$(mise ls 2>&1)
 missing=$(echo "$mise_output" | grep -c "(missing)" || true)

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import os
 import platform
@@ -13,6 +14,7 @@ from typing import Any, ClassVar
 from dotfiles_setup.ai import AIOrchestrator
 from dotfiles_setup.audit import DevEnvironmentAuditor, ToolManager
 from dotfiles_setup.docker import DevContainerManager
+from dotfiles_setup.ghcr import validate_ghcr_prereqs
 from dotfiles_setup.image import main as image_main
 from dotfiles_setup.verify import main as verify_main
 
@@ -134,6 +136,18 @@ def setup_parser() -> argparse.ArgumentParser:
     compare_parser.add_argument("--baseline", required=True, help="Baseline JSON path")
     compare_parser.add_argument("--candidate", required=True, help="Candidate JSON path")
 
+    ghcr_parser = subparsers.add_parser(
+        "ghcr-check",
+        help="Validate local GHCR publish prerequisites exposed via GitHub CLI",
+    )
+    ghcr_parser.add_argument("--owner", default="ray-manaloto", help="GitHub org/user owner")
+    ghcr_parser.add_argument("--repo", default="dotfiles", help="Repository name")
+    ghcr_parser.add_argument(
+        "--package-name",
+        default="dotfiles-devcontainer",
+        help="GHCR container package name",
+    )
+
     # version command
     subparsers.add_parser("version", help="Show the version of the library")
 
@@ -229,6 +243,17 @@ def handle_image(args: argparse.Namespace) -> None:
         )
 
 
+def handle_ghcr_check(args: argparse.Namespace, project_root: Path) -> None:
+    """Handle GHCR prerequisite validation."""
+    result = validate_ghcr_prereqs(
+        repo_root=project_root,
+        owner=args.owner,
+        repo=args.repo,
+        package_name=args.package_name,
+    )
+    sys.stdout.write(json.dumps(result, indent=2) + "\n")
+
+
 def _build_command_handlers(
     args: argparse.Namespace,
     project_root: Path,
@@ -268,6 +293,7 @@ def _build_command_handlers(
         "install": lambda: handle_install(project_root),
         "verify": lambda: handle_verify(args),
         "image": lambda: handle_image(args),
+        "ghcr-check": lambda: handle_ghcr_check(args, project_root),
         "sync-versions": lambda: handle_sync_versions(project_root),
     }
 

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -299,6 +299,15 @@ paths = [".github/workflows/ci.yml"]
 tokens = ["ray-manaloto/dotfiles-devcontainer"]
 
 [[suite]]
+name = "ci.explicit-packages-write"
+description = "CI workflow must explicitly request packages: write for GHCR publishing"
+category = "ci"
+check_type = "static"
+handler = "require_tokens"
+paths = [".github/workflows/ci.yml"]
+tokens = ["packages: write"]
+
+[[suite]]
 name = "ci.pr-builds-do-not-push"
 description = "Only main-branch and scheduled builds may publish GHCR images"
 category = "ci"

--- a/scripts/benchmark-docker.sh
+++ b/scripts/benchmark-docker.sh
@@ -110,7 +110,7 @@ fi
 
 # F8: hk validate
 echo "--- F8: hk Validate ---"
-HK_RESULT="$(docker run --rm --platform linux/amd64 dotfiles-devcontainer:dev bash -lc 'cd ~/.local/share/chezmoi && hk validate >/dev/null 2>&1' && echo 'PASS' || echo 'FAIL')"
+HK_RESULT="$(docker run --rm --platform linux/amd64 dotfiles-devcontainer:dev bash -lc 'cd ~/.local/share/chezmoi && HK_FILE=hk.pkl hk validate >/dev/null 2>&1' && echo 'PASS' || echo 'FAIL')"
 echo "hk validate: ${HK_RESULT}"
 
 # F9: Bind mount performance

--- a/tests/test_ghcr.py
+++ b/tests/test_ghcr.py
@@ -1,0 +1,112 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
+
+from dotfiles_setup.ghcr import GhcrCheckError, _parse_scopes, validate_ghcr_prereqs
+
+
+def test_parse_scopes_extracts_all_scopes() -> None:
+    text = "Token scopes: 'repo', 'read:org', 'workflow', 'write:packages'"
+    scopes = _parse_scopes(text)
+
+    assert scopes == {"repo", "read:org", "workflow", "write:packages"}
+
+
+def test_validate_ghcr_prereqs_requires_packages_write_scope(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workflow_path = tmp_path / ".github" / "workflows"
+    workflow_path.mkdir(parents=True)
+    (workflow_path / "ci.yml").write_text("permissions:\n  packages: write\n")
+
+    monkeypatch.setattr("dotfiles_setup.ghcr.which", lambda name: "/usr/bin/gh")
+
+    def fake_run(args: list[str], *, cwd: Path):  # type: ignore[no-untyped-def]
+        class Result:
+            def __init__(self, returncode: int, stdout: str, stderr: str = ""):
+                self.returncode = returncode
+                self.stdout = stdout
+                self.stderr = stderr
+
+        if args == ["gh", "auth", "status"]:
+            return Result(0, "", "Token scopes: 'repo', 'read:org', 'workflow'")
+        return Result(0, "[]")
+
+    monkeypatch.setattr("dotfiles_setup.ghcr._run", fake_run)
+
+    with pytest.raises(GhcrCheckError, match="write:packages"):
+        validate_ghcr_prereqs(
+            repo_root=tmp_path,
+            owner="ray-manaloto",
+            repo="dotfiles",
+            package_name="dotfiles-devcontainer",
+        )
+
+
+def test_validate_ghcr_prereqs_passes_when_inputs_are_valid(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workflow_path = tmp_path / ".github" / "workflows"
+    workflow_path.mkdir(parents=True)
+    (workflow_path / "ci.yml").write_text("permissions:\n  packages: write\n")
+
+    monkeypatch.setattr("dotfiles_setup.ghcr.which", lambda name: "/usr/bin/gh")
+
+    def fake_run(args: list[str], *, cwd: Path):  # type: ignore[no-untyped-def]
+        class Result:
+            def __init__(self, returncode: int, stdout: str, stderr: str = ""):
+                self.returncode = returncode
+                self.stdout = stdout
+                self.stderr = stderr
+
+        if args == ["gh", "auth", "status"]:
+            return Result(
+                0,
+                "",
+                "Token scopes: 'repo', 'read:org', 'workflow', 'write:packages'",
+            )
+        if args == [
+            "gh",
+            "api",
+            "/orgs/ray-manaloto/packages/container/dotfiles-devcontainer/versions?per_page=20",
+        ]:
+            return Result(0, "[]")
+        return Result(0, "{}")
+
+    def fake_run_gh_json(args: list[str], *, cwd: Path):  # type: ignore[no-untyped-def]
+        if args[:3] == ["repo", "view", "ray-manaloto/dotfiles"]:
+            return {
+                "nameWithOwner": "ray-manaloto/dotfiles",
+                "viewerPermission": "ADMIN",
+                "defaultBranchRef": {"name": "main"},
+            }
+        if args == ["api", "repos/ray-manaloto/dotfiles/actions/permissions"]:
+            return {"enabled": True}
+        if args == ["api", "repos/ray-manaloto/dotfiles/actions/permissions/workflow"]:
+            return {"default_workflow_permissions": "read"}
+        if args == ["api", "/orgs/ray-manaloto/packages/container/dotfiles-devcontainer"]:
+            return {
+                "name": "dotfiles-devcontainer",
+                "visibility": "private",
+                "html_url": "https://github.com/orgs/ray-manaloto/packages/container/package/dotfiles-devcontainer",
+                "owner": {"login": "ray-manaloto"},
+            }
+        raise AssertionError(args)
+
+    monkeypatch.setattr("dotfiles_setup.ghcr._run", fake_run)
+    monkeypatch.setattr("dotfiles_setup.ghcr._run_gh_json", fake_run_gh_json)
+
+    result = validate_ghcr_prereqs(
+        repo_root=tmp_path,
+        owner="ray-manaloto",
+        repo="dotfiles",
+        package_name="dotfiles-devcontainer",
+    )
+
+    assert result["status"] == "passed"
+    assert result["repo"] == "ray-manaloto/dotfiles"

--- a/tests/test_image_smoke.py
+++ b/tests/test_image_smoke.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
+
+from dotfiles_setup.image import build_smoke_script
+
+
+def test_smoke_script_pins_hk_file() -> None:
+    script = build_smoke_script()
+
+    assert "HK_FILE=hk.pkl hk validate" in script


### PR DESCRIPTION
## Summary
- pin smoke-time hk validation to the committed  file
- add a  preflight backed by Work seamlessly with GitHub from the command line.

USAGE
  gh <command> <subcommand> [flags]

CORE COMMANDS
  auth:          Authenticate gh and git with GitHub
  browse:        Open repositories, issues, pull requests, and more in the browser
  codespace:     Connect to and manage codespaces
  gist:          Manage gists
  issue:         Manage issues
  org:           Manage organizations
  pr:            Manage pull requests
  project:       Work with GitHub Projects.
  release:       Manage releases
  repo:          Manage repositories

GITHUB ACTIONS COMMANDS
  cache:         Manage GitHub Actions caches
  run:           View details about workflow runs
  workflow:      View details about GitHub Actions workflows

ALIAS COMMANDS
  co:            Alias for "pr checkout"

ADDITIONAL COMMANDS
  agent-task:    Work with agent tasks (preview)
  alias:         Create command shortcuts
  api:           Make an authenticated GitHub API request
  attestation:   Work with artifact attestations
  completion:    Generate shell completion scripts
  config:        Manage configuration for gh
  copilot:       Run the GitHub Copilot CLI (preview)
  extension:     Manage gh extensions
  gpg-key:       Manage GPG keys
  label:         Manage labels
  licenses:      View third-party license information
  preview:       Execute previews for gh features
  ruleset:       View info about repo rulesets
  search:        Search for repositories, issues, and pull requests
  secret:        Manage GitHub secrets
  ssh-key:       Manage SSH keys
  status:        Print information about relevant issues, pull requests, and notifications across repositories
  variable:      Manage GitHub Actions variables

HELP TOPICS
  accessibility: Learn about GitHub CLI's accessibility experiences
  actions:       Learn about working with GitHub Actions
  environment:   Environment variables that can be used with gh
  exit-codes:    Exit codes used by gh
  formatting:    Formatting options for JSON data exported from gh
  mintty:        Information about using gh with MinTTY
  reference:     A comprehensive reference of all gh commands

FLAGS
  --help      Show help for command
  --version   Show gh version

EXAMPLES
  $ gh issue create
  $ gh repo clone cli/cli
  $ gh pr checkout 321

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual
  Learn about exit codes using `gh help exit-codes`
  Learn about accessibility experiences using `gh help accessibility`
- enforce the GHCR preflight in 

## Why
The merged main run was able to publish the image after package access was corrected, but  still failed because  in  searched for  before  and exited on the missing local override file.

## Validation
- ....                                                                     [100%]
4 passed in 0.01s
- {
  "status": "passed",
  "repo": "ray-manaloto/dotfiles",
  "viewer_permission": "ADMIN",
  "default_branch": "main",
  "workflow_default_permissions": "read",
  "package_visibility": "private",
  "package_url": "https://github.com/orgs/ray-manaloto/packages/container/package/dotfiles-devcontainer",
  "note": "CLI validation covers auth scopes, repo Actions settings, workflow package-write intent, and package existence. GitHub does not expose the package's Actions repository allowlist cleanly through gh API, so that setting still requires occasional UI confirmation."
}
- {
  "results": [
    {
      "status": "passed",
      "name": "ci.sbom-attestation"
    },
    {
      "status": "passed",
      "name": "ci.provenance-attestation"
    },
    {
      "status": "passed",
      "name": "ci.no-mise-data-in-cache-map"
    },
    {
      "status": "passed",
      "name": "ci.gha-cache-enabled"
    },
    {
      "status": "passed",
      "name": "ci.no-actions-cache-workaround"
    },
    {
      "status": "passed",
      "name": "ci.unconditional-ghcr-login"
    },
    {
      "status": "passed",
      "name": "ci.image-name-dotfiles-devcontainer"
    },
    {
      "status": "passed",
      "name": "ci.explicit-packages-write"
    },
    {
      "status": "passed",
      "name": "ci.pr-builds-do-not-push"
    },
    {
      "status": "passed",
      "name": "ci.smoke-test-skips-pr"
    }
  ],
  "passed": 10,
  "failed": 0,
  "skipped": 0
}
- 
- 
- branch pre-push checks passed during 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GHCR (GitHub Container Registry) prerequisite validation to verify publishing requirements are met.
  * Introduced new command-line utility to check configuration and permissions.

* **Tests**
  * Added comprehensive test coverage for GHCR validation and smoke script behavior.

* **Chores**
  * Updated CI verification suite to include explicit package-write permission validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->