### PR TITLE
Remove /tmp/dotfiles mount from smoke test — use baked-in image content

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -95,6 +95,9 @@ RUN mise reshim -f
 # Final global permissions check
 RUN chmod -R 777 /opt/mise /etc/mise /opt/cargo /opt/rustup
 
+# Copy hk config for smoke-test validation (hk validate)
+COPY hk.pkl /etc/hk/hk.pkl
+
 # Ensure mise is activated for all users
 RUN echo "eval \"\$(/usr/local/bin/mise activate bash)\"" > /etc/profile.d/mise.sh && \
     echo "eval \"\$(/usr/local/bin/mise activate zsh)\"" > /etc/profile.d/mise.zsh

--- a/python/src/dotfiles_setup/image.py
+++ b/python/src/dotfiles_setup/image.py
@@ -37,12 +37,10 @@ def build_smoke_script() -> str:
     """Build the inline smoke test script."""
     return """\
 set -euo pipefail
+MISE_CFG="${MISE_CONFIG_DIR:-/etc/mise}/config.toml"
 echo "=== hk validate ==="
-cd /tmp/dotfiles
-mise trust .
-HK_FILE=hk.pkl hk validate
+HK_FILE=/etc/hk/hk.pkl hk validate
 echo "=== mise ls (check no missing — system config only) ==="
-cd "$HOME"
 mise_output=$(mise ls 2>&1)
 missing=$(echo "$mise_output" | grep -c "(missing)" || true)
 echo "Missing tools: $missing"
@@ -50,7 +48,6 @@ if [ "$missing" -gt 0 ]; then
   echo "$mise_output" | grep "(missing)"
   exit 1
 fi
-cd /tmp/dotfiles
 echo "=== shell integration ==="
 command -v zsh || { echo "FAIL: zsh not found"; exit 1; }
 command -v git || { echo "FAIL: git not found"; exit 1; }
@@ -75,16 +72,16 @@ if [ ! -d /opt/mise/installs ]; then
   echo "FAIL: /opt/mise/installs missing"; exit 1
 fi
 echo "=== backend policy checks ==="
-grep -q 'npm.package_manager = "bun"' "${MISE_CONFIG_DIR:-$HOME/.config/mise}/config.toml" || {
+grep -q 'npm.package_manager = "bun"' "$MISE_CFG" || {
   echo "FAIL: bun package manager policy missing"; exit 1;
 }
-grep -q 'pipx.uvx = true' "${MISE_CONFIG_DIR:-$HOME/.config/mise}/config.toml" || {
+grep -q 'pipx.uvx = true' "$MISE_CFG" || {
   echo "FAIL: uvx policy missing"; exit 1;
 }
-grep -q 'cargo.binstall = true' "${MISE_CONFIG_DIR:-$HOME/.config/mise}/config.toml" || {
+grep -q 'cargo.binstall = true' "$MISE_CFG" || {
   echo "FAIL: cargo-binstall policy missing"; exit 1;
 }
-grep -q 'python.uv_venv_auto = "source"' "${MISE_CONFIG_DIR:-$HOME/.config/mise}/config.toml" || {
+grep -q 'python.uv_venv_auto = "source"' "$MISE_CFG" || {
   echo "FAIL: python uv venv policy missing"; exit 1;
 }
 echo "=== clang tooling checks ==="
@@ -125,8 +122,6 @@ def build_smoke_docker_cmd(image_ref: str, *, platform: str = "linux/amd64") -> 
         "--rm",
         "--platform",
         platform,
-        "--volume",
-        f"{_project_root()}:/tmp/dotfiles:ro",
         "--entrypoint",
         "/bin/bash",
         image_ref,

--- a/tests/test_image_smoke.py
+++ b/tests/test_image_smoke.py
@@ -13,15 +13,13 @@ from dotfiles_setup.image import (
 def test_smoke_script_pins_hk_file() -> None:
     script = build_smoke_script()
 
-    assert "HK_FILE=hk.pkl hk validate" in script
+    assert "HK_FILE=/etc/hk/hk.pkl hk validate" in script
 
 
-def test_smoke_docker_cmd_mounts_repo_checkout() -> None:
+def test_smoke_docker_cmd_no_volume_mount() -> None:
     cmd = build_smoke_docker_cmd("ghcr.io/ray-manaloto/dotfiles-devcontainer:test")
 
-    assert "--volume" in cmd
-    mount = cmd[cmd.index("--volume") + 1]
-    assert mount.endswith(":/tmp/dotfiles:ro")
+    assert "--volume" not in cmd
 
 
 def test_smoke_script_does_not_require_llvm_symbolizer() -> None:


### PR DESCRIPTION
## Summary

Eliminates the host repo volume mount from the smoke test. The smoke test now validates only what's baked into the image — no dependency on host files at runtime.

## Changes

- **Dockerfile**: COPY `hk.pkl` to `/etc/hk/hk.pkl` for `hk validate`
- **image.py**: Remove `--volume` mount, use `/etc/hk/hk.pkl`, use `MISE_CONFIG_DIR` env var for policy checks, run `mise ls` from `$HOME` (system config only)
- **test_image_smoke.py**: Update assertions (no mount, new hk path)

## Root Cause

Mounting the host repo caused:
1. `mise ls` to read host `mise.toml` → host-only tools showed as "missing"
2. Wrong config path for backend policy checks (`$HOME/.config/mise` vs `/etc/mise`)
3. `mise trust` errors for the mounted config

## Test plan

- [x] 36 pytest tests pass
- [x] docker_bake_check pass
- [x] hk pre-commit + pre-push hooks pass
- [ ] Smoke-test passes on main (builds new image with COPY hk.pkl)

Supersedes fixes in #38, #39, #40 — this is the proper solution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)