### PR TITLE
Fix smoke-test: scope mise ls to system config only

### DIFF
--- a/python/src/dotfiles_setup/image.py
+++ b/python/src/dotfiles_setup/image.py
@@ -41,7 +41,8 @@ echo "=== hk validate ==="
 cd /tmp/dotfiles
 mise trust .
 HK_FILE=hk.pkl hk validate
-echo "=== mise ls (check no missing) ==="
+echo "=== mise ls (check no missing — system config only) ==="
+cd "$HOME"
 mise_output=$(mise ls 2>&1)
 missing=$(echo "$mise_output" | grep -c "(missing)" || true)
 echo "Missing tools: $missing"
@@ -49,6 +50,7 @@ if [ "$missing" -gt 0 ]; then
   echo "$mise_output" | grep "(missing)"
   exit 1
 fi
+cd /tmp/dotfiles
 echo "=== shell integration ==="
 command -v zsh || { echo "FAIL: zsh not found"; exit 1; }
 command -v git || { echo "FAIL: git not found"; exit 1; }


### PR DESCRIPTION
## Summary

Fix smoke-test failure where 3 host-only tools showed as "missing" in the Docker image.

## Root Cause

The smoke script ran `mise ls` from `/tmp/dotfiles` (the mounted repo), causing mise to read both:
- `/etc/mise/config.toml` (system — Docker tools, installed in image)
- `/tmp/dotfiles/mise.toml` (host tools, NOT installed in image)

Three host-only linting tools (`@devcontainers/cli`, `agnix`, `agents-lint`) appeared as "missing" because they're in `mise.toml` but not in `mise-system.toml`.

## Fix

`cd $HOME` before running `mise ls` so only the system config is read, then `cd` back for subsequent checks that need `hk.pkl`.

## Test plan

- [x] 36 pytest tests pass
- [x] actionlint clean
- [x] hk pre-commit + pre-push hooks pass
- [ ] Smoke-test passes on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)