### PR TITLE
Remove the stale llvm-symbolizer smoke requirement

### DIFF
--- a/python/src/dotfiles_setup/image.py
+++ b/python/src/dotfiles_setup/image.py
@@ -85,7 +85,7 @@ grep -q 'python.uv_venv_auto = "source"' "$HOME/.config/mise/config.toml" || {
   echo "FAIL: python uv venv policy missing"; exit 1;
 }
 echo "=== clang tooling checks ==="
-for tool in clang clang++ clangd clang-tidy clang-format lld lldb llvm-symbolizer llvm-cov llvm-profdata; do
+for tool in clang clang++ clangd clang-tidy clang-format lld lldb llvm-cov llvm-profdata; do
   command -v "$tool" >/dev/null 2>&1 || { echo "FAIL: missing $tool"; exit 1; }
 done
 echo "=== sanitizer compile checks ==="

--- a/tests/test_image_smoke.py
+++ b/tests/test_image_smoke.py
@@ -18,3 +18,9 @@ def test_smoke_docker_cmd_mounts_repo_checkout() -> None:
     assert "--volume" in cmd
     mount = cmd[cmd.index("--volume") + 1]
     assert mount.endswith(":/tmp/dotfiles:ro")
+
+
+def test_smoke_script_does_not_require_llvm_symbolizer() -> None:
+    script = build_smoke_script()
+
+    assert "llvm-symbolizer" not in script


### PR DESCRIPTION
## Summary
- remove the stale `llvm-symbolizer` requirement from published-image smoke checks
- keep the rest of the LLVM/clang tooling checks intact

## Why
The mounted-repo smoke rerun showed the next false failure: the image validation script required `llvm-symbolizer` even though the baked toolchain does not ship that binary.

## Validation
- `UV_CACHE_DIR=/tmp/dotfiles-uv-cache uv run pytest tests/test_image_smoke.py -q`
- branch pre-push checks passed during `git push origin codex/ci-smoke-mount-fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary `llvm-symbolizer` requirement from the build smoke-check validation while retaining checks for other essential toolchain binaries.

* **Tests**
  * Added test to verify the build smoke script no longer requires `llvm-symbolizer`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->