### PR TITLE
Fix host-user devcontainer SSH runtime

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,9 @@
   "name": "dotfiles-devcontainer",
   "build": {
     "dockerfile": "Dockerfile.host-user",
+    "options": [
+      "--platform=linux/amd64"
+    ],
     "args": {
       "DEVCONTAINER_USERNAME": "${localEnv:USER}",
       "BASE_IMAGE": "ghcr.io/ray-manaloto/dotfiles-devcontainer:dev"
@@ -13,16 +16,20 @@
   "updateRemoteUserUID": false,
   "init": true,
   "overrideCommand": true,
-  "postCreateCommand": "chezmoi init --apply --source '/workspaces/${localWorkspaceFolderBasename}' --force && cd '/workspaces/${localWorkspaceFolderBasename}' && mise reshim -f && mise prepare",
-  "postStartCommand": "cd '/workspaces/${localWorkspaceFolderBasename}' && UV_CACHE_DIR=/tmp/dotfiles-uv-cache uv run --project '/workspaces/${localWorkspaceFolderBasename}/python' dotfiles-setup ensure-ssh",
+  "initializeCommand": "cd '${localWorkspaceFolder}/python' && uv run dotfiles-setup docker initialize-host",
+  "postCreateCommand": "cd '/workspaces/${localWorkspaceFolderBasename}' && mise trust . && mise reshim -f",
+  "postStartCommand": "cd '/workspaces/${localWorkspaceFolderBasename}' && mise trust . && PYTHONPATH='/workspaces/${localWorkspaceFolderBasename}/python/src' mise exec python -- python -m dotfiles_setup.main ensure-ssh",
   "containerEnv": {
     "DEVCONTAINER": "true",
     "DOTFILES_HOST_USER": "${localEnv:USER}",
+    "DOTFILES_HOST_STATE_DIR": "/tmp/dotfiles-host-state",
+    "SSH_AUTH_SOCK": "/tmp/dotfiles-ssh-agent.sock",
     "MISE_TRUSTED_CONFIG_PATHS": "/home/${localEnv:USER}/.config/mise",
     "MISE_STRICT": "1"
   },
   "remoteEnv": {
-    "PATH": "${containerEnv:PATH}:/home/${localEnv:USER}/.local/share/mise/shims"
+    "PATH": "${containerEnv:PATH}:/home/${localEnv:USER}/.local/share/mise/shims",
+    "SSH_AUTH_SOCK": "/tmp/dotfiles-ssh-agent.sock"
   },
   "runArgs": [
     "--platform=linux/amd64",
@@ -37,6 +44,6 @@
     "type=bind,source=${localEnv:HOME}/.claude,target=/home/${localEnv:USER}/.claude",
     "type=bind,source=${localEnv:HOME}/.codex,target=/home/${localEnv:USER}/.codex",
     "type=bind,source=${localEnv:HOME}/.gemini,target=/home/${localEnv:USER}/.gemini",
-    "type=bind,source=${localEnv:HOME}/.ssh,target=/home/${localEnv:USER}/.ssh,readonly"
+    "type=bind,source=${localEnv:HOME}/.local/state/dotfiles,target=/tmp/dotfiles-host-state"
   ]
 }

--- a/home/.chezmoiscripts/run_once_before_01_install_mise.sh
+++ b/home/.chezmoiscripts/run_once_before_01_install_mise.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 set -eu
+
+if [ "${DEVCONTAINER:-}" = "true" ] && command -v mise >/dev/null 2>&1; then
+    exit 0
+fi
+
 # Install mise — pinned version for Docker build reproducibility
 MISE_VERSION="${MISE_VERSION:-v2026.3.18}"
 MISE_INSTALL_PATH="${MISE_INSTALL_PATH:-$HOME/.local/bin/mise}"

--- a/home/.chezmoiscripts/run_onchange_after_10_mise_install.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_10_mise_install.sh.tmpl
@@ -4,6 +4,10 @@ set -eu
 # Re-runs when mise config template changes:
 # {{ include "dot_config/mise/config.toml.tmpl" | sha256sum }}
 
+if [ "${DEVCONTAINER:-}" = "true" ]; then
+  exit 0
+fi
+
 MISE="${MISE_INSTALL_PATH:-$(command -v mise || printf '%s' "$HOME/.local/bin/mise")}"
 SYSTEM_ARGS=""
 if [ "${MISE_INSTALL_MODE:-}" = "system" ]; then

--- a/python/src/dotfiles_setup/audit.py
+++ b/python/src/dotfiles_setup/audit.py
@@ -14,7 +14,11 @@ import sys
 from pathlib import Path
 from typing import Any, ClassVar
 
+from dotfiles_setup.docker import ensure_container_ssh_proxy, host_authorized_keys
+
 logger = logging.getLogger(__name__)
+
+NON_SYSTEM_UID_MIN = 1000
 
 
 class ToolManager:
@@ -190,7 +194,7 @@ class DevEnvironmentAuditor:
         non_root_users = [
             entry.pw_name
             for entry in pwd.getpwall()
-            if entry.pw_uid >= 1000 and entry.pw_name not in {"nobody"}
+            if entry.pw_uid >= NON_SYSTEM_UID_MIN and entry.pw_name != "nobody"
         ]
         sole_non_root_user = len(non_root_users) == 1 and current_user in non_root_users
 
@@ -362,26 +366,49 @@ class DevEnvironmentAuditor:
         ssh_dir = Path.home() / ".ssh"
         ssh_dir.mkdir(mode=0o700, exist_ok=True)
 
-        # 2. Get public keys from agent
+        if os.environ.get("DEVCONTAINER") == "true":
+            proxy_socket = ensure_container_ssh_proxy()
+            if proxy_socket:
+                os.environ["SSH_AUTH_SOCK"] = proxy_socket
+                logger.info("Using container SSH agent proxy at %s", proxy_socket)
+
+        public_key_lines: list[str] = []
+
+        # 2a. Get public keys from agent when available
         try:
             result = subprocess.run(
                 ["ssh-add", "-L"],
                 capture_output=True,
                 text=True,
-                check=True
+                check=True,
             )
             public_keys = result.stdout.strip()
             if public_keys:
-                auth_keys_path = ssh_dir / "authorized_keys"
-                # Atomic write to authorized_keys
-                auth_keys_path.write_text(public_keys + "\n")
-                auth_keys_path.chmod(0o600)
-                count = len(public_keys.splitlines())
-                logger.info("Authorized %d keys from agent", count)
+                public_key_lines.extend(
+                    line.strip() for line in public_keys.splitlines() if line.strip()
+                )
+                logger.info(
+                    "Collected %d keys from SSH agent",
+                    len(public_key_lines),
+                )
             else:
                 logger.warning("No keys found in SSH agent to authorize")
         except subprocess.CalledProcessError:
             logger.warning("SSH agent unreachable during authorization sync")
+
+        # 2b. Fall back to host-provided public keys from runtime state.
+        public_key_lines.extend(host_authorized_keys())
+
+        unique_public_keys = list(
+            dict.fromkeys(line for line in public_key_lines if line)
+        )
+        if unique_public_keys:
+            auth_keys_path = ssh_dir / "authorized_keys"
+            auth_keys_path.write_text("\n".join(unique_public_keys) + "\n")
+            auth_keys_path.chmod(0o600)
+            logger.info("Authorized %d SSH keys", len(unique_public_keys))
+        else:
+            logger.warning("No SSH public keys available to authorize")
 
         # 3. Ensure sshd is running
         try:

--- a/python/src/dotfiles_setup/docker.py
+++ b/python/src/dotfiles_setup/docker.py
@@ -1,44 +1,399 @@
-"""Docker management module for dotfiles setup."""
+"""Docker and devcontainer runtime management for dotfiles setup."""
 
 from __future__ import annotations
 
 import logging
 import os
+import select
 import shutil
+import signal
+import socket
 import subprocess
+import sys
+import threading
+import time
+from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_HOST_STATE_DIR = Path.home() / ".local" / "state" / "dotfiles"
+CONTAINER_HOST_STATE_DIR = Path("/tmp/dotfiles-host-state")  # noqa: S108
+HOST_PROXY_HOST = "host.docker.internal"
+HOST_AUTHORIZED_KEYS_FILE = "authorized_keys"
+HOST_SSH_PROXY_PID_FILE = "ssh-agent-proxy.pid"
+HOST_SSH_PROXY_PORT_FILE = "ssh-agent-port"
+HOST_SSH_PROXY_TARGET_FILE = "ssh-agent.target"
+CONTAINER_SSH_PROXY_SOCKET = Path("/tmp/dotfiles-ssh-agent.sock")  # noqa: S108
+CONTAINER_SSH_PROXY_PID_FILE = Path("/tmp/dotfiles-ssh-agent-proxy.pid")  # noqa: S108
+
+
+def host_state_dir() -> Path:
+    """Resolve the devcontainer runtime state directory."""
+    raw_dir = os.environ.get("DOTFILES_HOST_STATE_DIR")
+    if raw_dir:
+        return Path(raw_dir)
+    if os.environ.get("DEVCONTAINER") == "true":
+        return CONTAINER_HOST_STATE_DIR
+    return DEFAULT_HOST_STATE_DIR
+
+
+def parse_host_port(value: str) -> tuple[str, int]:
+    """Parse a host:port pair."""
+    host, port = value.rsplit(":", 1)
+    return host, int(port)
+
+
+def _collect_public_keys_from_agent() -> list[str]:
+    """Collect public keys currently loaded in the SSH agent."""
+    result = subprocess.run(
+        ["ssh-add", "-L"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _write_host_authorized_keys(state_dir: Path, public_keys: list[str]) -> None:
+    """Persist authorized keys for the container to consume."""
+    unique_keys = list(dict.fromkeys(public_keys))
+    auth_keys_path = state_dir / HOST_AUTHORIZED_KEYS_FILE
+    content = "\n".join(unique_keys)
+    if content:
+        content += "\n"
+    auth_keys_path.write_text(content, encoding="utf-8")
+    auth_keys_path.chmod(0o600)
+
+
+def _resolve_host_ssh_auth_sock() -> str:
+    """Resolve the host SSH agent socket path."""
+    candidate = os.environ.get("SSH_AUTH_SOCK", "")
+    if candidate and Path(candidate).is_socket():
+        return candidate
+
+    launchctl = shutil.which("launchctl")
+    if not launchctl:
+        return ""
+
+    result = subprocess.run(
+        [launchctl, "getenv", "SSH_AUTH_SOCK"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    launchd_sock = result.stdout.strip()
+    if launchd_sock and Path(launchd_sock).is_socket():
+        return launchd_sock
+    return ""
+
+
+def _proxy_connection(
+    client: socket.socket,
+    *,
+    target_unix: Path | None,
+    target_tcp: tuple[str, int] | None,
+) -> None:
+    if (target_unix is None) == (target_tcp is None):
+        msg = "exactly one target mode must be configured"
+        raise ValueError(msg)
+
+    if target_unix is not None:
+        upstream = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        upstream.connect(os.fspath(target_unix))
+    else:
+        if target_tcp is None:
+            msg = "TCP target must be set when no Unix target is configured"
+            raise RuntimeError(msg)
+        upstream = socket.create_connection(target_tcp)
+
+    try:
+        sockets = [client, upstream]
+        while True:
+            readable, _, _ = select.select(sockets, [], [])
+            for source in readable:
+                payload = source.recv(65536)
+                if not payload:
+                    return
+                destination = upstream if source is client else client
+                destination.sendall(payload)
+    finally:
+        try:
+            upstream.close()
+        finally:
+            client.close()
+
+
+def serve_proxy(
+    *,
+    listen_unix: Path | None,
+    listen_tcp: tuple[str, int] | None,
+    target_unix: Path | None,
+    target_tcp: tuple[str, int] | None,
+) -> int:
+    """Serve a small socket proxy for SSH agent forwarding."""
+    if (listen_unix is None) == (listen_tcp is None):
+        msg = "exactly one listen mode must be configured"
+        raise RuntimeError(msg)
+    if (target_unix is None) == (target_tcp is None):
+        msg = "exactly one target mode must be configured"
+        raise RuntimeError(msg)
+
+    if listen_unix is not None:
+        listen_unix.parent.mkdir(parents=True, exist_ok=True)
+        listen_unix.unlink(missing_ok=True)
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        server.bind(os.fspath(listen_unix))
+        listen_unix.chmod(0o600)
+    else:
+        if listen_tcp is None:
+            msg = "TCP listen endpoint must be configured"
+            raise RuntimeError(msg)
+        server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        server.bind(listen_tcp)
+
+    server.listen()
+
+    def _stop(_signum: int, _frame: object) -> None:
+        raise SystemExit(0)
+
+    signal.signal(signal.SIGTERM, _stop)
+    signal.signal(signal.SIGINT, _stop)
+
+    try:
+        while True:
+            client, _ = server.accept()
+            worker = threading.Thread(
+                target=_proxy_connection,
+                args=(client,),
+                kwargs={"target_unix": target_unix, "target_tcp": target_tcp},
+                daemon=True,
+            )
+            worker.start()
+    finally:
+        server.close()
+        if listen_unix is not None:
+            listen_unix.unlink(missing_ok=True)
+
+
+def _choose_host_ssh_proxy_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _stop_proxy(pid_file: Path, socket_path: Path | None = None) -> None:
+    raw_pid = pid_file.read_text(encoding="utf-8").strip() if pid_file.exists() else ""
+    if raw_pid.isdigit():
+        with suppress(OSError):
+            os.kill(int(raw_pid), signal.SIGTERM)
+    pid_file.unlink(missing_ok=True)
+    if socket_path is not None:
+        socket_path.unlink(missing_ok=True)
+
+
+def _wait_for_unix_socket(socket_path: Path, *, timeout_seconds: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if socket_path.exists() and socket_path.is_socket():
+            return True
+        time.sleep(0.1)
+    return False
+
+
+def _wait_for_tcp_port(host: str, port: int, *, timeout_seconds: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(0.2)
+            if sock.connect_ex((host, port)) == 0:
+                return True
+        time.sleep(0.1)
+    return False
+
+
+def initialize_host_ssh_runtime() -> dict[str, str]:
+    """Prepare host-side SSH runtime state for devcontainer launches."""
+    state_dir = host_state_dir()
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    public_keys = _collect_public_keys_from_agent()
+    _write_host_authorized_keys(state_dir, public_keys)
+
+    pid_file = state_dir / HOST_SSH_PROXY_PID_FILE
+    target_file = state_dir / HOST_SSH_PROXY_TARGET_FILE
+    port_file = state_dir / HOST_SSH_PROXY_PORT_FILE
+
+    target_socket = _resolve_host_ssh_auth_sock()
+    if not target_socket:
+        _stop_proxy(pid_file)
+        target_file.unlink(missing_ok=True)
+        port_file.unlink(missing_ok=True)
+        return {
+            "state_dir": str(state_dir),
+            "ssh_proxy_port": "",
+            "authorized_keys": str(len(public_keys)),
+        }
+
+    current_target = (
+        target_file.read_text(encoding="utf-8").strip() if target_file.exists() else ""
+    )
+    current_port = (
+        port_file.read_text(encoding="utf-8").strip() if port_file.exists() else ""
+    )
+    if current_target == target_socket and current_port.isdigit():
+        raw_pid = (
+            pid_file.read_text(encoding="utf-8").strip()
+            if pid_file.exists()
+            else ""
+        )
+        if raw_pid.isdigit():
+            try:
+                os.kill(int(raw_pid), 0)
+            except OSError:
+                pass
+            else:
+                if _wait_for_tcp_port(
+                    "127.0.0.1",
+                    int(current_port),
+                    timeout_seconds=0.5,
+                ):
+                    return {
+                        "state_dir": str(state_dir),
+                        "ssh_proxy_port": current_port,
+                        "authorized_keys": str(len(public_keys)),
+                    }
+
+    _stop_proxy(pid_file)
+    target_file.unlink(missing_ok=True)
+    port_file.unlink(missing_ok=True)
+
+    port = _choose_host_ssh_proxy_port()
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "dotfiles_setup.main",
+            "docker",
+            "proxy",
+            "--listen-tcp",
+            f"127.0.0.1:{port}",
+            "--target-unix",
+            target_socket,
+        ],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    pid_file.write_text(f"{proc.pid}\n", encoding="utf-8")
+    target_file.write_text(target_socket + "\n", encoding="utf-8")
+    port_file.write_text(f"{port}\n", encoding="utf-8")
+
+    if not _wait_for_tcp_port("127.0.0.1", port):
+        _stop_proxy(pid_file)
+        target_file.unlink(missing_ok=True)
+        port_file.unlink(missing_ok=True)
+        msg = f"failed to create host SSH proxy on 127.0.0.1:{port}"
+        raise RuntimeError(msg)
+
+    return {
+        "state_dir": str(state_dir),
+        "ssh_proxy_port": str(port),
+        "authorized_keys": str(len(public_keys)),
+    }
+
+
+def host_authorized_keys() -> list[str]:
+    """Read the host-provided authorized keys file."""
+    auth_keys_path = host_state_dir() / HOST_AUTHORIZED_KEYS_FILE
+    if not auth_keys_path.exists():
+        return []
+    return [
+        line.strip()
+        for line in auth_keys_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def ensure_container_ssh_proxy() -> str:
+    """Ensure the in-container SSH agent proxy socket is available."""
+    state_dir = host_state_dir()
+    port_file = state_dir / HOST_SSH_PROXY_PORT_FILE
+    proxy_port = (
+        port_file.read_text(encoding="utf-8").strip()
+        if port_file.exists()
+        else ""
+    )
+    if not proxy_port.isdigit():
+        return ""
+
+    if CONTAINER_SSH_PROXY_SOCKET.exists() and CONTAINER_SSH_PROXY_SOCKET.is_socket():
+        raw_pid = (
+            CONTAINER_SSH_PROXY_PID_FILE.read_text(encoding="utf-8").strip()
+            if CONTAINER_SSH_PROXY_PID_FILE.exists()
+            else ""
+        )
+        if raw_pid.isdigit():
+            try:
+                os.kill(int(raw_pid), 0)
+            except OSError:
+                pass
+            else:
+                return str(CONTAINER_SSH_PROXY_SOCKET)
+
+    _stop_proxy(CONTAINER_SSH_PROXY_PID_FILE, CONTAINER_SSH_PROXY_SOCKET)
+
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "dotfiles_setup.main",
+            "docker",
+            "proxy",
+            "--listen-unix",
+            str(CONTAINER_SSH_PROXY_SOCKET),
+            "--target-tcp",
+            f"{HOST_PROXY_HOST}:{proxy_port}",
+        ],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    CONTAINER_SSH_PROXY_PID_FILE.write_text(f"{proc.pid}\n", encoding="utf-8")
+
+    if not _wait_for_unix_socket(CONTAINER_SSH_PROXY_SOCKET):
+        _stop_proxy(CONTAINER_SSH_PROXY_PID_FILE, CONTAINER_SSH_PROXY_SOCKET)
+        msg = f"failed to create container SSH proxy at {CONTAINER_SSH_PROXY_SOCKET}"
+        raise RuntimeError(msg)
+
+    return str(CONTAINER_SSH_PROXY_SOCKET)
+
 
 class DevContainerManager:
-    """Manages the lifecycle of the devcontainer for local validation.
-
-    Strictly uses @devcontainers/cli for orchestration to ensure
-    lifecycle scripts (onCreateCommand, postCreateCommand) are executed.
-    """
+    """Manage the local devcontainer lifecycle."""
 
     DEFAULT_IMAGE_NAME = "dotfiles-dev-local"
     DEFAULT_BASE_IMAGE = "ghcr.io/ray-manaloto/dotfiles-devcontainer:dev"
 
     def __init__(self, project_root: Path, image_name: str | None = None) -> None:
-        """Initialize the DevContainerManager.
-
-        Args:
-            project_root: The project root path.
-            image_name: Optional image name.
-        """
+        """Initialize the devcontainer manager."""
         self.project_root = project_root
         self.image_name = (
             image_name
             or os.environ.get("DOTFILES_IMAGE")
             or self.DEFAULT_IMAGE_NAME
         )
-        self.base_image = os.environ.get("DOTFILES_BASE_IMAGE", self.DEFAULT_BASE_IMAGE)
+        self.base_image = os.environ.get(
+            "DOTFILES_BASE_IMAGE",
+            self.DEFAULT_BASE_IMAGE,
+        )
 
     def _get_bin(self, name: str) -> str:
-        """Get the absolute path of a binary."""
         path = shutil.which(name)
         if not path:
             msg = f"Required binary '{name}' not found in PATH"
@@ -51,12 +406,8 @@ class DevContainerManager:
         *,
         capture: bool = False,
     ) -> subprocess.CompletedProcess[str]:
-        """Run a devcontainer CLI command."""
         bin_path = self._get_bin("devcontainer")
         cmd = [bin_path, *args]
-
-        # Ensure we inherit host environment for variable substitution
-        # This is critical for DOCKER_CONTEXT and port variables.
         env = os.environ.copy()
 
         if not capture:
@@ -71,7 +422,7 @@ class DevContainerManager:
         )
 
     def build(self) -> None:
-        """Pull the published base image, then build the thin local host-user overlay."""
+        """Build the thin host-user overlay image."""
         logger.info("Pulling published base image %s...", self.base_image)
         docker = self._get_bin("docker")
         subprocess.run(
@@ -81,35 +432,37 @@ class DevContainerManager:
             env=os.environ.copy(),
         )
         logger.info("Building thin local host-user overlay...")
-        self._run_cli([
-            "build",
-            "--workspace-folder", str(self.project_root),
-            "--image-name", self.image_name,
-        ])
+        self._run_cli(
+            [
+                "build",
+                "--workspace-folder",
+                str(self.project_root),
+                "--image-name",
+                self.image_name,
+            ]
+        )
 
     def up(self) -> None:
-        """Bring the devcontainer up."""
+        """Start the local devcontainer."""
         self.build()
         logger.info("Bringing devcontainer up...")
-        self._run_cli([
-            "up",
-            "--workspace-folder", str(self.project_root),
-            "--remove-existing-container",
-        ])
+        self._run_cli(
+            [
+                "up",
+                "--workspace-folder",
+                str(self.project_root),
+                "--remove-existing-container",
+            ]
+        )
 
     def down(self) -> None:
-        """Bring the devcontainer down."""
+        """Stop the local devcontainer."""
         logger.info("Bringing devcontainer down...")
-        self._run_cli([
-            "down",
-            "--workspace-folder", str(self.project_root),
-        ])
+        self._run_cli(["down", "--workspace-folder", str(self.project_root)])
 
     def test(self) -> None:
-        """Run functional tests inside the container using devcontainer exec."""
+        """Run the functional verification suite inside the container."""
         logger.info("Running functional tests inside container...")
-
-        # SSH Port is dynamic via DOTFILES_SSH_PORT
         ssh_port = os.environ.get("DOTFILES_SSH_PORT", "4444")
         test_cmd = (
             "bash -lc '"
@@ -120,8 +473,23 @@ class DevContainerManager:
             "bats tests/infra/*.bats'"
         )
 
-        self._run_cli([
-            "exec",
-            "--workspace-folder", str(self.project_root),
-            "bash", "-c", test_cmd,
-        ])
+        self._run_cli(
+            [
+                "exec",
+                "--workspace-folder",
+                str(self.project_root),
+                "bash",
+                "-c",
+                test_cmd,
+            ]
+        )
+
+    def initialize_host(self) -> None:
+        """Prepare host-side SSH runtime state."""
+        result = initialize_host_ssh_runtime()
+        logger.info(
+            "Prepared devcontainer host SSH runtime at %s (proxy port: %s, keys: %s)",
+            result["state_dir"],
+            result["ssh_proxy_port"] or "disabled",
+            result["authorized_keys"],
+        )

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -13,7 +13,7 @@ from typing import Any, ClassVar
 
 from dotfiles_setup.ai import AIOrchestrator
 from dotfiles_setup.audit import DevEnvironmentAuditor, ToolManager
-from dotfiles_setup.docker import DevContainerManager
+from dotfiles_setup.docker import DevContainerManager, parse_host_port, serve_proxy
 from dotfiles_setup.ghcr import validate_ghcr_prereqs
 from dotfiles_setup.image import main as image_main
 from dotfiles_setup.verify import main as verify_main
@@ -38,7 +38,7 @@ class EnvironmentValidator:
             logger.warning("MISE_STRICT is not set to 1. This is not recommended.")
 
 
-def setup_parser() -> argparse.ArgumentParser:
+def setup_parser() -> argparse.ArgumentParser:  # noqa: PLR0915
     """Configure the argument parser."""
     parser = argparse.ArgumentParser(description="Reproducible Dotfiles Orchestrator")
     subparsers = parser.add_subparsers(dest="command", help="Commands")
@@ -85,6 +85,18 @@ def setup_parser() -> argparse.ArgumentParser:
     docker_subparsers.add_parser("up", help="Bring the devcontainer up")
     docker_subparsers.add_parser("test", help="Run tests inside the container")
     docker_subparsers.add_parser("down", help="Bring the devcontainer down")
+    docker_subparsers.add_parser(
+        "initialize-host",
+        help="Prepare host-side SSH runtime for direct devcontainer launches",
+    )
+    proxy_parser = docker_subparsers.add_parser(
+        "proxy",
+        help="Run a socket proxy for SSH agent forwarding",
+    )
+    proxy_parser.add_argument("--listen-unix")
+    proxy_parser.add_argument("--listen-tcp")
+    proxy_parser.add_argument("--target-unix")
+    proxy_parser.add_argument("--target-tcp")
 
     # verify command
     verify_parser = subparsers.add_parser("verify", help="Run verification suites")
@@ -123,7 +135,10 @@ def setup_parser() -> argparse.ArgumentParser:
         "--image-ref", required=True, help="Image reference to inspect"
     )
     size_parser.add_argument("--platform", default="linux/amd64", help="Platform")
-    benchmark_parser = image_sub.add_parser("benchmark", help="Benchmark image smoke/report timings")
+    benchmark_parser = image_sub.add_parser(
+        "benchmark",
+        help="Benchmark image smoke/report timings",
+    )
     benchmark_parser.add_argument(
         "--image-ref", required=True, help="Image reference to benchmark"
     )
@@ -132,15 +147,26 @@ def setup_parser() -> argparse.ArgumentParser:
         "--output-path",
         help="Optional JSON output path for benchmark metrics",
     )
-    compare_parser = image_sub.add_parser("metrics-compare", help="Compare two benchmark JSON files")
+    compare_parser = image_sub.add_parser(
+        "metrics-compare",
+        help="Compare two benchmark JSON files",
+    )
     compare_parser.add_argument("--baseline", required=True, help="Baseline JSON path")
-    compare_parser.add_argument("--candidate", required=True, help="Candidate JSON path")
+    compare_parser.add_argument(
+        "--candidate",
+        required=True,
+        help="Candidate JSON path",
+    )
 
     ghcr_parser = subparsers.add_parser(
         "ghcr-check",
         help="Validate local GHCR publish prerequisites exposed via GitHub CLI",
     )
-    ghcr_parser.add_argument("--owner", default="ray-manaloto", help="GitHub org/user owner")
+    ghcr_parser.add_argument(
+        "--owner",
+        default="ray-manaloto",
+        help="GitHub org/user owner",
+    )
     ghcr_parser.add_argument("--repo", default="dotfiles", help="Repository name")
     ghcr_parser.add_argument(
         "--package-name",
@@ -170,6 +196,15 @@ def handle_docker(args: argparse.Namespace, project_root: Path) -> None:
         docker_manager.test()
     elif args.docker_command == "down":
         docker_manager.down()
+    elif args.docker_command == "initialize-host":
+        docker_manager.initialize_host()
+    elif args.docker_command == "proxy":
+        serve_proxy(
+            listen_unix=Path(args.listen_unix) if args.listen_unix else None,
+            listen_tcp=parse_host_port(args.listen_tcp) if args.listen_tcp else None,
+            target_unix=Path(args.target_unix) if args.target_unix else None,
+            target_tcp=parse_host_port(args.target_tcp) if args.target_tcp else None,
+        )
 
 
 def handle_audit() -> None:
@@ -221,7 +256,13 @@ def handle_image(args: argparse.Namespace) -> None:
     if args.image_command == "smoke":
         sys.exit(image_main(args.image_ref, platform=args.platform))
     if args.image_command == "size-report":
-        sys.exit(image_main(args.image_ref, platform=args.platform, command="size-report"))
+        sys.exit(
+            image_main(
+                args.image_ref,
+                platform=args.platform,
+                command="size-report",
+            )
+        )
     if args.image_command == "benchmark":
         output_path = Path(args.output_path) if args.output_path else None
         sys.exit(


### PR DESCRIPTION
## Summary
- replace the host ~/.ssh bind mount with host-state-backed SSH agent proxying
- populate container-local authorized_keys during devcontainer startup
- skip redundant mise install hooks in devcontainer startup so baked tools are reused

## Validation
- uv run ruff check src/dotfiles_setup/docker.py src/dotfiles_setup/main.py src/dotfiles_setup/audit.py
- uv run pytest tests/test_image_smoke.py tests/test_audit.py -q
- devcontainer up --workspace-folder .worktrees/ci-remediation-23872422984
- docker exec <container> whoami/id plus ~/.ssh/authorized_keys checks
- ssh -p 4444 rmanaloto@127.0.0.1 'whoami && id'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SSH proxy authentication support for development containers, enabling secure key forwarding from host to container.
  * Introduced improved container initialization process with better host state management.

* **Chores**
  * Optimized development container startup and initialization sequence for faster setup.
  * Enhanced SSH key management and authorized keys handling in container environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->