### PR TITLE
hk: invoke ruff+ty via `uv run` instead of hk builtin steps

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -25,15 +25,22 @@ hooks {
         batch = true
       }
 
-      // --- Python: ruff + ty (keep glob — types would match .py.tmpl templates) ---
-      ["ruff_format"] {
+      // --- Python: ruff + ty invoked directly via uv so hk uses
+      //     python/pyproject.toml config verbatim. Replaces the hk builtin
+      //     steps, which silently dropped rules (see Issue #45). ruff + ty
+      //     are pinned via python/uv.lock (dev dependency-group).
+      //     Order per Astral ruff docs: `ruff check --fix` BEFORE `ruff format`
+      //     (lint fixes reorder imports; format then cleans up). ---
+      ["py_ruff"] {
         glob = List("python/src/**/*.py", "tests/**/*.py")
-        batch = true
+        check = "uv run --project python ruff check python/src tests"
+        fix = "uv run --project python ruff check --fix python/src tests"
       }
-      ["ruff"] {
+      ["py_ruff_format"] {
         glob = List("python/src/**/*.py", "tests/**/*.py")
-        batch = true
-        check_first = true
+        check = "uv run --project python ruff format --check python/src tests"
+        fix = "uv run --project python ruff format python/src tests"
+        depends = List("py_ruff")
       }
       ["python_check_ast"] {
         glob = List("python/src/**/*.py", "tests/**/*.py")
@@ -43,14 +50,16 @@ hooks {
         glob = List("python/src/**/*.py", "tests/**/*.py")
         batch = true
       }
-      ["ty"] {
+      ["py_ty"] {
         glob = List("python/src/**/*.py", "tests/**/*.py")
+        check = "uv run --project python ty check python/src tests"
       }
 
       // --- Zero inline lint suppressions (enforces zero-skip policy) ---
+      // Covers: ruff `noqa`, mypy `type: ignore`, ty `ty: ignore`, pylint, bandit `nosec`
       ["no_lint_skip"] {
         glob = List("python/src/**/*.py", "tests/**/*.py")
-        check = "! grep -rn 'noqa\\|type: ignore\\|pylint: disable\\|nosec' python/src/ tests/"
+        check = "! grep -rn 'noqa\\|type: ignore\\|ty: ignore\\|pylint: disable\\|nosec' python/src/ tests/"
       }
 
       // --- Dockerfile & Bake ---

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -95,4 +95,10 @@ enable_all = true
 [dependency-groups]
 dev = [
     "pytest>=9.0.2",
+    # Linter/formatter and type-checker invoked directly by hk.pkl via
+    # `uv run --project python` so hk uses pyproject.toml config with no
+    # builtin-step rule dropouts (see Issue #45). Unpinned → `uv lock`
+    # resolves latest; bump via `uv lock --upgrade-package ruff --upgrade-package ty`.
+    "ruff",
+    "ty",
 ]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -32,6 +32,8 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -41,7 +43,11 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.0.2" }]
+dev = [
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "ruff" },
+    { name = "ty" },
+]
 
 [[package]]
 name = "iniconfig"
@@ -170,6 +176,55 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/97/e9f1ca355108ef7194e38c812ef40ba98c7208f47b13ad78d023caa583da/ruff-0.15.9.tar.gz", hash = "sha256:29cbb1255a9797903f6dde5ba0188c707907ff44a9006eb273b5a17bfa0739a2", size = 4617361, upload-time = "2026-04-02T18:17:20.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/1f/9cdfd0ac4b9d1e5a6cf09bedabdf0b56306ab5e333c85c87281273e7b041/ruff-0.15.9-py3-none-linux_armv6l.whl", hash = "sha256:6efbe303983441c51975c243e26dff328aca11f94b70992f35b093c2e71801e1", size = 10511206, upload-time = "2026-04-02T18:16:41.574Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/f6/32bfe3e9c136b35f02e489778d94384118bb80fd92c6d92e7ccd97db12ce/ruff-0.15.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4965bac6ac9ea86772f4e23587746f0b7a395eccabb823eb8bfacc3fa06069f7", size = 10923307, upload-time = "2026-04-02T18:17:08.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/25/de55f52ab5535d12e7aaba1de37a84be6179fb20bddcbe71ec091b4a3243/ruff-0.15.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:eaf05aad70ca5b5a0a4b0e080df3a6b699803916d88f006efd1f5b46302daab8", size = 10316722, upload-time = "2026-04-02T18:16:44.206Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/690d75f3fd6278fe55fff7c9eb429c92d207e14b25d1cae4064a32677029/ruff-0.15.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9439a342adb8725f32f92732e2bafb6d5246bd7a5021101166b223d312e8fc59", size = 10623674, upload-time = "2026-04-02T18:16:50.951Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/ec/176f6987be248fc5404199255522f57af1b4a5a1b57727e942479fec98ad/ruff-0.15.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9c5e6faf9d97c8edc43877c3f406f47446fc48c40e1442d58cfcdaba2acea745", size = 10351516, upload-time = "2026-04-02T18:16:57.206Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/fc/51cffbd2b3f240accc380171d51446a32aa2ea43a40d4a45ada67368fbd2/ruff-0.15.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b34a9766aeec27a222373d0b055722900fbc0582b24f39661aa96f3fe6ad901", size = 11150202, upload-time = "2026-04-02T18:17:06.452Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d4/25292a6dfc125f6b6528fe6af31f5e996e19bf73ca8e3ce6eb7fa5b95885/ruff-0.15.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:89dd695bc72ae76ff484ae54b7e8b0f6b50f49046e198355e44ea656e521fef9", size = 11988891, upload-time = "2026-04-02T18:17:18.575Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e1/1eebcb885c10e19f969dcb93d8413dfee8172578709d7ee933640f5e7147/ruff-0.15.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ce187224ef1de1bd225bc9a152ac7102a6171107f026e81f317e4257052916d5", size = 11480576, upload-time = "2026-04-02T18:16:52.986Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6b/a1548ac378a78332a4c3dcf4a134c2475a36d2a22ddfa272acd574140b50/ruff-0.15.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b0c7c341f68adb01c488c3b7d4b49aa8ea97409eae6462d860a79cf55f431b6", size = 11254525, upload-time = "2026-04-02T18:17:02.041Z" },
+    { url = "https://files.pythonhosted.org/packages/42/aa/4bb3af8e61acd9b1281db2ab77e8b2c3c5e5599bf2a29d4a942f1c62b8d6/ruff-0.15.9-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:55cc15eee27dc0eebdfcb0d185a6153420efbedc15eb1d38fe5e685657b0f840", size = 11204072, upload-time = "2026-04-02T18:17:13.581Z" },
+    { url = "https://files.pythonhosted.org/packages/69/48/d550dc2aa6e423ea0bcc1d0ff0699325ffe8a811e2dba156bd80750b86dc/ruff-0.15.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6537f6eed5cda688c81073d46ffdfb962a5f29ecb6f7e770b2dc920598997ed", size = 10594998, upload-time = "2026-04-02T18:16:46.369Z" },
+    { url = "https://files.pythonhosted.org/packages/63/47/321167e17f5344ed5ec6b0aa2cff64efef5f9e985af8f5622cfa6536043f/ruff-0.15.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6d3fcbca7388b066139c523bda744c822258ebdcfbba7d24410c3f454cc9af71", size = 10359769, upload-time = "2026-04-02T18:17:10.994Z" },
+    { url = "https://files.pythonhosted.org/packages/67/5e/074f00b9785d1d2c6f8c22a21e023d0c2c1817838cfca4c8243200a1fa87/ruff-0.15.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:058d8e99e1bfe79d8a0def0b481c56059ee6716214f7e425d8e737e412d69677", size = 10850236, upload-time = "2026-04-02T18:16:48.749Z" },
+    { url = "https://files.pythonhosted.org/packages/76/37/804c4135a2a2caf042925d30d5f68181bdbd4461fd0d7739da28305df593/ruff-0.15.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8e1ddb11dbd61d5983fa2d7d6370ef3eb210951e443cace19594c01c72abab4c", size = 11358343, upload-time = "2026-04-02T18:16:55.068Z" },
+    { url = "https://files.pythonhosted.org/packages/88/3d/1364fcde8656962782aa9ea93c92d98682b1ecec2f184e625a965ad3b4a6/ruff-0.15.9-py3-none-win32.whl", hash = "sha256:bde6ff36eaf72b700f32b7196088970bf8fdb2b917b7accd8c371bfc0fd573ec", size = 10583382, upload-time = "2026-04-02T18:17:04.261Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/56/5c7084299bd2cacaa07ae63a91c6f4ba66edc08bf28f356b24f6b717c799/ruff-0.15.9-py3-none-win_amd64.whl", hash = "sha256:45a70921b80e1c10cf0b734ef09421f71b5aa11d27404edc89d7e8a69505e43d", size = 11744969, upload-time = "2026-04-02T18:16:59.611Z" },
+    { url = "https://files.pythonhosted.org/packages/03/36/76704c4f312257d6dbaae3c959add2a622f63fcca9d864659ce6d8d97d3d/ruff-0.15.9-py3-none-win_arm64.whl", hash = "sha256:0694e601c028fd97dc5c6ee244675bc241aeefced7ef80cd9c6935a871078f53", size = 11005870, upload-time = "2026-04-02T18:17:15.773Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.29"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d5/853561de49fae38c519e905b2d8da9c531219608f1fccc47a0fc2c896980/ty-0.0.29.tar.gz", hash = "sha256:e7936cca2f691eeda631876c92809688dbbab68687c3473f526cd83b6a9228d8", size = 5469221, upload-time = "2026-04-05T15:01:21.328Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/b7/911f9962115acfa24e3b2ec9d4992dd994c38e8769e1b1d7680bb4d28a51/ty-0.0.29-py3-none-linux_armv6l.whl", hash = "sha256:b8a40955f7660d3eaceb0d964affc81b790c0765e7052921a5f861ff8a471c30", size = 10568206, upload-time = "2026-04-05T15:01:19.165Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c3/fcae2167d4c77a97269f92f11d1b43b03617f81de1283d5d05b43432110c/ty-0.0.29-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6b6849adae15b00bbe2d3c5b078967dcb62eba37d38936b8eeb4c81a82d2e3b8", size = 10442530, upload-time = "2026-04-05T15:01:28.471Z" },
+    { url = "https://files.pythonhosted.org/packages/97/33/5a6bfa240cfcb9c36046ae2459fa9ea23238d20130d8656ff5ac4d6c012a/ty-0.0.29-py3-none-macosx_11_0_arm64.whl", hash = "sha256:dcdd9b17209788152f7b7ea815eda07989152325052fe690013537cc7904ce49", size = 9915735, upload-time = "2026-04-05T15:01:10.365Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1e/318f45fae232118e81a6306c30f50de42c509c412128d5bd231eab699ffb/ty-0.0.29-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9d8ed4789bae78ffaf94462c0d25589a734cab0366b86f2bbcb1bb90e1a7a169", size = 10419748, upload-time = "2026-04-05T15:01:32.375Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/a8/5687872e2ab5a0f7dd4fd8456eac31e9381ad4dc74961f6f29965ad4dd91/ty-0.0.29-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:91ec374b8565e0ad0900011c24641ebbef2da51adbd4fb69ff3280c8a7eceb02", size = 10394738, upload-time = "2026-04-05T15:01:06.473Z" },
+    { url = "https://files.pythonhosted.org/packages/de/68/015d118097eeb95e6a44c4abce4c0a28b7b9dfb3085b7f0ee48e4f099633/ty-0.0.29-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:298a8d5faa2502d3810bbbb47a030b9455495b9921594206043c785dd61548cf", size = 10910613, upload-time = "2026-04-05T15:01:17.17Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/01/47ce3c6c53e0670eadbe80756b167bf80ed6681d1ba57cfde2e8065a13d1/ty-0.0.29-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3c8fba1a3524c6109d1e020d92301c79d41bf442fa8d335b9fa366239339cb70", size = 11475750, upload-time = "2026-04-05T15:01:30.461Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/cf/e361845b1081c9264ad5b7c963231bab03f2666865a9f2a115c4233f2137/ty-0.0.29-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4c48adf88a70d264128c39ee922ed14a947817fced1e93c08c1a89c9244edcde", size = 11190055, upload-time = "2026-04-05T15:01:12.369Z" },
+    { url = "https://files.pythonhosted.org/packages/79/12/0fb0857e9a62cb11586e9a712103877bbf717f5fb570d16634408cfdefee/ty-0.0.29-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ce0a7a0e96bc7b42518cd3a1a6a6298ef64ff40ca4614355c1aa807059b5c6f", size = 11020539, upload-time = "2026-04-05T15:01:37.022Z" },
+    { url = "https://files.pythonhosted.org/packages/20/36/5a26753802083f80cd125db6c4348ad42b3c982ec36e718e0bf4c18f75e5/ty-0.0.29-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a6ac86a05b4a3731d45365ab97780acc7b8146fa62fccb3cbe94fe6546c67a97", size = 10396399, upload-time = "2026-04-05T15:01:26.167Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e6/b4e75b5752239ab3ab400f19faef4dbef81d05aab5d3419fda0c062a3765/ty-0.0.29-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6bbbf53141af0f3150bf288d716263f1a3550054e4b3551ca866d38192ba9891", size = 10421461, upload-time = "2026-04-05T15:01:08.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/21/1084b5b609f9abed62070ec0b31c283a403832a6310c8bbc208bd45ee1e6/ty-0.0.29-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1c9e06b770c1d0ff5efc51e34312390db31d53fcf3088163f413030b42b74f84", size = 10599187, upload-time = "2026-04-05T15:01:23.52Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a1/ce19a2ca717bbcc1ee11378aba52ef70b6ce5b87245162a729d9fdc2360f/ty-0.0.29-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:0307fe37e3f000ef1a4ae230bbaf511508a78d24a5e51b40902a21b09d5e6037", size = 11121198, upload-time = "2026-04-05T15:01:15.22Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/6b/f1430b279af704321566ce7ec2725d3d8258c2f815ebd93e474c64cd4543/ty-0.0.29-py3-none-win32.whl", hash = "sha256:7a2a898217960a825f8bc0087e1fdbaf379606175e98f9807187221d53a4a8ed", size = 9995331, upload-time = "2026-04-05T15:01:01.32Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ef/3ef01c17785ff9a69378465c7d0faccd48a07b163554db0995e5d65a5a23/ty-0.0.29-py3-none-win_amd64.whl", hash = "sha256:fc1294200226b91615acbf34e0a9ad81caf98c081e9c6a912a31b0a7b603bc3f", size = 11023644, upload-time = "2026-04-05T15:01:04.432Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/55/87280a994d6a2d2647c65e12abbc997ed49835794366153c04c4d9304d76/ty-0.0.29-py3-none-win_arm64.whl", hash = "sha256:f9794bbd1bb3ce13f78c191d0c89ae4c63f52c12b6daa0c6fe220b90d019d12c", size = 10428165, upload-time = "2026-04-05T15:01:34.665Z" },
 ]
 
 [[package]]

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -55,6 +55,4 @@ def test_audit_exit_code() -> None:
         check=False,
     )
     # Exit 0 = all passed, 1 = some failed. Both valid.
-    assert result.returncode in [0, 1], (
-        f"Unexpected exit code: {result.returncode}"
-    )
+    assert result.returncode in [0, 1], f"Unexpected exit code: {result.returncode}"

--- a/tests/test_ghcr.py
+++ b/tests/test_ghcr.py
@@ -33,9 +33,7 @@ def test_validate_ghcr_prereqs_requires_packages_write_scope(
 
     monkeypatch.setattr("dotfiles_setup.ghcr.which", lambda _name: "/usr/bin/gh")
 
-    def fake_run(
-        args: list[str], *, cwd: Path
-    ) -> subprocess.CompletedProcess[str]:
+    def fake_run(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
         _ = cwd  # unused but required by _run signature
         if args == ["gh", "auth", "status"]:
             return subprocess.CompletedProcess(
@@ -65,9 +63,7 @@ def test_validate_ghcr_prereqs_passes_when_inputs_are_valid(
 
     monkeypatch.setattr("dotfiles_setup.ghcr.which", lambda _name: "/usr/bin/gh")
 
-    def fake_run(
-        args: list[str], *, cwd: Path
-    ) -> subprocess.CompletedProcess[str]:
+    def fake_run(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
         _ = cwd  # unused but required by _run signature
         if args == ["gh", "auth", "status"]:
             return subprocess.CompletedProcess(
@@ -84,9 +80,7 @@ def test_validate_ghcr_prereqs_passes_when_inputs_are_valid(
             return subprocess.CompletedProcess(args, 0, "[]")
         return subprocess.CompletedProcess(args, 0, "{}")
 
-    def fake_run_gh_json(
-        args: list[str], *, cwd: Path
-    ) -> dict[str, Any]:
+    def fake_run_gh_json(args: list[str], *, cwd: Path) -> dict[str, Any]:
         _ = cwd  # unused but required by _run_gh_json signature
         if args[:3] == ["repo", "view", "ray-manaloto/dotfiles"]:
             return {


### PR DESCRIPTION
## Summary

Replace hk's builtin `["ruff"]`, `["ruff_format"]`, and `["ty"]` steps with custom-named `["py_ruff"]`, `["py_ruff_format"]`, `["py_ty"]` steps that shell out to `uv run --project python ruff/ty …`. This makes hk use `python/pyproject.toml` config verbatim (`select = ["ALL"]` with documented ignores) and eliminates the class of bug where hk's builtin step silently drops rules — the root cause of Issue #45.

**Stacks on [#46 / #45 fix](https://github.com/ray-manaloto/dotfiles/pull/new/fix-issue-45-ruff-warnings)** because enabling the new step surfaces the #45 warnings as hk failures; the fix must land first.

## Why this matters

Issue #45 reached main because hk's builtin ruff step reported green while raw `ruff check` surfaced TC003 + PLC0415. Any rule hk's builtin suppresses would have the same fate. Invoking ruff directly removes that gap structurally — whatever `ruff check` does on a developer's shell is what hk and CI do.

Additional hardening in the same commit:
- Step order now matches Astral ruff docs: `ruff check --fix` **before** `ruff format` (lint fixes reorder imports; format then cleans up). Previous hk.pkl had this reversed.
- `no_lint_skip` grep tightened to catch `ty: ignore` alongside `noqa`, `type: ignore`, `pylint: disable`, `nosec`.
- `ruff format --check` caught pre-existing drift in `tests/test_audit.py` and `tests/test_ghcr.py` that the old hk builtin missed — formatted as part of this commit.

## Changes

- `python/pyproject.toml` — add `ruff` and `ty` to `[dependency-groups] dev`. Unpinned; `uv lock` resolves latest (currently ruff 0.15.9, ty 0.0.29). Bump via `uv lock --upgrade-package ruff --upgrade-package ty`.
- `python/uv.lock` — regenerated.
- `hk.pkl` — replace 3 builtin steps with custom `check`/`fix` commands; rename to `py_*` to avoid colliding with hk's restricted builtin schemas; reorder `py_ruff_format` to depend on `py_ruff`; tighten `no_lint_skip` grep.
- `tests/test_audit.py`, `tests/test_ghcr.py` — ruff format fixes (pre-existing drift).

## Why pyproject dev-group (not mise.toml)

- **Reproducibility** — `uv.lock` pins the exact resolved version across every machine and CI run.
- **Coupling** — ruff and ty are configured inside `pyproject.toml` (`[tool.ruff]`, `[tool.ty]`). Tool and config live in the same file.
- **Policy fit** — `~/CLAUDE.md` says _"pyproject.toml for Python tools"_. Python-native tools belong in pyproject; system tools (hk, pkl, hadolint, shellcheck) stay in mise.
- **Latest enforcement** — `uv lock --upgrade-package` in a periodic chore bumps to latest reproducibly.

## Test plan

- [x] `uv run --project python ruff check python/src tests` → clean
- [x] `uv run --project python ruff format --check python/src tests` → clean
- [x] `uv run --project python ty check python/src tests` → clean
- [x] `uv run --project python pytest tests/ -x -q` → 65/65 passing
- [x] `HK_PKL_BACKEND=pkl hk validate` → valid
- [ ] CI lint/contract-preflight/build/smoke-test green

## Caveats / follow-ups

- `ty` is pre-1.0 (0.0.29); expect faster churn on bumps. Pinning via lockfile means each upgrade is an explicit `uv lock --upgrade-package ty` PR with its own CI signal.
- `hk.pkl` still `amends` `v1.40.0/hk@1.40.0#/Config.pkl` while the installed hk is `1.41.0`. `hk validate` accepts this, but bumping the amends version is a small follow-up worth doing.
- The `hk-common.pkl` shared steps still use hk builtins for non-Python tools. They don't have the same drop-rules problem because they're simpler schemas, but worth auditing as a separate task.