### PR TITLE
Remove GitButler plugin from Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,4 @@
 {
-  "prefersReducedMotion": true,
   "hooks": {
     "PreToolUse": [
       {
@@ -49,7 +48,7 @@
     "auto-memory@claude-community": false,
     "guide@claude-code-guide": false,
     "codex@openai-codex": false,
-    "astral@astral-sh": true,
-    "gitbutler@gitbutler-tools": true
-  }
+    "astral@astral-sh": true
+  },
+  "prefersReducedMotion": true
 }


### PR DESCRIPTION
## Summary

Abandoning the GitButler Claude Code plugin. GitButler's virtual-branch workspace composition caused the Issue #45 fix to silently depend on commits from another branch (`enforce-notepad-ci-docs`) without capturing them as real parents — the committed SHA `94645a2` threw `ImportError` on a clean checkout because \`_project_root\` only existed in the composed workspace, not in the commit's actual ancestry. Recovery required leaving the GitButler workspace entirely and redoing the commits on plain git branches (#47, #48).

## Changes

- \`.claude/settings.json\` — remove \`gitbutler@gitbutler-tools: true\` plugin entry. Incidental JSON key reordering from the plugin system serializer.

## Companion actions

- [x] PR #46 (Install GitButler CLI skill) closed.
- [x] GitButler marketplace + plugin removed locally via \`/plugin\`.
- [ ] \`.omc/skills/gitbutler-worktree-commit-push-workflow.md\` refactored to plain-git worktree workflow (gitignored, local-only; tracked in \`.omc/plans/gitbutler-removal-refactor.md\`).

## Test plan

- [x] Local settings.json valid JSON (tested by Claude Code reload after plugin removal)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->