### PR TITLE
Fix benchmark size parsing in published-image smoke

### DIFF
--- a/python/src/dotfiles_setup/image.py
+++ b/python/src/dotfiles_setup/image.py
@@ -177,8 +177,13 @@ def _gzip_size_for_image(image_ref: str) -> int:
 
 def _parse_human_size(size: str) -> int:
     cleaned = size.strip()
-    units = {"B": 1, "KB": 1024, "MB": 1024**2, "GB": 1024**3}
-    for unit, scale in units.items():
+    units = [
+        ("GB", 1024**3),
+        ("MB", 1024**2),
+        ("KB", 1024),
+        ("B", 1),
+    ]
+    for unit, scale in units:
         if cleaned.endswith(unit):
             number = cleaned[: -len(unit)] or "0"
             return int(float(number) * scale)

--- a/tests/test_image_smoke.py
+++ b/tests/test_image_smoke.py
@@ -3,7 +3,11 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
 
-from dotfiles_setup.image import build_smoke_docker_cmd, build_smoke_script
+from dotfiles_setup.image import (
+    _parse_human_size,
+    build_smoke_docker_cmd,
+    build_smoke_script,
+)
 
 
 def test_smoke_script_pins_hk_file() -> None:
@@ -31,3 +35,7 @@ def test_smoke_script_does_not_require_standalone_llvm_tools() -> None:
 
     assert "llvm-cov" not in script
     assert "llvm-profdata" not in script
+
+
+def test_parse_human_size_handles_gigabytes_before_bytes_suffix() -> None:
+    assert _parse_human_size("12.3GB") == int(12.3 * 1024**3)


### PR DESCRIPTION
Follow-up for the benchmark failure on main CI:  matched overlapping suffixes in the wrong order, so values like  were being parsed as  +  and throwing ValueError. This change matches the longest suffix first and adds a regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file size parsing logic to correctly interpret unit suffixes (GB, MB, KB, B) in proper sequential order, preventing potential misinterpretation of size values when parsing human-readable file sizes.

* **Tests**
  * Added test coverage to verify file size parsing correctly handles gigabyte-denominated values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->