### PR TITLE
Fix smoke-test: use MISE_CONFIG_DIR for backend policy checks

### DIFF
--- a/python/src/dotfiles_setup/image.py
+++ b/python/src/dotfiles_setup/image.py
@@ -75,16 +75,16 @@ if [ ! -d /opt/mise/installs ]; then
   echo "FAIL: /opt/mise/installs missing"; exit 1
 fi
 echo "=== backend policy checks ==="
-grep -q 'npm.package_manager = "bun"' "$HOME/.config/mise/config.toml" || {
+grep -q 'npm.package_manager = "bun"' "${MISE_CONFIG_DIR:-$HOME/.config/mise}/config.toml" || {
   echo "FAIL: bun package manager policy missing"; exit 1;
 }
-grep -q 'pipx.uvx = true' "$HOME/.config/mise/config.toml" || {
+grep -q 'pipx.uvx = true' "${MISE_CONFIG_DIR:-$HOME/.config/mise}/config.toml" || {
   echo "FAIL: uvx policy missing"; exit 1;
 }
-grep -q 'cargo.binstall = true' "$HOME/.config/mise/config.toml" || {
+grep -q 'cargo.binstall = true' "${MISE_CONFIG_DIR:-$HOME/.config/mise}/config.toml" || {
   echo "FAIL: cargo-binstall policy missing"; exit 1;
 }
-grep -q 'python.uv_venv_auto = "source"' "$HOME/.config/mise/config.toml" || {
+grep -q 'python.uv_venv_auto = "source"' "${MISE_CONFIG_DIR:-$HOME/.config/mise}/config.toml" || {
   echo "FAIL: python uv venv policy missing"; exit 1;
 }
 echo "=== clang tooling checks ==="


### PR DESCRIPTION
## Summary

Backend policy checks hardcoded `$HOME/.config/mise/config.toml` but the Dockerfile sets `MISE_CONFIG_DIR=/etc/mise`. Policies exist at `/etc/mise/config.toml`, not `$HOME/.config/mise/config.toml`.

## Fix

Use `${MISE_CONFIG_DIR:-$HOME/.config/mise}/config.toml` — respects the env var with fallback.

## Test plan

- [x] 36 pytest tests pass
- [x] hk hooks pass
- [ ] Smoke-test passes on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Tests**
- Updated smoke-test script to support customizable configuration directories. All backend policy checks for npm, pipx, cargo, and Python environments now dynamically resolve configuration paths based on environment-specified settings with fallback to defaults, eliminating hardcoded path dependencies and improving flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->