### PR TITLE
Fix Docker size parsing in published-image benchmark

### DIFF
--- a/python/src/dotfiles_setup/image.py
+++ b/python/src/dotfiles_setup/image.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import subprocess
 import sys
 import time
@@ -177,16 +178,20 @@ def _gzip_size_for_image(image_ref: str) -> int:
 
 def _parse_human_size(size: str) -> int:
     cleaned = size.strip()
-    units = [
-        ("GB", 1024**3),
-        ("MB", 1024**2),
-        ("KB", 1024),
-        ("B", 1),
-    ]
-    for unit, scale in units:
-        if cleaned.endswith(unit):
-            number = cleaned[: -len(unit)] or "0"
-            return int(float(number) * scale)
+    match = re.fullmatch(r"(?i)\s*([0-9]+(?:\.[0-9]+)?)\s*([kmgt]?b)\s*", cleaned)
+    if match:
+        number = float(match.group(1))
+        unit = match.group(2).upper()
+        scales = {
+            "B": 1,
+            "KB": 1024,
+            "MB": 1024**2,
+            "GB": 1024**3,
+            "TB": 1024**4,
+        }
+        return int(number * scales[unit])
+    if cleaned.isdigit():
+        return int(cleaned)
     return 0
 
 

--- a/tests/test_image_smoke.py
+++ b/tests/test_image_smoke.py
@@ -39,3 +39,11 @@ def test_smoke_script_does_not_require_standalone_llvm_tools() -> None:
 
 def test_parse_human_size_handles_gigabytes_before_bytes_suffix() -> None:
     assert _parse_human_size("12.3GB") == int(12.3 * 1024**3)
+
+
+def test_parse_human_size_handles_lowercase_kilobytes() -> None:
+    assert _parse_human_size("1.17kB") == int(1.17 * 1024)
+
+
+def test_parse_human_size_handles_plain_bytes() -> None:
+    assert _parse_human_size("512") == 512


### PR DESCRIPTION
This PR lands the actual missing parser fix on top of current main. It replaces suffix-slicing in `_parse_human_size` with a case-insensitive regex parser so Docker history values like `1.17kB`, `12.3GB`, and plain byte counts are parsed correctly during the published-image benchmark step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file size parsing to support case-insensitive units (B, KB, MB, GB, TB), decimal numbers, optional whitespace, and inputs without suffixes.

* **Tests**
  * Added test coverage for enhanced size parsing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->