### PR TITLE
docs: remove stale devcontainer registry note from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,9 +55,6 @@ Registry: `ghcr.io/sortakool/dotfiles-devcontainer`
 - Use `uv run --project python` (not `--directory python`) when pytest runs from repo root — `--directory` changes cwd, breaking relative test paths
 - hk caches pkl-evaluated configs at `~/Library/Caches/hk/configs/` — clear after editing hk.pkl if changes don't take effect
 
-## Open Issues
-- **HIGH**: `devcontainer.json` image reference uses wrong registry — update to `ghcr.io/sortakool/dotfiles-devcontainer:dev`
-
 ## Testing
 ```bash
 uv run --project python pytest tests/ -x -q                # All 65 tests


### PR DESCRIPTION
## Summary
- Removes the **Open Issues / HIGH** entry in `CLAUDE.md` that told future sessions to update `devcontainer.json` to `ghcr.io/sortakool/dotfiles-devcontainer:dev`.
- That instruction is **inverted**: \`sortakool\` is the *old* registry per the Phase 2 spec; \`docker-bake.hcl\` already uses the canonical \`ghcr.io/ray-manaloto\`. Acting on the note would regress the registry migration.
- Additionally, \`.devcontainer/devcontainer.json\` doesn't reference any ghcr registry today — it builds locally from \`Dockerfile.host-user\` with a local \`BASE_IMAGE\` tag — so there's nothing matching the note's premise.
- Real registry wiring (if needed) belongs to PR #9 (Phase 2 host-user migration), which already rewrites \`devcontainer.json\` end-to-end.

## Test plan
- [x] \`HK_PKL_BACKEND=pkl hk run pre-commit --all --stash none\` passes
- [x] \`uv run --project python pytest tests/ -x -q\` — 65 passed
- [ ] CI green on PR

Refs: \`docker-bake.hcl:1\` (canonical \`ghcr.io/ray-manaloto\`), \`docs/ultrapowers/specs/2026-03-29-devcontainer-host-user-migration-design.md:326\` (\`Old: ghcr.io/sortakool/...\`), PR #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Resolved and removed documentation for a high-severity container configuration issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->