### PR TITLE
Fix #45: resolve ruff TC003/PLC0415 in image.py and verify.py

### DIFF
--- a/python/src/dotfiles_setup/image.py
+++ b/python/src/dotfiles_setup/image.py
@@ -10,16 +10,14 @@ import subprocess
 import sys
 import time
 import zlib
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+from dotfiles_setup import _project_root
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 logger = logging.getLogger(__name__)
-
-
-def _project_root() -> Path:
-    from dotfiles_setup import _project_root as _root
-
-    return _root()
 
 
 def _run(

--- a/python/src/dotfiles_setup/verify.py
+++ b/python/src/dotfiles_setup/verify.py
@@ -10,6 +10,8 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
+from dotfiles_setup import _project_root
+
 logger = logging.getLogger(__name__)
 
 
@@ -79,13 +81,6 @@ def fail(reason: str) -> None:
         VerificationError: Always raised with the given reason.
     """
     raise VerificationError(reason)
-
-
-def _project_root() -> Path:
-    """Return the project root directory."""
-    from dotfiles_setup import _project_root as _root
-
-    return _root()
 
 
 def _resolve_paths(entry: dict[str, Any]) -> list[Path]:


### PR DESCRIPTION
## Summary

Resolves [#45](https://github.com/ray-manaloto/dotfiles/issues/45). The nested `from dotfiles_setup import _project_root as _root` imports in PR #44 were cargo-culted — `dotfiles_setup/__init__.py` has no transitive imports of `image`/`verify`, so no circular dependency exists. Verified by importing both modules from the package root on a clean checkout.

## Changes

- `image.py` — delete `_project_root` wrapper, import `_project_root` at module top, move `pathlib.Path` under `TYPE_CHECKING` (annotation-only usage under ` from __future__ import annotations`).
- `verify.py` — delete `_project_root` wrapper, import `_project_root` at module top. `Path` stays top-level (used at runtime).

## Test plan

- [x] ` uv run --project python ruff check python/src/dotfiles_setup/` → clean
- [x] `uv run --project python pytest tests/ -x -q` → 65/65 passing
- [ ] CI lint/contract-preflight/build/smoke-test green

## Related

Follow-up PR #47 (hk uv-run refactor) stacks on top of this — hk's builtin ruff step silently missed TC003/PLC0415, which is how #45 reached main in the first place. #47 fixes that class of bug structurally by replacing the builtin steps with direct `uv run ruff` invocations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal module imports to centralize path resolution logic, eliminating duplicate utility functions across modules.
  * Optimized type annotation imports to reduce runtime overhead while maintaining type safety.

*No user-facing changes. Functionality remains unchanged.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->