### PR TITLE
Fix smoke-test: correct MISE_DATA_DIR path (/opt/mise)

### DIFF
--- a/python/src/dotfiles_setup/image.py
+++ b/python/src/dotfiles_setup/image.py
@@ -71,8 +71,8 @@ echo "=== path constraints ==="
 if [ ! -x /usr/local/bin/mise ]; then
   echo "FAIL: /usr/local/bin/mise missing"; exit 1
 fi
-if [ ! -d /usr/local/share/mise/installs ]; then
-  echo "FAIL: /usr/local/share/mise/installs missing"; exit 1
+if [ ! -d /opt/mise/installs ]; then
+  echo "FAIL: /opt/mise/installs missing"; exit 1
 fi
 echo "=== backend policy checks ==="
 grep -q 'npm.package_manager = "bun"' "$HOME/.config/mise/config.toml" || {


### PR DESCRIPTION
## Summary

Fix smoke-test path constraint: `/usr/local/share/mise/installs` → `/opt/mise/installs`.

## Root Cause

The Dockerfile sets `MISE_DATA_DIR=/opt/mise`, so tool installs live at `/opt/mise/installs`. The smoke test was checking the wrong default path.

## Test plan

- [x] 36 pytest tests pass
- [x] hk pre-commit + pre-push hooks pass
- [ ] Smoke-test passes on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed smoke-test validation to check for Mise installation at the correct location, improving installation verification accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->