### PR TITLE
Mount the repo into published-image smoke validation

### DIFF
--- a/python/src/dotfiles_setup/image.py
+++ b/python/src/dotfiles_setup/image.py
@@ -113,22 +113,29 @@ echo "=== All smoke checks passed ==="
 """
 
 
-def smoke(image_ref: str, *, platform: str = "linux/amd64") -> dict[str, Any]:
-    """Run smoke tests against a container image."""
-    logger.info("Smoking image: %s", image_ref)
+def build_smoke_docker_cmd(image_ref: str, *, platform: str = "linux/amd64") -> list[str]:
+    """Build the docker command used for smoke validation."""
     script = build_smoke_script()
-    cmd = [
+    return [
         "docker",
         "run",
         "--rm",
         "--platform",
         platform,
+        "--volume",
+        f"{_project_root()}:/tmp/dotfiles:ro",
         "--entrypoint",
         "/bin/bash",
         image_ref,
         "-lc",
         script,
     ]
+
+
+def smoke(image_ref: str, *, platform: str = "linux/amd64") -> dict[str, Any]:
+    """Run smoke tests against a container image."""
+    logger.info("Smoking image: %s", image_ref)
+    cmd = build_smoke_docker_cmd(image_ref, platform=platform)
     result = subprocess.run(cmd, capture_output=True, text=True, check=False)
     if result.returncode != 0:
         logger.error("Smoke test FAILED:\n%s\n%s", result.stdout, result.stderr)

--- a/tests/test_image_smoke.py
+++ b/tests/test_image_smoke.py
@@ -3,10 +3,18 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
 
-from dotfiles_setup.image import build_smoke_script
+from dotfiles_setup.image import build_smoke_docker_cmd, build_smoke_script
 
 
 def test_smoke_script_pins_hk_file() -> None:
     script = build_smoke_script()
 
     assert "HK_FILE=hk.pkl hk validate" in script
+
+
+def test_smoke_docker_cmd_mounts_repo_checkout() -> None:
+    cmd = build_smoke_docker_cmd("ghcr.io/ray-manaloto/dotfiles-devcontainer:test")
+
+    assert "--volume" in cmd
+    mount = cmd[cmd.index("--volume") + 1]
+    assert mount.endswith(":/tmp/dotfiles:ro")


### PR DESCRIPTION
## Summary
- mount the checked-out repo into the smoke container at `/tmp/dotfiles`
- keep the smoke script's repo-backed validation path aligned with the runtime

## Why
PR #24 fixed the first smoke regression by pinning `hk validate` to `hk.pkl`, but the smoke container still had no repo mounted at `/tmp/dotfiles`, so the config file path was still missing at runtime.

## Validation
- `UV_CACHE_DIR=/tmp/dotfiles-uv-cache uv run pytest tests/test_image_smoke.py -q`
- branch pre-push checks passed during `git push origin codex/ci-smoke-mount-fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal Docker testing command construction for better maintainability.

* **Tests**
  * Enhanced test coverage for Docker-based testing infrastructure to ensure proper project environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->