### PR TITLE
Fix smoke-test: conditional cacheonly output for non-push builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
             ${{ steps.meta.outputs.bake-file-labels }}
           set: |
             *.secrets=id=github_token,src=/tmp/github_token
-            *.output=type=cacheonly
+            ${{ (github.ref != 'refs/heads/main' && github.event_name != 'schedule') && '*.output=type=cacheonly' || '' }}
 
       - name: Build performance summary
         if: always()


### PR DESCRIPTION
## Summary

- Fix regression from PR #34 where `*.output=type=cacheonly` unconditionally overrode bake-action's `push:` parameter
- Image was never pushed to ghcr.io on main, causing smoke-test to fail with `manifest unknown`

## Root Cause

The W4 Rekor TUF fix added `*.output=type=cacheonly` to the bake-action `set:` block. The `set:` parameter has higher precedence than `push:`, so even when `push: true` on main, the output was cacheonly (no image push).

## Fix

Make `cacheonly` conditional — only set when NOT on main/schedule (where we need to push the image):

```yaml
${{ (github.ref != 'refs/heads/main' && github.event_name != 'schedule') && '*.output=type=cacheonly' || '' }}
```

## Test plan

- [x] actionlint clean
- [x] 36 pytest tests pass
- [x] hk pre-commit hooks pass
- [ ] After merge: smoke-test pulls image successfully on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to conditionally manage build cache output behavior based on branch and event type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->