### PR TITLE
docs(research): cache mintlify llms.txt + llms-full.txt for all 16 catalog repos

### DIFF
--- a/.claude/skills/mintlify/SKILL.md
+++ b/.claude/skills/mintlify/SKILL.md
@@ -41,14 +41,53 @@ Do **not** use it when:
   flat index of titles + short descriptions, not a search endpoint;
   do keyword filtering client-side.
 
-## Step-by-step lookup pattern
+## Local cache — use this FIRST
+
+As of 2026-04-07, every repo in `docs/research/mintlify-catalog.md`
+has both `llms.txt` and `llms-full.txt` cached under
+`docs/research/mintlify-cache/<owner>/<repo>/`. **Grep the local
+cache before reaching for `curl`** — zero latency, no network
+round-trips, greppable across the whole cache:
+
+```bash
+# Fast page-title/description index:
+grep -i <topic> docs/research/mintlify-cache/jdx/mise/llms.txt
+
+# Full inline content of every page, grep-friendly:
+grep -B1 -A15 -i <topic> docs/research/mintlify-cache/jdx/mise/llms-full.txt
+
+# Search across every cached repo at once:
+grep -rHi <topic> docs/research/mintlify-cache/
+```
+
+Per-repo line counts, sha256s, and the refresh protocol are in
+`docs/research/mintlify-cache/README.md`. Fall back to `curl` only
+when (a) the topic touches a repo not yet in the cache or (b) the
+cache is stale relative to an upstream doc update.
+
+## Step-by-step lookup pattern (cache-first)
 
 Pick the repo you want, then walk the two steps in order:
 
-### Step 1 — discover pages via `llms.txt`
+### Step 1 — grep the local cache (preferred)
+
+```bash
+# Index (cheap, page titles + 1-line descriptions):
+grep -i <topic> docs/research/mintlify-cache/<owner>/<repo>/llms.txt
+# Full inline content (use when llms.txt titles don't surface what you need):
+grep -B1 -A15 -i <topic> docs/research/mintlify-cache/<owner>/<repo>/llms-full.txt
+```
+
+`llms-full.txt` inlines the full content of every page concatenated
+(e.g., `jdx/mise/llms-full.txt` = 5,436 lines of inline doc content
+vs. ~40 lines in `llms.txt`). Grep it when the page title alone
+doesn't tell you what you need.
+
+### Step 1 (fallback) — `curl` when cache miss
 
 ```bash
 curl -sSL "https://www.mintlify.com/<owner>/<repo>/llms.txt" | head -40
+curl -sSL "https://www.mintlify.com/<owner>/<repo>/llms-full.txt" | grep -B2 -A15 -i <topic>
 ```
 
 Output is one line per page, each in the form:
@@ -68,16 +107,18 @@ curl -sSL "https://www.mintlify.com/<owner>/<repo>/<path>.md"
 Returns clean markdown — title, headings, code blocks, tables, no
 HTML chrome. Pipe to `head -N` to bound context cost.
 
-### Worked example — looking up mise's `[shell_alias]` docs
+### Worked example — looking up mise's `[shell_alias]` docs (cache-first)
 
 ```bash
-# Step 1: find the aliases page
-curl -sSL "https://www.mintlify.com/jdx/mise/llms.txt" | grep -i alias
-# → - [Aliases](https://www.mintlify.com/jdx/mise/dev-tools/aliases.md): ...
+# Step 1: grep the cached llms-full.txt for inline content
+grep -B2 -A15 -i 'shell_alias' docs/research/mintlify-cache/jdx/mise/llms-full.txt
 
-# Step 2: fetch it
+# Fallback step 2 (only if llms-full.txt didn't give enough context):
 curl -sSL "https://www.mintlify.com/jdx/mise/dev-tools/aliases.md" | head -60
 ```
+
+The cached file usually gives you enough inline content that the
+per-page `.md` fetch is unnecessary.
 
 This is the exact path used in
 `docs/research/devcontainer-spec-delta-2026-04-06.md` to validate

--- a/docs/research/mintlify-cache/README.md
+++ b/docs/research/mintlify-cache/README.md
@@ -1,0 +1,91 @@
+# Mintlify llms.txt / llms-full.txt Cache
+
+Local cache of the AI-optimized doc endpoints for every repo in
+`docs/research/mintlify-catalog.md`. Prefer these local files over
+`curl` round-trips to the upstream URLs — they are zero-latency,
+greppable, and do not count against any network budget.
+
+## Refresh protocol
+
+Run `/tmp/mintlify-cache-download.sh` (transient probe script,
+checked in as a reference inside this README below). Re-run when:
+
+- A row in `docs/research/mintlify-catalog.md` fails in practice.
+- You suspect an upstream doc page has been updated (compare the
+  recorded sha256 below against a fresh fetch).
+- A new repo is added to the catalog.
+
+## How to use
+
+```bash
+# Cheap index — one line per page:
+grep -i <topic> docs/research/mintlify-cache/jdx/mise/llms.txt
+
+# Full content, greppable across the whole site:
+grep -B1 -A15 -i <topic> docs/research/mintlify-cache/jdx/mise/llms-full.txt
+
+# Or walk every cached repo at once:
+grep -rHi <topic> docs/research/mintlify-cache/
+```
+
+`llms.txt` is small (title + URL + 1-line description per page).
+`llms-full.txt` is the full inline content of every page
+concatenated — use it for grep-based discovery of content that
+`llms.txt` doesn't surface via page titles alone.
+
+For specific pages, fall back to `curl https://www.mintlify.com/<owner>/<repo>/<path>.md`
+(the `.md` per-page fetch is not cached — only `llms.txt` and
+`llms-full.txt` are, because the full page set is too large).
+
+## Per-repo status (from the 2026-04-07 refresh run)
+
+| Repo | llms.txt | lines | sha256 (first 16) | llms-full.txt | lines | sha256 (first 16) |
+|---|---|---|---|---|---|---|
+| jdx/pklr                     | ok   |     27 | 30488441e3d035a6 | ok   |   3135 | 040c99f983fb27e8 |
+| wagoodman/dive               | ok   |     19 | 4cb75ddae00e81a0 | ok   |   1790 | 2dc5694586220c2b |
+| jdx/pitchfork                | ok   |     50 | e3b8703d5f3597da | ok   |   4989 | d4ea85607aa106e2 |
+| jdx/mise-env-fnox            | ok   |     16 | 2c73c9d134b5c6db | ok   |    350 | f6ceba22e20a7da4 |
+| jdx/mise-action              | ok   |     21 | b88709f8abba6675 | ok   |   1066 | d40edf5f2bbb351e |
+| devcontainers/features       | ok   |     43 | 3f19a5b8494c4748 | ok   |   3256 | 265ada8941625f0d |
+| jdx/hk                       | ok   |     26 | da608a21a7448f79 | ok   |   3975 | ba36f4a49c3d22cc |
+| jdx/mise                     | ok   |     44 | 288e5cf27808fb5f | ok   |   5436 | 2d908e35fed57326 |
+| jdx/fnox                     | ok   |     30 | 659e415ea372d761 | ok   |   6084 | d45b2f80af22ec05 |
+| twpayne/chezmoi              | ok   |     86 | 69dbf2ca466f602a | ok   |  22330 | d50e9c96790b240c |
+| starship/starship            | ok   |     27 | ac7dd6f2240bc6b6 | ok   |   3848 | 9c342fa43d07f5db |
+| devcontainers/cli            | ok   |     32 | 877557808c06c022 | ok   |   5002 | cd9074736a541669 |
+| devcontainers/spec           | ok   |     31 | 966a1697665143b0 | ok   |   4991 | b037230ec01337d2 |
+| devcontainers/images         | ok   |     35 | ba41c3748e298012 | ok   |   4681 | 8a5cce31b17f7aa5 |
+| knowsuchagency/mcp2cli       | ok   |     28 | 298d5d4d1d82a626 | ok   |   2653 | 88fcf25cea5dd9ad |
+| yeachan-heo/oh-my-claudecode | ok   |     37 | 1a3bdd2d13512188 | ok   |   5859 | b47caa46c4acf243 |
+
+## Refresh command
+
+```bash
+# The probe/download script lives at /tmp/mintlify-cache-download.sh
+# during the session in which the cache was built. The authoritative
+# version is inlined below for reproducibility.
+bash /tmp/mintlify-cache-download.sh
+```
+
+## Reference probe script (inline, 2026-04-07)
+
+```bash
+REPOS=(
+  "jdx/pklr" "wagoodman/dive" "jdx/pitchfork" "jdx/mise-env-fnox"
+  "jdx/mise-action" "devcontainers/features" "jdx/hk" "jdx/mise"
+  "jdx/fnox" "twpayne/chezmoi" "starship/starship" "devcontainers/cli"
+  "devcontainers/spec" "devcontainers/images" "knowsuchagency/mcp2cli"
+  "yeachan-heo/oh-my-claudecode"
+)
+for r in "${REPOS[@]}"; do
+  mkdir -p "docs/research/mintlify-cache/${r}"
+  curl -sSL -o "docs/research/mintlify-cache/${r}/llms.txt" \
+       "https://www.mintlify.com/${r}/llms.txt"
+  curl -sSL -o "docs/research/mintlify-cache/${r}/llms-full.txt" \
+       "https://www.mintlify.com/${r}/llms-full.txt"
+done
+```
+
+Last refreshed: 2026-04-07 (Session K precursor run). Next refresh:
+at the discretion of whoever needs fresher content — these files are
+static snapshots and will drift as upstream docs evolve.

--- a/docs/research/mintlify-cache/devcontainers/cli/llms-full.txt
+++ b/docs/research/mintlify-cache/devcontainers/cli/llms-full.txt
@@ -1,0 +1,5002 @@
+# devcontainer build
+Source: https://www.mintlify.com/devcontainers/cli/commands/build
+
+Build a dev container image.
+
+The `build` command builds the Docker image for a dev container without starting a container. It processes `devcontainer.json`, applies any configured features, and produces a tagged image you can push to a registry or reuse across environments.
+
+This is useful in CI/CD pipelines to prebuild images and speed up container startup times.
+
+## Usage
+
+```bash theme={null}
+devcontainer build [path] [options]
+```
+
+The optional `path` positional argument sets the workspace folder directly.
+
+## Options
+
+### Workspace and configuration
+
+<ParamField type="string">
+  Workspace folder path. The `devcontainer.json` will be looked up relative to this path. If not provided, defaults to the current directory.
+</ParamField>
+
+<ParamField type="string">
+  `devcontainer.json` path. The default is to use `.devcontainer/devcontainer.json` or, if that does not exist, `.devcontainer.json` in the workspace folder.
+</ParamField>
+
+<ParamField type="string">
+  Additional features to apply to the dev container (JSON as per `"features"` section in `devcontainer.json`).
+</ParamField>
+
+### Image naming
+
+<ParamField type="string">
+  Image name. Can be specified multiple times to tag the image with multiple names.
+</ParamField>
+
+<ParamField type="string">
+  Provide key and value configuration that adds metadata to an image. Can be specified multiple times.
+</ParamField>
+
+### Build behavior
+
+<ParamField type="boolean">
+  Builds the image with `--no-cache`.
+</ParamField>
+
+<ParamField type="string">
+  Control whether BuildKit should be used. Accepted values: `auto`, `never`.
+</ParamField>
+
+<ParamField type="string">
+  Set target platforms (e.g., `linux/amd64,linux/arm64`). Requires BuildKit.
+</ParamField>
+
+### Caching
+
+<ParamField type="string">
+  Additional image to use as potential layer cache. Can be specified multiple times.
+</ParamField>
+
+<ParamField type="string">
+  A destination of buildx cache.
+</ParamField>
+
+### Registry
+
+<ParamField type="boolean">
+  Push to a container registry.
+</ParamField>
+
+<ParamField type="string">
+  Overrides the default behavior to load built images into the local Docker registry. Valid options are the same ones provided to the `--output` option of `docker buildx build`.
+</ParamField>
+
+### Logging
+
+<ParamField type="string">
+  Log level. Accepted values: `info`, `debug`, `trace`.
+</ParamField>
+
+<ParamField type="string">
+  Log format. Accepted values: `text`, `json`.
+</ParamField>
+
+## Output
+
+On success, the command writes a JSON object to stdout:
+
+```json theme={null}
+{
+  "outcome": "success",
+  "imageName": ["ghcr.io/myorg/my-devcontainer:latest"]
+}
+```
+
+On failure:
+
+```json theme={null}
+{
+  "outcome": "error",
+  "message": "An error occurred building the container.",
+  "description": "..."
+}
+```
+
+## Examples
+
+### Build the image for the current workspace
+
+```bash theme={null}
+devcontainer build --workspace-folder .
+```
+
+### Build and tag with a specific name
+
+```bash theme={null}
+devcontainer build \
+  --workspace-folder . \
+  --image-name ghcr.io/myorg/my-devcontainer:latest
+```
+
+### Build for multiple platforms
+
+<Note>
+  Multi-platform builds require Docker BuildKit and a configured buildx builder.
+</Note>
+
+```bash theme={null}
+devcontainer build \
+  --workspace-folder . \
+  --platform linux/amd64,linux/arm64 \
+  --image-name ghcr.io/myorg/my-devcontainer:latest
+```
+
+### Build and push to a registry in one step
+
+```bash theme={null}
+devcontainer build \
+  --workspace-folder . \
+  --image-name ghcr.io/myorg/my-devcontainer:latest \
+  --push
+```
+
+### Build without cache
+
+```bash theme={null}
+devcontainer build \
+  --workspace-folder . \
+  --no-cache \
+  --image-name ghcr.io/myorg/my-devcontainer:latest
+```
+
+### Use a cache source to speed up CI builds
+
+```bash theme={null}
+devcontainer build \
+  --workspace-folder . \
+  --cache-from ghcr.io/myorg/my-devcontainer:cache \
+  --image-name ghcr.io/myorg/my-devcontainer:latest
+```
+
+### Export the image to a tarball instead of loading it locally
+
+```bash theme={null}
+devcontainer build \
+  --workspace-folder . \
+  --output type=tar,dest=./devcontainer-image.tar \
+  --image-name my-devcontainer
+```
+
+### Apply additional features at build time
+
+```bash theme={null}
+devcontainer build \
+  --workspace-folder . \
+  --additional-features '{"ghcr.io/devcontainers/features/python:1": {"version": "3.12"}}' \
+  --image-name ghcr.io/myorg/my-devcontainer:py312
+```
+
+### Add image labels
+
+```bash theme={null}
+devcontainer build \
+  --workspace-folder . \
+  --label org.opencontainers.image.source=https://github.com/myorg/myrepo \
+  --label org.opencontainers.image.version=1.0.0 \
+  --image-name ghcr.io/myorg/my-devcontainer:latest
+```
+
+
+# devcontainer exec
+Source: https://www.mintlify.com/devcontainers/cli/commands/exec
+
+Execute a command on a running dev container.
+
+The `exec` command runs an arbitrary command inside an already-running dev container. It resolves the container by workspace folder, container ID, or id-labels, then executes the given command with the remote user's environment applied.
+
+Use `exec` to run builds, tests, or any shell command in the same environment your dev container provides, without opening an interactive shell.
+
+## Usage
+
+```bash theme={null}
+devcontainer exec [options] <cmd> [args..]
+```
+
+`<cmd>` and any following `[args..]` are passed directly to the container.
+
+## Options
+
+### Container identification
+
+<ParamField type="string">
+  Workspace folder path. The `devcontainer.json` will be looked up relative to this path. If `--container-id`, `--id-label`, and `--workspace-folder` are not provided, this defaults to the current directory.
+</ParamField>
+
+<ParamField type="string">
+  Id of the container to run the user commands for.
+</ParamField>
+
+<ParamField type="string">
+  Id label(s) of the format `name=value`. If no `--container-id` is given the id labels will be used to look up the container. If no `--id-label` is given, one will be inferred from the `--workspace-folder` path.
+</ParamField>
+
+### Configuration
+
+<ParamField type="string">
+  `devcontainer.json` path. The default is to use `.devcontainer/devcontainer.json` or, if that does not exist, `.devcontainer.json` in the workspace folder.
+</ParamField>
+
+<ParamField type="string">
+  `devcontainer.json` path to override any `devcontainer.json` in the workspace folder (or built-in configuration). This is required when there is no `devcontainer.json` otherwise.
+</ParamField>
+
+### Environment
+
+<ParamField type="string">
+  Remote environment variables of the format `name=value`. These will be added when executing the user commands. Can be specified multiple times.
+</ParamField>
+
+<ParamField type="string">
+  Default value for the `devcontainer.json`'s `"userEnvProbe"`. Accepted values: `none`, `loginInteractiveShell`, `interactiveShell`, `loginShell`.
+</ParamField>
+
+### Docker
+
+<ParamField type="string">
+  Docker CLI path.
+</ParamField>
+
+<ParamField type="string">
+  Docker Compose CLI path.
+</ParamField>
+
+### Logging
+
+<ParamField type="string">
+  Log level for the terminal log file. When set to `trace`, the log level for the log file will also be set to `trace`. Accepted values: `info`, `debug`, `trace`.
+</ParamField>
+
+<ParamField type="string">
+  Log format. Accepted values: `text`, `json`.
+</ParamField>
+
+## Examples
+
+### Run a build command
+
+```bash theme={null}
+devcontainer exec --workspace-folder . cargo build --release
+```
+
+### Run tests
+
+```bash theme={null}
+devcontainer exec --workspace-folder . npm test
+```
+
+### Open an interactive shell
+
+```bash theme={null}
+devcontainer exec --workspace-folder . bash
+```
+
+### Target a container by ID
+
+```bash theme={null}
+devcontainer exec --container-id abc123def456 go test ./...
+```
+
+### Target a container using id-labels
+
+```bash theme={null}
+devcontainer exec \
+  --id-label devcontainer.local_folder=/home/user/my-project \
+  pytest tests/
+```
+
+### Pass extra environment variables
+
+```bash theme={null}
+devcontainer exec \
+  --workspace-folder . \
+  --remote-env CI=true \
+  --remote-env BUILD_NUMBER=42 \
+  make all
+```
+
+### Use a custom config path
+
+```bash theme={null}
+devcontainer exec \
+  --workspace-folder . \
+  --config .devcontainer/ci.devcontainer.json \
+  ./scripts/validate.sh
+```
+
+<Tip>
+  The exit code of `exec` mirrors the exit code of the command you ran inside the container, so it integrates naturally with CI pipelines.
+</Tip>
+
+
+# devcontainer read-configuration
+Source: https://www.mintlify.com/devcontainers/cli/commands/read-configuration
+
+Read and output the resolved dev container configuration.
+
+The `read-configuration` command parses and resolves a `devcontainer.json` file (and any applicable image metadata), then writes the result as JSON to stdout. No container is created or started.
+
+Use this command to inspect the effective configuration before provisioning, or to integrate configuration data into tooling and scripts.
+
+## Usage
+
+```bash theme={null}
+devcontainer read-configuration [options]
+```
+
+## Options
+
+### Workspace and container identification
+
+<ParamField type="string">
+  Workspace folder path. The `devcontainer.json` will be looked up relative to this path. If `--container-id`, `--id-label`, and `--workspace-folder` are not provided, this defaults to the current directory.
+</ParamField>
+
+<ParamField type="string">
+  Id of the container to run the user commands for.
+</ParamField>
+
+<ParamField type="string">
+  Id label(s) of the format `name=value`. If no `--container-id` is given the id labels will be used to look up the container. If no `--id-label` is given, one will be inferred from the `--workspace-folder` path.
+</ParamField>
+
+### Configuration
+
+<ParamField type="string">
+  `devcontainer.json` path. The default is to use `.devcontainer/devcontainer.json` or, if that does not exist, `.devcontainer.json` in the workspace folder.
+</ParamField>
+
+<ParamField type="string">
+  `devcontainer.json` path to override any `devcontainer.json` in the workspace folder (or built-in configuration). This is required when there is no `devcontainer.json` otherwise.
+</ParamField>
+
+<ParamField type="string">
+  Additional features to apply to the dev container (JSON as per `"features"` section in `devcontainer.json`).
+</ParamField>
+
+### Output options
+
+<ParamField type="boolean">
+  Include features configuration.
+</ParamField>
+
+<ParamField type="boolean">
+  Include merged configuration.
+</ParamField>
+
+### Docker
+
+<ParamField type="string">
+  Docker CLI path.
+</ParamField>
+
+<ParamField type="string">
+  Docker Compose CLI path.
+</ParamField>
+
+### Logging
+
+<ParamField type="string">
+  Log level for the terminal log file. When set to `trace`, the log level for the log file will also be set to `trace`. Accepted values: `info`, `debug`, `trace`.
+</ParamField>
+
+<ParamField type="string">
+  Log format. Accepted values: `text`, `json`.
+</ParamField>
+
+## Output format
+
+The command writes a JSON object to stdout with the following top-level fields:
+
+```json theme={null}
+{
+  "configuration": { ... },
+  "workspace": { ... },
+  "featuresConfiguration": null,
+  "mergedConfiguration": null
+}
+```
+
+| Field                   | Description                                                                                                                              |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `configuration`         | The resolved `devcontainer.json` contents after variable substitution.                                                                   |
+| `workspace`             | Workspace metadata such as the resolved workspace folder path.                                                                           |
+| `featuresConfiguration` | Feature resolution details. Only present when `--include-features-configuration` is set.                                                 |
+| `mergedConfiguration`   | The configuration after merging image metadata from features and base images. Only present when `--include-merged-configuration` is set. |
+
+### Example output
+
+```json theme={null}
+{
+  "configuration": {
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "features": {
+      "ghcr.io/devcontainers/features/node:1": {}
+    },
+    "remoteUser": "vscode",
+    "postCreateCommand": "npm install"
+  },
+  "workspace": {
+    "workspaceFolder": "/workspaces/my-project"
+  },
+  "featuresConfiguration": null,
+  "mergedConfiguration": null
+}
+```
+
+## Examples
+
+### Read the configuration for the current workspace
+
+```bash theme={null}
+devcontainer read-configuration --workspace-folder .
+```
+
+### Read configuration and include merged metadata
+
+```bash theme={null}
+devcontainer read-configuration \
+  --workspace-folder . \
+  --include-merged-configuration
+```
+
+### Use a custom config file
+
+```bash theme={null}
+devcontainer read-configuration \
+  --workspace-folder . \
+  --config .devcontainer/ci.devcontainer.json
+```
+
+### Extract a single field with `jq`
+
+```bash theme={null}
+devcontainer read-configuration --workspace-folder . \
+  | jq '.configuration.remoteUser'
+```
+
+### Check the merged configuration including all feature contributions
+
+```bash theme={null}
+devcontainer read-configuration \
+  --workspace-folder . \
+  --include-features-configuration \
+  --include-merged-configuration \
+  | jq '.mergedConfiguration'
+```
+
+<Note>
+  When a running container is identified via `--container-id` or `--id-label`, the command applies container environment variable substitution on top of the base configuration, giving you the exact values the container sees.
+</Note>
+
+
+# devcontainer run-user-commands
+Source: https://www.mintlify.com/devcontainers/cli/commands/run-user-commands
+
+Run user commands on an existing dev container.
+
+The `run-user-commands` command executes the lifecycle hooks defined in `devcontainer.json` — such as `onCreateCommand`, `updateContentCommand`, `postCreateCommand`, and `postStartCommand` — against an already-running container.
+
+Use this command after `devcontainer set-up` to apply user-specific configuration (like dotfiles and post-create scripts) to a container that has already been provisioned.
+
+## Usage
+
+```bash theme={null}
+devcontainer run-user-commands [options]
+```
+
+## Options
+
+### Container identification
+
+<ParamField type="string">
+  Workspace folder path. The `devcontainer.json` will be looked up relative to this path. If `--container-id`, `--id-label`, and `--workspace-folder` are not provided, this defaults to the current directory.
+</ParamField>
+
+<ParamField type="string">
+  Id of the container to run the user commands for.
+</ParamField>
+
+<ParamField type="string">
+  Id label(s) of the format `name=value`. If no `--container-id` is given the id labels will be used to look up the container. If no `--id-label` is given, one will be inferred from the `--workspace-folder` path.
+</ParamField>
+
+### Configuration
+
+<ParamField type="string">
+  `devcontainer.json` path. The default is to use `.devcontainer/devcontainer.json` or, if that does not exist, `.devcontainer.json` in the workspace folder.
+</ParamField>
+
+<ParamField type="string">
+  `devcontainer.json` path to override any `devcontainer.json` in the workspace folder (or built-in configuration). This is required when there is no `devcontainer.json` otherwise.
+</ParamField>
+
+### Lifecycle control
+
+<ParamField type="boolean">
+  Stop running user commands after running the command configured with `waitFor` or the `updateContentCommand` by default.
+</ParamField>
+
+<ParamField type="boolean">
+  Stop after `onCreateCommand` and `updateContentCommand`, rerunning `updateContentCommand` if it has run before.
+</ParamField>
+
+### Environment
+
+<ParamField type="string">
+  Remote environment variables of the format `name=value`. These will be added when executing the user commands. Can be specified multiple times.
+</ParamField>
+
+<ParamField type="string">
+  Path to a JSON file containing secret environment variables as key-value pairs.
+</ParamField>
+
+### Dotfiles
+
+<ParamField type="string">
+  URL of a dotfiles Git repository (e.g., `https://github.com/owner/repository.git`).
+</ParamField>
+
+<ParamField type="string">
+  The command to run after cloning the dotfiles repository. Defaults to run the first file of `install.sh`, `install`, `bootstrap.sh`, `bootstrap`, `setup.sh` and `setup` found in the dotfiles repository's root folder.
+</ParamField>
+
+<ParamField type="string">
+  The path to clone the dotfiles repository to. Defaults to `~/dotfiles`.
+</ParamField>
+
+### Docker
+
+<ParamField type="string">
+  Docker CLI path.
+</ParamField>
+
+<ParamField type="string">
+  Docker Compose CLI path.
+</ParamField>
+
+### Logging
+
+<ParamField type="string">
+  Log level for the terminal log file. When set to `trace`, the log level for the log file will also be set to `trace`. Accepted values: `info`, `debug`, `trace`.
+</ParamField>
+
+<ParamField type="string">
+  Log format. Accepted values: `text`, `json`.
+</ParamField>
+
+## Output
+
+On success, the command writes a JSON object to stdout:
+
+```json theme={null}
+{
+  "outcome": "success"
+}
+```
+
+On failure:
+
+```json theme={null}
+{
+  "outcome": "error",
+  "message": "An error occurred running user commands in the container.",
+  "description": "..."
+}
+```
+
+## When to use this command
+
+`run-user-commands` is designed for scenarios where container provisioning is split into two phases:
+
+1. **Infrastructure phase** — `devcontainer set-up` or `devcontainer up --skip-post-create` creates the container and configures the system.
+2. **User phase** — `devcontainer run-user-commands` applies user-specific configuration (dotfiles, post-create scripts) without recreating the container.
+
+This split is useful for shared or hosted environments where system setup and personal configuration happen at different times or under different permissions.
+
+## Examples
+
+### Run all user commands for the current workspace
+
+```bash theme={null}
+devcontainer run-user-commands --workspace-folder .
+```
+
+### Run user commands on a specific container
+
+```bash theme={null}
+devcontainer run-user-commands --container-id abc123def456
+```
+
+### Target a container by id-label
+
+```bash theme={null}
+devcontainer run-user-commands \
+  --id-label devcontainer.local_folder=/home/user/my-project
+```
+
+### Install dotfiles during user setup
+
+```bash theme={null}
+devcontainer run-user-commands \
+  --workspace-folder . \
+  --dotfiles-repository https://github.com/myuser/dotfiles.git \
+  --dotfiles-install-command install.sh
+```
+
+### Run only up to `waitFor` (skip blocking post-create commands)
+
+```bash theme={null}
+devcontainer run-user-commands \
+  --workspace-folder . \
+  --skip-non-blocking-commands
+```
+
+### Stop after `onCreateCommand` for prebuild scenarios
+
+<Tip>
+  Combine `--prebuild` with a registry-push workflow so the result of `onCreateCommand` is cached in the image layer.
+</Tip>
+
+```bash theme={null}
+devcontainer run-user-commands \
+  --workspace-folder . \
+  --prebuild
+```
+
+### Inject secrets from a file
+
+<Warning>
+  Never commit secrets files to source control. Add the file to your `.gitignore`.
+</Warning>
+
+```bash theme={null}
+devcontainer run-user-commands \
+  --workspace-folder . \
+  --secrets-file ./my-secrets.json
+```
+
+### Pass extra environment variables
+
+```bash theme={null}
+devcontainer run-user-commands \
+  --workspace-folder . \
+  --remote-env MY_VAR=hello \
+  --remote-env ANOTHER_VAR=world
+```
+
+
+# devcontainer up
+Source: https://www.mintlify.com/devcontainers/cli/commands/up
+
+Create and run a dev container.
+
+The `up` command creates and starts a dev container based on your `devcontainer.json` configuration. It provisions the container, installs features, and runs lifecycle commands such as `onCreateCommand`, `postCreateCommand`, and `postStartCommand`.
+
+If a container already exists for the given workspace, `up` reuses it unless you pass `--remove-existing-container`.
+
+## Usage
+
+```bash theme={null}
+devcontainer up [options]
+```
+
+## Options
+
+### Workspace and configuration
+
+<ParamField type="string">
+  Workspace folder path. The `devcontainer.json` will be looked up relative to this path. If `--id-label`, `--override-config`, and `--workspace-folder` are not provided, this defaults to the current directory.
+</ParamField>
+
+<ParamField type="string">
+  `devcontainer.json` path. The default is to use `.devcontainer/devcontainer.json` or, if that does not exist, `.devcontainer.json` in the workspace folder.
+</ParamField>
+
+<ParamField type="string">
+  `devcontainer.json` path to override any `devcontainer.json` in the workspace folder (or built-in configuration). This is required when there is no `devcontainer.json` otherwise.
+</ParamField>
+
+<ParamField type="string">
+  Id label(s) of the format `name=value`. These will be set on the container and used to query for an existing container. If no `--id-label` is given, one will be inferred from the `--workspace-folder` path.
+</ParamField>
+
+<ParamField type="string">
+  Additional features to apply to the dev container (JSON as per `"features"` section in `devcontainer.json`).
+</ParamField>
+
+### Docker
+
+<ParamField type="string">
+  Docker CLI path.
+</ParamField>
+
+<ParamField type="string">
+  Docker Compose CLI path.
+</ParamField>
+
+### Container lifecycle
+
+<ParamField type="boolean">
+  Removes the dev container if it already exists.
+</ParamField>
+
+<ParamField type="boolean">
+  Fail if the container does not exist.
+</ParamField>
+
+<ParamField type="boolean">
+  Builds the image with `--no-cache` if the container does not exist.
+</ParamField>
+
+<ParamField type="boolean">
+  Do not run `onCreateCommand`, `updateContentCommand`, `postCreateCommand`, `postStartCommand` or `postAttachCommand` and do not install dotfiles.
+</ParamField>
+
+<ParamField type="boolean">
+  Stop running user commands after running the command configured with `waitFor` or the `updateContentCommand` by default.
+</ParamField>
+
+<ParamField type="boolean">
+  Do not run `postAttachCommand`.
+</ParamField>
+
+<ParamField type="boolean">
+  Stop after `onCreateCommand` and `updateContentCommand`, rerunning `updateContentCommand` if it has run before.
+</ParamField>
+
+<ParamField type="string">
+  Default for updating the remote user's UID and GID to the local user's one. Accepted values: `never`, `on`, `off`.
+</ParamField>
+
+### Mounts and environment
+
+<ParamField type="string">
+  Additional mount point(s). Format: `type=<bind|volume>,source=<source>,target=<target>[,external=<true|false>]`. Can be specified multiple times.
+</ParamField>
+
+<ParamField type="string">
+  Remote environment variables of the format `name=value`. These will be added when executing the user commands. Can be specified multiple times.
+</ParamField>
+
+### Image caching
+
+<ParamField type="string">
+  Additional image to use as potential layer cache during image building. Can be specified multiple times.
+</ParamField>
+
+<ParamField type="string">
+  Additional image to use as potential layer cache during image building.
+</ParamField>
+
+<ParamField type="string">
+  Control whether BuildKit should be used. Accepted values: `auto`, `never`.
+</ParamField>
+
+### Dotfiles
+
+<ParamField type="string">
+  URL of a dotfiles Git repository (e.g., `https://github.com/owner/repository.git`).
+</ParamField>
+
+<ParamField type="string">
+  The command to run after cloning the dotfiles repository. Defaults to run the first file of `install.sh`, `install`, `bootstrap.sh`, `bootstrap`, `setup.sh` and `setup` found in the dotfiles repository's root folder.
+</ParamField>
+
+<ParamField type="string">
+  The path to clone the dotfiles repository to. Defaults to `~/dotfiles`.
+</ParamField>
+
+### Secrets
+
+<ParamField type="string">
+  Path to a JSON file containing secret environment variables as key-value pairs.
+</ParamField>
+
+### Output and logging
+
+<ParamField type="boolean">
+  Include configuration in result.
+</ParamField>
+
+<ParamField type="boolean">
+  Include merged configuration in result.
+</ParamField>
+
+<ParamField type="string">
+  Log level for the terminal log file. When set to `trace`, the log level for the log file will also be set to `trace`. Accepted values: `info`, `debug`, `trace`.
+</ParamField>
+
+<ParamField type="string">
+  Log format. Accepted values: `text`, `json`.
+</ParamField>
+
+## Output
+
+On success, the command writes a JSON object to stdout:
+
+```json theme={null}
+{
+  "outcome": "success",
+  "containerId": "abc123def456...",
+  "remoteUser": "vscode",
+  "remoteWorkspaceFolder": "/workspaces/my-project"
+}
+```
+
+On failure, it writes:
+
+```json theme={null}
+{
+  "outcome": "error",
+  "message": "An error occurred setting up the container.",
+  "description": "..."
+}
+```
+
+## Examples
+
+### Start a dev container in the current directory
+
+```bash theme={null}
+devcontainer up --workspace-folder .
+```
+
+### Use a custom config file
+
+```bash theme={null}
+devcontainer up --workspace-folder . --config ./custom/.devcontainer.json
+```
+
+### Add an extra bind mount
+
+```bash theme={null}
+devcontainer up \
+  --workspace-folder . \
+  --mount type=bind,source=/host/data,target=/container/data
+```
+
+### Pass remote environment variables
+
+```bash theme={null}
+devcontainer up \
+  --workspace-folder . \
+  --remote-env MY_VAR=hello \
+  --remote-env ANOTHER_VAR=world
+```
+
+### Rebuild without cache and remove any existing container
+
+```bash theme={null}
+devcontainer up \
+  --workspace-folder . \
+  --remove-existing-container \
+  --build-no-cache
+```
+
+### Apply additional features at runtime
+
+```bash theme={null}
+devcontainer up \
+  --workspace-folder . \
+  --additional-features '{"ghcr.io/devcontainers/features/node:1": {}}'
+```
+
+### Install dotfiles during setup
+
+```bash theme={null}
+devcontainer up \
+  --workspace-folder . \
+  --dotfiles-repository https://github.com/myuser/dotfiles.git \
+  --dotfiles-install-command install.sh
+```
+
+### Use a secrets file
+
+<Warning>
+  Never commit secrets files to source control. Add the file to your `.gitignore`.
+</Warning>
+
+```bash theme={null}
+devcontainer up \
+  --workspace-folder . \
+  --secrets-file ./my-secrets.json
+```
+
+Where `my-secrets.json` contains:
+
+```json theme={null}
+{
+  "NPM_TOKEN": "npm_abc123",
+  "GITHUB_TOKEN": "[REDACTED-GHTOKEN-DOCS-EXAMPLE]"
+}
+```
+
+### Use layer cache for faster builds
+
+```bash theme={null}
+devcontainer up \
+  --workspace-folder . \
+  --cache-from ghcr.io/myorg/my-devcontainer:cache
+```
+
+### Stop early for prebuild scenarios
+
+<Tip>
+  Use `--prebuild` in CI pipelines to bake `onCreateCommand` output into an image layer without running post-start hooks.
+</Tip>
+
+```bash theme={null}
+devcontainer up \
+  --workspace-folder . \
+  --prebuild
+```
+
+
+# Advanced Configuration
+Source: https://www.mintlify.com/devcontainers/cli/configuration/advanced
+
+GPU support, multi-container setups with Docker Compose, secrets, mounts, BuildKit caching, and lockfiles.
+
+## GPU support
+
+Dev containers can request GPU access for machine learning workloads, CUDA development, or any task that benefits from hardware acceleration.
+
+### The --gpu-availability flag
+
+Pass `--gpu-availability` to `devcontainer up` to control how the CLI handles GPU requirements:
+
+| Value      | Behavior                                                                      |
+| ---------- | ----------------------------------------------------------------------------- |
+| `"detect"` | Detect whether a GPU is available on the host and use it if present (default) |
+| `"all"`    | Require a GPU; fail if none is available                                      |
+| `"none"`   | Never use a GPU, even if one is present                                       |
+
+```bash theme={null}
+devcontainer up --workspace-folder . --gpu-availability all
+```
+
+### Declaring GPU requirements in devcontainer.json
+
+Use `hostRequirements.gpu` to declare that the container needs GPU access:
+
+```json devcontainer.json theme={null}
+{
+  "hostRequirements": {
+    "gpu": true
+  }
+}
+```
+
+Set `"optional"` to request a GPU when available without making it a hard requirement:
+
+```json theme={null}
+{
+  "hostRequirements": {
+    "gpu": "optional"
+  }
+}
+```
+
+Specify minimum hardware with a `HostGPURequirements` object:
+
+```json theme={null}
+{
+  "hostRequirements": {
+    "gpu": {
+      "cores": 4,
+      "memory": "8gb"
+    }
+  }
+}
+```
+
+***
+
+## Docker Compose
+
+Use Docker Compose when your development environment requires multiple services running together, such as a web app alongside a database or message queue.
+
+### Configuration
+
+A Docker Compose dev container requires three fields in `devcontainer.json`:
+
+```json devcontainer.json theme={null}
+{
+  "name": "Full Stack App",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace"
+}
+```
+
+<AccordionGroup>
+  <Accordion title="dockerComposeFile">
+    Path to one or more Docker Compose files, resolved relative to `devcontainer.json`. Accepts a string or an array for multi-file setups.
+
+    ```json theme={null}
+    {
+      "dockerComposeFile": ["docker-compose.yml", "docker-compose.override.yml"]
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="service">
+    The name of the Compose service the CLI should attach to. This service must exist in the Compose file.
+
+    ```json theme={null}
+    { "service": "app" }
+    ```
+  </Accordion>
+
+  <Accordion title="runServices">
+    An optional list of services to start. If omitted, all services defined in the Compose file are started.
+
+    ```json theme={null}
+    { "runServices": ["app", "db"] }
+    ```
+  </Accordion>
+
+  <Accordion title="shutdownAction">
+    What to do when the last client disconnects. For Docker Compose, use `"stopCompose"` to stop all services.
+
+    ```json theme={null}
+    { "shutdownAction": "stopCompose" }
+    ```
+  </Accordion>
+</AccordionGroup>
+
+### The --docker-compose-path flag
+
+If the `docker compose` or `docker-compose` binary is not on your `PATH`, specify its location:
+
+```bash theme={null}
+devcontainer up \
+  --workspace-folder . \
+  --docker-compose-path /usr/local/bin/docker-compose
+```
+
+### Complete example
+
+```yaml docker-compose.yml theme={null}
+services:
+  app:
+    build: .
+    volumes:
+      - ..:/workspace:cached
+    command: sleep infinity
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_PASSWORD: devpassword
+      POSTGRES_DB: myapp
+```
+
+```json devcontainer.json theme={null}
+{
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace",
+  "forwardPorts": [3000, 5432],
+  "postCreateCommand": "npm install && npm run db:migrate",
+  "shutdownAction": "stopCompose"
+}
+```
+
+***
+
+## Secrets
+
+Use `--secrets-file` to supply sensitive environment variables without exposing them in `devcontainer.json` or on the command line.
+
+### File format
+
+The secrets file is a JSON object where keys are environment variable names and values are their values:
+
+```json secrets.json theme={null}
+{
+  "GITHUB_TOKEN": "[REDACTED-GHTOKEN-DOCS-EXAMPLE]",
+  "NPM_TOKEN": "npm_xxxxxxxxxxxxxxxxxxxx",
+  "DATABASE_PASSWORD": "supersecret"
+}
+```
+
+### Usage
+
+```bash theme={null}
+devcontainer up \
+  --workspace-folder . \
+  --secrets-file ~/.config/devcontainer/secrets.json
+```
+
+The variables are injected into the container environment and available to lifecycle scripts and the remote session.
+
+<Warning>
+  Do not commit secrets files to source control. Add them to `.gitignore` and store them outside of your project directory when possible.
+</Warning>
+
+### Secrets vs --remote-env
+
+Prefer `--secrets-file` over `--remote-env` for sensitive values. `--remote-env` values appear in shell history and process listings. The secrets file is read once by the CLI process and not logged.
+
+***
+
+## Mounts
+
+### The --mount flag
+
+Add bind mounts or volumes at container start without modifying `devcontainer.json`:
+
+```bash theme={null}
+devcontainer up \
+  --workspace-folder . \
+  --mount "type=bind,source=/host/path,target=/container/path" \
+  --mount "type=volume,source=node_modules,target=/workspace/node_modules"
+```
+
+The `--mount` flag accepts the same format as `docker run --mount`. The full syntax is:
+
+```
+type=<bind|volume>,source=<source>,target=<target>[,external=<true|false>]
+```
+
+Pass `--mount` multiple times to add multiple mounts.
+
+### The mounts property in devcontainer.json
+
+Persistent mounts belong in `devcontainer.json` under the `mounts` property:
+
+```json devcontainer.json theme={null}
+{
+  "mounts": [
+    "type=bind,source=${localWorkspaceFolder}/data,target=/data",
+    {
+      "type": "volume",
+      "source": "node_modules",
+      "target": "/workspace/node_modules"
+    }
+  ]
+}
+```
+
+Each entry is either a mount string or a mount object with `type`, `source`, and `target` fields.
+
+<Tip>
+  Use a named volume for `node_modules` or other dependency directories to avoid the performance penalty of bind-mounting large directory trees from the host.
+</Tip>
+
+***
+
+## BuildKit and caching
+
+BuildKit is enabled by default (`--buildkit auto`) when it is available. The following flags control build behavior for both `devcontainer up` and `devcontainer build`.
+
+### --buildkit
+
+Control whether BuildKit is used:
+
+```bash theme={null}
+devcontainer build --workspace-folder . --buildkit never
+```
+
+| Value     | Behavior                              |
+| --------- | ------------------------------------- |
+| `"auto"`  | Use BuildKit if available (default)   |
+| `"never"` | Always use the classic Docker builder |
+
+### --cache-from
+
+Specify an image to use as a layer cache source. This is useful in CI to reuse layers from a previously built image:
+
+```bash theme={null}
+devcontainer build \
+  --workspace-folder . \
+  --cache-from ghcr.io/myorg/myrepo:cache
+```
+
+Pass `--cache-from` multiple times to specify multiple cache sources.
+
+### --cache-to
+
+Export the build cache to a destination after the build. Primarily useful with BuildKit's cache backends:
+
+```bash theme={null}
+devcontainer build \
+  --workspace-folder . \
+  --cache-to type=registry,ref=ghcr.io/myorg/myrepo:cache,mode=max
+```
+
+### --no-cache
+
+Build the image without using any cached layers:
+
+```bash theme={null}
+devcontainer build --workspace-folder . --no-cache
+```
+
+### CI caching example
+
+```bash theme={null}
+devcontainer build \
+  --workspace-folder . \
+  --cache-from ghcr.io/myorg/devcontainer:cache \
+  --cache-to type=registry,ref=ghcr.io/myorg/devcontainer:cache,mode=max \
+  --image-name ghcr.io/myorg/devcontainer:latest
+```
+
+***
+
+## Lockfiles (experimental)
+
+Lockfiles pin dev container Feature versions so your environment is reproducible across machines and over time.
+
+<Note>
+  Lockfile support is experimental. The flags are hidden and the format may change between releases.
+</Note>
+
+### Writing a lockfile
+
+Pass `--experimental-lockfile` to `devcontainer up` or `devcontainer build` to write a lockfile alongside `devcontainer.json`:
+
+```bash theme={null}
+devcontainer up \
+  --workspace-folder . \
+  --experimental-lockfile
+```
+
+### Enforcing a lockfile
+
+Pass `--experimental-frozen-lockfile` to fail if the resolved Feature versions differ from those in the lockfile:
+
+```bash theme={null}
+devcontainer up \
+  --workspace-folder . \
+  --experimental-frozen-lockfile
+```
+
+Use this in CI to detect when a Feature has changed unexpectedly.
+
+### Managing Feature versions
+
+Two commands help you inspect and update Feature versions:
+
+**Check for updates:**
+
+```bash theme={null}
+devcontainer outdated --workspace-folder .
+```
+
+This shows the current version of each Feature alongside the latest available version.
+
+**Upgrade the lockfile:**
+
+```bash theme={null}
+devcontainer upgrade --workspace-folder .
+```
+
+This resolves the latest compatible version of each Feature and rewrites the lockfile. Review the diff before committing.
+
+
+# devcontainer.json
+Source: https://www.mintlify.com/devcontainers/cli/configuration/devcontainer-json
+
+Configure your dev container with the devcontainer.json file.
+
+The `devcontainer.json` file is the central configuration file for a dev container. It tells the CLI how to build the container, what tools to install, which ports to expose, and what commands to run at each stage of the container lifecycle.
+
+## File location
+
+The CLI looks for `devcontainer.json` in the following locations, in order:
+
+1. `.devcontainer/devcontainer.json`
+2. `.devcontainer.json`
+
+Both paths are resolved relative to the workspace folder (`--workspace-folder`).
+
+## Base configuration types
+
+Every `devcontainer.json` must use one of three base configuration types. These are mutually exclusive.
+
+<Tabs>
+  <Tab title="Image">
+    Pull a pre-built image directly from a registry.
+
+    ```json devcontainer.json theme={null}
+    {
+      "name": "My Dev Container",
+      "image": "mcr.microsoft.com/devcontainers/base:ubuntu"
+    }
+    ```
+
+    Use this when you do not need to customize the image build step and an existing image meets your requirements.
+  </Tab>
+
+  <Tab title="Dockerfile">
+    Build a custom image from a Dockerfile.
+
+    ```json devcontainer.json theme={null}
+    {
+      "name": "My Dev Container",
+      "build": {
+        "dockerfile": "Dockerfile",
+        "context": "..",
+        "args": {
+          "NODE_VERSION": "20"
+        }
+      }
+    }
+    ```
+
+    The legacy `"dockerFile"` top-level key is also supported but `"build.dockerfile"` is preferred.
+  </Tab>
+
+  <Tab title="Docker Compose">
+    Run against a multi-container setup defined in a Docker Compose file.
+
+    ```json devcontainer.json theme={null}
+    {
+      "name": "My Dev Container",
+      "dockerComposeFile": "docker-compose.yml",
+      "service": "app",
+      "workspaceFolder": "/workspace"
+    }
+    ```
+
+    `workspaceFolder` is required when using Docker Compose.
+  </Tab>
+</Tabs>
+
+## Complete examples
+
+<AccordionGroup>
+  <Accordion title="Image-based">
+    ```json devcontainer.json theme={null}
+    {
+      "name": "Node.js",
+      "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+      "features": {
+        "ghcr.io/devcontainers/features/github-cli:1": {}
+      },
+      "forwardPorts": [3000],
+      "postCreateCommand": "npm install",
+      "remoteUser": "node"
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="Dockerfile-based">
+    ```json devcontainer.json theme={null}
+    {
+      "name": "Python",
+      "build": {
+        "dockerfile": "Dockerfile",
+        "args": {
+          "PYTHON_VERSION": "3.12"
+        }
+      },
+      "features": {
+        "ghcr.io/devcontainers/features/git:1": {}
+      },
+      "forwardPorts": [8000],
+      "postCreateCommand": "pip install -r requirements.txt",
+      "containerUser": "vscode",
+      "remoteUser": "vscode"
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="Docker Compose">
+    ```json devcontainer.json theme={null}
+    {
+      "name": "Full Stack App",
+      "dockerComposeFile": "docker-compose.yml",
+      "service": "app",
+      "workspaceFolder": "/workspace",
+      "forwardPorts": [3000, 5432],
+      "postCreateCommand": "npm install",
+      "shutdownAction": "stopCompose"
+    }
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Properties
+
+### Identity and image
+
+<AccordionGroup>
+  <Accordion title="name">
+    A display name for the dev container.
+
+    ```json theme={null}
+    { "name": "My Project" }
+    ```
+  </Accordion>
+
+  <Accordion title="image">
+    The Docker image to use as the base. Only applies to image-based configurations.
+
+    ```json theme={null}
+    { "image": "mcr.microsoft.com/devcontainers/base:ubuntu" }
+    ```
+  </Accordion>
+</AccordionGroup>
+
+### Ports
+
+<AccordionGroup>
+  <Accordion title="forwardPorts">
+    An array of ports to forward from the container to the host. Accepts integers or `"host:container"` strings.
+
+    ```json theme={null}
+    { "forwardPorts": [3000, "8080:80"] }
+    ```
+  </Accordion>
+
+  <Accordion title="appPort">
+    A port or list of ports to publish from the container. Unlike `forwardPorts`, these are published at container start rather than forwarded by a client tool.
+
+    ```json theme={null}
+    { "appPort": [3000, "8080:80"] }
+    ```
+  </Accordion>
+
+  <Accordion title="portsAttributes">
+    Per-port configuration. Keys are port numbers or ranges as strings.
+
+    ```json theme={null}
+    {
+      "portsAttributes": {
+        "3000": {
+          "label": "Application",
+          "onAutoForward": "notify"
+        },
+        "5432": {
+          "label": "PostgreSQL",
+          "onAutoForward": "silent"
+        }
+      }
+    }
+    ```
+
+    `onAutoForward` accepts: `"notify"`, `"openBrowser"`, `"openBrowserOnce"`, `"openPreview"`, `"silent"`, `"ignore"`.
+  </Accordion>
+</AccordionGroup>
+
+### Features
+
+<AccordionGroup>
+  <Accordion title="features">
+    A map of dev container Features to install. Keys are Feature IDs; values are option objects, a version string, or `{}` for defaults.
+
+    ```json theme={null}
+    {
+      "features": {
+        "ghcr.io/devcontainers/features/git:1": {},
+        "ghcr.io/devcontainers/features/node:1": {
+          "version": "20"
+        }
+      }
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="overrideFeatureInstallOrder">
+    Control the order in which Features are installed. Provide an array of Feature IDs. Features not listed are installed after those that are.
+
+    ```json theme={null}
+    {
+      "overrideFeatureInstallOrder": [
+        "ghcr.io/devcontainers/features/common-utils",
+        "ghcr.io/devcontainers/features/node"
+      ]
+    }
+    ```
+  </Accordion>
+</AccordionGroup>
+
+### Environment variables
+
+<AccordionGroup>
+  <Accordion title="containerEnv">
+    Environment variables set inside the container at the system level. These are set before any lifecycle scripts run.
+
+    ```json theme={null}
+    {
+      "containerEnv": {
+        "NODE_ENV": "development",
+        "DATABASE_URL": "postgres://localhost/mydb"
+      }
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="remoteEnv">
+    Environment variables injected when a client (such as a terminal or editor) attaches to the container. Set a value to `null` to unset an inherited variable.
+
+    ```json theme={null}
+    {
+      "remoteEnv": {
+        "PATH": "${containerEnv:PATH}:/home/vscode/.local/bin",
+        "DEBUG": null
+      }
+    }
+    ```
+  </Accordion>
+</AccordionGroup>
+
+### Users
+
+<AccordionGroup>
+  <Accordion title="containerUser">
+    The user that processes inside the container run as. Equivalent to `--user` in Docker.
+
+    ```json theme={null}
+    { "containerUser": "root" }
+    ```
+  </Accordion>
+
+  <Accordion title="remoteUser">
+    The user that client-attached processes (terminals, lifecycle scripts) run as. Defaults to the container user.
+
+    ```json theme={null}
+    { "remoteUser": "vscode" }
+    ```
+  </Accordion>
+
+  <Accordion title="updateRemoteUserUID">
+    When `true`, the remote user's UID and GID are updated to match the host user's. Defaults to `true`. Set to `false` when running as root.
+
+    ```json theme={null}
+    { "updateRemoteUserUID": false }
+    ```
+  </Accordion>
+
+  <Accordion title="userEnvProbe">
+    Controls how the user's shell environment is sourced when running lifecycle commands. Accepted values:
+
+    | Value                     | Behavior                              |
+    | ------------------------- | ------------------------------------- |
+    | `"none"`                  | No shell sourcing                     |
+    | `"loginInteractiveShell"` | Login and interactive shell (default) |
+    | `"interactiveShell"`      | Interactive shell only                |
+    | `"loginShell"`            | Login shell only                      |
+
+    ```json theme={null}
+    { "userEnvProbe": "loginInteractiveShell" }
+    ```
+  </Accordion>
+</AccordionGroup>
+
+### Container runtime
+
+<AccordionGroup>
+  <Accordion title="runArgs">
+    Additional arguments passed to `docker run` when creating the container.
+
+    ```json theme={null}
+    { "runArgs": ["--network=host", "--cpus=2"] }
+    ```
+  </Accordion>
+
+  <Accordion title="mounts">
+    Additional mount points. Each entry is a mount string or object.
+
+    ```json theme={null}
+    {
+      "mounts": [
+        "type=bind,source=${localWorkspaceFolder}/data,target=/data",
+        {
+          "type": "volume",
+          "source": "node_modules",
+          "target": "/workspace/node_modules"
+        }
+      ]
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="workspaceFolder">
+    The path inside the container to use as the working directory. Required for Docker Compose configurations.
+
+    ```json theme={null}
+    { "workspaceFolder": "/workspace" }
+    ```
+  </Accordion>
+
+  <Accordion title="workspaceMount">
+    Overrides the default bind mount used to mount the workspace into the container.
+
+    ```json theme={null}
+    { "workspaceMount": "type=bind,source=${localWorkspaceFolder},target=/workspace,consistency=cached" }
+    ```
+  </Accordion>
+
+  <Accordion title="overrideCommand">
+    When `true`, overrides the container's default `CMD` with an infinite sleep so the container stays running. Defaults to `true`.
+
+    ```json theme={null}
+    { "overrideCommand": false }
+    ```
+  </Accordion>
+
+  <Accordion title="shutdownAction">
+    What happens to the container when the last client disconnects.
+
+    * `"none"` — container keeps running
+    * `"stopContainer"` — container is stopped (default for image/Dockerfile)
+    * `"stopCompose"` — all Compose services are stopped (Docker Compose only)
+
+    ```json theme={null}
+    { "shutdownAction": "stopContainer" }
+    ```
+  </Accordion>
+
+  <Accordion title="init, privileged, capAdd, securityOpt">
+    Low-level Linux security and init options.
+
+    ```json theme={null}
+    {
+      "init": true,
+      "privileged": false,
+      "capAdd": ["SYS_PTRACE"],
+      "securityOpt": ["seccomp=unconfined"]
+    }
+    ```
+
+    * `init` — run an init process (`tini`) as PID 1
+    * `privileged` — run the container in privileged mode
+    * `capAdd` — Linux capabilities to add
+    * `securityOpt` — security options passed to `docker run`
+  </Accordion>
+</AccordionGroup>
+
+### Host requirements
+
+Declare the minimum host resources the container requires. Tools that support this can surface warnings or prevent startup when the host does not meet the requirements.
+
+```json theme={null}
+{
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "8gb",
+    "storage": "32gb",
+    "gpu": true
+  }
+}
+```
+
+`gpu` accepts `true`, `false`, `"optional"`, or an object with `cores` and `memory`:
+
+```json theme={null}
+{
+  "hostRequirements": {
+    "gpu": {
+      "cores": 2,
+      "memory": "4gb"
+    }
+  }
+}
+```
+
+### Customizations
+
+Tool-specific configuration lives under `customizations`. Each key is a tool identifier; the value is that tool's configuration schema.
+
+```json theme={null}
+{
+  "customizations": {
+    "vscode": {
+      "extensions": ["esbenp.prettier-vscode"],
+      "settings": {
+        "editor.formatOnSave": true
+      }
+    }
+  }
+}
+```
+
+<Note>
+  The top-level `extensions` and `settings` keys from older versions of the spec are automatically migrated to `customizations.vscode` at runtime.
+</Note>
+
+
+# Dotfiles
+Source: https://www.mintlify.com/devcontainers/cli/configuration/dotfiles
+
+Automatically personalize your dev container with your dotfiles repository.
+
+Dotfiles support lets you clone a personal Git repository into a dev container and run an install script, so your shell configuration, aliases, and editor settings follow you into every container automatically.
+
+## How it works
+
+<Steps>
+  <Step title="Clone the repository">
+    The CLI clones your dotfiles repository into the container at the path specified by `--dotfiles-target-path` (default: `~/dotfiles`).
+  </Step>
+
+  <Step title="Run the install script">
+    The CLI looks for an install script in the root of the cloned repository and runs it. The script is resolved by checking for the first of the following files that exists:
+
+    1. `install.sh`
+    2. `install`
+    3. `bootstrap.sh`
+    4. `bootstrap`
+    5. `setup.sh`
+    6. `setup`
+
+    You can override this with `--dotfiles-install-command`.
+  </Step>
+</Steps>
+
+<Note>
+  Dotfiles installation runs after `postCreateCommand` and is skipped when `--skip-post-create` is passed.
+</Note>
+
+## CLI flags
+
+Pass these flags to `devcontainer up` or `devcontainer run-user-commands`:
+
+<AccordionGroup>
+  <Accordion title="--dotfiles-repository">
+    The URL of the Git repository to clone.
+
+    ```bash theme={null}
+    --dotfiles-repository https://github.com/myuser/dotfiles
+    ```
+
+    Any Git URL accepted by `git clone` works, including SSH URLs.
+  </Accordion>
+
+  <Accordion title="--dotfiles-install-command">
+    The command to run after cloning. If omitted, the CLI searches the repository root for the default install scripts listed above.
+
+    ```bash theme={null}
+    --dotfiles-install-command "chmod +x install.sh && ./install.sh"
+    ```
+
+    The command runs from the repository root inside the container.
+  </Accordion>
+
+  <Accordion title="--dotfiles-target-path">
+    The path inside the container where the repository is cloned. Defaults to `~/dotfiles`.
+
+    ```bash theme={null}
+    --dotfiles-target-path /home/vscode/.dotfiles
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Example usage
+
+```bash theme={null}
+devcontainer up \
+  --workspace-folder . \
+  --dotfiles-repository https://github.com/myuser/dotfiles \
+  --dotfiles-install-command "install.sh" \
+  --dotfiles-target-path ~/dotfiles
+```
+
+## Setting dotfiles in devcontainer.json
+
+Some tools that wrap the CLI pass dotfiles configuration through their own settings UI rather than CLI flags. If you need to commit dotfiles configuration alongside a project, you can place it in `devcontainer.json` under `customizations`:
+
+```json devcontainer.json theme={null}
+{
+  "name": "My Dev Container",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "customizations": {
+    "dotfiles": {
+      "repository": "https://github.com/myuser/dotfiles",
+      "installCommand": "install.sh",
+      "targetPath": "~/dotfiles"
+    }
+  }
+}
+```
+
+<Warning>
+  Committing a personal dotfiles repository URL in a shared `devcontainer.json` applies your personal configuration to everyone who uses that container. Prefer passing `--dotfiles-repository` as a user-level or machine-level setting in your tool's configuration instead.
+</Warning>
+
+## Writing an idempotent install script
+
+The install script may run more than once if the container is rebuilt. Write it so it is safe to run repeatedly.
+
+<Tip>
+  Check whether a symlink or file already exists before creating it. Use `ln -sf` (force) or guard with `[ -f ]` checks.
+</Tip>
+
+```bash install.sh theme={null}
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+link() {
+  local src="$DOTFILES_DIR/$1"
+  local dst="$HOME/$2"
+  mkdir -p "$(dirname "$dst")"
+  ln -sf "$src" "$dst"
+  echo "Linked $dst -> $src"
+}
+
+link "zshrc"        ".zshrc"
+link "gitconfig"    ".gitconfig"
+link "config/nvim"  ".config/nvim"
+
+# Install tools only if not already present
+if ! command -v starship &>/dev/null; then
+  curl -sS https://starship.rs/install.sh | sh -s -- --yes
+fi
+```
+
+Key practices:
+
+* Use `ln -sf` so existing symlinks are overwritten without error.
+* Guard network installs with `command -v` or file existence checks.
+* Use `set -euo pipefail` so the script fails fast on errors.
+* Avoid hardcoding paths; derive them from `$HOME` or the script's own directory.
+
+
+# Lifecycle Scripts
+Source: https://www.mintlify.com/devcontainers/cli/configuration/lifecycle-scripts
+
+Run commands at specific stages of the dev container lifecycle.
+
+Lifecycle scripts let you automate setup and teardown tasks at well-defined points during a dev container's lifetime. Each hook maps to a field in `devcontainer.json`.
+
+## Command syntax
+
+Every lifecycle command accepts one of three forms:
+
+<Tabs>
+  <Tab title="String">
+    A single shell command. The shell is determined by the container's default shell.
+
+    ```json theme={null}
+    { "postCreateCommand": "npm install" }
+    ```
+  </Tab>
+
+  <Tab title="Array">
+    A command and its arguments as an array. No shell expansion is applied.
+
+    ```json theme={null}
+    { "postCreateCommand": ["npm", "install", "--prefer-offline"] }
+    ```
+  </Tab>
+
+  <Tab title="Object (parallel)">
+    A map of named commands that run in parallel. Keys are labels; values are strings or arrays.
+
+    ```json theme={null}
+    {
+      "postStartCommand": {
+        "server": "npm run dev",
+        "db": "docker-compose up -d db"
+      }
+    }
+    ```
+  </Tab>
+</Tabs>
+
+## Hooks
+
+The hooks run in the following order. Unless noted otherwise, they run inside the container as the `remoteUser`.
+
+```mermaid theme={null}
+flowchart TD
+    A[initializeCommand] -->|on host| B[Container created]
+    B --> C[onCreateCommand]
+    C --> D[updateContentCommand]
+    D --> E[postCreateCommand]
+    E --> F[Container started]
+    F --> G[postStartCommand]
+    G --> H[Client attaches]
+    H --> I[postAttachCommand]
+```
+
+<AccordionGroup>
+  <Accordion title="initializeCommand">
+    **Runs on: host**
+
+    Executes on the host machine before the container is created or started. Because the container does not exist yet, this hook cannot run container commands.
+
+    Use it for host-side prerequisites: checking environment variables, authenticating to a registry, or preparing bind-mount directories.
+
+    ```json theme={null}
+    {
+      "initializeCommand": "echo 'Starting container setup'"
+    }
+    ```
+
+    <Warning>
+      `initializeCommand` runs on the host, not inside the container. Do not rely on container tooling here.
+    </Warning>
+  </Accordion>
+
+  <Accordion title="onCreateCommand">
+    **Runs on: container — once, on first creation**
+
+    Executes inside the container the first time it is created. It does not run again when the container is restarted or rebuilt unless the container is deleted and recreated.
+
+    Use it for one-time setup that is expensive to repeat, such as compiling native extensions or generating certificates.
+
+    ```json theme={null}
+    {
+      "onCreateCommand": "sudo apt-get install -y build-essential"
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="updateContentCommand">
+    **Runs on: container — on creation and when workspace content changes**
+
+    Similar to `onCreateCommand`, but also re-runs whenever the workspace content is updated. This is intended for tools that rebuild indexes or caches when source files change.
+
+    ```json theme={null}
+    {
+      "updateContentCommand": "pip install -r requirements.txt"
+    }
+    ```
+
+    <Note>
+      When `--prebuild` is passed to `devcontainer up`, execution stops after `updateContentCommand`. This is useful for pre-building container images.
+    </Note>
+  </Accordion>
+
+  <Accordion title="postCreateCommand">
+    **Runs on: container — once, after first creation**
+
+    The most commonly used hook. Runs once after the container is created and `updateContentCommand` has finished. Use it for dependency installation, code generation, or any other setup that should happen exactly once.
+
+    ```json theme={null}
+    {
+      "postCreateCommand": "npm install"
+    }
+    ```
+
+    Multiple commands using parallel object syntax:
+
+    ```json theme={null}
+    {
+      "postCreateCommand": {
+        "deps": "npm install",
+        "hooks": "npx husky install"
+      }
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="postStartCommand">
+    **Runs on: container — every time the container starts**
+
+    Executes each time the container starts, including restarts. Use it for long-running background processes or tasks that must be re-initialized on each start.
+
+    ```json theme={null}
+    {
+      "postStartCommand": {
+        "server": "npm run dev",
+        "db": "docker-compose up -d db"
+      }
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="postAttachCommand">
+    **Runs on: container — each time a client attaches**
+
+    Executes each time a tool (such as an editor or terminal) attaches to the running container. Use it for per-session setup that depends on which client is connecting.
+
+    ```json theme={null}
+    {
+      "postAttachCommand": "zsh"
+    }
+    ```
+
+    Pass `--skip-post-attach` to `devcontainer up` to suppress this hook.
+  </Accordion>
+</AccordionGroup>
+
+## Controlling blocking with waitFor
+
+By default, `devcontainer up` waits for `updateContentCommand` to complete before returning. The `waitFor` property lets you change which command blocks the return.
+
+```json theme={null}
+{
+  "waitFor": "postCreateCommand"
+}
+```
+
+Accepted values match the `DevContainerConfigCommand` type:
+
+| Value                    | Blocks until                               |
+| ------------------------ | ------------------------------------------ |
+| `"initializeCommand"`    | `initializeCommand` completes              |
+| `"onCreateCommand"`      | `onCreateCommand` completes                |
+| `"updateContentCommand"` | `updateContentCommand` completes (default) |
+| `"postCreateCommand"`    | `postCreateCommand` completes              |
+| `"postStartCommand"`     | `postStartCommand` completes               |
+| `"postAttachCommand"`    | `postAttachCommand` completes              |
+
+Commands that run after the `waitFor` target execute in the background without blocking the caller.
+
+## CLI flags
+
+Two flags on `devcontainer up` modify lifecycle script behavior:
+
+<AccordionGroup>
+  <Accordion title="--skip-post-create">
+    Skips all of the following and does not install dotfiles:
+
+    * `onCreateCommand`
+    * `updateContentCommand`
+    * `postCreateCommand`
+    * `postStartCommand`
+    * `postAttachCommand`
+
+    ```bash theme={null}
+    devcontainer up --workspace-folder . --skip-post-create
+    ```
+
+    Use this when you want to start a container quickly for inspection without running setup scripts.
+  </Accordion>
+
+  <Accordion title="--skip-non-blocking-commands">
+    Stops after the command specified by `waitFor` (or `updateContentCommand` by default) without running the hooks that follow it.
+
+    ```bash theme={null}
+    devcontainer up --workspace-folder . --skip-non-blocking-commands
+    ```
+
+    This is useful in CI when you only need the container to be ready up to a specific point in the lifecycle.
+  </Accordion>
+</AccordionGroup>
+
+## Full example
+
+```json devcontainer.json theme={null}
+{
+  "name": "Full-stack App",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+
+  "initializeCommand": "docker network inspect devnet || docker network create devnet",
+
+  "onCreateCommand": "sudo apt-get update && sudo apt-get install -y postgresql-client",
+
+  "updateContentCommand": "npm ci",
+
+  "postCreateCommand": {
+    "db-migrate": "npm run db:migrate",
+    "git-hooks": "npx husky install"
+  },
+
+  "postStartCommand": {
+    "server": "npm run dev",
+    "watch": "npm run build:watch"
+  },
+
+  "postAttachCommand": "echo 'Welcome to the dev container!'",
+
+  "waitFor": "postCreateCommand"
+}
+```
+
+
+# Generating Feature documentation
+Source: https://www.mintlify.com/devcontainers/cli/features/generate-docs
+
+Auto-generate markdown documentation for your Dev Container Features.
+
+The `devcontainer features generate-docs` command reads each Feature's `devcontainer-feature.json` and writes a `README.md` into the same directory. Running this command as part of your CI pipeline keeps documentation in sync with Feature metadata automatically.
+
+## Usage
+
+```bash theme={null}
+devcontainer features generate-docs \
+  --namespace my-org/my-features-repo \
+  --github-owner my-org \
+  --github-repo my-features-repo
+```
+
+The command iterates over every non-hidden subdirectory at the project root's `src/` folder (or the path provided by `--project-folder`), finds `devcontainer-feature.json` in each, and writes `README.md` alongside it.
+
+## Flags
+
+| Flag               | Alias | Default   | Description                                                                                                                   |
+| ------------------ | ----- | --------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `--project-folder` | `-p`  | `.`       | Path to the folder containing the `src` subdirectory. Typically the git root.                                                 |
+| `--namespace`      | `-n`  | —         | **Required.** The OCI namespace for the collection (`<owner>/<repo>`). Used to build the example usage snippet in the README. |
+| `--registry`       | `-r`  | `ghcr.io` | OCI registry name. Used in the example usage snippet.                                                                         |
+| `--github-owner`   | —     | `""`      | GitHub owner. When provided alongside `--github-repo`, generates a link to the `devcontainer-feature.json` on GitHub.         |
+| `--github-repo`    | —     | `""`      | GitHub repository name.                                                                                                       |
+| `--log-level`      | —     | `info`    | One of `info`, `debug`, `trace`.                                                                                              |
+
+<Note>
+  If `--github-owner` and `--github-repo` are both set, the generated README links directly to the `devcontainer-feature.json` file on `github.com`. Otherwise, the link is the bare filename.
+</Note>
+
+## Generated README format
+
+Each `README.md` is generated from a standard template populated with fields from `devcontainer-feature.json`:
+
+````markdown src/my-feature/README.md theme={null}
+# My Feature (my-feature)
+
+Installs my-tool and configures the environment.
+
+## Example Usage
+
+```json
+"features": {
+    "ghcr.io/my-org/my-features-repo/my-feature:1": {}
+}
+```
+
+## Options
+
+| Options Id | Description | Type | Default Value |
+|-----|-----|-----|-----|
+| version | Version of my-tool to install. | string | latest |
+
+## Customizations
+
+### VS Code Extensions
+
+- `my-publisher.my-extension`
+
+---
+
+_Note: This file was auto-generated from the [devcontainer-feature.json](https://github.com/my-org/my-features-repo/blob/main/src/my-feature/devcontainer-feature.json).  Add additional notes to a `NOTES.md`._
+````
+
+The version tag in the example usage snippet is derived from the major component of the Feature's `version` field (e.g. `1.2.3` → `:1`). If no version is present, `latest` is used.
+
+### Customizing with NOTES.md
+
+To add content that should appear in the README but cannot be expressed in `devcontainer-feature.json`, create a `NOTES.md` file in the Feature directory. Its contents are appended after the options table and customizations section.
+
+```
+src/
+└── my-feature/
+    ├── devcontainer-feature.json
+    ├── install.sh
+    └── NOTES.md          ← appended verbatim to the generated README
+```
+
+### Deprecated and legacy Features
+
+If `deprecated: true` is set in `devcontainer-feature.json`, the generated README prepends a bold deprecation notice. Similarly, any `legacyIds` values are called out at the top of the file.
+
+## Running in CI
+
+Add `generate-docs` to your CI workflow after any change to a `devcontainer-feature.json` to keep READMEs up to date. A typical GitHub Actions step:
+
+```yaml .github/workflows/release.yaml theme={null}
+- name: Generate documentation
+  run: |
+    devcontainer features generate-docs \
+      --namespace ${{ github.repository }} \
+      --github-owner ${{ github.repository_owner }} \
+      --github-repo ${{ github.event.repository.name }}
+
+- name: Commit updated READMEs
+  run: |
+    git config user.name "github-actions[bot]"
+    git config user.email "github-actions[bot]@users.noreply.github.com"
+    git add src/*/README.md
+    git diff --cached --quiet || git commit -m "docs: regenerate Feature READMEs"
+    git push
+```
+
+<Tip>
+  Pin your CI workflow to a specific version of the Dev Containers CLI to avoid unexpected output changes when the template is updated.
+</Tip>
+
+
+# Dev Container Features
+Source: https://www.mintlify.com/devcontainers/cli/features/overview
+
+Add tools, runtimes, and utilities to any dev container using Features.
+
+Dev Container Features are self-contained, shareable units of installation code and configuration. A Feature encapsulates everything needed to install a tool, runtime, or utility into a dev container — you reference it by ID in your `devcontainer.json`, and the CLI handles the rest.
+
+Features are distributed as OCI artifacts, primarily via `ghcr.io`, and versioned using semver tags.
+
+## Using Features in devcontainer.json
+
+Add a `features` object to your `devcontainer.json`. Each key is a Feature identifier (registry path + version tag), and the value is a set of options to pass to that Feature's `install.sh`.
+
+```json devcontainer.json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  }
+}
+```
+
+<Tip>
+  Browse community-maintained Features at [containers.dev/features](https://containers.dev/features).
+</Tip>
+
+## Feature structure
+
+Every Feature lives in its own directory containing two required files:
+
+```
+src/
+└── my-feature/
+    ├── devcontainer-feature.json   # Metadata: id, version, options, description
+    └── install.sh                  # Installation script run inside the container
+```
+
+`devcontainer-feature.json` declares the Feature's identity, available options, and other metadata consumed by the CLI and the registry. `install.sh` is the script executed inside the container during the build phase.
+
+## OCI registry distribution
+
+Features are packaged as OCI artifacts and pushed to a registry such as `ghcr.io`. The Feature identifier in `devcontainer.json` is the full OCI reference:
+
+```
+ghcr.io/<owner>/<repo>/<feature-id>:<major-version>
+```
+
+A `devcontainer-collection.json` index is published alongside individual Features so tooling can enumerate all Features in a namespace.
+
+## CLI subcommands
+
+The `devcontainer features` group provides everything you need to test, package, publish, and inspect Features.
+
+<CardGroup>
+  <Card title="Test" icon="flask-conical" href="/features/test">
+    Run the built-in test framework against your local Feature source tree.
+  </Card>
+
+  <Card title="Package & Publish" icon="box" href="/features/package-publish">
+    Bundle Features into OCI artifacts and push them to a registry.
+  </Card>
+
+  <Card title="Generate docs" icon="file-text" href="/features/generate-docs">
+    Auto-generate a `README.md` for each Feature from its metadata.
+  </Card>
+
+  <Card title="Info" icon="circle-info" href="/features/package-publish#inspecting-published-features">
+    Fetch manifest, tags, or dependency information for a published Feature.
+  </Card>
+
+  <Card title="Resolve dependencies" icon="network" href="/features/package-publish#resolving-dependencies">
+    Inspect the installation order and dependency graph for Features in a config.
+  </Card>
+</CardGroup>
+
+
+# Packaging and Publishing Features
+Source: https://www.mintlify.com/devcontainers/cli/features/package-publish
+
+Package and publish Dev Container Features to an OCI registry.
+
+The `devcontainer features package` and `devcontainer features publish` commands bundle your Feature source into OCI artifacts and push them to a registry such as `ghcr.io`.
+
+## devcontainer-feature.json
+
+Every Feature must have a `devcontainer-feature.json` in its source directory. This file provides the metadata that drives packaging, publishing, and documentation generation.
+
+```json src/my-feature/devcontainer-feature.json theme={null}
+{
+  "id": "my-feature",
+  "version": "1.0.0",
+  "name": "My Feature",
+  "description": "Installs my-tool and configures the environment.",
+  "options": {
+    "version": {
+      "type": "string",
+      "default": "latest",
+      "description": "Version of my-tool to install."
+    }
+  },
+  "installsAfter": [],
+  "customizations": {
+    "vscode": {
+      "extensions": ["my-publisher.my-extension"]
+    }
+  }
+}
+```
+
+<Note>
+  The `version` field must follow semver (e.g. `1.2.3`). The publish command uses the major version component as the primary OCI tag and also pushes patch and minor tags.
+</Note>
+
+## Publishing workflow
+
+<Steps>
+  <Step title="Authenticate with the registry">
+    Log in to `ghcr.io` (or your chosen registry) using Docker:
+
+    ```bash theme={null}
+    echo $GITHUB_TOKEN | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+    ```
+
+    The publish command reads credentials from the Docker credential store. Authentication must succeed before publishing.
+  </Step>
+
+  <Step title="Ensure devcontainer-feature.json is complete">
+    Each Feature in `src/<FEATURE>/` must have a `devcontainer-feature.json` with at minimum an `id` and a `version`.
+
+    Features without a `version` field are skipped with a warning during publish.
+  </Step>
+
+  <Step title="Package the Features">
+    The `package` command creates OCI-ready tarballs in the output directory without pushing:
+
+    ```bash theme={null}
+    devcontainer features package ./src --output-folder ./output
+    ```
+
+    The target can be either a `src/` folder containing multiple Features, or a path directly to a single Feature directory. A `devcontainer-collection.json` index is written to the output directory alongside the individual Feature archives.
+
+    | Flag                          | Alias | Default    | Description                                                         |
+    | ----------------------------- | ----- | ---------- | ------------------------------------------------------------------- |
+    | `--output-folder`             | `-o`  | `./output` | Directory where archives are written. Created if it does not exist. |
+    | `--force-clean-output-folder` | `-f`  | `false`    | Delete the output folder before packaging.                          |
+    | `--log-level`                 | —     | `info`     | One of `info`, `debug`, `trace`.                                    |
+  </Step>
+
+  <Step title="Publish to the registry">
+    The `publish` command packages Features and pushes each one to the registry in a single step:
+
+    ```bash theme={null}
+    devcontainer features publish ./src \
+      --registry ghcr.io \
+      --namespace my-org/my-features-repo
+    ```
+
+    The namespace identifies the collection. Published references take the form:
+
+    ```
+    ghcr.io/<namespace>/<feature-id>:<version>
+    ```
+
+    | Flag          | Alias | Default   | Description                                                            |
+    | ------------- | ----- | --------- | ---------------------------------------------------------------------- |
+    | `--registry`  | `-r`  | `ghcr.io` | OCI registry to publish to.                                            |
+    | `--namespace` | `-n`  | —         | **Required.** Unique identifier for the collection (`<owner>/<repo>`). |
+    | `--log-level` | —     | `info`    | One of `info`, `debug`, `trace`.                                       |
+
+    On success, the command outputs a JSON object mapping each Feature ID to its published digest and tags.
+  </Step>
+</Steps>
+
+<Warning>
+  If a Feature with `legacyIds` is published, the same artifact is also published under each legacy identifier to maintain backwards compatibility with older references.
+</Warning>
+
+## Inspecting published Features
+
+The `devcontainer features info` command queries a published Feature without downloading its full archive.
+
+```bash theme={null}
+devcontainer features info <mode> <feature>
+```
+
+Replace `<mode>` with one of:
+
+| Mode           | Description                                                  |
+| -------------- | ------------------------------------------------------------ |
+| `manifest`     | Fetch the OCI manifest and canonical identifier.             |
+| `tags`         | List all published version tags.                             |
+| `dependencies` | Build and display the dependency graph as a Mermaid diagram. |
+| `verbose`      | Return all of the above.                                     |
+
+**Examples:**
+
+```bash theme={null}
+# Show all published tags
+devcontainer features info tags ghcr.io/devcontainers/features/node
+
+# Show the OCI manifest as JSON
+devcontainer features info manifest ghcr.io/devcontainers/features/node --output-format json
+
+# Show the dependency graph
+devcontainer features info dependencies ghcr.io/devcontainers/features/node
+```
+
+Pass `--output-format json` to receive machine-readable JSON instead of formatted text.
+
+<Note>
+  If the manifest requires authentication, run `docker login` for the registry first. The info command will print `No manifest found! If this manifest requires authentication, please login.` if it cannot fetch the manifest.
+</Note>
+
+## Resolving dependencies
+
+The `devcontainer features resolve-dependencies` command reads the `devcontainer.json` in a workspace and outputs the resolved installation order for all Features, accounting for `dependsOn` relationships.
+
+```bash theme={null}
+devcontainer features resolve-dependencies --workspace-folder ./my-project
+```
+
+Output includes a Mermaid dependency diagram followed by a JSON object:
+
+```json theme={null}
+{
+  "installOrder": [
+    {
+      "id": "ghcr.io/devcontainers/features/common-utils@sha256:abc123...",
+      "options": {}
+    },
+    {
+      "id": "ghcr.io/devcontainers/features/node@sha256:def456...",
+      "options": { "version": "20" }
+    }
+  ]
+}
+```
+
+| Flag                 | Default           | Description                                                                                 |
+| -------------------- | ----------------- | ------------------------------------------------------------------------------------------- |
+| `--workspace-folder` | Current directory | Path to the workspace containing `.devcontainer.json` or `.devcontainer/devcontainer.json`. |
+| `--log-level`        | `error`           | One of `error`, `info`, `debug`, `trace`.                                                   |
+
+<Tip>
+  Paste the Mermaid diagram output into [mermaid.live](https://mermaid.live/) to visualize the dependency graph interactively.
+</Tip>
+
+
+# Testing Features
+Source: https://www.mintlify.com/devcontainers/cli/features/test
+
+Use the built-in test framework to validate your Dev Container Features.
+
+The `devcontainer features test` command provides a structured test framework for Feature authors. It uses the CLI's `build` and `exec` commands to spin up a container from your local source tree and run assertion scripts inside it.
+
+For a test to pass:
+
+1. The generated dev container must build and start successfully.
+2. The assertion script must exit with code `0`.
+
+<Note>
+  Auto-generated tests execute the Feature with its **default options**. Use scenarios to test specific option combinations.
+</Note>
+
+## Directory structure
+
+The test command expects `src` and `test` directories to mirror each other at the project root:
+
+```
+.
+├── src/
+│   ├── dotnet/
+│   │   ├── devcontainer-feature.json
+│   │   └── install.sh
+│   └── oryx/
+│       ├── devcontainer-feature.json
+│       └── install.sh
+└── test/
+    ├── _global/
+    │   ├── scenarios.json
+    │   └── some_global_scenario.sh
+    ├── dotnet/
+    │   ├── duplicate.sh
+    │   └── test.sh
+    └── oryx/
+        ├── scenarios.json
+        ├── install_dotnet_and_oryx.sh
+        └── test.sh
+```
+
+Each Feature under `src/<FEATURE>/` must have a corresponding `test/<FEATURE>/` directory containing at minimum a `test.sh`.
+
+## Test modes
+
+<Tabs>
+  <Tab title="Auto-generated">
+    The default mode. The CLI generates a minimal `devcontainer.json` using the Feature source from `src/<FEATURE>/`, the `--base-image`, and an optional `--remote-user`. It then runs `test/<FEATURE>/test.sh` inside the container.
+
+    This is the fastest way to assert that a Feature installs and runs correctly with its default options.
+
+    To skip this mode, pass `--skip-autogenerated`.
+  </Tab>
+
+  <Tab title="Scenarios">
+    Scenarios let you define richer test configurations — multiple Features, custom options, or Dockerfile-based builds. Each scenario is a named entry in `test/<FEATURE>/scenarios.json`.
+
+    For each scenario, the CLI builds the described container and runs a `.sh` file with the same name as the scenario key.
+
+    To skip this mode, pass `--skip-scenarios`.
+  </Tab>
+
+  <Tab title="Duplicate tests">
+    When `test/<FEATURE>/duplicate.sh` exists, the CLI generates a dev container that installs the same Feature **twice** with different options. This validates that a Feature is idempotent and can coexist with itself.
+
+    Option values are injected as environment variables into the assertion script (e.g., `VERSION`, `VERSION__DEFAULT`).
+
+    To skip this mode, pass `--skip-duplicated`.
+  </Tab>
+</Tabs>
+
+## Scenarios
+
+A `scenarios.json` file defines one or more named test scenarios. Each scenario is a valid `devcontainer.json` fragment.
+
+```json test/oryx/scenarios.json theme={null}
+{
+  "install_dotnet_and_oryx": {
+    "image": "ubuntu:focal",
+    "features": {
+      "dotnet": {
+        "version": "6",
+        "installUsingApt": "false"
+      },
+      "oryx": {}
+    }
+  }
+}
+```
+
+For this scenario, the CLI builds the container described above, then looks for `test/oryx/install_dotnet_and_oryx.sh` and executes it inside the container.
+
+### Providing additional build files
+
+To supply a `Dockerfile`, lifecycle scripts, or other files for a scenario, create a subdirectory under `test/<FEATURE>/` with the same name as the scenario key. Files placed there are copied into the hidden `.devcontainer` folder before the build.
+
+```json scenarios.json (excerpt) theme={null}
+{
+  "frowning_with_a_dockerfile": {
+    "build": {
+      "dockerfile": "Dockerfile"
+    },
+    "features": {
+      "smile": { "shouldFrown": true }
+    }
+  }
+}
+```
+
+```
+test/
+└── smile/
+    ├── frowning_with_a_dockerfile/     ← files copied to .devcontainer
+    │   └── Dockerfile
+    ├── frowning_with_a_dockerfile.sh
+    └── test.sh
+```
+
+### Global scenarios
+
+The `test/_global/` directory holds scenario tests that are not tied to a specific Feature. Use it to test interactions between multiple Features in the same repository.
+
+```
+test/
+└── _global/
+    ├── scenarios.json
+    └── my_cross_feature_scenario.sh
+```
+
+Pass `--global-scenarios-only` to run only these tests.
+
+## dev-container-features-test-lib
+
+The test library is a set of bash helper functions automatically made available inside test containers. Using it is optional but recommended.
+
+Source it at the top of any `test.sh` or scenario script:
+
+```bash test.sh theme={null}
+source dev-container-features-test-lib
+```
+
+### Available functions
+
+| Function                                | Description                                                          |
+| --------------------------------------- | -------------------------------------------------------------------- |
+| `check <label> <cmd> [args...]`         | Runs `cmd`. Prints pass/fail depending on exit code.                 |
+| `checkMultiple <label> <cmd> [args...]` | Like `check`, but accumulates results without stopping on failure.   |
+| `reportResults`                         | Prints a summary and exits with a non-zero code if any check failed. |
+
+### Example test script
+
+```bash test/oryx/install_dotnet_and_oryx.sh theme={null}
+#!/bin/bash
+
+set -e
+
+source dev-container-features-test-lib
+
+check "Oryx version" oryx --version
+check "Dotnet is available" dotnet --version
+check "oryx-install-dotnet-2.1" oryx prep --skip-detection --platforms-and-versions dotnet=2.1.30
+check "dotnet-2-installed-by-oryx" ls /opt/dotnet/ | grep 2.1
+
+# Report result
+reportResults
+```
+
+## Running tests
+
+To run all tests for a single Feature:
+
+```bash theme={null}
+devcontainer features test -f dotnet --base-image ubuntu
+```
+
+To run only global scenarios:
+
+```bash theme={null}
+devcontainer features test --global-scenarios-only
+```
+
+To run all tests in the current directory against a specific base image:
+
+```bash theme={null}
+devcontainer features test --base-image mcr.microsoft.com/devcontainers/base:ubuntu
+```
+
+## Flags reference
+
+| Flag                         | Alias | Default        | Description                                                                                         |
+| ---------------------------- | ----- | -------------- | --------------------------------------------------------------------------------------------------- |
+| `--project-folder`           | `-p`  | `.`            | Path to the folder containing `src` and `test`. Defaults to the current directory.                  |
+| `--features`                 | `-f`  | —              | One or more Feature names to test. Omit to test all. Cannot combine with `--global-scenarios-only`. |
+| `--filter`                   | —     | —              | Filter scenario tests to only those whose name contains this string.                                |
+| `--base-image`               | `-i`  | `ubuntu:focal` | Base image for auto-generated and duplicate tests. Not used for scenarios.                          |
+| `--remote-user`              | `-u`  | —              | Remote user for auto-generated tests.                                                               |
+| `--skip-autogenerated`       | —     | `false`        | Skip auto-generated tests.                                                                          |
+| `--skip-scenarios`           | —     | `false`        | Skip scenario tests. Cannot combine with `--global-scenarios-only`.                                 |
+| `--skip-duplicated`          | —     | `false`        | Skip duplicate-style tests.                                                                         |
+| `--global-scenarios-only`    | —     | `false`        | Run only tests in `test/_global/`. Cannot combine with `-f`.                                        |
+| `--preserve-test-containers` | —     | `false`        | Do not remove containers after the test run.                                                        |
+| `--quiet`                    | `-q`  | `false`        | Suppress output.                                                                                    |
+| `--log-level`                | —     | `info`         | One of `info`, `debug`, `trace`.                                                                    |
+
+
+# Installation
+Source: https://www.mintlify.com/devcontainers/cli/installation
+
+Install the Dev Containers CLI via npm, the standalone install script, or build from source.
+
+## Prerequisites
+
+Before installing the CLI, make sure you have the following:
+
+* **Docker** — required to build and run containers. Install from [docs.docker.com](https://docs.docker.com/get-docker/).
+* **Node.js >=20.0.0** — required for the npm installation method and for building from source. Not required when using the install script.
+
+## Installation methods
+
+### Install script
+
+The install script downloads a bundled Node.js runtime, so no pre-installed Node.js is required. It works on Linux and macOS (x64 and arm64).
+
+<Steps>
+  <Step title="Download and run the install script">
+    ```bash theme={null}
+    curl -fsSL https://raw.githubusercontent.com/devcontainers/cli/main/scripts/install.sh | sh
+    ```
+  </Step>
+
+  <Step title="Add the CLI to your PATH">
+    ```bash theme={null}
+    export PATH="$HOME/.devcontainers/bin:$PATH"
+    ```
+
+    To make this permanent, add the line above to your shell profile (e.g. `~/.bashrc`, `~/.zshrc`).
+  </Step>
+</Steps>
+
+#### Additional install script options
+
+```bash theme={null}
+# Install a specific version
+sh install.sh --version 0.82.0
+
+# Install to a custom directory
+sh install.sh --prefix ~/.local/devcontainers
+
+# Update to the latest version
+sh install.sh --update
+
+# Uninstall
+sh install.sh --uninstall
+```
+
+***
+
+### npm
+
+<Note>
+  Installing via npm requires Python and C/C++ to be present on your system in order to build one of the native dependencies.
+</Note>
+
+<CodeGroup>
+  ```bash npm theme={null}
+  npm install -g @devcontainers/cli
+  ```
+
+  ```bash yarn theme={null}
+  yarn global add @devcontainers/cli
+  ```
+
+  ```bash pnpm theme={null}
+  pnpm add -g @devcontainers/cli
+  ```
+</CodeGroup>
+
+***
+
+### Build from source
+
+Use this method to work with the latest unreleased code or contribute to the project.
+
+<Steps>
+  <Step title="Clone the repository">
+    ```bash theme={null}
+    git clone https://github.com/devcontainers/cli.git
+    cd cli
+    ```
+  </Step>
+
+  <Step title="Install dependencies and compile">
+    ```sh theme={null}
+    yarn
+    yarn compile
+    ```
+  </Step>
+
+  <Step title="Run the CLI from the build output">
+    ```sh theme={null}
+    node devcontainer.js --help
+    ```
+  </Step>
+</Steps>
+
+<Note>
+  The repository includes a `devcontainer.json` configuration you can use to open the project itself in a dev container, which provides all required dependencies automatically.
+</Note>
+
+***
+
+## Verify installation
+
+After installing by any method, confirm the CLI is available:
+
+```bash theme={null}
+devcontainer --version
+```
+
+You should see output similar to:
+
+```
+0.85.0
+```
+
+To see all available commands:
+
+```bash theme={null}
+devcontainer --help
+```
+
+
+# Introduction
+Source: https://www.mintlify.com/devcontainers/cli/introduction
+
+What the Dev Containers CLI is and how it fits into the Dev Containers ecosystem.
+
+## What is a dev container?
+
+A development container lets you use a container as a full-featured development environment. Rather than installing tools, runtimes, and dependencies directly on your machine, you define them in a `devcontainer.json` file and run everything inside a container.
+
+Dev containers can be used to:
+
+* **Run your application** in an isolated, reproducible environment.
+* **Separate tools and runtimes** from your host system so team members get identical setups.
+* **Aid in continuous integration and testing** by running the same container in CI that you use locally.
+
+Dev containers can run locally or remotely, in private or public cloud environments.
+
+## What is the Dev Containers CLI?
+
+The Dev Containers CLI (`@devcontainers/cli`) is the reference implementation of the [Dev Containers specification](https://containers.dev/). It reads a `devcontainer.json` configuration file and creates, configures, and manages the container lifecycle from the command line.
+
+The CLI is published by Microsoft and is also the engine that powers the Dev Containers extension for VS Code and GitHub Codespaces.
+
+## Key use cases
+
+* **Local development** — spin up a fully configured environment on your machine with a single command.
+* **CI/CD pipelines** — run tests and build steps inside the same container used for development, eliminating environment drift.
+* **Pre-building images** — build and push dev container images ahead of time so containers start instantly.
+* **Authoring Features and Templates** — create, package, publish, and test reusable [Dev Container Features](https://containers.dev/implementors/features/) and [Templates](https://containers.dev/implementors/templates/).
+
+## How it relates to the specification
+
+The CLI implements the [Development Containers Specification](https://containers.dev/), which defines how `devcontainer.json` files are structured and how lifecycle commands, features, and environment variables are applied. Any tool that follows the spec — VS Code, GitHub Codespaces, JetBrains IDEs — produces and consumes the same configuration files.
+
+## Available commands
+
+| Command              | Description                                               |
+| -------------------- | --------------------------------------------------------- |
+| `up`                 | Create and run a dev container                            |
+| `build`              | Build or pre-build a dev container image                  |
+| `exec`               | Execute a command inside a running container              |
+| `run-user-commands`  | Run lifecycle commands such as `postCreateCommand`        |
+| `set-up`             | Set up an existing container as a dev container           |
+| `read-configuration` | Output the resolved configuration for a workspace         |
+| `outdated`           | Show current and available Feature versions               |
+| `upgrade`            | Upgrade the Feature lockfile to latest versions           |
+| `features`           | Author, package, publish, and test Dev Container Features |
+| `templates`          | Author, apply, publish, and test Dev Container Templates  |
+
+<Note>
+  `devcontainer stop` and `devcontainer down` are planned but not yet implemented. Use `docker stop` and `docker rm` in the meantime.
+</Note>
+
+## Get started
+
+<CardGroup>
+  <Card title="Installation" icon="download" href="/installation">
+    Install the CLI via the install script, npm, or from source.
+  </Card>
+
+  <Card title="Quickstart" icon="rocket" href="/quickstart">
+    Spin up your first dev container in under five minutes.
+  </Card>
+</CardGroup>
+
+
+# Quickstart
+Source: https://www.mintlify.com/devcontainers/cli/quickstart
+
+Spin up your first dev container in under five minutes.
+
+This guide walks you through starting a dev container using the Rust sample project from Microsoft. By the end you will have a running container and a compiled Rust program.
+
+## Prerequisites
+
+* Docker installed and running
+* The Dev Containers CLI installed — see [Installation](/installation)
+* Git
+
+## Steps
+
+<Steps>
+  <Step title="Install the CLI">
+    If you haven't already, install the CLI using the install script:
+
+    ```bash theme={null}
+    curl -fsSL https://raw.githubusercontent.com/devcontainers/cli/main/scripts/install.sh | sh
+    export PATH="$HOME/.devcontainers/bin:$PATH"
+    ```
+
+    Verify it works:
+
+    ```bash theme={null}
+    devcontainer --version
+    ```
+  </Step>
+
+  <Step title="Clone the sample repository">
+    Clone the Rust sample project to your machine:
+
+    ```bash theme={null}
+    git clone https://github.com/microsoft/vscode-remote-try-rust
+    ```
+  </Step>
+
+  <Step title="Start the dev container">
+    Run `devcontainer up` pointing at the cloned folder:
+
+    ```bash theme={null}
+    devcontainer up --workspace-folder vscode-remote-try-rust
+    ```
+
+    The CLI will build the container image and start it. You will see Docker build output followed by a JSON result line:
+
+    ```
+    [88 ms] dev-containers-cli 0.1.0.
+    [165 ms] Start: Run: docker build -f /home/node/vscode-remote-try-rust/.devcontainer/Dockerfile -t vsc-vscode-remote-try-rust-89420ad7399ba74f55921e49cc3ecfd2 --build-arg VARIANT=bullseye /home/node/vscode-remote-try-rust/.devcontainer
+    [+] Building 0.5s (5/5) FINISHED
+     => [internal] load build definition from Dockerfile                       0.0s
+     => => transferring dockerfile: 38B                                        0.0s
+     => [internal] load .dockerignore                                          0.0s
+     => => transferring context: 2B                                            0.0s
+     => [internal] load metadata for mcr.microsoft.com/vscode/devcontainers/r  0.4s
+     => CACHED [1/1] FROM mcr.microsoft.com/vscode/devcontainers/rust:1-bulls  0.0s
+     => exporting to image                                                     0.0s
+     => => exporting layers                                                    0.0s
+     => => writing image sha256:39873ccb81e6fb613975e11e37438eee1d49c963a436d  0.0s
+     => => naming to docker.io/library/vsc-vscode-remote-try-rust-89420ad7399  0.0s
+    {"outcome":"success","containerId":"f0a055ff056c1c1bb99cc09930efbf3a0437c54d9b4644695aa23c1d57b4bd11","remoteUser":"vscode","remoteWorkspaceFolder":"/workspaces/vscode-remote-try-rust"}
+    ```
+
+    The final JSON line confirms the container is running. Note the `containerId`, `remoteUser`, and `remoteWorkspaceFolder` fields — these describe the container that was just created.
+  </Step>
+
+  <Step title="Run a command inside the container">
+    Use `devcontainer exec` to run a command inside the running container:
+
+    ```bash theme={null}
+    devcontainer exec --workspace-folder vscode-remote-try-rust cargo run
+    ```
+
+    The CLI compiles and runs the Rust sample:
+
+    ```
+    [33 ms] dev-containers-cli 0.1.0.
+       Compiling hello_remote_world v0.1.0 (/workspaces/vscode-remote-try-rust)
+        Finished dev [unoptimized + debuginfo] target(s) in 1.06s
+         Running `target/debug/hello_remote_world`
+    Hello, VS Code Remote - Containers!
+    {"outcome":"success"}
+    ```
+
+    The program prints `Hello, VS Code Remote - Containers!` and the CLI reports `{"outcome":"success"}`.
+  </Step>
+</Steps>
+
+<Note>
+  On subsequent runs, Docker will use its layer cache so the container starts much faster.
+</Note>
+
+## What's next
+
+<CardGroup>
+  <Card title="devcontainer up" icon="play" href="/commands/up">
+    Learn all the options for starting and configuring dev containers.
+  </Card>
+
+  <Card title="devcontainer build" icon="hammer" href="/commands/build">
+    Pre-build images to speed up container startup times.
+  </Card>
+
+  <Card title="Dev Container Features" icon="puzzle-piece" href="/features/overview">
+    Add tools and runtimes to any dev container with reusable Features.
+  </Card>
+
+  <Card title="devcontainer.json reference" icon="file-code" href="/configuration/devcontainer-json">
+    Explore all the configuration options available in devcontainer.json.
+  </Card>
+</CardGroup>
+
+
+# devcontainer build
+Source: https://www.mintlify.com/devcontainers/cli/reference/build
+
+Complete reference for the devcontainer build command.
+
+The `devcontainer build` command builds a dev container image without starting it. On success it writes a JSON result to stdout and exits with code `0`. On failure it exits with code `1`.
+
+## Usage
+
+```bash theme={null}
+devcontainer build [path] [options]
+```
+
+The optional `[path]` positional is the workspace folder path. If omitted, the current directory is used.
+
+<Note>
+  `--push` and `--output` are mutually exclusive.
+</Note>
+
+<Warning>
+  `--platform`, `--push`, `--output`, and `--cache-to` are not supported when the devcontainer.json uses `dockerComposeFile`.
+</Warning>
+
+## Options
+
+<AccordionGroup>
+  <Accordion title="Docker">
+    <ParamField type="string">
+      Docker CLI path.
+    </ParamField>
+
+    <ParamField type="string">
+      Docker Compose CLI path.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="Workspace">
+    <ParamField type="string">
+      Workspace folder path. The devcontainer.json will be looked up relative to this path. If not provided, defaults to the current directory.
+    </ParamField>
+
+    <ParamField type="string">
+      devcontainer.json path. The default is to use `.devcontainer/devcontainer.json` or, if that does not exist, `.devcontainer.json` in the workspace folder.
+    </ParamField>
+
+    <ParamField type="string">
+      Host path to a directory that is intended to be persisted and share state between sessions.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="Logging">
+    <ParamField type="string">
+      Log level. Choices: `info`, `debug`, `trace`.
+    </ParamField>
+
+    <ParamField type="string">
+      Log format. Choices: `text`, `json`.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="Build">
+    <ParamField type="boolean">
+      Builds the image with `--no-cache`.
+    </ParamField>
+
+    <ParamField type="string">
+      Image name. May be specified multiple times to apply multiple tags.
+    </ParamField>
+
+    <ParamField type="string">
+      Additional image to use as potential layer cache.
+
+      May be specified multiple times.
+    </ParamField>
+
+    <ParamField type="string">
+      A destination of buildx cache.
+    </ParamField>
+
+    <ParamField type="string">
+      Control whether BuildKit should be used. Choices: `auto`, `never`.
+    </ParamField>
+
+    <ParamField type="string">
+      Set target platforms.
+    </ParamField>
+
+    <ParamField type="boolean">
+      Push to a container registry.
+    </ParamField>
+
+    <ParamField type="string">
+      Provide key and value configuration that adds metadata to an image.
+
+      May be specified multiple times.
+    </ParamField>
+
+    <ParamField type="string">
+      Overrides the default behavior to load built images into the local docker registry. Valid options are the same ones provided to the `--output` option of `docker buildx build`.
+    </ParamField>
+
+    <ParamField type="string">
+      Additional features to apply to the dev container (JSON as per `"features"` section in devcontainer.json).
+    </ParamField>
+  </Accordion>
+</AccordionGroup>
+
+## Output
+
+All output is written to stdout as a single line of JSON.
+
+### Success
+
+```json theme={null}
+{
+  "outcome": "success",
+  "imageName": ["<image-name>"]
+}
+```
+
+`imageName` is an array containing one or more image name strings, corresponding to the tags applied during the build.
+
+### Error
+
+```json theme={null}
+{
+  "outcome": "error",
+  "message": "<short error message>",
+  "description": "<detailed description>"
+}
+```
+
+The process exits with code `1` on error.
+
+
+# devcontainer.json properties
+Source: https://www.mintlify.com/devcontainers/cli/reference/devcontainer-json-properties
+
+Complete reference for all supported devcontainer.json properties.
+
+A `devcontainer.json` file describes how to build and configure a development container. There are three mutually exclusive base configurations: image-based, Dockerfile-based, and Docker Compose-based. All three share a large set of common properties.
+
+## Base configuration
+
+Choose exactly one of the following approaches.
+
+<AccordionGroup>
+  <Accordion title="Image-based">
+    Use a pre-built Docker image as the base for your dev container.
+
+    <ResponseField name="image" type="string">
+      The name of a Docker image to use as the dev container base. Only optional when setting up an existing container as a dev container.
+
+      ```json theme={null}
+      { "image": "mcr.microsoft.com/devcontainers/base:ubuntu" }
+      ```
+    </ResponseField>
+  </Accordion>
+
+  <Accordion title="Dockerfile-based">
+    Build your dev container from a Dockerfile. You can use either the top-level shorthand or the nested `build` object.
+
+    <ResponseField name="dockerFile" type="string">
+      Path to the Dockerfile, relative to the `devcontainer.json` file. Shorthand alternative to `build.dockerfile`.
+
+      ```json theme={null}
+      { "dockerFile": "../Dockerfile" }
+      ```
+    </ResponseField>
+
+    <ResponseField name="context" type="string">
+      Path to the build context when using the `dockerFile` shorthand, relative to the `devcontainer.json` file.
+    </ResponseField>
+
+    <ResponseField name="build" type="object">
+      Object containing Dockerfile build settings.
+
+      <Expandable title="properties">
+        <ResponseField name="build.dockerfile" type="string">
+          Path to the Dockerfile, relative to the `devcontainer.json` file.
+
+          ```json theme={null}
+          { "build": { "dockerfile": "Dockerfile" } }
+          ```
+        </ResponseField>
+
+        <ResponseField name="build.context" type="string">
+          Path to the build context, relative to the `devcontainer.json` file. Defaults to the directory containing `devcontainer.json`.
+        </ResponseField>
+
+        <ResponseField name="build.args" type="object">
+          Build arguments (`--build-arg`) passed to `docker build` as key-value pairs.
+
+          ```json theme={null}
+          { "build": { "args": { "NODE_VERSION": "18" } } }
+          ```
+        </ResponseField>
+
+        <ResponseField name="build.target" type="string">
+          The target build stage to use when the Dockerfile contains multiple stages.
+        </ResponseField>
+
+        <ResponseField name="build.cacheFrom" type="string | string[]">
+          One or more image names to use as layer cache sources during the build.
+
+          ```json theme={null}
+          { "build": { "cacheFrom": "ghcr.io/myorg/myimage:latest" } }
+          ```
+        </ResponseField>
+
+        <ResponseField name="build.options" type="string[]">
+          Additional arguments to pass to `docker build`, for example `["--add-host=host.docker.internal:host-gateway"]`.
+        </ResponseField>
+      </Expandable>
+    </ResponseField>
+  </Accordion>
+
+  <Accordion title="Docker Compose-based">
+    Use Docker Compose to orchestrate multiple containers.
+
+    <ResponseField name="dockerComposeFile" type="string | string[]">
+      Path or array of paths to Docker Compose files, relative to the `devcontainer.json` file.
+
+      ```json theme={null}
+      { "dockerComposeFile": "docker-compose.yml" }
+      ```
+
+      ```json theme={null}
+      { "dockerComposeFile": ["docker-compose.yml", "docker-compose.override.yml"] }
+      ```
+    </ResponseField>
+
+    <ResponseField name="service" type="string">
+      The name of the service in the Docker Compose file to use as the dev container.
+    </ResponseField>
+
+    <ResponseField name="runServices" type="string[]">
+      Additional services from the Docker Compose file to start alongside the dev container service.
+
+      ```json theme={null}
+      { "runServices": ["db", "redis"] }
+      ```
+    </ResponseField>
+  </Accordion>
+</AccordionGroup>
+
+## Container identity
+
+<ResponseField name="name" type="string">
+  A display name for the dev container.
+</ResponseField>
+
+<ResponseField name="containerUser" type="string">
+  The user to run container processes as (equivalent to `--user` in `docker run`). If not set, the image's default user is used.
+</ResponseField>
+
+<ResponseField name="remoteUser" type="string">
+  The user that lifecycle scripts, remote tools, and terminal sessions run as inside the container. Defaults to `containerUser`.
+
+  <Note>This does not change which user the container process runs as — use `containerUser` for that.</Note>
+</ResponseField>
+
+<ResponseField name="updateRemoteUserUID" type="boolean">
+  When `true` (the default), the CLI updates the UID and GID of the `remoteUser` inside the container to match the local user's UID and GID. This avoids file permission issues when bind-mounting the workspace.
+</ResponseField>
+
+<ResponseField name="userEnvProbe" type="&#x22;none&#x22; | &#x22;loginInteractiveShell&#x22; | &#x22;interactiveShell&#x22; | &#x22;loginShell&#x22;">
+  Controls how the CLI probes the container to determine the remote user's environment, particularly `PATH`. The shell invocation method determines which profile and rc files are sourced. Defaults to `loginInteractiveShell`.
+
+  | Value                   | Shell invocation                                   |
+  | ----------------------- | -------------------------------------------------- |
+  | `none`                  | No shell is launched; no profile files are sourced |
+  | `loginInteractiveShell` | `bash --login -i`                                  |
+  | `interactiveShell`      | `bash -i`                                          |
+  | `loginShell`            | `bash --login`                                     |
+
+  See [Environment variables — userEnvProbe](/reference/environment-variables#userenvprobe) for details.
+</ResponseField>
+
+## Networking and ports
+
+<ResponseField name="forwardPorts" type="(number | string)[]">
+  Ports to forward from the container to the host. Each entry is either a port number or a `"host:container"` string to map to a specific host port.
+
+  ```json theme={null}
+  { "forwardPorts": [3000, "8080:80"] }
+  ```
+</ResponseField>
+
+<ResponseField name="appPort" type="number | string | (number | string)[]">
+  A port, string, or array of ports/strings to forward. Similar to `forwardPorts` but intended for the primary application port.
+</ResponseField>
+
+<ResponseField name="portsAttributes" type="object">
+  Per-port configuration. Keys are port numbers or ranges; values are `PortAttributes` objects.
+
+  <Expandable title="PortAttributes properties">
+    <ResponseField name="label" type="string">
+      A human-readable label for the port shown in tools like VS Code.
+    </ResponseField>
+
+    <ResponseField name="onAutoForward" type="string">
+      The action to take when the port is automatically forwarded. Common values: `"notify"`, `"openBrowser"`, `"openBrowserOnce"`, `"openPreview"`, `"silent"`, `"ignore"`.
+    </ResponseField>
+
+    <ResponseField name="elevateIfNeeded" type="boolean">
+      When `true`, elevates privileges if the port number requires it (ports below 1024 on Linux).
+    </ResponseField>
+  </Expandable>
+
+  ```json theme={null}
+  {
+    "portsAttributes": {
+      "3000": { "label": "Application", "onAutoForward": "openBrowser" },
+      "5432": { "label": "Postgres", "onAutoForward": "silent" }
+    }
+  }
+  ```
+</ResponseField>
+
+<ResponseField name="otherPortsAttributes" type="object">
+  Default `PortAttributes` configuration applied to any port not explicitly listed in `portsAttributes`.
+</ResponseField>
+
+## Environment
+
+<ResponseField name="containerEnv" type="Record<string, string>">
+  Environment variables set on the container itself, available to all processes. Variables are passed to `docker run` via `--env`.
+
+  ```json theme={null}
+  { "containerEnv": { "MY_VARIABLE": "value" } }
+  ```
+
+  <Warning>These values are stored in image metadata. Do not use `containerEnv` for secrets.</Warning>
+</ResponseField>
+
+<ResponseField name="remoteEnv" type="Record<string, string | null>">
+  Environment variables injected by the CLI into lifecycle scripts and remote tool sessions. Supports variable substitution. Set a value to `null` to unset a variable.
+
+  ```json theme={null}
+  {
+    "remoteEnv": {
+      "PATH": "${containerEnv:PATH}:/home/user/.local/bin",
+      "LOCAL_HOME": "${localEnv:HOME}"
+    }
+  }
+  ```
+
+  See [Environment variables](/reference/environment-variables) for supported substitution patterns.
+</ResponseField>
+
+## Mounts and filesystem
+
+<ResponseField name="mounts" type="(Mount | string)[]">
+  Additional mount points added to the container. Each entry is either a mount object or a Docker `--mount` string.
+
+  <Expandable title="Mount object properties">
+    <ResponseField name="type" type="&#x22;bind&#x22; | &#x22;volume&#x22;">
+      The mount type.
+    </ResponseField>
+
+    <ResponseField name="source" type="string">
+      The source path on the host (for bind mounts) or the volume name.
+    </ResponseField>
+
+    <ResponseField name="target" type="string">
+      The absolute path inside the container.
+    </ResponseField>
+
+    <ResponseField name="external" type="boolean">
+      When `true`, marks the volume as external (not managed by the dev container lifecycle).
+    </ResponseField>
+  </Expandable>
+
+  ```json theme={null}
+  {
+    "mounts": [
+      {
+        "type": "bind",
+        "source": "${localEnv:HOME}/.ssh",
+        "target": "/home/user/.ssh"
+      }
+    ]
+  }
+  ```
+</ResponseField>
+
+<ResponseField name="workspaceFolder" type="string">
+  The absolute path inside the container where the workspace is mounted. Required for Docker Compose configurations.
+</ResponseField>
+
+<ResponseField name="workspaceMount" type="string">
+  Overrides the default workspace mount. Uses Docker `--mount` string syntax. Useful when you need custom mount options.
+</ResponseField>
+
+## Container runtime
+
+<ResponseField name="runArgs" type="string[]">
+  Additional arguments passed to `docker run` when creating the container.
+
+  ```json theme={null}
+  { "runArgs": ["--network=host", "--cap-add=SYS_PTRACE"] }
+  ```
+</ResponseField>
+
+<ResponseField name="overrideCommand" type="boolean">
+  When `true` (the default), the container's default command (`CMD`) is overridden with a long-running process to keep it alive. Set to `false` to use the image's built-in command.
+</ResponseField>
+
+<ResponseField name="shutdownAction" type="&#x22;none&#x22; | &#x22;stopContainer&#x22; | &#x22;stopCompose&#x22;">
+  What happens to the container when the last client disconnects.
+
+  | Value           | Behavior                                                |
+  | --------------- | ------------------------------------------------------- |
+  | `none`          | Container keeps running                                 |
+  | `stopContainer` | Container is stopped (image-based and Dockerfile-based) |
+  | `stopCompose`   | All Compose services are stopped (Docker Compose only)  |
+</ResponseField>
+
+<ResponseField name="init" type="boolean">
+  When `true`, runs a minimal init process (`tini`) inside the container to forward signals and reap zombie processes. Equivalent to `docker run --init`.
+</ResponseField>
+
+<ResponseField name="privileged" type="boolean">
+  When `true`, runs the container in privileged mode. Equivalent to `docker run --privileged`.
+
+  <Warning>Privileged mode grants the container nearly full host access. Use only when required.</Warning>
+</ResponseField>
+
+<ResponseField name="capAdd" type="string[]">
+  Linux capabilities to add to the container. Equivalent to `docker run --cap-add`.
+
+  ```json theme={null}
+  { "capAdd": ["SYS_PTRACE"] }
+  ```
+</ResponseField>
+
+<ResponseField name="securityOpt" type="string[]">
+  Security options for the container. Equivalent to `docker run --security-opt`.
+
+  ```json theme={null}
+  { "securityOpt": ["seccomp=unconfined"] }
+  ```
+</ResponseField>
+
+## Features
+
+<ResponseField name="features" type="Record<string, string | boolean | object>">
+  Dev container Features to install. Keys are Feature identifiers (OCI references, GitHub references, or local paths); values are option objects, or a shorthand string/boolean for single-option Features.
+
+  ```json theme={null}
+  {
+    "features": {
+      "ghcr.io/devcontainers/features/node:1": { "version": "18" },
+      "ghcr.io/devcontainers/features/git:1": {}
+    }
+  }
+  ```
+</ResponseField>
+
+<ResponseField name="overrideFeatureInstallOrder" type="string[]">
+  Explicitly sets the installation order for Features. Any Features not listed are installed after those that are, in an automatically determined order.
+
+  ```json theme={null}
+  { "overrideFeatureInstallOrder": ["ghcr.io/devcontainers/features/common-utils"] }
+  ```
+</ResponseField>
+
+## Lifecycle commands
+
+Lifecycle commands run at specific points during the container lifecycle. Each accepts a string (shell command), an array of strings (command + arguments, without a shell), or for some hooks an object whose keys are label names and values are commands to run in parallel.
+
+<Tip>Use `waitFor` to tell the CLI which command to wait on before declaring the container ready, enabling later commands to run in the background.</Tip>
+
+<ResponseField name="initializeCommand" type="string | string[]">
+  Runs on the **host** before the container is created or started. Because it runs on the host, this command has access to host environment variables and tools but not the container.
+</ResponseField>
+
+<ResponseField name="onCreateCommand" type="string | string[]">
+  Runs inside the container after it is created for the first time. Runs once per container lifetime.
+</ResponseField>
+
+<ResponseField name="updateContentCommand" type="string | string[]">
+  Runs inside the container when the source content changes (for example, after a `git pull`). May run more than once over the container lifetime.
+</ResponseField>
+
+<ResponseField name="postCreateCommand" type="string | string[]">
+  Runs inside the container after `onCreateCommand` and `updateContentCommand` complete. Runs once per container lifetime.
+</ResponseField>
+
+<ResponseField name="postStartCommand" type="string | string[]">
+  Runs inside the container each time the container starts (not just when it is first created).
+</ResponseField>
+
+<ResponseField name="postAttachCommand" type="string | string[]">
+  Runs inside the container each time a client attaches to it.
+</ResponseField>
+
+<ResponseField name="waitFor" type="&#x22;initializeCommand&#x22; | &#x22;onCreateCommand&#x22; | &#x22;updateContentCommand&#x22; | &#x22;postCreateCommand&#x22; | &#x22;postStartCommand&#x22; | &#x22;postAttachCommand&#x22;">
+  The lifecycle command the CLI should wait for before reporting the container as ready. Subsequent commands continue running in the background. Defaults to `updateContentCommand`.
+</ResponseField>
+
+## Host requirements
+
+The `hostRequirements` object declares minimum hardware the host must satisfy. Tools can use this to warn users or prevent container creation on under-resourced machines.
+
+<ResponseField name="hostRequirements" type="object">
+  <Expandable title="properties">
+    <ResponseField name="hostRequirements.cpus" type="number">
+      Minimum number of CPU cores required.
+    </ResponseField>
+
+    <ResponseField name="hostRequirements.memory" type="string">
+      Minimum memory required. Use a string with a unit suffix, for example `"4gb"`.
+    </ResponseField>
+
+    <ResponseField name="hostRequirements.storage" type="string">
+      Minimum storage required. Use a string with a unit suffix, for example `"32gb"`.
+    </ResponseField>
+
+    <ResponseField name="hostRequirements.gpu" type="boolean | &#x22;optional&#x22; | object">
+      GPU requirement. `true` requires a GPU; `"optional"` uses a GPU when available; an object specifies minimum GPU capabilities.
+
+      <Expandable title="GPU object properties">
+        <ResponseField name="cores" type="number">
+          Minimum number of GPU cores required.
+        </ResponseField>
+
+        <ResponseField name="memory" type="string">
+          Minimum GPU memory required, for example `"4gb"`.
+        </ResponseField>
+      </Expandable>
+    </ResponseField>
+  </Expandable>
+
+  ```json theme={null}
+  {
+    "hostRequirements": {
+      "cpus": 4,
+      "memory": "8gb",
+      "storage": "32gb",
+      "gpu": { "cores": 1, "memory": "4gb" }
+    }
+  }
+  ```
+</ResponseField>
+
+## Customizations
+
+<ResponseField name="customizations" type="Record<string, any>">
+  Tool-specific configuration. Each key is a tool identifier; the value is an object defined by that tool.
+
+  The VS Code extension uses `customizations.vscode` to configure extensions and settings:
+
+  ```json theme={null}
+  {
+    "customizations": {
+      "vscode": {
+        "extensions": ["dbaeumer.vscode-eslint"],
+        "settings": {
+          "editor.formatOnSave": true
+        }
+      }
+    }
+  }
+  ```
+
+  <Note>The top-level `extensions`, `settings`, and `devPort` properties are deprecated. Use `customizations.vscode` instead.</Note>
+</ResponseField>
+
+
+# Environment variables
+Source: https://www.mintlify.com/devcontainers/cli/reference/environment-variables
+
+Environment variables available inside dev containers and how to configure them.
+
+Dev containers provide several ways to set and propagate environment variables, from static values in `devcontainer.json` to dynamic substitution from the host environment.
+
+## Container environment variables
+
+### containerEnv
+
+`containerEnv` sets environment variables on the container process at creation time. Every process running in the container — including long-running services — sees these values.
+
+```json devcontainer.json theme={null}
+{
+  "containerEnv": {
+    "NODE_ENV": "development",
+    "PORT": "3000"
+  }
+}
+```
+
+Values are passed to `docker run --env` and are also stored in image metadata.
+
+<Warning>
+  Because `containerEnv` values are stored in image metadata, do not use this property for secrets or credentials. Use the `--secrets-file` CLI flag instead.
+</Warning>
+
+### remoteEnv
+
+`remoteEnv` sets environment variables that the CLI injects into lifecycle script executions and remote tool sessions (such as integrated terminals). These variables are layered on top of the container's environment; they are not set at the Docker level and do not affect services started independently inside the container.
+
+```json devcontainer.json theme={null}
+{
+  "remoteEnv": {
+    "PATH": "${containerEnv:PATH}:/home/user/.local/bin",
+    "LOCAL_HOME": "${localEnv:HOME}",
+    "WORKSPACE": "${containerWorkspaceFolder}"
+  }
+}
+```
+
+Setting a key to `null` unsets the variable:
+
+```json devcontainer.json theme={null}
+{
+  "remoteEnv": {
+    "UNWANTED_VAR": null
+  }
+}
+```
+
+## Variable substitution
+
+Both `containerEnv` and `remoteEnv` (as well as several other string-valued properties in `devcontainer.json`) support variable substitution using the `${variable}` syntax.
+
+<AccordionGroup>
+  <Accordion title="Host environment — ${localEnv:NAME}">
+    Reads the variable `NAME` from the host (local) environment at the time the CLI processes the configuration.
+
+    ```json theme={null}
+    { "remoteEnv": { "HOST_USER": "${localEnv:USER}" } }
+    ```
+
+    <Tip>If the variable is not set on the host, the substitution resolves to an empty string.</Tip>
+  </Accordion>
+
+  <Accordion title="Container environment — ${containerEnv:NAME}">
+    Reads the variable `NAME` from the running container's environment. Only valid in `remoteEnv`, where the container is already running when the substitution is evaluated.
+
+    ```json theme={null}
+    {
+      "remoteEnv": {
+        "PATH": "${containerEnv:PATH}:/usr/local/mytools/bin"
+      }
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="Workspace paths">
+    | Pattern                           | Resolves to                                                           |
+    | --------------------------------- | --------------------------------------------------------------------- |
+    | `${localWorkspaceFolder}`         | Absolute path to the workspace folder on the **host**                 |
+    | `${containerWorkspaceFolder}`     | Absolute path to the workspace folder **inside the container**        |
+    | `${localWorkspaceFolderBasename}` | The base name (last path segment) of the workspace folder on the host |
+
+    ```json theme={null}
+    {
+      "remoteEnv": {
+        "PROJECT_ROOT": "${containerWorkspaceFolder}",
+        "PROJECT_NAME": "${localWorkspaceFolderBasename}"
+      }
+    }
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## userEnvProbe
+
+The `userEnvProbe` property controls how the CLI determines the remote user's shell environment — particularly the `PATH` — when entering the container. The CLI runs a short-lived shell using the specified invocation style and captures the resulting environment.
+
+```json devcontainer.json theme={null}
+{
+  "userEnvProbe": "loginInteractiveShell"
+}
+```
+
+| Value                   | Shell invocation  | Profile files sourced                          |
+| ----------------------- | ----------------- | ---------------------------------------------- |
+| `none`                  | No shell launched | None                                           |
+| `loginInteractiveShell` | `bash --login -i` | `/etc/profile`, `~/.bash_profile`, `~/.bashrc` |
+| `interactiveShell`      | `bash -i`         | `~/.bashrc`                                    |
+| `loginShell`            | `bash --login`    | `/etc/profile`, `~/.bash_profile`              |
+
+The default value is `loginInteractiveShell`, which sources the broadest set of profile files and produces an environment closest to an interactive login session.
+
+<Note>
+  Tools can override the default with the `--default-user-env-probe` CLI flag when invoking `devcontainer up`, `set-up`, or `run-user-commands`.
+</Note>
+
+## Remote environment via CLI flags
+
+You can inject additional remote environment variables at runtime without modifying `devcontainer.json` by using the `--remote-env` flag on the `up`, `set-up`, and `run-user-commands` commands.
+
+```bash theme={null}
+devcontainer up --workspace-folder . \
+  --remote-env MY_TOKEN=abc123 \
+  --remote-env DEBUG=true
+```
+
+The format is `NAME=VALUE`. Pass the flag multiple times to set multiple variables. These variables are added to the same layer as `remoteEnv` from `devcontainer.json` and are not stored in image metadata.
+
+<Note>The value may be empty: `--remote-env EMPTY_VAR=` is valid.</Note>
+
+## Secrets
+
+The `--secrets-file` flag on `up` and `run-user-commands` loads secret environment variables from a JSON file. Secrets are injected into lifecycle scripts and remote sessions in the same way as `remoteEnv`, but they are **never stored in container or image metadata**.
+
+```bash theme={null}
+devcontainer up --workspace-folder . --secrets-file ./secrets.json
+```
+
+The secrets file must be a flat JSON object of string key-value pairs:
+
+```json secrets.json theme={null}
+{
+  "NPM_TOKEN": "npm_xxxxxxxxxxxx",
+  "DATABASE_URL": "postgres://user:pass@localhost/mydb",
+  "API_KEY": "[REDACTED-OPENAI-DOCS-EXAMPLE]"
+}
+```
+
+<Warning>
+  Keep your secrets file out of source control. Add it to `.gitignore` and never commit it to your repository.
+</Warning>
+
+
+# devcontainer exec
+Source: https://www.mintlify.com/devcontainers/cli/reference/exec
+
+Complete reference for the devcontainer exec command.
+
+The `devcontainer exec` command runs a command inside an already-running dev container. The exit code mirrors the exit code of the executed command.
+
+## Usage
+
+```bash theme={null}
+devcontainer exec [options] <cmd> [args..]
+```
+
+<ParamField type="string">
+  Command to execute.
+</ParamField>
+
+<ParamField type="string[]">
+  Arguments to the command.
+</ParamField>
+
+<Note>
+  If `--container-id`, `--id-label`, and `--workspace-folder` are all omitted, `--workspace-folder` defaults to the current working directory.
+</Note>
+
+## Options
+
+<AccordionGroup>
+  <Accordion title="Container selection">
+    <ParamField type="string">
+      Workspace folder path. The devcontainer.json will be looked up relative to this path. If `--container-id`, `--id-label`, and `--workspace-folder` are not provided, this defaults to the current directory.
+    </ParamField>
+
+    <ParamField type="string">
+      Id of the container to run the user commands for.
+    </ParamField>
+
+    <ParamField type="string">
+      Id label(s) of the format `name=value`. If no `--container-id` is given the id labels will be used to look up the container. If no `--id-label` is given, one will be inferred from the `--workspace-folder` path.
+
+      May be specified multiple times.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="Configuration">
+    <ParamField type="string">
+      devcontainer.json path. The default is to use `.devcontainer/devcontainer.json` or, if that does not exist, `.devcontainer.json` in the workspace folder.
+    </ParamField>
+
+    <ParamField type="string">
+      devcontainer.json path to override any devcontainer.json in the workspace folder (or built-in configuration). This is required when there is no devcontainer.json otherwise.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="Docker">
+    <ParamField type="string">
+      Docker CLI path.
+    </ParamField>
+
+    <ParamField type="string">
+      Docker Compose CLI path.
+    </ParamField>
+
+    <ParamField type="string">
+      Container data folder where user data inside the container will be stored.
+    </ParamField>
+
+    <ParamField type="string">
+      Container system data folder where system data inside the container will be stored.
+    </ParamField>
+
+    <ParamField type="string">
+      Host path to a directory that is intended to be persisted and share state between sessions.
+    </ParamField>
+
+    <ParamField type="boolean">
+      Mount the workspace using its Git root.
+    </ParamField>
+
+    <ParamField type="boolean">
+      Mount the Git worktree common dir for Git operations to work in the container. This requires the worktree to be created with relative paths (`git worktree add --relative-paths`).
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="Logging">
+    <ParamField type="string">
+      Log level for the `--terminal-log-file`. When set to `trace`, the log level for `--log-file` will also be set to `trace`. Choices: `info`, `debug`, `trace`.
+    </ParamField>
+
+    <ParamField type="string">
+      Log format. Choices: `text`, `json`.
+    </ParamField>
+
+    <ParamField type="number">
+      Number of columns to render the output for. This is required for some of the subprocesses to correctly render their output. Implies `--terminal-rows`.
+    </ParamField>
+
+    <ParamField type="number">
+      Number of rows to render the output for. This is required for some of the subprocesses to correctly render their output. Implies `--terminal-columns`.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="Environment">
+    <ParamField type="string">
+      Default value for the devcontainer.json's `"userEnvProbe"`. Choices: `none`, `loginInteractiveShell`, `interactiveShell`, `loginShell`.
+    </ParamField>
+
+    <ParamField type="string">
+      Remote environment variables of the format `name=value`. These will be added when executing the user commands.
+
+      May be specified multiple times.
+    </ParamField>
+  </Accordion>
+</AccordionGroup>
+
+## Examples
+
+```bash theme={null}
+# Run a command in the container resolved from the current directory
+devcontainer exec -- bash -c "echo hello"
+
+# Run a command in a specific container
+devcontainer exec --container-id <id> node --version
+
+# Run a command with a custom remote environment variable
+devcontainer exec --remote-env MY_VAR=value -- make test
+```
+
+
+# devcontainer features
+Source: https://www.mintlify.com/devcontainers/cli/reference/features-commands
+
+Complete reference for all devcontainer features subcommands.
+
+The `devcontainer features` group of commands provides tooling to test, package, publish, and inspect dev container Features.
+
+## Subcommands
+
+<AccordionGroup>
+  <Accordion title="features test [target]">
+    Test Features in a collection.
+
+    ```bash theme={null}
+    devcontainer features test [target] [options]
+    ```
+
+    The deprecated `[target]` positional is the path to the folder containing `src` and `test` sub-folders. Use `--project-folder` instead.
+
+    <ParamField type="string">
+      Path to folder containing `src` and `test` sub-folders. This is likely the git root of the project. Alias: `-p`.
+    </ParamField>
+
+    <ParamField type="string[]">
+      Feature(s) to test as space-separated parameters. Omit to run all tests. Cannot be combined with `--global-scenarios-only`. Alias: `-f`.
+    </ParamField>
+
+    <ParamField type="string">
+      Filter current tests to only run scenarios containing this string. Cannot be combined with `--skip-scenarios`.
+    </ParamField>
+
+    <ParamField type="boolean">
+      Run only scenario tests under `tests/_global`. Cannot be combined with `-f`.
+    </ParamField>
+
+    <ParamField type="boolean">
+      Skip all `scenario` style tests. Cannot be combined with `--global-scenarios-only`.
+    </ParamField>
+
+    <ParamField type="boolean">
+      Skip all `autogenerated` style tests (test.sh).
+    </ParamField>
+
+    <ParamField type="boolean">
+      Skip all `duplicate` style tests (duplicate.sh).
+    </ParamField>
+
+    <ParamField type="boolean">
+      Allow an element of randomness in test cases.
+    </ParamField>
+
+    <ParamField type="string">
+      Base Image. Not used for scenarios. Alias: `-i`.
+    </ParamField>
+
+    <ParamField type="string">
+      Remote user. Not used for scenarios. Alias: `-u`.
+    </ParamField>
+
+    <ParamField type="string">
+      Log level. Choices: `info`, `debug`, `trace`.
+    </ParamField>
+
+    <ParamField type="boolean">
+      Do not remove test containers after running tests.
+    </ParamField>
+
+    <ParamField type="boolean">
+      Quiets output. Alias: `-q`.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="features package <target>">
+    Package Features from a collection into distributable archives.
+
+    ```bash theme={null}
+    devcontainer features package <target> [options]
+    ```
+
+    <ParamField type="string">
+      Package features at provided `[target]` (default is cwd), where `[target]` is either:
+
+      1. A path to the `src` folder of the collection with one or more features.
+      2. A path to a single feature that contains a `devcontainer-feature.json`.
+
+      A `devcontainer-collection.json` will also be generated in the output directory.
+    </ParamField>
+
+    <ParamField type="string">
+      Path to output directory. Will create directories as needed. Alias: `-o`.
+    </ParamField>
+
+    <ParamField type="boolean">
+      Automatically delete previous output directory before packaging. Alias: `-f`.
+    </ParamField>
+
+    <ParamField type="string">
+      Log level. Choices: `info`, `debug`, `trace`.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="features publish <target>">
+    Package and publish Features to an OCI registry.
+
+    ```bash theme={null}
+    devcontainer features publish <target> [options]
+    ```
+
+    <ParamField type="string">
+      Package and publish features at provided `[target]` (default is cwd), where `[target]` is either:
+
+      1. A path to the `src` folder of the collection with one or more features.
+      2. A path to a single feature that contains a `devcontainer-feature.json`.
+    </ParamField>
+
+    <ParamField type="string">
+      Name of the OCI registry. Alias: `-r`.
+    </ParamField>
+
+    <ParamField type="string">
+      Unique identifier for the collection of features. Example: `<owner>/<repo>`. Alias: `-n`.
+    </ParamField>
+
+    <ParamField type="string">
+      Log level. Choices: `info`, `debug`, `trace`.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="features info <mode> <feature>">
+    Fetch metadata for a published Feature.
+
+    ```bash theme={null}
+    devcontainer features info <mode> <feature> [options]
+    ```
+
+    <ParamField type="string">
+      Data to query. Choices: `manifest`, `tags`, `dependencies`, `verbose`. Select `verbose` to return everything.
+    </ParamField>
+
+    <ParamField type="string">
+      Feature identifier (e.g., `ghcr.io/devcontainers/features/node:1`).
+    </ParamField>
+
+    <ParamField type="string">
+      Log level. Choices: `info`, `debug`, `trace`.
+    </ParamField>
+
+    <ParamField type="string">
+      Output format. Choices: `text`, `json`.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="features resolve-dependencies">
+    Read and resolve the dependency graph from a devcontainer.json configuration, then output the computed installation order.
+
+    ```bash theme={null}
+    devcontainer features resolve-dependencies [options]
+    ```
+
+    <ParamField type="string">
+      Workspace folder to use for the configuration. If `--workspace-folder` is not provided, this defaults to the current directory.
+    </ParamField>
+
+    <ParamField type="string">
+      Log level. Choices: `error`, `info`, `debug`, `trace`.
+    </ParamField>
+
+    The command outputs a Mermaid dependency diagram followed by a JSON object:
+
+    ```json theme={null}
+    {
+      "installOrder": [
+        { "id": "<feature-ref>@<digest>", "options": {} }
+      ]
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="features generate-docs">
+    Generate documentation for a Feature collection.
+
+    ```bash theme={null}
+    devcontainer features generate-docs [options]
+    ```
+
+    <ParamField type="string">
+      Path to folder containing `src` and `test` sub-folders. This is likely the git root of the project. Alias: `-p`.
+    </ParamField>
+
+    <ParamField type="string">
+      Name of the OCI registry. Alias: `-r`.
+    </ParamField>
+
+    <ParamField type="string">
+      Unique identifier for the collection of features. Example: `<owner>/<repo>`. Alias: `-n`.
+    </ParamField>
+
+    <ParamField type="string">
+      GitHub owner for docs.
+    </ParamField>
+
+    <ParamField type="string">
+      GitHub repo for docs.
+    </ParamField>
+
+    <ParamField type="string">
+      Log level. Choices: `info`, `debug`, `trace`.
+    </ParamField>
+  </Accordion>
+</AccordionGroup>
+
+
+# devcontainer templates
+Source: https://www.mintlify.com/devcontainers/cli/reference/templates-commands
+
+Complete reference for all devcontainer templates subcommands.
+
+The `devcontainer templates` group of commands provides tooling to apply, package, publish, and inspect dev container Templates.
+
+## Subcommands
+
+<AccordionGroup>
+  <Accordion title="templates apply">
+    Apply a Template to the current project.
+
+    ```bash theme={null}
+    devcontainer templates apply [options]
+    ```
+
+    <ParamField type="string">
+      Target workspace folder to apply Template. If `--workspace-folder` is not provided, this defaults to the current directory. Alias: `-w`.
+    </ParamField>
+
+    <ParamField type="string">
+      Reference to a Template in a supported OCI registry. Alias: `-t`.
+    </ParamField>
+
+    <ParamField type="string">
+      Arguments to replace within the provided Template, provided as JSON. Alias: `-a`.
+    </ParamField>
+
+    <ParamField type="string">
+      Features to add to the provided Template, provided as JSON. Alias: `-f`.
+    </ParamField>
+
+    <ParamField type="string">
+      Log level. Choices: `info`, `debug`, `trace`.
+    </ParamField>
+
+    <ParamField type="string">
+      Directory to use for temporary files. If not provided, the system default will be inferred.
+    </ParamField>
+
+    <ParamField type="string">
+      List of paths within the Template to omit applying, provided as JSON. To ignore a directory append `/*`. Example: `[".github/*", "dir/a/*", "file.ts"]`.
+    </ParamField>
+
+    On success the command writes the applied file paths to stdout:
+
+    ```json theme={null}
+    { "files": ["<relative-path>", ...] }
+    ```
+  </Accordion>
+
+  <Accordion title="templates publish <target>">
+    Package and publish Templates to an OCI registry.
+
+    ```bash theme={null}
+    devcontainer templates publish <target> [options]
+    ```
+
+    <ParamField type="string">
+      Package and publish templates at provided `[target]` (default is cwd), where `[target]` is either:
+
+      1. A path to the `src` folder of the collection with one or more templates.
+      2. A path to a single template that contains a `devcontainer-template.json`.
+    </ParamField>
+
+    <ParamField type="string">
+      Name of the OCI registry. Alias: `-r`.
+    </ParamField>
+
+    <ParamField type="string">
+      Unique identifier for the collection of templates. Example: `<owner>/<repo>`. Alias: `-n`.
+    </ParamField>
+
+    <ParamField type="string">
+      Log level. Choices: `info`, `debug`, `trace`.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="templates metadata <templateId>">
+    Fetch a published Template's metadata from its OCI manifest.
+
+    ```bash theme={null}
+    devcontainer templates metadata <templateId> [options]
+    ```
+
+    <ParamField type="string">
+      Template identifier (e.g., `ghcr.io/devcontainers/templates/debian:latest`).
+    </ParamField>
+
+    <ParamField type="string">
+      Log level. Choices: `info`, `debug`, `trace`.
+    </ParamField>
+
+    <Warning>
+      Templates must have been published with a CLI version from after [this commit](https://github.com/devcontainers/cli/commit/6c6aebfa7b74aea9d67760fd1e74b09573d31536) to contain attached metadata in the manifest. Ask the Template owner to republish if metadata is missing.
+    </Warning>
+
+    On success the command writes the template metadata JSON to stdout.
+  </Accordion>
+
+  <Accordion title="templates generate-docs">
+    Generate documentation for a Template collection.
+
+    ```bash theme={null}
+    devcontainer templates generate-docs [options]
+    ```
+
+    <ParamField type="string">
+      Path to folder containing `src` and `test` sub-folders. This is likely the git root of the project. Alias: `-p`.
+    </ParamField>
+
+    <ParamField type="string">
+      GitHub owner for docs.
+    </ParamField>
+
+    <ParamField type="string">
+      GitHub repo for docs.
+    </ParamField>
+
+    <ParamField type="string">
+      Log level. Choices: `info`, `debug`, `trace`.
+    </ParamField>
+  </Accordion>
+</AccordionGroup>
+
+
+# devcontainer up
+Source: https://www.mintlify.com/devcontainers/cli/reference/up
+
+Complete reference for the devcontainer up command.
+
+The `devcontainer up` command creates and starts a dev container from a `devcontainer.json` configuration. On success it writes a JSON result to stdout and exits with code `0`. On failure it exits with code `1`.
+
+## Usage
+
+```bash theme={null}
+devcontainer up [options]
+```
+
+<Note>
+  If `--id-label`, `--override-config`, and `--workspace-folder` are all omitted, `--workspace-folder` defaults to the current working directory.
+</Note>
+
+## Options
+
+<AccordionGroup>
+  <Accordion title="Docker">
+    <ParamField type="string">
+      Docker CLI path.
+    </ParamField>
+
+    <ParamField type="string">
+      Docker Compose CLI path.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="Workspace">
+    <ParamField type="string">
+      Workspace folder path. The devcontainer.json will be looked up relative to this path. If `--id-label`, `--override-config`, and `--workspace-folder` are not provided, this defaults to the current directory.
+    </ParamField>
+
+    <ParamField type="string">
+      Workspace mount consistency. Choices: `consistent`, `cached`, `delegated`.
+    </ParamField>
+
+    <ParamField type="boolean">
+      Mount the workspace using its Git root.
+    </ParamField>
+
+    <ParamField type="boolean">
+      Mount the Git worktree common dir for Git operations to work in the container. This requires the worktree to be created with relative paths (`git worktree add --relative-paths`).
+    </ParamField>
+
+    <ParamField type="string">
+      Additional mount point(s). Format: `type=<bind|volume>,source=<source>,target=<target>[,external=<true|false>]`
+
+      May be specified multiple times.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="Container data folders">
+    <ParamField type="string">
+      Container data folder where user data inside the container will be stored.
+    </ParamField>
+
+    <ParamField type="string">
+      Container system data folder where system data inside the container will be stored.
+    </ParamField>
+
+    <ParamField type="string">
+      Folder to cache CLI data, for example userEnvProbe results.
+    </ParamField>
+
+    <ParamField type="string">
+      Host path to a directory that is intended to be persisted and share state between sessions.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="Configuration">
+    <ParamField type="string">
+      devcontainer.json path. The default is to use `.devcontainer/devcontainer.json` or, if that does not exist, `.devcontainer.json` in the workspace folder.
+    </ParamField>
+
+    <ParamField type="string">
+      devcontainer.json path to override any devcontainer.json in the workspace folder (or built-in configuration). This is required when there is no devcontainer.json otherwise.
+    </ParamField>
+
+    <ParamField type="string">
+      Id label(s) of the format `name=value`. These will be set on the container and used to query for an existing container. If no `--id-label` is given, one will be inferred from the `--workspace-folder` path.
+
+      May be specified multiple times.
+    </ParamField>
+
+    <ParamField type="string">
+      Additional features to apply to the dev container (JSON as per `"features"` section in devcontainer.json).
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="Logging">
+    <ParamField type="string">
+      Log level for the `--terminal-log-file`. When set to `trace`, the log level for `--log-file` will also be set to `trace`. Choices: `info`, `debug`, `trace`.
+    </ParamField>
+
+    <ParamField type="string">
+      Log format. Choices: `text`, `json`.
+    </ParamField>
+
+    <ParamField type="number">
+      Number of columns to render the output for. This is required for some of the subprocesses to correctly render their output. Implies `--terminal-rows`.
+    </ParamField>
+
+    <ParamField type="number">
+      Number of rows to render the output for. This is required for some of the subprocesses to correctly render their output. Implies `--terminal-columns`.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="GPU">
+    <ParamField type="string">
+      Availability of GPUs in case the dev container requires any. `all` expects a GPU to be available. Choices: `all`, `detect`, `none`.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="Environment">
+    <ParamField type="string">
+      Default value for the devcontainer.json's `"userEnvProbe"`. Choices: `none`, `loginInteractiveShell`, `interactiveShell`, `loginShell`.
+    </ParamField>
+
+    <ParamField type="string">
+      Remote environment variables of the format `name=value`. These will be added when executing the user commands.
+
+      May be specified multiple times.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="Build">
+    <ParamField type="boolean">
+      Builds the image with `--no-cache` if the container does not exist.
+    </ParamField>
+
+    <ParamField type="string">
+      Additional image to use as potential layer cache during image building.
+
+      May be specified multiple times.
+    </ParamField>
+
+    <ParamField type="string">
+      Additional image to use as potential layer cache during image building.
+    </ParamField>
+
+    <ParamField type="string">
+      Control whether BuildKit should be used. Choices: `auto`, `never`.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="Lifecycle">
+    <ParamField type="string">
+      Default for updating the remote user's UID and GID to the local user's one. Choices: `never`, `on`, `off`.
+    </ParamField>
+
+    <ParamField type="boolean">
+      Removes the dev container if it already exists.
+    </ParamField>
+
+    <ParamField type="boolean">
+      Fail if the container does not exist.
+    </ParamField>
+
+    <ParamField type="boolean">
+      Do not run onCreateCommand, updateContentCommand, postCreateCommand, postStartCommand or postAttachCommand and do not install dotfiles.
+    </ParamField>
+
+    <ParamField type="boolean">
+      Stop running user commands after running the command configured with waitFor or the updateContentCommand by default.
+    </ParamField>
+
+    <ParamField type="boolean">
+      Do not run postAttachCommand.
+    </ParamField>
+
+    <ParamField type="boolean">
+      Stop after onCreateCommand and updateContentCommand, rerunning updateContentCommand if it has run before.
+    </ParamField>
+
+    <ParamField type="boolean">
+      Do not run postAttachCommand.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="Dotfiles">
+    <ParamField type="string">
+      URL of a dotfiles Git repository (e.g., `https://github.com/owner/repository.git`).
+    </ParamField>
+
+    <ParamField type="string">
+      The command to run after cloning the dotfiles repository. Defaults to run the first file of `install.sh`, `install`, `bootstrap.sh`, `bootstrap`, `setup.sh` and `setup` found in the dotfiles repository's root folder.
+    </ParamField>
+
+    <ParamField type="string">
+      The path to clone the dotfiles repository to. Defaults to `~/dotfiles`.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="Secrets">
+    <ParamField type="string">
+      Path to a json file containing secret environment variables as key-value pairs.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="Output">
+    <ParamField type="boolean">
+      Include configuration in result.
+    </ParamField>
+
+    <ParamField type="boolean">
+      Include merged configuration in result.
+    </ParamField>
+  </Accordion>
+</AccordionGroup>
+
+## Output
+
+All output is written to stdout as a single line of JSON.
+
+### Success
+
+```json theme={null}
+{
+  "outcome": "success",
+  "containerId": "<container-id>",
+  "remoteUser": "<username>",
+  "remoteWorkspaceFolder": "<path-inside-container>"
+}
+```
+
+### Error
+
+```json theme={null}
+{
+  "outcome": "error",
+  "message": "<short error message>",
+  "description": "<detailed description>"
+}
+```
+
+The process exits with code `1` on error.
+
+
+# Applying templates
+Source: https://www.mintlify.com/devcontainers/cli/templates/apply
+
+Apply a Dev Container Template to scaffold a new project.
+
+The `devcontainer templates apply` command pulls a template artifact from an OCI registry and writes the resulting `.devcontainer/` files into your workspace. Option values you supply are substituted before the files are written; any option you omit falls back to the `default` declared in the template's manifest.
+
+## Full workflow
+
+<Steps>
+  <Step title="Browse available templates">
+    Visit [containers.dev/templates](https://containers.dev/templates) to find a template for your stack. Each listing shows the template's OCI reference (e.g. `ghcr.io/devcontainers/templates/python`), the available options, and a link to its source.
+
+    You can also inspect a template's options directly from the CLI before applying it:
+
+    ```bash theme={null}
+    devcontainer templates metadata ghcr.io/devcontainers/templates/python
+    ```
+
+    The command prints the full `devcontainer-template.json` manifest as JSON, including every option name, type, default value, and description.
+  </Step>
+
+  <Step title="Apply the template">
+    Run `devcontainer templates apply` with at least `--template-id`. Pass `--template-args` to set option values and `--workspace-folder` to target a directory other than the current one.
+
+    ```bash theme={null}
+    devcontainer templates apply \
+      --template-id ghcr.io/devcontainers/templates/python \
+      --template-args '{"imageVariant": "3.12"}' \
+      --workspace-folder ./my-project
+    ```
+
+    The CLI prints a JSON object listing the files it wrote:
+
+    ```json theme={null}
+    {"files":["./.devcontainer/devcontainer.json"]}
+    ```
+
+    <Note>
+      If `--workspace-folder` is omitted, the template is applied to the current directory.
+    </Note>
+  </Step>
+
+  <Step title="Inspect the generated files">
+    The template scaffolds a `.devcontainer/` folder in the target workspace. For the Debian template, for example:
+
+    ```bash theme={null}
+    devcontainer templates apply \
+      --template-id ghcr.io/devcontainers/templates/debian \
+      --template-args '{"imageVariant": "buster"}' \
+      --workspace-folder ./my-project
+    ```
+
+    Produces:
+
+    ```
+    my-project/
+    └── .devcontainer/
+        └── devcontainer.json
+    ```
+
+    With the contents:
+
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "Debian",
+      "image": "mcr.microsoft.com/devcontainers/base:buster"
+    }
+    ```
+  </Step>
+
+  <Step title="Start the container">
+    Once the `.devcontainer/` folder is in place, open the workspace in a Dev Container-aware tool or use the CLI directly:
+
+    ```bash theme={null}
+    devcontainer up --workspace-folder ./my-project
+    ```
+  </Step>
+</Steps>
+
+## Command reference
+
+```bash theme={null}
+devcontainer templates apply [options]
+```
+
+### Flags
+
+<ParamField type="string">
+  OCI reference to the template to apply. Accepts a fully qualified reference such as `ghcr.io/devcontainers/templates/python` or `ghcr.io/devcontainers/templates/python:1`. Alias: `-t`.
+</ParamField>
+
+<ParamField type="string">
+  Path to the target workspace folder. The `.devcontainer/` files will be written here. Alias: `-w`.
+</ParamField>
+
+<ParamField type="string">
+  Template option values to substitute, provided as a JSON object. Keys map to option IDs declared in the template's `devcontainer-template.json`. Any key you omit falls back to the option's `default`. Alias: `-a`.
+</ParamField>
+
+<ParamField type="string">
+  Additional Features to inject into the generated `devcontainer.json`, provided as a JSON array of feature objects. Each object must have an `id` field and an optional `options` map. Alias: `-f`.
+
+  ```json theme={null}
+  [
+    { "id": "ghcr.io/devcontainers/features/git:1", "options": { "version": "latest" } }
+  ]
+  ```
+</ParamField>
+
+<ParamField type="string">
+  JSON array of paths within the template to skip when writing files. Append `/*` to omit an entire directory. Example: `[".github/*", "Makefile"]`.
+</ParamField>
+
+<ParamField type="string">
+  Directory to use for temporary files during the fetch. Defaults to the system temporary directory.
+</ParamField>
+
+<ParamField type="string">
+  Verbosity of log output written to stderr. One of `info`, `debug`, or `trace`.
+</ParamField>
+
+## Template options
+
+Template options are declared in the template's `devcontainer-template.json` under the `options` key. Each option has a type (`string` or `boolean`), an optional `default`, and an optional set of allowed values (`enum`) or non-binding suggestions (`proposals`).
+
+```json theme={null}
+{
+  "options": {
+    "imageVariant": {
+      "type": "string",
+      "description": "Python version to use",
+      "proposals": ["3.12", "3.11", "3.10"],
+      "default": "3.12"
+    },
+    "installTools": {
+      "type": "boolean",
+      "description": "Install common development tools",
+      "default": true
+    }
+  }
+}
+```
+
+Pass all option values as a flat JSON object to `--template-args`:
+
+```bash theme={null}
+devcontainer templates apply \
+  --template-id ghcr.io/devcontainers/templates/python \
+  --template-args '{"imageVariant": "3.11", "installTools": "false"}'
+```
+
+<Note>
+  All option values in `--template-args` are strings, including boolean options. Pass `"true"` or `"false"` as string values.
+</Note>
+
+Use `devcontainer templates metadata <templateId>` to print the full option schema for any published template before you apply it.
+
+## Merging with an existing devcontainer.json
+
+If your workspace already contains a `.devcontainer/devcontainer.json`, applying a template will overwrite only the files included in the template archive. To preserve specific files, use `--omit-paths` to exclude them from the apply operation.
+
+<Warning>
+  Files included in the template that share a name with existing files in your workspace will be overwritten without prompting.
+</Warning>
+
+## Adding Features at apply time
+
+Use `--features` to inject Dev Container Features into the generated configuration at the same time as you apply the template:
+
+```bash theme={null}
+devcontainer templates apply \
+  --template-id ghcr.io/devcontainers/templates/python \
+  --template-args '{"imageVariant": "3.12"}' \
+  --features '[
+    { "id": "ghcr.io/devcontainers/features/git:1" },
+    { "id": "ghcr.io/devcontainers/features/docker-in-docker:2" }
+  ]' \
+  --workspace-folder .
+```
+
+The listed Features are added to the `features` field of the generated `devcontainer.json`.
+
+
+# Dev Container Templates
+Source: https://www.mintlify.com/devcontainers/cli/templates/overview
+
+Bootstrap new projects with pre-configured Dev Container Templates.
+
+Dev Container Templates are pre-built, shareable configurations that scaffold an entire development environment for a specific language, framework, or stack. Applying a template writes a `.devcontainer/` folder — including `devcontainer.json` and any supporting files such as a `Dockerfile` — directly into your project.
+
+## What is a template?
+
+A template bundles everything needed to open a project in a container:
+
+* A `devcontainer.json` with the correct image, mounts, extensions, and settings for the target stack.
+* Optional supporting files such as a `Dockerfile` or `docker-compose.yml`.
+* A `devcontainer-template.json` manifest that describes the template, declares user-configurable options, and provides versioning metadata.
+
+When you apply a template, the CLI pulls the artifact from an OCI registry, substitutes any option values you supply, and writes the resulting files into your workspace.
+
+## Templates vs. Features
+
+Templates and Features both extend Dev Containers, but they serve different purposes.
+
+|                 | Templates                            | Features                                       |
+| --------------- | ------------------------------------ | ---------------------------------------------- |
+| **Purpose**     | Scaffold a new project from scratch  | Add tools or runtimes to an existing container |
+| **Scope**       | Replaces or creates `.devcontainer/` | Modifies `devcontainer.json` features field    |
+| **When to use** | Starting a new repo                  | Extending an existing configuration            |
+
+A template gives you a starting point. A feature adds something — a CLI tool, a language runtime, a service — on top of that starting point.
+
+## Template structure
+
+Each template lives in its own directory and follows this layout:
+
+<Tree>
+  <Tree.Folder name="src">
+    <Tree.Folder name="my-template">
+      <Tree.File name="devcontainer-template.json" />
+
+      <Tree.Folder name=".devcontainer">
+        <Tree.File name="devcontainer.json" />
+
+        <Tree.File name="Dockerfile" />
+      </Tree.Folder>
+    </Tree.Folder>
+  </Tree.Folder>
+</Tree>
+
+The `devcontainer-template.json` manifest declares the template's ID, version, human-readable name, description, and any user-configurable options:
+
+```json devcontainer-template.json theme={null}
+{
+  "id": "python",
+  "version": "1.0.0",
+  "name": "Python 3",
+  "description": "A Python 3 environment.",
+  "options": {
+    "imageVariant": {
+      "type": "string",
+      "description": "Python version",
+      "proposals": ["3.12", "3.11", "3.10"],
+      "default": "3.12"
+    }
+  }
+}
+```
+
+Option values you pass at apply time are substituted into the `.devcontainer/` files before they are written to disk. Any option you omit receives the `default` value declared in the manifest.
+
+## Community template registry
+
+The community maintains a public index of templates at [containers.dev/templates](https://containers.dev/templates). Templates listed there are published to `ghcr.io/devcontainers/templates` and can be applied directly with the CLI.
+
+## Available subcommands
+
+The `devcontainer templates` group provides four subcommands:
+
+| Subcommand      | Description                                                  |
+| --------------- | ------------------------------------------------------------ |
+| `apply`         | Download and apply a template to a workspace folder          |
+| `publish`       | Package and publish templates to an OCI registry             |
+| `metadata`      | Fetch the metadata manifest for a published template         |
+| `generate-docs` | Auto-generate README documentation for a template collection |
+
+```bash theme={null}
+devcontainer templates apply \
+  --template-id ghcr.io/devcontainers/templates/python:latest \
+  --workspace-folder .
+```
+
+<Columns>
+  <Card title="Applying templates" icon="download" href="/templates/apply">
+    Apply a template from an OCI registry to scaffold a new project.
+  </Card>
+
+  <Card title="Publishing templates" icon="upload" href="/templates/publish">
+    Package and publish your own templates to share with others.
+  </Card>
+</Columns>
+
+
+# Publishing templates
+Source: https://www.mintlify.com/devcontainers/cli/templates/publish
+
+Package and publish Dev Container Templates to an OCI registry.
+
+The `devcontainer templates publish` command packages each template in a source directory and pushes them to an OCI registry as individual artifacts. Published templates can then be applied by anyone using the `devcontainer templates apply` command.
+
+<Tip>
+  The [template-starter](https://github.com/devcontainers/template-starter) repository includes a ready-made GitHub Actions workflow that handles authentication and publishing automatically using the `devcontainers/action` action.
+</Tip>
+
+## Repository structure
+
+Organize your template source files under a `src/` directory. Each subdirectory of `src/` becomes a separate published template whose ID matches the directory name.
+
+<Tree>
+  <Tree.Folder name="src">
+    <Tree.Folder name="python">
+      <Tree.File name="devcontainer-template.json" />
+
+      <Tree.Folder name=".devcontainer">
+        <Tree.File name="devcontainer.json" />
+      </Tree.Folder>
+    </Tree.Folder>
+
+    <Tree.Folder name="node">
+      <Tree.File name="devcontainer-template.json" />
+
+      <Tree.Folder name=".devcontainer">
+        <Tree.File name="devcontainer.json" />
+
+        <Tree.File name="Dockerfile" />
+      </Tree.Folder>
+    </Tree.Folder>
+  </Tree.Folder>
+
+  <Tree.Folder name="test">
+    <Tree.Folder name="python">
+      <Tree.File name="test.sh" />
+    </Tree.Folder>
+
+    <Tree.Folder name="node">
+      <Tree.File name="test.sh" />
+    </Tree.Folder>
+  </Tree.Folder>
+</Tree>
+
+Pass the `src/` directory as the `<target>` positional argument to `devcontainer templates publish`.
+
+## devcontainer-template.json
+
+Every template directory must contain a `devcontainer-template.json` manifest. This file describes the template and declares its user-configurable options.
+
+### Required fields
+
+<ParamField type="string">
+  Unique identifier for the template. Must match the name of the source directory.
+</ParamField>
+
+<ParamField type="string">
+  Semantic version string (e.g. `"1.0.0"`). The CLI skips templates without a version field.
+</ParamField>
+
+### Optional fields
+
+<ParamField type="string">
+  Human-readable display name shown in registries and tooling.
+</ParamField>
+
+<ParamField type="string">
+  Short description of what the template configures.
+</ParamField>
+
+<ParamField type="string">
+  URL to extended documentation or the source repository.
+</ParamField>
+
+<ParamField type="string">
+  URL to the template's license.
+</ParamField>
+
+<ParamField type="string">
+  Name of the person or organization that maintains the template.
+</ParamField>
+
+<ParamField type="string[]">
+  Search keywords for registry indexing.
+</ParamField>
+
+<ParamField type="string[]">
+  Supported OS platforms, e.g. `["linux", "macOS", "windows"]`.
+</ParamField>
+
+<ParamField type="object">
+  Map of user-configurable option IDs to option definitions. See [template options](#template-options) below.
+</ParamField>
+
+<ParamField type="string[]">
+  OCI references to Features that the template depends on.
+</ParamField>
+
+<ParamField type="string[]">
+  Paths within the template that tools may omit when applying.
+</ParamField>
+
+### Example
+
+```json devcontainer-template.json theme={null}
+{
+  "id": "python",
+  "version": "1.0.0",
+  "name": "Python 3",
+  "description": "A Python 3 development environment.",
+  "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/python",
+  "licenseURL": "https://github.com/devcontainers/templates/blob/main/LICENSE",
+  "publisher": "Microsoft Corporation",
+  "keywords": ["python", "django", "flask"],
+  "platforms": ["linux"],
+  "options": {
+    "imageVariant": {
+      "type": "string",
+      "description": "Python version (use -bullseye variants for older systems)",
+      "proposals": ["3.12", "3.11", "3.10", "3.12-bullseye", "3.11-bullseye"],
+      "default": "3.12"
+    }
+  }
+}
+```
+
+### Template options
+
+Each key in the `options` object maps to a configurable value that is substituted into the `.devcontainer/` files when a user applies the template.
+
+<AccordionGroup>
+  <Accordion title="String option">
+    ```json theme={null}
+    "imageVariant": {
+      "type": "string",
+      "description": "Python version to use",
+      "proposals": ["3.12", "3.11", "3.10"],
+      "default": "3.12"
+    }
+    ```
+
+    Use `proposals` for non-binding suggestions or `enum` to restrict to a fixed set of values.
+  </Accordion>
+
+  <Accordion title="Boolean option">
+    ```json theme={null}
+    "installTools": {
+      "type": "boolean",
+      "description": "Install common development tools",
+      "default": true
+    }
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Full publish workflow
+
+<Steps>
+  <Step title="Authenticate with the registry">
+    Publishing requires write access to the target OCI registry. For GitHub Container Registry, provide a Personal Access Token with `write:packages` scope.
+
+    <CodeGroup>
+      ```bash docker login theme={null}
+      echo $CR_PAT | docker login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin
+      ```
+
+      ```bash environment variable theme={null}
+      export GITHUB_TOKEN="[REDACTED-GHTOKEN-DOCS-EXAMPLE]"
+      ```
+    </CodeGroup>
+
+    The CLI supports two authentication methods:
+
+    * **`~/.docker/config.json`** — written by `docker login`. Note that OS-specific credential helpers (such as the Docker Desktop credential helper) are not currently recognized.
+    * **`DEVCONTAINERS_OCI_AUTH` environment variable** — a comma-separated list of `service|user|token` tuples:
+      ```
+      DEVCONTAINERS_OCI_AUTH=ghcr.io|myuser|[REDACTED-GHTOKEN-DOCS-EXAMPLE]
+      ```
+  </Step>
+
+  <Step title="Organize the source directory">
+    Make sure each template has a `devcontainer-template.json` with a `version` field and a `.devcontainer/devcontainer.json`. The directory name is used as the template ID.
+
+    ```
+    src/
+    ├── python/
+    │   ├── devcontainer-template.json
+    │   └── .devcontainer/
+    │       └── devcontainer.json
+    └── node/
+        ├── devcontainer-template.json
+        └── .devcontainer/
+            ├── devcontainer.json
+            └── Dockerfile
+    ```
+  </Step>
+
+  <Step title="Run devcontainer templates publish">
+    Pass the source directory as the positional `<target>` argument along with `--registry` and `--namespace`:
+
+    ```bash theme={null}
+    GITHUB_TOKEN="$CR_PAT" devcontainer templates publish \
+      --registry ghcr.io \
+      --namespace my-org/templates \
+      ./src
+    ```
+
+    The CLI packages each template, pushes it to the registry under `<registry>/<namespace>/<id>`, and also publishes a collection index artifact. It prints a JSON summary of every template that was published.
+
+    <Note>
+      The CLI skips any template whose `devcontainer-template.json` does not contain a `version` field and logs a warning.
+    </Note>
+  </Step>
+
+  <Step title="Verify the published template">
+    Use `devcontainer templates metadata` to confirm that the manifest is reachable and contains the expected metadata:
+
+    ```bash theme={null}
+    devcontainer templates metadata ghcr.io/my-org/templates/python
+    ```
+
+    The output is the full `devcontainer-template.json` content as parsed from the OCI manifest annotations.
+  </Step>
+
+  <Step title="Apply the published template">
+    Once published, anyone can apply the template using its OCI reference:
+
+    ```bash theme={null}
+    devcontainer templates apply \
+      --template-id ghcr.io/my-org/templates/python \
+      --template-args '{"imageVariant": "3.12"}' \
+      --workspace-folder .
+    ```
+  </Step>
+</Steps>
+
+## Command reference
+
+```bash theme={null}
+devcontainer templates publish <target> [options]
+```
+
+### Arguments
+
+<ParamField type="string">
+  Path to the directory containing template source subdirectories (typically `./src`).
+</ParamField>
+
+### Flags
+
+<ParamField type="string">
+  Hostname of the OCI registry to publish to, e.g. `ghcr.io`. Alias: `-r`.
+</ParamField>
+
+<ParamField type="string">
+  Registry namespace (path prefix) under which templates are published, e.g. `my-org/templates`. Alias: `-n`.
+</ParamField>
+
+<ParamField type="string">
+  Verbosity of log output written to stderr. One of `info`, `debug`, or `trace`.
+</ParamField>
+
+## Versioning
+
+Templates use [semantic versioning](https://semver.org/). The version in `devcontainer-template.json` controls which tags are pushed to the registry. For a template at version `1.2.3`, the CLI publishes the following tags:
+
+* `1.2.3` (exact version)
+* `1.2` (minor alias)
+* `1` (major alias)
+* `latest`
+
+Increment the version in `devcontainer-template.json` before each publish to release a new version.
+
+## Generating documentation
+
+The `devcontainer templates generate-docs` command reads all `devcontainer-template.json` files in the source directory and writes a `README.md` for each template, documenting its options in a standard format.
+
+```bash theme={null}
+devcontainer templates generate-docs \
+  --project-folder . \
+  --github-owner my-org \
+  --github-repo my-templates
+```
+
+### Flags
+
+<ParamField type="string">
+  Root of the project containing `src/` and `test/` subdirectories. Alias: `-p`.
+</ParamField>
+
+<ParamField type="string">
+  GitHub owner used to construct source links in the generated documentation.
+</ParamField>
+
+<ParamField type="string">
+  GitHub repository name used to construct source links in the generated documentation.
+</ParamField>
+
+<Tip>
+  Run `generate-docs` as part of your CI pipeline before publishing so that each template always has up-to-date documentation committed alongside the source.
+</Tip>
+
+

--- a/docs/research/mintlify-cache/devcontainers/cli/llms.txt
+++ b/docs/research/mintlify-cache/devcontainers/cli/llms.txt
@@ -1,0 +1,33 @@
+# Dev Containers CLI
+
+## Docs
+
+- [devcontainer build](https://www.mintlify.com/devcontainers/cli/commands/build.md): Build a dev container image.
+- [devcontainer exec](https://www.mintlify.com/devcontainers/cli/commands/exec.md): Execute a command on a running dev container.
+- [devcontainer read-configuration](https://www.mintlify.com/devcontainers/cli/commands/read-configuration.md): Read and output the resolved dev container configuration.
+- [devcontainer run-user-commands](https://www.mintlify.com/devcontainers/cli/commands/run-user-commands.md): Run user commands on an existing dev container.
+- [devcontainer up](https://www.mintlify.com/devcontainers/cli/commands/up.md): Create and run a dev container.
+- [Advanced Configuration](https://www.mintlify.com/devcontainers/cli/configuration/advanced.md): GPU support, multi-container setups with Docker Compose, secrets, mounts, BuildKit caching, and lockfiles.
+- [devcontainer.json](https://www.mintlify.com/devcontainers/cli/configuration/devcontainer-json.md): Configure your dev container with the devcontainer.json file.
+- [Dotfiles](https://www.mintlify.com/devcontainers/cli/configuration/dotfiles.md): Automatically personalize your dev container with your dotfiles repository.
+- [Lifecycle Scripts](https://www.mintlify.com/devcontainers/cli/configuration/lifecycle-scripts.md): Run commands at specific stages of the dev container lifecycle.
+- [Generating Feature documentation](https://www.mintlify.com/devcontainers/cli/features/generate-docs.md): Auto-generate markdown documentation for your Dev Container Features.
+- [Dev Container Features](https://www.mintlify.com/devcontainers/cli/features/overview.md): Add tools, runtimes, and utilities to any dev container using Features.
+- [Packaging and Publishing Features](https://www.mintlify.com/devcontainers/cli/features/package-publish.md): Package and publish Dev Container Features to an OCI registry.
+- [Testing Features](https://www.mintlify.com/devcontainers/cli/features/test.md): Use the built-in test framework to validate your Dev Container Features.
+- [Installation](https://www.mintlify.com/devcontainers/cli/installation.md): Install the Dev Containers CLI via npm, the standalone install script, or build from source.
+- [Introduction](https://www.mintlify.com/devcontainers/cli/introduction.md): What the Dev Containers CLI is and how it fits into the Dev Containers ecosystem.
+- [Quickstart](https://www.mintlify.com/devcontainers/cli/quickstart.md): Spin up your first dev container in under five minutes.
+- [devcontainer build](https://www.mintlify.com/devcontainers/cli/reference/build.md): Complete reference for the devcontainer build command.
+- [devcontainer.json properties](https://www.mintlify.com/devcontainers/cli/reference/devcontainer-json-properties.md): Complete reference for all supported devcontainer.json properties.
+- [Environment variables](https://www.mintlify.com/devcontainers/cli/reference/environment-variables.md): Environment variables available inside dev containers and how to configure them.
+- [devcontainer exec](https://www.mintlify.com/devcontainers/cli/reference/exec.md): Complete reference for the devcontainer exec command.
+- [devcontainer features](https://www.mintlify.com/devcontainers/cli/reference/features-commands.md): Complete reference for all devcontainer features subcommands.
+- [devcontainer templates](https://www.mintlify.com/devcontainers/cli/reference/templates-commands.md): Complete reference for all devcontainer templates subcommands.
+- [devcontainer up](https://www.mintlify.com/devcontainers/cli/reference/up.md): Complete reference for the devcontainer up command.
+- [Applying templates](https://www.mintlify.com/devcontainers/cli/templates/apply.md): Apply a Dev Container Template to scaffold a new project.
+- [Dev Container Templates](https://www.mintlify.com/devcontainers/cli/templates/overview.md): Bootstrap new projects with pre-configured Dev Container Templates.
+- [Publishing templates](https://www.mintlify.com/devcontainers/cli/templates/publish.md): Package and publish Dev Container Templates to an OCI registry.
+
+
+Built with [Mintlify](https://mintlify.com).

--- a/docs/research/mintlify-cache/devcontainers/features/llms-full.txt
+++ b/docs/research/mintlify-cache/devcontainers/features/llms-full.txt
@@ -1,0 +1,3256 @@
+# Contributing
+Source: https://www.mintlify.com/devcontainers/features/contributing/overview
+
+How to contribute bug fixes and improvements to Dev Container Features
+
+<Note>
+  This repository only accepts improvements and bug fixes for the [existing set of maintained Features](https://github.com/devcontainers/features/tree/main/src). If you want to create a new Feature, add it to a repository you control. See [Self-authoring Features](/guides/self-authoring) for guidance.
+</Note>
+
+## Contribution workflow
+
+<Steps>
+  <Step title="Fork the repository">
+    Fork [devcontainers/features](https://github.com/devcontainers/features) on GitHub, then clone your fork locally:
+
+    ```bash theme={null}
+    git clone https://github.com/<your-username>/features.git
+    cd features
+    ```
+  </Step>
+
+  <Step title="Open in your editor or dev container">
+    Open the repository in your editor. The repository includes a dev container configuration, so you can open it directly in VS Code with the Dev Containers extension or in GitHub Codespaces for a pre-configured environment with all required tools.
+  </Step>
+
+  <Step title="Make your changes">
+    Each Feature lives under `src/<feature-id>/`. Edit the relevant `install.sh` and `devcontainer-feature.json` files. Keep changes focused — one bug fix or improvement per pull request makes review faster.
+  </Step>
+
+  <Step title="Test with devcontainer features test">
+    Run the test suite for the Feature you changed before opening a pull request. See [Testing Features](/contributing/testing) for full details.
+
+    ```bash theme={null}
+    devcontainer features test --workspace-folder . --features <feature-id>
+    ```
+  </Step>
+
+  <Step title="Bump the version in devcontainer-feature.json">
+    Update the `version` field in `src/<feature-id>/devcontainer-feature.json` according to [semantic versioning](https://semver.org/):
+
+    * **Patch** (`1.0.x`) — bug fixes with no behavior change
+    * **Minor** (`1.x.0`) — backward-compatible improvements
+    * **Major** (`x.0.0`) — breaking changes
+
+    ```json src/<feature-id>/devcontainer-feature.json theme={null}
+    {
+      "id": "go",
+      "version": "1.3.1",
+      ...
+    }
+    ```
+  </Step>
+
+  <Step title="Commit and push">
+    Commit your changes with a clear message describing what was fixed or improved, then push to your fork:
+
+    ```bash theme={null}
+    git add .
+    git commit -m "fix(go): handle version resolution on AlmaLinux 9"
+    git push origin my-fix-branch
+    ```
+  </Step>
+
+  <Step title="Open a pull request">
+    Open a pull request from your fork to the `main` branch of `devcontainers/features`. The CI pipeline will run tests automatically against several base images. Address any failures before requesting review.
+  </Step>
+</Steps>
+
+<Note>
+  When contributing code to this project, you may be asked to sign a Contributor License Agreement (CLA). You can review and sign it at [opensource.microsoft.com/cla](https://opensource.microsoft.com/cla/).
+</Note>
+
+## Reporting issues
+
+Found a bug or want to request an improvement to an existing Feature? [Open an issue](https://github.com/devcontainers/features/issues/new) on GitHub. Include the Feature name, the base image you are using, and steps to reproduce the problem.
+
+## Security issues
+
+<Warning>
+  Do not report security vulnerabilities or bugs involving sensitive information in the public issue tracker. Instead, report them to the [Microsoft Security Response Center](https://msrc.microsoft.com/create-report). You can read more about the security policy in [`SECURITY.md`](https://github.com/devcontainers/spec/blob/main/SECURITY.md).
+</Warning>
+
+## Getting help
+
+Have a question or want to discuss an idea before opening an issue? Join the [dev container community Slack channel](https://aka.ms/devcontainer_community) to connect with maintainers and other contributors.
+
+
+# Testing Features
+Source: https://www.mintlify.com/devcontainers/features/contributing/testing
+
+How to write and run tests for Dev Container Features
+
+Every Feature in this repository has a corresponding test directory under `test/`. The [devcontainer CLI](https://github.com/devcontainers/cli) executes these tests by building a temporary container with the Feature applied and running the test script inside it.
+
+## Test directory structure
+
+The `test/` directory mirrors `src/` — one subfolder per Feature:
+
+```
+.
+├── src
+│   ├── go
+│   │   ├── devcontainer-feature.json
+│   │   └── install.sh
+│   └── python
+│       ├── devcontainer-feature.json
+│       └── install.sh
+└── test
+    ├── go
+    │   ├── scenarios.json
+    │   ├── install_go_alma-8.sh
+    │   ├── install_go_fedora.sh
+    │   └── test.sh
+    └── python
+        ├── scenarios.json
+        ├── install_jupyterlab.sh
+        └── test.sh
+```
+
+Each Feature's test folder contains at minimum a `test.sh` file. Features with more complex requirements also include a `scenarios.json` file and per-scenario test scripts.
+
+## Writing test.sh
+
+`test.sh` is the default test script. It runs against the Feature installed on the default base image. Use the `dev-container-features-test-lib` helper to declare checks.
+
+Here is the real `test.sh` for the `go` Feature:
+
+```bash test/go/test.sh theme={null}
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+# go
+check "version" go version
+
+# revive
+check "revive version" revive --version
+check "revive is installed at correct path" bash -c "which revive | grep /go/bin/revive"
+
+# gomodifytags
+check "gomodifytags is installed at correct path" bash -c "which gomodifytags | grep /go/bin/gomodifytags"
+
+# goplay
+check "goplay is installed at correct path" bash -c "which goplay | grep /go/bin/goplay"
+
+# gotests
+check "gotests is installed at correct path" bash -c "which gotests | grep /go/bin/gotests"
+
+# impl
+check "impl is installed at correct path" bash -c "which impl | grep /go/bin/impl"
+
+# Report result
+reportResults
+```
+
+Each `check` call takes a label and a command. The test passes when every command exits with code `0`. `reportResults` prints a summary and exits non-zero if any check failed.
+
+## Running tests
+
+Install the [devcontainer CLI](https://github.com/devcontainers/cli) if you have not already:
+
+```bash theme={null}
+npm install -g @devcontainers/cli
+```
+
+<CodeGroup>
+  ```bash Single feature theme={null}
+  devcontainer features test \
+    --workspace-folder . \
+    --features go
+  ```
+
+  ```bash All features theme={null}
+  devcontainer features test \
+    --workspace-folder .
+  ```
+</CodeGroup>
+
+By default the CLI uses `mcr.microsoft.com/devcontainers/base:ubuntu` as the base image. Pass `--base-image` to test against a specific image:
+
+```bash theme={null}
+devcontainer features test \
+  --workspace-folder . \
+  --features go \
+  --base-image ubuntu:jammy
+```
+
+<Tip>
+  Always test inside a clean container. Running tests on your local machine or inside an existing dev container can mask failures caused by pre-installed tools or environment variables that will not be present for other users.
+</Tip>
+
+## Scenario-based testing
+
+When a Feature needs to be tested with different option combinations or on different base images, add a `scenarios.json` file alongside `test.sh`. Each entry in `scenarios.json` defines an image, a set of Feature options, and an optional `postCreateCommand`. The CLI runs the matching `<scenario-name>.sh` script inside the configured container.
+
+Here is an excerpt from `test/go/scenarios.json`:
+
+```json test/go/scenarios.json theme={null}
+{
+    "install_go_alma-8": {
+        "image": "almalinux:8",
+        "features": {
+            "go": {
+                "version": "latest",
+                "golangciLintVersion": "1.50.0"
+            }
+        }
+    },
+    "install_go_fedora": {
+        "image": "fedora",
+        "features": {
+            "go": {
+                "version": "latest",
+                "golangciLintVersion": "1.50.0"
+            }
+        }
+    },
+    "install_go_twice": {
+        "image": "mcr.microsoft.com/devcontainers/go:1.18",
+        "features": {
+            "go": {
+                "version": "1.19"
+            }
+        }
+    },
+    "install_go_tool_in_postCreate": {
+        "image": "ubuntu:focal",
+        "features": {
+            "go": {
+                "version": "latest",
+                "golangciLintVersion": "1.50.0"
+            }
+        },
+        "postCreateCommand": "go install filippo.io/mkcert@v1.4.2"
+    }
+}
+```
+
+For each scenario key (e.g. `install_go_alma-8`), create a corresponding shell script at `test/go/install_go_alma-8.sh` with the checks to run inside that container. To run only scenario tests and skip the auto-generated default test:
+
+```bash theme={null}
+devcontainer features test \
+  --workspace-folder . \
+  --features go \
+  --skip-autogenerated
+```
+
+To run only the default `test.sh` and skip scenarios:
+
+```bash theme={null}
+devcontainer features test \
+  --workspace-folder . \
+  --features go \
+  --skip-scenarios
+```
+
+## CI on pull requests
+
+Tests run automatically in GitHub Actions on every pull request. The [`test-pr.yaml`](https://github.com/devcontainers/features/blob/main/.github/workflows/test-pr.yaml) workflow detects which Features changed and runs two jobs:
+
+* **`test`** — runs `test.sh` against seven base images (`ubuntu:focal`, `ubuntu:jammy`, `debian:11`, `debian:12`, and three `mcr.microsoft.com/devcontainers/base` variants) for each changed Feature.
+* **`test-scenarios`** — runs all scenarios defined in `scenarios.json` for each changed Feature.
+
+You do not need to manually trigger CI — pushing to your pull request branch starts the workflow automatically.
+
+
+# Anaconda
+Source: https://www.mintlify.com/devcontainers/features/features/anaconda
+
+Installs the Anaconda distribution, including the conda package manager and a full-featured Python environment for data science.
+
+This feature installs the [Anaconda Distribution](https://www.anaconda.com/), which bundles the `conda` package manager, Python, and a large collection of pre-built data science libraries. Anaconda is placed at `/usr/local/conda` and added to the `PATH`.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+"features": {
+  "ghcr.io/devcontainers/features/anaconda:1": {
+    "version": "latest"
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  Select or enter an Anaconda version to install.
+</ParamField>
+
+## Environment variables
+
+| Variable    | Value                          |
+| ----------- | ------------------------------ |
+| `CONDA_DIR` | `/usr/local/conda`             |
+| `PATH`      | `/usr/local/conda/bin:${PATH}` |
+
+## Using conda
+
+The `conda` package manager is available on the `PATH` after the container starts. Additional packages can be installed from the default Anaconda channel or any channel you configure:
+
+```bash theme={null}
+conda install numpy pandas scikit-learn
+```
+
+To use a different Python version than the one bundled with Anaconda:
+
+```bash theme={null}
+conda install python=3.7
+```
+
+To add or change channels, see the [conda channel configuration docs](https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/channels.html).
+
+## Anaconda repository licensing
+
+Access to the Anaconda repository is covered by the [Anaconda Terms of Service](https://legal.anaconda.com/policies/en/?name=terms-of-service), which may require some organizations to obtain a commercial license. However, when used with **GitHub Codespaces** or **GitHub Actions**, all users are permitted to use the Anaconda repository, including organizations that would otherwise require a paid license for commercial activities.
+
+<Note>
+  This feature works on recent versions of Debian/Ubuntu-based distributions and RHEL-based distributions (AlmaLinux, Rocky Linux, Fedora) with `bash` available. The `apt` package manager is required on Debian/Ubuntu.
+</Note>
+
+
+# AWS CLI
+Source: https://www.mintlify.com/devcontainers/features/features/aws-cli
+
+Installs the AWS CLI along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.
+
+This feature installs the AWS Command Line Interface (CLI) v2 and all required system dependencies (including `gpg`) that are commonly absent from minimal base images. After installation, the `aws` command is available on the `PATH`.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+"features": {
+  "ghcr.io/devcontainers/features/aws-cli:1": {
+    "version": "latest"
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  Select or enter an AWS CLI version to install. Available versions are listed in the [AWS CLI v2 changelog](https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst).
+</ParamField>
+
+<ParamField type="boolean">
+  Suppress verbose output during installation when set to `true`.
+</ParamField>
+
+## VS Code extensions
+
+| Extension                              | Description                                                                                              |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `AmazonWebServices.aws-toolkit-vscode` | AWS Toolkit for VS Code — browse resources, invoke Lambda functions, and work with CloudFormation stacks |
+
+## Notes
+
+<Note>
+  This feature works on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager. `bash` is required to execute the install script.
+</Note>
+
+
+# Azure CLI
+Source: https://www.mintlify.com/devcontainers/features/features/azure-cli
+
+Installs the Azure CLI along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.
+
+This feature installs the Azure Command Line Interface (CLI) and all required system dependencies (including `gpg`) that are commonly absent from minimal base images. Optionally installs [Azure Bicep](https://learn.microsoft.com/azure/azure-resource-manager/bicep/overview) and additional Azure CLI extensions.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+"features": {
+  "ghcr.io/devcontainers/features/azure-cli:1": {
+    "version": "latest",
+    "installBicep": false
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  Select or enter an Azure CLI version. Available versions may vary by Linux distribution.
+</ParamField>
+
+<ParamField type="string">
+  Optional comma-separated list of Azure CLI extensions to install (e.g. `azure-devops,containerapp`).
+</ParamField>
+
+<ParamField type="boolean">
+  Optionally install Azure Bicep alongside the Azure CLI.
+</ParamField>
+
+<ParamField type="string">
+  Select or enter a Bicep version to install when `installBicep` is `true`. Accepts `latest` or a specific version such as `v0.31.92`.
+</ParamField>
+
+<ParamField type="boolean">
+  Install the Azure CLI using Python instead of pipx.
+</ParamField>
+
+## VS Code extensions
+
+| Extension            | Description                                                                        |
+| -------------------- | ---------------------------------------------------------------------------------- |
+| `ms-vscode.azurecli` | Azure CLI extension for VS Code — run Azure CLI commands with IntelliSense support |
+
+## Notes
+
+<Note>
+  This feature works on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager. `bash` is required to execute the install script.
+</Note>
+
+
+# Common Utilities
+Source: https://www.mintlify.com/devcontainers/features/features/common-utils
+
+Installs a set of common command line utilities, Oh My Zsh!, and sets up a non-root user.
+
+The `common-utils` feature installs a curated set of command line utilities, configures Oh My Zsh!, and creates a non-root user with a customized shell prompt. It is a foundational feature used by many dev container images and is typically installed first.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+"features": {
+  "ghcr.io/devcontainers/features/common-utils:2": {
+    "installZsh": true,
+    "configureZshAsDefaultShell": false,
+    "installOhMyZsh": true,
+    "installOhMyZshConfig": true,
+    "upgradePackages": true,
+    "username": "automatic",
+    "userUid": "automatic",
+    "userGid": "automatic",
+    "nonFreePackages": false,
+    "installSsl": true
+  }
+}
+```
+
+## Options
+
+<ParamField type="boolean">
+  Install ZSH.
+</ParamField>
+
+<ParamField type="boolean">
+  Change the default shell to ZSH.
+</ParamField>
+
+<ParamField type="boolean">
+  Install Oh My Zsh!.
+</ParamField>
+
+<ParamField type="boolean">
+  Allow installing the default dev container `.zshrc` templates.
+</ParamField>
+
+<ParamField type="boolean">
+  Upgrade OS packages during setup.
+</ParamField>
+
+<ParamField type="string">
+  Name of the non-root user to configure. Set to `none` to skip user creation. Use `automatic` to detect or create a default user. Common values: `devcontainer`, `vscode`, `codespace`.
+</ParamField>
+
+<ParamField type="string">
+  UID for the non-root user. Use `automatic` to assign the next available UID.
+</ParamField>
+
+<ParamField type="string">
+  GID for the non-root user. Use `automatic` to assign the next available GID.
+</ParamField>
+
+<ParamField type="boolean">
+  Add packages from the non-free Debian repository. Applies to Debian only.
+</ParamField>
+
+<ParamField type="boolean">
+  Install SSL certificates and tooling.
+</ParamField>
+
+## Notes
+
+<Warning>
+  Many dev container base images have already allocated UID and GID `1000`. Adding this feature with `userUid: "1000"` or `userGid: "1000"` on top of such images will cause a build error. Use `automatic` or choose a different UID/GID such as `1001`.
+</Warning>
+
+### Customizing the command prompt
+
+By default, the shell prompt shows information about the current git repository. For large repositories, this can cause a slow prompt. You can adjust the behavior from a terminal or in `postStartCommand`:
+
+```bash theme={null}
+# Enable the "dirty" indicator (uncommitted changes)
+git config devcontainers-theme.show-dirty 1
+
+# Disable git info in the prompt entirely
+git config devcontainers-theme.hide-status 1
+```
+
+For ZSH, the default theme is a standard Oh My Zsh! theme. Change it by editing the `ZSH_THEME` variable in `~/.zshrc`.
+
+### OS support
+
+This feature works on recent versions of Debian/Ubuntu, Red Hat Enterprise Linux, Fedora, RockyLinux, and Alpine Linux.
+
+
+# Conda
+Source: https://www.mintlify.com/devcontainers/features/features/conda
+
+A cross-platform, language-agnostic binary package manager.
+
+This feature installs [Miniconda](https://docs.conda.io/en/latest/miniconda.html), providing the `conda` package manager without the full Anaconda distribution. Conda is placed at `/opt/conda` and added to the `PATH`, keeping the image lean while still enabling environment and package management for Python, R, and other languages.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+"features": {
+  "ghcr.io/devcontainers/features/conda:1": {
+    "version": "latest",
+    "addCondaForge": false
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  Select or enter a conda version to install. Common values: `latest`, `4.12.0`, `4.11.0`.
+</ParamField>
+
+<ParamField type="boolean">
+  Add the [conda-forge](https://conda-forge.org/) community channel to the conda configuration.
+</ParamField>
+
+## Environment variables
+
+| Variable       | Value                               |
+| -------------- | ----------------------------------- |
+| `CONDA_DIR`    | `/opt/conda`                        |
+| `CONDA_SCRIPT` | `/opt/conda/etc/profile.d/conda.sh` |
+| `PATH`         | `/opt/conda/bin:${PATH}`            |
+
+## Using conda
+
+Install packages from the default Anaconda channel or from any configured channel:
+
+```bash theme={null}
+conda install numpy pandas scikit-learn
+```
+
+To install a specific Python version:
+
+```bash theme={null}
+conda install python=3.7
+```
+
+To manage channels, see the [conda channel configuration docs](https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/channels.html).
+
+## Anaconda repository licensing
+
+Access to the Anaconda repository is covered by the [Anaconda Terms of Service](https://legal.anaconda.com/policies/en/?name=terms-of-service), which may require some organizations to obtain a commercial license. However, when used with **GitHub Codespaces** or **GitHub Actions**, all users are permitted to use the Anaconda repository, including organizations that would otherwise require a paid license for commercial activities.
+
+<Note>
+  This feature works on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager. `bash` is required to execute the install script.
+</Note>
+
+
+# GitHub Copilot CLI
+Source: https://www.mintlify.com/devcontainers/features/features/copilot-cli
+
+Installs the GitHub Copilot CLI.
+
+The GitHub Copilot CLI feature installs the `copilot` CLI tool into your dev container. It provides AI-powered suggestions for shell commands directly in your terminal.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+{
+  "features": {
+    "ghcr.io/devcontainers/features/copilot-cli:1": {
+      "version": "latest"
+    }
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  Select the version of the GitHub Copilot CLI to install. Accepts `latest` or `prerelease`.
+</ParamField>
+
+## Notes
+
+<Note>
+  The GitHub Copilot CLI requires authentication with a GitHub account that has access to GitHub Copilot. Run `gh copilot --help` inside the container to get started.
+</Note>
+
+This feature installs after `ghcr.io/devcontainers/features/common-utils` when both are present.
+
+
+# Light-weight Desktop
+Source: https://www.mintlify.com/devcontainers/features/features/desktop-lite
+
+Adds a lightweight Fluxbox-based desktop to the container, accessible via a VNC viewer or web browser. GUI commands run from the VS Code terminal open on the desktop automatically.
+
+The `desktop-lite` feature installs a lightweight [Fluxbox](http://fluxbox.org/) desktop environment inside the container. The desktop is exposed over VNC and via a browser-based [noVNC](https://novnc.com/) client. Any GUI application launched from the VS Code integrated terminal automatically appears on the desktop.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+"features": {
+  "ghcr.io/devcontainers/features/desktop-lite:1": {
+    "password": "vscode",
+    "webPort": "6080",
+    "vncPort": "5901",
+    "noVncVersion": "1.6.0"
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  Currently unused. Reserved for future use.
+</ParamField>
+
+<ParamField type="string">
+  The version of noVNC to use for the browser-based VNC client.
+</ParamField>
+
+<ParamField type="string">
+  Password for desktop connections. Set to `noPassword` to allow passwordless connections from localhost. Common values: `vscode`, `codespaces`, `password`.
+</ParamField>
+
+<ParamField type="string">
+  Port for the noVNC web client. Forward this port to access the desktop from a browser.
+</ParamField>
+
+<ParamField type="string">
+  Port for the TigerVNC server. Forward this port to connect with a VNC viewer application.
+</ParamField>
+
+## Environment variables
+
+<ParamField type="string">
+  Set to `:1`. Tells GUI applications which X display to render to, ensuring they appear on the Fluxbox desktop.
+</ParamField>
+
+## Connecting to the desktop
+
+### Browser (noVNC)
+
+<Steps>
+  <Step title="Forward the noVNC port">
+    Add port `6080` to `devcontainer.json`:
+
+    ```jsonc devcontainer.json theme={null}
+    "forwardPorts": [6080],
+    "portsAttributes": {
+      "6080": {
+        "label": "desktop"
+      }
+    }
+    ```
+
+    Or use the **Ports** view in VS Code (F1 → "Ports: Focus on Ports View").
+  </Step>
+
+  <Step title="Open in browser">
+    In the Ports view, select port `6080` and click the Globe icon to open the noVNC client.
+  </Step>
+
+  <Step title="Connect">
+    Click **Connect** and enter the desktop password (`vscode` by default).
+  </Step>
+</Steps>
+
+### VNC viewer
+
+<Steps>
+  <Step title="Forward the VNC port">
+    Forward port `5901` to your local machine. For the Dev Container CLI, use the `appPort` property instead of `forwardPorts`.
+  </Step>
+
+  <Step title="Connect with a VNC viewer">
+    Open your VNC viewer (e.g., [RealVNC Viewer](https://www.realvnc.com/en/connect/download/viewer/)) and connect to `localhost:5901`. Set the color depth to 24-bit for full color.
+  </Step>
+
+  <Step title="Authenticate">
+    Enter the desktop password (`vscode` by default).
+  </Step>
+</Steps>
+
+## Customizing Fluxbox
+
+Right-click anywhere on the desktop to open the application menu. Configuration files are located in `$HOME/.fluxbox`. If you add custom Fluxbox configuration to this path in your base image or Dockerfile, the feature uses it instead of the default configuration.
+
+See the [Fluxbox menu documentation](http://www.fluxbox.org/help/man-fluxbox-menu.php) for format details.
+
+## Installing a browser
+
+**Firefox ESR** — add to your `.devcontainer/Dockerfile`:
+
+```dockerfile theme={null}
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive && apt-get install -y firefox-esr
+```
+
+**Google Chrome** — add to your `.devcontainer/Dockerfile`:
+
+```dockerfile theme={null}
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && curl -sSL https://dl.google.com/linux/direct/google-chrome-stable_current_$(dpkg --print-architecture).deb -o /tmp/chrome.deb \
+    && apt-get -y install /tmp/chrome.deb
+```
+
+<Note>
+  Chrome sandbox support requires a non-root user. Use the `common-utils` feature to set one up, or launch Chrome with `google-chrome --no-sandbox`.
+</Note>
+
+## Notes
+
+<Warning>
+  If applications crash inside the desktop, you may need to increase shared memory. Add the following to `devcontainer.json`:
+
+  ```jsonc devcontainer.json theme={null}
+  "runArgs": ["--shm-size=1g"]
+  ```
+
+  Or with Docker Compose:
+
+  ```yaml theme={null}
+  services:
+    your-service-here:
+      shm_size: '1gb'
+  ```
+</Warning>
+
+<Note>
+  The desktop environment is started via the feature's entrypoint script (`/usr/local/share/desktop-init.sh`) each time the container starts. The feature sets `init: true` to enable proper process management.
+</Note>
+
+<Note>
+  The `desktop-lite` feature installs after `common-utils` when both are present in the same dev container configuration.
+</Note>
+
+### OS support
+
+This feature works on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed. `bash` is required to execute the install script.
+
+
+# Docker (Docker-in-Docker)
+Source: https://www.mintlify.com/devcontainers/features/features/docker-in-docker
+
+Create child containers inside a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.
+
+The Docker-in-Docker feature runs a dedicated Docker daemon **inside** your dev container. Containers you start are isolated from the host Docker instance, which means bind mounts and networking behave consistently regardless of where the dev container is running.
+
+<Warning>
+  This feature requires `"privileged": true` on the dev container. A dedicated volume (`dind-var-lib-docker-<devcontainerId>`) is mounted at `/var/lib/docker` to persist the Docker layer cache across rebuilds.
+</Warning>
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+"features": {
+  "ghcr.io/devcontainers/features/docker-in-docker:2": {
+    "version": "latest",
+    "moby": true,
+    "dockerDashComposeVersion": "v2"
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  Select or enter a Docker/Moby Engine version. Availability can vary by OS version. Common values: `latest`, `none`, `20.10`.
+</ParamField>
+
+<ParamField type="boolean">
+  Install the OSS Moby build instead of Docker CE.
+</ParamField>
+
+<ParamField type="string">
+  Install a specific version of moby-buildx when using Moby.
+</ParamField>
+
+<ParamField type="string">
+  Default version of Docker Compose. Accepted values: `v1`, `v2`, `none`.
+</ParamField>
+
+<ParamField type="boolean">
+  Allow automatically setting the dockerd DNS server when the installation script detects it is running in Azure.
+</ParamField>
+
+<ParamField type="string">
+  Define default address pools for Docker networks. Example: `base=192.168.0.0/16,size=24`.
+</ParamField>
+
+<ParamField type="boolean">
+  Install Docker Buildx.
+</ParamField>
+
+<ParamField type="boolean">
+  Install Compose Switch, a replacement for the Compose V1 `docker-compose` (Python) executable. Translates commands to Compose V2 `docker compose`.
+</ParamField>
+
+<ParamField type="boolean">
+  Disable ip6tables. This option is only applicable for Docker versions 27 and greater.
+</ParamField>
+
+## Environment variables
+
+| Variable          | Value |
+| ----------------- | ----- |
+| `DOCKER_BUILDKIT` | `1`   |
+
+## VS Code extensions
+
+| Extension                         | Description                                                        |
+| --------------------------------- | ------------------------------------------------------------------ |
+| `ms-azuretools.vscode-containers` | Docker extension for building and managing containers from VS Code |
+
+## Notes
+
+<Note>
+  The host and the container must be running on the same chip architecture. You cannot use Docker-in-Docker with an emulated `linux/amd64` image on an Apple Silicon Mac (e.g. `FROM --platform=linux/amd64 ...`).
+</Note>
+
+<Tip>
+  This feature works on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager. `bash` is required to execute the install script.
+</Tip>
+
+
+# Docker (docker-outside-of-docker)
+Source: https://www.mintlify.com/devcontainers/features/features/docker-outside-of-docker
+
+Re-use the host docker socket, adding the Docker CLI to a container. Feature invokes a script to enable using a forwarded Docker socket within a container to run Docker commands.
+
+The docker-outside-of-docker feature forwards the host's Docker socket into the dev container and installs the Docker CLI, letting you run `docker` commands that actually execute on the **host** Docker daemon. This avoids the overhead of a nested daemon and shares the host's image cache.
+
+<Note>
+  This feature was previously published as `docker-from-docker`. The legacy ID is still recognized for backward compatibility.
+</Note>
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+"features": {
+  "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+    "version": "latest",
+    "moby": true,
+    "dockerDashComposeVersion": "latest"
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  Select or enter a Docker/Moby CLI version. Availability can vary by OS version. Common values: `latest`, `none`, `20.10`.
+</ParamField>
+
+<ParamField type="boolean">
+  Install the OSS Moby build instead of Docker CE.
+</ParamField>
+
+<ParamField type="string">
+  Install a specific version of moby-buildx when using Moby.
+</ParamField>
+
+<ParamField type="string">
+  Compose version to use for docker-compose. Accepted values: `latest`, `v1`, `v2`, `none`.
+</ParamField>
+
+<ParamField type="boolean">
+  Install Docker Buildx.
+</ParamField>
+
+<ParamField type="boolean">
+  Install Compose Switch, a replacement for the Compose V1 `docker-compose` (Python) executable. Translates commands to Compose V2 `docker compose`.
+</ParamField>
+
+<ParamField type="string">
+  Path where the Docker socket is mounted inside the container. For rootless Docker, override the mount in `devcontainer.json` to map your host socket to this path.
+</ParamField>
+
+## VS Code extensions
+
+| Extension                         | Description                                                        |
+| --------------------------------- | ------------------------------------------------------------------ |
+| `ms-azuretools.vscode-containers` | Docker extension for building and managing containers from VS Code |
+
+## Rootless Docker support
+
+By default the feature binds `/var/run/docker.sock` on the host to `/var/run/docker-host.sock` inside the container. For rootless Docker installations the socket is typically at `/run/user/$UID/docker.sock`. Override the mount in `devcontainer.json`:
+
+```jsonc devcontainer.json theme={null}
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+  },
+  "mounts": [
+    {
+      "source": "/run/user/1000/docker.sock",
+      "target": "/var/run/docker-host.sock",
+      "type": "bind"
+    }
+  ]
+}
+```
+
+Replace `1000` with your actual user ID (`id -u`).
+
+## Bind mounts from the workspace folder
+
+Because Docker commands run on the host daemon, bind mount paths must be **host** paths, not container paths. Use the `LOCAL_WORKSPACE_FOLDER` environment variable to pass the host path through:
+
+```jsonc devcontainer.json theme={null}
+"remoteEnv": { "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}" }
+```
+
+```bash theme={null}
+docker run -it --rm -v ${LOCAL_WORKSPACE_FOLDER}:/workspace debian bash
+```
+
+<Warning>
+  This feature does not support bind mounting folders outside the workspace folder. If you need that capability, consider using the [Docker-in-Docker](/features/docker-in-docker) feature instead.
+</Warning>
+
+## Notes
+
+<Note>
+  The host and the container must be running on the same chip architecture. You cannot use this feature with an emulated image on a different architecture.
+</Note>
+
+
+# Dotnet CLI
+Source: https://www.mintlify.com/devcontainers/features/features/dotnet
+
+This Feature installs the latest .NET SDK, which includes the .NET CLI and the shared runtime. Options are provided to choose a different version or additional versions.
+
+The Dotnet CLI feature installs the .NET SDK into your dev container, including the .NET CLI and shared runtime. You can install a single version, multiple SDK versions, standalone runtimes, ASP.NET Core runtimes, and optional workloads.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+{
+  "features": {
+    "ghcr.io/devcontainers/features/dotnet:2": {
+      "version": "latest"
+    }
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  Select or enter a .NET SDK version. Accepts `latest`, `lts`, `none`, or a specific version such as `9.0`, `8.0`, or `6.0.412`. Use `X.Y-preview` or `X.Y-daily` for prerelease builds.
+</ParamField>
+
+<ParamField type="string">
+  Additional .NET SDK versions to install, separated by commas. Accepts the same values as `version`.
+</ParamField>
+
+<ParamField type="string">
+  Additional .NET runtime versions to install, separated by commas. Useful when you need to run .NET apps without building them from source. Accepts the same values as `version`.
+</ParamField>
+
+<ParamField type="string">
+  Additional ASP.NET Core runtime versions to install, separated by commas. Accepts the same values as `version`.
+</ParamField>
+
+<ParamField type="string">
+  Additional .NET SDK workloads to install, separated by commas. Run `dotnet workload search` to discover available workloads.
+</ParamField>
+
+<ParamField type="boolean">
+  Install shell tab completions for the `dotnet` CLI. Requires .NET SDK 10 or newer.
+</ParamField>
+
+## Environment variables
+
+| Variable                          | Value                |
+| --------------------------------- | -------------------- |
+| `DOTNET_ROOT`                     | `/usr/share/dotnet`  |
+| `PATH`                            | `$PATH:$DOTNET_ROOT` |
+| `DOTNET_RUNNING_IN_CONTAINER`     | `true`               |
+| `DOTNET_USE_POLLING_FILE_WATCHER` | `true`               |
+
+## VS Code extensions
+
+* `ms-dotnettools.csharp`
+
+## Notes
+
+This feature works on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed. `bash` is required to execute the install script.
+
+
+# Git (from source)
+Source: https://www.mintlify.com/devcontainers/features/features/git
+
+Install an up-to-date version of Git, built from source as needed. Auto-detects the latest stable version and installs needed dependencies.
+
+The `git` feature installs an up-to-date version of Git. When the desired version is not available through the system package manager or a PPA, it builds Git from source automatically. This is useful when you need the latest features or a specific version not yet available in distribution repositories.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+"features": {
+  "ghcr.io/devcontainers/features/git:1": {
+    "version": "os-provided",
+    "ppa": true
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  The version of Git to install. Accepts a version number (e.g., `2.44.0`), or one of the following values:
+
+  * `os-provided` — Use the version shipped with the OS package manager (default).
+  * `latest` — Install the latest stable release, building from source if needed.
+  * `system` — Alias for `os-provided`.
+</ParamField>
+
+<ParamField type="boolean">
+  Install Git from the official Git PPA when available. Applies only to Ubuntu distributions. When `false`, the version from the default APT repositories is used.
+</ParamField>
+
+## Notes
+
+<Note>
+  The `git` feature installs after `common-utils` when both are present in the same dev container configuration.
+</Note>
+
+### OS support
+
+This feature works on recent versions of Alpine, Debian/Ubuntu, Red Hat Enterprise Linux, Fedora, Alma, and RockyLinux with the `apk`, `apt`, `yum`, `dnf`, or `microdnf` package manager installed. `bash` is required to execute the install script.
+
+
+# Git Large File Support (LFS)
+Source: https://www.mintlify.com/devcontainers/features/features/git-lfs
+
+Installs Git Large File Support (Git LFS) along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like git and curl.
+
+The `git-lfs` feature installs [Git LFS](https://git-lfs.com/), which replaces large files (audio, video, datasets, graphics) with lightweight text pointers in the repository while storing the actual file contents on a remote server. It also ensures that required dependencies such as `git` and `curl` are present.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+"features": {
+  "ghcr.io/devcontainers/features/git-lfs:1": {
+    "version": "latest",
+    "autoPull": true,
+    "installDirectlyFromGitHubRelease": false
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  The version of Git LFS to install. Use `latest` to install the most recent release, or specify a version number (e.g., `3.5.1`). Set to `none` to skip installation.
+</ParamField>
+
+<ParamField type="boolean">
+  Automatically pull LFS files when the container is created (via `postCreateCommand`). When set to `false`, you can pull LFS assets manually by running `git lfs pull` inside the container.
+</ParamField>
+
+<ParamField type="boolean">
+  Install `git-lfs` directly from GitHub releases instead of using the system package manager feeds.
+</ParamField>
+
+## Notes
+
+<Tip>
+  When `autoPull` is `true`, the feature registers a `postCreateCommand` that runs `/usr/local/share/pull-git-lfs-artifacts.sh` to fetch LFS objects after the container is built.
+</Tip>
+
+<Note>
+  The `git-lfs` feature installs after `common-utils` when both are present in the same dev container configuration.
+</Note>
+
+### OS support
+
+This feature works on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed. `bash` is required to execute the install script.
+
+
+# GitHub CLI
+Source: https://www.mintlify.com/devcontainers/features/features/github-cli
+
+Installs the GitHub CLI. Auto-detects latest version and installs needed dependencies.
+
+This feature installs the GitHub CLI (`gh`) and its required dependencies. The CLI is installed directly from the GitHub releases page by default. You can also install additional `gh` extensions at provisioning time.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+"features": {
+  "ghcr.io/devcontainers/features/github-cli:1": {
+    "version": "latest"
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  Select a version of the GitHub CLI to install. Use `latest` to always install the newest release, or `none` to skip installation.
+</ParamField>
+
+<ParamField type="boolean">
+  Install the GitHub CLI directly from the GitHub releases page rather than a package manager repository.
+</ParamField>
+
+<ParamField type="string">
+  Comma-separated list of GitHub CLI extensions to install at provisioning time (e.g. `dlvhdr/gh-dash,github/gh-copilot`).
+</ParamField>
+
+## Notes
+
+<Tip>
+  When using `gh api -f`, note that it does not support object values. Use multiple `-f` flags with hierarchical keys and string values instead.
+</Tip>
+
+<Tip>
+  When using GitHub Actions `actions/upload-artifact` or `actions/download-artifact`, use v4 or later.
+</Tip>
+
+<Note>
+  This feature works on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager. `bash` is required to execute the install script.
+</Note>
+
+
+# Go
+Source: https://www.mintlify.com/devcontainers/features/features/go
+
+Installs Go and common Go utilities. Auto-detects latest version and installs needed dependencies.
+
+The Go feature installs Go and common Go utilities into your dev container. It auto-detects the latest available version and installs all required dependencies, including `golangci-lint` for static analysis.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+{
+  "features": {
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "latest",
+      "golangciLintVersion": "latest"
+    }
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  Select or enter a Go version to install. Accepts `latest`, `none`, or a specific version such as `1.24` or `1.23`.
+</ParamField>
+
+<ParamField type="string">
+  Version of golangci-lint to install. Accepts `latest` or a specific version string.
+</ParamField>
+
+## Environment variables
+
+| Variable | Value                               |
+| -------- | ----------------------------------- |
+| `GOROOT` | `/usr/local/go`                     |
+| `GOPATH` | `/go`                               |
+| `PATH`   | `/usr/local/go/bin:/go/bin:${PATH}` |
+
+## VS Code extensions
+
+* `golang.Go`
+
+## Notes
+
+This feature adds `SYS_PTRACE` capability and sets `seccomp=unconfined` to support Go debuggers such as Delve.
+
+```jsonc devcontainer.json theme={null}
+{
+  "features": {
+    "ghcr.io/devcontainers/features/go:1": {}
+  },
+  "capAdd": ["SYS_PTRACE"],
+  "securityOpt": ["seccomp=unconfined"]
+}
+```
+
+This feature works on recent versions of Debian/Ubuntu, Red Hat Enterprise Linux, Fedora, Alma, and Rocky Linux distributions with the `apt`, `yum`, `dnf`, or `microdnf` package manager installed. `bash` is required to execute the install script.
+
+
+# Hugo
+Source: https://www.mintlify.com/devcontainers/features/features/hugo
+
+Installs Hugo, a popular open-source static site generator written in Go.
+
+The `hugo` feature installs [Hugo](https://gohugo.io/), a fast open-source static site generator. You can install the standard build or the extended edition, which adds support for SASS/SCSS compilation and other advanced features.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+"features": {
+  "ghcr.io/devcontainers/features/hugo:1": {
+    "version": "latest",
+    "extended": false
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  The version of Hugo to install. Use `latest` for the most recent release, or specify a version number (e.g., `0.124.1`).
+</ParamField>
+
+<ParamField type="boolean">
+  Install the Hugo extended edition. Required for projects that use SASS/SCSS processing or other features exclusive to the extended build.
+</ParamField>
+
+## Environment variables
+
+<ParamField type="string">
+  Set to `/usr/local/hugo`. The root directory where Hugo is installed.
+</ParamField>
+
+<ParamField type="string">
+  Extended to include `/usr/local/hugo/bin` so that the `hugo` binary is available on the path.
+</ParamField>
+
+## Notes
+
+<Tip>
+  If your site uses custom themes that rely on SASS/SCSS (for example, many Hugo themes do), set `extended` to `true` to avoid build errors.
+</Tip>
+
+<Note>
+  The `hugo` feature installs after `common-utils` when both are present in the same dev container configuration.
+</Note>
+
+### OS support
+
+This feature works on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed. `bash` is required to execute the install script.
+
+
+# Java
+Source: https://www.mintlify.com/devcontainers/features/features/java
+
+Installs Java, SDKMAN! (if not installed), and needed dependencies.
+
+The Java feature installs Java via SDKMAN!, along with optional build tools including Gradle, Maven, Ant, and Groovy. Multiple JDK distributions and versions are supported.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+{
+  "features": {
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "latest",
+      "jdkDistro": "ms"
+    }
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  Select or enter a Java version to install. Accepts `latest`, `none`, or a specific version such as `21`, `17`, `11`, or `8`.
+</ParamField>
+
+<ParamField type="string">
+  Additional Java versions to install, separated by commas.
+</ParamField>
+
+<ParamField type="string">
+  Select or enter a JDK distribution. Accepts `ms` (Microsoft), `open` (Eclipse Temurin / OpenJDK), `oracle`, `tem` (Temurin), or `amzn` (Amazon Corretto).
+</ParamField>
+
+<ParamField type="boolean">
+  Install Gradle, a build automation tool for multi-language software development.
+</ParamField>
+
+<ParamField type="string">
+  Select or enter a Gradle version. Accepts `latest` or a specific version such as `7.5.1` or `6.9.3`.
+</ParamField>
+
+<ParamField type="boolean">
+  Install Maven, a project management and build tool for Java.
+</ParamField>
+
+<ParamField type="string">
+  Select or enter a Maven version. Accepts `latest` or a specific version such as `3.8.6` or `3.6.3`.
+</ParamField>
+
+<ParamField type="boolean">
+  Install Ant, a build automation tool for Java projects.
+</ParamField>
+
+<ParamField type="string">
+  Select or enter an Ant version. Accepts `latest` or a specific version such as `1.10.12`.
+</ParamField>
+
+<ParamField type="boolean">
+  Install Groovy, a powerful, optionally typed and dynamic language with static-typing and static compilation capabilities.
+</ParamField>
+
+<ParamField type="string">
+  Select or enter a Groovy version. Accepts `latest` or a specific version such as `4.0.16` or `3.0.19`.
+</ParamField>
+
+## Environment variables
+
+| Variable     | Value                                                                                                                                                                                                                     |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SDKMAN_DIR` | `/usr/local/sdkman`                                                                                                                                                                                                       |
+| `JAVA_HOME`  | `/usr/local/sdkman/candidates/java/current`                                                                                                                                                                               |
+| `PATH`       | `/usr/local/sdkman/bin:/usr/local/sdkman/candidates/java/current/bin:/usr/local/sdkman/candidates/gradle/current/bin:/usr/local/sdkman/candidates/maven/current/bin:/usr/local/sdkman/candidates/ant/current/bin:${PATH}` |
+
+## VS Code extensions
+
+* `vscjava.vscode-java-pack`
+
+## Notes
+
+For licensing information on the available JDK distributions, see the [NOTICE.txt](https://github.com/devcontainers/features/tree/main/src/java/NOTICE.txt) file in the source repository.
+
+This feature works on Debian/Ubuntu, Red Hat Enterprise Linux, Fedora, Alma, and Rocky Linux distributions with the `apt`, `yum`, `dnf`, or `microdnf` package manager installed.
+
+
+# Kubectl, Helm, and Minikube
+Source: https://www.mintlify.com/devcontainers/features/features/kubectl-helm-minikube
+
+Installs latest version of kubectl, Helm, and optionally minikube. Auto-detects latest versions and installs needed dependencies.
+
+This feature installs the Kubernetes CLI (`kubectl`), the Helm package manager, and optionally Minikube for running a local single-node cluster. All tools are auto-detected and pinned to their latest stable releases unless you specify a version.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+"features": {
+  "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+    "version": "latest",
+    "helm": "latest",
+    "minikube": "latest"
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  Select or enter a Kubernetes version (`kubectl`) to install. Common values: `latest`, `none`, `1.23`, `1.22`, `1.21`.
+</ParamField>
+
+<ParamField type="string">
+  Select or enter a Helm version to install. Use `none` to skip Helm installation.
+</ParamField>
+
+<ParamField type="string">
+  Select or enter a Minikube version to install. Use `none` to skip Minikube installation.
+</ParamField>
+
+<ParamField type="string">
+  Fallback kubectl version to use when the latest stable version cannot be fetched from upstream.
+</ParamField>
+
+## Ingress and port forwarding
+
+When configuring [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) for your cluster, Kubernetes binds to a specific interface's IP rather than `localhost`. Use the Kubernetes node's IP when connecting, even with a single-node Minikube cluster.
+
+In VS Code Dev Containers you can forward `<ip>:<port>` directly via the `forwardPorts` property or the port-forwarding UI. In GitHub Codespaces, forward the port to localhost using `kubectl`:
+
+```bash theme={null}
+minikube start
+minikube addons enable ingress
+# Forward to localhost in the background
+nohup kubectl port-forward --pod-running-timeout=24h -n ingress-nginx service/ingress-nginx-controller :80 &
+```
+
+<Tip>
+  A `minikube-config` volume is mounted at `/home/vscode/.minikube` so your Minikube configuration persists across container rebuilds.
+</Tip>
+
+## Notes
+
+<Note>
+  This feature works on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager. `bash` is required to execute the install script.
+</Note>
+
+
+# Nix Package Manager
+Source: https://www.mintlify.com/devcontainers/features/features/nix
+
+Installs the Nix package manager and optionally a set of packages.
+
+The `nix` feature installs the [Nix](https://nixos.org/) package manager and optionally installs a list of packages or a Nix Flake into the profile. Nix provides reproducible, declarative package management and supports both multi-user and single-user installation models.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+"features": {
+  "ghcr.io/devcontainers/features/nix:1": {
+    "version": "latest",
+    "multiUser": true,
+    "packages": "nixpkgs.ripgrep,nixpkgs.fd",
+    "useAttributePath": false,
+    "flakeUri": "",
+    "extraNixConfig": ""
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  Version of Nix to install. Use `latest` for the most recent stable release, or specify a version number such as `2.11`.
+</ParamField>
+
+<ParamField type="boolean">
+  Perform a multi-user install instead of a single-user install. See the [installation model comparison](#multi-user-vs-single-user-installs) below.
+</ParamField>
+
+<ParamField type="string">
+  Optional comma-separated list of Nix packages to install into the profile. For example: `nixpkgs.hello,nixpkgs.curl`.
+</ParamField>
+
+<ParamField type="boolean">
+  Use the exact attribute path of a package in the Nixpkgs repository. Aligns with the `nix-env -iA` command. When enabled, package names must be fully-qualified attribute paths (e.g., `nixpkgs.hello`).
+</ParamField>
+
+<ParamField type="string">
+  Optional URI to a Nix Flake to install into the profile. Remote URIs work best (e.g., `github:nixos/nixpkgs/nixpkgs-unstable#hello`). Local file paths require the file to be present in the image.
+</ParamField>
+
+<ParamField type="string">
+  Optional comma-separated list of extra configuration lines to append to `/etc/nix/nix.conf`.
+</ParamField>
+
+## Environment variables
+
+<ParamField type="string">
+  Extended to include `/nix/var/nix/profiles/default/bin` and `/nix/var/nix/profiles/default/sbin` so that Nix-installed binaries are available on the path.
+</ParamField>
+
+## Multi-user vs. single-user installs
+
+| Model                    | Pros                                                               | Cons                                                                                                         |
+| ------------------------ | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| **Multi-user** (default) | Works with any user including root. Unaffected by UID/GID changes. | Requires Nix 2.11+. Container must run as root or have `sudo` with passwordless access for the `remoteUser`. |
+| **Single-user**          | No root or `sudo` required.                                        | Only works for the user specified in `remoteUser`. UID/GID changes break Nix access.                         |
+
+### Manually starting the Nix daemon
+
+If `sudo` requires a password, the Nix daemon cannot start automatically. Start it manually from a terminal:
+
+```bash theme={null}
+sudo /usr/local/share/nix-entrypoint.sh
+```
+
+Use the same command to restart a stopped daemon. Logs are written to `/tmp/nix-daemon.log`.
+
+## Notes
+
+<Tip>
+  For Flake URIs, remote paths work best. To use a local Flake from your source tree, add the install command to `postCreateCommand` in `devcontainer.json` instead of using the `flakeUri` option.
+</Tip>
+
+<Note>
+  Nix packages are stored in a named Docker volume (`nix-store-${devcontainerId}`) mounted at `/nix`. This volume persists across container rebuilds.
+</Note>
+
+<Note>
+  The `nix` feature installs after `common-utils` when both are present in the same dev container configuration.
+</Note>
+
+### OS support
+
+This feature works on recent versions of Debian/Ubuntu, Red Hat Enterprise Linux, Fedora, RockyLinux, and Alpine Linux.
+
+
+# Node.js
+Source: https://www.mintlify.com/devcontainers/features/features/node
+
+Installs Node.js, nvm, yarn, pnpm, and needed dependencies.
+
+The Node.js feature installs Node.js via nvm, along with yarn and pnpm. It supports multiple Node.js versions and provides flexible installation options for package managers and native module compilation dependencies.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+{
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    }
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  Select or enter a Node.js version to install. Accepts `lts`, `latest`, `none`, or a specific major version such as `22` or `20`.
+</ParamField>
+
+<ParamField type="boolean">
+  Install dependencies required to compile native Node.js modules (node-gyp).
+</ParamField>
+
+<ParamField type="string">
+  The path where NVM will be installed.
+</ParamField>
+
+<ParamField type="string">
+  Select or enter the pnpm version to install. Accepts `latest`, `none`, or a specific version such as `8.8.0`.
+</ParamField>
+
+<ParamField type="string">
+  Version of NVM to install. Accepts `latest` or a specific version such as `0.39`.
+</ParamField>
+
+<ParamField type="boolean">
+  On Debian and Ubuntu, install Yarn globally via APT instead of Corepack. On other Linux distributions, Yarn is always installed via Corepack with an NPM fallback.
+</ParamField>
+
+## Environment variables
+
+| Variable              | Value                                      |
+| --------------------- | ------------------------------------------ |
+| `NVM_DIR`             | `/usr/local/share/nvm`                     |
+| `NVM_SYMLINK_CURRENT` | `true`                                     |
+| `PATH`                | `/usr/local/share/nvm/current/bin:${PATH}` |
+
+## VS Code extensions
+
+* `dbaeumer.vscode-eslint`
+
+## Notes
+
+### Using nvm from lifecycle commands
+
+Lifecycle commands such as `postCreateCommand` run in non-interactive, non-login shells where nvm is not automatically sourced. Source the nvm startup script explicitly before using it:
+
+```jsonc devcontainer.json theme={null}
+{
+  "postCreateCommand": ". ${NVM_DIR}/nvm.sh && nvm install --lts"
+}
+```
+
+Note that the default shell in these contexts is `sh`, not `bash` — use `. ${NVM_DIR}/nvm.sh` instead of `source ${NVM_DIR}/nvm.sh`.
+
+Alternatively, start an interactive bash shell:
+
+```jsonc devcontainer.json theme={null}
+{
+  "postCreateCommand": "bash -i -c 'nvm install --lts'"
+}
+```
+
+This feature works on Debian/Ubuntu, Red Hat Enterprise Linux, Fedora, Alma, and Rocky Linux distributions with the `apt`, `yum`, `dnf`, or `microdnf` package manager installed. Red Hat 7 family distributions must use Node.js versions below 18 due to system library constraints.
+
+
+# NVIDIA CUDA
+Source: https://www.mintlify.com/devcontainers/features/features/nvidia-cuda
+
+Installs shared libraries for NVIDIA CUDA.
+
+This feature installs NVIDIA CUDA shared libraries, making GPU-accelerated computing available inside the dev container. It is only useful when the dev container runs on a host machine with a physical NVIDIA GPU and the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/overview.html) installed on the host.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+"features": {
+  "ghcr.io/devcontainers/features/nvidia-cuda:3": {
+    "cudaVersion": "12.5",
+    "installCudnn": false,
+    "installToolkit": false
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  Version of CUDA to install. Supported versions: `12.5`, `12.4`, `12.3`, `12.2`, `12.1`, `12.0`, `11.8`, `11.7`, `11.6`, `11.5`, `11.4`, `11.3`, `11.2`.
+</ParamField>
+
+<ParamField type="boolean">
+  Additionally install the CUDA Deep Neural Network (cuDNN) shared library.
+</ParamField>
+
+<ParamField type="boolean">
+  Additionally install cuDNN development libraries and headers (required when compiling code that links against cuDNN).
+</ParamField>
+
+<ParamField type="boolean">
+  Additionally install the NVIDIA Tools Extension (NVTX) for profiling and annotation.
+</ParamField>
+
+<ParamField type="boolean">
+  Additionally install the full NVIDIA CUDA Toolkit (compilers, profilers, and development tools).
+</ParamField>
+
+<ParamField type="string">
+  Version of cuDNN to install when `installCudnn` or `installCudnnDev` is `true`. Use `automatic` to select a compatible version for the chosen `cudaVersion`. Specific versions supported: `9.4.0.58`, `9.3.0.75`, `9.2.1.18`, `9.2.0.82`, `9.1.1.17`, `9.1.0.70`, `9.0.0.312`, `8.9.5.29` and earlier 8.x releases.
+</ParamField>
+
+## Enabling GPU passthrough
+
+Add `hostRequirements` to your `devcontainer.json` to request GPU access:
+
+```jsonc devcontainer.json theme={null}
+{
+  "hostRequirements": {
+    "gpu": "optional"
+  }
+}
+```
+
+<Tip>
+  Using `"gpu": "optional"` allows the container to start on both GPU and CPU hosts. Using `"gpu": true` will fail on CPU-only machines.
+</Tip>
+
+After the container starts, verify GPU visibility with:
+
+```bash theme={null}
+nvidia-smi
+```
+
+## Installing the NVIDIA Container Toolkit
+
+If `nvidia-smi` is not available inside the container, install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/overview.html) on the **host** machine first. Ensure the NVIDIA driver for your Linux distribution is installed before installing the toolkit.
+
+<Warning>
+  This feature installs CUDA libraries only. It does not install NVIDIA drivers — those must be installed on the host machine separately.
+</Warning>
+
+## Notes
+
+<Note>
+  This feature works on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager. `bash` is required to execute the install script.
+</Note>
+
+
+# Oryx
+Source: https://www.mintlify.com/devcontainers/features/features/oryx
+
+Installs the oryx CLI.
+
+This feature installs the [Oryx](https://github.com/microsoft/Oryx) CLI — Microsoft's automatic build system that detects and builds source code for multiple language runtimes. Oryx is placed at `/usr/local/oryx` and added to the `PATH`, with dynamic SDK installation enabled so it can download and use additional SDKs at runtime.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+"features": {
+  "ghcr.io/devcontainers/features/oryx:2": {}
+}
+```
+
+This feature has no configurable options. All behavior is controlled through the environment variables listed below.
+
+## Environment variables
+
+| Variable                          | Value                           | Description                                                             |
+| --------------------------------- | ------------------------------- | ----------------------------------------------------------------------- |
+| `ORYX_SDK_STORAGE_BASE_URL`       | `https://oryx-cdn.microsoft.io` | Base URL for the Oryx SDK storage CDN                                   |
+| `ENABLE_DYNAMIC_INSTALL`          | `true`                          | Allows Oryx to download and install SDKs dynamically at build time      |
+| `DYNAMIC_INSTALL_ROOT_DIR`        | `/opt`                          | Root directory where dynamically installed SDKs are placed              |
+| `ORYX_PREFER_USER_INSTALLED_SDKS` | `true`                          | Prefers SDKs already installed by the user over those installed by Oryx |
+| `ORYX_DIR`                        | `/usr/local/oryx`               | Installation directory for the Oryx CLI                                 |
+| `DEBIAN_FLAVOR`                   | `bookworm`                      | Debian flavor used when resolving package compatibility                 |
+| `PATH`                            | `/usr/local/oryx:${PATH}`       | Oryx CLI directory prepended to the PATH                                |
+
+## Notes
+
+<Warning>
+  Oryx does not support Debian "jammy" (Ubuntu 22.04). Check the [supported platform versions](https://github.com/microsoft/Oryx/blob/main/doc/supportedPlatformVersions.md) in the Oryx repository before using this feature with a non-Debian-bookworm base image.
+</Warning>
+
+<Note>
+  `bash` is required to execute the install script.
+</Note>
+
+
+# PHP
+Source: https://www.mintlify.com/devcontainers/features/features/php
+
+Installs PHP and optionally Composer into your dev container.
+
+The PHP feature installs PHP from source into your dev container. Composer, the PHP dependency manager, is installed by default.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+{
+  "features": {
+    "ghcr.io/devcontainers/features/php:1": {
+      "version": "latest",
+      "installComposer": true
+    }
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  Select or enter a PHP version to install. Accepts `latest`, `none`, or a specific version such as `8`, `8.2`, or `8.2.0`.
+</ParamField>
+
+<ParamField type="boolean">
+  Install PHP Composer, the dependency manager for PHP.
+</ParamField>
+
+## Environment variables
+
+| Variable   | Value                                |
+| ---------- | ------------------------------------ |
+| `PHP_PATH` | `/usr/local/php/current`             |
+| `PATH`     | `/usr/local/php/current/bin:${PATH}` |
+
+## VS Code extensions
+
+* `xdebug.php-debug`
+* `bmewburn.vscode-intelephense-client`
+* `xdebug.php-pack`
+* `devsense.phptools-vscode`
+
+## Notes
+
+This feature works on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed. `bash` is required to execute the install script.
+
+
+# PowerShell
+Source: https://www.mintlify.com/devcontainers/features/features/powershell
+
+Installs PowerShell along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.
+
+The `powershell` feature installs [PowerShell](https://learn.microsoft.com/en-us/powershell/) (pwsh) and its dependencies. It also installs the PowerShell VS Code extension and optionally sets up a PowerShell profile and additional modules.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+"features": {
+  "ghcr.io/devcontainers/features/powershell:2": {
+    "version": "latest",
+    "modules": "",
+    "powershellProfileURL": ""
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  The version of PowerShell to install. Accepted values:
+
+  * `latest` — Most recent stable release (default).
+  * `lts` — Latest long-term support release.
+  * `preview` — Latest preview release.
+  * `stable` — Alias for `latest`.
+  * `none` — Skip installation.
+  * A specific version number such as `7.5` or `7.4`.
+</ParamField>
+
+<ParamField type="string">
+  Optional comma-separated list of PowerShell modules to install. To pin a module version, use `==` syntax. For example: `Az.Resources==2.5.0,Pester`.
+</ParamField>
+
+<ParamField type="string">
+  Optional publicly accessible URL to download a PowerShell profile file. The file is fetched and placed as the user's PowerShell profile during setup.
+</ParamField>
+
+## VS Code extensions
+
+The following extension is automatically installed when this feature is added to a dev container:
+
+* [`ms-vscode.powershell`](https://marketplace.visualstudio.com/items?itemName=ms-vscode.powershell) — PowerShell language support, debugging, and IntelliSense.
+
+## Notes
+
+<Note>
+  The `powershell` feature installs after `common-utils` when both are present in the same dev container configuration.
+</Note>
+
+### OS support
+
+This feature works on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed. `bash` is required to execute the install script.
+
+
+# Python
+Source: https://www.mintlify.com/devcontainers/features/features/python
+
+Installs the provided version of Python, as well as PIPX, and other common Python utilities. JupyterLab is conditionally installed with the python feature. Note: May require source code compilation.
+
+The Python feature installs Python, PIPX, and a curated set of common Python development tools into your dev container. JupyterLab can be enabled optionally. Some versions may require source code compilation.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+{
+  "features": {
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "latest",
+      "installTools": true
+    }
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  Select a Python version to install. Accepts `latest`, `os-provided`, `none`, or a specific version such as `3.12` or `3.11`.
+</ParamField>
+
+<ParamField type="boolean">
+  Whether to install the tools specified by `toolsToInstall`.
+</ParamField>
+
+<ParamField type="string">
+  Comma-separated list of Python tools to install when `installTools` is `true`.
+</ParamField>
+
+<ParamField type="boolean">
+  Optimize Python for performance when compiled. Enabling this significantly increases build time.
+</ParamField>
+
+<ParamField type="boolean">
+  Enable building a shared Python library (`libpython`).
+</ParamField>
+
+<ParamField type="string">
+  The path where Python will be installed.
+</ParamField>
+
+<ParamField type="boolean">
+  Install JupyterLab, a web-based interactive development environment for notebooks.
+</ParamField>
+
+<ParamField type="string">
+  Configure JupyterLab to accept HTTP requests from the specified origin.
+</ParamField>
+
+<ParamField type="string">
+  Connect to GPG keyservers using a proxy for fetching source code signatures.
+</ParamField>
+
+## Environment variables
+
+| Variable       | Value                                                                              |
+| -------------- | ---------------------------------------------------------------------------------- |
+| `PYTHON_PATH`  | `/usr/local/python/current`                                                        |
+| `PIPX_HOME`    | `/usr/local/py-utils`                                                              |
+| `PIPX_BIN_DIR` | `/usr/local/py-utils/bin`                                                          |
+| `PATH`         | `/usr/local/python/current/bin:/usr/local/py-utils/bin:/usr/local/jupyter:${PATH}` |
+
+## VS Code extensions
+
+* `ms-python.python`
+* `ms-python.vscode-pylance`
+* `ms-python.autopep8`
+
+## Notes
+
+This feature works on recent versions of Debian/Ubuntu, Red Hat Enterprise Linux, Fedora, Alma, and Rocky Linux distributions with the `apt`, `yum`, `dnf`, or `microdnf` package manager installed. `bash` is required to execute the install script.
+
+
+# Ruby (via rvm)
+Source: https://www.mintlify.com/devcontainers/features/features/ruby
+
+Installs Ruby, rvm, rbenv, common Ruby utilities, and needed dependencies.
+
+The Ruby feature installs Ruby via rvm, along with rbenv and common Ruby utilities. It manages Ruby versions through rvm and makes the selected version available on the `PATH`.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+{
+  "features": {
+    "ghcr.io/devcontainers/features/ruby:1": {
+      "version": "latest"
+    }
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  Select or enter a Ruby version to install. Accepts `latest`, `none`, or a specific version such as `3.4` or `3.2`.
+</ParamField>
+
+## Environment variables
+
+| Variable       | Value                                                                                                                                         |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GEM_PATH`     | `/usr/local/rvm/gems/default:/usr/local/rvm/gems/default@global`                                                                              |
+| `GEM_HOME`     | `/usr/local/rvm/gems/default`                                                                                                                 |
+| `MY_RUBY_HOME` | `/usr/local/rvm/rubies/default`                                                                                                               |
+| `PATH`         | `/usr/local/rvm/gems/default/bin:/usr/local/rvm/gems/default@global/bin:/usr/local/rvm/rubies/default/bin:/usr/local/share/rbenv/bin:${PATH}` |
+
+## VS Code extensions
+
+* `shopify.ruby-lsp`
+
+## Notes
+
+This feature works on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed. `bash` is required to execute the install script.
+
+
+# Rust
+Source: https://www.mintlify.com/devcontainers/features/features/rust
+
+Installs Rust, common Rust utilities, and their required dependencies
+
+The Rust feature installs Rust via rustup, along with common utilities such as `rust-analyzer`, `rustfmt`, and `clippy`. You can choose a specific Rust version, rustup profile, additional compilation targets, and toolchain components.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+{
+  "features": {
+    "ghcr.io/devcontainers/features/rust:1": {
+      "version": "latest",
+      "profile": "minimal"
+    }
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  Select or enter a version of Rust to install. Accepts `latest`, `none`, or a specific version such as `1.87` or `1.80`.
+</ParamField>
+
+<ParamField type="string">
+  Select a rustup install profile. Accepts `minimal`, `default`, or `complete`.
+</ParamField>
+
+<ParamField type="string">
+  Optional comma-separated list of additional Rust targets to install. For example: `aarch64-unknown-linux-gnu,armv7-unknown-linux-gnueabihf`.
+</ParamField>
+
+<ParamField type="string">
+  Optional comma-separated list of Rust toolchain components to install. For example: `rust-analyzer,rust-src,rustfmt,clippy`.
+</ParamField>
+
+## Environment variables
+
+| Variable      | Value                          |
+| ------------- | ------------------------------ |
+| `CARGO_HOME`  | `/usr/local/cargo`             |
+| `RUSTUP_HOME` | `/usr/local/rustup`            |
+| `PATH`        | `/usr/local/cargo/bin:${PATH}` |
+
+## VS Code extensions
+
+* `vadimcn.vscode-lldb`
+* `rust-lang.rust-analyzer`
+* `tamasfe.even-better-toml`
+
+## Notes
+
+This feature adds `SYS_PTRACE` capability and sets `seccomp=unconfined` to support native debuggers such as `lldb` and `gdb` for Rust debugging.
+
+```jsonc devcontainer.json theme={null}
+{
+  "features": {
+    "ghcr.io/devcontainers/features/rust:1": {}
+  },
+  "capAdd": ["SYS_PTRACE"],
+  "securityOpt": ["seccomp=unconfined"]
+}
+```
+
+<Warning>
+  Alpine Linux is not supported because the `rustup-init` binary requires glibc, which Alpine replaces with musl libc.
+</Warning>
+
+This feature works on recent versions of Debian/Ubuntu, Red Hat Enterprise Linux, Fedora, Alma, Rocky Linux, and Mariner distributions with the `apt`, `yum`, `dnf`, `microdnf`, or `tdnf` package manager installed. `bash` is required to execute the install script.
+
+
+# SSH server
+Source: https://www.mintlify.com/devcontainers/features/features/sshd
+
+Adds an SSH server into a container so that you can use an external terminal, sftp, or SSHFS to interact with it.
+
+The `sshd` feature installs and starts an OpenSSH server inside the dev container. This lets you connect with any SSH-capable client, transfer files via SFTP, or mount the container filesystem over SSHFS — all without requiring a dedicated IDE connection.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+"features": {
+  "ghcr.io/devcontainers/features/sshd:1": {
+    "gatewayPorts": "no"
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  Currently unused. Reserved for future use.
+</ParamField>
+
+<ParamField type="string">
+  Controls whether other hosts on the same network can connect to forwarded ports. Accepted values:
+
+  * `no` — Only the local machine can connect to forwarded ports (default).
+  * `yes` — Any host in the network can connect.
+  * `clientspecified` — The connecting client decides which addresses to bind.
+</ParamField>
+
+## Connecting to the container
+
+<Steps>
+  <Step title="Set a password">
+    The first time you start the container, set a password for your user. If running as a non-root user with `sudo`:
+
+    ```bash theme={null}
+    sudo passwd $(whoami)
+    ```
+
+    Or as root:
+
+    ```bash theme={null}
+    passwd
+    ```
+  </Step>
+
+  <Step title="Forward the SSH port">
+    Forward port `2222` (the default SSH port) to your local machine. Add it to `devcontainer.json`:
+
+    ```jsonc devcontainer.json theme={null}
+    "forwardPorts": [2222]
+    ```
+
+    Or use the **Ports** view in VS Code (F1 → "Ports: Focus on Ports View").
+  </Step>
+
+  <Step title="Connect with SSH">
+    Use a local terminal to connect with the password you set:
+
+    ```bash theme={null}
+    ssh -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o GlobalKnownHostsFile=/dev/null vscode@localhost
+    ```
+
+    Replace `vscode` with your actual container username. The `-o` flags suppress known-hosts warnings when connecting to different containers.
+  </Step>
+</Steps>
+
+### Using SSHFS
+
+[SSHFS](https://en.wikipedia.org/wiki/SSHFS) lets you mount the container filesystem on your local machine using only the SSH connection.
+
+**Install an SSHFS client:**
+
+* **Windows** — Install [WinFsp](https://github.com/billziss-gh/winfsp/releases) and [SSHFS-Win](https://github.com/billziss-gh/sshfs-win/releases).
+* **macOS** — `brew install macfuse gromgit/fuse/sshfs-mac`
+* **Linux** — `sudo apt-get install sshfs`
+
+**Mount on macOS / Linux:**
+
+```bash theme={null}
+mkdir -p ~/sshfs/devcontainer
+sshfs "vscode@localhost:/workspaces" "$HOME/sshfs/devcontainer" \
+  -p 2222 \
+  -o follow_symlinks \
+  -o StrictHostKeyChecking=no \
+  -o UserKnownHostsFile=/dev/null \
+  -o GlobalKnownHostsFile=/dev/null \
+  -C
+```
+
+**Mount on Windows** (Run dialog, Win+R):
+
+```
+\\sshfs.r\vscode@localhost!2222\workspaces
+```
+
+Replace `vscode` with your container username and `2222` with the forwarded local port.
+
+## Notes
+
+<Note>
+  The SSH server is started via the feature's entrypoint script (`/usr/local/share/ssh-init.sh`) each time the container starts.
+</Note>
+
+<Note>
+  The `sshd` feature installs after `common-utils` when both are present in the same dev container configuration.
+</Note>
+
+### OS support
+
+This feature works on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager installed. `bash` is required to execute the install script.
+
+
+# Terraform, tflint, and Terragrunt
+Source: https://www.mintlify.com/devcontainers/features/features/terraform
+
+Installs the Terraform CLI and optionally TFLint and Terragrunt. Auto-detects latest version and installs needed dependencies.
+
+This feature installs the Terraform CLI along with optional tooling for linting (`tflint`), workflow management (`terragrunt`), policy enforcement (`sentinel`), security scanning (`tfsec`), and documentation generation (`terraform-docs`). Versions are auto-detected unless you specify one explicitly.
+
+## Usage
+
+```jsonc devcontainer.json theme={null}
+"features": {
+  "ghcr.io/devcontainers/features/terraform:1": {
+    "version": "latest",
+    "tflint": "latest",
+    "terragrunt": "latest"
+  }
+}
+```
+
+## Options
+
+<ParamField type="string">
+  Terraform version to install. Common values: `latest`, `none`, `1.1`, `1.0`, `0.15`.
+</ParamField>
+
+<ParamField type="string">
+  TFLint version to install. See the [TFLint releases](https://github.com/terraform-linters/tflint/releases) page for available versions. Common values: `latest`, `0.47.0`, `0.46.1`.
+</ParamField>
+
+<ParamField type="string">
+  Terragrunt version to install.
+</ParamField>
+
+<ParamField type="boolean">
+  Install HashiCorp Sentinel — a language and framework for policy built to be embedded in existing software to enable fine-grained, logic-based policy decisions.
+</ParamField>
+
+<ParamField type="boolean">
+  Install tfsec — a static analysis tool that spots potential misconfigurations in your Terraform code.
+</ParamField>
+
+<ParamField type="boolean">
+  Install terraform-docs — a utility to generate documentation from Terraform modules.
+</ParamField>
+
+<ParamField type="string">
+  Connect to a keyserver using a proxy by configuring this option.
+</ParamField>
+
+<ParamField type="string">
+  Custom server URL for downloading Terraform and Sentinel packages, including protocol (e.g. `https://releases.hashicorp.com`). Defaults to the official HashiCorp download server when left empty.
+</ParamField>
+
+## VS Code extensions
+
+| Extension             | Description                                                         |
+| --------------------- | ------------------------------------------------------------------- |
+| `HashiCorp.terraform` | Official HashiCorp Terraform extension with language server support |
+
+## Custom download server
+
+The `customDownloadServer` option lets you specify an alternative server for downloading Terraform and Sentinel packages. This is useful for organizations that maintain internal mirrors or proxy HashiCorp downloads. The server must mirror the HashiCorp releases directory structure.
+
+```jsonc devcontainer.json theme={null}
+"features": {
+  "ghcr.io/devcontainers/features/terraform:1": {
+    "customDownloadServer": "https://my-mirror.example.com"
+  }
+}
+```
+
+<Warning>
+  Always verify that a custom download server is trustworthy and maintained by your organization. The feature performs SHA256 integrity checks, but these are only as reliable as the source providing the checksums. When possible, use the official HashiCorp download server.
+</Warning>
+
+## Licensing
+
+On August 10, 2023, HashiCorp moved Terraform from the MPL v2 open-source license to the BSL v1.1 license, starting with version 1.6. Review the [Terraform license](https://github.com/hashicorp/terraform/blob/main/LICENSE) before using Terraform 1.6 or later in commercial contexts.
+
+## Notes
+
+<Note>
+  This feature works on recent versions of Debian/Ubuntu-based distributions with the `apt` package manager. `bash` is required to execute the install script.
+</Note>
+
+
+# Combining Features
+Source: https://www.mintlify.com/devcontainers/features/guides/combining-features
+
+How to compose multiple Features in a single devcontainer.json
+
+Multiple Features can coexist in a single `devcontainer.json`. You add them all to the same `"features"` object, and the supporting tool installs each one in turn. Environment variables, VS Code extensions, and settings contributed by each Feature are merged automatically.
+
+## Basic multi-Feature example
+
+The following configuration combines Go, Python, Docker-in-Docker, and the GitHub CLI into one dev container:
+
+```jsonc .devcontainer/devcontainer.json theme={null}
+{
+  "name": "full-stack",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": true,
+      "configureZshAsDefaultShell": true,
+      "username": "automatic"
+    },
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.12",
+      "installTools": true
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "moby": true,
+      "dockerDashComposeVersion": "v2"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  }
+}
+```
+
+<Note>
+  `common-utils` is a frequently used base dependency. It installs Zsh, Oh My Zsh!, sets up a non-root user, and configures other shell conveniences. Many other Features declare `common-utils` in their `installsAfter` list, so including it ensures a consistent shell environment before language tools are layered on top.
+</Note>
+
+## Install ordering with `installsAfter`
+
+By default, when multiple Features have no ordering constraints, the supporting tool may install them in any order or in parallel. To guarantee that one Feature installs before another, Features declare an `installsAfter` list in their manifests.
+
+For example, the Go Feature's manifest includes:
+
+```json theme={null}
+"installsAfter": [
+  "ghcr.io/devcontainers/features/common-utils"
+]
+```
+
+This tells the supporting tool: if `common-utils` is also present in the `devcontainer.json`, install it first, then install `go`. The same pattern applies to Python, Node, Docker-in-Docker, Rust, Terraform, and most other Features in this collection — they all declare `common-utils` as an `installsAfter` dependency.
+
+<Note>
+  `installsAfter` is an ordering hint, not an implicit dependency pull. If `common-utils` is not in your `devcontainer.json`, the ordering hint is ignored — the dependency is not installed automatically.
+</Note>
+
+## Use-case examples
+
+<Tabs>
+  <Tab title="Frontend dev">
+    Node.js with Docker for running local services and the GitHub CLI for pull request workflows:
+
+    ```jsonc .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "frontend",
+      "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+      "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+          "installZsh": true,
+          "configureZshAsDefaultShell": true,
+          "username": "automatic"
+        },
+        "ghcr.io/devcontainers/features/node:1": {
+          "version": "lts",
+          "nodeGypDependencies": true
+        },
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+          "moby": true,
+          "dockerDashComposeVersion": "v2"
+        },
+        "ghcr.io/devcontainers/features/github-cli:1": {}
+      }
+    }
+    ```
+  </Tab>
+
+  <Tab title="Backend dev">
+    Go with Docker for container builds and GitHub CLI for repository operations:
+
+    ```jsonc .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "backend",
+      "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+      "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+          "installZsh": true,
+          "configureZshAsDefaultShell": true,
+          "username": "automatic"
+        },
+        "ghcr.io/devcontainers/features/go:1": {
+          "version": "latest",
+          "golangciLintVersion": "latest"
+        },
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+          "moby": true,
+          "dockerDashComposeVersion": "v2"
+        },
+        "ghcr.io/devcontainers/features/github-cli:1": {}
+      }
+    }
+    ```
+  </Tab>
+
+  <Tab title="DevOps">
+    Terraform and the cloud CLIs for infrastructure-as-code workflows:
+
+    ```jsonc .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "devops",
+      "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+      "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+          "installZsh": true,
+          "configureZshAsDefaultShell": true,
+          "username": "automatic"
+        },
+        "ghcr.io/devcontainers/features/terraform:1": {
+          "version": "latest",
+          "tflint": "latest",
+          "terragrunt": "latest"
+        },
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+          "moby": true,
+          "dockerDashComposeVersion": "v2"
+        },
+        "ghcr.io/devcontainers/features/github-cli:1": {},
+        "ghcr.io/devcontainers/features/aws-cli:1": {}
+      }
+    }
+    ```
+  </Tab>
+</Tabs>
+
+## Merged VS Code extensions
+
+When you combine Features, each Feature's `customizations.vscode.extensions` list is merged. Opening the container in VS Code installs all extensions from all Features automatically. For example, combining `go`, `python`, and `docker-in-docker` results in these extensions being installed:
+
+| Feature            | Extension                                                            |
+| ------------------ | -------------------------------------------------------------------- |
+| `go`               | `golang.Go`                                                          |
+| `python`           | `ms-python.python`, `ms-python.vscode-pylance`, `ms-python.autopep8` |
+| `docker-in-docker` | `ms-azuretools.vscode-containers`                                    |
+
+No manual extension installation is required.
+
+
+# Self-authoring Features
+Source: https://www.mintlify.com/devcontainers/features/guides/self-authoring
+
+How to create, test, and publish your own Dev Container Features
+
+Anyone can create their own Dev Container Features and distribute them via the GitHub Container Registry. You do not need to contribute to the official `devcontainers/features` repository — your Features live in a repository you control.
+
+<Steps>
+  <Step title="Create a repo from the starter template">
+    The [`devcontainers/feature-starter`](https://github.com/devcontainers/feature-starter) repository is a GitHub template with the scaffolding, GitHub Actions workflows, and documentation needed to author and publish Features.
+
+    Click **Use this template** on the repository page, or use the GitHub CLI:
+
+    ```bash theme={null}
+    gh repo create my-features \
+      --template devcontainers/feature-starter \
+      --public \
+      --clone
+    ```
+
+    The template includes:
+
+    * An example Feature with `devcontainer-feature.json` and `install.sh`
+    * A publish workflow (`.github/workflows/release.yaml`) using the `devcontainers/action` GitHub Action
+    * A test workflow (`.github/workflows/test.yaml`)
+  </Step>
+
+  <Step title="Author your Feature">
+    Each Feature lives in its own subfolder under `src/`. The folder name becomes the Feature's ID. At minimum, each Feature requires two files:
+
+    ```
+    src/
+    └── my-tool/
+        ├── devcontainer-feature.json
+        └── install.sh
+    ```
+
+    ### Minimal `devcontainer-feature.json`
+
+    ```json src/my-tool/devcontainer-feature.json theme={null}
+    {
+      "id": "my-tool",
+      "version": "1.0.0",
+      "name": "My Tool",
+      "description": "Installs my-tool and its dependencies.",
+      "options": {
+        "version": {
+          "type": "string",
+          "default": "latest",
+          "description": "Version of my-tool to install"
+        }
+      }
+    }
+    ```
+
+    | Field         | Required | Description                                    |
+    | ------------- | -------- | ---------------------------------------------- |
+    | `id`          | Yes      | Unique identifier — must match the folder name |
+    | `version`     | Yes      | Semantic version of the Feature package itself |
+    | `name`        | Yes      | Human-readable display name                    |
+    | `description` | No       | Short description shown in tooling UIs         |
+    | `options`     | No       | User-configurable installation options         |
+
+    ### Minimal `install.sh`
+
+    The `install.sh` script runs inside the container as root. Option values are injected as environment variables — the option name is uppercased (e.g. the `version` option becomes `$VERSION`).
+
+    ```bash src/my-tool/install.sh theme={null}
+    #!/bin/bash
+    set -e
+
+    VERSION="${VERSION:-"latest"}"
+
+    echo "Installing my-tool version: ${VERSION}"
+
+    # Resolve latest if needed
+    if [ "${VERSION}" = "latest" ]; then
+      VERSION=$(curl -sSL https://api.github.com/repos/example/my-tool/releases/latest \
+        | grep '"tag_name"' | sed 's/.*"tag_name": "\(.*\)".*/\1/')
+    fi
+
+    # Download and install
+    curl -sSL "https://example.com/my-tool/${VERSION}/install.sh" | bash
+
+    echo "Done."
+    ```
+
+    <Tip>
+      Start the script with `set -e` so it exits immediately on any error. This prevents partially installed tools from being silently ignored during container builds.
+    </Tip>
+  </Step>
+
+  <Step title="Test your Feature">
+    Use the `devcontainer features test` command from the [devcontainer CLI](https://github.com/devcontainers/cli) to run your test scripts locally before publishing.
+
+    Create a test script at `test/my-tool/test.sh`:
+
+    ```bash test/my-tool/test.sh theme={null}
+    #!/bin/bash
+    set -e
+
+    # Source the test library
+    source dev-container-features-test-lib
+
+    # Verify the tool is on PATH
+    check "my-tool version" my-tool --version
+
+    reportResults
+    ```
+
+    Run the tests:
+
+    ```bash theme={null}
+    devcontainer features test \
+      --features my-tool \
+      --base-image mcr.microsoft.com/devcontainers/base:ubuntu \
+      --project-folder .
+    ```
+
+    The CLI builds a temporary container with your Feature applied and executes `test.sh` inside it. Tests pass when every `check` call exits successfully.
+  </Step>
+
+  <Step title="Publish to GitHub Container Registry">
+    The `devcontainers/action` GitHub Action handles OCI packaging and publishing. The starter template already includes the release workflow — push a tag to trigger it.
+
+    ```bash theme={null}
+    git tag v1.0.0
+    git push origin v1.0.0
+    ```
+
+    The action packages each Feature under `src/` and pushes them to:
+
+    ```
+    ghcr.io/<your-github-username>/<repo-name>/<feature-id>:<version>
+    ```
+
+    For example, if your GitHub username is `myorg` and your repo is `my-features`, the Feature is available at:
+
+    ```
+    ghcr.io/myorg/my-features/my-tool:1
+    ```
+
+    Reference it in any `devcontainer.json`:
+
+    ```jsonc theme={null}
+    "features": {
+      "ghcr.io/myorg/my-features/my-tool:1": {
+        "version": "latest"
+      }
+    }
+    ```
+
+    <Note>
+      The repository must be public, or the container image must be made public in your package settings, for other users to reference your Feature without authentication.
+    </Note>
+  </Step>
+
+  <Step title="Share with the community">
+    Once your Feature is published, you can add it to the [community index at containers.dev/features](https://containers.dev/features). The index makes your Feature discoverable to other developers and to tooling that surfaces suggested Features.
+
+    To add your Feature to the index, follow the instructions in the [feature-starter README](https://github.com/devcontainers/feature-starter#adding-features-to-the-index). The process involves submitting a pull request to the [devcontainers/devcontainers.github.io](https://github.com/devcontainers/devcontainers.github.io) repository with a reference to your Feature collection.
+  </Step>
+</Steps>
+
+## Feature structure reference
+
+A complete Feature folder can include additional optional files:
+
+```
+src/
+└── my-tool/
+    ├── devcontainer-feature.json   # Required — manifest
+    ├── install.sh                  # Required — installation script
+    ├── README.md                   # Optional — shown on containers.dev
+    └── NOTES.md                    # Optional — additional implementation notes
+```
+
+The `README.md` is displayed on the [containers.dev/features](https://containers.dev/features) index page for your Feature, so it is worth including usage examples and a full option table.
+
+
+# Using Features
+Source: https://www.mintlify.com/devcontainers/features/guides/using-features
+
+How to add Dev Container Features to your devcontainer.json
+
+Features are added to a dev container by including a `"features"` block in your `devcontainer.json`. Each entry in the block references a Feature by its URI and supplies any options you want to override.
+
+## The `features` property
+
+The `features` property is a JSON object where each key is a Feature reference URI and each value is an options object:
+
+```jsonc .devcontainer/devcontainer.json theme={null}
+{
+  "name": "my-project",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "latest"
+    }
+  }
+}
+```
+
+If you have no options to pass, use an empty object `{}` as the value.
+
+## Feature reference URI format
+
+Every Feature published to the GitHub Container Registry follows this URI format:
+
+```
+ghcr.io/devcontainers/features/<id>:<version>
+```
+
+| Segment                          | Description                                                                     |
+| -------------------------------- | ------------------------------------------------------------------------------- |
+| `ghcr.io/devcontainers/features` | The registry and collection path for the official devcontainers Feature set     |
+| `<id>`                           | The Feature identifier — matches the folder name under `src/` in the repository |
+| `:<version>`                     | The version tag — see [Versioning](/guides/versioning) for pinning strategies   |
+
+For example, the Go Feature's full reference is `ghcr.io/devcontainers/features/go:1`.
+
+## Passing options
+
+Each Feature exposes a set of named options you can configure. Pass them as key-value pairs in the options object.
+
+### Go Feature options
+
+The `go` Feature (`ghcr.io/devcontainers/features/go`) supports these options:
+
+| Option                | Type   | Default    | Description                                     |
+| --------------------- | ------ | ---------- | ----------------------------------------------- |
+| `version`             | string | `"latest"` | Go version to install (e.g. `"1.24"`, `"1.23"`) |
+| `golangciLintVersion` | string | `"latest"` | Version of golangci-lint to install             |
+
+```jsonc theme={null}
+"ghcr.io/devcontainers/features/go:1": {
+  "version": "1.23",
+  "golangciLintVersion": "latest"
+}
+```
+
+### Python Feature options
+
+The `python` Feature (`ghcr.io/devcontainers/features/python`) supports these options:
+
+| Option              | Type    | Default         | Description                                                     |
+| ------------------- | ------- | --------------- | --------------------------------------------------------------- |
+| `version`           | string  | `"os-provided"` | Python version to install (e.g. `"3.12"`, `"3.11"`)             |
+| `installTools`      | boolean | `true`          | Install common Python tools (flake8, black, mypy, pytest, etc.) |
+| `installJupyterlab` | boolean | `false`         | Install JupyterLab                                              |
+
+```jsonc theme={null}
+"ghcr.io/devcontainers/features/python:1": {
+  "version": "3.12",
+  "installTools": true,
+  "installJupyterlab": false
+}
+```
+
+## Complete example
+
+The following `devcontainer.json` adds both Go and Python to a base Ubuntu image:
+
+<Tabs>
+  <Tab title="Ubuntu">
+    ```jsonc .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "my-project",
+      "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+      "features": {
+        "ghcr.io/devcontainers/features/go:1": {
+          "version": "1.23",
+          "golangciLintVersion": "latest"
+        },
+        "ghcr.io/devcontainers/features/python:1": {
+          "version": "3.12",
+          "installTools": true,
+          "installJupyterlab": false
+        }
+      }
+    }
+    ```
+  </Tab>
+
+  <Tab title="Debian">
+    ```jsonc .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "my-project",
+      "image": "mcr.microsoft.com/devcontainers/base:debian",
+      "features": {
+        "ghcr.io/devcontainers/features/go:1": {
+          "version": "1.23",
+          "golangciLintVersion": "latest"
+        },
+        "ghcr.io/devcontainers/features/python:1": {
+          "version": "3.12",
+          "installTools": true,
+          "installJupyterlab": false
+        }
+      }
+    }
+    ```
+  </Tab>
+
+  <Tab title="devcontainers base">
+    ```jsonc .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "my-project",
+      "image": "mcr.microsoft.com/devcontainers/base:jammy",
+      "features": {
+        "ghcr.io/devcontainers/features/go:1": {
+          "version": "1.23",
+          "golangciLintVersion": "latest"
+        },
+        "ghcr.io/devcontainers/features/python:1": {
+          "version": "3.12",
+          "installTools": true,
+          "installJupyterlab": false
+        }
+      }
+    }
+    ```
+  </Tab>
+</Tabs>
+
+## What happens when a Feature is added
+
+When a supporting tool builds your dev container with Features, it:
+
+1. **Runs `install.sh`** inside the container for each requested Feature. The script receives your option values as environment variables and performs all installation steps.
+2. **Sets environment variables** declared in the Feature's `containerEnv`. For example, the Go Feature sets `GOROOT`, `GOPATH`, and prepends Go binaries to `PATH` — these are available in every terminal session and process inside the container.
+3. **Installs VS Code extensions** listed in the Feature's `customizations.vscode.extensions`. Adding the Go Feature automatically installs the `golang.Go` extension; adding the Python Feature installs `ms-python.python` and `ms-python.vscode-pylance`.
+4. **Applies VS Code settings** from each Feature's `customizations.vscode.settings`. Extensions and settings from all Features are merged before being applied.
+
+## Supported environments
+
+A [tool that supports the dev container specification](https://containers.dev/supporting) is required to build and run a dev container with Features. The most widely used supporting tools are:
+
+* **VS Code Dev Containers** — the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) for Visual Studio Code builds and connects to dev containers locally using Docker.
+* **GitHub Codespaces** — cloud-hosted dev containers backed by the same specification. Add Features to `devcontainer.json` in your repository and they are applied when creating a Codespace.
+* **devcontainer CLI** — the [reference CLI implementation](https://github.com/devcontainers/cli) for building and testing dev containers from the command line.
+
+For the full list of supporting tools, see [containers.dev/supporting](https://containers.dev/supporting).
+
+
+# Versioning
+Source: https://www.mintlify.com/devcontainers/features/guides/versioning
+
+How to pin, update, and manage Feature versions
+
+Dev Container Features follow [semantic versioning](https://semver.org/) (`major.minor.patch`). You control how aggressively your container tracks updates by choosing how precisely you pin the version tag in your Feature reference URI.
+
+## Version tag formats
+
+Append a version tag after the Feature ID with a colon:
+
+```
+ghcr.io/devcontainers/features/<id>:<tag>
+```
+
+The supported tag formats are:
+
+| Tag           | Example   | Behavior                                                                   |
+| ------------- | --------- | -------------------------------------------------------------------------- |
+| Major only    | `:1`      | Receives all minor and patch updates within that major version             |
+| Major + minor | `:1.0`    | Receives patch updates only within that minor version                      |
+| Full patch    | `:1.0.0`  | Pinned to an exact release; never updates automatically                    |
+| Latest        | `:latest` | Always resolves to the highest published version across all major releases |
+| Omitted       | *(none)*  | Equivalent to `:latest`                                                    |
+
+## Pinning strategies
+
+### Major version (`:1`)
+
+Pinning to a major version is the recommended approach for most projects. You receive backwards-compatible improvements and bug fixes automatically, while major breaking changes require an explicit update on your part.
+
+```jsonc .devcontainer/devcontainer.json theme={null}
+{
+  "features": {
+    // Go Feature — currently at 1.3.3; receives 1.x.x updates automatically
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "latest"
+    },
+    // Docker-in-Docker — currently at 2.16.1; receives 2.x.x updates automatically
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "moby": true
+    }
+  }
+}
+```
+
+### Minor version (`:1.0`)
+
+Pinning to a minor version lets patch releases through but blocks minor version bumps. Use this when you want security fixes without feature changes.
+
+```jsonc .devcontainer/devcontainer.json theme={null}
+{
+  "features": {
+    "ghcr.io/devcontainers/features/go:1.3": {
+      "version": "latest"
+    }
+  }
+}
+```
+
+### Exact patch version (`:1.0.0`)
+
+Pinning to a full patch version freezes the Feature entirely. The container builds identically every time, regardless of what is published to the registry.
+
+```jsonc .devcontainer/devcontainer.json theme={null}
+{
+  "features": {
+    // Frozen at Go Feature 1.3.3
+    "ghcr.io/devcontainers/features/go:1.3.3": {
+      "version": "latest"
+    },
+    // Frozen at Docker-in-Docker Feature 2.16.1
+    "ghcr.io/devcontainers/features/docker-in-docker:2.16.1": {
+      "moby": true
+    }
+  }
+}
+```
+
+<Warning>
+  Do not use `:latest` (or omit the version tag) in production or shared environments. The `:latest` tag always resolves to the highest published version across all major releases. A future major release may introduce breaking changes that cause your container build to fail or behave unexpectedly without any change on your part.
+</Warning>
+
+## Versioning semantics
+
+The version tag refers to the **Feature package version**, not the version of the tool being installed. These are independent:
+
+* `ghcr.io/devcontainers/features/go:1` pins the Go *Feature* to major version 1.
+* The `"version": "1.23"` option inside the object controls which version of the *Go language* is installed.
+
+```jsonc theme={null}
+// Feature package version: 1 (major pin)
+// Go language version: 1.23
+"ghcr.io/devcontainers/features/go:1": {
+  "version": "1.23"
+}
+```
+
+## Finding available versions
+
+Published versions of each Feature are listed in the GitHub Container Registry under the `devcontainers/features` package namespace.
+
+To browse available versions for the Go Feature, visit:
+
+```
+https://github.com/devcontainers/features/pkgs/container/features%2Fgo/versions
+```
+
+Replace `go` in the URL path with the ID of any other Feature to see its version history.
+
+You can also list versions using the GitHub CLI:
+
+```bash theme={null}
+gh api /orgs/devcontainers/packages/container/features%2Fgo/versions \
+  --jq '.[].metadata.container.tags[]' | sort -V
+```
+
+
+# How Features work
+Source: https://www.mintlify.com/devcontainers/features/how-features-work
+
+Understand the Feature lifecycle, manifest format, and installation model
+
+<Note>
+  The authoritative specification for Dev Container Features is published at [containers.dev/implementors/features](https://containers.dev/implementors/features/).
+</Note>
+
+A Dev Container Feature is a folder containing exactly two required files:
+
+* **`devcontainer-feature.json`** — the manifest that declares the Feature's identity, options, environment variables, and VS Code customizations
+* **`install.sh`** — the shell script that runs inside the container to install the tool
+
+Supporting tools read the manifest, resolve dependencies, then execute `install.sh` for each requested Feature.
+
+## Anatomy of a Feature
+
+The folder structure for a Feature looks like this:
+
+```
+src/
+└── go/
+    ├── devcontainer-feature.json
+    └── install.sh
+```
+
+The folder name becomes the Feature's distribution identifier. The manifest contains all metadata; the script contains all installation logic.
+
+## The `devcontainer-feature.json` manifest
+
+Below is the real manifest for the Go Feature (`ghcr.io/devcontainers/features/go`):
+
+```jsonc src/go/devcontainer-feature.json theme={null}
+{
+    "id": "go",
+    "version": "1.3.3",
+    "name": "Go",
+    "documentationURL": "https://github.com/devcontainers/features/tree/main/src/go",
+    "description": "Installs Go and common Go utilities. Auto-detects latest version and installs needed dependencies.",
+    "options": {
+        "version": {
+            "type": "string",
+            "proposals": [
+                "latest",
+                "none",
+                "1.24",
+                "1.23"
+            ],
+            "default": "latest",
+            "description": "Select or enter a Go version to install"
+        },
+        "golangciLintVersion": {
+            "type": "string",
+            "default": "latest",
+            "description": "Version of golangci-lint to install"
+        }
+    },
+    "init": true,
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "golang.Go"
+            ],
+            "settings": {
+                "github.copilot.chat.codeGeneration.instructions": [
+                    {
+                        "text": "This dev container includes Go and common Go utilities pre-installed and available on the `PATH`, along with the Go language extension for Go development."
+                    }
+                ]
+            }
+        }
+    },
+    "containerEnv": {
+        "GOROOT": "/usr/local/go",
+        "GOPATH": "/go",
+        "PATH": "/usr/local/go/bin:/go/bin:${PATH}"
+    },
+    "capAdd": [
+        "SYS_PTRACE"
+    ],
+    "securityOpt": [
+        "seccomp=unconfined"
+    ],
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
+}
+```
+
+### Field reference
+
+<AccordionGroup>
+  <Accordion title="id">
+    A short, unique identifier for the Feature within its collection. Combined with the registry host and collection path to form the full Feature reference:
+
+    ```
+    ghcr.io/devcontainers/features/go
+    ```
+
+    The `id` must match the folder name under `src/`.
+  </Accordion>
+
+  <Accordion title="version">
+    The semantic version of the Feature itself — not the version of the tool being installed. Follows [semver](https://semver.org/) conventions.
+
+    When you reference a Feature in `devcontainer.json`, you pin to a version of the Feature package:
+
+    ```jsonc theme={null}
+    // Pin to the major version of the Feature package
+    "ghcr.io/devcontainers/features/go:1": {}
+    ```
+  </Accordion>
+
+  <Accordion title="name">
+    A human-readable display name shown in tooling UIs and documentation. Does not affect installation behavior.
+  </Accordion>
+
+  <Accordion title="description">
+    A short description of what the Feature installs or configures. Used in tooling UIs and the generated documentation.
+  </Accordion>
+
+  <Accordion title="options">
+    A map of user-configurable options. Each option has:
+
+    * `type` — `"string"`, `"boolean"`, or `"integer"`
+    * `default` — the value used when the option is not specified
+    * `description` — shown in tooling UIs
+    * `proposals` (optional) — a list of suggested values for string options
+    * `enum` (optional) — a strict list of allowed values for string options
+
+    Options are passed to `install.sh` as environment variables. A string option named `golangciLintVersion` becomes the variable `$GOLANGCILINTVERSION` (uppercased).
+
+    ```jsonc devcontainer.json theme={null}
+    "ghcr.io/devcontainers/features/go:1": {
+        "version": "1.23",
+        "golangciLintVersion": "latest"
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="containerEnv">
+    A map of environment variables that are set in the container at runtime. These persist for all processes in the container, not just the installation script.
+
+    The Go Feature sets `GOROOT`, `GOPATH`, and prepends the Go binaries to `PATH`:
+
+    ```jsonc theme={null}
+    "containerEnv": {
+        "GOROOT": "/usr/local/go",
+        "GOPATH": "/go",
+        "PATH": "/usr/local/go/bin:/go/bin:${PATH}"
+    }
+    ```
+
+    The special token `${PATH}` references the container's existing `PATH` value so prepending does not discard existing entries.
+  </Accordion>
+
+  <Accordion title="customizations">
+    Tool-specific configuration applied when the dev container is opened. The `vscode` key is the most common and supports two sub-keys:
+
+    * `extensions` — a list of VS Code extension IDs to install automatically
+    * `settings` — VS Code workspace settings to apply
+
+    For the Go Feature, this installs the `golang.Go` extension and configures a Copilot code generation hint:
+
+    ```jsonc theme={null}
+    "customizations": {
+        "vscode": {
+            "extensions": ["golang.Go"],
+            "settings": { ... }
+        }
+    }
+    ```
+
+    Extensions and settings from all Features are merged together by the supporting tool.
+  </Accordion>
+
+  <Accordion title="installsAfter">
+    An ordered list of Feature references that must be fully installed before this Feature runs its `install.sh`. This is how Features declare dependencies.
+
+    The Go Feature declares:
+
+    ```jsonc theme={null}
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
+    ```
+
+    If `common-utils` is also in your `devcontainer.json`, the supporting tool installs it first. If it is not in your `devcontainer.json`, the ordering hint is ignored — `installsAfter` does not implicitly pull in dependencies.
+  </Accordion>
+</AccordionGroup>
+
+## Installation lifecycle
+
+When a supporting tool builds a dev container with Features, it follows this sequence:
+
+1. **Parse** `devcontainer.json` and collect all requested Features.
+2. **Fetch** each Feature's `devcontainer-feature.json` manifest from the OCI registry.
+3. **Resolve install order** using `installsAfter` declarations to build a dependency-aware sequence. Features with no ordering constraints may be installed in any order or in parallel.
+4. **Run `install.sh`** for each Feature in sequence, inside the container. The script receives the user-supplied option values as environment variables.
+5. **Apply `containerEnv`** values so they are available at runtime, not just during installation.
+6. **Apply VS Code customizations** (extensions and settings) when the container is opened in VS Code.
+
+## Environment variables set by Features
+
+Each Feature can contribute runtime environment variables via `containerEnv`. These are set for the container's lifetime — every terminal session and every process inside the container sees them.
+
+| Feature | Variable | Value                               |
+| ------- | -------- | ----------------------------------- |
+| `go`    | `GOROOT` | `/usr/local/go`                     |
+| `go`    | `GOPATH` | `/go`                               |
+| `go`    | `PATH`   | `/usr/local/go/bin:/go/bin:${PATH}` |
+
+Variables from multiple Features are merged. If two Features set the same variable, behavior depends on the supporting tool's implementation — to avoid conflicts, use `${EXISTING_VAR}` references rather than hardcoding values.
+
+## VS Code customizations
+
+When you open a dev container in VS Code, extensions listed in each Feature's `customizations.vscode.extensions` are installed automatically in the container's VS Code server. Settings in `customizations.vscode.settings` are applied as workspace settings.
+
+This means adding the Go Feature to your `devcontainer.json` automatically installs the `golang.Go` extension — no manual extension installation required.
+
+Extensions and settings from all Features and from the top-level `devcontainer.json` `customizations` block are merged before being applied.
+
+
+# Dev Container Features
+Source: https://www.mintlify.com/devcontainers/features/introduction
+
+A curated collection of reusable Dev Container Features that instantly add languages, tools, and CLIs to any development container.
+
+Dev Container Features are self-contained units of installation code and configuration that install atop any base container image. Missing Go, Node.js, or Terraform in your container? Add the relevant Feature to your `devcontainer.json` — no Dockerfile editing required.
+
+These Features are maintained by the Dev Container spec maintainers and distributed via the GitHub Container Registry at `ghcr.io/devcontainers/features`.
+
+<CardGroup>
+  <Card title="Quickstart" icon="rocket" href="/quickstart">
+    Add your first Feature to a dev container in under 5 minutes
+  </Card>
+
+  <Card title="How Features Work" icon="gear" href="/how-features-work">
+    Understand the Feature lifecycle, manifest format, and installation model
+  </Card>
+
+  <Card title="Features Reference" icon="book" href="/features/go">
+    Browse all 28 available Features with full option documentation
+  </Card>
+
+  <Card title="Combining Features" icon="layer-group" href="/guides/combining-features">
+    Compose multiple Features together in a single devcontainer.json
+  </Card>
+</CardGroup>
+
+## What are Dev Container Features?
+
+A Feature is a folder containing:
+
+* A `devcontainer-feature.json` manifest defining the Feature ID, version, options, and VS Code customizations
+* An `install.sh` script that runs inside the container to install the tool
+
+When a supporting tool (like VS Code Dev Containers or GitHub Codespaces) builds your dev container, it runs each Feature's installation script in sequence, resulting in a fully-configured environment.
+
+```jsonc devcontainer.json theme={null}
+{
+  "name": "my-project",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "dockerDashComposeVersion": "v2"
+    }
+  }
+}
+```
+
+## Available Features
+
+<CardGroup>
+  <Card title="Languages" icon="code" href="/features/go">
+    Go, Python, Node.js, Java, .NET, Rust, Ruby, PHP
+  </Card>
+
+  <Card title="Containers & Kubernetes" icon="docker" href="/features/docker-in-docker">
+    Docker-in-Docker, Docker-outside-of-Docker, Kubectl, Helm, Minikube
+  </Card>
+
+  <Card title="Cloud & DevOps" icon="cloud" href="/features/terraform">
+    Terraform, AWS CLI, Azure CLI, GitHub CLI
+  </Card>
+
+  <Card title="Utilities & Tools" icon="wrench" href="/features/common-utils">
+    Common Utils, Git, Git LFS, SSHD, Nix, PowerShell, Hugo, Desktop Lite
+  </Card>
+
+  <Card title="Data Science & ML" icon="chart-line" href="/features/anaconda">
+    Anaconda, Conda, NVIDIA CUDA, Oryx
+  </Card>
+
+  <Card title="Self-Authoring" icon="pen" href="/guides/self-authoring">
+    Create and publish your own Features
+  </Card>
+</CardGroup>
+
+## How to reference a Feature
+
+All Features in this repository are referenced by their `ghcr.io` URI with a version tag:
+
+```jsonc theme={null}
+"features": {
+    "ghcr.io/devcontainers/features/node:1": {
+        "version": "lts"
+    }
+}
+```
+
+See [versioning](/guides/versioning) for how to pin to major, minor, or patch versions.
+
+
+# Quickstart
+Source: https://www.mintlify.com/devcontainers/features/quickstart
+
+Get up and running with Dev Container Features in minutes
+
+<Note>
+  A supporting tool is required to build dev containers. Use the [VS Code Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers), [GitHub Codespaces](https://github.com/features/codespaces), or any other [tool that supports the dev container specification](https://containers.dev/supporting).
+</Note>
+
+<Steps>
+  <Step title="Prerequisites">
+    You need a `devcontainer.json` file at the root of your project (inside a `.devcontainer/` folder or at `.devcontainer.json`).
+
+    If you don't have one yet, create `.devcontainer/devcontainer.json` with a base image:
+
+    ```jsonc .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "my-project",
+      "image": "mcr.microsoft.com/devcontainers/base:ubuntu"
+    }
+    ```
+
+    Any generic Debian-based image works as a starting point. Features install on top of it.
+  </Step>
+
+  <Step title="Add a Feature">
+    Add a `"features"` block to your `devcontainer.json`. Each key is a Feature reference in the form `ghcr.io/devcontainers/features/<id>:<major-version>`, and the value is an object of options.
+
+    The example below adds Go and the Common Utilities Feature (which installs Zsh, Oh My Zsh!, and sets up a non-root user):
+
+    ```jsonc .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "my-project",
+      "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+      "features": {
+        "ghcr.io/devcontainers/features/go:1": {
+          "version": "latest"
+        },
+        "ghcr.io/devcontainers/features/common-utils:2": {
+          "installZsh": true,
+          "configureZshAsDefaultShell": true,
+          "username": "automatic"
+        }
+      }
+    }
+    ```
+
+    <Tip>
+      Pin to a major version like `:1` rather than `:latest`. Major-version tags receive backwards-compatible updates automatically, whereas `:latest` always resolves to the highest published version and may include breaking changes across major releases.
+    </Tip>
+  </Step>
+
+  <Step title="Rebuild the container">
+    After editing `devcontainer.json`, rebuild the container to apply the new Features.
+
+    <Tabs>
+      <Tab title="VS Code">
+        Open the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) and run:
+
+        ```
+        Dev Containers: Rebuild Container
+        ```
+      </Tab>
+
+      <Tab title="CLI">
+        Run the following from your project root:
+
+        ```bash theme={null}
+        devcontainer build --workspace-folder .
+        ```
+
+        The [devcontainer CLI](https://github.com/devcontainers/cli) is the reference implementation of the dev container specification.
+      </Tab>
+
+      <Tab title="GitHub Codespaces">
+        Commit your updated `devcontainer.json` and create a new Codespace, or rebuild an existing one from the Codespace settings menu.
+      </Tab>
+    </Tabs>
+  </Step>
+
+  <Step title="Verify installation">
+    Once the container is running, open a terminal inside it and confirm the tools are available:
+
+    ```bash theme={null}
+    # Verify Go is installed
+    go version
+
+    # Verify Zsh is installed (from common-utils)
+    zsh --version
+    ```
+
+    You should see output similar to:
+
+    ```
+    go version go1.24.1 linux/amd64
+    zsh 5.9 (x86_64-ubuntu-linux-gnu)
+    ```
+  </Step>
+</Steps>
+
+## Next steps
+
+<CardGroup>
+  <Card title="How Features work" icon="gear" href="/how-features-work">
+    Learn about the Feature manifest, installation lifecycle, and VS Code customizations
+  </Card>
+
+  <Card title="Combining Features" icon="layer-group" href="/guides/combining-features">
+    Compose multiple Features and understand install ordering
+  </Card>
+
+  <Card title="Features reference" icon="book" href="/features/go">
+    Browse all available Features with full option documentation
+  </Card>
+
+  <Card title="Versioning" icon="tag" href="/guides/versioning">
+    Pin to major, minor, or patch versions
+  </Card>
+</CardGroup>
+
+

--- a/docs/research/mintlify-cache/devcontainers/features/llms.txt
+++ b/docs/research/mintlify-cache/devcontainers/features/llms.txt
@@ -1,0 +1,44 @@
+# Dev Container Features
+
+## Docs
+
+- [Contributing](https://www.mintlify.com/devcontainers/features/contributing/overview.md): How to contribute bug fixes and improvements to Dev Container Features
+- [Testing Features](https://www.mintlify.com/devcontainers/features/contributing/testing.md): How to write and run tests for Dev Container Features
+- [Anaconda](https://www.mintlify.com/devcontainers/features/features/anaconda.md): Installs the Anaconda distribution, including the conda package manager and a full-featured Python environment for data science.
+- [AWS CLI](https://www.mintlify.com/devcontainers/features/features/aws-cli.md): Installs the AWS CLI along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.
+- [Azure CLI](https://www.mintlify.com/devcontainers/features/features/azure-cli.md): Installs the Azure CLI along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.
+- [Common Utilities](https://www.mintlify.com/devcontainers/features/features/common-utils.md): Installs a set of common command line utilities, Oh My Zsh!, and sets up a non-root user.
+- [Conda](https://www.mintlify.com/devcontainers/features/features/conda.md): A cross-platform, language-agnostic binary package manager.
+- [GitHub Copilot CLI](https://www.mintlify.com/devcontainers/features/features/copilot-cli.md): Installs the GitHub Copilot CLI.
+- [Light-weight Desktop](https://www.mintlify.com/devcontainers/features/features/desktop-lite.md): Adds a lightweight Fluxbox-based desktop to the container, accessible via a VNC viewer or web browser. GUI commands run from the VS Code terminal open on the desktop automatically.
+- [Docker (Docker-in-Docker)](https://www.mintlify.com/devcontainers/features/features/docker-in-docker.md): Create child containers inside a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.
+- [Docker (docker-outside-of-docker)](https://www.mintlify.com/devcontainers/features/features/docker-outside-of-docker.md): Re-use the host docker socket, adding the Docker CLI to a container. Feature invokes a script to enable using a forwarded Docker socket within a container to run Docker commands.
+- [Dotnet CLI](https://www.mintlify.com/devcontainers/features/features/dotnet.md): This Feature installs the latest .NET SDK, which includes the .NET CLI and the shared runtime. Options are provided to choose a different version or additional versions.
+- [Git (from source)](https://www.mintlify.com/devcontainers/features/features/git.md): Install an up-to-date version of Git, built from source as needed. Auto-detects the latest stable version and installs needed dependencies.
+- [Git Large File Support (LFS)](https://www.mintlify.com/devcontainers/features/features/git-lfs.md): Installs Git Large File Support (Git LFS) along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like git and curl.
+- [GitHub CLI](https://www.mintlify.com/devcontainers/features/features/github-cli.md): Installs the GitHub CLI. Auto-detects latest version and installs needed dependencies.
+- [Go](https://www.mintlify.com/devcontainers/features/features/go.md): Installs Go and common Go utilities. Auto-detects latest version and installs needed dependencies.
+- [Hugo](https://www.mintlify.com/devcontainers/features/features/hugo.md): Installs Hugo, a popular open-source static site generator written in Go.
+- [Java](https://www.mintlify.com/devcontainers/features/features/java.md): Installs Java, SDKMAN! (if not installed), and needed dependencies.
+- [Kubectl, Helm, and Minikube](https://www.mintlify.com/devcontainers/features/features/kubectl-helm-minikube.md): Installs latest version of kubectl, Helm, and optionally minikube. Auto-detects latest versions and installs needed dependencies.
+- [Nix Package Manager](https://www.mintlify.com/devcontainers/features/features/nix.md): Installs the Nix package manager and optionally a set of packages.
+- [Node.js](https://www.mintlify.com/devcontainers/features/features/node.md): Installs Node.js, nvm, yarn, pnpm, and needed dependencies.
+- [NVIDIA CUDA](https://www.mintlify.com/devcontainers/features/features/nvidia-cuda.md): Installs shared libraries for NVIDIA CUDA.
+- [Oryx](https://www.mintlify.com/devcontainers/features/features/oryx.md): Installs the oryx CLI.
+- [PHP](https://www.mintlify.com/devcontainers/features/features/php.md): Installs PHP and optionally Composer into your dev container.
+- [PowerShell](https://www.mintlify.com/devcontainers/features/features/powershell.md): Installs PowerShell along with needed dependencies. Useful for base Dockerfiles that often are missing required install dependencies like gpg.
+- [Python](https://www.mintlify.com/devcontainers/features/features/python.md): Installs the provided version of Python, as well as PIPX, and other common Python utilities. JupyterLab is conditionally installed with the python feature. Note: May require source code compilation.
+- [Ruby (via rvm)](https://www.mintlify.com/devcontainers/features/features/ruby.md): Installs Ruby, rvm, rbenv, common Ruby utilities, and needed dependencies.
+- [Rust](https://www.mintlify.com/devcontainers/features/features/rust.md): Installs Rust, common Rust utilities, and their required dependencies
+- [SSH server](https://www.mintlify.com/devcontainers/features/features/sshd.md): Adds an SSH server into a container so that you can use an external terminal, sftp, or SSHFS to interact with it.
+- [Terraform, tflint, and Terragrunt](https://www.mintlify.com/devcontainers/features/features/terraform.md): Installs the Terraform CLI and optionally TFLint and Terragrunt. Auto-detects latest version and installs needed dependencies.
+- [Combining Features](https://www.mintlify.com/devcontainers/features/guides/combining-features.md): How to compose multiple Features in a single devcontainer.json
+- [Self-authoring Features](https://www.mintlify.com/devcontainers/features/guides/self-authoring.md): How to create, test, and publish your own Dev Container Features
+- [Using Features](https://www.mintlify.com/devcontainers/features/guides/using-features.md): How to add Dev Container Features to your devcontainer.json
+- [Versioning](https://www.mintlify.com/devcontainers/features/guides/versioning.md): How to pin, update, and manage Feature versions
+- [How Features work](https://www.mintlify.com/devcontainers/features/how-features-work.md): Understand the Feature lifecycle, manifest format, and installation model
+- [Dev Container Features](https://www.mintlify.com/devcontainers/features/introduction.md): A curated collection of reusable Dev Container Features that instantly add languages, tools, and CLIs to any development container.
+- [Quickstart](https://www.mintlify.com/devcontainers/features/quickstart.md): Get up and running with Dev Container Features in minutes
+
+
+Built with [Mintlify](https://mintlify.com).

--- a/docs/research/mintlify-cache/devcontainers/images/llms-full.txt
+++ b/docs/research/mintlify-cache/devcontainers/images/llms-full.txt
@@ -1,0 +1,4681 @@
+# Adding an image
+Source: https://www.mintlify.com/devcontainers/images/build/adding-an-image
+
+Step-by-step guide to contributing a new devcontainer image, from creating the Dockerfile to configuring manifest.json and setting up tests.
+
+This guide walks you through adding a new image to the repository. Read the [build system overview](/build/overview) first if you haven't already.
+
+<Warning>
+  Only [@devcontainers/maintainers](https://github.com/orgs/devcontainers/teams/maintainers) can onboard an image to MCR because it requires access to the Microsoft Container Registry configuration. If you want to contribute your own pre-built image, you can reference it directly in your devcontainer without going through this process.
+</Warning>
+
+## Prerequisites
+
+Before you start, decide on the following:
+
+* The name of your image (used as the directory name under `src/` and as the repository name in MCR)
+* Which base image or parent devcontainer image you will build on
+* Which variants you need, if any (e.g., different OS versions or runtime versions)
+* Which CPU architectures to support (`linux/amd64` only, or also `linux/arm64`)
+
+***
+
+<Steps>
+  <Step title="Update ARG values in your Dockerfile">
+    Before anything else, update any `ARG` values in your `Dockerfile` to reflect the defaults you want built into the image. Use boolean `ARG`s with `if` statements to make optional components skippable:
+
+    ```dockerfile theme={null}
+    ARG INSTALL_ZSH="true"
+    ARG UPGRADE_PACKAGES="false"
+    ```
+
+    <Warning>
+      The `build.args` and `build.dockerfile` properties in `devcontainer.json` are **intentionally ignored** during image build. Only `build.context` is used. Set your actual build defaults directly in the `Dockerfile`.
+    </Warning>
+  </Step>
+
+  <Step title="Create the Dockerfile">
+    Create `src/<your-image-name>/Dockerfile`. This is the file used to build the actual image.
+
+    If you plan to use [variants](/build/manifest#the-build-namespace), add a `VARIANT` build argument before the `FROM` statement:
+
+    ```dockerfile theme={null}
+    ARG VARIANT=3.12
+    FROM python:${VARIANT}
+
+    # Install common dependencies
+    RUN apt-get update \
+        && export DEBIAN_FRONTEND=noninteractive \
+        && apt-get -y install --no-install-recommends git curl \
+        && apt-get autoremove -y \
+        && apt-get clean -y \
+        && rm -rf /var/lib/apt/lists/*
+    ```
+
+    See [Dockerfile tips](/tips) for best practices on layer caching and image size.
+
+    You can also create a stub `Dockerfile` that references the published image, which makes it easy for users to customize their container:
+
+    ```dockerfile theme={null}
+    # For information on the image contents, see the Dockerfile at:
+    # https://github.com/devcontainers/images/tree/main/src/<your-image-name>/Dockerfile
+    ARG VARIANT="3.12"
+    FROM mcr.microsoft.com/devcontainers/<your-image-name>:0-${VARIANT}
+    ```
+  </Step>
+
+  <Step title="Create manifest.json">
+    Create `src/<your-image-name>/manifest.json`. This file tells the build system how to tag and track your image. A minimal example:
+
+    ```json theme={null}
+    {
+      "build": {
+        "rootDistro": "debian",
+        "latest": true,
+        "architectures": ["linux/amd64", "linux/arm64"],
+        "tags": [
+          "my-image:${VERSION}"
+        ]
+      },
+      "dependencies": {
+        "image": "debian:bookworm",
+        "imageLink": "https://hub.docker.com/_/debian",
+        "apt": ["git", "curl"],
+        "other": {
+          "git": {}
+        }
+      }
+    }
+    ```
+
+    For a multi-variant image:
+
+    ```json theme={null}
+    {
+      "variants": ["3.12", "3.11", "3.10"],
+      "build": {
+        "rootDistro": "debian",
+        "latest": "3.12",
+        "architectures": ["linux/amd64", "linux/arm64"],
+        "tags": [
+          "my-image:${VERSION}-${VARIANT}"
+        ]
+      },
+      "dependencies": {
+        "image": "python:${VARIANT}",
+        "imageLink": "https://hub.docker.com/_/python"
+      }
+    }
+    ```
+
+    See the [manifest.json reference](/build/manifest) for all available fields.
+  </Step>
+
+  <Step title="Add a meta.env file">
+    Create an empty `src/<your-image-name>/meta.env` file:
+
+    ```bash theme={null}
+    touch src/<your-image-name>/meta.env
+    ```
+
+    The build system automatically populates this file with the image version, repository, and history file path at build time. This powers the `devcontainer-info` command that is added by `common-debian.sh`.
+
+    Do not add content to this file manually — it is overwritten during every build.
+  </Step>
+
+  <Step title="Set up testing">
+    Create a `test-project/` directory inside your image folder with a `test.sh` script. The smoke test workflows run this script inside the built container to verify correctness.
+
+    ```bash theme={null}
+    mkdir src/<your-image-name>/test-project
+    ```
+
+    A minimal `test.sh`:
+
+    ```bash theme={null}
+    #!/bin/bash
+    set -e
+
+    # Verify key tools are available
+    echo "Testing image..."
+    git --version
+    echo "All tests passed."
+    ```
+
+    Make the script executable:
+
+    ```bash theme={null}
+    chmod +x src/<your-image-name>/test-project/test.sh
+    ```
+
+    See [Testing](/build/testing) for instructions on running the smoke tests locally.
+  </Step>
+
+  <Step title="Test your build locally">
+    Build the image locally without pushing to verify your configuration:
+
+    ```bash theme={null}
+    build/vscdc push --no-push \
+      --registry mcr.microsoft.com \
+      --registry-path devcontainers \
+      --release main \
+      <your-image-name>
+    ```
+
+    Then run the container to verify its contents:
+
+    ```bash theme={null}
+    docker run -it --init --privileged --rm \
+      mcr.microsoft.com/devcontainers/<your-image-name>:dev bash
+    ```
+
+    See [Testing](/build/testing) for the full local test workflow.
+  </Step>
+
+  <Step title="Update MCR configuration (maintainers only)">
+    If you are a maintainer onboarding the image to MCR, update the internal vscode config files as described in the [MCR setup wiki](https://github.com/microsoft/vscode-internalbacklog/wiki/Remote-Container-Images-MCR-Setup).
+  </Step>
+</Steps>
+
+## Image directory structure
+
+After completing these steps, your image directory should look like this:
+
+```text theme={null}
+src/<your-image-name>/
+├── .devcontainer/
+│   ├── devcontainer.json
+│   └── Dockerfile          ← stub Dockerfile for users
+├── Dockerfile              ← used to build the actual image
+├── manifest.json
+├── meta.env
+├── README.md
+└── test-project/
+    └── test.sh
+```
+
+
+# manifest.json reference
+Source: https://www.mintlify.com/devcontainers/images/build/manifest
+
+Complete reference for every field in the manifest.json file that controls how devcontainer images are built, tagged, and tracked.
+
+Every image in `src/<image-name>/` has a `manifest.json` file that tells the build system how to build the image, which tags to apply, and which dependencies to track for component governance and history markdown generation.
+
+The file has two top-level namespaces: [`build`](#the-build-namespace) and [`dependencies`](#the-dependencies-namespace), plus an optional top-level [`version`](#the-version-property) and [`variants`](#the-variants-property) property.
+
+```json theme={null}
+{
+  "version": "1.0.0",
+  "variants": ["3.11", "3.12"],
+  "build": { ... },
+  "dependencies": { ... }
+}
+```
+
+***
+
+## The `build` namespace
+
+The `build` namespace defines how source files map to image tags in the registry.
+
+```json theme={null}
+"build": {
+  "architectures": ["linux/amd64", "linux/arm64"],
+  "rootDistro": "debian",
+  "latest": true,
+  "tags": [
+    "base:${VERSION}-debian-11",
+    "base:${VERSION}-bullseye"
+  ]
+}
+```
+
+<AccordionGroup>
+  <Accordion title="architectures">
+    Specifies which CPU architectures to build. By default only `linux/amd64` is built.
+
+    ```json theme={null}
+    "architectures": ["linux/amd64", "linux/arm64"]
+    ```
+
+    When using variants, you can specify different architectures per variant using an object:
+
+    ```json theme={null}
+    "architectures": {
+      "bullseye": ["linux/amd64", "linux/arm64"],
+      "buster": ["linux/amd64"]
+    }
+    ```
+
+    <Warning>
+      Adding `linux/arm64` does not work well with Debian 10/buster or Ubuntu 20.04/focal due to a `libssl` issue. Test each architecture carefully before adding it.
+    </Warning>
+  </Accordion>
+
+  <Accordion title="rootDistro">
+    The Linux distribution family of the image. Controls how packages are detected for dependency tracking.
+
+    Accepted values: `"debian"`, `"alpine"`, `"redhat"`
+
+    ```json theme={null}
+    "rootDistro": "debian"
+    ```
+
+    <Tip>
+      Use `"debian"` for both Debian and Ubuntu-based images.
+    </Tip>
+  </Accordion>
+
+  <Accordion title="latest">
+    Controls whether the `latest` tag is applied to this image (or variant). Set to `true` to apply `latest`, `false` to skip it, or a variant name string to apply `latest` only to that variant.
+
+    ```json theme={null}
+    "latest": true
+    ```
+
+    With variants:
+
+    ```json theme={null}
+    "latest": "3.12"
+    ```
+  </Accordion>
+
+  <Accordion title="tags">
+    An array of tag patterns applied to every built image (or every variant when variants are defined). The `${VERSION}` placeholder is replaced with the image version at release time. The `${VARIANT}` placeholder is replaced with the current variant.
+
+    ```json theme={null}
+    "tags": [
+      "python:${VERSION}-${VARIANT}"
+    ]
+    ```
+
+    For a release `1.2.3` and variant `3.12`, this produces tags:
+
+    * `python:1.2.3-3.12`
+    * `python:1.2-3.12`
+    * `python:1-3.12`
+    * `python:3.12` (equivalent of latest for that variant)
+  </Accordion>
+
+  <Accordion title="variants">
+    An array of variant values. Each variant triggers a separate image build with `VARIANT` passed as a Docker build argument. The first entry (or the value of `build.latest`) receives the `latest` tag.
+
+    ```json theme={null}
+    "variants": ["3.12", "3.11", "3.10"]
+    ```
+
+    The corresponding Dockerfile uses `VARIANT` in its `FROM` statement:
+
+    ```dockerfile theme={null}
+    ARG VARIANT=3.12
+    FROM python:${VARIANT}
+    ```
+  </Accordion>
+
+  <Accordion title="variantTags">
+    Additional tags applied only to specific variants, supplementing the common `tags` array. Useful when certain variants need alias tags that don't apply to all variants.
+
+    ```json theme={null}
+    "variantTags": {
+      "bullseye": [
+        "base:debian-11",
+        "base:debian11",
+        "base:debian"
+      ],
+      "buster": [
+        "base:debian-10",
+        "base:debian10"
+      ]
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="variantBuildArgs">
+    Per-variant Docker build arguments to pass in addition to `VARIANT`. Use this when your Dockerfile needs different argument values for each variant.
+
+    ```json theme={null}
+    "variantBuildArgs": {
+      "17-bullseye": {
+        "TARGET_JAVA_VERSION": "17",
+        "BASE_IMAGE_VERSION_CODENAME": "bullseye"
+      },
+      "11-bullseye": {
+        "TARGET_JAVA_VERSION": "11",
+        "BASE_IMAGE_VERSION_CODENAME": "bullseye"
+      }
+    }
+    ```
+
+    The Dockerfile receives these as build args:
+
+    ```dockerfile theme={null}
+    ARG TARGET_JAVA_VERSION=11
+    ARG BASE_IMAGE_VERSION_CODENAME=bullseye
+    FROM openjdk:${TARGET_JAVA_VERSION}-jdk-${BASE_IMAGE_VERSION_CODENAME}
+    ```
+  </Accordion>
+
+  <Accordion title="parent">
+    Specifies the parent image name within this repository when the image is built on top of another devcontainer image (rather than a public base image). The build system uses this to order builds correctly.
+
+    ```json theme={null}
+    "parent": "ruby"
+    ```
+  </Accordion>
+</AccordionGroup>
+
+***
+
+## The `version` property
+
+By default, all images share the repository's version. When you need to version an image independently (for example, because upstream changes may cause breaking changes), set a `version` property at the top level:
+
+```json theme={null}
+"version": "1.3.13"
+```
+
+The version follows [semver](https://semver.org/) and is used in place of the repository version when generating image tags.
+
+***
+
+## The `variants` property
+
+See [`build.variants`](#the-build-namespace) above. The top-level `variants` array is the canonical list of variants to build; `build.latest` selects which one gets the `latest` tag.
+
+***
+
+## The `dependencies` namespace
+
+The `dependencies` namespace tracks what is installed in the image for component governance (`cgmanifest.json`) and version history markdown. It does **not** affect the build itself.
+
+<Warning>
+  Whenever you add a third-party OSS dependency, update `NOTICES.txt` in the repository root with its license terms. Packages installed directly from a Linux distribution's package manager can be skipped (they are covered by the distribution image). Closed-source dependencies are not allowed.
+</Warning>
+
+```json theme={null}
+"dependencies": {
+  "image": "debian:${VARIANT}",
+  "imageLink": "https://hub.docker.com/_/debian",
+  "apt": ["apt-utils", "git"],
+  "pip": ["requests"],
+  "gem": ["jekyll"],
+  "git": {
+    "Oh My Zsh!": "/home/vscode/.oh-my-zsh"
+  },
+  "other": {
+    "kubectl": null
+  },
+  "languages": {
+    "Python": { "cgIgnore": true, "path": "/usr/local" }
+  }
+}
+```
+
+<AccordionGroup>
+  <Accordion title="image and imageLink">
+    `image` is the base Docker image. `imageLink` is a URL to its description or registry page.
+
+    ```json theme={null}
+    "image": "continuumio/anaconda3:latest",
+    "imageLink": "https://hub.docker.com/r/continuumio/anaconda3"
+    ```
+  </Accordion>
+
+  <Accordion title="apt and apk">
+    Arrays of Debian/Ubuntu (`apt`) or Alpine (`apk`) package names. Most packages are tracked for visibility only and are not included in `cgmanifest.json` (they come from the distribution). For third-party repository packages, use object syntax to set `"cgIgnore": false`:
+
+    ```json theme={null}
+    "apt": [
+      {
+        "cgIgnore": false,
+        "name": "azure-cli",
+        "annotation": "Azure CLI"
+      },
+      "cmake",
+      "cppcheck"
+    ]
+    ```
+
+    Version information is extracted automatically.
+  </Accordion>
+
+  <Accordion title="git">
+    Dependencies installed via shallow `git clone`. Maps a human-readable name to the path where the clone lives in the image:
+
+    ```json theme={null}
+    "git": {
+      "Oh My Zsh!": "/home/vscode/.oh-my-zsh",
+      "nvm": "/usr/local/share/nvm"
+    }
+    ```
+
+    The commit ID is extracted automatically.
+  </Accordion>
+
+  <Accordion title="pip and pipx">
+    Python packages installed via `pip` or `pipx`:
+
+    ```json theme={null}
+    "pip": ["requests", "numpy", "certifi"],
+    "pipx": ["pylint", "virtualenv"]
+    ```
+  </Accordion>
+
+  <Accordion title="gem and npm">
+    Ruby gems and globally installed npm packages:
+
+    ```json theme={null}
+    "gem": ["rake", "jekyll", "bundler"],
+    "npm": ["eslint", "typescript"]
+    ```
+  </Accordion>
+
+  <Accordion title="go and cargo">
+    Go modules and Rust cargo packages. Both accept an object mapping the package name to a version command. Use `null` to auto-detect the version:
+
+    ```json theme={null}
+    "cargo": {
+      "rustfmt": null,
+      "clippy": "rustc --version"
+    },
+    "go": {
+      "golang.org/x/tools/gopls": null
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="other">
+    Handles dependency types not covered by the other properties. Maps a dependency name to a `versionCommand`, `path`, and `downloadUrl`. Use `cgIgnore` to exclude from governance tracking and `markdownIgnore` to exclude from history markdown:
+
+    ```json theme={null}
+    "other": {
+      "kubectl": {
+        "versionCommand": "kubectl version --client --output=json | jq -r '.clientVersion.gitVersion'",
+        "path": "/usr/local/bin",
+        "downloadUrl": "https://github.com/kubernetes/kubectl"
+      }
+    }
+    ```
+
+    Many common tools have default settings in `build/config.json` under `otherDependencyDefaultSettings`. For those, you only need to specify the name and any overrides:
+
+    ```json theme={null}
+    "other": {
+      "kubectl": null,
+      "Helm": null,
+      "git": { "path": "/usr/local" }
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="languages">
+    Elevates dependencies into the "Languages" section of history markdown files. Accepts a `versionCommand` that can return a newline-delimited list of versions when `cgIgnore` is `true`:
+
+    ```json theme={null}
+    "languages": {
+      "Python": {
+        "cgIgnore": true,
+        "path": "/opt/conda"
+      },
+      "Ruby": {
+        "cgIgnore": true,
+        "versionCommand": "ls /opt/ruby | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+'",
+        "path": "/opt/ruby/<version>"
+      }
+    }
+    ```
+  </Accordion>
+</AccordionGroup>
+
+
+# Build system overview
+Source: https://www.mintlify.com/devcontainers/images/build/overview
+
+An overview of the build CLI, GitHub Actions workflows, and dev-tagged images used to build and publish devcontainer images to MCR.
+
+The `build/` directory contains the tools and configuration that build, tag, and push devcontainer images to the Microsoft Container Registry (MCR). This page describes the main components contributors interact with.
+
+<Info>
+  Only [@devcontainers/maintainers](https://github.com/orgs/devcontainers/teams/maintainers) can onboard new images to MCR because it requires access to the registry configuration. If you want to contribute a new image, see [Adding an image](/build/adding-an-image).
+</Info>
+
+## The vscdc CLI
+
+The `build/vscdc` CLI is a Node.js tool that automates image building, pushing, and metadata generation. It has three primary commands:
+
+<AccordionGroup>
+  <Accordion title="push — build and push images">
+    Builds one or more images and pushes them to a container registry. Pass `--no-push` to build locally without pushing.
+
+    ```bash theme={null}
+    build/vscdc push --help
+    ```
+
+    Common usage for local testing:
+
+    ```bash theme={null}
+    build/vscdc push --no-push --registry mcr.microsoft.com --registry-path devcontainers --release main <image-name>
+    ```
+  </Accordion>
+
+  <Accordion title="cg — generate cgmanifest.json">
+    Generates the component governance manifest (`cgmanifest.json`) by inspecting the installed packages defined in each image's `manifest.json`. This feeds into Microsoft's component governance tracking.
+
+    ```bash theme={null}
+    build/vscdc cg --registry mcr.microsoft.com --registry-path devcontainers --release main <image-name>
+    ```
+  </Accordion>
+
+  <Accordion title="info — generate history markdown">
+    Generates the version history markdown files for one or more images. These appear in each image's `history/` directory.
+
+    ```bash theme={null}
+    build/vscdc info --build --markdown --overwrite --registry mcr.microsoft.com --registry-path devcontainers --release main <image-name>
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## GitHub Actions workflows
+
+The repository uses several GitHub Actions workflows that call the `vscdc` CLI:
+
+| Workflow              | Trigger                  | Purpose                                                                                                                                                                               |
+| --------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `push-dev.yml`        | Weekly (Monday) + manual | Builds and pushes `dev`-tagged images for all images in the repository. Also fires a repository dispatch to trigger `cgmanifest.json` generation.                                     |
+| `push.yml`            | Release tag (`vX.Y.Z`)   | Builds and pushes release-versioned images. Updates source files with SHA hashes for script sources. Run `git fetch --tags --force` locally after it completes.                       |
+| `push-again.yml`      | Manual                   | Re-pushes an updated version of an image for an existing release. Use this only when a push partially failed (e.g. `linux/amd64` succeeded but `linux/arm64` had a connection error). |
+| `smoke-*.yaml`        | PR / push                | Builds images without pushing and runs `test-project/test.sh` inside the container to catch breaking changes. Uses the `smoke-test` action.                                           |
+| `version-history.yml` | `workflow_dispatch`      | Generates `cgmanifest.json` and history markdown files on demand.                                                                                                                     |
+
+## Dev-tagged images
+
+In addition to versioned release tags, the build system publishes **dev-tagged** image variants from the `main` branch. These give you early access to changes before they are officially released.
+
+### Purpose
+
+Dev images include:
+
+* Upstream OS package updates
+* New language runtime versions
+* Repository improvements not yet in a release
+
+### Tagging pattern
+
+Dev tags follow this pattern:
+
+```text theme={null}
+mcr.microsoft.com/devcontainers/<image>:dev
+mcr.microsoft.com/devcontainers/<image>:dev-<version>
+mcr.microsoft.com/devcontainers/<image>:dev-<distro>
+mcr.microsoft.com/devcontainers/<image>:dev-<version>-<distro>
+```
+
+### Update frequency
+
+The `push-dev.yml` workflow runs every Monday, keeping dev images current with the `main` branch.
+
+### When to use dev images
+
+<Tabs>
+  <Tab title="Good uses">
+    * Testing unreleased features before committing to them
+    * Validating that upcoming changes work with your project
+    * Development environments where you want the latest updates
+  </Tab>
+
+  <Tab title="Avoid for">
+    * Production workloads
+    * Reproducible CI/CD pipelines
+    * Stable team development environments
+  </Tab>
+</Tabs>
+
+**Example — switching from dev to stable:**
+
+```dockerfile theme={null}
+# Preview/testing
+FROM mcr.microsoft.com/devcontainers/python:dev-3.13
+
+# Stable/production
+FROM mcr.microsoft.com/devcontainers/python:3-3.13
+```
+
+## Related pages
+
+<CardGroup>
+  <Card title="manifest.json reference" icon="file-json" href="/build/manifest">
+    Full reference for every property in the `manifest.json` file.
+  </Card>
+
+  <Card title="Versioning" icon="tag" href="/build/versioning">
+    How image versions and tags are managed across releases.
+  </Card>
+
+  <Card title="Adding an image" icon="plus" href="/build/adding-an-image">
+    Step-by-step guide to contributing a new image.
+  </Card>
+
+  <Card title="Testing" icon="flask-conical" href="/build/testing">
+    How to build and test images locally before opening a PR.
+  </Card>
+</CardGroup>
+
+
+# Testing
+Source: https://www.mintlify.com/devcontainers/images/build/testing
+
+How to build and test devcontainer images locally using the vscdc CLI, Docker, and ARM64-specific build instructions.
+
+Before opening a pull request, test your image locally to confirm the build configuration is correct and the container works as expected. This page covers the full local test workflow.
+
+## Prerequisites
+
+* Docker installed and running on your machine
+* Node.js available (for the `vscdc` CLI)
+* The repository cloned locally
+
+## Building an image locally
+
+Use the `vscdc push` command with `--no-push` to build an image without pushing it to any registry:
+
+```bash theme={null}
+build/vscdc push --no-push \
+  --registry mcr.microsoft.com \
+  --registry-path devcontainers \
+  --release main \
+  <your-image-name>
+```
+
+Replace `<your-image-name>` with the name of the folder under `src/`. For example, to test the `python` image:
+
+```bash theme={null}
+build/vscdc push --no-push \
+  --registry mcr.microsoft.com \
+  --registry-path devcontainers \
+  --release main \
+  python
+```
+
+This builds all variants defined in the image's `manifest.json` and tags them locally using the `dev` tag pattern.
+
+## Verifying the built image
+
+After building, run the image with Docker to verify it has the expected contents:
+
+```bash theme={null}
+docker run -it --init --privileged --rm \
+  mcr.microsoft.com/devcontainers/<expected-repository>:dev-<expected-tag> \
+  bash
+```
+
+For example:
+
+```bash theme={null}
+docker run -it --init --privileged --rm \
+  mcr.microsoft.com/devcontainers/python:dev-3.12 \
+  bash
+```
+
+Inside the container, you can verify tools, check versions, and run any manual tests.
+
+## Running the test script
+
+If your image has a `test-project/test.sh` script, run it inside the container:
+
+```bash theme={null}
+docker run -it --init --privileged --rm \
+  -v "$(pwd)/src/<your-image-name>/test-project:/workspace" \
+  mcr.microsoft.com/devcontainers/<your-image-name>:dev \
+  bash /workspace/test.sh
+```
+
+The smoke test workflows run this script automatically on every PR.
+
+## Testing manifest generation
+
+Verify that the `cgmanifest.json` generation works correctly for your image:
+
+```bash theme={null}
+build/vscdc cg \
+  --registry mcr.microsoft.com \
+  --registry-path devcontainers \
+  --release main \
+  <your-image-name>
+```
+
+Review the output to confirm all dependencies are tracked as expected.
+
+## Testing history markdown generation
+
+Verify that the version history markdown generates without errors:
+
+```bash theme={null}
+build/vscdc info \
+  --build \
+  --markdown \
+  --overwrite \
+  --registry mcr.microsoft.com \
+  --registry-path devcontainers \
+  --release main \
+  <your-image-name>
+```
+
+Check the generated file in `src/<your-image-name>/history/` to confirm the dependency list looks correct.
+
+## Full local test workflow
+
+<Steps>
+  <Step title="Build the image locally">
+    ```bash theme={null}
+    build/vscdc push --no-push \
+      --registry mcr.microsoft.com \
+      --registry-path devcontainers \
+      --release main \
+      <your-image-name>
+    ```
+  </Step>
+
+  <Step title="Run the container and verify contents">
+    ```bash theme={null}
+    docker run -it --init --privileged --rm \
+      mcr.microsoft.com/devcontainers/<your-image-name>:dev \
+      bash
+    ```
+  </Step>
+
+  <Step title="Run the test script">
+    ```bash theme={null}
+    docker run -it --init --privileged --rm \
+      -v "$(pwd)/src/<your-image-name>/test-project:/workspace" \
+      mcr.microsoft.com/devcontainers/<your-image-name>:dev \
+      bash /workspace/test.sh
+    ```
+  </Step>
+
+  <Step title="Test manifest generation">
+    ```bash theme={null}
+    build/vscdc cg \
+      --registry mcr.microsoft.com \
+      --registry-path devcontainers \
+      --release main \
+      <your-image-name>
+    ```
+  </Step>
+
+  <Step title="Test history markdown generation">
+    ```bash theme={null}
+    build/vscdc info \
+      --build --markdown --overwrite \
+      --registry mcr.microsoft.com \
+      --registry-path devcontainers \
+      --release main \
+      <your-image-name>
+    ```
+  </Step>
+</Steps>
+
+## ARM64 builds and tests
+
+To build and test against ARM64 (`linux/arm64`) specifically, use the `devcontainer` CLI directly.
+
+### Building for ARM64
+
+Run the build command from inside the image's source directory, specifying the `--platform` flag:
+
+```bash theme={null}
+devcontainer build \
+  --workspace-folder src/<your-image-name> \
+  --platform linux/arm64 \
+  -t <your-image-name>-arm64
+```
+
+### Running the ARM64 container
+
+```bash theme={null}
+docker run \
+  --platform linux/arm64 \
+  -it <your-image-name>-arm64 \
+  bash
+```
+
+### Verifying the architecture
+
+Inside the running container, confirm it is ARM64:
+
+```bash theme={null}
+uname -m
+```
+
+On ARM64/Linux, this returns `aarch64`.
+
+### Running tests on ARM64
+
+Attach to the running container and run the test script:
+
+```bash theme={null}
+/workspace/test-project/test.sh
+```
+
+<Info>
+  See the [ARM documentation](https://developer.arm.com/documentation/102475/0100/Multi-architecture-images) for more on building multi-architecture images, and the [list of supported Linux ARM64 .NET SDK images](https://hub.docker.com/_/microsoft-dotnet-sdk) for .NET-specific guidance.
+</Info>
+
+
+# Versioning
+Source: https://www.mintlify.com/devcontainers/images/build/versioning
+
+How devcontainer images are versioned, how repository versions map to image tags, and the difference between dev and release tags.
+
+Understanding how images are versioned helps you choose the right tag for your project and know when your image will receive updates.
+
+## Repository version and image tags
+
+By default, every image in this repository inherits the repository's version number. When a release is cut by pushing a tag like `v1.3.0`, the build system applies a set of tags to each published image based on that version.
+
+For example, a release at version `0.40.0` produces the following tags for an image:
+
+```text theme={null}
+0.40.0-bullseye
+0.40-bullseye
+0-bullseye
+bullseye          ← equivalent of "latest" for bullseye specifically
+```
+
+If this image is also the one designated `latest`, it additionally receives:
+
+```text theme={null}
+latest
+```
+
+This scheme gives you three levels of version pinning:
+
+| Tag pattern           | Update behavior                                             |
+| --------------------- | ----------------------------------------------------------- |
+| `0.40.0-bullseye`     | Never updates automatically. Exact version only.            |
+| `0.40-bullseye`       | Receives patch-level fix releases within `0.40.x`.          |
+| `0-bullseye`          | Receives all non-breaking updates within major version `0`. |
+| `bullseye` / `latest` | Always points to the latest published release.              |
+
+<Tip>
+  Referencing the major version (e.g., `0-bullseye`) is a good balance: you get bug fixes and security patches without risking breaking changes from a major version bump.
+</Tip>
+
+## The `version` property for independent versioning
+
+In most cases it makes sense to version an image with the repository. However, some images — like `universal` — receive upstream changes that could introduce breaking changes independently of a repo release. For these images, the `manifest.json` file sets a `version` property:
+
+```json theme={null}
+"version": "1.3.13"
+```
+
+When this property is present, the build system uses it instead of the repository version when generating image tags. This lets an image have its own semver lifecycle separate from the rest of the repository.
+
+## Semver tagging explained
+
+The version number in image tags follows [Semantic Versioning](https://semver.org/):
+
+* **MAJOR** — incompatible changes to the image's default configuration or included tools
+* **MINOR** — new features, additional tools, or new variants added in a backwards-compatible way
+* **PATCH** — bug fixes, security patches, OS package updates
+
+When a release is tagged in the repository (e.g., `v1.3.0`), the pipeline generates all three tag levels automatically. You never need to set MAJOR, MINOR, or PATCH tags manually.
+
+## Dev vs release tags
+
+Every image has two tag families: **release** tags and **dev** tags.
+
+<Tabs>
+  <Tab title="Release tags">
+    Release tags are created when a `vX.Y.Z` git tag is pushed. They are stable, immutable references to a specific build.
+
+    ```text theme={null}
+    mcr.microsoft.com/devcontainers/python:3-3.12
+    mcr.microsoft.com/devcontainers/python:1.2-3.12
+    mcr.microsoft.com/devcontainers/python:1.2.3-3.12
+    ```
+
+    Use release tags for production workloads and reproducible CI/CD pipelines.
+  </Tab>
+
+  <Tab title="Dev tags">
+    Dev tags are generated weekly from the `main` branch by the `push-dev.yml` workflow. They are mutable and update every Monday.
+
+    ```text theme={null}
+    mcr.microsoft.com/devcontainers/python:dev
+    mcr.microsoft.com/devcontainers/python:dev-3.12
+    mcr.microsoft.com/devcontainers/python:dev-3.12-bookworm
+    ```
+
+    Use dev tags for testing unreleased changes or previewing upcoming features.
+  </Tab>
+</Tabs>
+
+## Updating source files after a release
+
+The `push.yml` workflow updates source files with SHA hashes for script sources as part of the release process. After it completes, run the following locally to pull the updated tags:
+
+```bash theme={null}
+git fetch --tags --force
+```
+
+Without `--force`, git may refuse to update existing tags that have moved.
+
+
+# Choosing an image
+Source: https://www.mintlify.com/devcontainers/images/choosing-an-image
+
+Compare base, language, and universal images to find the right one for your project.
+
+The images in this repository fall into three categories: base images, language images, and the universal image. This page explains the differences and helps you pick the right starting point.
+
+## Decision guide
+
+* **Starting a new project with a single primary language** → use the matching language image (e.g., `python`, `go`, `javascript-node`).
+* **Working in a repository with multiple languages** or **using GitHub Codespaces without a `devcontainer.json`** → use the `universal` image.
+* **Building a custom image from scratch** or **need a minimal footprint** → use a base image (`base-ubuntu`, `base-debian`, or `base-alpine`).
+* **Data science with Conda** → use `anaconda` or `miniconda`.
+* **Building a Jekyll static site** → use `jekyll`.
+
+## Base images
+
+Base images provide a minimal starting point: `git`, `zsh` with Oh My Zsh!, a non-root `vscode` user with `sudo` access, and common system dependencies. They do not include a language runtime. Use them as a `FROM` in your own Dockerfile or when you want to layer everything yourself using Dev Container Features.
+
+<Tabs>
+  <Tab title="Ubuntu">
+    | Property      | Value                                         |
+    | ------------- | --------------------------------------------- |
+    | MCR path      | `mcr.microsoft.com/devcontainers/base:ubuntu` |
+    | OS            | Ubuntu                                        |
+    | Architectures | x86-64, arm64                                 |
+
+    **Available tags:**
+
+    ```
+    mcr.microsoft.com/devcontainers/base:ubuntu          # latest LTS
+    mcr.microsoft.com/devcontainers/base:ubuntu24.04     # Ubuntu 24.04 (Noble)
+    mcr.microsoft.com/devcontainers/base:noble           # Ubuntu 24.04 alias
+    mcr.microsoft.com/devcontainers/base:ubuntu22.04     # Ubuntu 22.04 (Jammy)
+    mcr.microsoft.com/devcontainers/base:jammy           # Ubuntu 22.04 alias
+    ```
+
+    With semver pinning:
+
+    ```
+    mcr.microsoft.com/devcontainers/base:2-jammy
+    mcr.microsoft.com/devcontainers/base:2.1-jammy
+    mcr.microsoft.com/devcontainers/base:2.1.7-jammy
+    ```
+  </Tab>
+
+  <Tab title="Debian">
+    | Property      | Value                                         |
+    | ------------- | --------------------------------------------- |
+    | MCR path      | `mcr.microsoft.com/devcontainers/base:debian` |
+    | OS            | Debian                                        |
+    | Architectures | x86-64, arm64                                 |
+
+    **Available tags:**
+
+    ```
+    mcr.microsoft.com/devcontainers/base:debian          # latest
+    mcr.microsoft.com/devcontainers/base:trixie          # Debian 13
+    mcr.microsoft.com/devcontainers/base:bookworm        # Debian 12
+    mcr.microsoft.com/devcontainers/base:bullseye        # Debian 11
+    ```
+
+    With semver pinning:
+
+    ```
+    mcr.microsoft.com/devcontainers/base:2-trixie
+    mcr.microsoft.com/devcontainers/base:2.1-trixie
+    mcr.microsoft.com/devcontainers/base:2.1.7-trixie
+    ```
+  </Tab>
+
+  <Tab title="Alpine">
+    | Property      | Value                                         |
+    | ------------- | --------------------------------------------- |
+    | MCR path      | `mcr.microsoft.com/devcontainers/base:alpine` |
+    | OS            | Alpine Linux                                  |
+    | Architectures | x86-64, arm64                                 |
+
+    **Available tags:**
+
+    ```
+    mcr.microsoft.com/devcontainers/base:alpine          # latest
+    mcr.microsoft.com/devcontainers/base:alpine-3.23
+    mcr.microsoft.com/devcontainers/base:alpine-3.22
+    mcr.microsoft.com/devcontainers/base:alpine-3.21
+    mcr.microsoft.com/devcontainers/base:alpine-3.20
+    ```
+
+    With semver pinning:
+
+    ```
+    mcr.microsoft.com/devcontainers/base:3-alpine
+    mcr.microsoft.com/devcontainers/base:3.0-alpine
+    mcr.microsoft.com/devcontainers/base:3.0.3-alpine
+    ```
+
+    <Note>
+      Alpine images are smaller but use `musl libc` instead of `glibc`. Some language toolchains and native extensions behave differently or are unavailable on Alpine. Prefer Debian or Ubuntu unless you have a specific reason to use Alpine.
+    </Note>
+  </Tab>
+</Tabs>
+
+## Language images
+
+Language images extend the base images with a specific runtime, language tools, and commonly used utilities. Most also include `nvm` so you can install a different version of Node.js alongside the primary language.
+
+<AccordionGroup>
+  <Accordion title="Universal">
+    The universal image is the largest image in this set. It includes Python, Node.js, JavaScript, TypeScript, C++, Java, C#, F#, .NET Core, PHP, Go, Ruby, and Conda. Use it when your project uses more than one language, or when you want a general-purpose sandbox.
+
+    GitHub Codespaces uses this image by default when no `devcontainer.json` is present.
+
+    | Property      | Value                                             |
+    | ------------- | ------------------------------------------------- |
+    | MCR path      | `mcr.microsoft.com/devcontainers/universal:linux` |
+    | OS            | Ubuntu (Noble)                                    |
+    | Architectures | x86-64 only                                       |
+
+    ```
+    mcr.microsoft.com/devcontainers/universal:linux
+    mcr.microsoft.com/devcontainers/universal:noble
+    ```
+
+    With semver pinning:
+
+    ```
+    mcr.microsoft.com/devcontainers/universal:6-noble
+    mcr.microsoft.com/devcontainers/universal:6.0-noble
+    mcr.microsoft.com/devcontainers/universal:6.0.0-noble
+    ```
+
+    <Warning>
+      The universal image is only published for x86-64. If you develop on Apple Silicon (arm64), use a language-specific image instead.
+    </Warning>
+  </Accordion>
+
+  <Accordion title="Python">
+    | Property      | Value                                    |
+    | ------------- | ---------------------------------------- |
+    | MCR path      | `mcr.microsoft.com/devcontainers/python` |
+    | OS            | Debian                                   |
+    | Architectures | x86-64, arm64 (`bookworm`, `bullseye`)   |
+    | Includes      | Python 3, pip, pipx, git, zsh, nvm       |
+
+    ```
+    mcr.microsoft.com/devcontainers/python:3          # latest Python 3
+    mcr.microsoft.com/devcontainers/python:3.13
+    mcr.microsoft.com/devcontainers/python:3.13-bookworm
+    mcr.microsoft.com/devcontainers/python:3.13-trixie
+    ```
+  </Accordion>
+
+  <Accordion title="Node.js / JavaScript">
+    | Property      | Value                                             |
+    | ------------- | ------------------------------------------------- |
+    | MCR path      | `mcr.microsoft.com/devcontainers/javascript-node` |
+    | OS            | Debian                                            |
+    | Architectures | x86-64, arm64 (`bookworm`, `bullseye`)            |
+    | Includes      | Node.js, nvm, eslint, yarn, git, zsh              |
+
+    ```
+    mcr.microsoft.com/devcontainers/javascript-node:24
+    mcr.microsoft.com/devcontainers/javascript-node:22
+    mcr.microsoft.com/devcontainers/javascript-node:20
+    mcr.microsoft.com/devcontainers/javascript-node:24-bookworm
+    mcr.microsoft.com/devcontainers/javascript-node:24-trixie
+    ```
+  </Accordion>
+
+  <Accordion title="TypeScript / Node.js">
+    | Property      | Value                                                                    |
+    | ------------- | ------------------------------------------------------------------------ |
+    | MCR path      | `mcr.microsoft.com/devcontainers/typescript-node`                        |
+    | OS            | Debian                                                                   |
+    | Architectures | x86-64, arm64 (`bookworm`, `bullseye`)                                   |
+    | Includes      | Node.js, TypeScript compiler, eslint, nvm, yarn, tslint-to-eslint-config |
+
+    ```
+    mcr.microsoft.com/devcontainers/typescript-node:24
+    mcr.microsoft.com/devcontainers/typescript-node:22
+    mcr.microsoft.com/devcontainers/typescript-node:20
+    mcr.microsoft.com/devcontainers/typescript-node:24-bookworm
+    mcr.microsoft.com/devcontainers/typescript-node:24-trixie
+    ```
+  </Accordion>
+
+  <Accordion title="Go">
+    | Property      | Value                                |
+    | ------------- | ------------------------------------ |
+    | MCR path      | `mcr.microsoft.com/devcontainers/go` |
+    | OS            | Debian                               |
+    | Architectures | x86-64, arm64 (`trixie`, `bookworm`) |
+    | Includes      | Go, git, zsh                         |
+
+    ```
+    mcr.microsoft.com/devcontainers/go:1
+    mcr.microsoft.com/devcontainers/go:1.26
+    mcr.microsoft.com/devcontainers/go:1.25
+    mcr.microsoft.com/devcontainers/go:1.26-trixie
+    mcr.microsoft.com/devcontainers/go:1.26-bookworm
+    ```
+  </Accordion>
+
+  <Accordion title="Java">
+    | Property      | Value                                  |
+    | ------------- | -------------------------------------- |
+    | MCR path      | `mcr.microsoft.com/devcontainers/java` |
+    | OS            | Debian                                 |
+    | Architectures | x86-64, arm64 (`bookworm`, `bullseye`) |
+    | Includes      | JDK, SDKMAN!, nvm, git, zsh            |
+
+    ```
+    mcr.microsoft.com/devcontainers/java:25
+    mcr.microsoft.com/devcontainers/java:21
+    mcr.microsoft.com/devcontainers/java:17
+    mcr.microsoft.com/devcontainers/java:11
+    mcr.microsoft.com/devcontainers/java:21-bookworm
+    mcr.microsoft.com/devcontainers/java:21-trixie
+    ```
+
+    Use the [Java Feature](https://github.com/devcontainers/features/tree/main/src/java) to add Maven or Gradle.
+  </Accordion>
+
+  <Accordion title=".NET (C# / F#)">
+    | Property      | Value                                                        |
+    | ------------- | ------------------------------------------------------------ |
+    | MCR path      | `mcr.microsoft.com/devcontainers/dotnet`                     |
+    | OS            | Ubuntu (`noble`, `jammy`) or Debian (`bookworm`, `bullseye`) |
+    | Architectures | x86-64, arm64                                                |
+    | Includes      | .NET SDK, git, zsh, nvm                                      |
+
+    ```
+    mcr.microsoft.com/devcontainers/dotnet:10.0
+    mcr.microsoft.com/devcontainers/dotnet:9.0
+    mcr.microsoft.com/devcontainers/dotnet:8.0
+    mcr.microsoft.com/devcontainers/dotnet:10.0-noble
+    mcr.microsoft.com/devcontainers/dotnet:9.0-bookworm
+    mcr.microsoft.com/devcontainers/dotnet:8.0-jammy
+    ```
+  </Accordion>
+
+  <Accordion title="C++">
+    | Property      | Value                                 |
+    | ------------- | ------------------------------------- |
+    | MCR path      | `mcr.microsoft.com/devcontainers/cpp` |
+    | OS            | Debian or Ubuntu                      |
+    | Architectures | x86-64, arm64                         |
+    | Includes      | GCC, Clang, CMake, Vcpkg, git, zsh    |
+
+    ```
+    mcr.microsoft.com/devcontainers/cpp:debian13
+    mcr.microsoft.com/devcontainers/cpp:debian12
+    mcr.microsoft.com/devcontainers/cpp:ubuntu24.04
+    mcr.microsoft.com/devcontainers/cpp:ubuntu22.04
+    ```
+  </Accordion>
+
+  <Accordion title="PHP">
+    | Property      | Value                                 |
+    | ------------- | ------------------------------------- |
+    | MCR path      | `mcr.microsoft.com/devcontainers/php` |
+    | OS            | Debian                                |
+    | Architectures | x86-64, arm64 (`trixie`, `bookworm`)  |
+    | Includes      | PHP, Apache, Composer, nvm, git, zsh  |
+
+    ```
+    mcr.microsoft.com/devcontainers/php:8
+    mcr.microsoft.com/devcontainers/php:8.5
+    mcr.microsoft.com/devcontainers/php:8.4
+    mcr.microsoft.com/devcontainers/php:8.3
+    mcr.microsoft.com/devcontainers/php:8.4-trixie
+    mcr.microsoft.com/devcontainers/php:8.4-bookworm
+    ```
+  </Accordion>
+
+  <Accordion title="Ruby">
+    | Property      | Value                                            |
+    | ------------- | ------------------------------------------------ |
+    | MCR path      | `mcr.microsoft.com/devcontainers/ruby`           |
+    | OS            | Debian                                           |
+    | Architectures | x86-64, arm64 (`trixie`, `bookworm`, `bullseye`) |
+    | Includes      | Ruby, rvm, rbenv, bundler, nvm, git, zsh         |
+
+    ```
+    mcr.microsoft.com/devcontainers/ruby:4
+    mcr.microsoft.com/devcontainers/ruby:3.4
+    mcr.microsoft.com/devcontainers/ruby:3.3
+    mcr.microsoft.com/devcontainers/ruby:3.2
+    mcr.microsoft.com/devcontainers/ruby:3.4-trixie
+    mcr.microsoft.com/devcontainers/ruby:3.4-bookworm
+    ```
+  </Accordion>
+
+  <Accordion title="Rust">
+    | Property      | Value                                            |
+    | ------------- | ------------------------------------------------ |
+    | MCR path      | `mcr.microsoft.com/devcontainers/rust`           |
+    | OS            | Debian                                           |
+    | Architectures | x86-64, arm64 (`bookworm`, `bullseye`, `trixie`) |
+    | Includes      | Rust toolchain, cargo, rustfmt, clippy, git, zsh |
+
+    ```
+    mcr.microsoft.com/devcontainers/rust:latest
+    mcr.microsoft.com/devcontainers/rust:1
+    mcr.microsoft.com/devcontainers/rust:1-trixie
+    mcr.microsoft.com/devcontainers/rust:1-bookworm
+    mcr.microsoft.com/devcontainers/rust:1-bullseye
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Specialized images
+
+<AccordionGroup>
+  <Accordion title="Anaconda">
+    | Property      | Value                                      |
+    | ------------- | ------------------------------------------ |
+    | MCR path      | `mcr.microsoft.com/devcontainers/anaconda` |
+    | OS            | Debian                                     |
+    | Architectures | x86-64, arm64                              |
+    | Includes      | Anaconda Python 3, conda, pipx, git, zsh   |
+
+    ```
+    mcr.microsoft.com/devcontainers/anaconda
+    mcr.microsoft.com/devcontainers/anaconda:3
+    ```
+
+    The image automatically installs dependencies from `environment.yml` in your project root at build time. Use it for data science and machine learning workflows that rely on Conda-managed packages.
+
+    <Note>
+      Access to the Anaconda repository is governed by the [Anaconda Terms of Service](https://aka.ms/vscode-remote/conda/terms). When used with GitHub Codespaces or GitHub Actions, all users are permitted to use the Anaconda Repository — including organizations that would otherwise require a commercial license.
+    </Note>
+  </Accordion>
+
+  <Accordion title="Miniconda">
+    | Property      | Value                                       |
+    | ------------- | ------------------------------------------- |
+    | MCR path      | `mcr.microsoft.com/devcontainers/miniconda` |
+    | OS            | Debian                                      |
+    | Architectures | x86-64 only                                 |
+    | Includes      | Miniconda Python 3, conda, pipx, git, zsh   |
+
+    ```
+    mcr.microsoft.com/devcontainers/miniconda
+    mcr.microsoft.com/devcontainers/miniconda:3
+    ```
+
+    Miniconda is a minimal Conda installer. Unlike the Anaconda image, it does not include the full Anaconda package suite — you install only what you need. Use it when you want Conda environment management without the full Anaconda footprint.
+  </Accordion>
+
+  <Accordion title="Jekyll">
+    | Property      | Value                                    |
+    | ------------- | ---------------------------------------- |
+    | MCR path      | `mcr.microsoft.com/devcontainers/jekyll` |
+    | OS            | Debian                                   |
+    | Architectures | x86-64, arm64 (`bookworm`, `bullseye`)   |
+    | Includes      | Ruby, Bundler, Jekyll, nvm, git, zsh     |
+
+    ```
+    mcr.microsoft.com/devcontainers/jekyll
+    mcr.microsoft.com/devcontainers/jekyll:bookworm
+    mcr.microsoft.com/devcontainers/jekyll:bullseye
+    ```
+
+    If your project contains a `Gemfile`, the container installs all gems automatically at startup using `bundle install`. Without a `Gemfile`, it installs the latest version of Jekyll.
+  </Accordion>
+</AccordionGroup>
+
+## OS variant tags
+
+Most language images support pinning to a specific Debian or Ubuntu release. Append the release codename to any version tag:
+
+| Suffix      | OS           | Notes                  |
+| ----------- | ------------ | ---------------------- |
+| `-trixie`   | Debian 13    | Newest Debian release  |
+| `-bookworm` | Debian 12    | Current Debian stable  |
+| `-bullseye` | Debian 11    | Previous Debian stable |
+| `-noble`    | Ubuntu 24.04 | Current Ubuntu LTS     |
+| `-jammy`    | Ubuntu 22.04 | Previous Ubuntu LTS    |
+
+For example:
+
+```
+mcr.microsoft.com/devcontainers/python:3.13-bookworm
+mcr.microsoft.com/devcontainers/dotnet:9.0-noble
+mcr.microsoft.com/devcontainers/go:1.26-trixie
+```
+
+<Tip>
+  Pin to an OS variant when you need reproducible system package versions, or when a specific OS is required by your deployment target.
+</Tip>
+
+## Universal vs. language-specific
+
+|                    | Universal                                    | Language-specific        |
+| ------------------ | -------------------------------------------- | ------------------------ |
+| Languages included | Python, Node, Go, Java, .NET, PHP, Ruby, C++ | One primary language     |
+| Image size         | Large (\~10 GB compressed)                   | Smaller                  |
+| arm64 support      | No                                           | Yes (most images)        |
+| Best for           | Multi-language repos, Codespaces defaults    | Single-language projects |
+| Startup time       | Slower (larger image)                        | Faster                   |
+
+If your project is primarily one language but occasionally needs another, use the language-specific image and add the other language as a [Dev Container Feature](https://containers.dev/features) rather than using the universal image.
+
+
+# Anaconda (Python 3)
+Source: https://www.mintlify.com/devcontainers/images/images/anaconda
+
+A dev container image for developing Anaconda and Python 3 applications, with conda package management and Jupyter support.
+
+The Anaconda image gives you a full Anaconda 3 environment on Debian with the `conda` package manager, Python 3, Jupyter Notebook, and Jupyter Lab pre-installed. It installs dependencies from your `environment.yml` automatically at build time.
+
+## Image metadata
+
+| Property          | Value                                        |
+| ----------------- | -------------------------------------------- |
+| Published image   | `mcr.microsoft.com/devcontainers/anaconda:3` |
+| Architectures     | x86-64, aarch64/arm64                        |
+| Container OS      | Debian                                       |
+| Container host OS | Linux, macOS, Windows                        |
+
+## Using this image
+
+Reference the image in your `.devcontainer/devcontainer.json`:
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Anaconda (Python 3)",
+  "image": "mcr.microsoft.com/devcontainers/anaconda"
+}
+```
+
+Or update the `FROM` statement in your own `Dockerfile`:
+
+```dockerfile theme={null}
+FROM mcr.microsoft.com/devcontainers/anaconda:3
+```
+
+### Pinning to a version
+
+Reference a [semantic version](https://semver.org/) to control how often you receive updates:
+
+```text theme={null}
+mcr.microsoft.com/devcontainers/anaconda:1-3
+mcr.microsoft.com/devcontainers/anaconda:1.3-3
+mcr.microsoft.com/devcontainers/anaconda:1.3.13-3
+```
+
+See the [full list of available tags](https://mcr.microsoft.com/v2/devcontainers/anaconda/tags/list).
+
+## Anaconda terms of service
+
+<Warning>
+  Access to the Anaconda repository is covered by the [Anaconda Terms of Service](https://aka.ms/vscode-remote/conda/terms), which may require some organizations to obtain a commercial license from Anaconda.
+
+  **However**, when this image is used with **GitHub Codespaces** or **GitHub Actions**, all users are permitted to use the Anaconda Repository through the service, including organizations normally required to obtain a paid commercial license. Third-party packages may be licensed by their publishers in ways that impact your intellectual property, and are used at your own risk.
+</Warning>
+
+## Using conda
+
+This image includes the [`conda` package manager](https://aka.ms/vscode-remote/conda/about). Additional packages you install with `conda` are downloaded from Anaconda or another repository you configure.
+
+### Common conda tasks
+
+<AccordionGroup>
+  <Accordion title="Install a package">
+    ```bash theme={null}
+    conda install <package_name>
+    ```
+  </Accordion>
+
+  <Accordion title="Install from a different channel">
+    Installing packages from mixed channels in the same environment can cause conflicts. Create a new environment when you need a package from a channel like `conda-forge`:
+
+    ```bash theme={null}
+    conda create --name <env_name> -c conda-forge --yes <package_name>
+    ```
+  </Accordion>
+
+  <Accordion title="Install a different Python version">
+    From a terminal:
+
+    ```bash theme={null}
+    conda install python=3.6
+    ```
+
+    Or in a Dockerfile:
+
+    ```dockerfile theme={null}
+    RUN conda install -y python=3.6
+    ```
+  </Accordion>
+
+  <Accordion title="Configure a different conda channel">
+    See the guide on [configuring conda channels](https://aka.ms/vscode-remote/conda/channel-setup) to reconfigure conda to use an alternative repository.
+  </Accordion>
+</AccordionGroup>
+
+### Loading environment.yml at build time
+
+The image automatically installs dependencies from an `environment.yml` file in your project root when the container is built. The relevant Dockerfile line is:
+
+```dockerfile theme={null}
+RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
+    && rm -rf /tmp/conda-tmp
+```
+
+Remove or modify this line if you want to manage environment setup manually.
+
+## Forwarding ports
+
+By default, frameworks like Flask only listen to `localhost` inside the container. Use the `forwardPorts` property in `devcontainer.json` to make ports accessible from your host:
+
+```json theme={null}
+"forwardPorts": [5000]
+```
+
+<Tip>
+  Use `forwardPorts` rather than `appPort`. The `appPort` property publishes the port, which requires your application to listen on `*` or `0.0.0.0`. `forwardPorts` does not have this restriction.
+</Tip>
+
+## Running Jupyter notebooks
+
+<Steps>
+  <Step title="Forward the Jupyter port">
+    Add port `8888` to `forwardPorts` in `.devcontainer/devcontainer.json`:
+
+    ```json theme={null}
+    "forwardPorts": [8888]
+    ```
+  </Step>
+
+  <Step title="Start Jupyter on container creation">
+    Add a `postStartCommand` to launch Jupyter after the container starts. Using `nohup` prevents it from being killed when the command exits:
+
+    ```json theme={null}
+    "postStartCommand": "nohup bash -c 'jupyter notebook --ip=0.0.0.0 --port=8888 --allow-root &'"
+    ```
+  </Step>
+
+  <Step title="Open the notebook URL">
+    Check the terminal output for the access URL, which includes a token:
+
+    ```text theme={null}
+    http://127.0.0.1:8888/?token=1234567
+    ```
+
+    Open this URL in your browser to edit and run notebooks.
+  </Step>
+</Steps>
+
+## Installing Node.js
+
+If your project uses Node.js-based utilities alongside Python, add the Node.js feature to `devcontainer.json`:
+
+```json theme={null}
+{
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "latest"
+    }
+  }
+}
+```
+
+## Image contents
+
+| Component        | Details                        |
+| ---------------- | ------------------------------ |
+| Base image       | `continuumio/anaconda3:latest` |
+| OS               | Debian                         |
+| Python           | Included via Anaconda          |
+| conda            | `/opt/conda`                   |
+| Jupyter Notebook | Included                       |
+| Jupyter Lab      | Included                       |
+| Version          | `1.3.13`                       |
+
+
+# Alpine
+Source: https://www.mintlify.com/devcontainers/images/images/base-alpine
+
+A minimal Alpine Linux container with Git and other common utilities installed, optimized for small image sizes.
+
+## Summary
+
+The Alpine base image gives you a minimal Alpine Linux container pre-configured for development. It includes Git, Zsh, Oh My Zsh!, and a non-root `vscode` user with `sudo` access, while keeping the total image footprint as small as possible.
+
+Use this image when image size matters, or when you want a simple, minimal Linux environment as your starting point. Alpine's `musl` libc and `apk` package manager differ from Debian-based distributions, so verify that your dependencies are compatible before choosing this image.
+
+<Warning>
+  Alpine uses `musl` libc instead of `glibc`. Some pre-compiled binaries or language runtimes may not work correctly on Alpine without extra configuration.
+</Warning>
+
+<Info>
+  See the [image history](https://github.com/devcontainers/images/tree/main/src/base-alpine/history) for a full list of tools and versions included in each published release.
+</Info>
+
+## Metadata
+
+| Property                  | Value                                                      |
+| ------------------------- | ---------------------------------------------------------- |
+| Published image           | `mcr.microsoft.com/devcontainers/base:alpine`              |
+| Available variants        | `alpine-3.23`, `alpine-3.22`, `alpine-3.21`, `alpine-3.20` |
+| Architectures             | x86-64, aarch64/arm64                                      |
+| Container OS              | Alpine Linux                                               |
+| Container host OS support | Linux, macOS, Windows                                      |
+| Languages / platforms     | Any                                                        |
+
+## Using this image
+
+Reference the image directly in your `.devcontainer/devcontainer.json` using the `image` property:
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Alpine",
+  "image": "mcr.microsoft.com/devcontainers/base:alpine"
+}
+```
+
+### Available tags
+
+Choose a tag that matches the Alpine version you need:
+
+* `mcr.microsoft.com/devcontainers/base:alpine` — latest
+* `mcr.microsoft.com/devcontainers/base:alpine-3.23`
+* `mcr.microsoft.com/devcontainers/base:alpine-3.22`
+* `mcr.microsoft.com/devcontainers/base:alpine-3.21`
+* `mcr.microsoft.com/devcontainers/base:alpine-3.20`
+
+## Extending the image
+
+Use the image as a base in your own `Dockerfile` to add language runtimes, tools, or project dependencies:
+
+```dockerfile Dockerfile theme={null}
+FROM mcr.microsoft.com/devcontainers/base:alpine-3.23
+
+# Install additional tools using apk
+RUN apk add --no-cache \
+    curl \
+    bash \
+    build-base
+```
+
+Then reference your `Dockerfile` from `devcontainer.json`:
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Alpine (custom)",
+  "build": {
+    "dockerfile": "Dockerfile"
+  }
+}
+```
+
+<Tip>
+  Use `apk add --no-cache` to avoid leaving the package index in the image layer, keeping your final image as small as possible.
+</Tip>
+
+## Pre-installed tools
+
+Every Alpine base image variant includes the following tools out of the box:
+
+<CardGroup>
+  <Card title="Git" icon="code-branch">
+    Version control via the `git` CLI.
+  </Card>
+
+  <Card title="Zsh" icon="terminal">
+    Zsh shell set as the default login shell.
+  </Card>
+
+  <Card title="Oh My Zsh!" icon="sparkles">
+    Zsh framework pre-configured at `/home/vscode/.oh-my-zsh`.
+  </Card>
+
+  <Card title="vscode user" icon="user">
+    Non-root `vscode` user with passwordless `sudo` access.
+  </Card>
+</CardGroup>
+
+The image is built directly on top of the official [`alpine`](https://hub.docker.com/_/alpine) base image, keeping the dependency footprint minimal.
+
+## Versioning
+
+You can pin to a [semantic version](https://semver.org/) of each image to control how frequently you receive updates:
+
+<Tabs>
+  <Tab title="Major (least frequent)">
+    Receives updates for all minor and patch releases within the major version.
+
+    ```text theme={null}
+    mcr.microsoft.com/devcontainers/base:3-alpine
+    ```
+  </Tab>
+
+  <Tab title="Minor">
+    Receives patch updates only.
+
+    ```text theme={null}
+    mcr.microsoft.com/devcontainers/base:3.0-alpine
+    ```
+  </Tab>
+
+  <Tab title="Patch (most stable)">
+    Pinned to a specific release. No automatic updates.
+
+    ```text theme={null}
+    mcr.microsoft.com/devcontainers/base:3.0.3-alpine
+    ```
+  </Tab>
+</Tabs>
+
+See the [full list of available tags](https://mcr.microsoft.com/v2/devcontainers/base/tags/list) on the Microsoft Container Registry.
+
+## License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the [MIT License](https://github.com/devcontainers/images/blob/main/LICENSE).
+
+
+# Debian
+Source: https://www.mintlify.com/devcontainers/images/images/base-debian
+
+A simple Debian container with Git and other common utilities installed, suitable for general-purpose development environments.
+
+## Summary
+
+The Debian base image gives you a lightweight Debian container pre-configured for development. It includes Git, Zsh, Oh My Zsh!, and a non-root `vscode` user with `sudo` access, so you can start writing code without any additional setup.
+
+Use this image when you want a stable Debian environment with a curated set of development utilities already in place. The `trixie` variant tracks the current Debian testing release, while `bookworm` and `bullseye` provide stable, long-term-support options.
+
+<Info>
+  See the [image history](https://github.com/devcontainers/images/tree/main/src/base-debian/history) for a full list of tools and versions included in each published release.
+</Info>
+
+## Metadata
+
+| Property                  | Value                                         |
+| ------------------------- | --------------------------------------------- |
+| Published image           | `mcr.microsoft.com/devcontainers/base:debian` |
+| Available variants        | `trixie`, `bookworm`, `bullseye`              |
+| Architectures             | x86-64, aarch64/arm64                         |
+| Container OS              | Debian                                        |
+| Container host OS support | Linux, macOS, Windows                         |
+| Languages / platforms     | Any                                           |
+
+## Using this image
+
+Reference the image directly in your `.devcontainer/devcontainer.json` using the `image` property:
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Debian",
+  "image": "mcr.microsoft.com/devcontainers/base:debian"
+}
+```
+
+### Available tags
+
+Choose a tag that matches the Debian release you need:
+
+* `mcr.microsoft.com/devcontainers/base:debian` — latest
+* `mcr.microsoft.com/devcontainers/base:trixie` (or `debian13`)
+* `mcr.microsoft.com/devcontainers/base:bookworm` (or `debian12`)
+* `mcr.microsoft.com/devcontainers/base:bullseye` (or `debian11`)
+
+## Extending the image
+
+Use the image as a base in your own `Dockerfile` to add language runtimes, tools, or project dependencies:
+
+```dockerfile Dockerfile theme={null}
+FROM mcr.microsoft.com/devcontainers/base:bookworm
+
+# Install additional tools
+RUN apt-get update && apt-get install -y \
+    curl \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+Then reference your `Dockerfile` from `devcontainer.json`:
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Debian (custom)",
+  "build": {
+    "dockerfile": "Dockerfile"
+  }
+}
+```
+
+## Pre-installed tools
+
+Every Debian base image variant includes the following tools out of the box:
+
+<CardGroup>
+  <Card title="Git" icon="code-branch">
+    Version control via the `git` CLI.
+  </Card>
+
+  <Card title="Zsh" icon="terminal">
+    Zsh shell set as the default login shell.
+  </Card>
+
+  <Card title="Oh My Zsh!" icon="sparkles">
+    Zsh framework pre-configured at `/home/vscode/.oh-my-zsh`.
+  </Card>
+
+  <Card title="vscode user" icon="user">
+    Non-root `vscode` user with passwordless `sudo` access.
+  </Card>
+</CardGroup>
+
+The image also bundles a set of common development dependencies sourced from the upstream [`buildpack-deps`](https://hub.docker.com/_/buildpack-deps) image.
+
+## Versioning
+
+You can pin to a [semantic version](https://semver.org/) of each image to control how frequently you receive updates:
+
+<Tabs>
+  <Tab title="Major (least frequent)">
+    Receives updates for all minor and patch releases within the major version.
+
+    ```text theme={null}
+    mcr.microsoft.com/devcontainers/base:2-trixie
+    ```
+  </Tab>
+
+  <Tab title="Minor">
+    Receives patch updates only.
+
+    ```text theme={null}
+    mcr.microsoft.com/devcontainers/base:2.1-trixie
+    ```
+  </Tab>
+
+  <Tab title="Patch (most stable)">
+    Pinned to a specific release. No automatic updates.
+
+    ```text theme={null}
+    mcr.microsoft.com/devcontainers/base:2.1.7-trixie
+    ```
+  </Tab>
+</Tabs>
+
+See the [full list of available tags](https://mcr.microsoft.com/v2/devcontainers/base/tags/list) on the Microsoft Container Registry.
+
+## License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the [MIT License](https://github.com/devcontainers/images/blob/main/LICENSE).
+
+
+# Ubuntu
+Source: https://www.mintlify.com/devcontainers/images/images/base-ubuntu
+
+A simple Ubuntu container with Git and other common utilities installed, suitable for general-purpose development environments.
+
+## Summary
+
+The Ubuntu base image gives you a lightweight Ubuntu container pre-configured for development. It includes Git, Zsh, Oh My Zsh!, and a non-root `vscode` user with `sudo` access, so you can start writing code without any additional setup.
+
+Use this image when you want a familiar Ubuntu environment with a curated set of development utilities already in place.
+
+<Info>
+  See the [image history](https://github.com/devcontainers/images/tree/main/src/base-ubuntu/history) for a full list of tools and versions included in each published release.
+</Info>
+
+## Metadata
+
+| Property                  | Value                                            |
+| ------------------------- | ------------------------------------------------ |
+| Published image           | `mcr.microsoft.com/devcontainers/base:ubuntu`    |
+| Available variants        | `ubuntu24.04` / `noble`, `ubuntu22.04` / `jammy` |
+| Architectures             | x86-64, aarch64/arm64                            |
+| Container OS              | Ubuntu                                           |
+| Container host OS support | Linux, macOS, Windows                            |
+| Languages / platforms     | Any                                              |
+
+## Using this image
+
+Reference the image directly in your `.devcontainer/devcontainer.json` using the `image` property:
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Ubuntu",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu"
+}
+```
+
+### Available tags
+
+Choose a tag that matches the Ubuntu version you need:
+
+* `mcr.microsoft.com/devcontainers/base:ubuntu` — latest LTS release
+* `mcr.microsoft.com/devcontainers/base:ubuntu24.04` (or `noble`)
+* `mcr.microsoft.com/devcontainers/base:ubuntu22.04` (or `jammy`)
+
+## Extending the image
+
+Use the image as a base in your own `Dockerfile` to add language runtimes, tools, or project dependencies:
+
+```dockerfile Dockerfile theme={null}
+FROM mcr.microsoft.com/devcontainers/base:ubuntu24.04
+
+# Install additional tools
+RUN apt-get update && apt-get install -y \
+    curl \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+Then reference your `Dockerfile` from `devcontainer.json`:
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Ubuntu (custom)",
+  "build": {
+    "dockerfile": "Dockerfile"
+  }
+}
+```
+
+## Pre-installed tools
+
+Every Ubuntu base image variant includes the following tools out of the box:
+
+<CardGroup>
+  <Card title="Git" icon="code-branch">
+    Version control via the `git` CLI.
+  </Card>
+
+  <Card title="Zsh" icon="terminal">
+    Zsh shell set as the default login shell.
+  </Card>
+
+  <Card title="Oh My Zsh!" icon="sparkles">
+    Zsh framework pre-configured at `/home/vscode/.oh-my-zsh`.
+  </Card>
+
+  <Card title="vscode user" icon="user">
+    Non-root `vscode` user with passwordless `sudo` access.
+  </Card>
+</CardGroup>
+
+The image also bundles a set of common development dependencies sourced from the upstream [`buildpack-deps`](https://hub.docker.com/_/buildpack-deps) image.
+
+## Versioning
+
+You can pin to a [semantic version](https://semver.org/) of each image to control how frequently you receive updates:
+
+<Tabs>
+  <Tab title="Major (least frequent)">
+    Receives updates for all minor and patch releases within the major version.
+
+    ```text theme={null}
+    mcr.microsoft.com/devcontainers/base:2-jammy
+    ```
+  </Tab>
+
+  <Tab title="Minor">
+    Receives patch updates only.
+
+    ```text theme={null}
+    mcr.microsoft.com/devcontainers/base:2.1-jammy
+    ```
+  </Tab>
+
+  <Tab title="Patch (most stable)">
+    Pinned to a specific release. No automatic updates.
+
+    ```text theme={null}
+    mcr.microsoft.com/devcontainers/base:2.1.7-jammy
+    ```
+  </Tab>
+</Tabs>
+
+See the [full list of available tags](https://mcr.microsoft.com/v2/devcontainers/base/tags/list) on the Microsoft Container Registry.
+
+## License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the [MIT License](https://github.com/devcontainers/images/blob/main/LICENSE).
+
+
+# C++
+Source: https://www.mintlify.com/devcontainers/images/images/cpp
+
+Pre-built dev container image for C++ development on Linux, with GCC, Clang, CMake, cppcheck, valgrind, lldb, and Vcpkg.
+
+Use this image to develop C++ applications on Debian or Ubuntu. It includes both GCC and Clang compilers, the CMake and Ninja build systems, static analysis with `cppcheck`, memory debugging with `valgrind`, the `lldb` debugger, and [Vcpkg](https://github.com/microsoft/vcpkg) for cross-platform package management.
+
+## Image metadata
+
+| Property           | Value                                                                                    |
+| ------------------ | ---------------------------------------------------------------------------------------- |
+| Published image    | `mcr.microsoft.com/devcontainers/cpp`                                                    |
+| Available variants | `debian13` (trixie), `debian12` (bookworm), `ubuntu24.04` (noble), `ubuntu22.04` (jammy) |
+| Architectures      | x86-64, arm64/aarch64                                                                    |
+| Container OS       | Debian (trixie, bookworm), Ubuntu (noble, jammy)                                         |
+| Container host OS  | Linux, macOS, Windows                                                                    |
+
+## Using this image
+
+Reference the image directly in your `.devcontainer/devcontainer.json` using the `image` property.
+
+<Tabs>
+  <Tab title="Latest Debian">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "C++",
+      "image": "mcr.microsoft.com/devcontainers/cpp"
+    }
+    ```
+  </Tab>
+
+  <Tab title="Debian 13">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "C++ (Debian 13)",
+      "image": "mcr.microsoft.com/devcontainers/cpp:debian13"
+    }
+    ```
+  </Tab>
+
+  <Tab title="Debian 12">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "C++ (Debian 12)",
+      "image": "mcr.microsoft.com/devcontainers/cpp:debian12"
+    }
+    ```
+  </Tab>
+
+  <Tab title="Ubuntu 24.04">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "C++ (Ubuntu 24.04)",
+      "image": "mcr.microsoft.com/devcontainers/cpp:ubuntu24.04"
+    }
+    ```
+  </Tab>
+</Tabs>
+
+### Available tags
+
+* `mcr.microsoft.com/devcontainers/cpp` — latest (Debian 13 / trixie)
+* `mcr.microsoft.com/devcontainers/cpp:debian` — latest Debian GA
+* `mcr.microsoft.com/devcontainers/cpp:debian13` (or `trixie`)
+* `mcr.microsoft.com/devcontainers/cpp:debian12` (or `bookworm`)
+* `mcr.microsoft.com/devcontainers/cpp:ubuntu` — latest Ubuntu LTS
+* `mcr.microsoft.com/devcontainers/cpp:ubuntu24.04` (or `noble`)
+* `mcr.microsoft.com/devcontainers/cpp:ubuntu22.04` (or `jammy`)
+
+## Included tools
+
+<CardGroup>
+  <Card title="GCC" icon="c">
+    GNU Compiler Collection — `gcc`, `g++`, and `make` via `build-essential`.
+  </Card>
+
+  <Card title="Clang / LLVM" icon="c">
+    Clang compiler, `lldb` debugger, and the full LLVM toolchain.
+  </Card>
+
+  <Card title="CMake" icon="hammer">
+    Cross-platform build system generator for configuring and building C++ projects.
+  </Card>
+
+  <Card title="Ninja" icon="bolt">
+    Fast, lightweight build system (`ninja-build`) commonly used with CMake.
+  </Card>
+
+  <Card title="cppcheck" icon="magnifying-glass">
+    Static analysis tool for detecting bugs and undefined behavior in C++ code.
+  </Card>
+
+  <Card title="valgrind" icon="bug">
+    Memory error detector and profiler for finding leaks and invalid memory access.
+  </Card>
+
+  <Card title="Vcpkg" icon="box">
+    Cross-platform C++ package manager with a bootstrapped clone at `$VCPKG_ROOT`.
+  </Card>
+
+  <Card title="gdb" icon="terminal">
+    GNU Debugger for stepping through and inspecting C++ programs.
+  </Card>
+</CardGroup>
+
+## Common tasks
+
+### Compile and run a program
+
+```bash theme={null}
+g++ -std=c++17 -o hello hello.cpp
+./hello
+```
+
+### Build with CMake
+
+```bash theme={null}
+mkdir build && cd build
+cmake ..
+cmake --build .
+```
+
+### Build with CMake and Ninja
+
+```bash theme={null}
+mkdir build && cd build
+cmake -G Ninja ..
+ninja
+```
+
+### Run static analysis with cppcheck
+
+```bash theme={null}
+cppcheck --enable=all --std=c++17 src/
+```
+
+### Check for memory leaks with valgrind
+
+```bash theme={null}
+valgrind --leak-check=full ./my_program
+```
+
+### Debug with lldb
+
+```bash theme={null}
+lldb ./my_program
+(lldb) run
+(lldb) bt
+```
+
+## Using Vcpkg
+
+The image includes a bootstrapped clone of Vcpkg at `$VCPKG_ROOT`. Use it to install C++ library dependencies.
+
+### Install a library
+
+```bash theme={null}
+cd "$VCPKG_ROOT"
+./vcpkg install fmt
+./vcpkg install nlohmann-json
+```
+
+### Update the package registry
+
+```bash theme={null}
+cd "$VCPKG_ROOT"
+git pull --ff-only
+```
+
+### Use Vcpkg manifest mode
+
+Create a `vcpkg.json` in your project root:
+
+```json vcpkg.json theme={null}
+{
+  "name": "my-project",
+  "version": "0.1.0",
+  "dependencies": [
+    "fmt",
+    "nlohmann-json"
+  ]
+}
+```
+
+<Note>
+  To use Vcpkg in manifest mode, install additional system packages. Add the following to your `Dockerfile`:
+
+  ```dockerfile theme={null}
+  RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+      && apt-get -y install autoconf automake libtool m4 autoconf-archive \
+      && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+  ```
+</Note>
+
+## Extending with features
+
+Use [Dev Container Features](https://containers.dev/features) to add language runtimes or cloud tools alongside C++.
+
+### Add Python
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "C++",
+  "image": "mcr.microsoft.com/devcontainers/cpp:debian13",
+  "features": {
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "latest"
+    }
+  }
+}
+```
+
+### Add Docker-in-Docker
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "C++",
+  "image": "mcr.microsoft.com/devcontainers/cpp:debian13",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  }
+}
+```
+
+## Versioning
+
+The image uses [semantic versioning](https://semver.org/). Pin to a major or minor version to control how frequently you receive updates.
+
+| Tag format       | Example            | Update behavior                   |
+| ---------------- | ------------------ | --------------------------------- |
+| OS variant only  | `cpp:trixie`       | Receives all non-breaking updates |
+| Major + OS       | `cpp:2-trixie`     | Locked to major version 2         |
+| Major.minor + OS | `cpp:2.1-trixie`   | Locked to minor version 2.1       |
+| Full semver + OS | `cpp:2.1.6-trixie` | Pinned to exact build             |
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/cpp:2-bookworm"
+}
+```
+
+<Tip>
+  Security patches are only applied to the latest non-breaking version (e.g., `2-trixie`). If you pin to a full semver like `2.1.6-trixie`, run `apt-get update && apt-get upgrade` in your Dockerfile to pick up OS-level security fixes.
+</Tip>
+
+
+# .NET
+Source: https://www.mintlify.com/devcontainers/images/images/dotnet
+
+Pre-built dev container image for C# and .NET development, based on the official .NET SDK with nvm and developer tooling included.
+
+Use this image to develop C# and .NET applications in a fully configured container. It builds directly on the official `mcr.microsoft.com/dotnet/sdk` image and adds `nvm`, `zsh` with Oh My Zsh!, and a non-root `vscode` user with `sudo` access.
+
+## Image metadata
+
+| Property           | Value                                                     |
+| ------------------ | --------------------------------------------------------- |
+| Published image    | `mcr.microsoft.com/devcontainers/dotnet`                  |
+| Available variants | `10.0`, `9.0`, `8.0` (noble, bookworm, jammy OS variants) |
+| Architectures      | x86-64, arm64/aarch64                                     |
+| Container OS       | Ubuntu (noble, jammy), Debian (bookworm)                  |
+| Container host OS  | Linux, macOS, Windows                                     |
+
+## Using this image
+
+Reference the image directly in your `.devcontainer/devcontainer.json` using the `image` property.
+
+<Tabs>
+  <Tab title="Latest">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": ".NET",
+      "image": "mcr.microsoft.com/devcontainers/dotnet"
+    }
+    ```
+  </Tab>
+
+  <Tab title=".NET 10.0">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": ".NET 10",
+      "image": "mcr.microsoft.com/devcontainers/dotnet:10.0"
+    }
+    ```
+  </Tab>
+
+  <Tab title=".NET 9.0">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": ".NET 9",
+      "image": "mcr.microsoft.com/devcontainers/dotnet:9.0"
+    }
+    ```
+  </Tab>
+
+  <Tab title=".NET 8.0">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": ".NET 8",
+      "image": "mcr.microsoft.com/devcontainers/dotnet:8.0"
+    }
+    ```
+  </Tab>
+</Tabs>
+
+### Available tags
+
+Pin to a specific .NET version or OS variant:
+
+* `mcr.microsoft.com/devcontainers/dotnet` — latest (.NET 10.0, Ubuntu noble)
+* `mcr.microsoft.com/devcontainers/dotnet:10.0` — .NET 10.0 (or `10.0-noble`)
+* `mcr.microsoft.com/devcontainers/dotnet:9.0` — .NET 9.0 (or `9.0-bookworm`, `9.0-noble`)
+* `mcr.microsoft.com/devcontainers/dotnet:8.0` — .NET 8.0 (or `8.0-bookworm`, `8.0-noble`, `8.0-jammy`)
+
+## Included tools
+
+<CardGroup>
+  <Card title=".NET SDK" icon="microsoft">
+    The full .NET SDK — `dotnet build`, `dotnet run`, `dotnet test`, `dotnet publish`, and `dotnet new`.
+  </Card>
+
+  <Card title="nvm" icon="node-js">
+    Node Version Manager, pre-installed for ASP.NET projects with JavaScript front-end tooling.
+  </Card>
+
+  <Card title="yarn" icon="box">
+    JavaScript package manager, available for projects with front-end dependencies.
+  </Card>
+
+  <Card title="git" icon="git-alt">
+    Git version control, available at the system level.
+  </Card>
+
+  <Card title="Oh My Zsh!" icon="terminal">
+    Zsh shell with Oh My Zsh! for a productive terminal experience.
+  </Card>
+</CardGroup>
+
+## Common tasks
+
+### Create a new project
+
+```bash theme={null}
+dotnet new webapi -n MyApi
+dotnet new mvc -n MyWebApp
+dotnet new console -n MyApp
+```
+
+### Build and run
+
+```bash theme={null}
+dotnet build
+dotnet run
+```
+
+### Run tests
+
+```bash theme={null}
+dotnet test
+```
+
+### Publish for deployment
+
+```bash theme={null}
+dotnet publish -c Release -o ./publish
+```
+
+### Install a NuGet package
+
+```bash theme={null}
+dotnet add package Newtonsoft.Json
+dotnet restore
+```
+
+### Install Node.js with nvm
+
+```bash theme={null}
+nvm install --lts
+nvm use --lts
+```
+
+## HTTPS development certificates
+
+ASP.NET Core requires an HTTPS certificate for local development. Because dev containers are ephemeral, the certificate is lost on each rebuild. Use a named volume to persist it.
+
+### Persisting the certificate across rebuilds
+
+Add a named volume and a lifecycle command in `devcontainer.json`:
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": ".NET",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:9.0",
+  "mounts": [
+    {
+      "type": "volume",
+      "source": "x509stores",
+      "target": "/home/vscode/.dotnet/corefx/cryptography/x509stores"
+    }
+  ],
+  "onCreateCommand": "bash .devcontainer/setup-dotnet-dev-cert.sh"
+}
+```
+
+Create `.devcontainer/setup-dotnet-dev-cert.sh`:
+
+```bash .devcontainer/setup-dotnet-dev-cert.sh theme={null}
+#!/usr/bin/env bash
+sudo chown -R vscode:vscode /home/vscode/.dotnet
+dotnet dev-certs https
+sudo -E dotnet dev-certs https --export-path /usr/local/share/ca-certificates/dotnet-dev-cert.crt --format pem
+sudo update-ca-certificates
+```
+
+### Mounting a local certificate
+
+For private projects, you can mount your local certificate into the container. Add the following to `devcontainer.json`:
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "remoteEnv": {
+    "ASPNETCORE_Kestrel__Certificates__Default__Password": "SecurePwdGoesHere",
+    "ASPNETCORE_Kestrel__Certificates__Default__Path": "/home/vscode/.aspnet/https/aspnetapp.pfx"
+  },
+  "mounts": [
+    "source=${env:HOME}${env:USERPROFILE}/.aspnet/https,target=/home/vscode/.aspnet/https,type=bind"
+  ]
+}
+```
+
+Export your local certificate first:
+
+<Tabs>
+  <Tab title="Windows PowerShell">
+    ```powershell theme={null}
+    dotnet dev-certs https --trust
+    dotnet dev-certs https -ep "$env:USERPROFILE/.aspnet/https/aspnetapp.pfx" -p "SecurePwdGoesHere"
+    ```
+  </Tab>
+
+  <Tab title="macOS / Linux">
+    ```bash theme={null}
+    dotnet dev-certs https --trust
+    dotnet dev-certs https -ep "${HOME}/.aspnet/https/aspnetapp.pfx" -p "SecurePwdGoesHere"
+    ```
+  </Tab>
+</Tabs>
+
+<Warning>
+  Do not use the mounted certificate approach for team or open source projects — the certificate password is stored in `devcontainer.json` in plain text.
+</Warning>
+
+## Extending with features
+
+Use [Dev Container Features](https://containers.dev/features) to add Node.js, the Azure CLI, or other tools.
+
+### Add Node.js
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": ".NET",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:9.0",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    }
+  }
+}
+```
+
+### Add the Azure CLI
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": ".NET with Azure",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:9.0",
+  "features": {
+    "ghcr.io/devcontainers/features/azure-cli:1": {
+      "version": "latest"
+    }
+  }
+}
+```
+
+## Versioning
+
+The image uses [semantic versioning](https://semver.org/). Pin to a major or minor version to control how frequently you receive updates.
+
+| Tag format         | Example            | Update behavior                   |
+| ------------------ | ------------------ | --------------------------------- |
+| .NET version only  | `dotnet:9.0`       | Receives all non-breaking updates |
+| Major + .NET       | `dotnet:2-9.0`     | Locked to major version 2         |
+| Major.minor + .NET | `dotnet:2.0-9.0`   | Locked to minor version 2.0       |
+| Full semver + .NET | `dotnet:2.0.6-9.0` | Pinned to exact build             |
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/dotnet:2-9.0-bookworm"
+}
+```
+
+<Tip>
+  Security patches are only applied to the latest non-breaking version (e.g., `2-9.0`). If you pin to a full semver like `2.0.6-9.0`, run `apt-get update && apt-get upgrade` in your Dockerfile to pick up OS-level security fixes.
+</Tip>
+
+
+# Go
+Source: https://www.mintlify.com/devcontainers/images/images/go
+
+A dev container image for Go development, with gopls, delve, golangci-lint, and common Go tooling pre-installed.
+
+The Go image provides a Debian-based environment for Go development. It comes with `gopls` (the official Go language server), `delve` (the Go debugger), `golangci-lint`, and several other commonly used Go tools pre-installed so you can start writing and debugging Go code immediately.
+
+## Metadata
+
+| Property                | Value                                                                                                            |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| Published image         | `mcr.microsoft.com/devcontainers/go`                                                                             |
+| Available variants      | `1` / `1-trixie`, `1.26` / `1.26-trixie`, `1.25` / `1.25-trixie`, `1.25-bookworm`, `1.26-bookworm`, `1-bookworm` |
+| Architectures           | x86-64, arm64/aarch64 (trixie and bookworm variants)                                                             |
+| Container OS            | Debian                                                                                                           |
+| Languages and platforms | Go                                                                                                               |
+
+## Using this image
+
+Reference the published image in your `.devcontainer/devcontainer.json`:
+
+```json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/go:1"
+}
+```
+
+### Available image tags
+
+Choose a Go version and optionally pin the Debian OS:
+
+* `mcr.microsoft.com/devcontainers/go` — latest
+* `mcr.microsoft.com/devcontainers/go:1` (or `1-trixie`, `1-bookworm`)
+* `mcr.microsoft.com/devcontainers/go:1.26` (or `1.26-trixie`, `1.26-bookworm`)
+* `mcr.microsoft.com/devcontainers/go:1.25` (or `1.25-trixie`, `1.25-bookworm`)
+
+See the [full list of available tags](https://mcr.microsoft.com/v2/devcontainers/go/tags/list).
+
+## Key included tools
+
+<AccordionGroup>
+  <Accordion title="Go tooling (pre-installed via go install)">
+    * **gopls** (`golang.org/x/tools/gopls`) — official Go language server
+    * **staticcheck** (`honnef.co/go/tools`) — advanced static analysis
+    * **golint** (`golang.org/x/lint`) — Go style linter
+    * **revive** (`github.com/mgechev/revive`) — fast, extensible linter
+    * **gopkgs** (`github.com/uudashr/gopkgs`) — lists available Go packages
+    * **go-outline** (`github.com/ramya-rao-a/go-outline`) — Go symbol extraction
+    * **delve** (`github.com/go-delve/delve`) — Go debugger
+    * **golangci-lint** (`github.com/golangci/golangci-lint`) — multi-linter runner
+  </Accordion>
+
+  <Accordion title="Build tools and other dependencies">
+    * `g++`, `gcc`, `libc6-dev`, `make`, `pkg-config` — C build toolchain (required by some Go packages with CGo)
+    * `git` — version control
+    * `nvm` — Node Version Manager (for front-end toolchains)
+    * `yarn` — JavaScript package manager
+    * `zsh` + Oh My Zsh! — enhanced shell
+    * Non-root `vscode` user with `sudo` access
+  </Accordion>
+</AccordionGroup>
+
+## Common tasks
+
+### Installing additional Go packages
+
+Use `go install` to add Go binaries to your environment:
+
+```bash theme={null}
+go install github.com/air-verse/air@latest       # live reload for Go apps
+go install github.com/swaggo/swag/cmd/swag@latest # Swagger docs generator
+```
+
+Installed binaries are placed in `$GOPATH/bin`, which is on `$PATH` by default.
+
+### Running and testing your application
+
+```bash theme={null}
+# Run directly
+go run ./cmd/server
+
+# Build a binary
+go build -o ./bin/server ./cmd/server
+
+# Run tests
+go test ./...
+
+# Run tests with coverage
+go test -cover ./...
+```
+
+### Debugging with Delve
+
+`delve` is pre-installed. Start a debug session from the command line:
+
+```bash theme={null}
+# Debug the main package
+dlv debug ./cmd/server
+
+# Attach to a running process
+dlv attach <pid>
+
+# Run tests with debugging
+dlv test ./...
+```
+
+### Linting with golangci-lint
+
+Run all configured linters at once:
+
+```bash theme={null}
+golangci-lint run ./...
+```
+
+Add a `.golangci.yml` to your project root to configure which linters to enable.
+
+### Installing Node.js for front-end toolchains
+
+If your Go back-end serves a JavaScript front-end, add the Node.js feature to `devcontainer.json`:
+
+```json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/go:1",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "latest"
+    }
+  }
+}
+```
+
+## Extending with features
+
+Use [Dev Container Features](https://containers.dev/features) to add tools on top of this image:
+
+```json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/go:1",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  }
+}
+```
+
+## Versioning
+
+Pin to a semantic version to control the update cadence:
+
+<CodeGroup>
+  ```text Major version (receives all non-breaking updates) theme={null}
+  mcr.microsoft.com/devcontainers/go:2-1.26
+  ```
+
+  ```text Minor version (receives patch updates only) theme={null}
+  mcr.microsoft.com/devcontainers/go:2.1-1.26
+  ```
+
+  ```text Patch version (fully pinned) theme={null}
+  mcr.microsoft.com/devcontainers/go:2.1.1-1.26
+  ```
+</CodeGroup>
+
+You can also combine with an OS pin:
+
+```text theme={null}
+mcr.microsoft.com/devcontainers/go:2.1.1-1.26-trixie
+mcr.microsoft.com/devcontainers/go:2.1.1-1.26-bookworm
+```
+
+<Note>
+  Security patches are applied only to the latest in-support versions (e.g., `2-1.26`). If you pin to a specific patch version, add `RUN apt-get update && apt-get upgrade` to your Dockerfile to pick up OS-level security fixes.
+</Note>
+
+
+# Java
+Source: https://www.mintlify.com/devcontainers/images/images/java
+
+Pre-built dev container image for Java development, with SDKMAN!, nvm, and support for JDK 11 through 25 on Debian.
+
+Use this image to develop Java applications in a fully configured container. It includes SDKMAN! for Java version management, `nvm` for optional Node.js installation, `zsh` with Oh My Zsh!, and a non-root `vscode` user with `sudo` access.
+
+## Image metadata
+
+| Property           | Value                                                    |
+| ------------------ | -------------------------------------------------------- |
+| Published image    | `mcr.microsoft.com/devcontainers/java`                   |
+| Available variants | `11`, `17`, `21`, `25` (trixie and bookworm OS variants) |
+| Architectures      | x86-64, arm64/aarch64                                    |
+| Container OS       | Debian (trixie, bookworm)                                |
+| Container host OS  | Linux, macOS, Windows                                    |
+
+## Using this image
+
+Reference the image directly in your `.devcontainer/devcontainer.json` using the `image` property.
+
+<Tabs>
+  <Tab title="Latest">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "Java",
+      "image": "mcr.microsoft.com/devcontainers/java"
+    }
+    ```
+  </Tab>
+
+  <Tab title="JDK 21">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "Java 21",
+      "image": "mcr.microsoft.com/devcontainers/java:21"
+    }
+    ```
+  </Tab>
+
+  <Tab title="JDK 17">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "Java 17",
+      "image": "mcr.microsoft.com/devcontainers/java:17"
+    }
+    ```
+  </Tab>
+
+  <Tab title="JDK 11">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "Java 11",
+      "image": "mcr.microsoft.com/devcontainers/java:11"
+    }
+    ```
+  </Tab>
+</Tabs>
+
+### Available tags
+
+Pin to a specific JDK version or OS variant using any of these tags:
+
+* `mcr.microsoft.com/devcontainers/java` — latest (JDK 25, Debian trixie)
+* `mcr.microsoft.com/devcontainers/java:25` — JDK 25 (or `25-trixie`, `25-bookworm`)
+* `mcr.microsoft.com/devcontainers/java:21` — JDK 21 (or `21-trixie`, `21-bookworm`)
+* `mcr.microsoft.com/devcontainers/java:17` — JDK 17 (or `17-trixie`, `17-bookworm`)
+* `mcr.microsoft.com/devcontainers/java:11` — JDK 11 (or `11-trixie`, `11-bookworm`)
+* `mcr.microsoft.com/devcontainers/java:8` — JDK 8 (or `8-trixie`, `8-bookworm`)
+
+<Note>
+  The Java 8 image (`mcr.microsoft.com/devcontainers/java:8`) is maintained as a separate image variant for legacy projects. For newer JDKs, use the tags above.
+</Note>
+
+## Included tools
+
+<CardGroup>
+  <Card title="SDKMAN!" icon="layer-group">
+    Manages Java SDK versions. Switch between JDKs without leaving the container.
+  </Card>
+
+  <Card title="JDK" icon="java">
+    The full Java Development Kit — `javac`, `java`, `jar`, and all standard tools.
+  </Card>
+
+  <Card title="nvm" icon="node-js">
+    Node Version Manager, pre-installed so you can add a Node.js runtime for front-end tooling.
+  </Card>
+
+  <Card title="yarn" icon="box">
+    JavaScript package manager, available for projects with front-end dependencies.
+  </Card>
+
+  <Card title="git" icon="git-alt">
+    Git version control, available at the system level.
+  </Card>
+
+  <Card title="Oh My Zsh!" icon="terminal">
+    Zsh shell with Oh My Zsh! for a productive terminal experience.
+  </Card>
+</CardGroup>
+
+## Common tasks
+
+### Run a Java program
+
+```bash theme={null}
+javac HelloWorld.java
+java HelloWorld
+```
+
+### Check the installed JDK version
+
+```bash theme={null}
+java -version
+javac -version
+```
+
+### Install a different JDK with SDKMAN!
+
+```bash theme={null}
+sdk list java
+sdk install java 21.0.3-tem
+sdk use java 21.0.3-tem
+```
+
+### Install Node.js with nvm
+
+```bash theme={null}
+nvm install --lts
+nvm use --lts
+node --version
+```
+
+### Build with Maven (after installing via feature)
+
+```bash theme={null}
+mvn clean install
+mvn test
+```
+
+### Build with Gradle (after installing via feature)
+
+```bash theme={null}
+gradle build
+gradle test
+```
+
+## Extending with features
+
+Use [Dev Container Features](https://containers.dev/features) to add Maven, Gradle, Node.js, or other tools without modifying the base image.
+
+### Add Maven and Gradle
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Java",
+  "image": "mcr.microsoft.com/devcontainers/java:21",
+  "features": {
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "none",
+      "installGradle": "true",
+      "installMaven": "true"
+    }
+  }
+}
+```
+
+### Add Node.js
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Java",
+  "image": "mcr.microsoft.com/devcontainers/java:21",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    }
+  }
+}
+```
+
+### Add multiple features
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Java Full Stack",
+  "image": "mcr.microsoft.com/devcontainers/java:21",
+  "features": {
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "none",
+      "installMaven": "true",
+      "installGradle": "true"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    }
+  }
+}
+```
+
+## Versioning
+
+The image uses [semantic versioning](https://semver.org/). Pin to a major or minor version to control how frequently you receive updates.
+
+| Tag format        | Example         | Update behavior                   |
+| ----------------- | --------------- | --------------------------------- |
+| JDK version only  | `java:21`       | Receives all non-breaking updates |
+| Major + JDK       | `java:3-21`     | Locked to major version 3         |
+| Major.minor + JDK | `java:3.0-21`   | Locked to minor version 3.0       |
+| Full semver + JDK | `java:3.0.6-21` | Pinned to exact build             |
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/java:3-21-bookworm"
+}
+```
+
+<Tip>
+  Security patches are only applied to the latest non-breaking version (e.g., `3-21`). If you pin to a full semver like `3.0.6-21`, run `apt-get update && apt-get upgrade` in your Dockerfile to pick up OS-level security fixes.
+</Tip>
+
+
+# Node.js & JavaScript
+Source: https://www.mintlify.com/devcontainers/images/images/javascript-node
+
+A dev container image for Node.js and JavaScript development, with ESLint, nvm, and yarn pre-installed.
+
+The Node.js & JavaScript image gives you a Debian-based environment tailored for Node.js development. It includes ESLint for linting, `nvm` for managing multiple Node.js versions, and `yarn` as an alternative package manager.
+
+## Metadata
+
+| Property                | Value                                                                                                                                                |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Published image         | `mcr.microsoft.com/devcontainers/javascript-node`                                                                                                    |
+| Available variants      | `24` / `24-trixie`, `22` / `22-trixie`, `20` / `20-trixie`, `24-bookworm`, `22-bookworm`, `20-bookworm`, `24-bullseye`, `22-bullseye`, `20-bullseye` |
+| Architectures           | x86-64, arm64/aarch64 (bookworm and bullseye variants)                                                                                               |
+| Container OS            | Debian                                                                                                                                               |
+| Languages and platforms | Node.js, JavaScript                                                                                                                                  |
+
+## Using this image
+
+Reference the published image in your `.devcontainer/devcontainer.json`:
+
+```json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22"
+}
+```
+
+### Available image tags
+
+Choose a Node.js version and optionally pin the Debian OS:
+
+* `mcr.microsoft.com/devcontainers/javascript-node` — latest
+* `mcr.microsoft.com/devcontainers/javascript-node:24` (or `24-trixie`, `24-bookworm`, `24-bullseye`)
+* `mcr.microsoft.com/devcontainers/javascript-node:22` (or `22-trixie`, `22-bookworm`, `22-bullseye`)
+* `mcr.microsoft.com/devcontainers/javascript-node:20` (or `20-trixie`, `20-bookworm`, `20-bullseye`)
+
+See the [full list of available tags](https://mcr.microsoft.com/v2/devcontainers/javascript-node/tags/list).
+
+## Key included tools
+
+<AccordionGroup>
+  <Accordion title="Node.js tooling">
+    * **Node.js** — JavaScript runtime (version selected by image tag)
+    * **npm** — Node.js package manager (bundled with Node.js)
+    * **eslint** — JavaScript linter, installed globally via npm
+    * **yarn** — alternative package manager
+    * **nvm** — Node Version Manager for switching Node.js versions
+  </Accordion>
+
+  <Accordion title="Other tools">
+    * `git` — version control
+    * `zsh` + Oh My Zsh! — enhanced shell
+    * Non-root `node` user with `sudo` access
+  </Accordion>
+</AccordionGroup>
+
+## Common tasks
+
+### Switching Node.js versions with nvm
+
+The image includes `nvm` so you can install and switch between Node.js versions without rebuilding the container:
+
+```bash theme={null}
+# List available versions
+nvm ls-remote --lts
+
+# Install a specific version
+nvm install 18
+
+# Switch to an installed version
+nvm use 18
+
+# Make a version the default for new shells
+nvm alias default 18
+```
+
+### Installing global packages
+
+Install CLI tools globally using npm:
+
+```bash theme={null}
+npm install -g typescript ts-node
+```
+
+Or using yarn:
+
+```bash theme={null}
+yarn global add typescript ts-node
+```
+
+### Running a development server
+
+Forward ports from the container to your host machine by adding `forwardPorts` to `devcontainer.json`:
+
+```json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+  "forwardPorts": [3000]
+}
+```
+
+### Installing project dependencies on container start
+
+Use `postCreateCommand` to install your project's dependencies automatically after the container is created:
+
+```json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+  "postCreateCommand": "npm install"
+}
+```
+
+## Extending with features
+
+Use [Dev Container Features](https://containers.dev/features) to add tools on top of this image:
+
+```json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+  "features": {
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.13"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  }
+}
+```
+
+## Versioning
+
+Pin to a semantic version to control the update cadence:
+
+<CodeGroup>
+  ```text Major version (receives all non-breaking updates) theme={null}
+  mcr.microsoft.com/devcontainers/javascript-node:4-24
+  ```
+
+  ```text Minor version (receives patch updates only) theme={null}
+  mcr.microsoft.com/devcontainers/javascript-node:4.0-24
+  ```
+
+  ```text Patch version (fully pinned) theme={null}
+  mcr.microsoft.com/devcontainers/javascript-node:4.0.9-24
+  ```
+</CodeGroup>
+
+You can also combine with an OS pin:
+
+```text theme={null}
+mcr.microsoft.com/devcontainers/javascript-node:4.0.9-24-trixie
+mcr.microsoft.com/devcontainers/javascript-node:4.0.9-24-bookworm
+mcr.microsoft.com/devcontainers/javascript-node:4.0.9-24-bullseye
+```
+
+<Note>
+  Security patches are applied only to the latest in-support versions (e.g., `4-24`). If you pin to a specific patch version, add `RUN apt-get update && apt-get upgrade` to your Dockerfile to pick up OS-level security fixes.
+</Note>
+
+
+# Jekyll
+Source: https://www.mintlify.com/devcontainers/images/images/jekyll
+
+A dev container image for developing static sites with Jekyll, including Ruby, Bundler, and GitHub Pages support.
+
+`mcr.microsoft.com/devcontainers/jekyll`
+
+The Jekyll image provides everything you need to develop static sites with Jekyll on Debian. It includes Ruby, Bundler, the `jekyll` and `github-pages` gems, and automatically installs your project's gem dependencies at container startup.
+
+<Info>
+  **Published image architecture(s):** x86-64, arm64/aarch64 (bookworm and bullseye variants)
+  **Container OS:** Debian
+</Info>
+
+## How gem installation works at startup
+
+The container installs Jekyll dependencies automatically based on your project:
+
+* **With a `Gemfile`:** The container runs `bundle install` at startup, installing the exact Jekyll version and plugins specified in your `Gemfile`. This is the [recommended approach](https://jekyllrb.com/docs/step-by-step/10-deployment/#gemfile).
+* **Without a `Gemfile`:** The container installs the latest version of Jekyll automatically. You may need to install additional plugins manually.
+
+## Referencing this image
+
+Use the `image` property in `.devcontainer/devcontainer.json`:
+
+<Tabs>
+  <Tab title="Latest">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "Jekyll",
+      "image": "mcr.microsoft.com/devcontainers/jekyll"
+    }
+    ```
+  </Tab>
+
+  <Tab title="Debian bookworm">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "Jekyll (bookworm)",
+      "image": "mcr.microsoft.com/devcontainers/jekyll:bookworm"
+    }
+    ```
+  </Tab>
+
+  <Tab title="Debian bullseye">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "Jekyll (bullseye)",
+      "image": "mcr.microsoft.com/devcontainers/jekyll:bullseye"
+    }
+    ```
+  </Tab>
+</Tabs>
+
+### Available variants
+
+| Variant    | Architectures            | Notes              |
+| ---------- | ------------------------ | ------------------ |
+| `bookworm` | linux/amd64, linux/arm64 | Debian 12 (latest) |
+| `bullseye` | linux/amd64, linux/arm64 | Debian 11          |
+| `buster`   | linux/amd64              | Debian 10 (older)  |
+
+### Pinning to a version
+
+Reference a [semantic version](https://semver.org/) to control update frequency:
+
+```text theme={null}
+mcr.microsoft.com/devcontainers/jekyll:2
+mcr.microsoft.com/devcontainers/jekyll:2-bookworm
+mcr.microsoft.com/devcontainers/jekyll:2.2
+mcr.microsoft.com/devcontainers/jekyll:2.2-bullseye
+mcr.microsoft.com/devcontainers/jekyll:2.2.7
+mcr.microsoft.com/devcontainers/jekyll:2.2.7-bookworm
+```
+
+<Warning>
+  Security patching only applies to the latest non-breaking, in-support versions of images. If you lock to a specific version, run `apt-get update && apt-get upgrade` in your Dockerfile to pick up OS security updates.
+</Warning>
+
+See the [full list of available tags](https://mcr.microsoft.com/v2/devcontainers/jekyll/tags/list).
+
+## Serving a Jekyll site
+
+<Steps>
+  <Step title="Forward port 4000">
+    Add port `4000` to `forwardPorts` in `.devcontainer/devcontainer.json`:
+
+    ```json theme={null}
+    "forwardPorts": [4000]
+    ```
+  </Step>
+
+  <Step title="Build and serve">
+    Open a terminal in the container and run:
+
+    ```bash theme={null}
+    bundle exec jekyll serve
+    ```
+
+    Jekyll serves your site at `http://localhost:4000` and watches for file changes.
+  </Step>
+
+  <Step title="Open in browser">
+    Navigate to `http://localhost:4000` in your browser. The page reloads automatically when you save changes to your source files.
+  </Step>
+</Steps>
+
+## Installing Node.js
+
+If your Jekyll site uses Node.js-based utilities for asset building, the container includes `nvm`. You can also add Node.js as a dev container feature:
+
+```json theme={null}
+{
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "latest"
+    }
+  }
+}
+```
+
+## Image contents
+
+| Component                    | Details                                           |
+| ---------------------------- | ------------------------------------------------- |
+| Base image                   | `mcr.microsoft.com/devcontainers/ruby:${VARIANT}` |
+| OS                           | Debian (bookworm or bullseye)                     |
+| Ruby                         | Included (version depends on variant)             |
+| Bundler                      | Included (`gem`)                                  |
+| Jekyll                       | Included (`gem`)                                  |
+| GitHub Pages                 | Included (`github-pages` gem)                     |
+| rake, ruby-debug-ide, debase | Included                                          |
+| nvm                          | `/usr/local/share/nvm`                            |
+| rbenv, ruby-build            | Included                                          |
+| Version                      | `2.2.7`                                           |
+
+
+# PHP
+Source: https://www.mintlify.com/devcontainers/images/images/php
+
+Pre-built dev container image for PHP development, with Apache, Xdebug, Composer, and nvm included.
+
+Use this image to develop PHP applications in a fully configured container. It builds on the official PHP Apache image and adds Xdebug for debugging, Composer for dependency management, `nvm` for optional Node.js installation, and a non-root `vscode` user with `sudo` access.
+
+## Image metadata
+
+| Property           | Value                                                        |
+| ------------------ | ------------------------------------------------------------ |
+| Published image    | `mcr.microsoft.com/devcontainers/php`                        |
+| Available variants | `8.5`, `8.4`, `8.3`, `8.2` (trixie and bookworm OS variants) |
+| Architectures      | x86-64, arm64/aarch64                                        |
+| Container OS       | Debian (trixie, bookworm)                                    |
+| Container host OS  | Linux, macOS, Windows                                        |
+
+## Using this image
+
+Reference the image directly in your `.devcontainer/devcontainer.json` using the `image` property.
+
+<Tabs>
+  <Tab title="Latest">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "PHP",
+      "image": "mcr.microsoft.com/devcontainers/php"
+    }
+    ```
+  </Tab>
+
+  <Tab title="PHP 8.5">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "PHP 8.5",
+      "image": "mcr.microsoft.com/devcontainers/php:8.5"
+    }
+    ```
+  </Tab>
+
+  <Tab title="PHP 8.4">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "PHP 8.4",
+      "image": "mcr.microsoft.com/devcontainers/php:8.4"
+    }
+    ```
+  </Tab>
+
+  <Tab title="PHP 8.3">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "PHP 8.3",
+      "image": "mcr.microsoft.com/devcontainers/php:8.3"
+    }
+    ```
+  </Tab>
+</Tabs>
+
+### Available tags
+
+* `mcr.microsoft.com/devcontainers/php` — latest (PHP 8.5, Debian trixie)
+* `mcr.microsoft.com/devcontainers/php:8` (or `8-trixie`, `8-bookworm`)
+* `mcr.microsoft.com/devcontainers/php:8.5` (or `8.5-trixie`, `8.5-bookworm`)
+* `mcr.microsoft.com/devcontainers/php:8.4` (or `8.4-trixie`, `8.4-bookworm`)
+* `mcr.microsoft.com/devcontainers/php:8.3` (or `8.3-trixie`, `8.3-bookworm`)
+* `mcr.microsoft.com/devcontainers/php:8.2` (or `8.2-trixie`, `8.2-bookworm`)
+
+## Included tools
+
+<CardGroup>
+  <Card title="PHP" icon="php">
+    PHP runtime with the Apache SAPI, plus the PHP CLI for running scripts directly.
+  </Card>
+
+  <Card title="Apache" icon="server">
+    Apache HTTP server pre-configured and available on port 8080.
+  </Card>
+
+  <Card title="Xdebug" icon="bug">
+    PHP debugging extension installed at `/usr/local/lib/php/extensions`, ready to connect to your IDE.
+  </Card>
+
+  <Card title="Composer" icon="box">
+    PHP dependency manager installed at `/usr/local`, for managing packages via `composer.json`.
+  </Card>
+
+  <Card title="nvm" icon="node-js">
+    Node Version Manager, pre-installed for front-end tooling in full-stack PHP projects.
+  </Card>
+
+  <Card title="yarn" icon="box">
+    JavaScript package manager, available for projects with front-end dependencies.
+  </Card>
+
+  <Card title="git" icon="git-alt">
+    Git version control, available at the system level.
+  </Card>
+
+  <Card title="Oh My Zsh!" icon="terminal">
+    Zsh shell with Oh My Zsh! for a productive terminal experience.
+  </Card>
+</CardGroup>
+
+## Common tasks
+
+### Run the PHP built-in server
+
+```bash theme={null}
+php -S 0.0.0.0:8080
+```
+
+### Start Apache
+
+```bash theme={null}
+apache2ctl start
+```
+
+Apache serves on port `8080` by default.
+
+### Link your project to Apache's web root
+
+Add the following `postCreateCommand` in `devcontainer.json` to symlink your project directory into Apache's `www` folder:
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "postCreateCommand": "sudo chmod a+x \"$(pwd)\" && sudo rm -rf /var/www/html && sudo ln -s \"$(pwd)\" /var/www/html"
+}
+```
+
+Or run it manually in the terminal:
+
+```bash theme={null}
+sudo chmod a+x "$(pwd)" && sudo rm -rf /var/www/html && sudo ln -s "$(pwd)" /var/www/html
+```
+
+### Install dependencies with Composer
+
+```bash theme={null}
+composer install
+composer require vendor/package
+```
+
+### Run PHP unit tests
+
+```bash theme={null}
+./vendor/bin/phpunit tests/
+```
+
+### Install Node.js with nvm
+
+```bash theme={null}
+nvm install --lts
+nvm use --lts
+npm install
+```
+
+## Extending with features
+
+Use [Dev Container Features](https://containers.dev/features) to add Node.js, databases, or other tools without modifying the base image.
+
+### Add Node.js
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "PHP",
+  "image": "mcr.microsoft.com/devcontainers/php:8.4",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    }
+  }
+}
+```
+
+### Add a MySQL client
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "PHP",
+  "image": "mcr.microsoft.com/devcontainers/php:8.4",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    },
+    "ghcr.io/devcontainers/features/mysql:1": {}
+  }
+}
+```
+
+## Versioning
+
+The image uses [semantic versioning](https://semver.org/). Pin to a major or minor version to control how frequently you receive updates.
+
+| Tag format        | Example       | Update behavior                   |
+| ----------------- | ------------- | --------------------------------- |
+| PHP version only  | `php:8.4`     | Receives all non-breaking updates |
+| Major + PHP       | `php:3-8`     | Locked to major version 3         |
+| Major.minor + PHP | `php:3.0-8`   | Locked to minor version 3.0       |
+| Full semver + PHP | `php:3.0.4-8` | Pinned to exact build             |
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/php:3-8.4-bookworm"
+}
+```
+
+<Tip>
+  Security patches are only applied to the latest non-breaking version (e.g., `3-8`). If you pin to a full semver like `3.0.4-8`, run `apt-get update && apt-get upgrade` in your Dockerfile to pick up OS-level security fixes.
+</Tip>
+
+
+# Python 3
+Source: https://www.mintlify.com/devcontainers/images/images/python
+
+A dev container image for Python 3 development, with linting tools, formatters, and type checkers pre-installed.
+
+The Python image gives you a ready-to-use Python 3 development environment on Debian. It ships with a curated set of linting, formatting, and static analysis tools installed via `pipx`, so they stay isolated from your project's Python environment.
+
+## Metadata
+
+| Property                | Value                                                                                                                                                                                                                                                             |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Published image         | `mcr.microsoft.com/devcontainers/python`                                                                                                                                                                                                                          |
+| Available variants      | `3` / `3-trixie`, `3.9` / `3.9-trixie`, `3.10` / `3.10-trixie`, `3.11` / `3.11-trixie`, `3.12` / `3.12-trixie`, `3.13` / `3.13-trixie`, `3.14` / `3.14-trixie`, `3-bookworm`, `3.10-bookworm`, `3.11-bookworm`, `3.12-bookworm`, `3.13-bookworm`, `3.14-bookworm` |
+| Architectures           | x86-64, arm64/aarch64 (bookworm and bullseye variants)                                                                                                                                                                                                            |
+| Container OS            | Debian                                                                                                                                                                                                                                                            |
+| Languages and platforms | Python                                                                                                                                                                                                                                                            |
+
+## Using this image
+
+Reference the published image in your `.devcontainer/devcontainer.json`:
+
+```json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/python:3"
+}
+```
+
+### Available image tags
+
+Choose a Python version and optionally pin the Debian OS:
+
+* `mcr.microsoft.com/devcontainers/python:3` — latest Python 3
+* `mcr.microsoft.com/devcontainers/python:3.14` (or `3.14-trixie`, `3.14-bookworm`)
+* `mcr.microsoft.com/devcontainers/python:3.13` (or `3.13-trixie`, `3.13-bookworm`)
+* `mcr.microsoft.com/devcontainers/python:3.12` (or `3.12-trixie`, `3.12-bookworm`)
+* `mcr.microsoft.com/devcontainers/python:3.11` (or `3.11-trixie`, `3.11-bookworm`)
+* `mcr.microsoft.com/devcontainers/python:3.10` (or `3.10-trixie`, `3.10-bookworm`)
+
+See the [full list of available tags](https://mcr.microsoft.com/v2/devcontainers/python/tags/list).
+
+## Key included tools
+
+<AccordionGroup>
+  <Accordion title="Python linting and formatting (via pipx)">
+    Each tool is installed in its own isolated environment using `pipx`:
+
+    * **pylint** — general-purpose linter
+    * **flake8** — style guide enforcement
+    * **autopep8** — auto-formatter (PEP 8)
+    * **black** — opinionated code formatter
+    * **yapf** — configurable formatter by Google
+    * **mypy** — static type checker
+    * **pydocstyle** — docstring style checker
+    * **pycodestyle** — PEP 8 style checker
+    * **bandit** — security-focused linter
+    * **virtualenv** — virtual environment manager
+    * **pipx** — tool for installing CLI Python apps
+  </Accordion>
+
+  <Accordion title="Other tools">
+    * `git` — version control
+    * `nvm` — Node Version Manager (for front-end toolchains)
+    * `yarn` — JavaScript package manager
+    * `zsh` + Oh My Zsh! — enhanced shell
+    * `setuptools` — Python packaging utility
+    * Non-root `vscode` user with `sudo` access
+  </Accordion>
+</AccordionGroup>
+
+## Common tasks
+
+### Installing packages with pip
+
+Install packages into your project's virtual environment:
+
+```bash theme={null}
+pip install requests flask
+```
+
+To install globally without `sudo`, use user-level installs:
+
+```bash theme={null}
+pip install --user <package>
+```
+
+Or use `sudo` for a global install:
+
+```bash theme={null}
+sudo pip install <package>
+```
+
+### Installing development tools with pipx
+
+Install additional Python CLI tools in isolated environments using `pipx`:
+
+```bash theme={null}
+pipx install prospector
+```
+
+This keeps the tool's dependencies from conflicting with your project's packages. See the [pipx documentation](https://pipxproject.github.io/pipx/docs/) for details.
+
+### Forwarding ports for Flask
+
+Flask listens on `localhost` inside the container by default, so you need to forward the port to access it from your host machine. Add `forwardPorts` to your `devcontainer.json`:
+
+```json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/python:3",
+  "forwardPorts": [5000]
+}
+```
+
+<Tip>
+  Use `forwardPorts` rather than `appPort`. The `appPort` property publishes the port, which requires your app to listen on `0.0.0.0` — conflicting with Flask's default. `forwardPorts` does not have this restriction.
+</Tip>
+
+Rebuild the container after adding `forwardPorts` using **Remote-Containers: Rebuild Container** from the Command Palette.
+
+### Baking requirements into the image
+
+If your dependencies rarely change, install them directly into your image to avoid running `pip install` on every container start. Add this to your `Dockerfile`:
+
+```dockerfile theme={null}
+COPY requirements.txt /tmp/pip-tmp/
+RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+    && rm -rf /tmp/pip-tmp
+```
+
+Include `"context": ".."` in `devcontainer.json` so the Dockerfile can access files in your project directory.
+
+### Running multiple Python versions in one container
+
+Use a custom `Dockerfile` to install multiple Python versions from the `deadsnakes` PPA:
+
+```dockerfile theme={null}
+FROM ubuntu:jammy
+ARG PYTHON_PACKAGES="python3.13 python3.12 python3 python3-pip python3-venv"
+RUN apt-get update && apt-get install --no-install-recommends -yq software-properties-common \
+     && add-apt-repository ppa:deadsnakes/ppa && apt-get update \
+     && apt-get install -yq --no-install-recommends ${PYTHON_PACKAGES} \
+     && pip3 install --no-cache-dir --upgrade pip setuptools wheel
+```
+
+### Installing Node.js for front-end toolchains
+
+The image includes `nvm` for on-demand Node.js installs. Alternatively, add the Node.js feature to `devcontainer.json`:
+
+```json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/python:3",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "latest"
+    }
+  }
+}
+```
+
+## Extending with features
+
+Use [Dev Container Features](https://containers.dev/features) to add tools on top of the Python image:
+
+```json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/python:3",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  }
+}
+```
+
+## Versioning
+
+Pin to a semantic version to control the update cadence:
+
+<CodeGroup>
+  ```text Major version (receives all non-breaking updates) theme={null}
+  mcr.microsoft.com/devcontainers/python:3-3.13
+  ```
+
+  ```text Minor version (receives patch updates only) theme={null}
+  mcr.microsoft.com/devcontainers/python:3.0-3.13
+  ```
+
+  ```text Patch version (fully pinned) theme={null}
+  mcr.microsoft.com/devcontainers/python:3.0.6-3.13
+  ```
+</CodeGroup>
+
+You can also pin both the image version and the OS variant:
+
+```text theme={null}
+mcr.microsoft.com/devcontainers/python:3.0.6-3.14-trixie
+mcr.microsoft.com/devcontainers/python:3.0.6-3.14-bookworm
+```
+
+<Note>
+  Security patches are applied only to the latest in-support versions. If you pin to a specific patch version, add `RUN apt-get update && apt-get upgrade` to your Dockerfile to pick up OS-level security fixes.
+</Note>
+
+
+# Ruby
+Source: https://www.mintlify.com/devcontainers/images/images/ruby
+
+Pre-built dev container image for Ruby development, with rvm, rbenv, ruby-build, bundler, and debugging tools included.
+
+Use this image to develop Ruby applications in a fully configured container. It builds on the official Ruby image and adds `rvm` and `rbenv` for version management, `ruby-build` for compiling Ruby versions, debugging gems (`ruby-debug-ide`, `debase`), `nvm` for optional Node.js, and a non-root `vscode` user with `sudo` access.
+
+## Image metadata
+
+| Property           | Value                                                             |
+| ------------------ | ----------------------------------------------------------------- |
+| Published image    | `mcr.microsoft.com/devcontainers/ruby`                            |
+| Available variants | `4`, `3.4`, `3.3`, `3.2` (trixie, bookworm, bullseye OS variants) |
+| Architectures      | x86-64, arm64/aarch64                                             |
+| Container OS       | Debian (trixie, bookworm, bullseye)                               |
+| Container host OS  | Linux, macOS, Windows                                             |
+
+## Using this image
+
+Reference the image directly in your `.devcontainer/devcontainer.json` using the `image` property.
+
+<Tabs>
+  <Tab title="Latest">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "Ruby",
+      "image": "mcr.microsoft.com/devcontainers/ruby"
+    }
+    ```
+  </Tab>
+
+  <Tab title="Ruby 4">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "Ruby 4",
+      "image": "mcr.microsoft.com/devcontainers/ruby:4"
+    }
+    ```
+  </Tab>
+
+  <Tab title="Ruby 3.4">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "Ruby 3.4",
+      "image": "mcr.microsoft.com/devcontainers/ruby:3.4"
+    }
+    ```
+  </Tab>
+
+  <Tab title="Ruby 3.3">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "Ruby 3.3",
+      "image": "mcr.microsoft.com/devcontainers/ruby:3.3"
+    }
+    ```
+  </Tab>
+</Tabs>
+
+### Available tags
+
+* `mcr.microsoft.com/devcontainers/ruby` — latest (Ruby 4, Debian trixie)
+* `mcr.microsoft.com/devcontainers/ruby:4` (or `4-trixie`, `4-bookworm`)
+* `mcr.microsoft.com/devcontainers/ruby:3.4` (or `3.4-trixie`, `3.4-bookworm`, `3.4-bullseye`)
+* `mcr.microsoft.com/devcontainers/ruby:3.3` (or `3.3-trixie`, `3.3-bookworm`, `3.3-bullseye`)
+* `mcr.microsoft.com/devcontainers/ruby:3.2` (or `3.2-trixie`, `3.2-bookworm`, `3.2-bullseye`)
+
+## Included tools
+
+<CardGroup>
+  <Card title="Ruby" icon="gem">
+    The Ruby interpreter, installed at `/usr/local`, matching the variant version.
+  </Card>
+
+  <Card title="rvm" icon="layer-group">
+    Ruby Version Manager for switching between Ruby versions within the container.
+  </Card>
+
+  <Card title="rbenv + ruby-build" icon="layer-group">
+    Alternative Ruby version management toolchain, installed at `/usr/local/share/rbenv` and `/usr/local/share/ruby-build`.
+  </Card>
+
+  <Card title="rake" icon="hammer">
+    Ruby build tool and task runner, pre-installed as a gem.
+  </Card>
+
+  <Card title="ruby-debug-ide + debase" icon="bug">
+    Debugging gems for integration with IDE debuggers.
+  </Card>
+
+  <Card title="nvm" icon="node-js">
+    Node Version Manager, pre-installed for front-end tooling in Rails or full-stack Ruby projects.
+  </Card>
+
+  <Card title="yarn + build-essential" icon="box">
+    JavaScript package manager and C build tools for compiling native Ruby gems.
+  </Card>
+
+  <Card title="Oh My Zsh!" icon="terminal">
+    Zsh shell with Oh My Zsh! for a productive terminal experience.
+  </Card>
+</CardGroup>
+
+## Common tasks
+
+### Check the Ruby version
+
+```bash theme={null}
+ruby --version
+gem --version
+```
+
+### Install gems with Bundler
+
+```bash theme={null}
+bundle install
+bundle exec rake
+```
+
+### Create a new Rails app
+
+```bash theme={null}
+gem install rails
+rails new my_app
+cd my_app
+bin/rails server
+```
+
+### Run tests with RSpec
+
+```bash theme={null}
+bundle exec rspec
+bundle exec rspec spec/models/
+```
+
+### Manage Ruby versions with rbenv
+
+```bash theme={null}
+rbenv install 3.4.0
+rbenv local 3.4.0
+ruby --version
+```
+
+### Install Node.js with nvm
+
+```bash theme={null}
+nvm install --lts
+nvm use --lts
+```
+
+## Extending with features
+
+Use [Dev Container Features](https://containers.dev/features) to add Node.js, databases, or other tools without modifying the base image.
+
+### Add Node.js
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Ruby",
+  "image": "mcr.microsoft.com/devcontainers/ruby:3.4",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    }
+  }
+}
+```
+
+### Add PostgreSQL client
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Ruby on Rails",
+  "image": "mcr.microsoft.com/devcontainers/ruby:3.4",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    },
+    "ghcr.io/devcontainers/features/postgres:1": {}
+  }
+}
+```
+
+## Versioning
+
+The image uses [semantic versioning](https://semver.org/). Pin to a major or minor version to control how frequently you receive updates.
+
+| Tag format         | Example        | Update behavior                   |
+| ------------------ | -------------- | --------------------------------- |
+| Ruby version only  | `ruby:3.4`     | Receives all non-breaking updates |
+| Major + Ruby       | `ruby:3-4`     | Locked to major version 3         |
+| Major.minor + Ruby | `ruby:3.0-4`   | Locked to minor version 3.0       |
+| Full semver + Ruby | `ruby:3.0.3-4` | Pinned to exact build             |
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/ruby:3-3.4-bookworm"
+}
+```
+
+<Tip>
+  Security patches are only applied to the latest non-breaking version (e.g., `3-4`). If you pin to a full semver like `3.0.3-4`, run `apt-get update && apt-get upgrade` in your Dockerfile to pick up OS-level security fixes.
+</Tip>
+
+
+# Rust
+Source: https://www.mintlify.com/devcontainers/images/images/rust
+
+Pre-built dev container image for Rust development, with cargo, rustfmt, clippy, rust-analyzer support, and lldb for debugging.
+
+Use this image to develop Rust applications in a fully configured container. It builds on the official Rust image and adds `rustfmt`, `clippy`, `rust-src`, `rust-analysis`, `lldb` for debugging, and a non-root `vscode` user with `sudo` access.
+
+## Image metadata
+
+| Property           | Value                                  |
+| ------------------ | -------------------------------------- |
+| Published image    | `mcr.microsoft.com/devcontainers/rust` |
+| Available variants | `trixie`, `bookworm`, `bullseye`       |
+| Architectures      | x86-64, arm64/aarch64                  |
+| Container OS       | Debian (trixie, bookworm, bullseye)    |
+| Container host OS  | Linux, macOS, Windows                  |
+
+## Using this image
+
+Reference the image directly in your `.devcontainer/devcontainer.json` using the `image` property.
+
+<Tabs>
+  <Tab title="Latest">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "Rust",
+      "image": "mcr.microsoft.com/devcontainers/rust:latest"
+    }
+    ```
+  </Tab>
+
+  <Tab title="Debian trixie">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "Rust (Debian trixie)",
+      "image": "mcr.microsoft.com/devcontainers/rust:trixie"
+    }
+    ```
+  </Tab>
+
+  <Tab title="Debian bookworm">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "Rust (Debian bookworm)",
+      "image": "mcr.microsoft.com/devcontainers/rust:bookworm"
+    }
+    ```
+  </Tab>
+
+  <Tab title="Debian bullseye">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "Rust (Debian bullseye)",
+      "image": "mcr.microsoft.com/devcontainers/rust:bullseye"
+    }
+    ```
+  </Tab>
+</Tabs>
+
+### Available tags
+
+* `mcr.microsoft.com/devcontainers/rust:latest` (or `trixie`)
+* `mcr.microsoft.com/devcontainers/rust:1` (or `1-trixie`, `1-bookworm`, `1-bullseye`)
+* `mcr.microsoft.com/devcontainers/rust:bookworm`
+* `mcr.microsoft.com/devcontainers/rust:bullseye`
+
+## Included tools
+
+<CardGroup>
+  <Card title="Rust + cargo" icon="rust">
+    The Rust toolchain managed by `rustup`, with `cargo` for building, testing, and managing dependencies.
+  </Card>
+
+  <Card title="rustfmt" icon="align-left">
+    The official Rust code formatter. Run `cargo fmt` to automatically format your code.
+  </Card>
+
+  <Card title="clippy" icon="scissors">
+    The Rust linter. Run `cargo clippy` to catch common mistakes and improve your code.
+  </Card>
+
+  <Card title="rust-src + rust-analysis" icon="magnifying-glass">
+    Rust standard library source code and analysis data, required by `rust-analyzer` for IDE features like go-to-definition.
+  </Card>
+
+  <Card title="lldb" icon="bug">
+    LLVM debugger for stepping through Rust programs with IDE debugger integrations.
+  </Card>
+
+  <Card title="gcc + libc6-dev" icon="c">
+    C linker and system libraries required for compiling Rust crates that link to native code.
+  </Card>
+
+  <Card title="python3-minimal" icon="python">
+    Minimal Python 3 runtime, used by some `lldb` scripts and debugging integrations.
+  </Card>
+
+  <Card title="Oh My Zsh!" icon="terminal">
+    Zsh shell with Oh My Zsh! for a productive terminal experience.
+  </Card>
+</CardGroup>
+
+## Common tasks
+
+### Create a new project
+
+```bash theme={null}
+cargo new my_project
+cargo new --lib my_library
+```
+
+### Build and run
+
+```bash theme={null}
+cargo build
+cargo run
+```
+
+### Build for release
+
+```bash theme={null}
+cargo build --release
+./target/release/my_project
+```
+
+### Run tests
+
+```bash theme={null}
+cargo test
+cargo test -- --nocapture
+```
+
+### Lint with Clippy
+
+```bash theme={null}
+cargo clippy
+cargo clippy -- -D warnings
+```
+
+### Format code with rustfmt
+
+```bash theme={null}
+cargo fmt
+cargo fmt --check
+```
+
+### Check without building
+
+```bash theme={null}
+cargo check
+```
+
+### Add a dependency
+
+```bash theme={null}
+cargo add serde --features derive
+cargo add tokio --features full
+```
+
+### Update dependencies
+
+```bash theme={null}
+cargo update
+```
+
+### Debug with lldb
+
+```bash theme={null}
+cargo build
+lldb ./target/debug/my_project
+(lldb) run
+(lldb) bt
+```
+
+## Extending with features
+
+Use [Dev Container Features](https://containers.dev/features) to add tools alongside Rust.
+
+### Add a Rust cross-compilation target
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Rust",
+  "image": "mcr.microsoft.com/devcontainers/rust:bookworm",
+  "postCreateCommand": "rustup target add aarch64-unknown-linux-gnu"
+}
+```
+
+### Add Node.js (for WASM tooling)
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Rust + WASM",
+  "image": "mcr.microsoft.com/devcontainers/rust:bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    }
+  },
+  "postCreateCommand": "cargo install wasm-pack"
+}
+```
+
+### Add Docker-in-Docker
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Rust",
+  "image": "mcr.microsoft.com/devcontainers/rust:bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  }
+}
+```
+
+## Versioning
+
+The image uses [semantic versioning](https://semver.org/). Pin to a major or minor version to control how frequently you receive updates.
+
+| Tag format            | Example        | Update behavior                   |
+| --------------------- | -------------- | --------------------------------- |
+| Rust channel + OS     | `rust:1`       | Receives all non-breaking updates |
+| Major + channel + OS  | `rust:2-1`     | Locked to major version 2         |
+| Major.minor + channel | `rust:2.0-1`   | Locked to minor version 2.0       |
+| Full semver + channel | `rust:2.0.9-1` | Pinned to exact build             |
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/rust:2-1-bookworm"
+}
+```
+
+<Tip>
+  Security patches are only applied to the latest non-breaking version (e.g., `2-1`). If you pin to a full semver like `2.0.9-1`, run `apt-get update && apt-get upgrade` in your Dockerfile to pick up OS-level security fixes.
+</Tip>
+
+
+# Node.js & TypeScript
+Source: https://www.mintlify.com/devcontainers/images/images/typescript-node
+
+A dev container image for TypeScript development on Node.js, with the TypeScript compiler, ESLint, nvm, and yarn pre-installed.
+
+The TypeScript image extends the Node.js & JavaScript image with the TypeScript compiler (`tsc`) and `tslint-to-eslint-config` installed globally. It gives you a Debian-based environment ready for typed Node.js development out of the box.
+
+## Metadata
+
+| Property                | Value                                                                                                                                                |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Published image         | `mcr.microsoft.com/devcontainers/typescript-node`                                                                                                    |
+| Available variants      | `24` / `24-trixie`, `22` / `22-trixie`, `20` / `20-trixie`, `24-bookworm`, `22-bookworm`, `20-bookworm`, `24-bullseye`, `22-bullseye`, `20-bullseye` |
+| Architectures           | x86-64, arm64/aarch64 (bookworm and bullseye variants)                                                                                               |
+| Container OS            | Debian                                                                                                                                               |
+| Languages and platforms | Node.js, TypeScript                                                                                                                                  |
+
+## Using this image
+
+Reference the published image in your `.devcontainer/devcontainer.json`:
+
+```json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:22"
+}
+```
+
+### Available image tags
+
+Choose a Node.js version and optionally pin the Debian OS:
+
+* `mcr.microsoft.com/devcontainers/typescript-node` — latest
+* `mcr.microsoft.com/devcontainers/typescript-node:24` (or `24-trixie`, `24-bookworm`, `24-bullseye`)
+* `mcr.microsoft.com/devcontainers/typescript-node:22` (or `22-trixie`, `22-bookworm`, `22-bullseye`)
+* `mcr.microsoft.com/devcontainers/typescript-node:20` (or `20-trixie`, `20-bookworm`, `20-bullseye`)
+
+See the [full list of available tags](https://mcr.microsoft.com/v2/devcontainers/typescript-node/tags/list).
+
+## Key included tools
+
+<AccordionGroup>
+  <Accordion title="TypeScript and Node.js tooling">
+    All npm packages listed below are installed globally:
+
+    * **TypeScript** (`typescript`) — the TypeScript compiler (`tsc`)
+    * **eslint** — JavaScript and TypeScript linter
+    * **tslint-to-eslint-config** — migration tool from the deprecated `tslint` to `eslint`
+    * **Node.js** — JavaScript runtime (version selected by image tag)
+    * **npm** — Node.js package manager (bundled with Node.js)
+    * **yarn** — alternative package manager
+    * **nvm** — Node Version Manager
+  </Accordion>
+
+  <Accordion title="Other tools">
+    * `git` — version control
+    * `zsh` + Oh My Zsh! — enhanced shell
+    * Non-root `node` user with `sudo` access
+  </Accordion>
+</AccordionGroup>
+
+## Common tasks
+
+### Compiling TypeScript
+
+Run the TypeScript compiler directly:
+
+```bash theme={null}
+tsc --init          # generate a tsconfig.json
+tsc                 # compile using tsconfig.json
+tsc --watch         # watch mode
+```
+
+### Linting TypeScript with ESLint
+
+`eslint` is installed globally, but you need to install TypeScript-specific ESLint plugins locally in your project to lint `.ts` files. As of ESLint 6, plugins must be local:
+
+```bash theme={null}
+npm install --save-dev \
+  @typescript-eslint/eslint-plugin \
+  @typescript-eslint/parser \
+  eslint \
+  typescript
+```
+
+Then configure `.eslintrc.json`:
+
+```json theme={null}
+{
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ]
+}
+```
+
+### Migrating from tslint to ESLint
+
+`tslint` is fully deprecated. The image includes `tslint-to-eslint-config` to help you migrate existing projects:
+
+```bash theme={null}
+npx tslint-to-eslint-config
+```
+
+This generates an `.eslintrc.js` based on your existing `tslint.json`.
+
+### Switching Node.js versions with nvm
+
+Use `nvm` to install and switch between Node.js versions without rebuilding the container:
+
+```bash theme={null}
+# Install a specific version
+nvm install 20
+
+# Switch to it
+nvm use 20
+
+# Set as default for new shells
+nvm alias default 20
+```
+
+### Running a TypeScript project in development
+
+Use `ts-node` for running TypeScript files directly, or `nodemon` + `ts-node` for watch mode:
+
+```bash theme={null}
+# Install ts-node locally
+npm install --save-dev ts-node nodemon
+
+# Run a file directly
+npx ts-node src/index.ts
+
+# Watch mode
+npx nodemon --exec ts-node src/index.ts
+```
+
+## Extending with features
+
+Use [Dev Container Features](https://containers.dev/features) to add tools on top of this image:
+
+```json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:22",
+  "features": {
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.13"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  }
+}
+```
+
+## Versioning
+
+Pin to a semantic version to control the update cadence:
+
+<CodeGroup>
+  ```text Major version (receives all non-breaking updates) theme={null}
+  mcr.microsoft.com/devcontainers/typescript-node:4-24
+  ```
+
+  ```text Minor version (receives patch updates only) theme={null}
+  mcr.microsoft.com/devcontainers/typescript-node:4.0-24
+  ```
+
+  ```text Patch version (fully pinned) theme={null}
+  mcr.microsoft.com/devcontainers/typescript-node:4.0.7-24
+  ```
+</CodeGroup>
+
+You can also combine with an OS pin:
+
+```text theme={null}
+mcr.microsoft.com/devcontainers/typescript-node:4.0.7-24-trixie
+mcr.microsoft.com/devcontainers/typescript-node:4.0.7-24-bookworm
+mcr.microsoft.com/devcontainers/typescript-node:4.0.7-24-bullseye
+```
+
+<Note>
+  Security patches are applied only to the latest in-support versions (e.g., `3-24`). If you pin to a specific patch version, add `RUN apt-get update && apt-get upgrade` to your Dockerfile to pick up OS-level security fixes.
+</Note>
+
+
+# Universal
+Source: https://www.mintlify.com/devcontainers/images/images/universal
+
+A large, multi-language image with popular runtimes pre-installed — the default image used by GitHub Codespaces.
+
+The Universal image is a large, Ubuntu-based dev container image that bundles many popular language runtimes, SDKs, and tools into one container. It is the image GitHub Codespaces uses by default when no custom image or Dockerfile is specified.
+
+## Metadata
+
+| Property                | Value                                                                                                 |
+| ----------------------- | ----------------------------------------------------------------------------------------------------- |
+| Published image         | `mcr.microsoft.com/devcontainers/universal:linux` / `mcr.microsoft.com/devcontainers/universal:noble` |
+| Available variants      | `noble`, `linux`                                                                                      |
+| Architectures           | x86-64                                                                                                |
+| Container OS            | Ubuntu (Noble)                                                                                        |
+| Languages and platforms | Python, Node.js, JavaScript, TypeScript, C++, Java, C#, F#, .NET Core, PHP, Go, Ruby, Conda           |
+
+## Using this image
+
+Reference the published image in your `.devcontainer/devcontainer.json`:
+
+```json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:linux"
+}
+```
+
+### Available image tags
+
+Pin to a specific OS variant:
+
+* `mcr.microsoft.com/devcontainers/universal:linux`
+* `mcr.microsoft.com/devcontainers/universal:noble`
+
+## Key included tools
+
+The Universal image includes runtimes and tooling for multiple languages in a single container.
+
+<AccordionGroup>
+  <Accordion title="Language runtimes">
+    Multiple versions of these runtimes are installed and managed by their respective version managers:
+
+    * **Python** — managed under `/usr/local/python`
+    * **Node.js** — managed by `nvm` at `/usr/local/share/nvm/versions/node`
+    * **Java** — managed by SDKMAN! at `/usr/local/sdkman/candidates/java`
+    * **.NET** — available via `dotnet`
+    * **Ruby** — managed by `rvm` at `/usr/local/rvm/rubies`
+    * **PHP** — available at `/usr/local/php`
+    * **Go** — available system-wide
+    * **GCC / Clang** — C and C++ compilers
+  </Accordion>
+
+  <Accordion title="Python tools (via pipx)">
+    `pylint`, `flake8`, `autopep8`, `black`, `yapf`, `mypy`, `pydocstyle`, `pycodestyle`, `bandit`, `virtualenv`, `pipx`
+  </Accordion>
+
+  <Accordion title="Python data science packages (via pip)">
+    `numpy`, `pandas`, `scipy`, `matplotlib`, `seaborn`, `scikit-learn`, `torch`, `requests`, `plotly`, `jupyterlab_git`, `certifi`, `setuptools`, `wheel`
+  </Accordion>
+
+  <Accordion title="Go tools">
+    `gopls`, `staticcheck` (honnef.co/go/tools), `golint`, `revive`, `gopkgs`, `go-outline`, `delve`, `golangci-lint`
+  </Accordion>
+
+  <Accordion title="Ruby gems">
+    `rake`, `ruby-debug-ide`, `debase`, `jekyll`
+  </Accordion>
+
+  <Accordion title="Other tools">
+    `git`, `git-lfs`, `Docker CLI`, `Docker Engine`, `Docker Compose`, `kubectl`, `Helm`, `GitHub CLI`, `yarn`, `Maven`, `Gradle`, `conda`, `SDKMAN!`, `rvm`, `nvm`, `nvs`, `rbenv`, `Oh My Zsh!`, `zsh`, `fish`, `cmake`, `build-essential`, `valgrind`, `lldb`, `llvm`, `gdb`, `clang`, `openssh-server`, `JupyterLab`
+  </Accordion>
+</AccordionGroup>
+
+## Common tasks
+
+### Disabling automatic Codespaces setup
+
+When you use the Universal image in GitHub Codespaces without a `postCreateCommand`, Codespaces runs automatic setup steps. You can disable this behavior:
+
+```json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:linux",
+  "customizations": {
+    "codespaces": {
+      "disableAutomaticConfiguration": true
+    }
+  }
+}
+```
+
+### Using Conda
+
+The image includes the `conda` package manager. You can install packages directly:
+
+```bash theme={null}
+conda install numpy scipy
+```
+
+<Note>
+  Access to the Anaconda repository is covered by the [Anaconda Terms of Service](https://aka.ms/vscode-remote/conda/terms). When used with GitHub Codespaces or GitHub Actions, all users — including those in organizations that normally require a commercial license — are permitted to use the Anaconda repository through the service.
+</Note>
+
+To use an alternative Conda channel, see [configuring Conda channels](https://aka.ms/vscode-remote/conda/channel-setup).
+
+### Switching Node.js versions with nvm
+
+`nvm` is pre-installed. Use it to install and switch between Node.js versions:
+
+```bash theme={null}
+# Install a specific version
+nvm install 20
+
+# Switch to an installed version
+nvm use 20
+
+# Set a default version
+nvm alias default 20
+```
+
+### Switching Ruby versions with rvm
+
+```bash theme={null}
+# Install a specific Ruby version
+rvm install 3.2
+
+# Use it in the current shell
+rvm use 3.2
+```
+
+### Accessing the container via SSH
+
+The Universal image runs an SSH server. To enable SSH access, use the [SSHD Feature](https://github.com/devcontainers/features/tree/main/src/sshd):
+
+```json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:linux",
+  "features": {
+    "ghcr.io/devcontainers/features/sshd:1": {}
+  }
+}
+```
+
+## Extending with features
+
+Use [Dev Container Features](https://containers.dev/features) to add tools without modifying the image:
+
+```json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:linux",
+  "features": {
+    "ghcr.io/devcontainers/features/aws-cli:1": {},
+    "ghcr.io/devcontainers/features/terraform:1": {}
+  }
+}
+```
+
+## Versioning
+
+Pin to a semantic version to control how often you receive updates:
+
+<CodeGroup>
+  ```text Major version (receives all non-breaking updates) theme={null}
+  mcr.microsoft.com/devcontainers/universal:6-noble
+  ```
+
+  ```text Minor version (receives patch updates only) theme={null}
+  mcr.microsoft.com/devcontainers/universal:6.0-noble
+  ```
+
+  ```text Patch version (fully pinned) theme={null}
+  mcr.microsoft.com/devcontainers/universal:6.0.0-noble
+  ```
+</CodeGroup>
+
+<Note>
+  Security patches are applied only to the latest in-support versions. If you pin to a specific patch version, run `apt-get update && apt-get upgrade` in your Dockerfile to pick up OS-level security fixes.
+</Note>
+
+See the [full list of available tags](https://mcr.microsoft.com/v2/devcontainers/universal/tags/list).
+
+
+# Introduction
+Source: https://www.mintlify.com/devcontainers/images/introduction
+
+Learn what dev container images are, how they relate to the Dev Containers spec, and how versioning works.
+
+Dev container images are pre-built Docker images that give you a fully configured development environment the moment you open a project. Instead of installing runtimes, language toolchains, and development tools manually on each machine, you reference an image in a `devcontainer.json` file and your editor or CI system handles the rest.
+
+This repository publishes images to the Microsoft Container Registry (MCR) under `mcr.microsoft.com/devcontainers/`. Every image includes the target language runtime, common development tools, `zsh` with Oh My Zsh!, a non-root `vscode` user with `sudo` access, and `git`.
+
+## The problem they solve
+
+Setting up a development environment is repetitive and error-prone. Differences in OS versions, installed packages, and environment variables cause "works on my machine" problems that slow teams down. Dev container images solve this by codifying the environment as a versioned, reproducible artifact that everyone on a team shares.
+
+<CardGroup>
+  <Card title="Quickstart" icon="rocket" href="/quickstart">
+    Get a dev container running in minutes using the Python image as an example.
+  </Card>
+
+  <Card title="Choosing an image" icon="images" href="/choosing-an-image">
+    Compare base, language, and universal images to find the right fit for your project.
+  </Card>
+
+  <Card title="Base images" icon="box" href="/images/base-ubuntu">
+    Minimal Ubuntu, Debian, and Alpine images as a foundation for custom containers.
+  </Card>
+
+  <Card title="Language images" icon="code" href="/images/universal">
+    Purpose-built images for Python, Node.js, Go, Java, .NET, Rust, and more.
+  </Card>
+</CardGroup>
+
+## How devcontainer.json works
+
+A `devcontainer.json` file tells your editor how to build or pull a container and how to configure it for development. It plays a similar role to `launch.json` for debugging — it defines the environment, not the code.
+
+At its simplest, a `devcontainer.json` references an image:
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Python 3",
+  "image": "mcr.microsoft.com/devcontainers/python:3"
+}
+```
+
+You can extend this with [Dev Container Features](https://containers.dev/features), port forwarding, lifecycle scripts, and editor-specific settings. The full configuration reference is defined by the [Dev Containers specification](https://containers.dev/).
+
+## Relationship to the Dev Containers spec
+
+The [Dev Containers specification](https://github.com/devcontainers/spec) defines the format for `devcontainer.json` and the contract that tools (VS Code, GitHub Codespaces, DevPod, and others) must follow to implement dev containers. This image repository is separate from the spec — it provides ready-made images that conform to the spec's expectations, such as the non-root user convention and the expected shell environment.
+
+<Note>
+  You can use any Docker image with a `devcontainer.json` file. The images in this repository are pre-configured to work well out of the box with dev container tooling, but they are not required by the spec.
+</Note>
+
+## VS Code Dev Containers and GitHub Codespaces
+
+**VS Code Dev Containers** uses the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) to pull the image, start the container, and attach VS Code directly to it. Your editor runs locally but all files, terminals, and language servers run inside the container.
+
+**GitHub Codespaces** runs the entire development environment in the cloud. When you open a repository in Codespaces without a `devcontainer.json`, GitHub uses `mcr.microsoft.com/devcontainers/universal:linux` by default — the same universal image published here. If your repository includes a `devcontainer.json`, Codespaces builds or pulls the image you specify.
+
+<Tip>
+  Because both tools follow the same spec, a `devcontainer.json` that works in VS Code will also work in GitHub Codespaces without modification.
+</Tip>
+
+## Image versioning
+
+Each image uses a two-part version tag combining the image's own [semantic version](https://semver.org/) with the language runtime version. For example, the Python image tags look like this:
+
+| Tag                                                 | Meaning                                       |
+| --------------------------------------------------- | --------------------------------------------- |
+| `mcr.microsoft.com/devcontainers/python:3`          | Latest Python 3.x image, latest image version |
+| `mcr.microsoft.com/devcontainers/python:3.13`       | Python 3.13, latest image version             |
+| `mcr.microsoft.com/devcontainers/python:3-3.13`     | Python 3.13, latest major image version       |
+| `mcr.microsoft.com/devcontainers/python:3.0-3.13`   | Python 3.13, latest minor image version       |
+| `mcr.microsoft.com/devcontainers/python:3.0.6-3.13` | Python 3.13, exact image version              |
+
+Using a less specific tag (like `:3`) means you receive non-breaking updates automatically. Using a fully pinned tag (like `:3.0.6-3.13`) locks the image completely.
+
+<Warning>
+  Security patches are applied only to the latest in-support image version (for example, `3-3.13`). If you pin to a specific patch version, run `apt-get update && apt-get upgrade` in your Dockerfile to pick up OS-level security updates.
+</Warning>
+
+### OS variant tags
+
+Many images also support pinning to a specific OS release using a suffix. For example:
+
+* `mcr.microsoft.com/devcontainers/python:3.13` — defaults to the current OS
+* `mcr.microsoft.com/devcontainers/python:3.13-bookworm` — Debian 12 (Bookworm)
+* `mcr.microsoft.com/devcontainers/python:3.13-trixie` — Debian 13 (Trixie)
+
+OS variant suffixes include `bookworm`, `trixie`, `bullseye` (Debian versions), and `noble`, `jammy` (Ubuntu versions). See [Choosing an image](/choosing-an-image) for a full breakdown.
+
+
+# Quickstart
+Source: https://www.mintlify.com/devcontainers/images/quickstart
+
+Go from zero to a running dev container in minutes using the Python image.
+
+This guide walks you through creating a `devcontainer.json` file, opening it in VS Code or GitHub Codespaces, extending the environment with a Dev Container Feature, and forwarding a port for a local web server.
+
+<Info>
+  **Prerequisites**: Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) and the [VS Code Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) if you plan to use VS Code. For GitHub Codespaces, no local tools are required.
+</Info>
+
+## Create a devcontainer.json
+
+<Steps>
+  <Step title="Create the configuration directory">
+    In the root of your project, create a `.devcontainer` directory with a `devcontainer.json` file inside it.
+
+    ```
+    your-project/
+    └── .devcontainer/
+        └── devcontainer.json
+    ```
+  </Step>
+
+  <Step title="Reference the Python image">
+    Add the following to `.devcontainer/devcontainer.json`:
+
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "Python 3",
+      "image": "mcr.microsoft.com/devcontainers/python:3"
+    }
+    ```
+
+    This pulls the latest Python 3 image from MCR. The image includes Python 3, `pip`, `pipx`, `git`, `zsh` with Oh My Zsh!, and a non-root `vscode` user with `sudo` access.
+  </Step>
+
+  <Step title="Open in a dev container">
+    <Tabs>
+      <Tab title="VS Code">
+        1. Open your project folder in VS Code.
+        2. When prompted, click **Reopen in Container** — or open the Command Palette (`F1`) and run **Dev Containers: Reopen in Container**.
+        3. VS Code pulls the image, starts the container, and attaches your editor to it. This takes a minute or two on the first run while Docker downloads the image.
+
+        <Tip>
+          After the first pull, subsequent opens are fast because Docker caches the image locally.
+        </Tip>
+      </Tab>
+
+      <Tab title="GitHub Codespaces">
+        1. Push your project (including the `.devcontainer` directory) to a GitHub repository.
+        2. On the repository page, click **Code** → **Codespaces** → **Create codespace on main**.
+        3. GitHub builds the container using your `devcontainer.json` and opens a browser-based VS Code connected to it.
+      </Tab>
+    </Tabs>
+  </Step>
+</Steps>
+
+## Add a Dev Container Feature
+
+[Dev Container Features](https://containers.dev/features) let you install additional tools without modifying the base image. To add Node.js to your Python container, update your `devcontainer.json`:
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Python 3",
+  "image": "mcr.microsoft.com/devcontainers/python:3",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "latest"
+    }
+  }
+}
+```
+
+After saving this file, rebuild the container:
+
+* **VS Code**: Run **Dev Containers: Rebuild Container** from the Command Palette (`F1`).
+* **Codespaces**: Click the Codespaces icon in the status bar and select **Full Rebuild Container**.
+
+Node.js will be installed alongside the Python toolchain when the container starts.
+
+## Forward a port
+
+Frameworks like Flask listen only on `localhost` inside the container. Use `forwardPorts` to make the port accessible from your host machine.
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Python 3",
+  "image": "mcr.microsoft.com/devcontainers/python:3",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "latest"
+    }
+  },
+  "forwardPorts": [5000]
+}
+```
+
+With this in place, a Flask app running inside the container on port `5000` is accessible at `http://localhost:5000` on your host.
+
+<Note>
+  Use `forwardPorts` rather than `appPort`. The `appPort` property *publishes* the port, which requires the application to listen on `0.0.0.0` — conflicting with Flask's default of `127.0.0.1`. `forwardPorts` tunnels the port through the dev container connection and does not have this limitation.
+</Note>
+
+Start a Flask app inside the container:
+
+```bash theme={null}
+pip install flask
+flask --app app.py run
+```
+
+Then open `http://localhost:5000` in your browser on the host.
+
+## Next steps
+
+<CardGroup>
+  <Card title="Choosing an image" icon="images" href="/choosing-an-image">
+    Browse all available images and find the right one for your language or framework.
+  </Card>
+
+  <Card title="Python image reference" icon="python" href="/images/python">
+    Full reference for the Python image, including available tags and configuration options.
+  </Card>
+
+  <Card title="Universal image" icon="globe" href="/images/universal">
+    A single multi-language image with Python, Node, Go, Java, .NET, PHP, Ruby, and C++.
+  </Card>
+
+  <Card title="Dev Container Features" icon="puzzle" href="https://containers.dev/features">
+    Browse hundreds of community-published features to extend any image.
+  </Card>
+</CardGroup>
+
+
+# Dockerfile tips
+Source: https://www.mintlify.com/devcontainers/images/tips
+
+Best practices for writing efficient Dockerfiles, including layer caching, cleanup, and package installation flags.
+
+## Why RUN statements use `&&` chaining
+
+Each `RUN` statement creates a Docker image layer. If one `RUN` statement adds temporary files, those files remain in that layer even if a later `RUN` statement deletes them. The image ends up larger than necessary, and pulling it from a registry takes longer.
+
+The solution is to clean up in the **same** `RUN` statement that installs or configures something. You have two options:
+
+<Tabs>
+  <Tab title="Inline cleanup with &&">
+    Chain commands with `&&` so cleanup happens in the same layer:
+
+    ```dockerfile theme={null}
+    RUN apt-get update \
+        && apt-get -y install --no-install-recommends git \
+        && apt-get autoremove -y \
+        && apt-get clean -y \
+        && rm -rf /var/lib/apt/lists/*
+    ```
+  </Tab>
+
+  <Tab title="Script with cleanup">
+    Copy a script into the container temporarily, run it, then delete it in the same `RUN`:
+
+    ```dockerfile theme={null}
+    COPY ./my-script.sh /tmp/my-script.sh
+    RUN bash /tmp/my-script.sh \
+        && rm -f /tmp/my-script.sh
+    ```
+  </Tab>
+</Tabs>
+
+## Clean up package lists
+
+Package lists downloaded by `apt-get update` [can be surprisingly large](https://askubuntu.com/questions/179955/var-lib-apt-lists-is-huge). Remove them after installation to keep image size down:
+
+```dockerfile theme={null}
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+The only downside is that you must run `apt-get update` before installing any package. In practice, adding packages to a `Dockerfile` is almost always the right approach anyway — it survives image rebuilds and keeps your environment reproducible.
+
+## Avoid installing recommended packages
+
+By default, `apt-get install` pulls in packages that are commonly used alongside the one you specified. In most cases these extra packages are unnecessary. Use `--no-install-recommends` to skip them:
+
+```dockerfile theme={null}
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends <your-package-list> \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+## Use `--no-cache` on Alpine
+
+On Alpine Linux, use `apk --no-cache` instead of the separate update-and-clean pattern. The `--no-cache` flag skips writing the package index to disk entirely:
+
+```dockerfile theme={null}
+RUN apk --no-cache add git curl bash
+```
+
+This is simpler and produces smaller layers than running `apk update` and then `apk cache clean` separately.
+
+## Summary
+
+| Practice                        | Why it matters                                           |
+| ------------------------------- | -------------------------------------------------------- |
+| Chain cleanup in the same `RUN` | Prevents temporary files from inflating layer size       |
+| `rm -rf /var/lib/apt/lists/*`   | Removes downloaded package index files                   |
+| `--no-install-recommends`       | Skips unnecessary packages pulled in by default          |
+| `apk --no-cache`                | Prevents Alpine package index from being written to disk |
+
+

--- a/docs/research/mintlify-cache/devcontainers/images/llms.txt
+++ b/docs/research/mintlify-cache/devcontainers/images/llms.txt
@@ -1,0 +1,36 @@
+# Dev Container Images
+
+## Docs
+
+- [Adding an image](https://www.mintlify.com/devcontainers/images/build/adding-an-image.md): Step-by-step guide to contributing a new devcontainer image, from creating the Dockerfile to configuring manifest.json and setting up tests.
+- [manifest.json reference](https://www.mintlify.com/devcontainers/images/build/manifest.md): Complete reference for every field in the manifest.json file that controls how devcontainer images are built, tagged, and tracked.
+- [Build system overview](https://www.mintlify.com/devcontainers/images/build/overview.md): An overview of the build CLI, GitHub Actions workflows, and dev-tagged images used to build and publish devcontainer images to MCR.
+- [Testing](https://www.mintlify.com/devcontainers/images/build/testing.md): How to build and test devcontainer images locally using the vscdc CLI, Docker, and ARM64-specific build instructions.
+- [Versioning](https://www.mintlify.com/devcontainers/images/build/versioning.md): How devcontainer images are versioned, how repository versions map to image tags, and the difference between dev and release tags.
+- [Choosing an image](https://www.mintlify.com/devcontainers/images/choosing-an-image.md): Compare base, language, and universal images to find the right one for your project.
+- [Anaconda (Python 3)](https://www.mintlify.com/devcontainers/images/images/anaconda.md): A dev container image for developing Anaconda and Python 3 applications, with conda package management and Jupyter support.
+- [Alpine](https://www.mintlify.com/devcontainers/images/images/base-alpine.md): A minimal Alpine Linux container with Git and other common utilities installed, optimized for small image sizes.
+- [Debian](https://www.mintlify.com/devcontainers/images/images/base-debian.md): A simple Debian container with Git and other common utilities installed, suitable for general-purpose development environments.
+- [Ubuntu](https://www.mintlify.com/devcontainers/images/images/base-ubuntu.md): A simple Ubuntu container with Git and other common utilities installed, suitable for general-purpose development environments.
+- [C++](https://www.mintlify.com/devcontainers/images/images/cpp.md): Pre-built dev container image for C++ development on Linux, with GCC, Clang, CMake, cppcheck, valgrind, lldb, and Vcpkg.
+- [.NET](https://www.mintlify.com/devcontainers/images/images/dotnet.md): Pre-built dev container image for C# and .NET development, based on the official .NET SDK with nvm and developer tooling included.
+- [Go](https://www.mintlify.com/devcontainers/images/images/go.md): A dev container image for Go development, with gopls, delve, golangci-lint, and common Go tooling pre-installed.
+- [Java](https://www.mintlify.com/devcontainers/images/images/java.md): Pre-built dev container image for Java development, with SDKMAN!, nvm, and support for JDK 11 through 25 on Debian.
+- [Node.js & JavaScript](https://www.mintlify.com/devcontainers/images/images/javascript-node.md): A dev container image for Node.js and JavaScript development, with ESLint, nvm, and yarn pre-installed.
+- [Jekyll](https://www.mintlify.com/devcontainers/images/images/jekyll.md): A dev container image for developing static sites with Jekyll, including Ruby, Bundler, and GitHub Pages support.
+- [PHP](https://www.mintlify.com/devcontainers/images/images/php.md): Pre-built dev container image for PHP development, with Apache, Xdebug, Composer, and nvm included.
+- [Python 3](https://www.mintlify.com/devcontainers/images/images/python.md): A dev container image for Python 3 development, with linting tools, formatters, and type checkers pre-installed.
+- [Ruby](https://www.mintlify.com/devcontainers/images/images/ruby.md): Pre-built dev container image for Ruby development, with rvm, rbenv, ruby-build, bundler, and debugging tools included.
+- [Rust](https://www.mintlify.com/devcontainers/images/images/rust.md): Pre-built dev container image for Rust development, with cargo, rustfmt, clippy, rust-analyzer support, and lldb for debugging.
+- [Node.js & TypeScript](https://www.mintlify.com/devcontainers/images/images/typescript-node.md): A dev container image for TypeScript development on Node.js, with the TypeScript compiler, ESLint, nvm, and yarn pre-installed.
+- [Universal](https://www.mintlify.com/devcontainers/images/images/universal.md): A large, multi-language image with popular runtimes pre-installed — the default image used by GitHub Codespaces.
+- [Introduction](https://www.mintlify.com/devcontainers/images/introduction.md): Learn what dev container images are, how they relate to the Dev Containers spec, and how versioning works.
+- [Quickstart](https://www.mintlify.com/devcontainers/images/quickstart.md): Go from zero to a running dev container in minutes using the Python image.
+- [Dockerfile tips](https://www.mintlify.com/devcontainers/images/tips.md): Best practices for writing efficient Dockerfiles, including layer caching, cleanup, and package installation flags.
+
+## OpenAPI Specs
+
+- [openapi](https://www.mintlify.com/devcontainers/images/api-reference/openapi.json)
+
+
+Built with [Mintlify](https://mintlify.com).

--- a/docs/research/mintlify-cache/devcontainers/spec/llms-full.txt
+++ b/docs/research/mintlify-cache/devcontainers/spec/llms-full.txt
@@ -1,0 +1,4991 @@
+# Authoring Features
+Source: https://www.mintlify.com/devcontainers/spec/ecosystem/authoring-features
+
+A practical guide to creating and publishing Dev Container Features, from folder structure to OCI registry distribution.
+
+Dev Container Features are self-contained, shareable units of installation code and configuration. Each Feature adds tooling, runtimes, or libraries to a development container.
+
+## Folder structure
+
+A Feature lives in its own folder and requires at minimum two files:
+
+```
+feature/
+├── devcontainer-feature.json
+├── install.sh
+└── (other files)
+```
+
+The folder name must match the `id` field in `devcontainer-feature.json`. All files in the folder are packaged and distributed together.
+
+When hosting multiple Features in a single repository, use a `src/` directory:
+
+```
+src/
+├── go/
+│   ├── devcontainer-feature.json
+│   └── install.sh
+├── python/
+│   ├── devcontainer-feature.json
+│   └── install.sh
+test/
+├── go/
+│   └── test.sh
+└── python/
+    └── test.sh
+```
+
+## Authoring workflow
+
+<Steps>
+  <Step title="Create the metadata file">
+    Create `devcontainer-feature.json` in your Feature folder. The `id`, `version`, and `name` fields are required; all other fields are optional.
+
+    ```json theme={null}
+    {
+      "id": "my-tool",
+      "version": "1.0.0",
+      "name": "My Tool",
+      "description": "Installs my-tool and configures the environment.",
+      "documentationURL": "https://github.com/myorg/features/tree/main/src/my-tool",
+      "options": {
+        "version": {
+          "type": "string",
+          "enum": ["latest", "2.0", "1.9"],
+          "default": "latest",
+          "description": "Select a version of my-tool to install."
+        }
+      }
+    }
+    ```
+
+    The `id` must be lowercase and unique within the repository.
+  </Step>
+
+  <Step title="Write the install.sh script">
+    Create `install.sh` as the entrypoint script. It runs as `root` during the container image build.
+
+    ```bash theme={null}
+    #!/usr/bin/env bash
+    set -e
+
+    VERSION=${VERSION:-"latest"}
+
+    echo "Installing my-tool version: $VERSION"
+
+    # Install as root
+    apt-get update && apt-get install -y curl
+
+    # Switch to non-root user for user-scoped operations
+    su ${_REMOTE_USER} -c "echo 'Configuring for user ${_REMOTE_USER}'"
+    ```
+
+    <Note>
+      Set the execute bit and invoke the script directly so the correct shell is used:
+      `chmod +x install.sh && ./install.sh`
+    </Note>
+
+    Use a shell available by default in your target distributions — `bash` for Debian/Ubuntu/Fedora, `sh` for Alpine. If your Feature requires a different shell, use `install.sh` to install it first, then invoke a secondary script.
+  </Step>
+
+  <Step title="Declare options">
+    Options are declared in `devcontainer-feature.json` under the `options` key. Each option ID is converted to an all-caps environment variable available in `install.sh`.
+
+    ```json theme={null}
+    {
+      "options": {
+        "version": {
+          "type": "string",
+          "enum": ["latest", "3.10", "3.9", "3.8", "3.7", "3.6"],
+          "default": "latest",
+          "description": "Select a Python version to install."
+        },
+        "pip": {
+          "type": "boolean",
+          "default": true,
+          "description": "Installs pip"
+        },
+        "optimize": {
+          "type": "boolean",
+          "default": true,
+          "description": "Optimize python installation"
+        }
+      }
+    }
+    ```
+
+    If a user's `devcontainer.json` sets `"version": "3.10"` and `"pip": false`, the following environment variables are passed to `install.sh`:
+
+    ```bash theme={null}
+    VERSION="3.10"
+    PIP="false"
+    OPTIMIZE="true"   # omitted by user, defaults applied
+    ```
+
+    Use `proposals` instead of `enum` when you want to suggest values but still allow free-form input.
+  </Step>
+
+  <Step title="Use user environment variables">
+    Feature scripts run as `root`. Four environment variables are always provided to help configure the environment for the actual container user:
+
+    | Variable               | Description                                                              |
+    | :--------------------- | :----------------------------------------------------------------------- |
+    | `_REMOTE_USER`         | The configured `remoteUser` (falls back to `_CONTAINER_USER` if not set) |
+    | `_CONTAINER_USER`      | The container's user                                                     |
+    | `_REMOTE_USER_HOME`    | Home directory of `_REMOTE_USER`                                         |
+    | `_CONTAINER_USER_HOME` | Home directory of `_CONTAINER_USER`                                      |
+
+    Use `su` to run commands as the non-root user:
+
+    ```bash theme={null}
+    #!/usr/bin/env bash
+    set -e
+
+    # Run as root
+    apt-get update && apt-get install -y some-package
+
+    # Run as the remote user
+    su ${_REMOTE_USER} -c "some-package --setup --user-dir ${_REMOTE_USER_HOME}/.some-package"
+    ```
+
+    <Tip>
+      `su` lets you perform both root and non-root operations even when `sudo` is absent from the base image.
+    </Tip>
+  </Step>
+
+  <Step title="Add lifecycle hooks">
+    Features can contribute lifecycle commands that run after the container is built. These mirror the lifecycle hooks available in `devcontainer.json`.
+
+    ```json theme={null}
+    {
+      "id": "my-tool",
+      "version": "1.0.0",
+      "name": "My Tool",
+      "onCreateCommand": "my-tool init",
+      "postCreateCommand": "/usr/local/share/my-tool/post-create.sh",
+      "postAttachCommand": {
+        "server": "my-tool serve --background",
+        "logger": "my-tool logs --follow"
+      }
+    }
+    ```
+
+    <AccordionGroup>
+      <Accordion title="Available lifecycle hooks">
+        | Hook                   | Description                                     |
+        | :--------------------- | :---------------------------------------------- |
+        | `onCreateCommand`      | Runs once when the container is first created   |
+        | `updateContentCommand` | Runs when the content of the project changes    |
+        | `postCreateCommand`    | Runs after the container is created             |
+        | `postStartCommand`     | Runs each time the container starts             |
+        | `postAttachCommand`    | Runs each time a tool attaches to the container |
+      </Accordion>
+
+      <Accordion title="Execution order">
+        For each lifecycle hook, Feature commands run in Feature installation order and always **before** the user's `devcontainer.json` lifecycle commands.
+
+        If a Feature provides a hook using the object syntax (multiple named commands), those commands run in parallel. Commands from subsequent Features and `devcontainer.json` only start after the parallel group completes.
+      </Accordion>
+    </AccordionGroup>
+
+    <Warning>
+      If you bundle a script with your Feature and reference it in a lifecycle hook, copy the script to a persistent location (outside `/tmp`) during `install.sh`. Supporting tools are not required to keep Feature install scripts around after the build.
+    </Warning>
+
+    ```bash theme={null}
+    # install.sh — copy the bundled script to a persistent path
+    cp ./post-create.sh /usr/local/share/my-tool/post-create.sh
+    chmod +x /usr/local/share/my-tool/post-create.sh
+    ```
+  </Step>
+
+  <Step title="Declare dependencies">
+    Use `dependsOn` for hard dependencies that must be installed before your Feature, and `installsAfter` for soft ordering hints.
+
+    **Hard dependency with `dependsOn`:**
+
+    ```json theme={null}
+    {
+      "id": "my-tool",
+      "version": "1.0.0",
+      "name": "My Tool",
+      "dependsOn": {
+        "ghcr.io/devcontainers/features/node:1": {},
+        "ghcr.io/devcontainers/features/go:1": {
+          "version": "1.21"
+        }
+      }
+    }
+    ```
+
+    All Features in `dependsOn` are automatically added to the installation set and installed before your Feature. Dependencies are evaluated recursively.
+
+    **Soft ordering with `installsAfter`:**
+
+    ```json theme={null}
+    {
+      "id": "my-tool",
+      "version": "1.0.0",
+      "name": "My Tool",
+      "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils",
+        "ghcr.io/devcontainers/features/node"
+      ]
+    }
+    ```
+
+    `installsAfter` only influences ordering for Features that are already queued to be installed — it does not add them to the installation set.
+  </Step>
+
+  <Step title="Publish to an OCI registry">
+    Features are distributed as tarballs pushed to an OCI registry. Use the [Dev Container CLI](https://github.com/devcontainers/cli) or the [Dev Container Publish GitHub Action](https://github.com/devcontainers/action).
+
+    Each Feature is published following the naming convention `<registry>/<namespace>/<id>[:version]`:
+
+    ```bash theme={null}
+    devcontainer features publish \
+      --namespace myorg/my-features \
+      --registry ghcr.io \
+      ./src
+    ```
+
+    The tool publishes major, minor, and patch version tags automatically (e.g. `1`, `1.2`, `1.2.3`, `latest`).
+
+    <Note>
+      The `namespace` is typically `<owner>/<repo>` from your source repository. It must be lowercase.
+    </Note>
+
+    Users then reference your Feature in their `devcontainer.json`:
+
+    ```json theme={null}
+    {
+      "features": {
+        "ghcr.io/myorg/my-features/my-tool:1": {
+          "version": "latest"
+        }
+      }
+    }
+    ```
+  </Step>
+</Steps>
+
+## Renaming a Feature
+
+When you need to rename a published Feature, use the `legacyIds` property to maintain backwards compatibility. Supporting tools will dual-publish under both the old and new identifiers.
+
+<Steps>
+  <Step title="Update the source folder and id">
+    Rename the source code folder to the new `id` and update the `id` field in `devcontainer-feature.json`. Optionally update `name`, `documentationURL`, and other metadata.
+  </Step>
+
+  <Step title="Add legacyIds">
+    Add the old `id` to the `legacyIds` array so supporting tools know to also publish under the old name:
+
+    ```json theme={null}
+    {
+      "id": "docker-outside-of-docker",
+      "version": "2.0.2",
+      "name": "Docker (Docker-outside-of-Docker)",
+      "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-outside-of-docker",
+      "legacyIds": [
+        "docker-from-docker"
+      ]
+    }
+    ```
+  </Step>
+
+  <Step title="Bump the version and republish">
+    Increment the semantic version — do not restart at `1.0.0`. Run `devcontainer features publish` or equivalent to release.
+  </Step>
+</Steps>
+
+<Note>
+  Supporting tools also use `legacyIds` to resolve `installsAfter` references that still use the old Feature ID, preserving installation ordering for other Feature authors who haven't updated their metadata yet.
+</Note>
+
+## Deprecating a Feature
+
+Set `"deprecated": true` in `devcontainer-feature.json` to signal that the Feature will receive no further updates:
+
+```json theme={null}
+{
+  "id": "old-tool",
+  "version": "3.1.0",
+  "name": "Old Tool",
+  "deprecated": true
+}
+```
+
+* Existing OCI artifacts remain accessible, so current `devcontainer.json` configurations continue to work.
+* Supporting tools (VS Code, GitHub Codespaces, containers.dev) will hide deprecated Features from discovery listings and may surface a warning to users.
+* You can still publish critical security fixes by bumping the version on a deprecated Feature.
+
+
+# Authoring Templates
+Source: https://www.mintlify.com/devcontainers/spec/ecosystem/authoring-templates
+
+A practical guide to creating and publishing Dev Container Templates, including option substitution syntax and OCI registry distribution.
+
+Dev Container Templates are source files packaged together that encode a complete development environment configuration. A supporting tool drops the Template's files into a user's project, substituting any configured options before writing them.
+
+## Folder structure
+
+A Template requires at minimum a `devcontainer-template.json` metadata file and a `.devcontainer/devcontainer.json`. Additional files (Dockerfiles, docker-compose files, scripts) are permitted and distributed alongside the required files.
+
+```
+template/
+├── devcontainer-template.json
+└── .devcontainer/
+    ├── devcontainer.json
+    └── (other files)
+```
+
+When hosting multiple Templates in a single repository, use a `src/` directory:
+
+```
+src/
+├── go/
+│   ├── devcontainer-template.json
+│   └── .devcontainer/
+│       └── devcontainer.json
+├── docker-from-docker/
+│   ├── devcontainer-template.json
+│   └── .devcontainer/
+│       ├── devcontainer.json
+│       └── Dockerfile
+└── go-postgres/
+    ├── devcontainer-template.json
+    └── .devcontainer/
+        ├── devcontainer.json
+        ├── docker-compose.yml
+        └── Dockerfile
+```
+
+<Note>
+  Templates and Features should be stored in separate git repositories.
+</Note>
+
+## Authoring workflow
+
+<Steps>
+  <Step title="Create the metadata file">
+    Create `devcontainer-template.json` in your Template folder. The `id` must match the folder name.
+
+    ```json theme={null}
+    {
+      "id": "java",
+      "version": "1.0.0",
+      "name": "Java",
+      "description": "Develop Java applications.",
+      "documentationURL": "https://github.com/devcontainers/templates/tree/main/src/java",
+      "platforms": ["Java"],
+      "publisher": "Dev Container Spec Maintainers",
+      "keywords": ["java", "jdk"]
+    }
+    ```
+
+    | Property           | Type   | Description                                |
+    | :----------------- | :----- | :----------------------------------------- |
+    | `id`               | string | Unique identifier matching the folder name |
+    | `version`          | string | Semantic version                           |
+    | `name`             | string | Display name                               |
+    | `description`      | string | Short description                          |
+    | `documentationURL` | string | URL to documentation                       |
+    | `licenseURL`       | string | URL to license                             |
+    | `options`          | object | Configurable options (see below)           |
+    | `platforms`        | array  | Languages/platforms supported              |
+    | `publisher`        | string | Maintainer name                            |
+    | `keywords`         | array  | Search keywords                            |
+    | `optionalPaths`    | array  | Files/directories the user may opt out of  |
+  </Step>
+
+  <Step title="Declare options">
+    Options let users customize the Template when they apply it. Declare them in the `options` map — each key becomes a placeholder in your Template files using the `${templateOption:optionId}` syntax.
+
+    ```json theme={null}
+    {
+      "options": {
+        "imageVariant": {
+          "type": "string",
+          "description": "Specify version of Java.",
+          "proposals": [
+            "17-bullseye",
+            "17-buster",
+            "11-bullseye",
+            "11-buster",
+            "17",
+            "11"
+          ],
+          "default": "17-bullseye"
+        },
+        "nodeVersion": {
+          "type": "string",
+          "proposals": ["latest", "16", "14", "10", "none"],
+          "default": "latest",
+          "description": "Specify version of node, or 'none' to skip node installation."
+        },
+        "installMaven": {
+          "type": "boolean",
+          "description": "Install Maven, a management tool for Java.",
+          "default": "false"
+        }
+      }
+    }
+    ```
+
+    | Property      | Type   | Description                                                   |
+    | :------------ | :----- | :------------------------------------------------------------ |
+    | `type`        | string | `"string"` or `"boolean"`                                     |
+    | `description` | string | Shown to users during Template selection                      |
+    | `proposals`   | array  | Suggested values; free-form input is allowed                  |
+    | `enum`        | array  | Strict list of allowed values; free-form input is not allowed |
+    | `default`     | string | Default value when the user does not provide one              |
+
+    Use `proposals` when you want to suggest common values but allow custom input. Use `enum` to enforce a strict set of valid values.
+  </Step>
+
+  <Step title="Use option substitution in devcontainer.json">
+    Reference options in any file within the `.devcontainer/` sub-directory using `${templateOption:optionId}`. Supporting tools replace each placeholder with the user's selected value before writing the files to the project.
+
+    ```json theme={null}
+    {
+      "name": "Java",
+      "image": "mcr.microsoft.com/devcontainers/java:0-${templateOption:imageVariant}",
+      "features": {
+        "ghcr.io/devcontainers/features/node:1": {
+          "version": "${templateOption:nodeVersion}",
+          "installMaven": "${templateOption:installMaven}"
+        }
+      }
+    }
+    ```
+
+    If a user selects `17-bullseye` for `imageVariant` and accepts defaults for the other options, the written `devcontainer.json` becomes:
+
+    ```json theme={null}
+    {
+      "name": "Java",
+      "image": "mcr.microsoft.com/devcontainers/java:0-17-bullseye",
+      "features": {
+        "ghcr.io/devcontainers/features/node:1": {
+          "version": "latest",
+          "installMaven": "false"
+        }
+      }
+    }
+    ```
+
+    Substitution applies to all files inside the Template's sub-directory — not just `devcontainer.json`. You can use `${templateOption:...}` in Dockerfiles, shell scripts, or any other file that ships with the Template.
+  </Step>
+
+  <Step title="Mark optional paths">
+    Use `optionalPaths` in `devcontainer-template.json` to identify files or directories that users can opt out of when applying the Template.
+
+    ```json theme={null}
+    {
+      "id": "cpp",
+      "version": "3.0.0",
+      "name": "C++",
+      "description": "Develop C++ applications",
+      "optionalPaths": [
+        "GETTING-STARTED.md",
+        "example-project-1/MyProject.csproj",
+        ".github/*"
+      ]
+    }
+    ```
+
+    * For a single file, provide the full relative path from the Template root.
+    * For a directory and all its contents, append `/*` to the path (e.g. `.github/*`).
+
+    Supporting tools must inspect this property and prompt the user before including these files in the output.
+  </Step>
+
+  <Step title="Publish to an OCI registry">
+    Templates are distributed as tarballs pushed to an OCI registry. Use the [Dev Container CLI](https://github.com/devcontainers/cli) or the [Dev Container Publish GitHub Action](https://github.com/devcontainers/action).
+
+    Each Template is published following the naming convention `<registry>/<namespace>/<id>[:version]`:
+
+    ```bash theme={null}
+    devcontainer templates publish \
+      --namespace myorg/my-templates \
+      --registry ghcr.io \
+      ./src
+    ```
+
+    The tool publishes major, minor, and patch version tags automatically (e.g. `1`, `1.2`, `1.2.3`, `latest`).
+
+    <Note>
+      The `namespace` must be different from the namespace used for your Features collection. Use a separate repository for Templates and Features.
+    </Note>
+
+    Users reference your Template via its OCI registry path:
+
+    * `ghcr.io/myorg/my-templates/java`
+    * `ghcr.io/myorg/my-templates/java:1`
+    * `ghcr.io/myorg/my-templates/java:latest`
+  </Step>
+
+  <Step title="Test a Template locally">
+    Reference a Template's source folder directly from the [Dev Container CLI](https://github.com/devcontainers/cli) to test before publishing:
+
+    ```bash theme={null}
+    devcontainer templates apply \
+      --workspace-folder ./my-project \
+      --template-id ./src/java
+    ```
+
+    This applies the Template to `./my-project`, prompting for option values and performing substitution as a published tool would, without requiring an OCI push first.
+
+    <Tip>
+      Add a `test/` directory alongside `src/` with a `test.sh` script per Template to automate integration testing. Many CI pipelines use the Dev Container CLI to spin up the environment and assert that expected tools are present.
+    </Tip>
+  </Step>
+</Steps>
+
+## Complete example
+
+The following is the full Java Template example showing all three parts working together.
+
+<CodeGroup>
+  ```json devcontainer-template.json theme={null}
+  {
+    "id": "java",
+    "version": "1.0.0",
+    "name": "Java",
+    "description": "Develop Java applications.",
+    "options": {
+      "imageVariant": {
+        "type": "string",
+        "description": "Specify version of java.",
+        "proposals": [
+          "17-bullseye",
+          "17-buster",
+          "11-bullseye",
+          "11-buster",
+          "17",
+          "11"
+        ],
+        "default": "17-bullseye"
+      },
+      "nodeVersion": {
+        "type": "string",
+        "proposals": ["latest", "16", "14", "10", "none"],
+        "default": "latest",
+        "description": "Specify version of node, or 'none' to skip node installation."
+      },
+      "installMaven": {
+        "type": "boolean",
+        "description": "Install Maven, a management tool for Java.",
+        "default": "false"
+      }
+    }
+  }
+  ```
+
+  ```json .devcontainer/devcontainer.json (template) theme={null}
+  {
+    "name": "Java",
+    "image": "mcr.microsoft.com/devcontainers/java:0-${templateOption:imageVariant}",
+    "features": {
+      "ghcr.io/devcontainers/features/node:1": {
+        "version": "${templateOption:nodeVersion}",
+        "installMaven": "${templateOption:installMaven}"
+      }
+    }
+  }
+  ```
+
+  ```json .devcontainer/devcontainer.json (after applying with defaults) theme={null}
+  {
+    "name": "Java",
+    "image": "mcr.microsoft.com/devcontainers/java:0-17-bullseye",
+    "features": {
+      "ghcr.io/devcontainers/features/node:1": {
+        "version": "latest",
+        "installMaven": "false"
+      }
+    }
+  }
+  ```
+</CodeGroup>
+
+
+# Contributing to the spec
+Source: https://www.mintlify.com/devcontainers/spec/ecosystem/contributing
+
+How to propose changes, file issues, and engage with the Dev Container Specification community.
+
+The Dev Container Specification is an open standard developed in public on GitHub. Contributions are welcome — whether you want to propose a new property, fix a schema error, or improve documentation.
+
+## Proposal workflow
+
+Changes to the specification go through a structured review process. New ideas start as proposals before they are formalized into the spec.
+
+<Steps>
+  <Step title="Open an issue">
+    File a proposal in the [devcontainers/spec](https://github.com/devcontainers/spec) repository to get early feedback before investing time in a formal writeup.
+  </Step>
+
+  <Step title="Document the proposal">
+    Formally describe the proposed change in terms of properties and their semantics. Format your proposal like the [`devcontainer.json` reference](https://aka.ms/devcontainer.json), which uses JSON with Comments (jsonc) format.
+
+    Include a property table like this:
+
+    | Property | Type   | Description                                                                                                                                  |
+    | -------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+    | `image`  | string | **Required** when using an image. The name of an image in a container registry that supporting tools should use to create the dev container. |
+
+    Active proposals live in the [`proposals/` folder](https://github.com/devcontainers/spec/tree/main/proposals) of the repository. Once finalized, they move to the [`docs/specs/` folder](https://github.com/devcontainers/spec/tree/main/docs/specs).
+  </Step>
+
+  <Step title="Open a schema PR">
+    Submit a PR to update the [devcontainer base schema](https://github.com/devcontainers/spec/blob/main/schemas/devContainer.base.schema.json) with your proposed additions. Include code or shell scripts demonstrating the implementation approach where applicable.
+  </Step>
+
+  <Step title="Update the reference docs">
+    Once there is discussion on your proposal, open a linked PR to update the [`devcontainer.json` reference doc](https://github.com/microsoft/vscode-docs/blob/main/docs/remote/devcontainerjson-reference.md). When your proposal is merged, the docs stay in sync with the spec.
+  </Step>
+</Steps>
+
+## Contributing tool-specific support
+
+Tool-specific properties belong in namespaces inside the `"customizations"` property. For example, VS Code properties are under `"vscode"`:
+
+```jsonc devcontainer.json theme={null}
+// Configure tool-specific properties.
+"customizations": {
+  // Configure properties specific to VS Code.
+  "vscode": {
+    // Set default container-specific settings.json values on container create.
+    "settings": {},
+
+    // Additional VS Code specific properties...
+  }
+}
+```
+
+You can propose a new namespace for your tool and document any properties specific to it.
+
+## Review labels
+
+The spec repository uses the following labels to track proposals through the review process:
+
+| Label          | Meaning                                             |
+| -------------- | --------------------------------------------------- |
+| `proposal`     | Issues under discussion, still collecting feedback. |
+| `finalization` | Proposals intended to become part of the spec.      |
+
+Milestones follow a "Month Year" pattern (for example, January 2022). If a finalized proposal is added to a milestone, it is intended to be merged during that milestone.
+
+## Formatting guidelines
+
+When contributing to official docs or referencing dev containers in your projects:
+
+<AccordionGroup>
+  <Accordion title="Naming conventions">
+    * Refer to the spec as the **"Development Container Specification"** — all capitals, singular "Container"
+    * The term "dev container" should not be capitalized on its own; only capitalize when referring to an official tool title (like the VS Code Dev Containers extension)
+    * Use backticks for `devcontainer.json` as a file type
+    * Features and Templates should always be capitalized
+    * Refer to the CLI as the **"Dev Container CLI"**
+  </Accordion>
+
+  <Accordion title="Emphasis and formatting">
+    * Use `devcontainer.json` with backticks when referring to the file format
+    * Use bolding for emphasis throughout sections rather than bolding every instance of a term
+  </Accordion>
+</AccordionGroup>
+
+## Where to file issues
+
+File issues in the repository that owns the relevant code or content:
+
+<CardGroup>
+  <Card title="Spec repository" icon="file-code" href="https://github.com/devcontainers/spec">
+    Proposals, spec changes, schema updates, and documentation for the core Development Container Specification.
+  </Card>
+
+  <Card title="Features and Templates" icon="puzzle-piece" href="https://github.com/devcontainers/features">
+    Issues with spec-maintained Features. For Templates, use the [devcontainers/templates](https://github.com/devcontainers/templates) repository.
+  </Card>
+
+  <Card title="Dev Container CLI" icon="terminal" href="https://github.com/devcontainers/cli">
+    CLI reference implementation bugs and non-spec-related feature requests.
+  </Card>
+
+  <Card title="CI integration" icon="circle-check" href="https://github.com/devcontainers/ci">
+    Issues with the GitHub Action and Azure DevOps Task for running dev containers in CI builds.
+  </Card>
+</CardGroup>
+
+## Community
+
+<CardGroup>
+  <Card title="Community Slack" icon="slack" href="https://aka.ms/dev-container-community">
+    Connect with community members and maintainers. Ask questions, share feedback, or discuss how your team uses dev containers.
+  </Card>
+
+  <Card title="GitHub Discussions" icon="comment" href="https://github.com/devcontainers/spec/discussions">
+    A space to connect with the community without needing to file a spec change. Great for questions and general discussion.
+  </Card>
+</CardGroup>
+
+
+# Features distribution
+Source: https://www.mintlify.com/devcontainers/spec/ecosystem/features-distribution
+
+How to package, publish, and distribute Dev Container Features via OCI registries, direct tarballs, or local paths.
+
+Dev Container Features can be authored and self-published by community members and organizations without central coordination. This page covers the distribution model, source code structure, packaging, and how supporting tools locate and download Features.
+
+<Tip>
+  Check out the [feature-template repository](https://github.com/devcontainers/feature-template) for a complete working example of authoring and publishing a Feature collection.
+</Tip>
+
+## Source code structure
+
+Feature source code is stored in a git repository. Multiple Features can share a single repository — this is called a **collection**. Features in a collection share the same namespace (e.g. `owner/repo`).
+
+```
+.
+├── README.md
+├── src/
+│   ├── dotnet/
+│   │   ├── devcontainer-feature.json
+│   │   ├── install.sh
+│   │   └── (other files)
+│   ├── go/
+│   │   ├── devcontainer-feature.json
+│   │   └── install.sh
+│   └── python/
+│       ├── devcontainer-feature.json
+│       └── install.sh
+└── test/
+    ├── dotnet/
+    │   └── test.sh
+    ├── go/
+    │   └── test.sh
+    └── python/
+        └── test.sh
+```
+
+* The `src/` directory contains sub-folders named after each Feature's `id` field.
+* Each sub-folder must contain at minimum a `devcontainer-feature.json` and `install.sh`.
+* Additional files in the sub-folder are included when packaging.
+* The optional `test/` directory can contain a `test.sh` script for each Feature. Supporting tools may run these tests against the Feature.
+
+## Packaging
+
+Features are distributed as tarballs. The packaging step bundles the entire contents of a Feature's sub-directory into a file named:
+
+```
+devcontainer-feature-<id>.tgz
+```
+
+A reference implementation for packaging and publishing is provided as a GitHub Action at [devcontainers/action](https://github.com/devcontainers/action).
+
+### devcontainer-collection.json
+
+Each collection includes an auto-generated `devcontainer-collection.json` metadata file. This file is generated by the packaging tooling and should not be edited manually.
+
+| Property            | Type   | Description                                                                                                                  |
+| :------------------ | :----- | :--------------------------------------------------------------------------------------------------------------------------- |
+| `sourceInformation` | object | Metadata from the implementing packaging tool.                                                                               |
+| `features`          | array  | The list of Features in this collection. Each element is the full contents of the corresponding `devcontainer-feature.json`. |
+
+## Distribution
+
+Features can be distributed in three ways:
+
+<Tabs>
+  <Tab title="OCI registry">
+    An OCI registry that implements the [OCI Artifact Distribution Specification](https://github.com/opencontainers/distribution-spec) is the primary distribution mechanism for Features.
+
+    Each packaged Feature is pushed following the naming convention:
+
+    ```
+    <registry>/<namespace>/<id>[:version]
+    ```
+
+    The version is the major, minor, and patch version according to semver. Features should be pushed for each major, minor, and patch tag to allow users to pin at different levels of specificity.
+
+    ```bash theme={null}
+    REGISTRY=ghcr.io
+    NAMESPACE=devcontainers/features
+    FEATURE=go
+    ARTIFACT_PATH=devcontainer-feature-go.tgz
+
+    for VERSION in 1  1.2  1.2.3  latest
+    do
+        oras push ${REGISTRY}/${NAMESPACE}/${FEATURE}:${VERSION} \
+                --manifest-config /dev/null:application/vnd.devcontainers \
+                                 ./${ARTIFACT_PATH}:application/vnd.devcontainers.layer.v1+tar
+    done
+    ```
+
+    The `devcontainer-collection.json` is pushed to the same namespace with no Feature name, always tagged as `latest`:
+
+    ```bash theme={null}
+    REGISTRY=ghcr.io
+    NAMESPACE=devcontainers/features
+
+    oras push ${REGISTRY}/${NAMESPACE}:latest \
+            --manifest-config /dev/null:application/vnd.devcontainers \
+                                ./devcontainer-collection.json:application/vnd.devcontainers.collection.layer.v1+json
+    ```
+
+    <Note>
+      The `namespace` is the globally identifiable name for the collection (typically `owner/repo`). It must be lowercase and follow the [OCI spec regex](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pulling-manifests).
+    </Note>
+  </Tab>
+
+  <Tab title="Direct tarball (HTTPS)">
+    A Feature can be referenced directly by an HTTPS URI pointing to the packaged `.tgz` tarball. The archive file must be named `devcontainer-feature-<featureId>.tgz`.
+
+    ```jsonc theme={null}
+    {
+      "features": {
+        "https://github.com/user/repo/releases/download/v1.0.0/devcontainer-feature-go.tgz": {
+          "version": "1.21"
+        }
+      }
+    }
+    ```
+
+    Supporting tools must download and extract the tarball to read the Feature metadata (including `dependsOn` and `installsAfter` properties).
+  </Tab>
+
+  <Tab title="Local path">
+    A Feature can be referenced from a local folder, relative to the folder containing `devcontainer.json`. This is useful when developing a Feature before publishing it.
+
+    ```jsonc theme={null}
+    {
+      "features": {
+        "./localFeatureA": {},
+        "./localFeatureB": {}
+      }
+    }
+    ```
+
+    See [locally referenced Features](#locally-referenced-features) for full requirements.
+  </Tab>
+</Tabs>
+
+## OCI manifest annotation
+
+When publishing to an OCI registry, implementing tools must populate an annotation named `dev.containers.metadata` on the manifest. This annotation is the escaped JSON object of the entire `devcontainer-feature.json` as it appears during packaging.
+
+Supporting tools can read this annotation to resolve Feature dependencies without downloading and extracting the tarball, which speeds up dependency resolution.
+
+```json theme={null}
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": {
+    "mediaType": "application/vnd.devcontainers",
+    "digest": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "size": 0
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.devcontainers.layer.v1+tar",
+      "digest": "sha256:738af5504b253dc6de51d2cb1556cdb7ce70ab18b2f32b0c2f12650ed6d2e4bc",
+      "size": 3584,
+      "annotations": {
+        "org.opencontainers.image.title": "devcontainer-feature-myFeature.tgz"
+      }
+    }
+  ],
+  "annotations": {
+    "dev.containers.metadata": "{\"name\": \"My Feature\",\"id\": \"myFeature\",\"version\": \"1.0.0\",\"dependsOn\": {\"ghcr.io/devcontainers/features/node:1\": {}}}"
+  }
+}
+```
+
+<Warning>
+  If no annotation is present on a Feature's manifest, the supporting tool **must** fall back to downloading and extracting the Feature's tarball to read its metadata. Failure to do so may result in a Feature being installed without its dependencies.
+</Warning>
+
+## How supporting tools locate Features
+
+When a user references a Feature in `devcontainer.json`, the supporting tool uses the identifier format to determine how to fetch it:
+
+| Identifier format                       | Resolution strategy                                                                                  |
+| :-------------------------------------- | :--------------------------------------------------------------------------------------------------- |
+| `<registry>/<namespace>/<id>[:version]` | Fetch the OCI manifest; read `dev.containers.metadata` annotation or extract tarball to get metadata |
+| `https://...tgz`                        | Download and extract the tarball; read `devcontainer-feature.json`                                   |
+| `./<relative-path>`                     | Read `devcontainer-feature.json` directly from the local filesystem                                  |
+
+Feature identifiers are treated as case-insensitive and normalized to lowercase by implementing tools.
+
+## Versioning
+
+Each Feature is individually versioned following the [semver specification](https://semver.org/). The `version` property in `devcontainer-feature.json` determines whether a new version should be published.
+
+* Tooling will not republish a Feature if that exact version has already been published.
+* Tooling must republish major and minor versions when the patch version changes (to keep `:1` and `:1.2` tags up to date).
+
+## Publishing workflow
+
+<Steps>
+  <Step title="Author your Feature">
+    Create a directory under `src/` with your Feature's ID as the name. Add `devcontainer-feature.json` and `install.sh` at minimum.
+  </Step>
+
+  <Step title="Test your Feature">
+    Add a `test/` directory with a `test.sh` script. Use the Dev Container CLI (`devcontainer features test`) to run tests locally.
+  </Step>
+
+  <Step title="Set up CI/CD">
+    Use the [Dev Container Publish GitHub Action](https://github.com/marketplace/actions/dev-container-publish) or the [Dev Container CLI](https://github.com/devcontainers/cli) to automate packaging and publishing on push.
+  </Step>
+
+  <Step title="Publish to the registry">
+    Run `devcontainer features publish` to package each Feature as a `.tgz`, push it to your OCI registry, and push the `devcontainer-collection.json` to the collection namespace.
+  </Step>
+</Steps>
+
+## Locally referenced Features
+
+Local Features are useful during development, before publishing to a registry.
+
+### Requirements
+
+A project that uses locally referenced Features must meet the following constraints:
+
+* The project must have a `.devcontainer/` folder at the root of the project workspace folder.
+* A local Feature's source code must be contained within a sub-folder of `.devcontainer/`.
+* The sub-folder name must match the Feature's `id` field.
+* A local Feature may **not** be referenced by absolute path.
+* The local Feature must contain at least `devcontainer-feature.json` and `install.sh`.
+
+### Example project structure
+
+```
+.
+└── .devcontainer/
+    ├── localFeatureA/
+    │   ├── devcontainer-feature.json
+    │   ├── install.sh
+    │   └── helpers.sh
+    ├── localFeatureB/
+    │   ├── devcontainer-feature.json
+    │   └── install.sh
+    └── devcontainer.json
+```
+
+```jsonc theme={null}
+// .devcontainer/devcontainer.json
+{
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "./localFeatureA": {},
+    "./localFeatureB": {
+      "someOption": true
+    }
+  }
+}
+```
+
+The relative path uses unix-style syntax (e.g. `./localFeatureA`) regardless of the host operating system.
+
+### Local Feature dependencies
+
+During development, a local Feature can depend on other local Features using a relative path in `dependsOn`. The path is relative to the folder containing the active `devcontainer.json`:
+
+```json theme={null}
+{
+  "id": "localFeatureB",
+  "version": "1.0.0",
+  "dependsOn": {
+    "./localFeatureA": {}
+  }
+}
+```
+
+<Note>
+  Each local Feature is considered unique and not equal to any other local Feature for the purposes of the [dependency resolution algorithm](/ecosystem/features-overview#installation-order).
+</Note>
+
+
+# Features overview
+Source: https://www.mintlify.com/devcontainers/spec/ecosystem/features-overview
+
+Dev Container Features are self-contained, shareable units of installation code and development container configuration that let you quickly add tooling, runtimes, and libraries to any dev container.
+
+**Dev Container Features** are self-contained, shareable units of installation code and development container configuration. Referencing one of them lets you quickly and easily add more tooling, runtime, or library "Features" into your development container for you or your collaborators to use.
+
+<Note>
+  While Features may be installed on top of any base image, the implementation of a Feature might restrict it to a subset of possible base images. For example, some Features may be authored to work with a certain Linux distro (e.g. Debian-based images that use the `apt` package manager).
+</Note>
+
+Feature metadata is captured by a `devcontainer-feature.json` file in the root folder of the Feature.
+
+<CardGroup>
+  <Card title="Features reference" icon="file-code" href="/ecosystem/features-reference">
+    Full metadata reference for `devcontainer-feature.json`, options, lifecycle hooks, and option resolution.
+  </Card>
+
+  <Card title="Features distribution" icon="cloud-arrow-up" href="/ecosystem/features-distribution">
+    How to package and publish Features to OCI registries for others to use.
+  </Card>
+</CardGroup>
+
+## Using Features in devcontainer.json
+
+Features are referenced in `devcontainer.json` under the top-level `features` object. You can specify any number of Features — at build time they are installed in an order determined by the [installation order rules](#installation-order).
+
+Each Feature is a key/value pair where the key is the Feature identifier and the value is an object of options (or an empty object for defaults).
+
+```jsonc theme={null}
+// .devcontainer/devcontainer.json
+{
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/go:1": {},
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.11",
+      "pip": true
+    }
+  }
+}
+```
+
+As a shorthand, you can pass a single string value instead of an object. The string is mapped to an option named `version`. These two forms are equivalent:
+
+```jsonc theme={null}
+"features": {
+  "ghcr.io/owner/repo/go": "1.21"
+}
+```
+
+```jsonc theme={null}
+"features": {
+  "ghcr.io/owner/repo/go": {
+    "version": "1.21"
+  }
+}
+```
+
+## Feature identifier formats
+
+The identifier format tells the supporting tool where to locate and download the Feature.
+
+| Format                                            | Description                                                            | Example                                                             |
+| :------------------------------------------------ | :--------------------------------------------------------------------- | :------------------------------------------------------------------ |
+| `<oci-registry>/<namespace>/<feature>[:<semver>]` | Feature published to an OCI registry                                   | `ghcr.io/devcontainers/features/go:1`                               |
+| `https://<uri-to-tgz>`                            | Direct HTTPS URI to a `.tgz` tarball                                   | `https://github.com/user/repo/releases/devcontainer-feature-go.tgz` |
+| `./<path-to-feature-dir>`                         | Relative path to a local folder containing `devcontainer-feature.json` | `./myGoFeature`                                                     |
+
+Feature identifiers are case-insensitive and should be normalized to lowercase.
+
+<Note>
+  The relative path for local Features is always relative to the folder containing `devcontainer.json`, regardless of the host operating system. Use unix-style syntax (e.g. `./myFeature`).
+</Note>
+
+A complete example using all three identifier formats:
+
+```jsonc theme={null}
+"features": {
+  "ghcr.io/user/repo/go": {},
+  "ghcr.io/user/repo1/go:1": {},
+  "ghcr.io/user/repo2/go:latest": {},
+  "https://github.com/user/repo/releases/devcontainer-feature-go.tgz": {
+    "optionA": "value"
+  },
+  "./myGoFeature": {
+    "optionA": true,
+    "optionB": "hello",
+    "version": "1.0.0"
+  }
+}
+```
+
+## Versioning
+
+Each Feature is individually versioned according to the [semver specification](https://semver.org/). The `version` property in `devcontainer-feature.json` defines the current version.
+
+* If you omit a version tag in the identifier, `:latest` is added implicitly.
+* Pin to a specific version by appending it to the Feature identifier (e.g. `ghcr.io/devcontainers/features/go:1.2.3`).
+* Tooling will not republish a Feature if that exact version has already been published, but it must republish major and minor versions in accordance with semver.
+
+```jsonc theme={null}
+"features": {
+  // Uses latest
+  "ghcr.io/devcontainers/features/go": {},
+  // Pins to major version 1
+  "ghcr.io/devcontainers/features/node:1": {},
+  // Pins to exact patch version
+  "ghcr.io/devcontainers/features/python:1.2.3": {}
+}
+```
+
+## Installation order
+
+By default, Features are installed in an order determined as optimal by the implementing tool. You can influence or control this order using three mechanisms:
+
+### dependsOn
+
+The `dependsOn` property in `devcontainer-feature.json` declares **hard dependencies** — Features that must be installed before the declaring Feature. Dependencies are resolved recursively.
+
+```json theme={null}
+{
+  "id": "myFeature",
+  "version": "1.0.0",
+  "dependsOn": {
+    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.11"
+    }
+  }
+}
+```
+
+If any dependency cannot be satisfied (e.g. circular dependency, resolution failure), the entire dev container creation fails.
+
+### installsAfter
+
+The `installsAfter` property in `devcontainer-feature.json` declares **soft dependencies** — it influences installation order only for Features that are already queued to be installed. Unlike `dependsOn`, it is not evaluated recursively, and the referenced Features cannot specify options or version pins.
+
+```json theme={null}
+{
+  "id": "myFeature",
+  "version": "1.0.0",
+  "installsAfter": [
+    "ghcr.io/devcontainers/features/node",
+    "ghcr.io/devcontainers/features/python"
+  ]
+}
+```
+
+### overrideFeatureInstallOrder
+
+The `overrideFeatureInstallOrder` property in `devcontainer.json` lets users explicitly control the order Features are installed. Feature IDs listed earlier in the array are installed first (once their dependencies are satisfied). This property cannot create an order that contradicts the dependency graph.
+
+```jsonc theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/go:1": {},
+    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers/features/python:1": {}
+  },
+  "overrideFeatureInstallOrder": [
+    "ghcr.io/devcontainers/features/python",
+    "ghcr.io/devcontainers/features/node",
+    "ghcr.io/devcontainers/features/go"
+  ]
+}
+```
+
+<Tip>
+  `overrideFeatureInstallOrder` entries do not specify a version. The tool matches them to the Features in the `features` object by their base identifier (version omitted).
+</Tip>
+
+## User environment variables
+
+Feature install scripts run as `root` and sometimes need to know which user account the dev container will be used with. The following environment variables are automatically passed to every Feature's `install.sh` script:
+
+| Variable               | Description                                                                       |
+| :--------------------- | :-------------------------------------------------------------------------------- |
+| `_REMOTE_USER`         | The configured `remoteUser`. If not set, falls back to `_CONTAINER_USER`.         |
+| `_CONTAINER_USER`      | The container's user as determined by the image or Dockerfile `USER` instruction. |
+| `_REMOTE_USER_HOME`    | Home directory of `_REMOTE_USER`.                                                 |
+| `_CONTAINER_USER_HOME` | Home directory of `_CONTAINER_USER`.                                              |
+
+The container user can be set by `containerUser` in `devcontainer.json` and image metadata, `user` in `docker-compose.yml`, the `USER` Dockerfile instruction, or inherited from the base image.
+
+```bash theme={null}
+#!/usr/bin/env bash
+# Example install.sh using user environment variables
+
+echo "Installing for user: ${_REMOTE_USER}"
+echo "User home: ${_REMOTE_USER_HOME}"
+
+# Run commands as the remote user
+su "${_REMOTE_USER}" -c "some-user-level-command"
+```
+
+
+# Features reference
+Source: https://www.mintlify.com/devcontainers/spec/ecosystem/features-reference
+
+Complete reference for the devcontainer-feature.json metadata file, including all properties, options, lifecycle hooks, and option resolution.
+
+A Feature is a self-contained entity in a folder with at minimum a `devcontainer-feature.json` metadata file and an `install.sh` entrypoint script. Additional files are permitted and are packaged alongside the required files.
+
+## Folder structure
+
+```
+feature/
+├── devcontainer-feature.json
+├── install.sh
+└── (other files)
+```
+
+Each sub-directory name must match the `id` field of the `devcontainer-feature.json`. Files outside the Feature's sub-directory are not included when packaging.
+
+## devcontainer-feature.json properties
+
+The `devcontainer-feature.json` file defines metadata about a Feature. All properties are optional except `id`, `version`, and `name`.
+
+### Required properties
+
+<ParamField type="string">
+  Unique identifier for the Feature within the context of the repository where the Feature exists. Must match the name of the directory where `devcontainer-feature.json` resides. Should be provided in lowercase.
+</ParamField>
+
+<ParamField type="string">
+  The semantic version of the Feature (e.g. `1.0.0`). Follows the [semver specification](https://semver.org/).
+</ParamField>
+
+<ParamField type="string">
+  A human-friendly display name for the Feature.
+</ParamField>
+
+### Metadata properties
+
+<ParamField type="string">
+  Description of the Feature. For the best appearance in supporting tools, avoid Markdown or HTML in the description.
+</ParamField>
+
+<ParamField type="string">
+  URL to the documentation for the Feature.
+</ParamField>
+
+<ParamField type="string">
+  URL to the license for the Feature.
+</ParamField>
+
+<ParamField type="string[]">
+  List of strings relevant to a user searching for this Feature.
+</ParamField>
+
+<ParamField type="boolean">
+  Indicates that the Feature is deprecated and will not receive further updates or support. Supporting tools use this property to highlight Feature deprecation. The OCI artifacts continue to exist, so existing dev configurations continue to work.
+</ParamField>
+
+<ParamField type="string[]">
+  Array of old IDs previously used to publish this Feature. Use this when renaming a Feature within a single namespace to preserve backwards compatibility. See [renaming a Feature](#renaming-a-feature).
+</ParamField>
+
+### Container configuration properties
+
+<ParamField type="object">
+  A set of name/value pairs that set or override environment variables in the container. These are emitted as `ENV` instructions in the Dockerfile before the Feature's `install.sh` is executed.
+
+  ```json theme={null}
+  {
+    "containerEnv": {
+      "MY_VAR": "value",
+      "PATH": "${PATH}:/usr/local/myFeature/bin"
+    }
+  }
+  ```
+</ParamField>
+
+<ParamField type="boolean">
+  Enables [privileged mode](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities) (`--privileged`) for the container when this Feature is used. Required by Features like Docker-in-Docker. If any Feature requires it, the flag is applied.
+</ParamField>
+
+<ParamField type="boolean">
+  Adds the [tini init process](https://github.com/krallin/tini) (`--init`) to the container when this Feature is used. If any Feature requires it, the flag is applied.
+</ParamField>
+
+<ParamField type="string[]">
+  Docker [capabilities](https://docs.docker.com/engine/security/#linux-kernel-capabilities) to add to the container. Values from all Features are concatenated.
+
+  ```json theme={null}
+  {
+    "capAdd": ["SYS_PTRACE"]
+  }
+  ```
+</ParamField>
+
+<ParamField type="string[]">
+  Container [security options](https://docs.docker.com/engine/security/seccomp/) to apply when creating the container (e.g. updating the seccomp profile). Values from all Features are concatenated.
+
+  ```json theme={null}
+  {
+    "securityOpt": ["seccomp=unconfined"]
+  }
+  ```
+</ParamField>
+
+<ParamField type="string">
+  Path to a script that should run at container startup. Set this if the Feature requires an entrypoint that fires when the container starts.
+</ParamField>
+
+<ParamField type="object[]">
+  Cross-orchestrator way to add additional mounts to the container. Each element accepts the same values as the [Docker CLI `--mount` flag](https://docs.docker.com/engine/reference/commandline/run/#mount). The pre-defined `${devcontainerId}` variable may be referenced in values.
+
+  ```json theme={null}
+  {
+    "mounts": [
+      {
+        "source": "dind-var-lib-docker-${devcontainerId}",
+        "target": "/var/lib/docker",
+        "type": "volume"
+      }
+    ]
+  }
+  ```
+</ParamField>
+
+<ParamField type="object">
+  Tool-specific configuration. Each tool uses a unique namespace under `customizations`. For each namespace, object values are replaced and array values are unioned across all contributing Features.
+
+  ```json theme={null}
+  {
+    "customizations": {
+      "vscode": {
+        "extensions": ["golang.Go"],
+        "settings": {
+          "go.toolsManagement.autoUpdate": true
+        }
+      }
+    }
+  }
+  ```
+</ParamField>
+
+### Dependency properties
+
+<ParamField type="object">
+  An object of Feature dependencies that **must** be installed before this Feature. Elements follow the same semantics as the `features` object in `devcontainer.json`, including options. Evaluated recursively.
+
+  The ID must refer to a Feature published to an OCI registry, a Feature tgz URI, or a Feature in the local file tree. Deprecated identifiers (GitHub Release) are not supported.
+
+  ```json theme={null}
+  {
+    "dependsOn": {
+      "ghcr.io/devcontainers/features/node:1": {},
+      "ghcr.io/devcontainers/features/python:1.2.3": {
+        "version": "3.11"
+      },
+      "ghcr.io/devcontainers/features/go@sha256:a4cdc44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855": {}
+    }
+  }
+  ```
+</ParamField>
+
+<ParamField type="string[]">
+  Array of Feature IDs (without version tags) that should be installed before this Feature, **if they are already queued to be installed**. This is a soft dependency — it only influences order, not whether a Feature is installed. Not evaluated recursively. Features referenced here cannot provide options or version pins.
+
+  ```json theme={null}
+  {
+    "installsAfter": [
+      "ghcr.io/devcontainers/features/node",
+      "ghcr.io/devcontainers/features/python"
+    ]
+  }
+  ```
+</ParamField>
+
+## The options property
+
+The `options` property defines user-configurable parameters for the Feature. Each option ID becomes an environment variable name (uppercased) available to `install.sh` at build time.
+
+```json theme={null}
+{
+  "options": {
+    "version": {
+      "type": "string",
+      "enum": ["latest", "3.11", "3.10", "3.9"],
+      "default": "latest",
+      "description": "Select a Python version to install."
+    },
+    "pip": {
+      "type": "boolean",
+      "default": true,
+      "description": "Install pip."
+    },
+    "optimize": {
+      "type": "boolean",
+      "default": true,
+      "description": "Optimize the Python installation."
+    }
+  }
+}
+```
+
+### Option properties
+
+<ParamField type="string">
+  Type of the option. Valid values: `"boolean"`, `"string"`.
+</ParamField>
+
+<ParamField type="string | boolean">
+  Default value used when the user omits this option from their configuration.
+</ParamField>
+
+<ParamField type="string">
+  Description displayed to the user by supporting tools.
+</ParamField>
+
+<ParamField type="string[]">
+  A list of suggested string values. Free-form values **are** allowed. Omit when using `enum`.
+</ParamField>
+
+<ParamField type="string[]">
+  A strict list of allowed string values. Free-form values are **not** allowed. Omit when using `proposals`.
+</ParamField>
+
+## Option resolution
+
+Options specified in `devcontainer.json` are passed to `install.sh` as environment variables sourced from a file named `devcontainer-features.env`.
+
+The option ID is sanitized using the following logic before becoming an environment variable name:
+
+```javascript theme={null}
+(str) => str
+  .replace(/[^\w_]/g, '_')
+  .replace(/^[\d_]+/g, '_')
+  .toUpperCase();
+```
+
+Any options defined in `devcontainer-feature.json` that are omitted by the user are implicitly exported with their default value.
+
+### Option resolution example
+
+Given a `python` Feature with the following options:
+
+```jsonc theme={null}
+// devcontainer-feature.json
+{
+  "options": {
+    "version": {
+      "type": "string",
+      "enum": ["latest", "3.11", "3.10", "3.9", "3.8"],
+      "default": "latest",
+      "description": "Select a Python version to install."
+    },
+    "pip": {
+      "type": "boolean",
+      "default": true,
+      "description": "Installs pip"
+    },
+    "optimize": {
+      "type": "boolean",
+      "default": true,
+      "description": "Optimize python installation"
+    }
+  }
+}
+```
+
+And the user's `devcontainer.json`:
+
+```jsonc theme={null}
+{
+  "features": {
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.11",
+      "pip": false
+    }
+  }
+}
+```
+
+The emitted environment variables (sourced by `install.sh`) are:
+
+```env theme={null}
+VERSION="3.11"
+PIP="false"
+OPTIMIZE="true"
+```
+
+The following `install.sh` script:
+
+```bash theme={null}
+#!/usr/bin/env bash
+
+echo "Version is $VERSION"
+echo "Pip? $PIP"
+echo "Optimize? $OPTIMIZE"
+```
+
+Produces:
+
+```
+Version is 3.11
+Pip? false
+Optimize? true
+```
+
+## Lifecycle hooks
+
+Features can contribute commands to each of the following lifecycle hooks. The property names and behavior mirror the matching properties in `devcontainer.json`.
+
+<ParamField type="string | string[] | object">
+  Runs when the container is created, after `initializeCommand` and before `updateContentCommand`.
+</ParamField>
+
+<ParamField type="string | string[] | object">
+  Runs when creating the container, and reruns when workspace content is updated while creating the container. Runs after `onCreateCommand` and before `postCreateCommand`.
+</ParamField>
+
+<ParamField type="string | string[] | object">
+  Runs after the container is created. Runs after `updateContentCommand` and before `postStartCommand`.
+</ParamField>
+
+<ParamField type="string | string[] | object">
+  Runs after the container starts. Runs after `postCreateCommand` and before `postAttachCommand`.
+</ParamField>
+
+<ParamField type="string | string[] | object">
+  Runs when attaching to the container, after `postStartCommand`.
+</ParamField>
+
+Each command type accepts:
+
+* A **string** — run in a shell.
+* An **array of strings** — run as a single command without a shell.
+* An **object** — each key/value pair runs in parallel within that hook.
+
+### Lifecycle hook behavior
+
+For each lifecycle hook, commands contributed by Features are executed in sequence (in Feature installation order), always **before** any user-provided lifecycle commands in `devcontainer.json`.
+
+If a Feature provides a command using the object syntax, all commands in that group execute in parallel but still block commands from subsequent Features and the `devcontainer.json`.
+
+If any lifecycle script exits with a non-zero code, subsequent scripts in the same hook and all following hooks are skipped.
+
+```jsonc theme={null}
+// devcontainer-feature.json example with lifecycle hooks
+{
+  "id": "myFeature",
+  "version": "1.0.0",
+  "onCreateCommand": "setup.sh && configure.sh",
+  "postCreateCommand": "/usr/local/share/post-create.sh",
+  "postAttachCommand": {
+    "server": "start-server.sh",
+    "indexer": "start-indexer.sh"
+  }
+}
+```
+
+<Note>
+  To use a script bundled with the Feature in a lifecycle hook, your `install.sh` must copy it to a persistent location outside of `/tmp`. Implementations are not required to persist Feature install scripts beyond the initial build.
+</Note>
+
+## Renaming a Feature
+
+Use `legacyIds` to rename a published Feature while preserving backwards compatibility. Tools that implement the distribution specification will dual-publish the Feature under both the old and new IDs.
+
+<Steps>
+  <Step title="Update the source directory and id">
+    Rename the Feature's source folder and update the `id` field in `devcontainer-feature.json` to the new name. Optionally update `name`, `documentationURL`, and other metadata.
+  </Step>
+
+  <Step title="Add legacyIds">
+    Add or update the `legacyIds` property to include the previously used `id`.
+  </Step>
+
+  <Step title="Bump the version">
+    Increment the semantic version. Do **not** restart at `1.0.0` — continue the existing version sequence.
+  </Step>
+
+  <Step title="Republish">
+    Run `devcontainer features publish` or the equivalent publishing tool.
+  </Step>
+</Steps>
+
+#### Example
+
+Renaming `docker-from-docker` to `docker-outside-of-docker`:
+
+```jsonc theme={null}
+// Before
+{
+  "id": "docker-from-docker",
+  "version": "2.0.1",
+  "name": "Docker (Docker-from-Docker)",
+  "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-from-docker"
+}
+```
+
+```jsonc theme={null}
+// After
+{
+  "id": "docker-outside-of-docker",
+  "version": "2.0.2",
+  "name": "Docker (Docker-outside-of-Docker)",
+  "documentationURL": "https://github.com/devcontainers/features/tree/main/src/docker-outside-of-docker",
+  "legacyIds": [
+    "docker-from-docker"
+  ]
+}
+```
+
+The `installsAfter` property in other Features that reference the old ID continues to work correctly — implementing tools resolve both the current and legacy IDs.
+
+## The devcontainerId variable
+
+The `${devcontainerId}` variable can be used in the `entrypoint`, `mounts`, and `customizations` properties of `devcontainer-feature.json`. It is replaced with a unique, stable identifier for the dev container at runtime.
+
+<Warning>
+  Do not use `${devcontainerId}` in properties that affect image building (such as `containerEnv`). The container ID is not known at image build time, which would prevent pre-building the image.
+</Warning>
+
+```json theme={null}
+{
+  "mounts": [
+    {
+      "source": "dind-var-lib-docker-${devcontainerId}",
+      "target": "/var/lib/docker",
+      "type": "volume"
+    }
+  ]
+}
+```
+
+## Implementation notes
+
+* `privileged` and `init` are applied if any single Feature requires them.
+* `capAdd` and `securityOpt` values are concatenated across all Features.
+* `containerEnv` is added as `ENV` instructions in the Dockerfile before the Feature executes.
+* Each Feature script executes as its own layer to aid in caching and rebuilding.
+* Feature scripts are executed as `root`. To perform user-level modifications, use `su ${_REMOTE_USER} -c "command"`.
+
+
+# Lockfile
+Source: https://www.mintlify.com/devcontainers/spec/ecosystem/lockfile
+
+How devcontainer-lock.json pins Feature versions to exact digest hashes for reproducible, secure dev container builds.
+
+The Dev Container lockfile (`devcontainer-lock.json`) records the exact version, download location, and integrity checksum for every Feature referenced in `devcontainer.json`. It is placed next to `devcontainer.json` and is generated by supporting tools.
+
+## Why the lockfile exists
+
+Without a lockfile, a `devcontainer.json` that references `"ghcr.io/devcontainers/features/node:1"` will silently resolve to a newer patch release each time the container is rebuilt. This means:
+
+* Two developers rebuilding the same `devcontainer.json` at different times may end up with different tool versions.
+* The image layer cache can be invalidated unexpectedly when a Feature author publishes a new version.
+* There is no record of what was actually installed — a Feature's OCI artifact could theoretically be replaced after the fact.
+
+The lockfile solves all three problems:
+
+* **Reproducibility** — pin `latest` or a major version tag once; subsequent builds use the exact same artifact.
+* **Cache stability** — the image cache checksum stays stable because the pinned digest does not change until you explicitly update the lockfile.
+* **Security (trust on first use)** — the integrity hash recorded at first use detects any future modification of the artifact at the same OCI tag.
+
+## The devcontainer-lock.json format
+
+The file contains a single top-level `"features"` object. Each key is the Feature identifier as written in `devcontainer.json` (normalized to lowercase). The value records how to retrieve the exact artifact.
+
+```json theme={null}
+{
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.0.4",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:567d704b3f4d3eca3acee51ded7c460a8395436d135d53d1175fb565daff42b8",
+      "integrity": "sha256:567d704b3f4d3eca3acee51ded7c460a8395436d135d53d1175fb565daff42b8"
+    },
+    "https://mycustomdomain.com/devcontainer-feature-myfeature.tgz": {
+      "version": "1.2.3",
+      "resolved": "https://mycustomdomain.com/devcontainer-feature-myfeature.tgz",
+      "integrity": "sha256:567d704b3f4d3eca3acee51ded7c460a8395436d135d53d1175fb565daff42b8"
+    }
+  }
+}
+```
+
+### Fields
+
+| Field       | Description                                                                                                                                                      |
+| :---------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `version`   | The full resolved semantic version (e.g. `1.0.4`)                                                                                                                |
+| `resolved`  | For OCI Features: the registry path with the sha256 digest appended (`@sha256:...`). For tarball Features: the original HTTPS URL.                               |
+| `integrity` | `sha256:` followed by the hex-encoded SHA-256 checksum of the downloaded artifact (the `.tgz` file).                                                             |
+| `dependsOn` | Array of Feature identifiers equal to the Feature's own `dependsOn` keys. Omitted when empty. Every Feature listed here also has its own record in the lockfile. |
+
+### OCI vs tarball Features
+
+<Tabs>
+  <Tab title="OCI registry Feature">
+    The `resolved` field uses the digest form of the OCI reference so that it bypasses the mutable tag and pulls the exact layer:
+
+    ```json theme={null}
+    {
+      "version": "1.0.4",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:567d704b3f4d3eca3acee51ded7c460a8395436d135d53d1175fb565daff42b8",
+      "integrity": "sha256:567d704b3f4d3eca3acee51ded7c460a8395436d135d53d1175fb565daff42b8"
+    }
+    ```
+  </Tab>
+
+  <Tab title="Tarball (HTTPS) Feature">
+    The `resolved` field is the original URL. The integrity checksum is still recorded for tamper detection:
+
+    ```json theme={null}
+    {
+      "version": "1.2.3",
+      "resolved": "https://mycustomdomain.com/devcontainer-feature-myfeature.tgz",
+      "integrity": "sha256:567d704b3f4d3eca3acee51ded7c460a8395436d135d53d1175fb565daff42b8"
+    }
+    ```
+  </Tab>
+</Tabs>
+
+<Note>
+  Local Features and deprecated GitHub Releases-based Features are not recorded in the lockfile.
+</Note>
+
+## Features with dependencies
+
+When a Feature declares `dependsOn`, each dependency also gets its own record in the lockfile. The dependent Feature's entry lists the dependency identifiers in a `dependsOn` array so the full resolution graph is captured.
+
+```json theme={null}
+{
+  "features": {
+    "ghcr.io/codspace/dependson/a": {
+      "version": "1.2.1",
+      "resolved": "ghcr.io/codspace/dependson/a@sha256:932027ef71da186210e6ceb3294c3459caaf6b548d2b547d5d26be3fc4b2264a",
+      "integrity": "sha256:932027ef71da186210e6ceb3294c3459caaf6b548d2b547d5d26be3fc4b2264a",
+      "dependsOn": [
+        "ghcr.io/codspace/dependson/e:2"
+      ]
+    },
+    "ghcr.io/codspace/dependson/e:2": {
+      "version": "2.3.4",
+      "resolved": "ghcr.io/codspace/dependson/e@sha256:9f36f159c70f8bebff57f341904b030733adb17ef12a5d58d4b3d89b2a6c7d5a",
+      "integrity": "sha256:9f36f159c70f8bebff57f341904b030733adb17ef12a5d58d4b3d89b2a6c7d5a"
+    }
+  }
+}
+```
+
+Feature identifiers inside `dependsOn` arrays are normalized to lowercase to simplify lookups, regardless of how they appear in `devcontainer-feature.json`.
+
+## How supporting tools generate and use the lockfile
+
+**Generating the lockfile:**
+
+When you run a supporting tool (such as `devcontainer build` or `devcontainer up`) and a lockfile does not already exist, the tool:
+
+1. Resolves each Feature tag to its current digest.
+2. Downloads the artifact and computes its SHA-256 checksum.
+3. Writes `devcontainer-lock.json` next to `devcontainer.json`.
+
+**Using an existing lockfile:**
+
+On subsequent builds, the tool reads `devcontainer-lock.json` and uses the `resolved` digest directly — skipping tag resolution entirely. It also verifies the downloaded artifact against the recorded `integrity` checksum and fails the build if they do not match.
+
+**Updating the lockfile:**
+
+To adopt newer Feature versions, delete `devcontainer-lock.json` (or run the tool's dedicated update command) and rebuild. The tool re-resolves all tags and writes a fresh lockfile.
+
+## When to commit vs ignore the lockfile
+
+<AccordionGroup>
+  <Accordion title="Commit the lockfile (recommended for most projects)">
+    Committing `devcontainer-lock.json` ensures that every developer and every CI run uses identical Feature versions. This is the right choice for:
+
+    * Application repositories where you want a stable, consistent toolchain
+    * Teams where reproducibility across machines matters
+    * Projects that need auditability of exactly what was installed
+
+    Treat `devcontainer-lock.json` the way you would `package-lock.json` or `Cargo.lock`: commit it, review changes to it in pull requests, and update it deliberately.
+  </Accordion>
+
+  <Accordion title="Ignore the lockfile">
+    Omitting the lockfile means each rebuild resolves Feature tags to whatever is current at build time. This may be appropriate for:
+
+    * Library repositories where always getting the latest tooling is preferred
+    * Personal scratch environments where reproducibility is not a concern
+
+    If you choose not to commit the lockfile, add it to `.gitignore`:
+
+    ```bash theme={null}
+    echo "devcontainer-lock.json" >> .gitignore
+    ```
+  </Accordion>
+</AccordionGroup>
+
+<Warning>
+  Without a committed lockfile, a Feature published to the same tag by its author can silently change what gets installed in your container. The `integrity` field in the lockfile is the only mechanism that detects this.
+</Warning>
+
+
+# Supporting tools and services
+Source: https://www.mintlify.com/devcontainers/spec/ecosystem/supporting-tools
+
+Editors, tools, and cloud services that implement the Dev Container Specification.
+
+This page outlines tools and services that support the Development Container Specification, including the `devcontainer.json` format. A `devcontainer.json` file in your project tells supporting tools and services how to access or create a dev container with a well-defined tool and runtime stack.
+
+While most [dev container properties](/spec/devcontainerjson-reference) apply to any supporting tool or service, a few are specific to certain tools. Those product-specific properties and limitations are documented below.
+
+<Note>
+  For the latest list of supporting tools, see [containers.dev/supporting](https://containers.dev/supporting).
+</Note>
+
+## Editors
+
+### Visual Studio Code
+
+The [VS Code Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) lets you use a container as a full-featured development environment. You can open any folder inside (or mounted into) a container and use VS Code's full feature set, including IntelliSense, debugging, and extensions.
+
+VS Code-specific properties are placed under a `vscode` namespace inside `customizations`:
+
+```jsonc devcontainer.json theme={null}
+"customizations": {
+  // Configure properties specific to VS Code.
+  "vscode": {
+    // Set default container-specific settings.json values on container create.
+    "settings": {},
+    "extensions": []
+  }
+}
+```
+
+| Property     | Type   | Description                                                                                     |
+| ------------ | ------ | ----------------------------------------------------------------------------------------------- |
+| `extensions` | array  | Extension IDs to install inside the container when it is created. Defaults to `[]`.             |
+| `settings`   | object | Default `settings.json` values added to the container-specific settings file. Defaults to `{}`. |
+
+<Tip>
+  If you've already built a container and connected to it, run **Dev Containers: Rebuild Container** from the Command Palette to pick up any `devcontainer.json` changes.
+</Tip>
+
+#### Limitations
+
+Some properties have specific limitations in the Dev Containers extension:
+
+| Property or variable              | Type   | Description                                                        |
+| --------------------------------- | ------ | ------------------------------------------------------------------ |
+| `workspaceMount`                  | string | Not yet supported when using Clone Repository in Container Volume. |
+| `workspaceFolder`                 | string | Not yet supported when using Clone Repository in Container Volume. |
+| `${localWorkspaceFolder}`         | Any    | Not yet supported when using Clone Repository in Container Volume. |
+| `${localWorkspaceFolderBasename}` | Any    | Not yet supported when using Clone Repository in Container Volume. |
+
+### Visual Studio
+
+Visual Studio added dev container support in Visual Studio 2022 17.4 for C++ projects using CMake Presets. It is part of the **Linux and embedded development with C++** workload, so make sure it is selected in your VS installation. Visual Studio manages the lifecycle of dev containers as you work, treating them as remote targets in a similar way to other Linux or WSL targets.
+
+See the [announcement blog post](https://devblogs.microsoft.com/cppblog/dev-containers-for-c-in-visual-studio/) for more details.
+
+### IntelliJ IDEA
+
+IntelliJ IDEA supports dev containers that can be run remotely via an SSH connection or locally using Docker. See the [IntelliJ IDEA documentation](https://www.jetbrains.com/help/idea/connect-to-devcontainer.html) for setup instructions.
+
+### Emacs
+
+[GNU Emacs](https://www.gnu.org/software/emacs/) supports dev containers through the community extension [devcontainer.el](https://johannes-mueller.github.io/devcontainer.el/). The extension is available through the [MELPA](https://melpa.org) package registry and can also be installed directly from [source on GitHub](https://github.com/johannes-mueller/devcontainer.el).
+
+***
+
+## Tools
+
+<CardGroup>
+  <Card title="Dev Container CLI" icon="terminal" href="https://github.com/devcontainers/cli">
+    The open-source reference CLI implementation of the Dev Container Specification. Supports Docker Compose and single-container setups.
+  </Card>
+
+  <Card title="VS Code extension CLI" icon="code" href="https://code.visualstudio.com/docs/remote/devcontainer-cli">
+    A CLI built into the VS Code Dev Containers extension. Can also be installed standalone from the command line.
+  </Card>
+
+  <Card title="Cachix devenv" icon="snowflake" href="https://devenv.sh/">
+    Automatically generates a `.devcontainer.json` file from your devenv configuration so you can use it with any Dev Container Spec-supporting tool. See the [devenv documentation](https://devenv.sh/integrations/codespaces-devcontainer/) for details.
+  </Card>
+
+  <Card title="Jetify Devbox" icon="box" href="https://www.jetify.com/devbox/">
+    A [Nix](https://nixos.org/)-based tool for creating reproducible development environments. The [Jetify VS Code extension](https://marketplace.visualstudio.com/items?itemName=jetpack-io.devbox) integrates Devbox with any Dev Container Spec-supporting tool or service.
+  </Card>
+</CardGroup>
+
+***
+
+## Cloud services
+
+### GitHub Codespaces
+
+A [codespace](https://docs.github.com/en/codespaces/overview) is a cloud-hosted development environment running on VM-based compute provided by GitHub.com, configurable from 2 to 32 cores. You can connect from the browser or locally using VS Code.
+
+GitHub Codespaces supports [VS Code properties](#visual-studio-code) when connected through the web editor or VS Code, plus a set of Codespaces-specific properties in the `codespaces` namespace.
+
+<Tip>
+  If you've already built a codespace and connected to it, run **Codespaces: Rebuild Container** from the Command Palette to pick up any `devcontainer.json` changes.
+</Tip>
+
+<Tip>
+  Codespaces automatically implements a `workspaceFolder` mount in Docker Compose scenarios.
+</Tip>
+
+#### Repository permissions
+
+To grant a codespace access to other repositories, use the `repositories` and `permissions` properties. See the [Codespaces documentation](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-repository-access-for-your-codespaces) for details.
+
+```jsonc devcontainer.json theme={null}
+"customizations": {
+  // Configure properties specific to Codespaces.
+  "codespaces": {
+    "repositories": {
+      "my_org/my_repo": {
+        "permissions": {
+          "issues": "write"
+        }
+      }
+    }
+  }
+}
+```
+
+#### Open files on startup
+
+Specify which files are opened when the codespace is created. Paths are relative to the repository root and files open in order, with the first file activated.
+
+```jsonc devcontainer.json theme={null}
+"customizations": {
+  // Configure properties specific to Codespaces.
+  "codespaces": {
+    "openFiles": [
+      "README",
+      "src/index.js"
+    ]
+  }
+}
+```
+
+#### Disable automatic configuration
+
+Codespaces performs default setup when `devcontainer.json` does not specify a `postCreateCommand`. To disable this behavior:
+
+```jsonc devcontainer.json theme={null}
+"customizations": {
+  // Configure properties specific to Codespaces.
+  "codespaces": {
+    "disableAutomaticConfiguration": true
+  }
+}
+```
+
+<Note>
+  Codespaces reads the `customizations.codespaces` and `hostRequirements` properties from `devcontainer.json`, not from image metadata.
+</Note>
+
+#### Limitations
+
+Some properties apply differently in Codespaces:
+
+| Property or variable        | Type   | Description                                                                                     |
+| --------------------------- | ------ | ----------------------------------------------------------------------------------------------- |
+| `mounts`                    | array  | Codespaces ignores `bind` mounts except for the Docker socket. Volume mounts are still allowed. |
+| `forwardPorts`              | array  | The `"host:port"` variation is not yet supported.                                               |
+| `portsAttributes`           | object | The `"host:port"` variation is not yet supported.                                               |
+| `shutdownAction`            | enum   | Does not apply to Codespaces.                                                                   |
+| `${localEnv:VARIABLE_NAME}` | Any    | The host is in the cloud rather than your local machine.                                        |
+| `customizations.codespaces` | object | Read from `devcontainer.json`, not image metadata.                                              |
+| `hostRequirements`          | object | Read from `devcontainer.json`, not image metadata.                                              |
+
+### CodeSandbox
+
+[CodeSandbox](https://codesandbox.io/) provides cloud development environments running on a microVM architecture. When you import a GitHub repository, CodeSandbox automatically provisions a dedicated environment for every branch. Using memory snapshotting, it can resume and branch an environment in under two seconds.
+
+CodeSandbox supports multiple editors: the CodeSandbox web editor, VS Code, and the CodeSandbox iOS app.
+
+### DevPod
+
+[DevPod](https://github.com/loft-sh/devpod) is a client-only tool that creates reproducible developer environments based on a `devcontainer.json` on any backend. Each environment runs in a container. Through DevPod providers, environments can be created on your local computer, a Kubernetes cluster, any reachable remote machine, or in a cloud VM.
+
+### Ona (formerly Gitpod)
+
+[Ona](https://ona.com/) (formerly Gitpod) provides secure, ephemeral development environments that run in the cloud or in your VPC, enabling humans and agents to collaborate on software projects. See the [Ona Dev Container docs](https://ona.com/docs/ona/configuration/devcontainer/overview) for details on constraints, customization, and automation options.
+
+
+# Templates distribution
+Source: https://www.mintlify.com/devcontainers/spec/ecosystem/templates-distribution
+
+Publish Dev Container Templates to an OCI registry so any supporting tool can discover and apply them.
+
+This page describes how to structure, package, version, and publish a collection of Dev Container Templates. Distribution follows the same model as [Features distribution](/ecosystem/features-distribution), using OCI registries as the primary transport mechanism.
+
+<Note>
+  Check out the [template-starter repository](https://github.com/devcontainers/template-starter) to get started quickly with a pre-configured publishing workflow.
+</Note>
+
+## Source code structure
+
+A Templates collection is stored in a single git repository. One repository can contain multiple Templates, each in its own sub-directory under `src/`. All Templates in the repository share the same namespace.
+
+<Warning>
+  Templates and Features must be placed in **separate** git repositories.
+</Warning>
+
+```text theme={null}
+.
+├── README.md
+└── src/
+    ├── dotnet/
+    │   ├── devcontainer-template.json
+    │   └── .devcontainer/
+    │       └── devcontainer.json
+    ├── docker-from-docker/
+    │   ├── devcontainer-template.json
+    │   └── .devcontainer/
+    │       ├── devcontainer.json
+    │       └── Dockerfile
+    └── go-postgres/
+        ├── devcontainer-template.json
+        └── .devcontainer/
+            ├── devcontainer.json
+            ├── docker-compose.yml
+            └── Dockerfile
+```
+
+Each sub-directory name must match the `id` field in the corresponding `devcontainer-template.json`. Any extra files placed inside a Template's sub-directory are included during packaging. Files outside a Template's sub-directory are ignored.
+
+## Versioning
+
+Each Template is independently versioned using [semver](https://semver.org/). The `version` field in `devcontainer-template.json` determines whether a Template is republished.
+
+<AccordionGroup>
+  <Accordion title="Republishing rules">
+    * If the exact `major.minor.patch` version already exists in the registry, the Template is **not** republished.
+    * Major and minor version tags (e.g. `1` and `1.2`) are always updated to point to the latest matching release.
+  </Accordion>
+
+  <Accordion title="When to bump the version">
+    Follow standard semver conventions: increment the patch version for bug fixes, minor for backward-compatible additions, and major for breaking changes.
+  </Accordion>
+</AccordionGroup>
+
+## Packaging
+
+Templates are distributed as tarballs. The tarball contains the full contents of the Template sub-directory, including `devcontainer-template.json`, `.devcontainer/devcontainer.json`, and any other included files.
+
+Tarballs are named `devcontainer-template-<id>.tgz`, where `<id>` is the Template's `id` field.
+
+A reference implementation for packaging and publishing is available as a GitHub Action:
+
+* [devcontainers/action](https://github.com/devcontainers/action) — GitHub Action for packaging and pushing Templates
+* [Dev Container Publish Action](https://github.com/marketplace/actions/dev-container-publish) — Marketplace action wrapper
+
+### devcontainer-collection.json
+
+When a collection is published, tooling auto-generates a `devcontainer-collection.json` index file and pushes it to the registry alongside the individual Templates.
+
+<ParamField type="object">
+  Metadata from the packaging tool that produced the collection.
+</ParamField>
+
+<ParamField type="object[]">
+  Array of Template metadata objects. Each entry is the full contents of one Template's `devcontainer-template.json`, merged into the top-level array.
+</ParamField>
+
+## Distribution via OCI registry
+
+An OCI registry that implements the [OCI Artifact Distribution Specification](https://github.com/opencontainers/distribution-spec) is the primary distribution mechanism. Supporting tools such as the [Dev Container CLI](https://github.com/devcontainers/cli) handle pushing and pulling automatically.
+
+### Naming convention
+
+Each packaged Template is pushed following this convention:
+
+```text theme={null}
+<registry>/<namespace>/<id>:<version>
+```
+
+The `namespace` is a unique identifier for the collection — typically `<owner>/<repo>` of the source repository. The `namespace` for a Templates collection must differ from the namespace used by any Features collection.
+
+Version tags pushed for each release: `major`, `major.minor`, `major.minor.patch`, and `latest`.
+
+### Pushing a Template
+
+The example below uses [`oras`](https://oras.land/) to illustrate how a Tool pushes a Template tarball with the required media types. Supporting tools implement this directly rather than shelling out to `oras`.
+
+```bash theme={null}
+REGISTRY=ghcr.io
+NAMESPACE=devcontainers/templates
+TEMPLATE=go
+ARTIFACT_PATH=devcontainer-template-go.tgz
+
+for VERSION in 1 1.2 1.2.3 latest
+do
+  oras push ${REGISTRY}/${NAMESPACE}/${TEMPLATE}:${VERSION} \
+    --config /dev/null:application/vnd.devcontainers \
+    ./${ARTIFACT_PATH}:application/vnd.devcontainers.layer.v1+tar
+done
+```
+
+Custom media types used:
+
+| Media type                                   | Purpose                                       |
+| -------------------------------------------- | --------------------------------------------- |
+| `application/vnd.devcontainers`              | OCI config descriptor for a Template artifact |
+| `application/vnd.devcontainers.layer.v1+tar` | Template tarball layer                        |
+
+### Pushing the collection index
+
+The `devcontainer-collection.json` index is pushed to the same registry under the bare namespace, always tagged `latest`:
+
+```bash theme={null}
+REGISTRY=ghcr.io
+NAMESPACE=devcontainers/templates
+
+oras push ${REGISTRY}/${NAMESPACE}:latest \
+  --config /dev/null:application/vnd.devcontainers \
+  ./devcontainer-collection.json:application/vnd.devcontainers.collection.layer.v1+json
+```
+
+| Media type                                               | Purpose                     |
+| -------------------------------------------------------- | --------------------------- |
+| `application/vnd.devcontainers.collection.layer.v1+json` | Collection index JSON layer |
+
+## How supporting tools apply Templates
+
+When a user selects a Template, a supporting tool:
+
+<Steps>
+  <Step title="Fetch the Template">
+    The tool resolves the OCI registry reference (`<registry>/<namespace>/<id>[:<version>]`) and downloads the tarball.
+  </Step>
+
+  <Step title="Read options">
+    The tool parses the `options` map from `devcontainer-template.json` and prompts the user for each option's value.
+  </Step>
+
+  <Step title="Resolve option values">
+    Selected values are collected into a key-value map. Default values are used for any option the user did not explicitly set.
+  </Step>
+
+  <Step title="Substitute placeholders">
+    The tool runs a string replacement over all files in the Template sub-directory, replacing every `${templateOption:optionId}` placeholder with the resolved value.
+  </Step>
+
+  <Step title="Write files to the project">
+    The modified `.devcontainer/devcontainer.json` and any other Template files are written into the project folder.
+  </Step>
+
+  <Step title="Handle optional paths">
+    For each entry in `optionalPaths`, the tool prompts the user on whether to include the file or directory, then includes or omits it accordingly.
+  </Step>
+</Steps>
+
+## Option resolution
+
+The following example walks through the full option resolution process for a `java` Template.
+
+### Template structure
+
+```text theme={null}
+java/
+├── devcontainer-template.json
+└── .devcontainer/
+    └── devcontainer.json
+```
+
+### Options declared in devcontainer-template.json
+
+```json devcontainer-template.json theme={null}
+{
+  "options": {
+    "imageVariant": {
+      "type": "string",
+      "description": "Specify version of Java.",
+      "proposals": [
+        "17-bullseye",
+        "17-buster",
+        "11-bullseye",
+        "11-buster",
+        "17",
+        "11"
+      ],
+      "default": "17-bullseye"
+    },
+    "nodeVersion": {
+      "type": "string",
+      "description": "Specify version of Node.js, or 'none' to skip Node.js installation.",
+      "proposals": [
+        "latest",
+        "16",
+        "14",
+        "10",
+        "none"
+      ],
+      "default": "latest"
+    },
+    "installMaven": {
+      "type": "boolean",
+      "description": "Install Maven, a management tool for Java.",
+      "default": "false"
+    }
+  }
+}
+```
+
+### Template devcontainer.json with placeholders
+
+```json .devcontainer/devcontainer.json (before substitution) theme={null}
+{
+  "name": "Java",
+  "image": "mcr.microsoft.com/devcontainers/java:0-${templateOption:imageVariant}",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "${templateOption:nodeVersion}",
+      "installMaven": "${templateOption:installMaven}"
+    }
+  }
+}
+```
+
+### Resolved values
+
+The user selects `17-bullseye` for `imageVariant` and accepts defaults for the remaining options:
+
+```json theme={null}
+{
+  "imageVariant": "17-bullseye",
+  "nodeVersion": "latest",
+  "installMaven": "false"
+}
+```
+
+### Final devcontainer.json after substitution
+
+```json .devcontainer/devcontainer.json (after substitution) theme={null}
+{
+  "name": "Java",
+  "image": "mcr.microsoft.com/devcontainers/java:0-17-bullseye",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "latest",
+      "installMaven": "false"
+    }
+  }
+}
+```
+
+The resolved file is dropped into the project as the starting point for containerizing it.
+
+
+# Templates overview
+Source: https://www.mintlify.com/devcontainers/spec/ecosystem/templates-overview
+
+Dev Container Templates are pre-packaged configurations that set up a complete development environment, ready to use in any supporting tool.
+
+A **Dev Container Template** is a set of source files that encodes the configuration for a complete development environment. You can apply a Template to a new or existing project, and a [supporting tool](/ecosystem/supporting-tools) will use that configuration to build your dev container automatically.
+
+The configuration is placed in `.devcontainer/devcontainer.json` and can reference additional files within the Template — such as boilerplate code or [lifecycle scripts](https://containers.dev/implementors/json_reference/#lifecycle-scripts). Template metadata lives in a `devcontainer-template.json` file at the root of the Template folder.
+
+<CardGroup>
+  <Card title="Templates distribution" icon="upload" href="/ecosystem/templates-distribution">
+    Publish and distribute your own Templates using OCI registries.
+  </Card>
+
+  <Card title="Features overview" icon="puzzle-piece" href="/ecosystem/features-overview">
+    Add individual tools and runtimes on top of any Template.
+  </Card>
+</CardGroup>
+
+## Folder structure
+
+A Template is a folder containing at least a `devcontainer-template.json` metadata file and a `.devcontainer/devcontainer.json` configuration file. Additional files are permitted and are packaged alongside the required files.
+
+```text theme={null}
+template/
+├── devcontainer-template.json
+├── .devcontainer/
+│   ├── devcontainer.json
+│   └── (other files)
+└── (other files)
+```
+
+## devcontainer-template.json properties
+
+The `devcontainer-template.json` file defines Template metadata consumed by supporting tools.
+
+<ParamField type="string">
+  Unique identifier for the Template within its repository or published package. Must match the name of the directory where `devcontainer-template.json` resides.
+</ParamField>
+
+<ParamField type="string">
+  Semantic version of the Template (e.g. `1.2.3`).
+</ParamField>
+
+<ParamField type="string">
+  Human-readable name for the Template.
+</ParamField>
+
+<ParamField type="string">
+  Short description of what the Template provides.
+</ParamField>
+
+<ParamField type="string">
+  URL pointing to the Template's documentation.
+</ParamField>
+
+<ParamField type="string">
+  URL pointing to the Template's license.
+</ParamField>
+
+<ParamField type="object">
+  A map of option IDs to their configuration. Supporting tools use these to prompt users for configuration choices, then substitute selected values into the Template files before applying them. See [the `options` property](#the-options-property) for details.
+</ParamField>
+
+<ParamField type="string[]">
+  Languages and platforms supported by the Template (e.g. `["Java", "Maven"]`).
+</ParamField>
+
+<ParamField type="string">
+  Name of the publisher or maintainer.
+</ParamField>
+
+<ParamField type="string[]">
+  Search terms that help users discover this Template.
+</ParamField>
+
+<ParamField type="string[]">
+  Files or directories that tooling may offer to include or exclude when applying the Template. See [the `optionalPaths` property](#the-optionalpaths-property) for details.
+</ParamField>
+
+## The `options` property
+
+The `options` property is a map of option IDs to their configuration objects. When a user applies a Template, supporting tools read these options and prompt the user to choose values. The selected values are then substituted into all files within the Template sub-directory before the files are dropped into the project.
+
+Reference an option value in any file using the `${templateOption:optionId}` syntax.
+
+```json devcontainer-template.json (options example) theme={null}
+{
+  "options": {
+    "optionId": {
+      "type": "string",
+      "description": "Description of the option",
+      "proposals": ["value1", "value2"],
+      "default": "value1"
+    }
+  }
+}
+```
+
+<Note>Option IDs must be unique within a single `devcontainer-template.json`.</Note>
+
+Each option entry supports the following fields:
+
+<ParamField type="string">
+  Data type of the option. Valid values: `string`, `boolean`.
+</ParamField>
+
+<ParamField type="string">
+  Human-readable description shown to the user when prompted.
+</ParamField>
+
+<ParamField type="string[]">
+  A list of suggested values. Free-form values are allowed. Omit when using `enum`.
+</ParamField>
+
+<ParamField type="string[]">
+  A strict list of allowed values. Free-form values are not allowed. Omit when using `proposals`.
+</ParamField>
+
+<ParamField type="string">
+  Default value used if the user does not select one.
+</ParamField>
+
+### Option substitution in files
+
+Any file within the Template sub-directory can reference option values using `${templateOption:optionId}`. The supporting tool replaces these placeholders with the user's selected values before writing the files to the project.
+
+The following example shows a `.devcontainer/devcontainer.json` that uses three Template options:
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Java",
+  "image": "mcr.microsoft.com/devcontainers/java:0-${templateOption:imageVariant}",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "${templateOption:nodeVersion}",
+      "installMaven": "${templateOption:installMaven}"
+    }
+  }
+}
+```
+
+After the user selects values, a supporting tool produces the final file with all placeholders replaced. See [option resolution](/ecosystem/templates-distribution#option-resolution) for a complete walkthrough.
+
+## The `optionalPaths` property
+
+Before applying a Template, supporting tools inspect `optionalPaths` and prompt the user on whether to include each listed file or directory. All paths are relative to the root of the Template source directory.
+
+* **Single file**: provide the full relative path without leading or trailing delimiters.
+* **Directory**: provide the full relative path with a trailing `/*`. The directory and all its descendants are recursively included or excluded.
+
+```jsonc devcontainer-template.json (optionalPaths example) theme={null}
+{
+  "id": "cpp",
+  "version": "3.0.0",
+  "name": "C++",
+  "description": "Develop C++ applications",
+  "optionalPaths": [
+    "GETTING-STARTED.md",                 // single file
+    "example-project-1/MyProject.csproj", // single file in nested directory
+    ".github/*"                           // entire recursive contents of directory
+  ]
+}
+```
+
+## Referencing a Template
+
+Templates are identified and distributed using an OCI registry path in the format:
+
+```text theme={null}
+<oci-registry>/<namespace>/<template>[:<semantic-version>]
+```
+
+Examples:
+
+```text theme={null}
+ghcr.io/user/repo/go
+ghcr.io/user/repo/go:1
+ghcr.io/user/repo/go:latest
+```
+
+The registry must implement the [OCI Artifact Distribution Specification](https://github.com/opencontainers/distribution-spec). Supporting tools use this ID to locate and download the Template tarball.
+
+## Versioning
+
+Each Template is independently versioned using [semver](https://semver.org/). Update the `version` field in `devcontainer-template.json` to publish a new release.
+
+<Tip>
+  Tooling will not republish a Template if the exact version already exists in the registry, but it will republish major and minor version tags to keep them up to date.
+</Tip>
+
+
+# Introduction
+Source: https://www.mintlify.com/devcontainers/spec/introduction
+
+Learn what development containers are, how the specification works, and why dev containers improve consistency across tools and teams.
+
+A **development container** lets you use a container as a full-featured development environment. It can run an application, separate tools and runtimes needed for a codebase, and aid in continuous integration and testing — all from a single, portable configuration file.
+
+The Development Container Specification defines a structured, open format for that configuration. Any tool or service that implements the spec can read the same file and produce a consistent, reproducible environment.
+
+## What is a dev container?
+
+A dev container is a container in which a user can develop an application. The container holds the execution environment the application needs — runtimes, libraries, language servers, debuggers — exactly as defined, every time.
+
+Unlike a production container, a dev container is intentionally enriched with development-specific tooling. You may not want those tools in a deployment image, and you may need different secrets or settings during development. Dev containers let you draw that boundary explicitly.
+
+<Note>
+  The specification does not replace container orchestration formats like Docker Compose. Instead, it enriches them with development-specific metadata while still supporting a simplified, un-orchestrated single-container option.
+</Note>
+
+## Why use dev containers?
+
+<CardGroup>
+  <Card title="Consistency" icon="check-double">
+    Every developer on a team gets the same tools, runtimes, and settings. Environment-specific bugs caused by "works on my machine" differences are eliminated.
+  </Card>
+
+  <Card title="Reproducibility" icon="rotate">
+    Containers are created from a declared configuration. Rebuilding produces the same environment. Onboarding a new developer takes minutes, not days.
+  </Card>
+
+  <Card title="Team onboarding" icon="users">
+    New contributors open the repository, open the container, and start working. No manual setup guides, no missing dependencies, no version mismatches.
+  </Card>
+
+  <Card title="CI/CD reuse" icon="arrows-rotate">
+    The same dev container configuration works in GitHub Actions and Azure DevOps via the [devcontainers/ci](https://github.com/devcontainers/ci) project, so local development and CI use identical environments.
+  </Card>
+</CardGroup>
+
+## How the spec works
+
+The specification defines a metadata format — primarily expressed as a `devcontainer.json` file — that tools use to create and configure a development container.
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Node.js",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "postCreateCommand": "npm install",
+  "customizations": {
+    "vscode": {
+      "extensions": ["dbaeumer.vscode-eslint"]
+    }
+  }
+}
+```
+
+A supporting tool reads this file, pulls or builds the image, applies features and lifecycle commands, and connects you to the running container.
+
+### Where devcontainer.json lives
+
+Tools search for a `devcontainer.json` file in the following locations within a project, in order of precedence:
+
+1. `.devcontainer/devcontainer.json`
+2. `.devcontainer.json`
+3. `.devcontainer/<folder>/devcontainer.json` (one level deep, for multi-configuration projects)
+
+<Tip>
+  The project workspace folder — where tools begin searching — is typically the root of the git repository (the directory containing `.git`).
+</Tip>
+
+## Containers and supporting tools
+
+The specification defines the metadata format. Separate tools and services implement it. This separation means you can write one `devcontainer.json` and use it with VS Code, GitHub Codespaces, JetBrains IDEs, and any other supporting tool — without changing the file.
+
+<CardGroup>
+  <Card title="Supporting tools" icon="toolbox" href="/ecosystem/supporting-tools">
+    See the full list of editors and services that implement the spec.
+  </Card>
+
+  <Card title="Dev Container CLI" icon="terminal" href="/ecosystem/supporting-tools">
+    The open-source CLI reference implementation lets you use dev containers directly from the command line or integrate the spec into your own tooling.
+  </Card>
+</CardGroup>
+
+Tool-specific behavior — such as VS Code extensions or Codespaces permissions — is isolated inside a `customizations` object, keeping the core configuration portable.
+
+```jsonc theme={null}
+"customizations": {
+  // Configure properties specific to VS Code.
+  "vscode": {
+    "settings": {},
+    "extensions": []
+  }
+}
+```
+
+## Specification components
+
+The spec is composed of several interconnected parts.
+
+### devcontainer.json
+
+The primary configuration format. A JSON with Comments (jsonc) file that describes the container image or build context, lifecycle commands, environment variables, mounts, forwarded ports, and tool customizations. See the [configuration reference](/spec/devcontainerjson-reference) for the full property list.
+
+### Orchestration options
+
+`devcontainer.json` supports three ways to define the container:
+
+* **Image-based**: reference a pre-built image by name
+* **Dockerfile-based**: build the container from a `Dockerfile`
+* **Docker Compose-based**: manage multiple containers with an existing Compose file
+
+See [orchestration options](/spec/orchestration) for details on each approach.
+
+### Lifecycle scripts
+
+Commands can run at each stage of the container lifecycle — during initialization, after creation, on each start, and when a tool attaches. This is how you install dependencies, run migrations, or start background services automatically.
+
+```json theme={null}
+{
+  "postCreateCommand": "npm install",
+  "postStartCommand": {
+    "server": "npm start",
+    "db": ["mysql", "-u", "root", "-p", "my database"]
+  }
+}
+```
+
+See [lifecycle scripts](/spec/lifecycle) for the full sequence.
+
+### Image metadata
+
+Dev container configuration can be embedded directly in a container image using a `devcontainer.metadata` label. This lets prebuilt images carry their own configuration, which is then merged with any local `devcontainer.json` at container creation time.
+
+```json theme={null}
+[
+  {
+    "postCreateCommand": "npm install",
+    "customizations": {}
+  }
+]
+```
+
+See [image metadata](/spec/image-metadata) for the merge logic and supported properties.
+
+### Features
+
+Features are self-contained, shareable units of installation code that add tools, runtimes, or libraries to a dev container. Add a Feature to any container with a single line in `devcontainer.json`:
+
+```json theme={null}
+"features": {
+  "ghcr.io/devcontainers/features/github-cli:1": {}
+}
+```
+
+<CardGroup>
+  <Card title="Features overview" icon="puzzle-piece" href="/ecosystem/features-overview">
+    Understand how Features work and how to use them.
+  </Card>
+
+  <Card title="Features reference" icon="file-lines" href="/ecosystem/features-reference">
+    Full reference for the devcontainer-feature.json format.
+  </Card>
+
+  <Card title="Authoring Features" icon="pen" href="/ecosystem/authoring-features">
+    Create and publish your own Features.
+  </Card>
+
+  <Card title="Features distribution" icon="upload" href="/ecosystem/features-distribution">
+    How Features are distributed via OCI registries.
+  </Card>
+</CardGroup>
+
+### Templates
+
+Templates are pre-built, ready-to-use dev container configurations for popular stacks. They provide a complete starting point — including a `devcontainer.json` and often a `Dockerfile` — so you don't have to build from scratch.
+
+<CardGroup>
+  <Card title="Templates overview" icon="copy" href="/ecosystem/templates-overview">
+    Browse and use community-maintained Templates.
+  </Card>
+
+  <Card title="Authoring Templates" icon="pen" href="/ecosystem/authoring-templates">
+    Publish your own Templates for others to use.
+  </Card>
+</CardGroup>
+
+## Next steps
+
+<CardGroup>
+  <Card title="Quickstart" icon="rocket" href="/quickstart">
+    Create your first devcontainer.json and open it in a supported tool.
+  </Card>
+
+  <Card title="Configuration reference" icon="sliders" href="/spec/devcontainerjson-reference">
+    Explore every property available in devcontainer.json.
+  </Card>
+
+  <Card title="Core concepts" icon="layer-group" href="/spec/devcontainer-reference">
+    Understand environments, metadata, orchestration, and lifecycle in depth.
+  </Card>
+
+  <Card title="Supporting tools" icon="toolbox" href="/ecosystem/supporting-tools">
+    See which editors and services implement the spec today.
+  </Card>
+</CardGroup>
+
+
+# Quickstart
+Source: https://www.mintlify.com/devcontainers/spec/quickstart
+
+Create your first devcontainer.json, open it in a supporting tool, and start developing inside a container in minutes.
+
+This guide walks you through creating a dev container from scratch using an image-based configuration — the simplest way to get started. By the end you will have a running containerized development environment and know the common ways to extend it.
+
+## Prerequisites
+
+<Steps>
+  <Step title="Install Docker">
+    Dev containers run on Docker. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) for macOS or Windows, or Docker Engine on Linux.
+
+    Verify your installation:
+
+    ```bash theme={null}
+    docker --version
+    ```
+  </Step>
+
+  <Step title="Install a supporting tool">
+    You need a tool that implements the Dev Container Specification to build and open your container.
+
+    <Tabs>
+      <Tab title="VS Code Dev Containers">
+        1. Install [Visual Studio Code](https://code.visualstudio.com/).
+        2. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) (`ms-vscode-remote.remote-containers`).
+
+        <Note>
+          The Dev Containers extension requires Docker Desktop (or Docker Engine on Linux) to be running before you open a container.
+        </Note>
+      </Tab>
+
+      <Tab title="GitHub Codespaces">
+        [GitHub Codespaces](https://docs.github.com/en/codespaces/overview) runs dev containers hosted in the cloud. No local Docker installation is required — push your `devcontainer.json` to a GitHub repository and open a codespace from the repository page.
+      </Tab>
+
+      <Tab title="Dev Container CLI">
+        The open-source CLI reference implementation works independently of any editor.
+
+        ```bash theme={null}
+        npm install -g @devcontainers/cli
+        ```
+
+        Verify the installation:
+
+        ```bash theme={null}
+        devcontainer --version
+        ```
+      </Tab>
+    </Tabs>
+  </Step>
+</Steps>
+
+## Create your first dev container
+
+<Steps>
+  <Step title="Create the configuration file">
+    In the root of your project, create a `.devcontainer` directory and add a `devcontainer.json` file:
+
+    ```bash theme={null}
+    mkdir .devcontainer
+    ```
+
+    Create `.devcontainer/devcontainer.json` with the following content:
+
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "name": "Node.js",
+      "image": "mcr.microsoft.com/devcontainers/javascript-node:22"
+    }
+    ```
+
+    This is the minimal image-based configuration. The `image` property is the only required field — it names a container image that Docker can pull. The `name` property is optional but helps identify the container in your tool's UI.
+
+    <Tip>
+      The [Microsoft Container Registry](https://mcr.microsoft.com/) hosts a set of pre-built dev container images for popular runtimes. You can also use any image from Docker Hub, GitHub Container Registry, or any other accessible registry.
+    </Tip>
+  </Step>
+
+  <Step title="Open the container">
+    <Tabs>
+      <Tab title="VS Code Dev Containers">
+        1. Open your project folder in VS Code.
+        2. VS Code detects the `.devcontainer/devcontainer.json` file and shows a notification: **Reopen in Container**.
+        3. Click **Reopen in Container**, or open the Command Palette (`F1`) and run **Dev Containers: Reopen in Container**.
+
+        VS Code builds the container image (if needed), starts the container, and reconnects your editor inside it. The first open may take a minute while the image is pulled.
+
+        <Note>
+          If you've already built the container and connected to it, run **Dev Containers: Rebuild Container** from the Command Palette to pick up any changes to your `devcontainer.json`.
+        </Note>
+      </Tab>
+
+      <Tab title="GitHub Codespaces">
+        1. Push your project (including `.devcontainer/devcontainer.json`) to a GitHub repository.
+        2. On the repository page, click **Code** → **Codespaces** → **Create codespace on main** (or your branch).
+
+        GitHub builds the dev container and opens a browser-based editor connected to it. You can also connect your local VS Code to the codespace from the same menu.
+
+        <Note>
+          If you've already built a codespace and connected to it, run **Codespaces: Rebuild Container** from the Command Palette to pick up any changes you make.
+        </Note>
+      </Tab>
+
+      <Tab title="Dev Container CLI">
+        From your project root, run:
+
+        ```bash theme={null}
+        devcontainer up --workspace-folder .
+        ```
+
+        This builds the image, starts the container, and mounts your workspace. To open a shell inside the running container:
+
+        ```bash theme={null}
+        devcontainer exec --workspace-folder . bash
+        ```
+      </Tab>
+    </Tabs>
+  </Step>
+
+  <Step title="Verify the environment">
+    Once connected, open a terminal inside the container and confirm the runtime is available:
+
+    ```bash theme={null}
+    node --version
+    npm --version
+    ```
+
+    Your project files are mounted inside the container at `/workspaces/<project-name>` by default. Any edits you make — inside the container or on your host — are reflected immediately.
+
+    <Tip>
+      Source code is stored outside the container so your in-flight edits are preserved even if you rebuild or recreate the container.
+    </Tip>
+  </Step>
+</Steps>
+
+## Common next steps
+
+Once your basic container is running, you can extend it in several ways.
+
+### Add Features
+
+Features are self-contained units that install tools or runtimes into your container. Add them to `devcontainer.json` under the `features` key:
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Node.js",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  }
+}
+```
+
+Rebuild the container after adding Features to apply them. Browse available Features at [containers.dev/features](https://containers.dev/features).
+
+### Add lifecycle scripts
+
+Run commands automatically at different points in the container lifecycle:
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Node.js",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+  "postCreateCommand": "npm install",
+  "postStartCommand": "npm run dev"
+}
+```
+
+| Property               | When it runs                                                                 |
+| ---------------------- | ---------------------------------------------------------------------------- |
+| `onCreateCommand`      | Once, immediately after the container is created for the first time          |
+| `updateContentCommand` | After `onCreateCommand`, when new content is available in the source tree    |
+| `postCreateCommand`    | Once, after `updateContentCommand`, when the container is assigned to a user |
+| `postStartCommand`     | Each time the container starts                                               |
+| `postAttachCommand`    | Each time a tool connects to the container                                   |
+
+To run commands in parallel, use the object form:
+
+```json theme={null}
+{
+  "postCreateCommand": {
+    "server": "npm start",
+    "db": ["mysql", "-u", "root", "-p", "my database"]
+  }
+}
+```
+
+See [lifecycle scripts](/spec/lifecycle) for the complete reference.
+
+### Add tool customizations
+
+Configure editor-specific settings inside the `customizations` object. For VS Code, you can pre-install extensions and set default settings:
+
+```jsonc .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Node.js",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+  "postCreateCommand": "npm install",
+  "customizations": {
+    // Configure properties specific to VS Code.
+    "vscode": {
+      // Set *default* container specific settings.json values on container create.
+      "settings": {},
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ]
+    }
+  }
+}
+```
+
+Customizations are tool-specific and ignored by tools that do not implement them. This keeps your `devcontainer.json` portable.
+
+### Forward ports
+
+If your application listens on a port inside the container, use `forwardPorts` to make it accessible from your local machine:
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Node.js",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+  "forwardPorts": [3000]
+}
+```
+
+### Use environment variables
+
+Set environment variables for the container with `containerEnv`, or for the tool and its processes with `remoteEnv`:
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "name": "Node.js",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+  "containerEnv": {
+    "MY_VARIABLE": "${localEnv:MY_VARIABLE}"
+  }
+}
+```
+
+The `${localEnv:VARIABLE_NAME}` syntax reads a value from your host machine's environment and passes it into the container. See [variables](/spec/variables) for all supported variable expressions.
+
+<Warning>
+  `containerEnv` variables are static for the life of the container. You must rebuild the container to update their values. Use `remoteEnv` for values that may change without a rebuild.
+</Warning>
+
+## What to explore next
+
+<CardGroup>
+  <Card title="Configuration reference" icon="sliders" href="/spec/devcontainerjson-reference">
+    Every property available in devcontainer.json, with types and descriptions.
+  </Card>
+
+  <Card title="Lifecycle scripts" icon="timeline" href="/spec/lifecycle">
+    Full reference for all lifecycle hooks and their execution order.
+  </Card>
+
+  <Card title="Features overview" icon="puzzle-piece" href="/ecosystem/features-overview">
+    Learn how Features work and how to find ones for your stack.
+  </Card>
+
+  <Card title="Orchestration options" icon="network-wired" href="/spec/orchestration">
+    Use a Dockerfile or Docker Compose instead of a plain image.
+  </Card>
+
+  <Card title="Image metadata" icon="tag" href="/spec/image-metadata">
+    Embed dev container config into prebuilt images.
+  </Card>
+
+  <Card title="Supporting tools" icon="toolbox" href="/ecosystem/supporting-tools">
+    All editors and services that implement the spec.
+  </Card>
+</CardGroup>
+
+
+# The devcontainerId variable
+Source: https://www.mintlify.com/devcontainers/spec/spec/devcontainer-id-variable
+
+Use ${devcontainerId} to reference a stable, unique identifier for a dev container — useful for scoping named volumes and other resources to a specific container.
+
+The `${devcontainerId}` variable gives you a stable, unique identifier for a dev container that persists across rebuilds. You can use it in `devcontainer.json` properties and in Feature metadata wherever you need to tie a resource — such as a named Docker volume — to a specific container instance.
+
+## What it solves
+
+Without a stable identifier, Features and configurations have no reliable way to name resources that belong to a single dev container. For example, the `docker-in-docker` Feature needs to mount a volume at `/var/lib/docker`. If multiple dev containers share the same Docker host, they must each get their own volume — but there is no static name that distinguishes one container from another across rebuilds.
+
+`${devcontainerId}` solves this by providing a value that is:
+
+* **Unique** among all dev containers on the same Docker host.
+* **Stable** across rebuilds of the same dev container.
+* **Alphanumeric only** — safe to embed in volume names, labels, and other identifiers.
+
+## Where you can use it
+
+`${devcontainerId}` is a substitution variable, not a build-time value. It must only appear in properties that are evaluated at container runtime, **not** in image build configuration. Using it in build-time properties would prevent image pre-building because the ID is not known until the container is created.
+
+### Supported properties in `devcontainer.json`
+
+`name`, `runArgs`, `initializeCommand`, `onCreateCommand`, `updateContentCommand`, `postCreateCommand`, `postStartCommand`, `postAttachCommand`, `workspaceFolder`, `workspaceMount`, `mounts`, `containerEnv`, `remoteEnv`, `containerUser`, `remoteUser`, `customizations`
+
+### Supported properties in Feature metadata (`devcontainer-feature.json`)
+
+`entrypoint`, `mounts`, `customizations`
+
+<Warning>
+  Do not use `${devcontainerId}` in Dockerfile build arguments or image build options. The identifier is unknown at image build time and cannot be resolved.
+</Warning>
+
+## Usage example
+
+The [`ghcr.io/devcontainers/features/docker-in-docker`](https://github.com/devcontainers/features/blob/main/src/docker-in-docker/devcontainer-feature.json) Feature uses `${devcontainerId}` to scope its Docker-in-Docker data volume to the specific container it is installed into:
+
+```jsonc devcontainer-feature.json theme={null}
+{
+  "id": "docker-in-docker",
+  "version": "1.0.4",
+  "mounts": [
+    {
+      "source": "dind-var-lib-docker-${devcontainerId}",
+      "target": "/var/lib/docker",
+      "type": "volume"
+    }
+  ]
+}
+```
+
+Each dev container gets its own `dind-var-lib-docker-<id>` volume. Rebuilding the container reuses the same volume because the ID remains stable.
+
+You can use the variable in `devcontainer.json` in the same way:
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "mounts": [
+    {
+      "source": "myproject-cache-${devcontainerId}",
+      "target": "/home/vscode/.cache",
+      "type": "volume"
+    }
+  ]
+}
+```
+
+## Label-based implementation
+
+Implementations may choose their own strategy for computing the identifier, but must guarantee uniqueness and stability. A recommended label-based approach is described below.
+
+### Concept
+
+A dev container is identified on its Docker host by a set of labels attached to the container. For a locally-opened folder, this might be a single label:
+
+```
+devcontainer.local_folder = /home/user/myproject
+```
+
+The identifier is derived by hashing this label set in a deterministic way.
+
+### Computation algorithm
+
+<Steps>
+  <Step title="Serialize the labels">
+    Represent the identifying labels as a JSON object. Sort the object keys alphabetically and remove any optional whitespace outside of keys and values. This ensures all implementations produce the same string for the same label set.
+
+    ```json theme={null}
+    {"devcontainer.local_folder":"/home/user/myproject"}
+    ```
+  </Step>
+
+  <Step title="Compute a SHA-256 hash">
+    Hash the UTF-8 encoded JSON string using SHA-256.
+  </Step>
+
+  <Step title="Encode the result">
+    Convert the hash to a base-32 representation. Left-pad with `'0'` characters to a total length of 52 characters.
+  </Step>
+</Steps>
+
+The result is a 52-character alphanumeric string that is safe to use in Docker resource names.
+
+### JavaScript reference implementation
+
+```javascript theme={null}
+const crypto = require('crypto');
+
+function uniqueIdForLabels(idLabels) {
+  // Sort properties to ensure deterministic serialization
+  const stringInput = JSON.stringify(idLabels, Object.keys(idLabels).sort());
+  const bufferInput = Buffer.from(stringInput, 'utf-8');
+
+  const hash = crypto.createHash('sha256')
+    .update(bufferInput)
+    .digest();
+
+  const uniqueId = BigInt(`0x${hash.toString('hex')}`)
+    .toString(32)
+    .padStart(52, '0');
+
+  return uniqueId;
+}
+```
+
+**Input:** an object whose keys are label names and whose values are label values.\
+**Output:** a 52-character base-32 string.
+
+<Info>
+  Implementations are free to use a different approach as long as the result is unique per dev container on the Docker host, stable across rebuilds, and contains only alphanumeric characters.
+</Info>
+
+## Related variables
+
+`${devcontainerId}` is one of several pre-defined variables available in `devcontainer.json`. See the [variables reference](/spec/variables) for the full list, including `${localEnv:VARIABLE_NAME}`, `${containerEnv:VARIABLE_NAME}`, and workspace folder variables.
+
+
+# Dev Container reference
+Source: https://www.mintlify.com/devcontainers/spec/spec/devcontainer-reference
+
+Core concepts of the Dev Container Specification: what development containers are, how metadata is structured, environment variables, mounts, and users.
+
+A **development container** is a container in which a user can develop an application. The purpose of the **Dev Container Specification** is to provide a way to enrich containers with the content and metadata necessary to enable development inside them. These container environments should be easy to use, create, and recreate.
+
+An **environment** is a logical instance of one or more development containers, along with any needed sidecar containers. An environment is based on one set of metadata that can be managed as a single unit. You can create multiple environments from the same configuration metadata for different purposes.
+
+## Metadata
+
+Development containers let you define a repeatable development environment for a user or team that includes the execution environment the application needs. A development container defines an environment in which you develop your application before you are ready to deploy.
+
+Working inside a development container can require additional **metadata** to drive tooling or service experiences beyond what a production container needs. Providing a structured and consistent form for this metadata is a core part of this specification.
+
+### devcontainer.json
+
+Metadata is stored in a JSON with Comments file called `devcontainer.json`. Tools using it should expect to find the file in one of the following locations, in order of precedence:
+
+<Steps>
+  <Step title=".devcontainer/devcontainer.json">
+    The most common location, inside a `.devcontainer` folder at the root of your project.
+  </Step>
+
+  <Step title=".devcontainer.json">
+    A single file at the project root, without a dedicated folder.
+  </Step>
+
+  <Step title=".devcontainer/<folder>/devcontainer.json">
+    A sub-folder one level deep inside `.devcontainer`, allowing multiple configurations in a single repository.
+  </Step>
+</Steps>
+
+<Note>
+  These files may exist in more than one location. Consider providing a mechanism for users to select one when appropriate.
+</Note>
+
+### Image metadata label
+
+Certain dev container metadata properties can also be stored in an image as a `devcontainer.metadata` label. This lets them be embedded in prebuilt images so the image and its configuration are self-contained. The label value is a JSON string representing an array of metadata snippets — one entry per [Dev Container Feature](https://containers.dev/features) and `devcontainer.json`:
+
+```json theme={null}
+[
+  {
+    "id": "ghcr.io/devcontainers/features/node:1",
+    "init": false,
+    "privileged": false,
+    "capAdd": [],
+    "securityOpt": [],
+    "entrypoint": "",
+    "mounts": [],
+    "customizations": {}
+  }
+]
+```
+
+Using an array allows subsequent image builds to append changes rather than merge at build time, which improves compatibility with arbitrary image build systems.
+
+#### Merge logic
+
+When a container is created, image label metadata is merged with any local `devcontainer.json` contents using the following rules:
+
+| Property               | Type                           | Merge logic                                                    |
+| ---------------------- | ------------------------------ | -------------------------------------------------------------- |
+| `id`                   | `string`                       | Not merged.                                                    |
+| `init`                 | `boolean`                      | `true` if at least one is `true`.                              |
+| `privileged`           | `boolean`                      | `true` if at least one is `true`.                              |
+| `capAdd`               | `string[]`                     | Union of all arrays without duplicates.                        |
+| `securityOpt`          | `string[]`                     | Union of all arrays without duplicates.                        |
+| `entrypoint`           | `string`                       | Collected list of all entrypoints.                             |
+| `mounts`               | `(string \| object)[]`         | Collected list. Last source wins on conflicts.                 |
+| `onCreateCommand`      | `string \| string[] \| object` | Collected list of all commands.                                |
+| `updateContentCommand` | `string \| string[] \| object` | Collected list of all commands.                                |
+| `postCreateCommand`    | `string \| string[] \| object` | Collected list of all commands.                                |
+| `postStartCommand`     | `string \| string[] \| object` | Collected list of all commands.                                |
+| `postAttachCommand`    | `string \| string[] \| object` | Collected list of all commands.                                |
+| `waitFor`              | enum                           | Last value wins.                                               |
+| `customizations`       | object                         | Merging is left to tools.                                      |
+| `containerUser`        | `string`                       | Last value wins.                                               |
+| `remoteUser`           | `string`                       | Last value wins.                                               |
+| `userEnvProbe`         | `string`                       | Last value wins.                                               |
+| `remoteEnv`            | object                         | Per variable, last value wins.                                 |
+| `containerEnv`         | object                         | Per variable, last value wins.                                 |
+| `overrideCommand`      | `boolean`                      | Last value wins.                                               |
+| `portsAttributes`      | map                            | Per port (not per port attribute), last value wins.            |
+| `otherPortsAttributes` | object                         | Last value wins (not per port attribute).                      |
+| `forwardPorts`         | `(number \| string)[]`         | Union without duplicates. Last one wins when mapping changes.  |
+| `shutdownAction`       | `string`                       | Last value wins.                                               |
+| `updateRemoteUserUID`  | `boolean`                      | Last value wins.                                               |
+| `hostRequirements`     | object                         | Max value wins per field (`cpus`, `memory`, `storage`, `gpu`). |
+
+Variables in string values are substituted at the time the value is applied. When order matters, `devcontainer.json` is considered last.
+
+## Environment variables
+
+Environment variables can be set at different points in the dev container lifecycle. The specification supports two classes:
+
+<CardGroup>
+  <Card title="Container env vars" icon="box">
+    Set on the container itself at creation time and available throughout its entire lifecycle. Configure using `containerEnv` for image and Dockerfile scenarios, or using `env` in Docker Compose files.
+  </Card>
+
+  <Card title="Remote env vars" icon="terminal">
+    Set by the supporting tool as part of configuring the runtime environment. Configure using `remoteEnv`. These can change during the lifetime of the container and are added after the container's `ENTRYPOINT` fires.
+  </Card>
+</CardGroup>
+
+This separation lets you use information not available at image build time and simplifies updating the environment for project-specific needs without modifying an image.
+
+```json theme={null}
+{
+  "containerEnv": {
+    "MY_VARIABLE": "${localEnv:MY_VARIABLE}"
+  },
+  "remoteEnv": {
+    "PATH": "${containerEnv:PATH}:/some/other/path"
+  }
+}
+```
+
+### userEnvProbe
+
+The `userEnvProbe` property tells implementing tools to "probe" for expected environment variables using the specified type of shell. This emulates developer-expected behavior around values added to profile and rc files.
+
+| Value                   | Shell probed                                    |
+| ----------------------- | ----------------------------------------------- |
+| `none`                  | No probing.                                     |
+| `interactiveShell`      | Interactive shell (e.g., picks up `~/.bashrc`). |
+| `loginShell`            | Login shell (e.g., picks up `~/.profile`).      |
+| `loginInteractiveShell` | Both login and interactive (default).           |
+
+<Tip>
+  `userEnvProbe` does not require that shell type be used for all sub-processes. Probed variables are merged with remote environment variables for any processes the implementer injects after container creation.
+</Tip>
+
+## Mounts
+
+Mounts give containers access to the underlying host machine, let containers share data, and persist information across container lifecycles.
+
+A default **workspace mount** is always included so your source code is accessible from inside the container. Source code is stored outside the container so that in-flight edits can be recovered or a new container can be created if the existing one no longer starts.
+
+<Note>
+  The workspace mount defaults to `/workspace` inside the container. While it is often a bind mount, this is not required by the specification. Cloud environments may not have access to the same filesystem as a local machine.
+</Note>
+
+### workspaceFolder and workspaceMount
+
+| Property          | Description                                                                                                                            |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `workspaceMount`  | Overrides the default local mount point for the workspace (image and Dockerfile scenarios). Requires `workspaceFolder` to also be set. |
+| `workspaceFolder` | Sets the default folder opened inside the container. Typically the mount point or a sub-folder under it.                               |
+
+```json theme={null}
+{
+  "workspaceMount": "source=${localWorkspaceFolder}/sub-folder,target=/workspace,type=bind,consistency=cached",
+  "workspaceFolder": "/workspace"
+}
+```
+
+<Tip>
+  Setting `workspaceFolder` to a sub-folder is especially useful for monorepos where you need the `.git` folder for source control but developers work within a specific sub-project.
+</Tip>
+
+This folder should point to the root of a repository (where the `.git` folder is found) so that source control operations work correctly inside the container.
+
+## Users
+
+Users control the permissions of applications executed in containers. The specification defines two types:
+
+<CardGroup>
+  <Card title="Container user" icon="user">
+    The user for all operations that run inside the container. Set in the container image, using `containerUser` for image and Dockerfile scenarios, or using the `user` property in Docker Compose files.
+  </Card>
+
+  <Card title="Remote user" icon="user-gear">
+    The user for running lifecycle scripts and the user tools and editors use when connecting to the container. Set with `remoteUser` in all scenarios. Defaults to the container user.
+  </Card>
+</CardGroup>
+
+```json theme={null}
+{
+  "containerUser": "root",
+  "remoteUser": "vscode"
+}
+```
+
+This separation lets the container `ENTRYPOINT` execute with different permissions than the developer, and allows developers to switch users without recreating the container.
+
+### updateRemoteUserUID
+
+On Linux, if `containerUser` or `remoteUser` is specified, you can set `updateRemoteUserUID` to `true` to have the user's UID and GID updated to match the local user's UID/GID. This prevents permission problems with bind mounts.
+
+```json theme={null}
+{
+  "remoteUser": "vscode",
+  "updateRemoteUserUID": true
+}
+```
+
+<Note>
+  Implementations may skip UID/GID syncing if they do not use bind mounts on Linux, or if they use a container engine that handles this translation automatically.
+</Note>
+
+## Project workspace folder
+
+The **project workspace folder** is where an implementing tool begins searching for `devcontainer.json` files. If the target project uses git, the project workspace folder is typically the root of the git repository (the directory containing the `.git` folder).
+
+
+# devcontainer.json reference
+Source: https://www.mintlify.com/devcontainers/spec/spec/devcontainerjson-reference
+
+Complete reference for all properties available in devcontainer.json, the metadata file that configures a development container.
+
+The `devcontainer.json` file contains the metadata and settings required to configure a **development container** for a given tool and runtime stack. It can be used by [tools and services that support the dev container spec](https://containers.dev/supporting) to create a development environment that contains one or more development containers.
+
+Properties marked with 🏷️ can also be stored in the `devcontainer.metadata` container image label. See the [image metadata reference](/spec/image-metadata) for details.
+
+## General properties
+
+<AccordionGroup>
+  <Accordion title="name">
+    <ParamField type="string">
+      A display name for the dev container shown in the UI.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="forwardPorts 🏷️">
+    <ParamField type="array">
+      An array of port numbers or `"host:port"` values that should always be forwarded from inside the primary container to the local machine (including on the web).
+
+      This is most useful for forwarding ports that cannot be auto-forwarded because the related process starts before the supporting service connects, or for forwarding a service not in the primary container in Docker Compose scenarios.
+
+      ```json theme={null}
+      "forwardPorts": [3000, "db:5432"]
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="portsAttributes 🏷️">
+    <ParamField type="object">
+      Maps a port number, `"host:port"` value, range, or regular expression to a set of default options. See [port attributes](#port-attributes) for available options.
+
+      ```json theme={null}
+      "portsAttributes": {
+        "3000": { "label": "Application port" },
+        "40000-55000": { "onAutoForward": "ignore" },
+        ".+\\/server.js": { "onAutoForward": "openPreview" }
+      }
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="otherPortsAttributes 🏷️">
+    <ParamField type="object">
+      Default options for ports, port ranges, and hosts that are not configured using `portsAttributes`. See [port attributes](#port-attributes) for available options.
+
+      ```json theme={null}
+      "otherPortsAttributes": { "onAutoForward": "silent" }
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="containerEnv 🏷️">
+    <ParamField type="object">
+      A set of name-value pairs that sets or overrides environment variables for the container. Environment and [pre-defined variables](/spec/variables) may be referenced in the values.
+
+      `containerEnv` sets the variable on the Docker container itself so all processes spawned in the container have access to it. The value is static for the life of the container — you must rebuild the container to update it.
+
+      Use `remoteEnv` instead if you need to reference an existing container variable (like updating `PATH`).
+
+      ```json theme={null}
+      "containerEnv": {
+        "MY_VARIABLE": "${localEnv:MY_VARIABLE}"
+      }
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="remoteEnv 🏷️">
+    <ParamField type="object">
+      A set of name-value pairs that sets or overrides environment variables for the supporting service or tool (and sub-processes like terminals) but not the container as a whole. Environment and [pre-defined variables](/spec/variables) may be referenced in the values.
+
+      Use `remoteEnv` when the value is not static, since you can update it without rebuilding the container.
+
+      ```json theme={null}
+      "remoteEnv": {
+        "PATH": "${containerEnv:PATH}:/some/other/path"
+      }
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="remoteUser 🏷️">
+    <ParamField type="string">
+      Overrides the user that the supporting tool runs as inside the container, including sub-processes like terminals, tasks, and debugging. Does not change the user the container as a whole runs as (see `containerUser` for that).
+
+      Defaults to the user the container is running as (often `root`).
+
+      A dev container configuration inherits `remoteUser` from the base image it uses.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="containerUser 🏷️">
+    <ParamField type="string">
+      Overrides the user for all operations run inside the container. Defaults to either `root` or the last `USER` instruction in the related Dockerfile.
+
+      To use a different user only for connected tools and processes, see `remoteUser`.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="updateRemoteUserUID 🏷️">
+    <ParamField type="boolean">
+      On Linux, if `containerUser` or `remoteUser` is specified, the user's UID/GID will be updated to match the local user's UID/GID to avoid permission problems with bind mounts.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="userEnvProbe 🏷️">
+    <ParamField type="string">
+      Indicates the type of shell to use to "probe" for user environment variables to include in the supporting tool's processes.
+
+      Available values:
+
+      * `none`
+      * `interactiveShell` — includes variables from `/etc/bash.bashrc` and `~/.bashrc`
+      * `loginShell` — includes variables from `/etc/profile` and `~/.profile`
+      * `loginInteractiveShell` — includes variables from all four files (default)
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="overrideCommand 🏷️">
+    <ParamField type="boolean">
+      Tells supporting tools whether they should run `/bin/sh -c "while sleep 1000; do :; done"` when starting the container instead of the container's default command (since the container can shut down if the default command fails).
+
+      Set to `false` if the default command must run for the container to function properly.
+
+      Defaults to `true` for image/Dockerfile configurations and `false` for Docker Compose.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="shutdownAction 🏷️">
+    <ParamField type="string">
+      Indicates whether supporting tools should stop the containers when the related tool window is closed or shut down.
+
+      Available values:
+
+      * `none`
+      * `stopContainer` — default for image or Dockerfile
+      * `stopCompose` — default for Docker Compose
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="init 🏷️">
+    <ParamField type="boolean">
+      Cross-orchestrator way to indicate whether the [tini init process](https://github.com/krallin/tini) should be used to help deal with zombie processes. Passes `--init` to the container.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="privileged 🏷️">
+    <ParamField type="boolean">
+      Cross-orchestrator way to cause the container to run in privileged mode (`--privileged`). Required for things like Docker-in-Docker, but has security implications particularly when running directly on Linux.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="capAdd 🏷️">
+    <ParamField type="string[]">
+      Cross-orchestrator way to add capabilities typically disabled for a container. Most often used to add the `ptrace` capability required to debug languages like C++, Go, and Rust.
+
+      ```json theme={null}
+      "capAdd": ["SYS_PTRACE"]
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="securityOpt 🏷️">
+    <ParamField type="string[]">
+      Cross-orchestrator way to set container security options.
+
+      ```json theme={null}
+      "securityOpt": ["seccomp=unconfined"]
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="mounts 🏷️">
+    <ParamField type="string | object[]">
+      Cross-orchestrator way to add additional mounts to a container. Each value is a string that accepts the same values as the [Docker CLI `--mount` flag](https://docs.docker.com/engine/reference/commandline/run/#mount), or an object with `type`, `source`, and `target` fields.
+
+      Environment and [pre-defined variables](/spec/variables) may be referenced in the value.
+
+      ```json theme={null}
+      "mounts": [
+        {
+          "source": "dind-var-lib-docker",
+          "target": "/var/lib/docker",
+          "type": "volume"
+        }
+      ]
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="features">
+    <ParamField type="object">
+      An object of [Dev Container Feature IDs](https://containers.dev/features) and related options to be added to your primary container. Options vary by feature — see each feature's documentation for details.
+
+      ```json theme={null}
+      "features": {
+        "ghcr.io/devcontainers/features/github-cli": {},
+        "ghcr.io/devcontainers/features/node": { "version": "lts" }
+      }
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="overrideFeatureInstallOrder">
+    <ParamField type="string[]">
+      By default, Features attempt to automatically set their install order based on an `installsAfter` property within each Feature. This property lets you override the install order when needed.
+
+      Provide Feature IDs without semantic version suffixes.
+
+      ```json theme={null}
+      "overrideFeatureInstallOrder": [
+        "ghcr.io/devcontainers/features/common-utils",
+        "ghcr.io/devcontainers/features/github-cli"
+      ]
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="customizations 🏷️">
+    <ParamField type="object">
+      Product-specific properties. Each tool uses a JSON object sub-property with a unique name to group its customizations.
+
+      ```json theme={null}
+      "customizations": {
+        "vscode": {
+          "extensions": ["dbaeumer.vscode-eslint"],
+          "settings": { "editor.formatOnSave": true }
+        }
+      }
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="secrets">
+    <ParamField type="object">
+      Declares recommended secrets for this dev container. Keys must be valid Unix environment variable names (`[a-zA-Z_][a-zA-Z0-9_]*`). Each value is an object with optional metadata.
+
+      Secrets declared here are **recommendations**, not requirements. Container creation is not blocked if a secret is absent.
+
+      ```json theme={null}
+      "secrets": {
+        "CHAT_GPT_API_KEY": {
+          "description": "API key for the OpenAI ChatGPT service.",
+          "documentationUrl": "https://openai.com/api/"
+        },
+        "STABLE_DIFFUSION_API_KEY": {}
+      }
+      ```
+
+      Each secret entry accepts:
+
+      * `description` (string) — A brief description displayed to users by supporting tools.
+      * `documentationUrl` (string, URI) — URL where users can learn how to obtain the secret.
+
+      Implementations may inject declared secrets as environment variables inside the container. See [Secrets support](/spec/secrets-support) for details.
+    </ParamField>
+  </Accordion>
+</AccordionGroup>
+
+## Image and Dockerfile properties
+
+These properties apply when working without a container orchestrator, by directly referencing an image or Dockerfile.
+
+<AccordionGroup>
+  <Accordion title="image">
+    <ParamField type="string">
+      The name of an image in a container registry (Docker Hub, GitHub Container Registry, Azure Container Registry) that supporting tools should use to create the dev container.
+
+      Required when using an image directly (without a Dockerfile).
+
+      ```json theme={null}
+      "image": "mcr.microsoft.com/devcontainers/typescript-node:1-18-bullseye"
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="build.dockerfile">
+    <ParamField type="string">
+      The location of a [Dockerfile](https://docs.docker.com/engine/reference/builder/) that defines the contents of the container. The path is relative to the `devcontainer.json` file.
+
+      Required when using a Dockerfile.
+
+      ```json theme={null}
+      "build": { "dockerfile": "Dockerfile" }
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="build.context">
+    <ParamField type="string">
+      Path that the Docker build should be run from, relative to `devcontainer.json`. A value of `".."` lets you reference content in sibling directories.
+
+      ```json theme={null}
+      "build": { "dockerfile": "Dockerfile", "context": ".." }
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="build.args">
+    <ParamField type="object">
+      Name-value pairs of [Docker image build arguments](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg) to pass when building a Dockerfile. Environment and [pre-defined variables](/spec/variables) may be referenced in the values.
+
+      ```json theme={null}
+      "build": {
+        "args": {
+          "MYARG": "MYVALUE",
+          "MYARGFROMENVVAR": "${localEnv:VARIABLE_NAME}"
+        }
+      }
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="build.options">
+    <ParamField type="string[]">
+      An array of [Docker image build options](https://docs.docker.com/engine/reference/commandline/build/#options) to pass when building a Dockerfile.
+
+      ```json theme={null}
+      "build": {
+        "options": ["--add-host=host.docker.internal:host-gateway"]
+      }
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="build.target">
+    <ParamField type="string">
+      A [Docker image build target](https://docs.docker.com/engine/reference/commandline/build/#specifying-target-build-stage---target) to pass when building a Dockerfile. Used for multi-stage builds.
+
+      ```json theme={null}
+      "build": { "target": "development" }
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="build.cacheFrom">
+    <ParamField type="string | string[]">
+      One or more images to use as caches when building the image. Identifiers are passed to the `docker build` command with `--cache-from`.
+
+      ```json theme={null}
+      "build": {
+        "cacheFrom": "ghcr.io/my-org/my-image:latest"
+      }
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="appPort">
+    <ParamField type="integer | string | array">
+      A port or array of ports that should be published locally when the container is running.
+
+      <Note>
+        In most cases, use `forwardPorts` instead. Unlike `forwardPorts`, your application may need to listen on all interfaces (`0.0.0.0`) for `appPort` to be available externally.
+      </Note>
+
+      ```json theme={null}
+      "appPort": [3000, "8000:8010"]
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="workspaceMount">
+    <ParamField type="string">
+      Overrides the default local mount point for the workspace when the container is created. Requires `workspaceFolder` to also be set. Supports the same values as the [Docker CLI `--mount` flag](https://docs.docker.com/engine/reference/commandline/run/#add-bind-mounts-or-volumes-using-the---mount-flag).
+
+      Environment and [pre-defined variables](/spec/variables) may be referenced in the value.
+
+      ```json theme={null}
+      "workspaceMount": "source=${localWorkspaceFolder}/sub-folder,target=/workspace,type=bind,consistency=cached",
+      "workspaceFolder": "/workspace"
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="workspaceFolder">
+    <ParamField type="string">
+      Sets the default path that supporting tools should open when connecting to the container. Requires `workspaceMount` to also be set (for image/Dockerfile scenarios). Defaults to the automatic source code mount location.
+
+      In Docker Compose scenarios, defaults to `"/"`.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="runArgs">
+    <ParamField type="string[]">
+      An array of [Docker CLI arguments](https://docs.docker.com/engine/reference/commandline/run/) to use when running the container.
+
+      ```json theme={null}
+      "runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"]
+      ```
+
+      <Note>
+        Do not include single quotes around arguments that contain spaces. Use the array format directly:
+        `"runArgs": ["--device-cgroup-rule=my rule here"]`
+      </Note>
+    </ParamField>
+  </Accordion>
+</AccordionGroup>
+
+## Docker Compose properties
+
+These properties apply when using Docker Compose as a multi-container orchestrator.
+
+<AccordionGroup>
+  <Accordion title="dockerComposeFile">
+    <ParamField type="string | string[]">
+      Path or ordered list of paths to Docker Compose files relative to the `devcontainer.json` file. Using an array is useful when [extending your Docker Compose configuration](https://docs.docker.com/compose/extends/#multiple-compose-files). Later files can override values from earlier ones.
+
+      The default `.env` file is picked up from the project root, or you can use `env_file` in your Compose file to specify an alternate location.
+
+      ```json theme={null}
+      "dockerComposeFile": ["docker-compose.yml", "docker-compose.dev.yml"]
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="service">
+    <ParamField type="string">
+      The name of the service that supporting tools should connect to once running. This is the primary container for your dev environment.
+
+      ```json theme={null}
+      "service": "app"
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="runServices">
+    <ParamField type="string[]">
+      An array of services in your Docker Compose configuration that should be started. These will also be stopped when you disconnect unless `shutdownAction` is `"none"`. Defaults to all services.
+
+      ```json theme={null}
+      "runServices": ["app", "db", "redis"]
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="workspaceFolder (Compose)">
+    <ParamField type="string">
+      Sets the default path that supporting tools should open when connecting to the container. This is typically the path to a volume mount where source code can be found in the container.
+    </ParamField>
+  </Accordion>
+</AccordionGroup>
+
+## Lifecycle scripts
+
+Lifecycle scripts run at different points in the container's lifecycle, in the order listed. Each command property accepts a string, array, or object value.
+
+<Note>
+  If a lifecycle script fails, subsequent scripts in the sequence will not execute.
+</Note>
+
+### Command formats
+
+All lifecycle script properties accept three formats:
+
+<Tabs>
+  <Tab title="String">
+    Executed via `/bin/sh`. Use `&&` to chain commands.
+
+    ```json theme={null}
+    "postCreateCommand": "apt-get update && apt-get install -y curl"
+    ```
+  </Tab>
+
+  <Tab title="Array">
+    Invokes the command directly without a shell. Single quotes are preserved literally.
+
+    ```json theme={null}
+    "postCreateCommand": ["yarn", "install"]
+    ```
+  </Tab>
+
+  <Tab title="Object (parallel)">
+    Each key is a unique name; each value is a string or array command. All commands in the object run in parallel during that lifecycle step.
+
+    ```json theme={null}
+    "postCreateCommand": {
+      "server": "npm start",
+      "db": ["mysql", "-u", "root", "-p", "my database"]
+    }
+    ```
+  </Tab>
+</Tabs>
+
+### Script reference
+
+<AccordionGroup>
+  <Accordion title="initializeCommand">
+    <ParamField type="string | string[] | object">
+      Runs on the **host machine** during initialization, including during container creation and on subsequent starts. The command may run more than once during a given session.
+
+      <Warning>
+        This command runs wherever the source code is located on the host. For cloud services, the host is in the cloud rather than your local machine.
+      </Warning>
+
+      ```json theme={null}
+      "initializeCommand": "echo 'Initializing...' && ./scripts/check-prerequisites.sh"
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="onCreateCommand 🏷️">
+    <ParamField type="string | string[] | object">
+      The first of three commands that finalize container setup when a dev container is created. Executes **inside** the container immediately after it starts for the first time.
+
+      Cloud services can use this command when caching or prebuilding a container. It will not typically have access to user-scoped assets or secrets.
+
+      ```json theme={null}
+      "onCreateCommand": "pip install -r requirements.txt"
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="updateContentCommand 🏷️">
+    <ParamField type="string | string[] | object">
+      The second of three setup commands. Executes inside the container after `onCreateCommand` whenever new content is available in the source tree during creation.
+
+      Runs at least once. Cloud services also periodically re-run this command to refresh cached or prebuilt containers. Like `onCreateCommand`, it can only use repository and org scoped secrets or permissions.
+
+      ```json theme={null}
+      "updateContentCommand": "npm install"
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="postCreateCommand 🏷️">
+    <ParamField type="string | string[] | object">
+      The last of three setup commands. Runs after `updateContentCommand`, once the dev container has been assigned to a user for the first time.
+
+      Cloud services can use this command to take advantage of user-specific secrets and permissions.
+
+      ```json theme={null}
+      "postCreateCommand": "bash scripts/install-dev-tools.sh"
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="postStartCommand 🏷️">
+    <ParamField type="string | string[] | object">
+      Runs each time the container is successfully started.
+
+      ```json theme={null}
+      "postStartCommand": "git config --global core.autocrlf false"
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="postAttachCommand 🏷️">
+    <ParamField type="string | string[] | object">
+      Runs each time a tool has successfully attached to the container.
+
+      ```json theme={null}
+      "postAttachCommand": {
+        "welcome": "echo 'Welcome to your dev container!'",
+        "status": ["git", "status"]
+      }
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="waitFor 🏷️">
+    <ParamField type="string">
+      Specifies which lifecycle command the tool should wait for before connecting. This lets you use earlier commands for steps that must complete before the tool connects, while later commands run in the background.
+
+      Available values: `initializeCommand`, `onCreateCommand`, `updateContentCommand`, `postCreateCommand`, `postStartCommand`
+    </ParamField>
+  </Accordion>
+</AccordionGroup>
+
+## Host requirements
+
+Declare the minimum hardware requirements for the container. Cloud services use these to automatically select the best compute option; other tools display a warning if requirements are not met.
+
+<AccordionGroup>
+  <Accordion title="hostRequirements.cpus 🏷️">
+    <ParamField type="integer">
+      Minimum required number of CPUs, virtual CPUs, or cores.
+
+      ```json theme={null}
+      "hostRequirements": { "cpus": 2 }
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="hostRequirements.memory 🏷️">
+    <ParamField type="string">
+      Minimum memory requirement with a `tb`, `gb`, `mb`, or `kb` suffix.
+
+      ```json theme={null}
+      "hostRequirements": { "memory": "4gb" }
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="hostRequirements.storage 🏷️">
+    <ParamField type="string">
+      Minimum storage requirement with a `tb`, `gb`, `mb`, or `kb` suffix.
+
+      ```json theme={null}
+      "hostRequirements": { "storage": "32gb" }
+      ```
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="hostRequirements.gpu">
+    <ParamField type="boolean | string | object">
+      Indicates whether a GPU is required.
+
+      * `true` — GPU required
+      * `false` — no GPU required
+      * `"optional"` — GPU used if available
+      * Object — configure specific GPU requirements:
+        * `cores` (integer) — minimum number of GPU cores
+        * `memory` (string) — minimum GPU memory with unit suffix
+
+      ```json theme={null}
+      "hostRequirements": {
+        "gpu": {
+          "cores": 4,
+          "memory": "8gb"
+        }
+      }
+      ```
+    </ParamField>
+  </Accordion>
+</AccordionGroup>
+
+## Port attributes
+
+The `portsAttributes` and `otherPortsAttributes` properties accept an object with the following fields.
+
+<AccordionGroup>
+  <Accordion title="label 🏷️">
+    <ParamField type="string">
+      Display name for the port in the ports view.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="protocol 🏷️">
+    <ParamField type="string">
+      Controls protocol handling for forwarded ports.
+
+      * Not set — port is treated as raw TCP, supporting any protocol when forwarded to `localhost`
+      * `"http"` — same handling as not set
+      * `"https"` — ignores SSL/TLS certificates present on the port and uses the correct certificate for the forwarded URL (e.g. `https://*.githubpreview.dev`)
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="onAutoForward 🏷️">
+    <ParamField type="string">
+      Controls what happens when a port is auto-forwarded after connecting to the container.
+
+      * `notify` — shows a notification (default)
+      * `openBrowser` — opens the system's default browser
+      * `openBrowserOnce` — opens the browser only the first time in a session
+      * `openPreview` — opens the URL in the tool's embedded preview browser
+      * `silent` — forwards the port with no further action
+      * `ignore` — port is not auto-forwarded
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="requireLocalPort 🏷️">
+    <ParamField type="boolean">
+      When `false`, supporting tools silently map to a different local port if the specified one is unavailable. When `true`, you are notified if the same port cannot be used.
+    </ParamField>
+  </Accordion>
+
+  <Accordion title="elevateIfNeeded 🏷️">
+    <ParamField type="boolean">
+      Forwarding low ports (22, 80, 443) to `localhost` on the same port may require elevated permissions on certain operating systems. When `true`, the tool automatically tries to elevate its permissions in this situation.
+    </ParamField>
+  </Accordion>
+</AccordionGroup>
+
+## Publishing vs. forwarding ports
+
+Docker has the concept of **publishing** ports when the container is created. Published ports behave like ports exposed to your local network — if your application only accepts calls from `localhost`, it will reject connections from published ports just as it would for network calls.
+
+**Forwarded** ports appear as `localhost` to the application, which is why `forwardPorts` is preferred over `appPort` in most cases.
+
+## Schema
+
+The full JSON schema for `devcontainer.json` is available at [github.com/devcontainers/spec](https://github.com/devcontainers/spec/blob/main/schemas/devContainer.base.schema.json).
+
+
+# GPU host requirement
+Source: https://www.mintlify.com/devcontainers/spec/spec/gpu-host-requirement
+
+Declare GPU requirements in devcontainer.json so cloud services and local tools can provision or validate the right hardware for your container.
+
+The `hostRequirements.gpu` property extends the existing host requirements system to express whether a GPU is needed, optional, or must meet specific core and memory thresholds.
+
+## Overview
+
+`devcontainer.json` supports a `hostRequirements` object that lets you describe the minimum hardware a container needs to run properly. Cloud services use these hints to select an appropriate machine type automatically; local tools may warn the user if requirements are not satisfied.
+
+The full set of host requirement properties:
+
+| Property                   | Type                              | Description                                                 |
+| -------------------------- | --------------------------------- | ----------------------------------------------------------- |
+| `hostRequirements.cpus`    | integer                           | Minimum number of CPUs / virtual CPUs / cores.              |
+| `hostRequirements.memory`  | string                            | Minimum RAM with a `tb`, `gb`, `mb`, or `kb` suffix.        |
+| `hostRequirements.storage` | string                            | Minimum disk space with a `tb`, `gb`, `mb`, or `kb` suffix. |
+| `hostRequirements.gpu`     | boolean \| `"optional"` \| object | GPU requirement — see below.                                |
+
+## The `gpu` property
+
+The `gpu` property accepts three forms: a boolean, the string `"optional"`, or an object with fine-grained constraints.
+
+### Boolean values
+
+Set `gpu` to `true` to require a GPU, or `false` (the default) to indicate that no GPU is needed.
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "hostRequirements": {
+    "gpu": true
+  }
+}
+```
+
+### Optional GPU
+
+Use `"optional"` to indicate that a GPU will be used if one is available, but is not strictly required.
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "hostRequirements": {
+    "gpu": "optional"
+  }
+}
+```
+
+<Info>
+  Cloud services that see `"optional"` may provision a GPU-enabled machine when capacity allows, or fall back gracefully to a CPU-only machine.
+</Info>
+
+### Object with constraints
+
+Use an object to specify minimum GPU resource requirements.
+
+<ParamField type="integer">
+  Minimum number of GPU cores required. For example, `2`.
+</ParamField>
+
+<ParamField type="string">
+  Minimum GPU memory with a `tb`, `gb`, `mb`, or `kb` suffix. For example, `"8gb"`.
+</ParamField>
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "hostRequirements": {
+    "gpu": {
+      "cores": 2,
+      "memory": "8gb"
+    }
+  }
+}
+```
+
+## Example configurations
+
+<AccordionGroup>
+  <Accordion title="Machine learning workload requiring a GPU">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "image": "mcr.microsoft.com/devcontainers/python:3.11",
+      "hostRequirements": {
+        "cpus": 4,
+        "memory": "16gb",
+        "storage": "64gb",
+        "gpu": {
+          "cores": 4,
+          "memory": "16gb"
+        }
+      }
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="GPU optional — accelerated when available">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "image": "mcr.microsoft.com/devcontainers/python:3.11",
+      "hostRequirements": {
+        "cpus": 2,
+        "memory": "8gb",
+        "gpu": "optional"
+      }
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="GPU required, no specific constraints">
+    ```json .devcontainer/devcontainer.json theme={null}
+    {
+      "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+      "hostRequirements": {
+        "gpu": true
+      }
+    }
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## How tools use this property
+
+**Cloud services** (such as GitHub Codespaces) read `hostRequirements.gpu` to select an appropriate compute SKU when creating the environment. If a GPU is required, the service will provision a GPU-enabled machine. With `"optional"`, the service may choose a GPU machine when available at no extra cost, otherwise falling back to CPU-only.
+
+**Local tools** use the property for validation. If the local Docker host does not have a GPU and `gpu` is set to `true`, the tool may display a warning before proceeding.
+
+<Warning>
+  Host requirements are **hints** to the implementing tool. Enforcement behavior varies by implementation. A tool is not required to block container creation if requirements are unmet — it may only warn.
+</Warning>
+
+## Schema reference
+
+```json schema excerpt theme={null}
+"hostRequirements": {
+  "type": "object",
+  "properties": {
+    "cpus": { "type": "integer", "minimum": 1 },
+    "memory": { "type": "string", "pattern": "^\\d+([tgmk]b)?$" },
+    "storage": { "type": "string", "pattern": "^\\d+([tgmk]b)?$" },
+    "gpu": {
+      "oneOf": [
+        {
+          "type": ["boolean", "string"],
+          "enum": [true, false, "optional"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "cores": { "type": "integer", "minimum": 1 },
+            "memory": { "type": "string", "pattern": "^\\d+([tgmk]b)?$" }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+
+# Image metadata
+Source: https://www.mintlify.com/devcontainers/spec/spec/image-metadata
+
+How to store dev container configuration in prebuilt images using the devcontainer.metadata label, and how that metadata is merged at container creation time.
+
+Dev container metadata properties can be stored in a container image label named `devcontainer.metadata`. This allows prebuilt images to carry their own configuration so the image and its related settings are self-contained. When a container is created, these stored properties are merged with any local `devcontainer.json` file.
+
+## Why use image metadata
+
+Storing metadata in the image is useful when:
+
+* You maintain prebuilt images and want configuration to travel with the image
+* You are using Dev Container Features, which embed their own metadata in the image during build
+* You want to reduce repetition across multiple `devcontainer.json` files that use the same base image
+
+## The devcontainer.metadata label
+
+The metadata is stored as a `devcontainer.metadata` Docker label whose value is a JSON string. The value must be either:
+
+* An **array** of metadata snippet objects (one per Feature and one for the `devcontainer.json`)
+* A **single object** with the same properties (supported for simplicity when adding metadata from other tools)
+
+Using an array means subsequent image builds can append to it rather than merging at build time, which improves compatibility with arbitrary build systems.
+
+### Label structure
+
+```json theme={null}
+[
+  {
+    "id": "ghcr.io/devcontainers/features/node:1",
+    "init": false,
+    "privileged": false,
+    "capAdd": [],
+    "securityOpt": [],
+    "entrypoint": "/usr/local/share/docker-init.sh",
+    "mounts": [],
+    "customizations": {}
+  },
+  {
+    "onCreateCommand": "npm install",
+    "postCreateCommand": "npm run build",
+    "remoteUser": "node",
+    "containerEnv": {
+      "NODE_ENV": "development"
+    }
+  }
+]
+```
+
+### Adding the label in a Dockerfile
+
+```dockerfile theme={null}
+LABEL devcontainer.metadata='[{"onCreateCommand": "npm install", "remoteUser": "node"}]'
+```
+
+<Note>
+  The size limit on Dockerfiles is around 1.3MB, with individual line lengths limited to 65k characters. Using one line per Feature should allow full use of these limits.
+</Note>
+
+### Adding the label via command line
+
+<Warning>
+  There is no documented size limit for labels, but the Docker daemon returns an error when the request header exceeds 500kb. This limit is shared — you cannot use a second label in the same build to work around it. If this becomes an issue, consider embedding the metadata as a file in the image.
+</Warning>
+
+## Supported properties
+
+The properties that can be stored in image metadata are marked with a 🏷️ in the [devcontainer.json reference](/spec/devcontainerjson-reference). This currently includes:
+
+**From `devcontainer.json`:** `mounts`, `onCreateCommand`, `updateContentCommand`, `postCreateCommand`, `postStartCommand`, `postAttachCommand`, `customizations`, `remoteUser`, `userEnvProbe`, `remoteEnv`, `containerEnv`, `overrideCommand`, `portsAttributes`, `otherPortsAttributes`, `forwardPorts`, `shutdownAction`, `updateRemoteUserUID`, `hostRequirements`, `waitFor`, `containerUser`
+
+**From Feature metadata:** `mounts`, `init`, `privileged`, `capAdd`, `securityOpt`, `entrypoint`, `customizations`
+
+## Merge logic
+
+When a container is created, the `devcontainer.metadata` label contents are merged with the local `devcontainer.json`. The table below describes how each property is merged. The `devcontainer.json` is always considered last when order matters.
+
+| Property               | Type/Format                                  | Merge logic                                                                | devcontainer.json | devcontainer-feature.json |
+| ---------------------- | -------------------------------------------- | -------------------------------------------------------------------------- | :---------------: | :-----------------------: |
+| `id`                   | e.g. `ghcr.io/devcontainers/features/node:1` | Not merged.                                                                |                   |             ✓             |
+| `init`                 | `boolean`                                    | `true` if at least one is `true`, `false` otherwise.                       |         ✓         |             ✓             |
+| `privileged`           | `boolean`                                    | `true` if at least one is `true`, `false` otherwise.                       |         ✓         |             ✓             |
+| `capAdd`               | `string[]`                                   | Union of all arrays without duplicates.                                    |         ✓         |             ✓             |
+| `securityOpt`          | `string[]`                                   | Union of all arrays without duplicates.                                    |         ✓         |             ✓             |
+| `entrypoint`           | `string`                                     | Collected list of all entrypoints.                                         |                   |             ✓             |
+| `mounts`               | `(string \| { type, src, dst })[]`           | Collected list of all mountpoints. On conflict, last source wins.          |         ✓         |             ✓             |
+| `onCreateCommand`      | `string \| string[] \| object`               | Collected list of all values.                                              |         ✓         |             ✓             |
+| `updateContentCommand` | `string \| string[] \| object`               | Collected list of all values.                                              |         ✓         |             ✓             |
+| `postCreateCommand`    | `string \| string[] \| object`               | Collected list of all values.                                              |         ✓         |             ✓             |
+| `postStartCommand`     | `string \| string[] \| object`               | Collected list of all values.                                              |         ✓         |             ✓             |
+| `postAttachCommand`    | `string \| string[] \| object`               | Collected list of all values.                                              |         ✓         |             ✓             |
+| `waitFor`              | enum                                         | Last value wins.                                                           |         ✓         |                           |
+| `customizations`       | Object of tool-specific customizations.      | Merging is left to each tool.                                              |         ✓         |             ✓             |
+| `containerUser`        | `string`                                     | Last value wins.                                                           |         ✓         |                           |
+| `remoteUser`           | `string`                                     | Last value wins.                                                           |         ✓         |                           |
+| `userEnvProbe`         | `string` (enum)                              | Last value wins.                                                           |         ✓         |                           |
+| `remoteEnv`            | Object of strings.                           | Per variable, last value wins.                                             |         ✓         |                           |
+| `containerEnv`         | Object of strings.                           | Per variable, last value wins.                                             |         ✓         |                           |
+| `overrideCommand`      | `boolean`                                    | Last value wins.                                                           |         ✓         |                           |
+| `portsAttributes`      | Map of ports to attributes.                  | Per port (not per attribute), last value wins.                             |         ✓         |                           |
+| `otherPortsAttributes` | Port attributes.                             | Last value wins (not per attribute).                                       |         ✓         |                           |
+| `forwardPorts`         | `(number \| string)[]`                       | Union of all ports without duplicates. Last one wins when mapping changes. |         ✓         |                           |
+| `shutdownAction`       | `string` (enum)                              | Last value wins.                                                           |         ✓         |                           |
+| `updateRemoteUserUID`  | `boolean`                                    | Last value wins.                                                           |         ✓         |                           |
+| `hostRequirements`     | `cpus`, `memory`, `storage`, `gpu`           | Max value wins.                                                            |         ✓         |                           |
+
+<Tip>
+  Variables in string values are substituted at the time the value is applied, not when the image is built. This means `${localEnv:VAR}` in image metadata resolves to the host environment variable at container creation time.
+</Tip>
+
+## How Features use image metadata
+
+When a Dev Container Feature is installed into an image, the feature's metadata (capabilities, mounts, entrypoints, etc.) is appended as a new entry in the `devcontainer.metadata` label array. This allows the feature's runtime requirements to be carried with the image and applied correctly even when the image is used without a `devcontainer.json`.
+
+For example, a feature that needs `SYS_PTRACE` capability would include:
+
+```json theme={null}
+{
+  "id": "ghcr.io/devcontainers/features/go:1",
+  "capAdd": ["SYS_PTRACE"]
+}
+```
+
+When the image is later used to create a container, this entry is merged with the `devcontainer.json` (if present), and `SYS_PTRACE` is added to the capabilities regardless of what the `devcontainer.json` specifies.
+
+
+# Container lifecycle
+Source: https://www.mintlify.com/devcontainers/spec/spec/lifecycle
+
+The four phases of a dev container's lifecycle: Configuration Validation, Environment Creation, Environment Stop, and Environment Resume — including all lifecycle scripts and parallel execution.
+
+A development environment moves through distinct lifecycle phases during use. Understanding these phases helps you choose which lifecycle scripts to use and when they run.
+
+<CardGroup>
+  <Card title="Configuration validation" icon="circle-check">
+    Validates that required metadata and parameters are present before any container work begins.
+  </Card>
+
+  <Card title="Environment creation" icon="play">
+    Builds images, creates containers, and runs setup commands to produce a ready-to-use environment.
+  </Card>
+
+  <Card title="Environment stop" icon="stop">
+    Stops all containers correctly using the appropriate orchestrator-specific steps to ensure no data is lost.
+  </Card>
+
+  <Card title="Environment resume" icon="rotate-right">
+    Restarts stopped containers and re-runs start and attach commands to restore the environment.
+  </Card>
+</CardGroup>
+
+## Configuration validation
+
+Before any container work begins, the tool validates the configuration. When using a `devcontainer.json` file, the following steps occur:
+
+<Steps>
+  <Step title="Check for a workspace source folder">
+    Validate that a workspace source folder has been provided. It is up to the implementing tool to decide what to do if no source folder is provided.
+  </Step>
+
+  <Step title="Locate devcontainer.json">
+    Search for a `devcontainer.json` file in one of the [supported locations](/spec/devcontainer-reference#devcontainerjson) within the workspace source folder.
+  </Step>
+
+  <Step title="Handle missing configuration">
+    If no `devcontainer.json` is found, the implementing tool or service decides how to proceed. This specification does not dictate that behavior.
+  </Step>
+
+  <Step title="Validate required parameters">
+    Confirm that the metadata contains all parameters required for the selected configuration type (image, Dockerfile, or Docker Compose).
+  </Step>
+</Steps>
+
+## Environment creation
+
+Environment creation takes the user's configuration through several sub-phases to produce a working, ready-to-use environment.
+
+### Initialization
+
+<Steps>
+  <Step title="Validate orchestrator access">
+    Confirm access to the container orchestrator specified by the configuration.
+  </Step>
+
+  <Step title="Run initializeCommand">
+    Execute `initializeCommand` on the **host machine**. This command runs during initialization, including during container creation and on subsequent starts.
+  </Step>
+</Steps>
+
+### Image creation
+
+This phase generates the final image(s) the development containers will use. The exact work is orchestrator-dependent — it may be pulling a Docker image, running `docker build`, or `docker-compose build`.
+
+<Note>
+  Image creation is useful on its own: it produces intermediate images that can be uploaded and reused by others, cutting down on creation time. Implementing tools are encouraged to expose a command that runs only this step.
+</Note>
+
+<Steps>
+  <Step title="Configuration validation">
+    Run [Configuration Validation](#configuration-validation) as described above.
+  </Step>
+
+  <Step title="Build or pull images">
+    Pull, build, or execute the defined container orchestration format to create images.
+  </Step>
+
+  <Step title="Validate results">
+    Validate the result of the build or pull operations.
+  </Step>
+</Steps>
+
+### Container creation
+
+After image creation, containers are created from the image and configured.
+
+<Steps>
+  <Step title="UID/GID sync (optional, Linux only)">
+    If `updateRemoteUserUID` is `true` and a `containerUser` or `remoteUser` is specified, update the user's UID and GID to match the local user's before creating the container. This prevents permission problems with bind mounts.
+  </Step>
+
+  <Step title="Create containers">
+    Create the container(s) based on the specified properties. Container [mounts](/spec/devcontainer-reference#mounts), [environment variables](/spec/devcontainer-reference#environment-variables), and [user](/spec/devcontainer-reference#users) configuration are applied at this point. Remote user and environment variable configuration are **not** applied yet.
+  </Step>
+
+  <Step title="Validate containers">
+    Confirm the container(s) were created successfully.
+  </Step>
+</Steps>
+
+### Post-container creation
+
+After the container is running, a set of commands execute inside the **main** container:
+
+1. `onCreateCommand`, `updateContentCommand`, and `postCreateCommand` run in sequence the first time the container is created.
+2. By default, `postCreateCommand` executes in the background after the environment is reported as successfully created.
+3. If `waitFor` is set, execution blocks until all commands in the sequence up to the specified command have completed. `waitFor` defaults to `updateContentCommand`.
+
+Remote [environment variables](/spec/devcontainer-reference#environment-variables) and [user](/spec/devcontainer-reference#users) configuration (inclusive of `userEnvProbe`) are applied to all processes created in the container.
+
+### Implementation-specific steps
+
+After post-container creation commands complete, implementation-specific commands can safely run. Any processes required by the implementation to support other specification properties should start at this point. These may run in parallel to any non-blocking, background post-container creation commands.
+
+Any user-facing processes must have remote environment variables and user configuration applied (inclusive of `userEnvProbe`). For example, this is the point at which `devcontainer exec` commands would run in the CLI reference implementation.
+
+<Tip>
+  This is also typically when tools apply settings from the `customizations` section — for example, VS Code installs extensions listed in `customizations.vscode.extensions`.
+</Tip>
+
+## Environment stop
+
+The goal of this phase is to stop all containers correctly using the appropriate orchestrator-specific steps, ensuring no data is lost. It is up to the implementing tool or service to decide when to trigger this event.
+
+## Environment resume
+
+While it is not strictly required to keep a development container after stopping it, resuming is the most common scenario.
+
+<Steps>
+  <Step title="Restart containers">
+    Restart all related containers.
+  </Step>
+
+  <Step title="Run implementation-specific steps">
+    Follow the appropriate [implementation-specific steps](#implementation-specific-steps).
+  </Step>
+
+  <Step title="Run postStartCommand and postAttachCommand">
+    Execute `postStartCommand` and `postAttachCommand` inside the container.
+  </Step>
+</Steps>
+
+As during container creation, remote environment variables and user configuration are applied to all created processes in the container (inclusive of `userEnvProbe`).
+
+## Lifecycle scripts
+
+These command properties control what runs at each point in the container lifecycle. Each runs from the `workspaceFolder`.
+
+| Property               | Runs on          | Description                                                                                                                                                                                |
+| ---------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `initializeCommand`    | Host machine     | Runs during initialization, including on container creation and subsequent starts. May run more than once per session.                                                                     |
+| `onCreateCommand`      | Inside container | First of three setup commands. Runs once when the container is first created. Cloud services may use this when prebuilding containers.                                                     |
+| `updateContentCommand` | Inside container | Second of three setup commands. Runs after `onCreateCommand` whenever new content is available in the source tree. Cloud services run this periodically to refresh cached containers.      |
+| `postCreateCommand`    | Inside container | Third and final setup command. Runs after `updateContentCommand` once the dev container has been assigned to a user for the first time. Cloud services can use user-specific secrets here. |
+| `postStartCommand`     | Inside container | Runs each time the container starts successfully.                                                                                                                                          |
+| `postAttachCommand`    | Inside container | Runs each time a tool successfully attaches to the container.                                                                                                                              |
+| `waitFor`              | —                | Specifies which command the tool should wait for before connecting. Defaults to `updateContentCommand`.                                                                                    |
+
+<Warning>
+  If any lifecycle script fails, subsequent scripts will not execute. For example, if `postCreateCommand` fails, `postStartCommand` and later scripts are skipped.
+</Warning>
+
+### Command formats
+
+Each lifecycle script property accepts three formats:
+
+<Tabs>
+  <Tab title="String">
+    Passed to `/bin/sh` for execution. Use `&&` to chain multiple commands.
+
+    ```json theme={null}
+    {
+      "postCreateCommand": "apt-get update && apt-get install -y curl"
+    }
+    ```
+  </Tab>
+
+  <Tab title="Array">
+    Invokes the command directly without a shell. The first element is the executable; remaining elements are arguments.
+
+    ```json theme={null}
+    {
+      "postCreateCommand": ["yarn", "install"]
+    }
+    ```
+  </Tab>
+
+  <Tab title="Object (parallel)">
+    Runs multiple named commands in parallel. Each key is a unique name; each value is a string or array command.
+
+    ```json theme={null}
+    {
+      "postCreateCommand": {
+        "server": "npm start",
+        "db": ["mysql", "-u", "root", "-p", "my database"]
+      }
+    }
+    ```
+  </Tab>
+</Tabs>
+
+### Parallel execution
+
+Dev containers support running multiple commands in parallel during a single lifecycle step using the object format. Each key in the object is a unique name for the command; each value is a string or array command. All commands must exit successfully for the stage to be considered successful.
+
+```json theme={null}
+{
+  "postCreateCommand": {
+    "server": "npm start",
+    "db": ["mysql", "-u", "root", "-p", "my database"]
+  }
+}
+```
+
+Each entry in the object runs in parallel during that lifecycle step. For serial execution of multiple commands, use `;` or `&&` in a string value.
+
+### initializeCommand runs on the host
+
+<Warning>
+  `initializeCommand` runs on the **host machine**, not inside the container. For cloud services, the host is in the cloud rather than your local machine.
+</Warning>
+
+```json theme={null}
+{
+  "initializeCommand": "echo 'Starting environment setup'",
+  "onCreateCommand": "npm install",
+  "updateContentCommand": "npm run build",
+  "postCreateCommand": {
+    "lint": "npm run lint",
+    "test": "npm test"
+  },
+  "postStartCommand": "npm run dev",
+  "postAttachCommand": "echo 'Attached to container'"
+}
+```
+
+
+# Orchestration
+Source: https://www.mintlify.com/devcontainers/spec/spec/orchestration
+
+The three orchestration modes in the Dev Container Specification: image-based, Dockerfile-based, and Docker Compose-based configurations.
+
+A core principle of this specification is to enrich existing container orchestrator formats with development container metadata rather than replacing them. The metadata schema includes optional properties for interoperating with different orchestrators.
+
+The specification currently supports three orchestration modes:
+
+<CardGroup>
+  <Card title="Image-based" icon="box-archive">
+    Reference a pre-built image directly. The simplest option when you already have an image ready to use.
+  </Card>
+
+  <Card title="Dockerfile-based" icon="file-code">
+    Build your container from a `Dockerfile`. Gives full control over the image contents.
+  </Card>
+
+  <Card title="Docker Compose-based" icon="layer-group">
+    Use Docker Compose to manage a set of containers. Best for multi-container applications.
+  </Card>
+</CardGroup>
+
+## Choosing an orchestration mode
+
+<Tabs>
+  <Tab title="Image-based">
+    Image-based configurations reference an image that must be reachable and downloadable via `docker pull`. Logins and tokens required for pulling are execution-environment-specific.
+
+    The only required property is `image`.
+
+    ```json theme={null}
+    {
+      "image": "mcr.microsoft.com/devcontainers/base:ubuntu"
+    }
+    ```
+
+    You can reference images from any container registry — DockerHub, GitHub Container Registry, Azure Container Registry, or others — as long as the image is accessible from the environment.
+
+    ```json theme={null}
+    {
+      "name": "Node.js dev container",
+      "image": "mcr.microsoft.com/devcontainers/javascript-node:18",
+      "forwardPorts": [3000],
+      "postCreateCommand": "npm install"
+    }
+    ```
+  </Tab>
+
+  <Tab title="Dockerfile-based">
+    Dockerfile-based configurations use a `Dockerfile` to define the container's starting point. Base images must be reachable by Docker when running `docker build`.
+
+    The only required property is `build.dockerfile`, a path relative to the `devcontainer.json` file.
+
+    ```json theme={null}
+    {
+      "name": "Custom dev container",
+      "build": {
+        "dockerfile": "Dockerfile"
+      }
+    }
+    ```
+
+    Additional `build` properties let you control how `docker build` runs:
+
+    | Property           | Type                 | Description                                                                              |
+    | ------------------ | -------------------- | ---------------------------------------------------------------------------------------- |
+    | `build.dockerfile` | `string`             | **Required.** Path to the Dockerfile, relative to `devcontainer.json`.                   |
+    | `build.context`    | `string`             | The path the Docker build runs from, relative to `devcontainer.json`. Defaults to `"."`. |
+    | `build.args`       | object               | Name-value pairs passed as `--build-arg` to `docker build`.                              |
+    | `build.options`    | `string[]`           | Array of additional options passed to the `docker build` command.                        |
+    | `build.target`     | `string`             | Specifies a build target stage (`--target`).                                             |
+    | `build.cacheFrom`  | `string \| string[]` | One or more images to use as cache sources (`--cache-from`).                             |
+
+    ```json theme={null}
+    {
+      "name": "Python dev container",
+      "build": {
+        "dockerfile": "../Dockerfile",
+        "context": "..",
+        "args": {
+          "PYTHON_VERSION": "3.11",
+          "INSTALL_DEV_DEPS": "true"
+        },
+        "options": ["--add-host=host.docker.internal:host-gateway"],
+        "target": "development",
+        "cacheFrom": "ghcr.io/myorg/myimage:cache"
+      },
+      "postCreateCommand": "pip install -r requirements-dev.txt"
+    }
+    ```
+  </Tab>
+
+  <Tab title="Docker Compose-based">
+    Docker Compose configurations use `docker-compose` (V1 or aliased V2) to create and manage a set of containers for an application. Images required for this must be reachable.
+
+    <Note>
+      The `image` and `build.dockerfile` properties are not needed in Docker Compose mode — Docker Compose handles image and build configuration natively in the Compose file.
+    </Note>
+
+    Three properties are specific to Docker Compose configurations:
+
+    | Property            | Required | Description                                                                                                                 |
+    | ------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
+    | `dockerComposeFile` | Yes      | Path or ordered array of paths to Docker Compose files, relative to `devcontainer.json`. Later files override earlier ones. |
+    | `service`           | Yes      | The name of the **main** service to connect to. Tools use this service as the primary development container.                |
+    | `runServices`       | No       | Array of services to start and stop with the environment. Defaults to all services.                                         |
+
+    ```json theme={null}
+    {
+      "name": "App with database",
+      "dockerComposeFile": "docker-compose.yml",
+      "service": "app",
+      "runServices": ["app", "db"],
+      "workspaceFolder": "/workspace",
+      "postCreateCommand": "npm install"
+    }
+    ```
+
+    A matching `docker-compose.yml` might look like:
+
+    ```yaml theme={null}
+    version: "3.8"
+    services:
+      app:
+        build:
+          context: .
+          dockerfile: Dockerfile
+        volumes:
+          - ../..:/workspace:cached
+        command: sleep infinity
+
+      db:
+        image: postgres:15
+        environment:
+          POSTGRES_PASSWORD: devpassword
+          POSTGRES_DB: myapp
+    ```
+
+    You can also supply multiple Compose files to extend or override configuration:
+
+    ```json theme={null}
+    {
+      "dockerComposeFile": [
+        "docker-compose.yml",
+        "docker-compose.dev.yml"
+      ],
+      "service": "app"
+    }
+    ```
+  </Tab>
+</Tabs>
+
+## Image-based configuration
+
+Image-based configurations only reference an image reachable via `docker pull`. The `image` property is the only required parameter.
+
+```json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu"
+}
+```
+
+## Dockerfile-based configuration
+
+Dockerfile-based configurations use `build.dockerfile` to specify the Dockerfile path. You can use `build.context`, `build.args`, `build.options`, `build.target`, and `build.cacheFrom` to control the build.
+
+```json theme={null}
+{
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".",
+    "args": {
+      "VARIANT": "18"
+    },
+    "target": "dev",
+    "cacheFrom": "ghcr.io/myorg/myimage:latest"
+  }
+}
+```
+
+## Docker Compose-based configuration
+
+Docker Compose configurations require `dockerComposeFile` and `service`. The `runServices` property is optional and controls which services start with the environment.
+
+```json theme={null}
+{
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "runServices": ["app", "db"]
+}
+```
+
+<Tip>
+  Use `runServices` to limit which services start when you open the dev container. Services not listed still exist in the Compose file but will not be started automatically.
+</Tip>
+
+
+# Secrets support
+Source: https://www.mintlify.com/devcontainers/spec/spec/secrets-support
+
+Declare recommended secrets in devcontainer.json so supporting tools can prompt users and inject them securely into the container environment.
+
+Many projects require sensitive values — API keys, passwords, tokens — to function. The `secrets` property in `devcontainer.json` lets you declare which secrets your dev container expects, along with metadata that tools can surface to users during setup.
+
+<Note>
+  Secrets declared in `devcontainer.json` are **recommendations**, not requirements. Container creation is not blocked if a secret is absent.
+</Note>
+
+## The `secrets` property
+
+The `secrets` property is a top-level object in `devcontainer.json`. Each key is an environment variable name following Unix naming conventions (`[a-zA-Z_][a-zA-Z0-9_]*`). The value is an object with optional metadata.
+
+```json .devcontainer/devcontainer.json theme={null}
+{
+  "image": "mcr.microsoft.com/devcontainers/base:bullseye",
+  "secrets": {
+    "CHAT_GPT_API_KEY": {
+      "description": "API key for the OpenAI ChatGPT service.",
+      "documentationUrl": "https://openai.com/api/"
+    },
+    "STABLE_DIFFUSION_API_KEY": {}
+  }
+}
+```
+
+### Secret metadata
+
+Each secret entry accepts two optional fields:
+
+<ParamField type="string">
+  A brief, human-readable description of what the secret is used for. Supporting tools may display this text when prompting the user to provide a value.
+</ParamField>
+
+<ParamField type="string">
+  A URL pointing to documentation where users can learn how to obtain the secret — for example, a page explaining how to generate an API key.
+</ParamField>
+
+## How supporting tools use secrets
+
+A conforming implementation should:
+
+1. **Prompt the user** for each declared secret before or during container creation, using the `description` and `documentationUrl` to provide context.
+2. **Inject secrets as environment variables** inside the container so they are available to processes at runtime — similar to how `remoteEnv` works.
+3. **Support dynamic updates** — users should be able to change a secret's value without rebuilding the container.
+
+<Info>
+  The spec does not prescribe exactly how secrets are stored or transmitted. Implementations may use a secrets file, the OS keychain (Windows Credential Manager, macOS Keychain), a cloud vault (Azure Key Vault, AWS Secrets Manager), or any other secure mechanism.
+</Info>
+
+### Example: passing secrets via a file
+
+One straightforward approach is a JSON file passed to the dev container CLI:
+
+```json secrets.json theme={null}
+{
+  "API_KEY": "adsjhsd6dfwdjfwde7edwfwedfdjedwf7wedfwe",
+  "NUGET_CONFIG": "<config>\n    <add key=\"dependencyVersion\" value=\"Highest\" />\n</config>",
+  "PASSWORD": "MyPassword123"
+}
+```
+
+The CLI reads the file and injects each key-value pair as an environment variable inside the container.
+
+## Security considerations
+
+<Warning>
+  Do **not** store secret values inside `devcontainer.json`. The file is typically committed to source control. Only declare secret **names** (environment variable keys) and metadata in `devcontainer.json`.
+</Warning>
+
+Historically, developers passed sensitive values through `remoteEnv` because no dedicated mechanism existed. The `secrets` property exists to address this gap — explicitly marking values as secrets allows implementations to handle them with appropriate care (secure storage, masked UI, audit logging) rather than treating them as ordinary environment variables.
+
+Key principles:
+
+* Secret **names** (keys) are safe to commit — they reveal what is needed but not the values themselves.
+* Secret **values** must never appear in `devcontainer.json`, Dockerfiles, or version-controlled configuration.
+* Implementations should avoid logging secret values in build output or diagnostic traces.
+
+## Schema reference
+
+```json schema excerpt theme={null}
+"secrets": {
+  "type": "object",
+  "description": "Recommended secrets for this dev container. Recommendations are provided as environment variable keys with optional metadata.",
+  "patternProperties": {
+    "^[a-zA-Z_][a-zA-Z0-9_]*$": {
+      "type": "object",
+      "properties": {
+        "description": { "type": "string" },
+        "documentationUrl": { "type": "string", "format": "uri" }
+      }
+    }
+  }
+}
+```
+
+<Tip>
+  The full `devcontainer.json` schema is available at [github.com/devcontainers/spec](https://github.com/devcontainers/spec/blob/main/schemas/devContainer.base.schema.json).
+</Tip>
+
+
+# Variables reference
+Source: https://www.mintlify.com/devcontainers/spec/spec/variables
+
+Template variables available in devcontainer.json string values, including host environment variables, container paths, and the unique container identifier.
+
+You can reference variables in certain string values in `devcontainer.json` using the format `${variableName}`. Variables are substituted when the container is created or when the value is applied.
+
+## Available variables
+
+<AccordionGroup>
+  <Accordion title="${localEnv:VARIABLE_NAME}">
+    The value of an environment variable on the **host machine**. Unset variables are left blank.
+
+    You can specify a default value for when the variable is not set:
+
+    ```
+    ${localEnv:VARIABLE_NAME:default_value}
+    ```
+
+    **Supported in:** all string properties
+
+    <Warning>
+      Clients like VS Code may need to be restarted to pick up newly set host environment variables.
+    </Warning>
+
+    <Note>
+      For cloud services, the "host" is the cloud machine rather than your local machine.
+    </Note>
+
+    **Examples:**
+
+    Set a variable containing the local home folder (works across Linux, macOS, and Windows):
+
+    ```json theme={null}
+    "remoteEnv": {
+      "LOCAL_USER_PATH": "${localEnv:HOME}${localEnv:USERPROFILE}"
+    }
+    ```
+
+    Pass a local API key into the container environment:
+
+    ```json theme={null}
+    "containerEnv": {
+      "MY_API_KEY": "${localEnv:MY_API_KEY}"
+    }
+    ```
+
+    On modern macOS, you can set a local variable with:
+
+    ```bash theme={null}
+    echo 'export VARIABLE_NAME=my-value' >> ~/.zshenv
+    ```
+  </Accordion>
+
+  <Accordion title="${containerEnv:VARIABLE_NAME}">
+    The value of an existing environment variable **inside the container** once it is up and running. Only available after the container has started.
+
+    You can specify a default value for when the variable is not set:
+
+    ```
+    ${containerEnv:VARIABLE_NAME:default_value}
+    ```
+
+    **Supported in:** `remoteEnv`
+
+    **Example:**
+
+    Extend the container's `PATH` without overwriting it:
+
+    ```json theme={null}
+    "remoteEnv": {
+      "PATH": "${containerEnv:PATH}:/some/other/path"
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="${localWorkspaceFolder}">
+    The path of the local folder that was opened in the supporting tool — the folder that contains `.devcontainer/devcontainer.json`.
+
+    **Supported in:** all string properties
+
+    **Example:**
+
+    Mount a sub-folder from the local workspace:
+
+    ```json theme={null}
+    "workspaceMount": "source=${localWorkspaceFolder}/sub-folder,target=/workspace,type=bind,consistency=cached"
+    ```
+  </Accordion>
+
+  <Accordion title="${containerWorkspaceFolder}">
+    The path where workspace files can be found **inside the container**.
+
+    **Supported in:** all string properties
+
+    **Example:**
+
+    Run a script from the workspace root inside the container:
+
+    ```json theme={null}
+    "postCreateCommand": "bash ${containerWorkspaceFolder}/scripts/setup.sh"
+    ```
+  </Accordion>
+
+  <Accordion title="${localWorkspaceFolderBasename}">
+    The name (not the full path) of the local folder that was opened in the supporting tool.
+
+    **Supported in:** all string properties
+
+    **Example:**
+
+    Use the project name as a container label:
+
+    ```json theme={null}
+    "runArgs": ["--label", "project=${localWorkspaceFolderBasename}"]
+    ```
+  </Accordion>
+
+  <Accordion title="${containerWorkspaceFolderBasename}">
+    The name (not the full path) of the folder where workspace files can be found inside the container.
+
+    **Supported in:** all string properties
+
+    **Example:**
+
+    Set an environment variable to the workspace folder name:
+
+    ```json theme={null}
+    "remoteEnv": {
+      "PROJECT_NAME": "${containerWorkspaceFolderBasename}"
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="${devcontainerId}">
+    An identifier that is unique to the dev container and stable across rebuilds. This is useful for naming resources (like volumes or network namespaces) that should persist across container rebuilds but remain isolated between different dev containers.
+
+    **Supported in:** `name`, `runArgs`, `initializeCommand`, `onCreateCommand`, `updateContentCommand`, `postCreateCommand`, `postStartCommand`, `postAttachCommand`, `workspaceFolder`, `workspaceMount`, `mounts`, `containerEnv`, `remoteEnv`, `containerUser`, `remoteUser`, `customizations`
+
+    **Example:**
+
+    Create a named volume that persists across rebuilds for this specific container:
+
+    ```json theme={null}
+    "mounts": [
+      {
+        "source": "devcontainer-${devcontainerId}-bashhistory",
+        "target": "/commandhistory",
+        "type": "volume"
+      }
+    ]
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Property support summary
+
+| Variable                              | General props | `remoteEnv` | `containerEnv` | Lifecycle scripts | `mounts` | `runArgs` |
+| ------------------------------------- | :-----------: | :---------: | :------------: | :---------------: | :------: | :-------: |
+| `${localEnv:...}`                     |       ✓       |      ✓      |        ✓       |         ✓         |     ✓    |     ✓     |
+| `${containerEnv:...}`                 |               |      ✓      |                |                   |          |           |
+| `${localWorkspaceFolder}`             |       ✓       |      ✓      |        ✓       |         ✓         |     ✓    |     ✓     |
+| `${containerWorkspaceFolder}`         |       ✓       |      ✓      |        ✓       |         ✓         |     ✓    |     ✓     |
+| `${localWorkspaceFolderBasename}`     |       ✓       |      ✓      |        ✓       |         ✓         |     ✓    |     ✓     |
+| `${containerWorkspaceFolderBasename}` |       ✓       |      ✓      |        ✓       |         ✓         |     ✓    |     ✓     |
+| `${devcontainerId}`                   |       ✓       |      ✓      |        ✓       |         ✓         |     ✓    |     ✓     |
+
+<Note>
+  `${containerEnv:...}` is only available in `remoteEnv` because it requires the container to already be running. All other variables are resolved before the container starts.
+</Note>
+
+## Variable substitution timing
+
+Variables are substituted when the value is applied, not when the `devcontainer.json` is parsed:
+
+* `${localEnv:...}` — resolved from the host at container creation time
+* `${containerEnv:...}` — resolved from the running container when `remoteEnv` is applied
+* Path variables — resolved at container creation time from the active workspace
+
+When using [image metadata](/spec/image-metadata), variables stored in image labels are also substituted at container creation time, not at image build time.
+
+

--- a/docs/research/mintlify-cache/devcontainers/spec/llms.txt
+++ b/docs/research/mintlify-cache/devcontainers/spec/llms.txt
@@ -1,0 +1,32 @@
+# Dev Container Specification
+
+## Docs
+
+- [Authoring Features](https://www.mintlify.com/devcontainers/spec/ecosystem/authoring-features.md): A practical guide to creating and publishing Dev Container Features, from folder structure to OCI registry distribution.
+- [Authoring Templates](https://www.mintlify.com/devcontainers/spec/ecosystem/authoring-templates.md): A practical guide to creating and publishing Dev Container Templates, including option substitution syntax and OCI registry distribution.
+- [Contributing to the spec](https://www.mintlify.com/devcontainers/spec/ecosystem/contributing.md): How to propose changes, file issues, and engage with the Dev Container Specification community.
+- [Features distribution](https://www.mintlify.com/devcontainers/spec/ecosystem/features-distribution.md): How to package, publish, and distribute Dev Container Features via OCI registries, direct tarballs, or local paths.
+- [Features overview](https://www.mintlify.com/devcontainers/spec/ecosystem/features-overview.md): Dev Container Features are self-contained, shareable units of installation code and development container configuration that let you quickly add tooling, runtimes, and libraries to any dev container.
+- [Features reference](https://www.mintlify.com/devcontainers/spec/ecosystem/features-reference.md): Complete reference for the devcontainer-feature.json metadata file, including all properties, options, lifecycle hooks, and option resolution.
+- [Lockfile](https://www.mintlify.com/devcontainers/spec/ecosystem/lockfile.md): How devcontainer-lock.json pins Feature versions to exact digest hashes for reproducible, secure dev container builds.
+- [Supporting tools and services](https://www.mintlify.com/devcontainers/spec/ecosystem/supporting-tools.md): Editors, tools, and cloud services that implement the Dev Container Specification.
+- [Templates distribution](https://www.mintlify.com/devcontainers/spec/ecosystem/templates-distribution.md): Publish Dev Container Templates to an OCI registry so any supporting tool can discover and apply them.
+- [Templates overview](https://www.mintlify.com/devcontainers/spec/ecosystem/templates-overview.md): Dev Container Templates are pre-packaged configurations that set up a complete development environment, ready to use in any supporting tool.
+- [Introduction](https://www.mintlify.com/devcontainers/spec/introduction.md): Learn what development containers are, how the specification works, and why dev containers improve consistency across tools and teams.
+- [Quickstart](https://www.mintlify.com/devcontainers/spec/quickstart.md): Create your first devcontainer.json, open it in a supporting tool, and start developing inside a container in minutes.
+- [The devcontainerId variable](https://www.mintlify.com/devcontainers/spec/spec/devcontainer-id-variable.md): Use ${devcontainerId} to reference a stable, unique identifier for a dev container — useful for scoping named volumes and other resources to a specific container.
+- [Dev Container reference](https://www.mintlify.com/devcontainers/spec/spec/devcontainer-reference.md): Core concepts of the Dev Container Specification: what development containers are, how metadata is structured, environment variables, mounts, and users.
+- [devcontainer.json reference](https://www.mintlify.com/devcontainers/spec/spec/devcontainerjson-reference.md): Complete reference for all properties available in devcontainer.json, the metadata file that configures a development container.
+- [GPU host requirement](https://www.mintlify.com/devcontainers/spec/spec/gpu-host-requirement.md): Declare GPU requirements in devcontainer.json so cloud services and local tools can provision or validate the right hardware for your container.
+- [Image metadata](https://www.mintlify.com/devcontainers/spec/spec/image-metadata.md): How to store dev container configuration in prebuilt images using the devcontainer.metadata label, and how that metadata is merged at container creation time.
+- [Container lifecycle](https://www.mintlify.com/devcontainers/spec/spec/lifecycle.md): The four phases of a dev container's lifecycle: Configuration Validation, Environment Creation, Environment Stop, and Environment Resume — including all lifecycle scripts and parallel execution.
+- [Orchestration](https://www.mintlify.com/devcontainers/spec/spec/orchestration.md): The three orchestration modes in the Dev Container Specification: image-based, Dockerfile-based, and Docker Compose-based configurations.
+- [Secrets support](https://www.mintlify.com/devcontainers/spec/spec/secrets-support.md): Declare recommended secrets in devcontainer.json so supporting tools can prompt users and inject them securely into the container environment.
+- [Variables reference](https://www.mintlify.com/devcontainers/spec/spec/variables.md): Template variables available in devcontainer.json string values, including host environment variables, container paths, and the unique container identifier.
+
+## OpenAPI Specs
+
+- [openapi](https://www.mintlify.com/devcontainers/spec/api-reference/openapi.json)
+
+
+Built with [Mintlify](https://mintlify.com).

--- a/docs/research/mintlify-cache/jdx/fnox/llms-full.txt
+++ b/docs/research/mintlify-cache/jdx/fnox/llms-full.txt
@@ -1,0 +1,6084 @@
+# CI/CD Integration
+Source: https://www.mintlify.com/jdx/fnox/guides/ci-cd
+
+Run fnox in GitHub Actions and other CI pipelines to securely inject secrets at deploy time.
+
+fnox works well in CI/CD pipelines. The same `fnox.toml` you use locally handles secret injection in CI — no separate secrets management tool required.
+
+## Core concepts for CI
+
+**Profile selection** — use `FNOX_PROFILE` or `--profile` to select the right environment:
+
+```bash theme={null}
+fnox exec --profile production -- ./deploy.sh
+# or
+FNOX_PROFILE=production fnox exec -- ./deploy.sh
+```
+
+**Strict mode** — set `FNOX_IF_MISSING=error` so the pipeline fails immediately if any secret is missing rather than running with incomplete configuration:
+
+```bash theme={null}
+FNOX_IF_MISSING=error fnox exec --profile production -- ./deploy.sh
+```
+
+**Age key via CI secret** — for encrypted inline secrets, provide the decryption key through your CI provider's secret store:
+
+```bash theme={null}
+# In GitHub Actions:
+env:
+  FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
+```
+
+## Installing fnox in CI
+
+The recommended approach is via [mise](https://mise.jdx.dev/), which reads the project's `mise.toml` or `.tool-versions` to install the correct fnox version:
+
+```yaml theme={null}
+- uses: jdx/mise-action@v3
+```
+
+## GitHub Actions
+
+### Testing with encrypted secrets
+
+For a test job that uses age-encrypted development secrets committed to the repository:
+
+```yaml theme={null}
+# .github/workflows/ci.yml
+name: CI
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v3
+
+      - name: Run tests
+        env:
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
+        run: fnox exec -- npm test
+```
+
+<Note>
+  For pull requests from forks, GitHub Actions does not expose secrets. Use `FNOX_IF_MISSING=ignore` or `FNOX_IF_MISSING=warn` in those jobs so tests that don't need real secrets still run.
+</Note>
+
+### Staging deployment (age-encrypted)
+
+```yaml theme={null}
+# .github/workflows/deploy.yml
+  deploy-staging:
+    if: github.ref == 'refs/heads/develop'
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v3
+
+      - name: Deploy to staging
+        env:
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
+        run: fnox exec --profile staging -- ./deploy.sh
+```
+
+### Production deployment (AWS Secrets Manager)
+
+```yaml theme={null}
+  deploy-production:
+    if: github.ref == 'refs/heads/main'
+    needs: test
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v3
+
+      - name: Deploy to production
+        env:
+          AWS_ACCESS_KEY_ID:     ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION:            us-east-1
+          FNOX_IF_MISSING:       error
+        run: fnox exec --profile production -- ./deploy.sh
+```
+
+### Complete example workflow
+
+```yaml theme={null}
+# .github/workflows/deploy.yml
+name: Deploy
+on:
+  push:
+    branches: [main, develop]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v3
+      - name: Run tests
+        env:
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
+        run: fnox exec -- npm test
+
+  deploy-staging:
+    if: github.ref == 'refs/heads/develop'
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v3
+      - name: Deploy to staging
+        env:
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
+        run: fnox exec --profile staging -- ./deploy.sh
+
+  deploy-production:
+    if: github.ref == 'refs/heads/main'
+    needs: test
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v3
+      - name: Deploy to production
+        env:
+          AWS_ACCESS_KEY_ID:     ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION:            us-east-1
+          FNOX_IF_MISSING:       error
+        run: fnox exec --profile production -- ./deploy.sh
+```
+
+## Setting up CI secrets in GitHub
+
+1. Go to your repository → **Settings** → **Secrets and variables** → **Actions**
+2. Add `FNOX_AGE_KEY` — the age private key for the CI recipient:
+   ```bash theme={null}
+   # Copy the CI age secret key
+   cat ~/.config/fnox/ci-age.txt | grep "AGE-SECRET-KEY"
+   ```
+3. Add `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` for the production deployment IAM user (or use OIDC for keyless auth)
+
+<Tip>
+  Create a dedicated CI age key (`age-keygen -o ~/.config/fnox/ci-age.txt`) and add its public key to the `recipients` list in `fnox.toml`. Re-encrypt all secrets with `fnox reencrypt -p age` after adding the new recipient.
+</Tip>
+
+## Handling fork pull requests
+
+Pull requests from forks do not have access to repository secrets. Use `FNOX_IF_MISSING=ignore` so those jobs don't fail when secrets are unavailable:
+
+```yaml theme={null}
+- name: Run tests (secrets unavailable in forks)
+  env:
+    FNOX_IF_MISSING: ignore
+  run: fnox exec -- npm test
+```
+
+## Tips
+
+* **Always use strict mode for deployments** — `FNOX_IF_MISSING=error` catches misconfigured secrets before they cause silent failures.
+* **Use profiles explicitly** — pass `--profile production` rather than relying on `FNOX_PROFILE` to make the intent clear in the workflow file.
+* **Avoid storing plaintext secrets in CI environment variables** — let fnox fetch them from AWS Secrets Manager or decrypt them from the committed ciphertext.
+* **Use GitHub environment protection rules** — pair `environment: production` with required reviewers or branch restrictions to gate production deployments.
+* **For cloud providers, prefer OIDC** — GitHub Actions supports keyless authentication to AWS, GCP, and Azure via OIDC, eliminating the need for long-lived `AWS_ACCESS_KEY_ID` secrets entirely.
+
+## Next steps
+
+<CardGroup>
+  <Card title="Profiles" icon="layers" href="/guides/profiles">
+    Configure per-environment secrets for use in CI.
+  </Card>
+
+  <Card title="Real-world example" icon="rocket" href="/guides/real-world-example">
+    See a complete setup including a CI/CD workflow.
+  </Card>
+
+  <Card title="Credential leases" icon="clock" href="/guides/leases">
+    Vend short-lived cloud credentials instead of storing static keys.
+  </Card>
+</CardGroup>
+
+
+# Hierarchical Configuration
+Source: https://www.mintlify.com/jdx/fnox/guides/hierarchical-config
+
+Merge fnox.toml files across parent directories for monorepos and multi-service projects.
+
+fnox searches parent directories for `fnox.toml` (or `.fnox.toml`) files and merges them. This makes it natural to share common secrets at the root of a monorepo while letting each service add its own.
+
+## How it works
+
+fnox builds its configuration by merging multiple sources in a fixed order, starting with the global config and working down to the current directory.
+
+Given this structure:
+
+```
+project/
+├── fnox.toml              # root config
+├── fnox.local.toml        # root local overrides (optional)
+└── services/
+    ├── api/
+    │   ├── fnox.toml      # API config
+    │   └── fnox.local.toml
+    └── worker/
+        ├── fnox.toml      # worker config
+        └── fnox.local.toml
+```
+
+When you run fnox from `project/services/api/`, the merge order is (lowest to highest priority):
+
+1. `~/.config/fnox/config.toml` — global config
+2. `project/fnox.toml` — root/parent config
+3. `project/fnox.local.toml` — root local overrides
+4. `project/services/api/fnox.toml` — current directory config
+5. `project/services/api/fnox.local.toml` — current directory local overrides
+
+Child configs override parent configs. Local configs override main configs at the same level.
+
+<Info>
+  The global config (`~/.config/fnox/config.toml`) is always loaded, even when `root = true` stops parent directory recursion.
+</Info>
+
+## Example setup
+
+### Root config — common secrets
+
+```toml theme={null}
+# project/fnox.toml
+
+[providers]
+age = { type = "age", recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"] }
+
+[secrets]
+LOG_LEVEL   = { default = "info" }
+ENVIRONMENT = { default = "development" }
+JWT_SECRET  = { provider = "age", value = "encrypted-shared-jwt..." }
+```
+
+### API service config
+
+```toml theme={null}
+# project/services/api/fnox.toml
+
+[secrets]
+API_PORT     = { default = "3000" }
+DATABASE_URL = { provider = "age", value = "encrypted-api-db..." }
+LOG_LEVEL    = { default = "debug" }  # override — more verbose during development
+```
+
+### Worker service config
+
+```toml theme={null}
+# project/services/worker/fnox.toml
+
+[secrets]
+QUEUE_URL           = { provider = "age", value = "encrypted-queue-url..." }
+WORKER_CONCURRENCY  = { default = "4" }
+```
+
+### Resulting secrets
+
+<CodeGroup>
+  ```bash From project/services/api/ theme={null}
+  fnox list
+  # ENVIRONMENT=development       (from root)
+  # JWT_SECRET=***                (from root)
+  # LOG_LEVEL=debug               (from api — overrides root)
+  # API_PORT=3000                 (from api)
+  # DATABASE_URL=***              (from api)
+  ```
+
+  ```bash From project/services/worker/ theme={null}
+  fnox list
+  # ENVIRONMENT=development       (from root)
+  # JWT_SECRET=***                (from root)
+  # LOG_LEVEL=info                (from root)
+  # QUEUE_URL=***                 (from worker)
+  # WORKER_CONCURRENCY=4          (from worker)
+  ```
+</CodeGroup>
+
+## Local overrides
+
+Use `fnox.local.toml` for user-specific overrides that should not be committed to version control:
+
+```bash theme={null}
+# Add to .gitignore
+echo "fnox.local.toml" >> .gitignore
+```
+
+```toml theme={null}
+# fnox.local.toml (gitignored)
+
+[secrets]
+DATABASE_URL = { default = "postgresql://localhost/mylocal" }
+DEBUG_MODE   = { default = "true" }
+```
+
+**Common uses:**
+
+* Override team secrets for a personal local database
+* Personal API keys and tokens
+* Machine-specific configuration
+* Testing with a different provider locally
+
+<Tip>
+  Commit a `fnox.local.toml.example` file (with placeholder values) so teammates know what overrides are available.
+</Tip>
+
+<Warning>
+  `fnox sync --local-file` only supports `fnox.toml` and `.fnox.toml`. Other filenames are rejected because adjacent local override files would not be loaded automatically.
+</Warning>
+
+## Profile-specific config files
+
+You can place profile overrides in a separate file named `fnox.<profile>.toml` (e.g., `fnox.production.toml`). fnox loads this file after `fnox.toml` when that profile is active.
+
+This keeps profile-specific settings out of the main config file and makes git history easier to read.
+
+## Stopping recursion with `root = true`
+
+If you want fnox to stop walking parent directories at a specific level, set `root = true` in that directory's `fnox.toml`:
+
+```toml theme={null}
+# project/fnox.toml
+root = true  # do not search further up the directory tree
+
+[providers]
+age = { type = "age", recipients = ["age1..."] }
+```
+
+The global config is still loaded regardless of `root = true`.
+
+## Importing other config files
+
+Use `import` for explicit cross-cutting concerns that don't fit the directory hierarchy:
+
+```toml theme={null}
+# Explicit file imports
+import = ["./shared/secrets.toml", "./envs/dev.toml"]
+```
+
+**Hierarchy vs imports:**
+
+| Method                | When to use                                        |
+| --------------------- | -------------------------------------------------- |
+| Hierarchy (automatic) | Location-based config in a monorepo                |
+| Imports (explicit)    | Shared secret bundles used across many directories |
+
+## Global configuration
+
+Machine-wide secrets that should be available in every project go in the global config:
+
+```bash theme={null}
+# Initialize global config
+fnox init --global
+
+# Add secrets to global config
+fnox set GITHUB_TOKEN "ghp_..." --global
+fnox set NPM_TOKEN "npm_..." --global
+
+# Add a provider to global config
+fnox provider add age age --global
+```
+
+**Location:** `~/.config/fnox/config.toml` (override with `FNOX_CONFIG_DIR`)
+
+**Use cases:** personal API tokens, machine-specific credentials, a default encryption provider available everywhere.
+
+## Tips
+
+* Keep the root config minimal — only shared providers and secrets that every service needs.
+* Put service-specific secrets in each service's own subdirectory.
+* Use `fnox.local.toml` for personal development overrides.
+* Use the global config for tokens like `GITHUB_TOKEN` that belong to you, not the project.
+* Profile inheritance works at every hierarchy level — each directory can define profile-specific overrides.
+* `.fnox.toml` is equivalent to `fnox.toml` (the same applies to `.fnox.local.toml`, `.fnox.staging.toml`, etc.) if you prefer dotfiles.
+
+## Next steps
+
+<CardGroup>
+  <Card title="Profiles" icon="layers" href="/guides/profiles">
+    Multi-environment management within a single config file.
+  </Card>
+
+  <Card title="Real-world example" icon="rocket" href="/guides/real-world-example">
+    See hierarchical config in a complete project setup.
+  </Card>
+</CardGroup>
+
+
+# How It Works
+Source: https://www.mintlify.com/jdx/fnox/guides/how-it-works
+
+Understand fnox's two storage modes, secret resolution order, and execution flow.
+
+fnox uses a single TOML config file (`fnox.toml`) that you check into git. Secrets are either encrypted directly inside that file or referenced by name from a remote provider — fnox handles the rest at runtime.
+
+## Two storage modes
+
+### Encrypted inline
+
+The encrypted ciphertext lives directly in the config file. This is safe to commit because only recipients with the corresponding private key can decrypt it.
+
+```toml theme={null}
+[providers]
+age = { type = "age", recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"] }
+
+[secrets]
+DATABASE_URL = { provider = "age", value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC4uLg==" }
+# ↑ encrypted ciphertext — safe to commit
+```
+
+**Supported providers for inline encryption:** `age`, `aws-kms`, `azure-kms`, `gcp-kms`
+
+### Remote references
+
+The config contains only a logical name pointing to a secret stored in an external system. The plaintext value never touches your repository.
+
+```toml theme={null}
+[providers]
+aws = { type = "aws-sm", region = "us-east-1", prefix = "myapp/" }
+
+[secrets]
+DATABASE_URL = { provider = "aws", value = "database-url" }
+# ↑ just a reference — actual secret lives in AWS Secrets Manager
+```
+
+**Supported providers for remote storage:** `aws-sm`, `azure-sm`, `gcp-sm`, `vault`, `1password`, `bitwarden`, `keychain`
+
+## Secret resolution order
+
+When fnox resolves a secret, it checks sources in this priority order. The first match wins.
+
+| Priority | Source               | Example                                      |
+| -------- | -------------------- | -------------------------------------------- |
+| 1        | Encrypted value      | `provider = "age"`, `value = "encrypted..."` |
+| 2        | Provider reference   | `provider = "aws"`, `value = "secret-name"`  |
+| 3        | Environment variable | Already set in the shell                     |
+| 4        | Default value        | `default = "fallback"`                       |
+
+<Info>
+  An environment variable already present in the shell takes precedence over a `default` value, but not over an explicitly configured provider reference.
+</Info>
+
+## Example config
+
+A typical `fnox.toml` might combine multiple modes:
+
+```toml theme={null}
+# Provider definitions
+[providers]
+age = { type = "age", recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"] }
+aws = { type = "aws-sm", region = "us-east-1" }
+
+[secrets]
+JWT_SECRET   = { provider = "age", value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC4uLg==" }  # encrypted in git
+DATABASE_URL = { provider = "aws", value = "prod-database-url" }                                    # remote in AWS
+NODE_ENV     = { default = "development" }                                                           # fallback value
+```
+
+## Execution flow
+
+When you run `fnox exec -- <command>`:
+
+<Steps>
+  <Step title="Locate config">
+    fnox reads `fnox.toml` from the current directory, then walks up parent directories until it finds all relevant config files (or hits `root = true`).
+  </Step>
+
+  <Step title="Determine active profile">
+    fnox checks `--profile` flag, then `FNOX_PROFILE` env var. Falls back to `default`.
+  </Step>
+
+  <Step title="Resolve secrets">
+    Each secret is resolved according to the priority order above. Encrypted secrets are decrypted; remote secrets are fetched from their provider.
+  </Step>
+
+  <Step title="Export environment">
+    All resolved secrets are set as environment variables in a subprocess environment. Nothing is written to disk or your current shell.
+  </Step>
+
+  <Step title="Execute command">
+    Your command runs with those environment variables available. When it exits, the subprocess environment is discarded.
+  </Step>
+</Steps>
+
+<Note>
+  fnox never modifies your current shell's environment directly (except when using shell integration). Secrets exist only for the lifetime of the subprocess.
+</Note>
+
+## Next steps
+
+<CardGroup>
+  <Card title="Profiles" icon="layers" href="/guides/profiles">
+    Manage secrets for development, staging, and production in one file.
+  </Card>
+
+  <Card title="Shell integration" icon="terminal" href="/guides/shell-integration">
+    Auto-load secrets when you cd into a project directory.
+  </Card>
+
+  <Card title="Hierarchical config" icon="folder-tree" href="/guides/hierarchical-config">
+    Organize secrets across directories in a monorepo.
+  </Card>
+
+  <Card title="Credential leases" icon="clock" href="/guides/leases">
+    Vend short-lived cloud credentials on demand.
+  </Card>
+</CardGroup>
+
+
+# Credential Leases
+Source: https://www.mintlify.com/jdx/fnox/guides/leases
+
+Vend short-lived cloud credentials from AWS, GCP, Azure, Vault, and more using fnox leases.
+
+Credential leases let fnox create temporary, short-lived credentials from cloud providers like AWS, GCP, Azure, and HashiCorp Vault. Instead of storing long-lived access keys in your environment, fnox requests credentials on demand, caches them until they near expiry, and injects them into subprocesses automatically.
+
+## Why leases?
+
+Long-lived credentials are a persistent security risk. If they leak, an attacker has access until someone notices and rotates them. Leases flip this model: credentials are created on demand, last minutes to hours, and expire on their own with no manual cleanup required.
+
+fnox supports three approaches depending on your security requirements:
+
+<CardGroup>
+  <Card title="Stored master credentials" icon="key">
+    Keep long-lived credentials in a provider (1Password, keychain, age). fnox creates leases automatically.
+  </Card>
+
+  <Card title="Hardware-protected" icon="shield">
+    Encrypt master credentials on disk. A physical security key (YubiKey / FIDO2) is required to decrypt them.
+  </Card>
+
+  <Card title="Prompt-based" icon="hand">
+    Never store master credentials on the machine. Paste them in when needed; fnox discards them after creating the lease.
+  </Card>
+</CardGroup>
+
+## Approach 1: Stored master credentials
+
+Store the long-lived credentials in any fnox provider and let fnox use them to create short-lived leases via `fnox exec`. The choice of provider determines how much friction is involved:
+
+* **1Password / Bitwarden** — requires authentication (password, biometric, or service account token). Best when you want a gate on every session.
+* **OS keychain** — unlocked at login. Convenient, but macOS may prompt for Touch ID on first access.
+* **Age / KMS** — encrypted in git. Good for CI and shared team setups.
+
+### Example: AWS STS with 1Password
+
+```toml theme={null}
+# fnox.toml
+
+[providers.op]
+type  = "1password"
+vault = "Development"
+
+# Long-lived IAM credentials stored in 1Password
+[secrets]
+AWS_ACCESS_KEY_ID     = { provider = "op", value = "AWS IAM/access key" }
+AWS_SECRET_ACCESS_KEY = { provider = "op", value = "AWS IAM/secret key" }
+
+# Lease: use those credentials to assume a role and get temp creds
+[leases.aws]
+type      = "aws-sts"
+region    = "us-east-1"
+role_arn  = "arn:aws:iam::123456789012:role/dev-role"
+duration  = "1h"
+```
+
+```bash theme={null}
+# fnox exec automatically:
+# 1. Retrieves AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY from 1Password
+#    (prompts to authenticate if needed)
+# 2. Calls sts:AssumeRole to get temporary credentials
+# 3. Injects AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN
+#    (the short-lived ones) into your subprocess
+fnox exec -- aws s3 ls
+```
+
+Using the OS keychain instead of 1Password:
+
+```toml theme={null}
+[providers.keychain]
+type = "keychain"
+
+[secrets]
+AWS_ACCESS_KEY_ID     = { provider = "keychain" }
+AWS_SECRET_ACCESS_KEY = { provider = "keychain" }
+```
+
+```bash theme={null}
+fnox set AWS_ACCESS_KEY_ID "AKIA..."
+fnox set AWS_SECRET_ACCESS_KEY "wJalr..."
+```
+
+### Example: GCP IAM
+
+```toml theme={null}
+# fnox.toml
+
+[providers.op]
+type  = "1password"
+vault = "Development"
+
+[secrets]
+GOOGLE_APPLICATION_CREDENTIALS = { provider = "op", value = "GCP Service Account/key file", as_file = true }
+
+[leases.gcp]
+type                  = "gcp-iam"
+service_account_email = "my-sa@my-project.iam.gserviceaccount.com"
+duration              = "1h"
+```
+
+```bash theme={null}
+# fnox exec writes the key file to a temp path, creates a short-lived OAuth2 token
+fnox exec -- gcloud storage ls
+```
+
+### Example: HashiCorp Vault
+
+```toml theme={null}
+# fnox.toml
+
+[providers.op]
+type  = "1password"
+vault = "Infrastructure"
+
+[secrets]
+VAULT_TOKEN = { provider = "op", value = "Vault/token" }
+
+[leases.vault-aws]
+type        = "vault"
+address     = "https://vault.example.com:8200"
+secret_path = "aws/creds/my-role"
+duration    = "1h"
+
+[leases.vault-aws.env_map]
+access_key     = "AWS_ACCESS_KEY_ID"
+secret_key     = "AWS_SECRET_ACCESS_KEY"
+security_token = "AWS_SESSION_TOKEN"
+```
+
+### Example: Azure
+
+```toml theme={null}
+# fnox.toml
+
+[providers.op]
+type  = "1password"
+vault = "Development"
+
+[secrets]
+AZURE_CLIENT_ID     = { provider = "op", value = "Azure SP/client id" }
+AZURE_CLIENT_SECRET = { provider = "op", value = "Azure SP/client secret" }
+AZURE_TENANT_ID     = { provider = "op", value = "Azure SP/tenant id" }
+
+[leases.azure]
+type  = "azure-token"
+scope = "https://management.azure.com/.default"
+```
+
+## Approach 2: Hardware-protected master credentials
+
+This approach stores master credentials encrypted on disk, requiring a physical security key for decryption. It combines the convenience of automatic lease creation with the strong security guarantee that decryption is physically impossible without the key present.
+
+fnox supports two hardware provider types:
+
+* **`yubikey`** — uses YubiKey HMAC-SHA1 challenge-response. Simple setup; works with any YubiKey with HMAC-SHA1 configured on a slot.
+* **`fido2`** — uses the FIDO2 hmac-secret extension. Works with any FIDO2-compatible key (YubiKey 5, SoloKeys, Nitrokey, etc.).
+
+Both derive an AES-256-GCM encryption key from the hardware device via HKDF-SHA256. Config is fully portable — move `fnox.local.toml` to any machine with the same key and it works.
+
+<Tip>
+  Put the hardware provider and master credential secrets in `fnox.local.toml` (gitignored) and keep only the lease backend config in `fnox.toml`.
+</Tip>
+
+### Setup (YubiKey)
+
+```toml theme={null}
+# fnox.local.toml (gitignored — personal provider + secrets)
+
+[providers.secure]
+type      = "yubikey"
+challenge = "a1b2c3..."  # auto-populated by `fnox provider add`
+slot      = "2"
+
+[secrets]
+AWS_ACCESS_KEY_ID     = { provider = "secure", env = false }
+AWS_SECRET_ACCESS_KEY = { provider = "secure", env = false }
+```
+
+```toml theme={null}
+# fnox.toml (committed — shared lease backend config)
+
+[leases.aws]
+type     = "aws-sts"
+region   = "us-east-1"
+role_arn = "arn:aws:iam::123456789012:role/dev-role"
+duration = "1h"
+```
+
+<Note>
+  `env = false` prevents the master credentials from being injected into subprocess environment variables. Only the short-lived assumed-role credentials are exposed.
+</Note>
+
+For FIDO2, replace the provider section:
+
+```toml theme={null}
+[providers.secure]
+type          = "fido2"
+credential_id = "a1b2c3..."  # auto-populated by `fnox provider add`
+salt          = "d4e5f6..."
+rp_id         = "fnox.secure"
+```
+
+### Initial setup
+
+```bash theme={null}
+# Create the hardware-backed provider (choose one)
+fnox provider add secure yubikey    # YubiKey HMAC-SHA1
+fnox provider add secure fido2      # Any FIDO2 key
+
+# Store master credentials (requires key tap)
+fnox set AWS_ACCESS_KEY_ID "AKIA..." --provider secure
+fnox set AWS_SECRET_ACCESS_KEY "wJalr..." --provider secure
+```
+
+### Daily workflow
+
+```bash theme={null}
+$ fnox exec -- aws s3 ls
+Tap your YubiKey...
+# → Derives encryption key from hardware device (one tap per session)
+# → Decrypts master creds
+# → Calls sts:AssumeRole
+# → Injects short-lived creds into subprocess
+# → Caches lease for reuse
+```
+
+The hardware tap happens once per `fnox exec` invocation, even when multiple secrets share the same provider. Subsequent calls reuse the cached lease without prompting until it nears expiry.
+
+## Approach 3: Prompt-based (no stored credentials)
+
+Ideal for remote machines, shared servers, or anywhere you don't want master credentials written to disk. You paste credentials in when `fnox lease create` prompts you; fnox uses them once to create the lease and then discards them.
+
+### Setup
+
+Configure only the lease backend — no secrets or providers needed:
+
+```toml theme={null}
+# fnox.toml
+
+[leases.aws]
+type     = "aws-sts"
+region   = "us-east-1"
+role_arn = "arn:aws:iam::123456789012:role/dev-role"
+duration = "1h"
+```
+
+### Daily workflow
+
+At the start of each session, create a lease interactively:
+
+```bash theme={null}
+$ fnox lease create aws -i
+AWS_ACCESS_KEY_ID (AWS access key): AKIA...
+AWS_SECRET_ACCESS_KEY (AWS secret key): wJalr...
+AWS_SESSION_TOKEN (AWS session token (optional)):
+
+Lease created (expires in 1h0m)
+
+AWS_ACCESS_KEY_ID         ASIA...F3YQ
+AWS_SECRET_ACCESS_KEY     wJal...EKEY
+AWS_SESSION_TOKEN         FwoG...==
+Expires                   2024-01-15T10:00:00+00:00
+```
+
+The credentials you paste are used once to call `sts:AssumeRole`, then discarded. Only the short-lived assumed-role credentials are cached. All subsequent `fnox exec` calls use the cache without prompting:
+
+```bash theme={null}
+fnox exec -- aws s3 ls
+fnox exec -- terraform plan
+```
+
+When the lease expires, run `fnox lease create aws -i` again.
+
+If you run `fnox exec` without a lease and without stored master credentials, fnox skips the lease gracefully and still runs the command with whatever other secrets are available:
+
+```
+Skipping lease 'aws': AWS credentials not found. Run 'aws sso login' or set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY.
+Run 'fnox lease create aws -i' to set up credentials interactively.
+```
+
+## Supported backends
+
+| Backend         | Type          | Max duration | Revocation              |
+| --------------- | ------------- | ------------ | ----------------------- |
+| AWS STS         | `aws-sts`     | 12 hours     | No-op (native TTL)      |
+| GCP IAM         | `gcp-iam`     | 1 hour       | No-op (native TTL)      |
+| Azure Token     | `azure-token` | \~1 hour     | No-op (native TTL)      |
+| HashiCorp Vault | `vault`       | 24 hours     | Vault lease revocation  |
+| Cloudflare      | `cloudflare`  | 24 hours     | Token deletion          |
+| GitHub App      | `github-app`  | 1 hour       | No-op (native TTL)      |
+| Custom command  | `command`     | 24 hours     | Optional revoke command |
+
+## Managing leases
+
+```bash theme={null}
+# List active leases
+fnox lease list --active
+
+# List expired leases
+fnox lease list --expired
+
+# Revoke a specific lease
+fnox lease revoke <lease-id>
+
+# Clean up all expired leases
+fnox lease cleanup
+```
+
+## How caching works
+
+fnox caches lease credentials in a per-project ledger file at `~/.local/state/fnox/leases/<hash>.toml`. A cached lease is reused until:
+
+* It is within 5 minutes of expiring
+* The backend configuration changes (e.g., you change the role ARN)
+* It is explicitly revoked with `fnox lease revoke`
+
+The ledger automatically prunes entries that have been expired or revoked for more than 24 hours.
+
+
+# MCP Server
+Source: https://www.mintlify.com/jdx/fnox/guides/mcp
+
+Use fnox as a session-scoped secret broker for AI agents via the Model Context Protocol.
+
+`fnox mcp` starts a [Model Context Protocol](https://modelcontextprotocol.io/) server over stdio. It lets AI agents like Claude Code access secrets without those secrets being present in the agent's environment as plain text.
+
+## Why use the MCP server?
+
+When you put `GITHUB_TOKEN` directly in an AI agent's environment, the agent can use it however it wants — without any audit trail. The fnox MCP server acts as a **session-scoped secret broker**: secrets are resolved on first access, cached in process memory, and cleared when the agent disconnects.
+
+## Quick setup
+
+<Steps>
+  <Step title="Configure secrets normally">
+    Your existing `fnox.toml` is all that's needed:
+
+    ```toml theme={null}
+    # fnox.toml
+    [providers]
+    age = { type = "age" }
+
+    [secrets]
+    GITHUB_TOKEN = { provider = "age", value = "AGE-SECRET-KEY-..." }
+    API_KEY      = { provider = "age", value = "AGE-SECRET-KEY-..." }
+    ```
+  </Step>
+
+  <Step title="Optionally restrict which tools and secrets are available">
+    By default both tools are enabled and all profile secrets are accessible. Override this in `fnox.toml`:
+
+    ```toml theme={null}
+    [mcp]
+    tools   = ["get_secret", "exec"]   # default: both enabled
+    secrets = ["GITHUB_TOKEN", "NPM_TOKEN"]  # only these are visible
+    ```
+
+    When `secrets` is set, unlisted secrets are never resolved — no unnecessary auth prompts and no accidental exposure.
+  </Step>
+
+  <Step title="Configure your AI agent">
+    Add fnox to your agent's MCP server list. For Claude Code, edit `.claude/settings.json`:
+
+    ```json theme={null}
+    {
+      "mcpServers": {
+        "fnox": {
+          "command": "fnox",
+          "args": ["mcp"]
+        }
+      }
+    }
+    ```
+
+    To use a specific profile:
+
+    ```json theme={null}
+    {
+      "mcpServers": {
+        "fnox": {
+          "command": "fnox",
+          "args": ["-P", "staging", "mcp"]
+        }
+      }
+    }
+    ```
+  </Step>
+</Steps>
+
+## Available tools
+
+### `get_secret`
+
+Retrieves a single secret by name. The agent provides the secret name (must match a key in your `fnox.toml` `[secrets]` section) and receives the resolved plaintext value.
+
+If a `secrets` allowlist is configured, names not on the list return "not found".
+
+### `exec`
+
+Executes a command with all allowed secrets injected as environment variables. The agent provides a command and arguments; the tool returns stdout and stderr.
+
+<Warning>
+  The agent controls which command is run, so it could execute `printenv` or `echo $SECRET` to read injected values. `exec` provides **audit visibility** — you can see what commands were run — not secret isolation. Use `tools = ["exec"]` with redaction enabled if you want to prevent raw secret retrieval while still allowing command execution.
+</Warning>
+
+## Secret allowlist
+
+Restrict which secrets the MCP server can access:
+
+```toml theme={null}
+[mcp]
+secrets = ["GITHUB_TOKEN", "NPM_TOKEN"]  # only these are available
+```
+
+When `secrets` is set:
+
+* `get_secret` can only retrieve listed secrets
+* `exec` only injects listed secrets as environment variables
+* Unlisted secrets are never resolved (no unnecessary auth prompts)
+
+When `secrets` is omitted, all profile secrets are available.
+
+## How it works
+
+<Steps>
+  <Step title="Server starts in non-interactive mode">
+    `fnox mcp` launches with stdin prompts disabled. This prevents provider authentication prompts from corrupting the JSON-RPC stream.
+  </Step>
+
+  <Step title="First tool call triggers batch resolution">
+    On the first call, all `env = true` profile secrets are resolved in a single batch. This amortizes the cost of YubiKey taps or SSO prompts across the session. Secrets with `env = false` are resolved on-demand when individually requested via `get_secret`.
+  </Step>
+
+  <Step title="Resolved secrets are cached in memory">
+    Subsequent tool calls use the in-memory cache. No disk writes occur (except for `as_file = true` secrets, which are written to ephemeral temp files and deleted when the command completes).
+  </Step>
+
+  <Step title="Session ends on disconnect">
+    When the agent disconnects (EOF), the process exits and all secrets are cleared from memory.
+  </Step>
+</Steps>
+
+## Security considerations
+
+* **Memory-only storage** — secrets live in process memory, not on disk (except ephemeral `as_file` temp files deleted after use).
+* **Output redaction** — the `exec` tool redacts resolved secret values from stdout/stderr before returning output to the agent. Commands like `printenv` or `echo $SECRET` return `[REDACTED]`. Redaction uses literal string matching and does not detect base64-encoded or transformed values.
+* **Output cap** — `exec` output is capped at 1 MiB to prevent unbounded memory usage.
+* **Tool visibility** — disabled tools are not advertised in `tools/list`. Agents only see tools they can actually call.
+* **Strict isolation with exec-only mode** — setting `tools = ["exec"]` with default redaction enabled prevents the agent from retrieving raw secret values through either tool.
+
+To disable redaction (not recommended):
+
+```toml theme={null}
+[mcp]
+redact_output = false
+```
+
+
+# Profiles
+Source: https://www.mintlify.com/jdx/fnox/guides/profiles
+
+Manage secrets for multiple environments in a single fnox.toml using profiles.
+
+Profiles let you store secrets for different environments — development, staging, production — in a single `fnox.toml` file. Each profile can define its own secrets, providers, and overrides while inheriting shared configuration from the top level.
+
+## Basic usage
+
+Define environment-specific secrets using `[profiles.<name>.secrets]`:
+
+```toml theme={null}
+# Default profile (development)
+[secrets]
+API_URL      = { default = "http://localhost:3000" }
+DATABASE_URL = { provider = "age", value = "encrypted-dev-db..." }
+
+# Staging profile
+[profiles.staging.secrets]
+API_URL      = { default = "https://staging.example.com" }
+DATABASE_URL = { provider = "age", value = "encrypted-staging-db..." }
+
+# Production profile
+[profiles.production.secrets]
+API_URL      = { default = "https://api.example.com" }
+DATABASE_URL = { provider = "aws", value = "prod-database-url" }
+```
+
+## Using profiles
+
+<Tabs>
+  <Tab title="CLI flag">
+    Pass `--profile` to any command:
+
+    ```bash theme={null}
+    fnox get API_URL --profile staging
+    fnox exec --profile production -- ./deploy.sh
+    ```
+  </Tab>
+
+  <Tab title="Environment variable">
+    Set `FNOX_PROFILE` once for the session:
+
+    ```bash theme={null}
+    export FNOX_PROFILE=production
+
+    fnox get DATABASE_URL   # uses production profile
+    fnox exec -- node server.js
+    ```
+  </Tab>
+
+  <Tab title="Shell integration">
+    With shell integration enabled, changing `FNOX_PROFILE` reloads secrets automatically on the next prompt:
+
+    ```bash theme={null}
+    eval "$(fnox activate bash)"
+
+    export FNOX_PROFILE=production
+    cd my-app
+    # fnox: +3 DATABASE_URL, API_KEY, JWT_SECRET (from production profile)
+
+    export FNOX_PROFILE=staging
+    # fnox detects the change on the next prompt automatically
+    # fnox: -3 +3 DATABASE_URL, API_KEY, JWT_SECRET (from staging profile)
+    ```
+  </Tab>
+</Tabs>
+
+## Profile inheritance
+
+Profiles automatically inherit every secret defined at the top level. You only need to specify values that differ from the default:
+
+```toml theme={null}
+# Define once — all profiles inherit these
+[secrets]
+LOG_LEVEL    = { default = "info" }
+API_TIMEOUT  = { default = "30" }
+DATABASE_URL = { provider = "age", value = "encrypted-dev-db..." }
+
+# Staging inherits everything; no overrides needed
+[profiles.staging]
+
+# Production overrides two secrets, inherits the rest
+[profiles.production.secrets]
+DATABASE_URL = { provider = "aws", value = "prod-db" }  # overrides DATABASE_URL
+LOG_LEVEL    = { default = "warn" }                     # overrides LOG_LEVEL
+# API_TIMEOUT="30" still inherited from top level
+```
+
+This eliminates duplication for secrets that are the same across environments.
+
+## Profile-specific providers
+
+Each profile can bring its own provider definitions. This is useful when different environments use different secret backends:
+
+```toml theme={null}
+# Development uses age encryption
+[providers]
+age = { type = "age", recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"] }
+
+# Production uses AWS Secrets Manager
+[profiles.production.providers]
+aws = { type = "aws-sm", region = "us-east-1", prefix = "myapp/" }
+
+[profiles.production.secrets]
+DATABASE_URL = { provider = "aws", value = "database-url" }
+```
+
+## Secret references in provider config
+
+Provider configuration fields can themselves reference secrets using `{ secret = "NAME" }`. This is useful for bootstrap scenarios where provider credentials are managed as secrets:
+
+```toml theme={null}
+[providers.age]
+type       = "age"
+recipients = ["age1..."]
+
+[providers.vault]
+type    = "vault"
+address = "http://vault.example.com:8200"
+token   = { secret = "VAULT_TOKEN" }  # resolved from secrets or env var
+
+[secrets]
+VAULT_TOKEN  = { provider = "age", value = "AGE-ENCRYPTED-TOKEN..." }
+DATABASE_URL = { provider = "vault", value = "database/creds/myapp" }
+```
+
+Resolution order for `{ secret = "NAME" }`: config secrets first, then environment variables. fnox detects circular dependencies and returns an error if found.
+
+## List profiles
+
+See all profiles defined in the current config:
+
+```bash theme={null}
+fnox profiles
+```
+
+```
+default (active)
+staging
+production
+```
+
+## Common patterns
+
+<AccordionGroup>
+  <Accordion title="Development + production">
+    Development secrets are encrypted in git with age; production reads from AWS Secrets Manager:
+
+    ```toml theme={null}
+    [providers]
+    age = { type = "age", recipients = ["age1..."] }
+
+    [secrets]
+    DATABASE_URL = { provider = "age", value = "encrypted..." }
+
+    [profiles.production.providers]
+    aws = { type = "aws-sm", region = "us-east-1" }
+
+    [profiles.production.secrets]
+    DATABASE_URL = { provider = "aws", value = "database-url" }
+    ```
+  </Accordion>
+
+  <Accordion title="Multi-region production">
+    Separate profiles per AWS region:
+
+    ```toml theme={null}
+    [profiles.production-us.providers]
+    aws = { type = "aws-sm", region = "us-east-1" }
+
+    [profiles.production-eu.providers]
+    aws = { type = "aws-sm", region = "eu-west-1" }
+    ```
+  </Accordion>
+
+  <Accordion title="Per-developer profiles">
+    Each developer gets their own database without changing shared config:
+
+    ```toml theme={null}
+    [profiles.alice.secrets]
+    DATABASE_URL = { default = "postgresql://localhost/alice_db" }
+
+    [profiles.bob.secrets]
+    DATABASE_URL = { default = "postgresql://localhost/bob_db" }
+    ```
+
+    ```bash theme={null}
+    export FNOX_PROFILE=alice
+    fnox exec -- npm start
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## CI/CD example
+
+Use the `--profile` flag to select environments in GitHub Actions workflows:
+
+```yaml theme={null}
+# .github/workflows/deploy.yml
+jobs:
+  deploy-staging:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: fnox exec --profile staging -- ./deploy.sh
+
+  deploy-production:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - run: fnox exec --profile production -- ./deploy.sh
+```
+
+## Next steps
+
+<CardGroup>
+  <Card title="Hierarchical config" icon="folder-tree" href="/guides/hierarchical-config">
+    Organize configs across directories with local overrides.
+  </Card>
+
+  <Card title="Real-world example" icon="rocket" href="/guides/real-world-example">
+    See a complete multi-environment setup from scratch.
+  </Card>
+</CardGroup>
+
+
+# Real-World Example
+Source: https://www.mintlify.com/jdx/fnox/guides/real-world-example
+
+Build a complete multi-environment secret setup with age encryption, AWS Secrets Manager, shell integration, and CI/CD.
+
+This guide walks through a complete fnox setup for a typical web API with development, staging, and production environments.
+
+## The scenario
+
+You're building an API that needs:
+
+* Database URL
+* API keys (Stripe, SendGrid)
+* JWT secret
+
+**Requirements:**
+
+* **Development** — secrets encrypted in git with age so any team member can clone and run immediately
+* **Staging** — secrets also encrypted in git with different values
+* **Production** — secrets stored in AWS Secrets Manager, never in git
+
+## Step 1: Initialize
+
+```bash theme={null}
+cd my-api
+fnox init
+git init
+```
+
+## Step 2: Set up age encryption
+
+```bash theme={null}
+# Generate an age key
+age-keygen -o ~/.config/fnox/age.txt
+
+# Get your public key
+grep "public key:" ~/.config/fnox/age.txt
+# Output: age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p
+
+# For teams: collect everyone's public keys and add them all as recipients
+```
+
+Add the shared age provider to `fnox.toml`:
+
+```toml theme={null}
+[providers.age]
+type       = "age"
+recipients = [
+  "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p",  # alice
+  "age1pr3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqabc123",  # bob
+  "age1zr3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqdxf456"   # ci
+]
+```
+
+Set the decryption key in your shell profile:
+
+```bash theme={null}
+# Add to ~/.bashrc or ~/.zshrc
+export FNOX_AGE_KEY=$(cat ~/.config/fnox/age.txt | grep "AGE-SECRET-KEY")
+```
+
+## Step 3: Add development secrets
+
+```bash theme={null}
+fnox set DATABASE_URL "postgresql://localhost/mydb" --provider age
+fnox set JWT_SECRET "$(openssl rand -hex 32)" --provider age
+fnox set STRIPE_KEY "sk_test_abc123" --provider age
+fnox set SENDGRID_KEY "SG.test123" --provider age
+```
+
+`fnox.toml` now contains encrypted ciphertext — commit it:
+
+```toml theme={null}
+[providers]
+age = { type = "age", recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"] }
+
+[secrets]
+DATABASE_URL = { provider = "age", value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC..." }
+JWT_SECRET   = { provider = "age", value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC..." }
+STRIPE_KEY   = { provider = "age", value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC..." }
+SENDGRID_KEY = { provider = "age", value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC..." }
+```
+
+```bash theme={null}
+git add fnox.toml
+git commit -m "Add encrypted development secrets"
+```
+
+## Step 4: Add staging profile
+
+Encrypt staging-specific values into a profile:
+
+```bash theme={null}
+fnox set DATABASE_URL "postgresql://staging.db.example.com/mydb" \
+  --provider age --profile staging
+
+fnox set JWT_SECRET "$(openssl rand -hex 32)" \
+  --provider age --profile staging
+
+fnox set STRIPE_KEY "sk_test_staging_xyz" \
+  --provider age --profile staging
+
+fnox set SENDGRID_KEY "SG.staging456" \
+  --provider age --profile staging
+```
+
+`fnox.toml` now contains both the default and staging profiles:
+
+```toml theme={null}
+# Development (default profile)
+[secrets]
+DATABASE_URL = { provider = "age", value = "..." }
+JWT_SECRET   = { provider = "age", value = "..." }
+STRIPE_KEY   = { provider = "age", value = "..." }
+SENDGRID_KEY = { provider = "age", value = "..." }
+
+# Staging profile
+[profiles.staging.secrets]
+DATABASE_URL = { provider = "age", value = "..." }
+JWT_SECRET   = { provider = "age", value = "..." }
+STRIPE_KEY   = { provider = "age", value = "..." }
+SENDGRID_KEY = { provider = "age", value = "..." }
+```
+
+## Step 5: Add production profile (AWS Secrets Manager)
+
+Add the production provider and secret references to `fnox.toml`:
+
+```toml theme={null}
+[profiles.production.providers]
+aws = { type = "aws-sm", region = "us-east-1", prefix = "myapi/" }
+
+[profiles.production.secrets]
+DATABASE_URL = { provider = "aws", value = "database-url", if_missing = "error" }
+JWT_SECRET   = { provider = "aws", value = "jwt-secret",   if_missing = "error" }
+STRIPE_KEY   = { provider = "aws", value = "stripe-key",   if_missing = "error" }
+SENDGRID_KEY = { provider = "aws", value = "sendgrid-key", if_missing = "error" }
+```
+
+Create the secrets in AWS:
+
+```bash theme={null}
+aws secretsmanager create-secret \
+  --name "myapi/database-url" \
+  --secret-string "postgresql://prod.rds.amazonaws.com/mydb"
+
+aws secretsmanager create-secret \
+  --name "myapi/jwt-secret" \
+  --secret-string "$(openssl rand -base64 64)"
+
+aws secretsmanager create-secret \
+  --name "myapi/stripe-key" \
+  --secret-string "[REDACTED-STRIPE-DOCS-EXAMPLE]"
+
+aws secretsmanager create-secret \
+  --name "myapi/sendgrid-key" \
+  --secret-string "SG.REAL_KEY_HERE"
+```
+
+Commit the references (not the values):
+
+```bash theme={null}
+git add fnox.toml
+git commit -m "Add production profile (AWS Secrets Manager)"
+```
+
+## Step 6: Local overrides
+
+Create `.gitignore` and a personal override file:
+
+```bash theme={null}
+echo "fnox.local.toml" >> .gitignore
+```
+
+```toml theme={null}
+# fnox.local.toml (not committed)
+
+[secrets]
+DATABASE_URL = { default = "postgresql://localhost/alice_db" }  # personal local DB
+DEBUG_MODE   = { default = "true" }
+```
+
+## Step 7: Enable shell integration
+
+```bash theme={null}
+# Enable for the current session
+eval "$(fnox activate bash)"
+
+# Persist across sessions
+echo 'eval "$(fnox activate bash)"' >> ~/.bashrc
+```
+
+Now secrets load automatically:
+
+```bash theme={null}
+cd my-api
+# fnox: +4 DATABASE_URL, JWT_SECRET, STRIPE_KEY, SENDGRID_KEY
+
+npm run dev  # secrets are already in the environment
+```
+
+Or without shell integration:
+
+```bash theme={null}
+fnox exec -- npm run dev
+```
+
+To use staging or production locally:
+
+```bash theme={null}
+# Staging
+fnox exec --profile staging -- ./deploy.sh
+
+# Production (requires AWS credentials)
+export AWS_REGION=us-east-1
+fnox exec --profile production -- ./deploy.sh
+```
+
+## Step 8: CI/CD setup
+
+### GitHub Actions workflow
+
+```yaml theme={null}
+# .github/workflows/ci.yml
+name: CI
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v3
+
+      - name: Run tests
+        env:
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
+        run: fnox exec -- npm test
+
+  deploy-staging:
+    if: github.ref == 'refs/heads/develop'
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v3
+
+      - name: Deploy to staging
+        env:
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
+        run: fnox exec --profile staging -- ./deploy.sh
+
+  deploy-production:
+    if: github.ref == 'refs/heads/main'
+    needs: test
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v3
+
+      - name: Deploy to production
+        env:
+          AWS_ACCESS_KEY_ID:     ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION:            us-east-1
+          FNOX_IF_MISSING:       error
+        run: fnox exec --profile production -- ./deploy.sh
+```
+
+### Set GitHub secrets
+
+1. Go to your repository → **Settings** → **Secrets and variables** → **Actions**
+2. Add `FNOX_AGE_KEY`:
+   ```bash theme={null}
+   # Copy the CI age secret key (from the CI recipient's age.txt)
+   cat ~/.config/fnox/ci-age.txt | grep "AGE-SECRET-KEY"
+   ```
+3. Add `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` for production
+
+## Step 9: Team onboarding
+
+When a new team member joins:
+
+```bash theme={null}
+# 1. Clone the repo
+git clone https://github.com/myorg/my-api
+cd my-api
+
+# 2. Install fnox (via mise)
+mise install
+
+# 3. Generate age key
+age-keygen -o ~/.config/fnox/age.txt
+
+# 4. Share public key with team lead
+grep "public key:" ~/.config/fnox/age.txt
+# → team lead adds the key to fnox.toml recipients
+
+# 5. Set decryption key
+echo 'export FNOX_AGE_KEY=$(cat ~/.config/fnox/age.txt | grep "AGE-SECRET-KEY")' >> ~/.bashrc
+source ~/.bashrc
+
+# 6. Enable shell integration
+echo 'eval "$(fnox activate bash)"' >> ~/.bashrc
+
+# 7. Team lead re-encrypts secrets to include the new recipient
+fnox reencrypt -p age
+
+# 8. Pull and run
+git pull
+cd my-api
+# fnox: +4 DATABASE_URL, JWT_SECRET, STRIPE_KEY, SENDGRID_KEY
+npm run dev  # just works
+```
+
+## File structure
+
+```
+my-api/
+├── .gitignore                 # fnox.local.toml, .env
+├── fnox.toml                  # committed (encrypted dev/staging + AWS refs for prod)
+├── fnox.local.toml            # gitignored (personal overrides)
+├── package.json
+├── src/
+└── .github/
+    └── workflows/
+        └── ci.yml
+```
+
+## Next steps
+
+<CardGroup>
+  <Card title="Profiles" icon="layers" href="/guides/profiles">
+    Deep dive into profile inheritance and patterns.
+  </Card>
+
+  <Card title="Shell integration" icon="terminal" href="/guides/shell-integration">
+    Advanced shell setup and output control.
+  </Card>
+
+  <Card title="Hierarchical config" icon="folder-tree" href="/guides/hierarchical-config">
+    Organize larger projects with monorepo-style config.
+  </Card>
+
+  <Card title="Credential leases" icon="clock" href="/guides/leases">
+    Replace static cloud credentials with short-lived leases.
+  </Card>
+</CardGroup>
+
+
+# Shell Integration
+Source: https://www.mintlify.com/jdx/fnox/guides/shell-integration
+
+Automatically load and unload secrets when you cd into and out of project directories.
+
+fnox can hook into your shell so secrets are loaded automatically when you enter a directory with a `fnox.toml` file, and unloaded when you leave.
+
+## Enable shell integration
+
+Add the activation line to your shell profile:
+
+<Tabs>
+  <Tab title="Bash">
+    ```bash theme={null}
+    # Add to ~/.bashrc or ~/.bash_profile
+    eval "$(fnox activate bash)"
+    ```
+  </Tab>
+
+  <Tab title="Zsh">
+    ```bash theme={null}
+    # Add to ~/.zshrc
+    eval "$(fnox activate zsh)"
+    ```
+  </Tab>
+
+  <Tab title="Fish">
+    ```fish theme={null}
+    # Add to ~/.config/fish/config.fish
+    fnox activate fish | source
+    ```
+  </Tab>
+
+  <Tab title="Nushell">
+    ```nu theme={null}
+    # Requires Nushell 0.96+
+    # Add to the end of your Nushell configuration
+    # (find it by running `$nu.config-path` in Nushell):
+    mkdir ($nu.data-dir | path join "vendor/autoload")
+    fnox activate nu | save -f ($nu.data-dir | path join "vendor/autoload/fnox.nu")
+    ```
+  </Tab>
+</Tabs>
+
+Restart your shell or source the config file to activate immediately.
+
+## How it works
+
+The shell hook fires on every prompt. When you enter a directory that contains `fnox.toml`, fnox resolves all secrets and exports them into your current shell:
+
+```
+~/projects $ cd my-app
+fnox: +3 DATABASE_URL, API_KEY, JWT_SECRET
+~/projects/my-app $
+```
+
+When you leave that directory, the secrets are removed from your shell:
+
+```
+~/projects/my-app $ cd ..
+fnox: -3 DATABASE_URL, API_KEY, JWT_SECRET
+~/projects $
+```
+
+<Note>
+  The hook runs on every prompt, not just on `cd`. It automatically detects changes to config files and to environment variables like `FNOX_PROFILE`.
+</Note>
+
+## Output control
+
+Control what fnox prints with the `FNOX_SHELL_OUTPUT` environment variable:
+
+```bash theme={null}
+# Silent — no output at all
+export FNOX_SHELL_OUTPUT=none
+
+# Normal — show count and key names (default)
+export FNOX_SHELL_OUTPUT=normal
+
+# Debug — verbose logging for troubleshooting
+export FNOX_SHELL_OUTPUT=debug
+```
+
+## Using profiles
+
+Set `FNOX_PROFILE` to switch which profile's secrets are loaded:
+
+```bash theme={null}
+# Load production secrets on cd
+export FNOX_PROFILE=production
+cd my-app
+# fnox: +3 DATABASE_URL, API_KEY, JWT_SECRET (from production profile)
+
+# Switch to staging — fnox detects the change on the next prompt
+export FNOX_PROFILE=staging
+# fnox: -3 +3 DATABASE_URL, API_KEY, JWT_SECRET (from staging profile)
+```
+
+## Hierarchical loading
+
+When you cd into a subdirectory, fnox merges config from all `fnox.toml` files found walking up the directory tree:
+
+```
+project/
+├── fnox.toml              # common secrets (shared keys, defaults)
+└── services/
+    ├── api/
+    │   └── fnox.toml      # API-specific secrets
+    └── worker/
+        └── fnox.toml      # worker-specific secrets
+```
+
+When you `cd services/api/`, fnox loads:
+
+1. Secrets from `project/fnox.toml`
+2. Secrets from `project/services/api/fnox.toml` (child overrides parent)
+
+See [Hierarchical configuration](/guides/hierarchical-config) for the full merge order.
+
+## Manual reload
+
+The shell hook automatically detects file changes and profile switches on each prompt. In most cases no manual action is needed.
+
+To force a complete reload:
+
+```bash theme={null}
+# Disable integration
+fnox deactivate
+
+# Re-enable integration
+eval "$(fnox activate bash)"
+```
+
+## Next steps
+
+<CardGroup>
+  <Card title="Profiles" icon="layers" href="/guides/profiles">
+    Switch environments by changing FNOX\_PROFILE.
+  </Card>
+
+  <Card title="Hierarchical config" icon="folder-tree" href="/guides/hierarchical-config">
+    Merge secrets across nested directories.
+  </Card>
+
+  <Card title="Real-world example" icon="rocket" href="/guides/real-world-example">
+    See a complete project setup with shell integration.
+  </Card>
+</CardGroup>
+
+
+# Installation
+Source: https://www.mintlify.com/jdx/fnox/installation
+
+Install fnox using mise, cargo, or from source.
+
+## Requirements
+
+* **OS**: macOS, Linux, or Windows
+* **Rust**: 1.91.1 or later (only required if building from source or installing via cargo)
+
+## Install fnox
+
+<Tabs>
+  <Tab title="mise (recommended)">
+    [mise](https://mise.jdx.dev) is the recommended way to install fnox. It handles installation and keeps fnox up to date.
+
+    <Steps>
+      <Step title="Install mise">
+        If you don't have mise installed, follow the [mise installation guide](https://mise.jdx.dev/getting-started.html).
+      </Step>
+
+      <Step title="Install fnox globally">
+        ```bash theme={null}
+        mise use -g fnox
+        ```
+
+        This installs the latest version of fnox and makes it available in your `PATH`.
+      </Step>
+
+      <Step title="Verify the installation">
+        ```bash theme={null}
+        fnox --version
+        ```
+      </Step>
+    </Steps>
+
+    <Tip>
+      To pin fnox to a specific version in a project, run `mise use fnox@1.20.0` inside that directory. This adds fnox to your project's `.mise.toml`.
+    </Tip>
+  </Tab>
+
+  <Tab title="cargo">
+    If you have Rust and Cargo installed:
+
+    ```bash theme={null}
+    cargo install fnox
+    ```
+
+    Verify the installation:
+
+    ```bash theme={null}
+    fnox --version
+    ```
+  </Tab>
+
+  <Tab title="From source">
+    To build from the latest source:
+
+    ```bash theme={null}
+    git clone https://github.com/jdx/fnox
+    cd fnox
+    cargo install --path .
+    ```
+
+    Verify the installation:
+
+    ```bash theme={null}
+    fnox --version
+    ```
+  </Tab>
+</Tabs>
+
+## Shell completions
+
+Fnox can generate completions for bash, zsh, and fish. Add the appropriate line to your shell profile to enable them.
+
+<CodeGroup>
+  ```bash bash theme={null}
+  fnox completion bash >> ~/.bashrc
+  ```
+
+  ```bash zsh theme={null}
+  fnox completion zsh >> ~/.zshrc
+  ```
+
+  ```bash fish theme={null}
+  fnox completion fish > ~/.config/fish/completions/fnox.fish
+  ```
+</CodeGroup>
+
+Reload your shell after adding the completion line:
+
+```bash theme={null}
+source ~/.bashrc  # or ~/.zshrc, etc.
+```
+
+## Next steps
+
+<CardGroup>
+  <Card title="Quick start" icon="rocket" href="/quickstart">
+    Set your first secret and run a command with it loaded in 5 minutes.
+  </Card>
+
+  <Card title="Shell integration" icon="terminal" href="/guides/shell-integration">
+    Auto-load secrets when you `cd` into a project directory.
+  </Card>
+</CardGroup>
+
+
+# What is Fnox?
+Source: https://www.mintlify.com/jdx/fnox/introduction
+
+Fnox is a CLI secret manager that supports encrypted secrets in git and remote cloud providers.
+
+Fnox is a flexible secret management tool that gives you a unified interface to work with secrets across development, CI, and production. The tagline says it all: **Fort Knox for your secrets.**
+
+## Two ways to store secrets
+
+Fnox supports two fundamentally different storage modes, and you can mix and match them within the same project.
+
+**Encrypted in git** — Secrets are encrypted and stored directly in `fnox.toml`. You commit the file to version control. Anyone on the team with the decryption key can read the secrets. Supported encryption backends: age, AWS KMS, Azure KMS, and GCP KMS.
+
+**Remote in the cloud** — `fnox.toml` holds a reference to a secret stored in an external provider. The secret value never lives in your repository. Supported providers include AWS Secrets Manager, AWS Parameter Store, Azure Key Vault, GCP Secret Manager, 1Password, Bitwarden, Bitwarden Secrets Manager, Infisical, and HashiCorp Vault.
+
+<Info>
+  You can use both modes simultaneously. A common pattern is encrypted secrets for development and remote secrets for production—managed through [profiles](/guides/profiles).
+</Info>
+
+## Key features
+
+<CardGroup>
+  <Card title="Works with your existing stack" icon="plug">
+    Already using AWS Secrets Manager or 1Password? Fnox integrates with them. No migration required.
+  </Card>
+
+  <Card title="Secrets in version control" icon="lock">
+    Store encrypted secrets in git using age or KMS. Clone the repo and immediately have development secrets.
+  </Card>
+
+  <Card title="Multi-environment profiles" icon="layer-group">
+    Manage dev, staging, and production secrets in one config file using profiles.
+  </Card>
+
+  <Card title="Shell integration" icon="terminal">
+    Auto-load secrets into your shell when you `cd` into a directory with a `fnox.toml`.
+  </Card>
+
+  <Card title="No vendor lock-in" icon="arrows-left-right">
+    Switch providers at any time. The CLI interface stays the same regardless of where secrets live.
+  </Card>
+
+  <Card title="Developer-focused" icon="code">
+    Simple TOML config, works offline with encrypted secrets, and runs any command with secrets loaded.
+  </Card>
+</CardGroup>
+
+## How it works
+
+Your project has a `fnox.toml` configuration file that defines providers and secrets. Run `fnox exec -- <command>` to inject secrets as environment variables, or enable shell integration to load them automatically.
+
+```toml theme={null}
+# fnox.toml
+
+[providers]
+age = { type = "age", recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"] }
+
+[secrets]
+# Development secrets (encrypted in git)
+DATABASE_URL = { provider = "age", value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC..." }  # ← encrypted, safe to commit
+API_KEY = { default = "dev-key-12345" }  # ← plain default for local dev
+
+[profiles.production.providers]
+aws = { type = "aws-sm", region = "us-east-1", prefix = "myapp/" }
+
+[profiles.production.secrets]
+DATABASE_URL = { provider = "aws", value = "database-url" }  # ← reference to AWS secret
+```
+
+```bash theme={null}
+# Development (uses encrypted secrets)
+fnox exec -- npm start
+
+# Production (uses AWS Secrets Manager)
+fnox exec --profile production -- ./deploy.sh
+```
+
+## Next steps
+
+<CardGroup>
+  <Card title="Quick start" icon="rocket" href="/quickstart">
+    Get fnox installed and your first secret stored in 5 minutes.
+  </Card>
+
+  <Card title="Providers overview" icon="cloud" href="/providers/overview">
+    Browse all supported encryption backends and cloud providers.
+  </Card>
+</CardGroup>
+
+
+# Age Encryption
+Source: https://www.mintlify.com/jdx/fnox/providers/age
+
+Encrypt secrets with age and store the ciphertext directly in fnox.toml. Supports native age keys and SSH keys — no extra key management needed.
+
+[age](https://github.com/FiloSottile/age) is a modern, simple encryption tool. fnox uses it to encrypt secrets and store the ciphertext inside `fnox.toml`, so the file is safe to commit to version control. age has first-class SSH key support — you can use the keys you already have.
+
+## Quick start
+
+<Steps>
+  <Step title="Install age">
+    <CodeGroup>
+      ```bash macOS theme={null}
+      brew install age
+      ```
+
+      ```bash Ubuntu / Debian theme={null}
+      sudo apt install age
+      ```
+
+      ```bash Other theme={null}
+      # Download from https://github.com/FiloSottile/age/releases
+      ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Generate an age key">
+    ```bash theme={null}
+    mkdir -p ~/.config/fnox
+    age-keygen -o ~/.config/fnox/age.txt
+    ```
+
+    The output looks like:
+
+    ```
+    # created: 2024-01-15T10:30:45-08:00
+    # public key: age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p
+    AGE-SECRET-KEY-1ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890ABCDEFGHIJKLMNOPQRS
+    ```
+  </Step>
+
+  <Step title="Configure the provider">
+    Add the provider to `fnox.toml` using the public key from the previous step:
+
+    ```toml theme={null}
+    [providers]
+    age = { type = "age", recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"] }
+    ```
+  </Step>
+
+  <Step title="Export your private key">
+    ```bash theme={null}
+    export FNOX_AGE_KEY=$(grep "AGE-SECRET-KEY" ~/.config/fnox/age.txt)
+    ```
+
+    Add this to your shell profile so it persists across sessions.
+  </Step>
+
+  <Step title="Encrypt a secret">
+    ```bash theme={null}
+    fnox set DATABASE_URL "postgresql://localhost/mydb" --provider age
+    ```
+
+    fnox writes encrypted ciphertext into `fnox.toml`:
+
+    ```toml theme={null}
+    [secrets]
+    DATABASE_URL = { provider = "age", value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+..." }
+    ```
+
+    The `value` is safe to commit.
+  </Step>
+</Steps>
+
+## Configuration
+
+```toml theme={null}
+[providers]
+age = { type = "age", recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"] }
+```
+
+The `recipients` field is a list of public keys that can decrypt secrets. Each recipient can use a different key type.
+
+| Field        | Required | Description                                |
+| ------------ | -------- | ------------------------------------------ |
+| `type`       | Yes      | Must be `"age"`                            |
+| `recipients` | Yes      | List of age public keys or SSH public keys |
+
+## Environment variables
+
+| Variable       | Description                                                                   |
+| -------------- | ----------------------------------------------------------------------------- |
+| `FNOX_AGE_KEY` | Inline age private key content (`AGE-SECRET-KEY-1...` or SSH private key PEM) |
+
+fnox resolves the decryption key in this order:
+
+1. `FNOX_AGE_KEY` environment variable (inline key content)
+2. `key_file` field in the provider config
+3. Default path `~/.config/fnox/age.txt`
+
+## SSH key support
+
+age supports SSH keys natively — no conversion needed. Both `ssh-ed25519` and `ssh-rsa` keys work as recipients.
+
+```toml theme={null}
+[providers.age]
+type = "age"
+recipients = [
+  "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGQs8YqSC... alice@example.com",
+  "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC5... bob@example.com"
+]
+```
+
+Set the decryption key using the SSH private key content:
+
+```bash theme={null}
+export FNOX_AGE_KEY=$(cat ~/.ssh/id_ed25519)
+```
+
+Or configure it directly in the provider:
+
+```toml theme={null}
+[providers.age]
+type = "age"
+key_file = "~/.ssh/id_ed25519"
+recipients = ["ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGQs8YqSC..."]
+```
+
+<Warning>
+  Password-protected SSH keys are not supported. If your SSH key has a passphrase, create a passphrase-free copy for use with fnox.
+</Warning>
+
+Get your SSH public key:
+
+```bash theme={null}
+cat ~/.ssh/id_ed25519.pub   # Ed25519
+cat ~/.ssh/id_rsa.pub       # RSA
+```
+
+## Usage
+
+```bash theme={null}
+# Encrypt and store
+fnox set DATABASE_URL "postgresql://localhost/mydb" --provider age
+
+# Decrypt and retrieve
+fnox get DATABASE_URL
+
+# Run a command with all secrets injected
+fnox exec -- npm run dev
+```
+
+## Multi-recipient team setup
+
+Each team member (and CI) adds their public key to the `recipients` list. Anyone whose key is listed can decrypt.
+
+### Setting up team access
+
+<Steps>
+  <Step title="Collect public keys">
+    Each member shares their public key:
+
+    ```bash theme={null}
+    # age key
+    grep "public key:" ~/.config/fnox/age.txt
+
+    # SSH key
+    cat ~/.ssh/id_ed25519.pub
+    ```
+  </Step>
+
+  <Step title="Add all recipients">
+    ```toml theme={null}
+    [providers.age]
+    type = "age"
+    recipients = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGQs...",  # alice
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBws...",  # bob
+      "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2el..."   # ci-bot
+    ]
+    ```
+  </Step>
+
+  <Step title="Encrypt secrets">
+    ```bash theme={null}
+    fnox set DATABASE_URL "postgresql://dev.example.com/db" --provider age
+    fnox set API_KEY "secret-key" --provider age
+    ```
+  </Step>
+
+  <Step title="Commit">
+    ```bash theme={null}
+    git add fnox.toml
+    git commit -m "Add encrypted development secrets"
+    git push
+    ```
+  </Step>
+
+  <Step title="Each member decrypts with their own key">
+    ```bash theme={null}
+    # SSH key
+    export FNOX_AGE_KEY_FILE=~/.ssh/id_ed25519
+
+    # Or age key
+    export FNOX_AGE_KEY="AGE-SECRET-KEY-1..."
+
+    fnox get DATABASE_URL  # Works for all recipients
+    ```
+  </Step>
+</Steps>
+
+### Adding a new team member
+
+1. The new member shares their public key.
+2. Add it to `recipients` in `fnox.toml`.
+3. Re-encrypt all secrets so the new key is included:
+   ```bash theme={null}
+   fnox reencrypt -p age
+
+   # Preview first
+   fnox reencrypt -p age --dry-run
+
+   # For multiple profiles
+   fnox reencrypt -p age -P staging -f
+   fnox reencrypt -p age -P prod -f
+   ```
+4. Commit and push. The new member pulls and sets their private key.
+
+## CI/CD setup (GitHub Actions)
+
+```yaml theme={null}
+name: CI
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run tests
+        env:
+          FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
+        run: fnox exec -- npm test
+```
+
+Generate a dedicated CI age key, add its public key to `recipients`, then store the private key as the `FNOX_AGE_KEY` GitHub secret:
+
+```bash theme={null}
+age-keygen -o ci-age.txt
+grep "AGE-SECRET-KEY" ci-age.txt   # copy this value to GitHub Secrets
+```
+
+## Troubleshooting
+
+**"no identity matched any of the recipients"**
+
+Your private key does not match any key in `recipients`. Verify the public key listed in the config:
+
+```bash theme={null}
+grep "public key:" ~/.config/fnox/age.txt
+grep "recipients" fnox.toml
+```
+
+**"failed to decrypt"**
+
+* Confirm `FNOX_AGE_KEY` or `FNOX_AGE_KEY_FILE` is set.
+* Verify the key file exists and is readable.
+* Confirm you are using the private key that corresponds to one of the recipients.
+
+**SSH key not working**
+
+* Only `ssh-ed25519` and `ssh-rsa` are supported.
+* Confirm the private key file path is correct.
+* Confirm the private key has no passphrase.
+
+
+# AWS KMS
+Source: https://www.mintlify.com/jdx/fnox/providers/aws-kms
+
+Encrypt secrets with AWS Key Management Service and store the ciphertext in fnox.toml. Combines git-based version control with AWS-managed keys and IAM access control.
+
+AWS KMS encrypts each secret using an AWS-managed key. The resulting ciphertext is stored in `fnox.toml` and safe to commit to version control. Decryption calls the KMS API, so AWS credentials are required at runtime.
+
+## KMS vs Secrets Manager
+
+| Feature        | AWS KMS                         | AWS Secrets Manager  |
+| -------------- | ------------------------------- | -------------------- |
+| Storage        | Local (ciphertext in fnox.toml) | Remote (in AWS)      |
+| Secrets in git | Yes (encrypted)                 | No (references only) |
+| Pricing        | \$1/key/month (one key for all) | \$0.40/secret/month  |
+| Rotation       | Manual                          | Automatic            |
+| Offline        | No (needs KMS API)              | No (needs AWS API)   |
+
+**Use KMS** when you want version-controlled secrets with AWS-managed keys.
+
+**Use Secrets Manager** when you want centralized storage without secrets in git.
+
+## Prerequisites
+
+* AWS account with credentials configured
+* A KMS key created in the target region
+* IAM permissions (see below)
+
+## Setup
+
+<Steps>
+  <Step title="Create a KMS key">
+    ```bash theme={null}
+    aws kms create-key \
+      --description "fnox secrets encryption" \
+      --key-usage ENCRYPT_DECRYPT
+    ```
+
+    Note the `KeyId` in the output. You can also create the key in the [AWS Console](https://console.aws.amazon.com/kms/) under KMS → Customer managed keys → Create key.
+  </Step>
+
+  <Step title="Configure AWS credentials">
+    <CodeGroup>
+      ```bash Environment variables theme={null}
+      export AWS_ACCESS_KEY_ID="AKIA..."
+      export AWS_SECRET_ACCESS_KEY="..."
+      export AWS_REGION="us-east-1"
+      ```
+
+      ```bash AWS CLI profile theme={null}
+      aws configure
+      # or
+      export AWS_PROFILE=myapp
+      ```
+
+      ```bash IAM role (EC2/ECS/Lambda) theme={null}
+      # No configuration needed — credentials come from instance metadata
+      ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Add the provider to fnox.toml">
+    ```toml theme={null}
+    [providers.kms]
+    type = "aws-kms"
+    key_id = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+    region = "us-east-1"
+    ```
+  </Step>
+
+  <Step title="Encrypt a secret">
+    ```bash theme={null}
+    fnox set DATABASE_URL "postgresql://prod.example.com/db" --provider kms
+    ```
+
+    The result in `fnox.toml`:
+
+    ```toml theme={null}
+    [secrets]
+    DATABASE_URL = { provider = "kms", value = "AQICAHhw...base64ciphertext..." }
+    ```
+  </Step>
+</Steps>
+
+## Configuration
+
+```toml theme={null}
+[providers.kms]
+type = "aws-kms"
+key_id = "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+region = "us-east-1"
+```
+
+| Field    | Required | Description                                          |
+| -------- | -------- | ---------------------------------------------------- |
+| `type`   | Yes      | Must be `"aws-kms"`                                  |
+| `key_id` | Yes      | KMS key ARN, key ID, or alias (e.g., `alias/my-key`) |
+| `region` | Yes      | AWS region where the key was created                 |
+
+The `key_id` accepts:
+
+* Full ARN: `arn:aws:kms:us-east-1:123456789012:key/...`
+* Key ID: `12345678-1234-1234-1234-123456789012`
+* Alias: `alias/my-key`
+
+## IAM permissions
+
+```json theme={null}
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["kms:Decrypt", "kms:Encrypt", "kms:DescribeKey"],
+      "Resource": "arn:aws:kms:REGION:ACCOUNT:key/KEY-ID"
+    }
+  ]
+}
+```
+
+## Usage
+
+```bash theme={null}
+# Encrypt and store
+fnox set DATABASE_URL "postgresql://prod.example.com/db" --provider kms
+
+# Decrypt and retrieve
+fnox get DATABASE_URL
+
+# Run a command with secrets injected
+fnox exec -- ./start-server.sh
+```
+
+## How it works
+
+1. **`fnox set`** — calls the AWS KMS `Encrypt` API and stores the base64 ciphertext in `fnox.toml`.
+2. **`fnox get`** — reads the ciphertext from `fnox.toml` and calls the AWS KMS `Decrypt` API to recover the plaintext.
+
+## Multi-environment example
+
+```toml theme={null}
+# Development: age encryption (free, offline)
+[providers]
+age = { type = "age", recipients = ["age1..."] }
+
+[secrets]
+DATABASE_URL = { provider = "age", value = "encrypted-dev..." }
+
+# Production: AWS KMS
+[profiles.production.providers]
+kms = { type = "aws-kms", key_id = "arn:aws:kms:us-east-1:123456789012:key/...", region = "us-east-1" }
+
+[profiles.production.secrets]
+DATABASE_URL = { provider = "kms", value = "AQICAHhw..." }
+```
+
+## Key rotation
+
+When rotating the KMS key, update `key_id` in `fnox.toml` and re-encrypt all secrets:
+
+```bash theme={null}
+fnox set DATABASE_URL "$(fnox get DATABASE_URL)" --provider kms
+fnox set API_KEY "$(fnox get API_KEY)" --provider kms
+```
+
+## Costs
+
+* **\$1.00 per key per month**
+* **\$0.03 per 10,000 API calls**
+
+One key covers all your secrets, making KMS significantly cheaper than Secrets Manager when you have many secrets.
+
+
+# AWS Parameter Store
+Source: https://www.mintlify.com/jdx/fnox/providers/aws-ps
+
+Store secrets in AWS Systems Manager Parameter Store. Hierarchical paths, free standard tier, and IAM access control make it a cost-effective alternative to Secrets Manager.
+
+AWS Systems Manager Parameter Store stores secrets at hierarchical paths like `/myapp/prod/database-url`. The standard tier is free for up to 10,000 parameters, making it a cost-effective choice when automatic rotation is not required.
+
+## Parameter Store vs Secrets Manager
+
+| Feature      | Parameter Store               | Secrets Manager           |
+| ------------ | ----------------------------- | ------------------------- |
+| Cost         | Free (standard tier)          | \$0.40/secret/month       |
+| Max size     | 4 KB (8 KB advanced)          | 64 KB                     |
+| Rotation     | Manual                        | Automatic                 |
+| Versioning   | Limited                       | Full versioning           |
+| Organization | Hierarchical paths (`/a/b/c`) | Flat with tags            |
+| Best for     | Config values, simple secrets | Complex secrets, rotation |
+
+## Quick start
+
+<Steps>
+  <Step title="Configure the provider">
+    ```toml theme={null}
+    [providers]
+    ps = { type = "aws-ps", region = "us-east-1", prefix = "/myapp/prod/" }
+    ```
+  </Step>
+
+  <Step title="Create a parameter in AWS">
+    ```bash theme={null}
+    aws ssm put-parameter \
+      --name "/myapp/prod/database-url" \
+      --value "postgresql://prod.example.com/db" \
+      --type "SecureString"
+    ```
+  </Step>
+
+  <Step title="Reference it in fnox.toml">
+    ```toml theme={null}
+    [secrets]
+    DATABASE_URL = { provider = "ps", value = "database-url" }
+    # With prefix "/myapp/prod/", fnox fetches "/myapp/prod/database-url"
+    ```
+  </Step>
+
+  <Step title="Fetch the secret">
+    ```bash theme={null}
+    fnox get DATABASE_URL
+    ```
+  </Step>
+</Steps>
+
+## Prerequisites
+
+* AWS account
+* AWS credentials configured (environment variables, CLI profile, or IAM role)
+* IAM permissions to read parameters (see below)
+
+## Configuration
+
+```toml theme={null}
+[providers]
+ps = { type = "aws-ps", region = "us-east-1" }
+
+# With all optional fields:
+ps = { type = "aws-ps", region = "us-east-1", profile = "my-aws-profile", prefix = "/myapp/prod/" }
+```
+
+| Field     | Required | Description                                                                                  |
+| --------- | -------- | -------------------------------------------------------------------------------------------- |
+| `type`    | Yes      | Must be `"aws-ps"`                                                                           |
+| `region`  | Yes      | AWS region (e.g. `us-east-1`)                                                                |
+| `profile` | No       | AWS CLI profile from `~/.aws/config`. Falls back to the default credential chain if omitted. |
+| `prefix`  | No       | Prepended to all parameter names                                                             |
+
+### Configure AWS credentials
+
+<CodeGroup>
+  ```bash Environment variables theme={null}
+  export AWS_ACCESS_KEY_ID="AKIA..."
+  export AWS_SECRET_ACCESS_KEY="..."
+  export AWS_REGION="us-east-1"
+  ```
+
+  ```bash AWS CLI profile theme={null}
+  aws configure
+  export AWS_PROFILE=myapp
+  ```
+
+  ```bash IAM role (EC2 / ECS / Lambda) theme={null}
+  # No configuration needed
+  ```
+</CodeGroup>
+
+## The prefix field
+
+`prefix` is prepended to the `value` of each secret reference:
+
+```toml theme={null}
+[providers]
+ps = { type = "aws-ps", region = "us-east-1", prefix = "/myapp/prod/" }
+
+[secrets]
+DATABASE_URL = { provider = "ps", value = "database-url" }  # fetches "/myapp/prod/database-url"
+API_KEY      = { provider = "ps", value = "api-key" }       # fetches "/myapp/prod/api-key"
+```
+
+Without a prefix, use the full path in `value`:
+
+```toml theme={null}
+[providers]
+ps = { type = "aws-ps", region = "us-east-1" }
+
+[secrets]
+DATABASE_URL = { provider = "ps", value = "/myapp/prod/database-url" }
+```
+
+## IAM permissions
+
+### Read-only (minimum)
+
+```json theme={null}
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DescribeParameters",
+      "Effect": "Allow",
+      "Action": "ssm:DescribeParameters",
+      "Resource": "*"
+    },
+    {
+      "Sid": "ReadParameters",
+      "Effect": "Allow",
+      "Action": ["ssm:GetParameter", "ssm:GetParameters"],
+      "Resource": "arn:aws:ssm:REGION:ACCOUNT:parameter/myapp/*"
+    }
+  ]
+}
+```
+
+<Warning>
+  `ssm:DescribeParameters` must use `"Resource": "*"` — it cannot be scoped to specific ARNs.
+</Warning>
+
+### Full access (for testing / writes)
+
+```json theme={null}
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DescribeParameters",
+      "Effect": "Allow",
+      "Action": "ssm:DescribeParameters",
+      "Resource": "*"
+    },
+    {
+      "Sid": "ParameterStorePermissions",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:GetParameter",
+        "ssm:GetParameters",
+        "ssm:PutParameter",
+        "ssm:DeleteParameter"
+      ],
+      "Resource": ["arn:aws:ssm:REGION:ACCOUNT:parameter/myapp/*"]
+    }
+  ]
+}
+```
+
+## Usage
+
+```bash theme={null}
+# Store a secret via fnox
+fnox set DATABASE_URL "postgresql://prod.db.example.com/mydb" --provider ps
+
+# Fetch a single secret
+fnox get DATABASE_URL
+
+# Run a command with all secrets injected
+fnox exec -- ./start-server.sh
+
+# Use a different environment profile
+fnox exec --profile production -- ./deploy.sh
+```
+
+## Hierarchical organization
+
+Parameter Store paths map naturally to environments and subsystems:
+
+```
+/myapp/
+  prod/
+    database/url
+    database/password
+    api/key
+  staging/
+    database/url
+    database/password
+```
+
+```toml theme={null}
+[providers]
+prod    = { type = "aws-ps", region = "us-east-1", prefix = "/myapp/prod/" }
+staging = { type = "aws-ps", region = "us-east-1", prefix = "/myapp/staging/" }
+
+[secrets]
+DATABASE_URL = { provider = "prod", value = "database/url" }
+
+[profiles.staging.secrets]
+DATABASE_URL = { provider = "staging", value = "database/url" }
+```
+
+## Multi-environment example
+
+```toml theme={null}
+# Development: age encryption
+[providers]
+age = { type = "age", recipients = ["age1..."] }
+
+[secrets]
+DATABASE_URL = { provider = "age", value = "encrypted-dev-db..." }
+
+# Staging
+[profiles.staging.providers]
+ps = { type = "aws-ps", region = "us-east-1", prefix = "/myapp/staging/" }
+
+[profiles.staging.secrets]
+DATABASE_URL = { provider = "ps", value = "database/url" }
+
+# Production with a dedicated AWS profile
+[profiles.production.providers]
+ps = { type = "aws-ps", region = "us-east-1", profile = "prod-account", prefix = "/myapp/prod/" }
+
+[profiles.production.secrets]
+DATABASE_URL = { provider = "ps", value = "database/url" }
+```
+
+```bash theme={null}
+fnox get DATABASE_URL                        # development
+fnox get DATABASE_URL --profile staging      # staging
+fnox get DATABASE_URL --profile production   # production
+```
+
+## CI/CD example (GitHub Actions)
+
+```yaml theme={null}
+name: Deploy
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Deploy
+        run: fnox exec --profile production -- ./deploy.sh
+```
+
+## Troubleshooting
+
+**AccessDeniedException**
+
+```bash theme={null}
+aws ssm describe-parameters
+aws ssm get-parameter --name "/myapp/prod/database-url" --with-decryption
+```
+
+**ParameterNotFound**
+
+```bash theme={null}
+aws ssm get-parameters-by-path --path "/myapp/prod/" --recursive
+grep prefix fnox.toml
+```
+
+**Invalid Region**
+
+```bash theme={null}
+grep region fnox.toml
+echo $AWS_REGION
+```
+
+
+# AWS Secrets Manager
+Source: https://www.mintlify.com/jdx/fnox/providers/aws-sm
+
+Store secrets remotely in AWS Secrets Manager. fnox.toml contains only name references — secrets never touch the filesystem or version control.
+
+AWS Secrets Manager provides centralized secret storage with IAM access control, CloudTrail audit logs, and automatic rotation. Your `fnox.toml` holds only the secret names; values are fetched at runtime.
+
+## Quick start
+
+<Steps>
+  <Step title="Configure the provider">
+    ```toml theme={null}
+    [providers]
+    aws = { type = "aws-sm", region = "us-east-1", prefix = "myapp/" }
+    ```
+  </Step>
+
+  <Step title="Create a secret in AWS">
+    ```bash theme={null}
+    aws secretsmanager create-secret \
+      --name "myapp/database-url" \
+      --secret-string "postgresql://prod.example.com/db"
+    ```
+  </Step>
+
+  <Step title="Reference it in fnox.toml">
+    ```toml theme={null}
+    [secrets]
+    DATABASE_URL = { provider = "aws", value = "database-url" }
+    # With prefix "myapp/", fnox fetches "myapp/database-url"
+    ```
+  </Step>
+
+  <Step title="Fetch the secret">
+    ```bash theme={null}
+    fnox get DATABASE_URL
+    ```
+  </Step>
+</Steps>
+
+## Prerequisites
+
+* AWS account
+* AWS credentials configured (environment variables, CLI profile, or IAM role)
+* IAM permissions to read secrets (see below)
+
+## Configuration
+
+```toml theme={null}
+[providers]
+aws = { type = "aws-sm", region = "us-east-1" }
+
+# With all optional fields:
+aws = { type = "aws-sm", region = "us-east-1", profile = "my-aws-profile", prefix = "myapp/" }
+```
+
+| Field     | Required | Description                                                                                  |
+| --------- | -------- | -------------------------------------------------------------------------------------------- |
+| `type`    | Yes      | Must be `"aws-sm"`                                                                           |
+| `region`  | Yes      | AWS region (e.g. `us-east-1`)                                                                |
+| `profile` | No       | AWS CLI profile from `~/.aws/config`. Falls back to the default credential chain if omitted. |
+| `prefix`  | No       | Prepended to all secret names                                                                |
+
+### Configure AWS credentials
+
+<CodeGroup>
+  ```bash Environment variables theme={null}
+  export AWS_ACCESS_KEY_ID="AKIA..."
+  export AWS_SECRET_ACCESS_KEY="..."
+  export AWS_REGION="us-east-1"
+  ```
+
+  ```bash AWS CLI profile theme={null}
+  aws configure
+  # or use a named profile
+  export AWS_PROFILE=myapp
+  ```
+
+  ```bash IAM role (EC2 / ECS / Lambda) theme={null}
+  # No configuration needed — credentials come from instance metadata automatically
+  ```
+</CodeGroup>
+
+## The prefix field
+
+`prefix` is prepended to the `value` of each secret reference:
+
+```toml theme={null}
+[providers]
+aws = { type = "aws-sm", region = "us-east-1", prefix = "myapp/" }
+
+[secrets]
+DATABASE_URL = { provider = "aws", value = "database-url" }  # fetches "myapp/database-url"
+API_KEY      = { provider = "aws", value = "api-key" }       # fetches "myapp/api-key"
+```
+
+Without a prefix, use the full secret name in `value`:
+
+```toml theme={null}
+[providers]
+aws = { type = "aws-sm", region = "us-east-1" }
+
+[secrets]
+DATABASE_URL = { provider = "aws", value = "myapp/database-url" }
+```
+
+## IAM permissions
+
+### Read-only (minimum)
+
+```json theme={null}
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ListSecrets",
+      "Effect": "Allow",
+      "Action": "secretsmanager:ListSecrets",
+      "Resource": "*"
+    },
+    {
+      "Sid": "ReadSecrets",
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DescribeSecret"
+      ],
+      "Resource": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:myapp/*"
+    }
+  ]
+}
+```
+
+<Warning>
+  `secretsmanager:ListSecrets` must use `"Resource": "*"` — it cannot be scoped to specific ARNs.
+</Warning>
+
+### Full access (for testing / writes)
+
+```json theme={null}
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ListSecretsPermission",
+      "Effect": "Allow",
+      "Action": "secretsmanager:ListSecrets",
+      "Resource": "*"
+    },
+    {
+      "Sid": "SecretsManagerPermissions",
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:PutSecretValue",
+        "secretsmanager:CreateSecret",
+        "secretsmanager:UpdateSecret",
+        "secretsmanager:DeleteSecret"
+      ],
+      "Resource": ["arn:aws:secretsmanager:REGION:ACCOUNT:secret:myapp/*"]
+    }
+  ]
+}
+```
+
+## Usage
+
+```bash theme={null}
+# Fetch a single secret
+fnox get DATABASE_URL
+
+# Run a command with all secrets injected
+fnox exec -- ./start-server.sh
+
+# Use a different environment profile
+fnox exec --profile production -- ./deploy.sh
+```
+
+## JSON secrets
+
+AWS Secrets Manager supports JSON-structured secrets. By default fnox returns the entire JSON string. Use `json_path` to extract a specific field:
+
+```bash theme={null}
+aws secretsmanager create-secret \
+  --name "myapp/db-credentials" \
+  --secret-string '{"host":"db.example.com","port":"5432","username":"admin","password":"secret"}'
+```
+
+```toml theme={null}
+[secrets]
+DB_CREDENTIALS = { provider = "aws", value = "db-credentials" }
+DB_PASS        = { provider = "aws", value = "db-credentials", json_path = "password" }
+```
+
+Nested paths use dot notation. Literal dots must be escaped (`\.`):
+
+```toml theme={null}
+[secrets]
+DB_HOST      = { provider = "aws", value = "config", json_path = "database.host" }
+DB_CACHE_KEY = { provider = "aws", value = "config", json_path = 'database.cache\.key' }
+```
+
+## Multi-environment example
+
+```toml theme={null}
+# Development: age encryption
+[providers]
+age = { type = "age", recipients = ["age1..."] }
+
+[secrets]
+DATABASE_URL = { provider = "age", value = "encrypted-dev-db..." }
+
+# Staging: AWS Secrets Manager (us-east-1)
+[profiles.staging.providers]
+aws = { type = "aws-sm", region = "us-east-1", prefix = "myapp-staging/" }
+
+[profiles.staging.secrets]
+DATABASE_URL = { provider = "aws", value = "database-url" }  # → myapp-staging/database-url
+
+# Production: AWS Secrets Manager (us-west-2) with a dedicated profile
+[profiles.production.providers]
+aws = { type = "aws-sm", region = "us-west-2", profile = "prod-account", prefix = "myapp-prod/" }
+
+[profiles.production.secrets]
+DATABASE_URL = { provider = "aws", value = "database-url" }  # → myapp-prod/database-url
+```
+
+```bash theme={null}
+fnox get DATABASE_URL                        # development
+fnox get DATABASE_URL --profile staging      # staging
+fnox get DATABASE_URL --profile production   # production
+```
+
+<Tip>
+  Use age encryption for development and staging secrets to reduce AWS Secrets Manager costs. Reserve AWS SM for production-only secrets.
+</Tip>
+
+## CI/CD example (GitHub Actions)
+
+```yaml theme={null}
+name: Deploy
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Deploy
+        run: fnox exec --profile production -- ./deploy.sh
+```
+
+## Troubleshooting
+
+**AccessDeniedException**
+
+```bash theme={null}
+aws secretsmanager list-secrets
+aws secretsmanager get-secret-value --secret-id "myapp/database-url"
+```
+
+**ResourceNotFoundException**
+
+Secret does not exist or the prefix is wrong:
+
+```bash theme={null}
+aws secretsmanager list-secrets
+grep prefix fnox.toml
+```
+
+**Invalid Region**
+
+```bash theme={null}
+grep region fnox.toml
+echo $AWS_REGION
+```
+
+
+# Azure Providers
+Source: https://www.mintlify.com/jdx/fnox/providers/azure
+
+Use Azure Key Vault for encryption (azure-kms) or remote secret storage (azure-sm). Both providers authenticate with Azure credentials and integrate with Azure RBAC.
+
+fnox supports two Azure Key Vault provider types:
+
+* **`azure-kms`** — encrypts secrets using a Key Vault key and stores the ciphertext in `fnox.toml`
+* **`azure-sm`** — stores secrets remotely in Key Vault Secrets; `fnox.toml` holds only name references
+
+<Tabs>
+  <Tab title="Azure KMS (encryption)">
+    ## Azure Key Vault Keys
+
+    `azure-kms` encrypts each secret with an Azure-managed key. The ciphertext is stored in `fnox.toml` and safe to commit to git. Decryption calls the Azure Key Vault API.
+
+    ### Quick start
+
+    ```bash theme={null}
+    # Create a Key Vault key
+    az keyvault key create \
+      --vault-name "myapp-vault" \
+      --name "encryption-key" \
+      --protection software
+
+    # Configure fnox
+    cat >> fnox.toml << 'EOF'
+    [providers]
+    azurekms = { type = "azure-kms", vault_url = "https://myapp-vault.vault.azure.net/", key_name = "encryption-key" }
+    EOF
+
+    # Encrypt a secret
+    fnox set DATABASE_URL "postgresql://prod.example.com/db" --provider azurekms
+
+    # Decrypt
+    fnox get DATABASE_URL
+    ```
+
+    ### Configuration
+
+    ```toml theme={null}
+    [providers]
+    azurekms = { type = "azure-kms", vault_url = "https://myapp-vault.vault.azure.net/", key_name = "encryption-key" }
+    ```
+
+    | Field       | Required | Description                                                                   |
+    | ----------- | -------- | ----------------------------------------------------------------------------- |
+    | `type`      | Yes      | Must be `"azure-kms"`                                                         |
+    | `vault_url` | Yes      | Full URL of the Azure Key Vault (e.g. `https://myapp-vault.vault.azure.net/`) |
+    | `key_name`  | Yes      | Name of the key within the vault                                              |
+
+    ### Required permissions
+
+    Grant the **Key Vault Crypto User** role to the identity that will encrypt and decrypt:
+
+    ```bash theme={null}
+    az role assignment create \
+      --role "Key Vault Crypto User" \
+      --assignee "user@example.com" \
+      --scope "/subscriptions/SUB-ID/resourceGroups/myapp-rg/providers/Microsoft.KeyVault/vaults/myapp-vault"
+    ```
+
+    ### How it works
+
+    1. **`fnox set`** — calls Azure Key Vault to encrypt the value and stores the base64 ciphertext in `fnox.toml`.
+    2. **`fnox get`** — reads the ciphertext from `fnox.toml` and calls Azure Key Vault to recover the plaintext.
+  </Tab>
+
+  <Tab title="Azure SM (remote storage)">
+    ## Azure Key Vault Secrets
+
+    `azure-sm` stores secrets remotely in Azure Key Vault Secrets. Your `fnox.toml` contains only the secret name; the value is fetched at runtime.
+
+    ### Quick start
+
+    ```bash theme={null}
+    # Create a Key Vault
+    az keyvault create --name "myapp-vault" --resource-group "myapp-rg"
+
+    # Configure fnox
+    cat >> fnox.toml << 'EOF'
+    [providers]
+    azure = { type = "azure-sm", vault_url = "https://myapp-vault.vault.azure.net/", prefix = "myapp-" }
+    EOF
+
+    # Create a secret in Azure
+    az keyvault secret set \
+      --vault-name "myapp-vault" \
+      --name "myapp-database-url" \
+      --value "postgresql://prod.example.com/db"
+
+    # Reference it in fnox.toml
+    cat >> fnox.toml << 'EOF'
+    [secrets]
+    DATABASE_URL = { provider = "azure", value = "database-url" }
+    EOF
+
+    # Fetch the secret
+    fnox get DATABASE_URL
+    ```
+
+    ### Configuration
+
+    ```toml theme={null}
+    [providers]
+    azure = { type = "azure-sm", vault_url = "https://myapp-vault.vault.azure.net/", prefix = "myapp-" }
+    # prefix is optional
+    ```
+
+    | Field       | Required | Description                     |
+    | ----------- | -------- | ------------------------------- |
+    | `type`      | Yes      | Must be `"azure-sm"`            |
+    | `vault_url` | Yes      | Full URL of the Azure Key Vault |
+    | `prefix`    | No       | Prepended to all secret names   |
+
+    ### Required permissions
+
+    Grant the **Key Vault Secrets User** role to the identity that will read secrets:
+
+    ```bash theme={null}
+    az role assignment create \
+      --role "Key Vault Secrets User" \
+      --assignee "user@example.com" \
+      --scope "/subscriptions/SUB-ID/resourceGroups/myapp-rg/providers/Microsoft.KeyVault/vaults/myapp-vault"
+    ```
+  </Tab>
+</Tabs>
+
+## Authentication
+
+Both `azure-kms` and `azure-sm` use the Azure SDK default credential chain. Choose the method that fits your environment:
+
+<CodeGroup>
+  ```bash Azure CLI (local development) theme={null}
+  az login
+  ```
+
+  ```bash Service principal (CI/CD) theme={null}
+  export AZURE_CLIENT_ID="..."
+  export AZURE_CLIENT_SECRET="..."
+  export AZURE_TENANT_ID="..."
+  ```
+
+  ```bash Managed identity (Azure VMs / Functions) theme={null}
+  # No configuration needed — credentials are automatic
+  ```
+</CodeGroup>
+
+## Multi-environment example
+
+```toml theme={null}
+# Development: age encryption
+[providers]
+age = { type = "age", recipients = ["age1..."] }
+
+[secrets]
+DATABASE_URL = { provider = "age", value = "encrypted-dev..." }
+
+# Production: Azure Key Vault Secrets
+[profiles.production.providers]
+azure = { type = "azure-sm", vault_url = "https://myapp-vault.vault.azure.net/", prefix = "myapp-prod-" }
+
+[profiles.production.secrets]
+DATABASE_URL = { provider = "azure", value = "database-url" }
+```
+
+
+# Google Cloud Providers
+Source: https://www.mintlify.com/jdx/fnox/providers/gcp
+
+Use GCP Cloud KMS for encryption (gcp-kms) or GCP Secret Manager for remote storage (gcp-sm). Both providers authenticate via Application Default Credentials.
+
+fnox supports two Google Cloud provider types:
+
+* **`gcp-kms`** — encrypts secrets with Cloud KMS and stores the ciphertext in `fnox.toml`
+* **`gcp-sm`** — stores secrets remotely in GCP Secret Manager; `fnox.toml` holds only name references
+
+<Tabs>
+  <Tab title="GCP KMS (encryption)">
+    ## Google Cloud KMS
+
+    `gcp-kms` encrypts each secret with a GCP-managed key. The ciphertext is stored in `fnox.toml` and safe to commit to git. Decryption calls the Cloud KMS API.
+
+    ### Quick start
+
+    ```bash theme={null}
+    # Enable Cloud KMS and create a key
+    gcloud services enable cloudkms.googleapis.com
+    gcloud kms keyrings create "fnox-keyring" --location="us-central1"
+    gcloud kms keys create "fnox-key" \
+      --keyring="fnox-keyring" \
+      --location="us-central1" \
+      --purpose="encryption"
+
+    # Configure fnox
+    cat >> fnox.toml << 'EOF'
+    [providers.gcpkms]
+    type = "gcp-kms"
+    project = "my-project-id"
+    location = "us-central1"
+    keyring = "fnox-keyring"
+    key = "fnox-key"
+    EOF
+
+    # Encrypt a secret
+    fnox set DATABASE_URL "postgresql://prod.example.com/db" --provider gcpkms
+
+    # Decrypt
+    fnox get DATABASE_URL
+    ```
+
+    ### Configuration
+
+    ```toml theme={null}
+    [providers.gcpkms]
+    type = "gcp-kms"
+    project = "my-project-id"
+    location = "us-central1"
+    keyring = "fnox-keyring"
+    key = "fnox-key"
+    ```
+
+    | Field      | Required | Description                             |
+    | ---------- | -------- | --------------------------------------- |
+    | `type`     | Yes      | Must be `"gcp-kms"`                     |
+    | `project`  | Yes      | GCP project ID                          |
+    | `location` | Yes      | Cloud KMS location (e.g. `us-central1`) |
+    | `keyring`  | Yes      | Name of the key ring                    |
+    | `key`      | Yes      | Name of the crypto key                  |
+
+    ### Required permissions
+
+    Grant the **Cloud KMS CryptoKey Encrypter/Decrypter** role:
+
+    ```bash theme={null}
+    gcloud kms keys add-iam-policy-binding "fnox-key" \
+      --keyring="fnox-keyring" \
+      --location="us-central1" \
+      --member="user:your-email@example.com" \
+      --role="roles/cloudkms.cryptoKeyEncrypterDecrypter"
+    ```
+
+    ### How it works
+
+    1. **`fnox set`** — calls Cloud KMS to encrypt the value and stores the base64 ciphertext in `fnox.toml`.
+    2. **`fnox get`** — reads the ciphertext from `fnox.toml` and calls Cloud KMS to recover the plaintext.
+  </Tab>
+
+  <Tab title="GCP Secret Manager (remote storage)">
+    ## GCP Secret Manager
+
+    `gcp-sm` stores secrets remotely in GCP Secret Manager. Your `fnox.toml` contains only the secret name; the value is fetched at runtime.
+
+    ### Quick start
+
+    ```bash theme={null}
+    # Enable the Secret Manager API
+    gcloud services enable secretmanager.googleapis.com
+
+    # Configure fnox
+    cat >> fnox.toml << 'EOF'
+    [providers]
+    gcp = { type = "gcp-sm", project = "my-project-id", prefix = "myapp-" }
+    EOF
+
+    # Create a secret in GCP
+    echo -n "postgresql://prod.example.com/db" | \
+      gcloud secrets create myapp-database-url --data-file=-
+
+    # Reference it in fnox.toml
+    cat >> fnox.toml << 'EOF'
+    [secrets]
+    DATABASE_URL = { provider = "gcp", value = "database-url" }
+    EOF
+
+    # Fetch the secret
+    fnox get DATABASE_URL
+    ```
+
+    ### Configuration
+
+    ```toml theme={null}
+    [providers]
+    gcp = { type = "gcp-sm", project = "my-project-id", prefix = "myapp-" }
+    # prefix is optional
+    ```
+
+    | Field     | Required | Description                   |
+    | --------- | -------- | ----------------------------- |
+    | `type`    | Yes      | Must be `"gcp-sm"`            |
+    | `project` | Yes      | GCP project ID                |
+    | `prefix`  | No       | Prepended to all secret names |
+
+    ### Required permissions
+
+    Grant the **Secret Manager Secret Accessor** role:
+
+    ```bash theme={null}
+    gcloud projects add-iam-policy-binding PROJECT-ID \
+      --member="user:your-email@example.com" \
+      --role="roles/secretmanager.secretAccessor"
+    ```
+  </Tab>
+</Tabs>
+
+## Authentication
+
+Both `gcp-kms` and `gcp-sm` use Application Default Credentials (ADC). Choose the method that fits your environment:
+
+<CodeGroup>
+  ```bash gcloud CLI (local development) theme={null}
+  gcloud auth application-default login
+  ```
+
+  ```bash Service account (CI/CD) theme={null}
+  export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account-key.json"
+  ```
+
+  ```bash Workload Identity (GKE) theme={null}
+  # No configuration needed — credentials are automatic
+  ```
+</CodeGroup>
+
+## Multi-environment example
+
+```toml theme={null}
+# Development: age encryption
+[providers]
+age = { type = "age", recipients = ["age1..."] }
+
+[secrets]
+DATABASE_URL = { provider = "age", value = "encrypted-dev..." }
+
+# Production: GCP Secret Manager
+[profiles.production.providers]
+gcp = { type = "gcp-sm", project = "my-project-id", prefix = "myapp-prod-" }
+
+[profiles.production.secrets]
+DATABASE_URL = { provider = "gcp", value = "database-url" }
+```
+
+
+# HashiCorp Vault
+Source: https://www.mintlify.com/jdx/fnox/providers/hashicorp-vault
+
+Integrate with self-hosted or HCP HashiCorp Vault for advanced secret management with dynamic secrets, fine-grained policies, and audit logging.
+
+HashiCorp Vault is a mature, self-hostable secret management system with advanced features including dynamic secrets, secret leasing, and fine-grained access policies. fnox integrates via the `vault` CLI.
+
+## Prerequisites
+
+* Vault server running (self-hosted or [HCP Vault](https://developer.hashicorp.com/hcp/docs/vault))
+* Vault CLI installed
+* Vault token with appropriate policies
+
+## Installation
+
+<CodeGroup>
+  ```bash macOS theme={null}
+  brew install vault
+  ```
+
+  ```bash Ubuntu / Debian theme={null}
+  wget -O- https://apt.releases.hashicorp.com/gpg | \
+    sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+  echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] \
+    https://apt.releases.hashicorp.com $(lsb_release -cs) main" | \
+    sudo tee /etc/apt/sources.list.d/hashicorp.list
+  sudo apt update && sudo apt install vault
+  ```
+</CodeGroup>
+
+## Configuration
+
+```toml theme={null}
+[providers]
+vault = { type = "vault", path = "secret/myapp" }
+# address and token are optional — fall back to environment variables
+```
+
+| Field       | Required | Description                                                          |
+| ----------- | -------- | -------------------------------------------------------------------- |
+| `type`      | Yes      | Must be `"vault"`                                                    |
+| `path`      | Yes      | Base path for secrets in Vault (e.g. `secret/myapp`)                 |
+| `address`   | No       | Vault server URL. Falls back to `FNOX_VAULT_ADDR` then `VAULT_ADDR`. |
+| `token`     | No       | Vault token. Falls back to `FNOX_VAULT_TOKEN` then `VAULT_TOKEN`.    |
+| `namespace` | No       | Vault namespace (HCP Vault and Vault Enterprise).                    |
+
+## Environment variables
+
+| Variable           | Description                                                  |
+| ------------------ | ------------------------------------------------------------ |
+| `VAULT_ADDR`       | Vault server address (e.g. `https://vault.example.com:8200`) |
+| `FNOX_VAULT_ADDR`  | fnox-specific override for `VAULT_ADDR`                      |
+| `VAULT_TOKEN`      | Vault authentication token                                   |
+| `FNOX_VAULT_TOKEN` | fnox-specific override for `VAULT_TOKEN`                     |
+
+fnox resolves the address and token in this order: provider config → `FNOX_VAULT_*` → `VAULT_*`.
+
+## Setup
+
+<Steps>
+  <Step title="Configure Vault access">
+    ```bash theme={null}
+    export VAULT_ADDR="https://vault.example.com:8200"
+
+    # Login interactively
+    vault login -method=userpass username=myuser
+
+    # Or export an existing token
+    export VAULT_TOKEN="hvs.CAESIJ..."
+    ```
+  </Step>
+
+  <Step title="Create a Vault policy">
+    ```hcl theme={null}
+    # policy.hcl
+    path "secret/data/myapp/*" {
+      capabilities = ["read"]
+    }
+
+    path "secret/metadata/myapp/*" {
+      capabilities = ["list"]
+    }
+    ```
+
+    ```bash theme={null}
+    vault policy write fnox-policy policy.hcl
+    ```
+  </Step>
+
+  <Step title="Store secrets in Vault">
+    ```bash theme={null}
+    # KV v2 engine
+    vault kv put secret/myapp/database url="postgresql://prod.example.com/db"
+    vault kv put secret/myapp/api-key value="[REDACTED-STRIPE-DOCS-EXAMPLE]"
+    ```
+  </Step>
+
+  <Step title="Reference secrets in fnox.toml">
+    ```toml theme={null}
+    [providers]
+    vault = { type = "vault", path = "secret/myapp" }
+
+    [secrets]
+    DATABASE_URL = { provider = "vault", value = "database/url" }
+    # → reads field "url" from secret/myapp/database
+    API_KEY = { provider = "vault", value = "api-key/value" }
+    # → reads field "value" from secret/myapp/api-key
+    ```
+  </Step>
+</Steps>
+
+## Secret paths
+
+The `value` in a secret reference is appended to the `path` from the provider config. The format is `secret-name/field`:
+
+```toml theme={null}
+[providers]
+vault = { type = "vault", path = "secret/myapp" }
+
+[secrets]
+DATABASE_URL = { provider = "vault", value = "database/url" }
+# → vault kv get -field=url secret/myapp/database
+
+API_KEY = { provider = "vault", value = "api-key/value" }
+# → vault kv get -field=value secret/myapp/api-key
+```
+
+If no field is specified (e.g. `value = "api-key"`), fnox reads the `value` field by default.
+
+## Authentication methods
+
+Vault supports many auth methods. Set `VAULT_TOKEN` after authenticating:
+
+<CodeGroup>
+  ```bash Token (direct) theme={null}
+  export VAULT_TOKEN="hvs.CAESIJ..."
+  ```
+
+  ```bash Username / password theme={null}
+  vault login -method=userpass username=myuser
+  # VAULT_TOKEN is set automatically after login
+  ```
+
+  ```bash AppRole (CI/CD) theme={null}
+  vault write auth/approle/login \
+    role_id="$ROLE_ID" \
+    secret_id="$SECRET_ID"
+  export VAULT_TOKEN="<token from response>"
+  ```
+
+  ```bash AWS IAM theme={null}
+  vault login -method=aws
+  ```
+</CodeGroup>
+
+## Usage
+
+```bash theme={null}
+export VAULT_ADDR="https://vault.example.com:8200"
+export VAULT_TOKEN="hvs.CAESIJ..."
+
+# Fetch a secret
+fnox get DATABASE_URL
+
+# Run a command with all secrets injected
+fnox exec -- ./app
+```
+
+## CI/CD example (GitHub Actions)
+
+```yaml theme={null}
+name: Deploy
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy
+        env:
+          VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+          VAULT_TOKEN: ${{ secrets.VAULT_TOKEN }}
+        run: fnox exec -- ./deploy.sh
+```
+
+## Multi-environment example
+
+```toml theme={null}
+# Development: age encryption
+[providers]
+age = { type = "age", recipients = ["age1..."] }
+
+[secrets]
+DATABASE_URL = { provider = "age", value = "encrypted-dev..." }
+
+# Production: HashiCorp Vault
+[profiles.production.providers]
+vault = { type = "vault", address = "https://vault.example.com:8200", path = "secret/myapp/prod" }
+
+[profiles.production.secrets]
+DATABASE_URL = { provider = "vault", value = "database/url" }
+```
+
+## Troubleshooting
+
+**"VAULT\_TOKEN not set"**
+
+```bash theme={null}
+export VAULT_TOKEN="hvs.CAESIJ..."
+```
+
+**"permission denied" (403)**
+
+Check that your token's policy grants read access to the secret path:
+
+```bash theme={null}
+vault token lookup
+vault kv get secret/myapp/database
+```
+
+**"vault: command not found"**
+
+Install the Vault CLI (see [Installation](#installation) above).
+
+
+# Local Storage Providers
+Source: https://www.mintlify.com/jdx/fnox/providers/local-storage
+
+Store secrets locally using the OS keychain, a KeePass database, password-store (pass), or plain text defaults. Best for personal projects and local development.
+
+Local storage providers keep secrets on your machine. They are well-suited for personal projects and local development, but are not appropriate for teams or CI/CD environments.
+
+<AccordionGroup>
+  <Accordion title="OS Keychain">
+    ## OS Keychain
+
+    fnox can store and retrieve secrets from your operating system's native credential store.
+
+    | Platform | Backend                                                 |
+    | -------- | ------------------------------------------------------- |
+    | macOS    | Keychain Access (built-in)                              |
+    | Windows  | Credential Manager (built-in)                           |
+    | Linux    | Secret Service via `libsecret` (GNOME Keyring, KWallet) |
+
+    ### Linux setup
+
+    On Linux you need `libsecret` installed before using this provider:
+
+    <CodeGroup>
+      ```bash Ubuntu / Debian theme={null}
+      sudo apt-get install libsecret-1-0 libsecret-1-dev
+      ```
+
+      ```bash Fedora / RHEL theme={null}
+      sudo dnf install libsecret libsecret-devel
+      ```
+
+      ```bash Arch theme={null}
+      sudo pacman -S libsecret
+      ```
+    </CodeGroup>
+
+    macOS and Windows have built-in support — no installation needed.
+
+    ### Configuration
+
+    ```toml theme={null}
+    [providers]
+    keychain = { type = "keychain", service = "fnox" }
+
+    # With optional prefix:
+    keychain = { type = "keychain", service = "fnox", prefix = "myapp/" }
+    ```
+
+    | Field     | Required | Description                                                                     |
+    | --------- | -------- | ------------------------------------------------------------------------------- |
+    | `type`    | Yes      | Must be `"keychain"`                                                            |
+    | `service` | Yes      | Namespace for fnox entries in the keychain (e.g. `"fnox"` or your project name) |
+    | `prefix`  | No       | Prepended to all secret names                                                   |
+
+    ### Usage
+
+    ```bash theme={null}
+    # Store a secret in the OS keychain
+    fnox set DATABASE_URL "postgresql://localhost/mydb" --provider keychain
+
+    # Retrieve
+    fnox get DATABASE_URL
+
+    # Run commands with secrets injected
+    fnox exec -- npm run dev
+    ```
+
+    The resulting `fnox.toml` contains only the entry name, not the actual value:
+
+    ```toml theme={null}
+    [secrets]
+    DATABASE_URL = { provider = "keychain", value = "database-url" }
+    ```
+
+    ### Bootstrap pattern
+
+    A common use is storing provider tokens locally so they don't need to be set manually each session:
+
+    ```toml theme={null}
+    [providers]
+    keychain = { type = "keychain", service = "fnox" }
+
+    [secrets]
+    OP_SERVICE_ACCOUNT_TOKEN = { provider = "keychain", value = "op-token" }
+    ```
+
+    ```bash theme={null}
+    export OP_SERVICE_ACCOUNT_TOKEN=$(fnox get OP_SERVICE_ACCOUNT_TOKEN)
+    ```
+
+    ### Limitations
+
+    <Warning>
+      The OS keychain requires a graphical session. It does not work in CI/CD, Docker containers, or headless SSH sessions. Use age encryption or a cloud provider for those environments.
+    </Warning>
+  </Accordion>
+
+  <Accordion title="KeePass">
+    ## KeePass
+
+    fnox reads and writes secrets to a local KeePass `.kdbx` database file (KDBX4 format), compatible with KeePass and KeePassXC.
+
+    ### Configuration
+
+    ```toml theme={null}
+    [providers]
+    keepass = { type = "keepass", database = "~/secrets.kdbx" }
+
+    # With keyfile for two-factor security:
+    keepass = { type = "keepass", database = "~/secrets.kdbx", keyfile = "~/keyfile.key" }
+    ```
+
+    | Field      | Required | Description                                                    |
+    | ---------- | -------- | -------------------------------------------------------------- |
+    | `type`     | Yes      | Must be `"keepass"`                                            |
+    | `database` | Yes      | Path to the `.kdbx` file. Shell expansion (`~`) is supported.  |
+    | `keyfile`  | No       | Path to an optional keyfile for two-factor database protection |
+
+    ### Authentication
+
+    Set the database master password via environment variable:
+
+    ```bash theme={null}
+    export FNOX_KEEPASS_PASSWORD="your-master-password"
+    # fallback:
+    export KEEPASS_PASSWORD="your-master-password"
+    ```
+
+    <Warning>
+      Do not put the master password directly in `fnox.toml`. Use environment variables.
+    </Warning>
+
+    ### Reference formats
+
+    | Format        | Example                      | Description                                      |
+    | ------------- | ---------------------------- | ------------------------------------------------ |
+    | Entry name    | `my-entry`                   | Returns the password field (searches all groups) |
+    | Entry + field | `my-entry/username`          | Returns a specific field                         |
+    | Group + entry | `work/my-entry`              | Returns password from entry in group             |
+    | Full path     | `work/project/api-key/notes` | Group path + entry + field                       |
+
+    Supported fields: `password` (default), `username`, `url`, `notes`, `title` (read-only). Field names are case-insensitive.
+
+    ### Usage
+
+    ```bash theme={null}
+    # Store a secret
+    fnox set DATABASE_URL "postgresql://localhost/mydb" --provider keepass
+
+    # Store with a specific path
+    fnox set API_USER "admin" --provider keepass --key-name "production/api-service/username"
+
+    # Retrieve
+    fnox get DATABASE_URL
+
+    # Run commands
+    fnox exec -- npm run dev
+    ```
+
+    ### Example configurations
+
+    ```toml theme={null}
+    # Personal database
+    [providers]
+    keepass = { type = "keepass", database = "~/Documents/passwords.kdbx" }
+
+    [secrets]
+    GITHUB_TOKEN = { provider = "keepass", value = "github/token" }
+    NPM_TOKEN    = { provider = "keepass", value = "npm/token" }
+    ```
+
+    ```toml theme={null}
+    # Organized by environment
+    [providers]
+    keepass = { type = "keepass", database = "~/work/secrets.kdbx" }
+
+    [secrets]
+    DEV_DB = { provider = "keepass", value = "development/database/password" }
+
+    [profiles.production.secrets]
+    PROD_DB = { provider = "keepass", value = "production/database/password" }
+    ```
+
+    ### Security
+
+    * Encrypted with AES-256 or ChaCha20 (KDBX4)
+    * Key derivation uses Argon2d
+    * Atomic writes protect against corruption
+  </Accordion>
+
+  <Accordion title="password-store (pass)">
+    ## password-store (pass)
+
+    fnox integrates with [`pass`](https://www.passwordstore.org/), the standard Unix password manager. Secrets are stored as GPG-encrypted files that can be synced via git.
+
+    ### Prerequisites
+
+    * GPG installed and a key pair generated
+    * `pass` installed
+
+    ### Installation
+
+    <CodeGroup>
+      ```bash macOS theme={null}
+      brew install gnupg pass
+      ```
+
+      ```bash Ubuntu / Debian theme={null}
+      sudo apt install gnupg pass
+      ```
+
+      ```bash Fedora / RHEL theme={null}
+      sudo dnf install gnupg2 pass
+      ```
+
+      ```bash Arch theme={null}
+      sudo pacman -S gnupg pass
+      ```
+    </CodeGroup>
+
+    ### Setup
+
+    ```bash theme={null}
+    # Generate a GPG key if you don't have one
+    gpg --full-generate-key
+    gpg --list-secret-keys --keyid-format LONG  # note the key ID
+
+    # Initialize password-store
+    pass init <your-gpg-key-id>
+    # Example: pass init 3AA5C34371567BD2
+    ```
+
+    ### Configuration
+
+    ```toml theme={null}
+    [providers]
+    pass = { type = "password-store", prefix = "fnox/" }
+    ```
+
+    ```toml theme={null}
+    [providers.pass]
+    type = "password-store"
+    prefix = "fnox/"         # Optional: prepend to all secret paths (default: none)
+    store_dir = "/custom/path"  # Optional: custom store location (default: ~/.password-store)
+    ```
+
+    | Field       | Required | Description                                                           |
+    | ----------- | -------- | --------------------------------------------------------------------- |
+    | `type`      | Yes      | Must be `"password-store"`                                            |
+    | `prefix`    | No       | Prepended to all secret paths (e.g. `"fnox/"`)                        |
+    | `store_dir` | No       | Custom password store directory (or set `PASSWORD_STORE_DIR` env var) |
+
+    ### Usage
+
+    ```bash theme={null}
+    # Store a secret
+    fnox set DATABASE_URL "postgresql://localhost/mydb" --provider pass
+
+    # Store with a nested path
+    fnox set DB_PASSWORD "secret123" --provider pass --key-name "database/production"
+
+    # Retrieve
+    fnox get DATABASE_URL
+
+    # Run commands
+    fnox exec -- npm run dev
+    ```
+
+    ### Secret reference formats
+
+    ```toml theme={null}
+    [secrets]
+    # With prefix "fnox/":
+    MY_SECRET   = { provider = "pass", value = "api-key" }       # → fnox/api-key.gpg
+    DB_PASSWORD = { provider = "pass", value = "db/production" } # → fnox/db/production.gpg
+    ```
+
+    ### Git integration
+
+    password-store has built-in git support. Changes are committed automatically when using `fnox set`:
+
+    ```bash theme={null}
+    pass git init
+    pass git remote add origin https://github.com/username/password-store.git
+    pass git push
+    ```
+
+    ### Environment variables
+
+    ```bash theme={null}
+    export PASSWORD_STORE_DIR=/path/to/store        # standard pass env var
+    export FNOX_PASSWORD_STORE_DIR=/path/to/store   # fnox-specific override
+    export GPG_TTY=$(tty)                           # required for TTY-based GPG prompts
+    ```
+
+    <Tip>
+      Add `export GPG_TTY=$(tty)` to your shell profile to prevent GPG passphrase prompts from failing.
+    </Tip>
+  </Accordion>
+
+  <Accordion title="Plain text">
+    ## Plain text
+
+    Plain text is the default when no provider is specified. Use it only for non-sensitive default values — never for passwords, API keys, or tokens.
+
+    ### Configuration
+
+    No provider setup is needed. Set `default` on a secret:
+
+    ```toml theme={null}
+    [secrets]
+    NODE_ENV   = { default = "development" }
+    LOG_LEVEL  = { default = "info" }
+    PORT       = { default = "3000" }
+    ```
+
+    ### When plain text is appropriate
+
+    * Non-sensitive configuration defaults (ports, log levels, feature flags)
+    * Public URLs
+    * Local development fallbacks
+
+    ```toml theme={null}
+    [secrets]
+    PUBLIC_API_URL = { default = "https://api.example.com" }
+    CDN_URL        = { default = "https://cdn.example.com" }
+    DEBUG_MODE     = { default = "false" }
+    ```
+
+    ### Fallback pattern
+
+    A `default` value is used when the provider-encrypted value cannot be decrypted (e.g. the key is not available locally):
+
+    ```toml theme={null}
+    [providers]
+    age = { type = "age", recipients = ["age1..."] }
+
+    [secrets]
+    DATABASE_URL = { provider = "age", value = "encrypted...", default = "postgresql://localhost/dev_db" }
+    ```
+
+    ### When NOT to use plain text
+
+    <Warning>
+      Never store sensitive data as plain text in `fnox.toml`.
+    </Warning>
+
+    ```toml theme={null}
+    # ❌ Never do this
+    DATABASE_PASSWORD = { default = "super-secret" }
+    STRIPE_KEY        = { default = "[REDACTED-STRIPE-DOCS-EXAMPLE]" }
+    JWT_SECRET        = { default = "my-secret-key" }
+
+    # ✅ Use encryption instead
+    DATABASE_PASSWORD = { provider = "age", value = "encrypted..." }
+    ```
+
+    Run `fnox scan` to detect accidentally committed secrets:
+
+    ```bash theme={null}
+    fnox scan
+    fnox scan src/
+    fnox scan --fix  # interactive
+    ```
+  </Accordion>
+</AccordionGroup>
+
+
+# Providers Overview
+Source: https://www.mintlify.com/jdx/fnox/providers/overview
+
+Choose the right secret storage provider for your project. fnox supports encryption, cloud storage, password managers, and local storage backends.
+
+Providers are the backends that store or encrypt your secrets. fnox.toml contains references to secrets (or encrypted ciphertext), while providers handle the actual storage and retrieval. You can use multiple providers in the same project.
+
+## Categories
+
+### Encryption
+
+Secrets are encrypted and stored directly in `fnox.toml`. The ciphertext is safe to commit to version control, and decryption happens locally using your key.
+
+<CardGroup>
+  <Card title="Age" icon="key" href="/providers/age">
+    Modern encryption with SSH key support. Free, offline, team-friendly.
+  </Card>
+
+  <Card title="AWS KMS" icon="lock" href="/providers/aws-kms">
+    AWS Key Management Service. Encrypted ciphertext stored in git with IAM access control.
+  </Card>
+
+  <Card title="Azure Key Vault Keys" icon="lock" href="/providers/azure">
+    Azure-managed encryption keys. Ciphertext stored in fnox.toml.
+  </Card>
+
+  <Card title="GCP Cloud KMS" icon="lock" href="/providers/gcp">
+    Google Cloud KMS encryption. Ciphertext stored in fnox.toml.
+  </Card>
+</CardGroup>
+
+### Cloud secret storage
+
+Secrets are stored remotely in a cloud provider. Your `fnox.toml` contains only references (names), not values or ciphertext.
+
+<CardGroup>
+  <Card title="AWS Secrets Manager" icon="cloud" href="/providers/aws-sm">
+    Centralized AWS secret storage with rotation and versioning.
+  </Card>
+
+  <Card title="AWS Parameter Store" icon="cloud" href="/providers/aws-ps">
+    Cost-effective AWS SSM storage with hierarchical paths.
+  </Card>
+
+  <Card title="Azure Key Vault Secrets" icon="cloud" href="/providers/azure">
+    Azure-managed remote secret storage.
+  </Card>
+
+  <Card title="GCP Secret Manager" icon="cloud" href="/providers/gcp">
+    Google Cloud centralized secret storage.
+  </Card>
+
+  <Card title="HashiCorp Vault" icon="server" href="/providers/hashicorp-vault">
+    Self-hosted or HCP Vault with dynamic secrets and fine-grained policies.
+  </Card>
+
+  <Card title="Bitwarden Secrets Manager" icon="shield" href="/providers/password-managers">
+    Bitwarden's DevOps-focused secrets product (bws CLI).
+  </Card>
+
+  <Card title="Doppler" icon="cloud" href="/providers/password-managers">
+    Developer-friendly cloud secrets with environment-based configs.
+  </Card>
+</CardGroup>
+
+### Password managers
+
+Retrieve secrets from password managers and secret services you already use.
+
+<CardGroup>
+  <Card title="1Password" icon="shield-check" href="/providers/password-managers">
+    1Password CLI integration with service account support.
+  </Card>
+
+  <Card title="Bitwarden" icon="shield" href="/providers/password-managers">
+    Bitwarden and self-hosted Vaultwarden vault integration.
+  </Card>
+
+  <Card title="Infisical" icon="cloud" href="/providers/password-managers">
+    Open-source secret management with environment scoping.
+  </Card>
+</CardGroup>
+
+### Local storage
+
+Secrets are stored on the local machine only — not suitable for teams or CI/CD.
+
+<CardGroup>
+  <Card title="OS Keychain" icon="laptop" href="/providers/local-storage">
+    macOS Keychain, Windows Credential Manager, Linux Secret Service.
+  </Card>
+
+  <Card title="KeePass" icon="database" href="/providers/local-storage">
+    Local KDBX database files, compatible with KeePassXC.
+  </Card>
+
+  <Card title="password-store (pass)" icon="terminal" href="/providers/local-storage">
+    GPG-encrypted files with git sync support.
+  </Card>
+
+  <Card title="Plain text" icon="file-text" href="/providers/local-storage">
+    Unencrypted defaults only. Never use for sensitive values.
+  </Card>
+</CardGroup>
+
+## Feature comparison
+
+| Feature        | age    | AWS KMS | AWS SM | 1Password | Vault |
+| -------------- | ------ | ------- | ------ | --------- | ----- |
+| Offline        | ✅      | ❌       | ❌      | ❌         | ❌     |
+| In git         | ✅      | ✅       | ❌      | ❌         | ❌     |
+| Free           | ✅      | 💰      | 💰     | 💰        | ✅\*   |
+| Audit logs     | ❌      | ✅       | ✅      | ✅         | ✅     |
+| Access control | ❌      | ✅       | ✅      | ✅         | ✅     |
+| Rotation       | Manual | Manual  | ✅      | Manual    | ✅     |
+| Team-friendly  | ✅      | ✅       | ✅      | ✅         | ✅     |
+
+\*Self-hosted Vault is free; HCP Vault is paid.
+
+## Mixing providers
+
+You can declare multiple providers in the same `fnox.toml` and assign each secret to the appropriate one. A common pattern is age for development secrets (encrypted in git) and a cloud provider for production.
+
+```toml theme={null}
+[providers]
+age = { type = "age", recipients = ["age1..."] }
+aws = { type = "aws-sm", region = "us-east-1" }
+
+# Development secrets (encrypted in git)
+[secrets]
+DATABASE_URL = { provider = "age", value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+" }
+
+# Production secrets (fetched from AWS)
+[profiles.production.providers]
+aws = { type = "aws-sm", region = "us-east-1", prefix = "myapp-prod/" }
+
+[profiles.production.secrets]
+DATABASE_URL = { provider = "aws", value = "database-url" }
+```
+
+```bash theme={null}
+# Development
+fnox get DATABASE_URL
+
+# Production
+fnox get DATABASE_URL --profile production
+```
+
+## Next steps
+
+* [Age Encryption](/providers/age) — Simple, free, works with SSH keys you already have
+* [AWS Parameter Store](/providers/aws-ps) — Cost-effective AWS secret storage
+* [AWS Secrets Manager](/providers/aws-sm) — Production AWS workloads with rotation
+* [1Password](/providers/password-managers) — Leverage an existing 1Password setup
+
+
+# Password Managers
+Source: https://www.mintlify.com/jdx/fnox/providers/password-managers
+
+Integrate fnox with 1Password, Bitwarden, Bitwarden Secrets Manager, Infisical, or Doppler. Secrets live in your existing password manager or cloud secrets service.
+
+fnox integrates with popular password managers and cloud secrets services. `fnox.toml` stores only name references; values are fetched from the service at runtime.
+
+<Tabs>
+  <Tab title="1Password">
+    ## 1Password
+
+    fnox integrates with 1Password via the `op` CLI. Use a service account token so no interactive login is required.
+
+    ### Prerequisites
+
+    * [1Password account](https://1password.com)
+    * [1Password CLI](https://developer.1password.com/docs/cli) (`op`) installed
+
+    ### Installation
+
+    <CodeGroup>
+      ```bash macOS theme={null}
+      brew install 1password-cli
+      ```
+
+      ```bash Linux theme={null}
+      curl -sS https://downloads.1password.com/linux/keys/1password.asc | \
+        sudo gpg --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg
+      echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] \
+        https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" | \
+        sudo tee /etc/apt/sources.list.d/1password.list
+      sudo apt update && sudo apt install 1password-cli
+      ```
+
+      ```bash Windows (Scoop) theme={null}
+      scoop install 1password-cli
+      ```
+    </CodeGroup>
+
+    ### Setup
+
+    <Steps>
+      <Step title="Create a service account">
+        1. Go to your [1Password account](https://my.1password.com)
+        2. Navigate to Settings → Integrations → Service Accounts
+        3. Create a new service account (e.g. "fnox-dev")
+        4. Grant access to the relevant vault
+        5. Copy the `OP_SERVICE_ACCOUNT_TOKEN` (starts with `ops_`)
+      </Step>
+
+      <Step title="Store the token (bootstrap with age)">
+        ```bash theme={null}
+        fnox set OP_SERVICE_ACCOUNT_TOKEN "ops_YOUR_TOKEN" --provider age
+        ```
+
+        This encrypts the token in `fnox.toml` so the team can bootstrap.
+      </Step>
+
+      <Step title="Configure the 1Password provider">
+        ```toml theme={null}
+        [providers]
+        onepass = { type = "1password", vault = "Development" }
+        # account is optional: onepass = { type = "1password", vault = "Development", account = "my.1password.com" }
+        ```
+      </Step>
+
+      <Step title="Reference secrets">
+        ```toml theme={null}
+        [secrets]
+        DATABASE_PASSWORD = { provider = "onepass", value = "Database" }
+        DB_USERNAME       = { provider = "onepass", value = "Database/username" }
+        API_KEY           = { provider = "onepass", value = "op://Development/API Keys/credential" }
+        ```
+      </Step>
+
+      <Step title="Bootstrap and use">
+        ```bash theme={null}
+        export OP_SERVICE_ACCOUNT_TOKEN=$(fnox get OP_SERVICE_ACCOUNT_TOKEN)
+        fnox exec -- npm start
+        ```
+      </Step>
+    </Steps>
+
+    ### Configuration
+
+    ```toml theme={null}
+    [providers]
+    onepass = { type = "1password", vault = "Development", account = "my.1password.com" }
+    ```
+
+    | Field     | Required | Description                 |
+    | --------- | -------- | --------------------------- |
+    | `type`    | Yes      | Must be `"1password"`       |
+    | `vault`   | Yes      | Name of the 1Password vault |
+    | `account` | No       | 1Password account URL       |
+
+    ### Secret reference formats
+
+    | Format          | Example                                  | Description                  |
+    | --------------- | ---------------------------------------- | ---------------------------- |
+    | Item name       | `"Database"`                             | Returns the `password` field |
+    | Item + field    | `"Database/username"`                    | Returns a specific field     |
+    | Full op\:// URI | `"op://Development/API Keys/credential"` | Fully qualified reference    |
+
+    ### Authentication
+
+    Always use service accounts for fnox — not personal tokens:
+
+    ```bash theme={null}
+    export OP_SERVICE_ACCOUNT_TOKEN="ops_..."
+    ```
+
+    <Warning>
+      Personal tokens require interactive login and MFA, making them unsuitable for automation. Use service accounts instead.
+    </Warning>
+  </Tab>
+
+  <Tab title="Bitwarden">
+    ## Bitwarden
+
+    fnox integrates with Bitwarden (and self-hosted Vaultwarden) via the `bw` CLI.
+
+    ### Prerequisites
+
+    * [Bitwarden account](https://bitwarden.com) or a self-hosted [Vaultwarden](https://github.com/dani-garcia/vaultwarden) instance
+    * Bitwarden CLI (`bw`) installed
+
+    ### Installation
+
+    <CodeGroup>
+      ```bash macOS theme={null}
+      brew install bitwarden-cli
+      ```
+
+      ```bash Linux / Node.js theme={null}
+      npm install -g @bitwarden/cli
+      ```
+
+      ```bash Windows (Chocolatey) theme={null}
+      choco install bitwarden-cli
+      ```
+    </CodeGroup>
+
+    ### Setup
+
+    <Steps>
+      <Step title="Login and unlock">
+        ```bash theme={null}
+        # Cloud Bitwarden
+        bw login
+
+        # Self-hosted Vaultwarden
+        bw config server https://vault.example.com
+        bw login
+
+        # Unlock and get session token
+        export BW_SESSION=$(bw unlock --raw)
+        ```
+      </Step>
+
+      <Step title="Store the session token (optional bootstrap)">
+        ```bash theme={null}
+        fnox set BW_SESSION "$(bw unlock --raw)" --provider age
+        # Bootstrap: export BW_SESSION=$(fnox get BW_SESSION)
+        ```
+      </Step>
+
+      <Step title="Configure the provider">
+        ```toml theme={null}
+        [providers]
+        bitwarden = { type = "bitwarden" }
+        # Optional: collection and organization filtering
+        # bitwarden = { type = "bitwarden", collection = "abc123-id", organization_id = "org-id" }
+        ```
+      </Step>
+
+      <Step title="Reference secrets">
+        ```toml theme={null}
+        [secrets]
+        DATABASE_PASSWORD = { provider = "bitwarden", value = "Database" }
+        DB_USERNAME       = { provider = "bitwarden", value = "Database/username" }
+        ```
+      </Step>
+    </Steps>
+
+    ### Configuration
+
+    ```toml theme={null}
+    [providers]
+    bitwarden = { type = "bitwarden", collection = "abc123-collection-id", organization_id = "org-id" }
+    ```
+
+    | Field             | Required | Description                                    |
+    | ----------------- | -------- | ---------------------------------------------- |
+    | `type`            | Yes      | Must be `"bitwarden"`                          |
+    | `collection`      | No       | Filter to a specific Bitwarden collection ID   |
+    | `organization_id` | No       | Filter to a specific Bitwarden organization ID |
+    | `profile`         | No       | `bw` CLI profile (for multiple accounts)       |
+    | `backend`         | No       | Use `"rbw"` to switch to the `rbw` backend     |
+
+    ### Secret reference formats
+
+    | Format       | Example               | Description                                                               |
+    | ------------ | --------------------- | ------------------------------------------------------------------------- |
+    | Item name    | `"Database"`          | Returns the `password` field                                              |
+    | Item + field | `"Database/username"` | Returns a specific field (`username`, `password`, `notes`, `uri`, `totp`) |
+
+    ### rbw support
+
+    [`rbw`](https://github.com/doy/rbw) is a stateful alternative to `bw`:
+
+    ```toml theme={null}
+    [providers.bitwarden]
+    type = "bitwarden"
+    backend = "rbw"
+    auth_command = "rbw unlock"
+    ```
+
+    <Warning>
+      Bitwarden session tokens expire. Re-run `export BW_SESSION=$(bw unlock --raw)` when the session expires.
+    </Warning>
+  </Tab>
+
+  <Tab title="Bitwarden Secrets Manager">
+    ## Bitwarden Secrets Manager
+
+    Bitwarden Secrets Manager (BSM) is a separate product from Bitwarden Password Manager, designed for DevOps and machine secrets. It uses the `bws` CLI and access tokens instead of session tokens.
+
+    ### Prerequisites
+
+    * [Bitwarden Secrets Manager](https://bitwarden.com/products/secrets-manager/) account
+    * `bws` CLI installed
+
+    ### Installation
+
+    <CodeGroup>
+      ```bash macOS theme={null}
+      brew install bws
+      ```
+
+      ```bash Other theme={null}
+      # Download from https://github.com/bitwarden/sdk-sm/releases
+      ```
+    </CodeGroup>
+
+    ### Setup
+
+    <Steps>
+      <Step title="Create a machine account and access token">
+        In the Bitwarden Secrets Manager web console:
+
+        1. Go to **Machine accounts**
+        2. Create a new machine account
+        3. Generate an access token
+        4. Note the project ID you want to access
+      </Step>
+
+      <Step title="Set the access token">
+        ```bash theme={null}
+        export BWS_ACCESS_TOKEN="<your-access-token>"
+
+        # Or store it encrypted with age for bootstrap
+        fnox set BWS_ACCESS_TOKEN "<your-access-token>" --provider age
+        ```
+      </Step>
+
+      <Step title="Configure the provider">
+        ```toml theme={null}
+        [providers]
+        bws = { type = "bitwarden-sm", project_id = "your-project-id" }
+        ```
+      </Step>
+
+      <Step title="Reference secrets">
+        ```toml theme={null}
+        [secrets]
+        DATABASE_URL = { provider = "bws", value = "database-url" }
+        API_KEY      = { provider = "bws", value = "stripe-api-key" }
+
+        # Access note or key name fields
+        MY_NOTE = { provider = "bws", value = "my-secret-name/note" }
+        ```
+      </Step>
+    </Steps>
+
+    ### Configuration
+
+    ```toml theme={null}
+    [providers]
+    bws = { type = "bitwarden-sm", project_id = "your-project-id", profile = "..." }
+    ```
+
+    | Field        | Required | Description                                           |
+    | ------------ | -------- | ----------------------------------------------------- |
+    | `type`       | Yes      | Must be `"bitwarden-sm"`                              |
+    | `project_id` | No       | BSM project ID (or set `BWS_PROJECT_ID` env var)      |
+    | `profile`    | No       | `bws` CLI profile for self-hosted or multiple servers |
+
+    ### Environment variables
+
+    | Variable                | Description                              |
+    | ----------------------- | ---------------------------------------- |
+    | `BWS_ACCESS_TOKEN`      | Bitwarden Secrets Manager access token   |
+    | `FNOX_BWS_ACCESS_TOKEN` | fnox-specific override (takes priority)  |
+    | `BWS_PROJECT_ID`        | Project ID fallback if not set in config |
+
+    ### BSM vs Bitwarden Password Manager
+
+    | Feature | Bitwarden SM (`bitwarden-sm`) | Bitwarden PM (`bitwarden`) |
+    | ------- | ----------------------------- | -------------------------- |
+    | CLI     | `bws`                         | `bw`                       |
+    | Auth    | Access token                  | Session token              |
+    | Purpose | DevOps / machine secrets      | Personal passwords         |
+    | Model   | Key-value secrets in projects | Vault items with fields    |
+  </Tab>
+
+  <Tab title="Infisical">
+    ## Infisical
+
+    Infisical is an open-source secrets manager with environment-based organization and self-hosting support.
+
+    ### Prerequisites
+
+    * [Infisical account](https://infisical.com) or self-hosted instance
+    * Infisical CLI installed
+
+    ### Installation
+
+    <CodeGroup>
+      ```bash macOS theme={null}
+      brew install infisical/get-cli/infisical
+      ```
+
+      ```bash Ubuntu / Debian theme={null}
+      curl -1sLf 'https://dl.cloudsmith.io/public/infisical/infisical-cli/setup.deb.sh' | sudo -E bash
+      sudo apt-get update && sudo apt-get install -y infisical
+      ```
+
+      ```bash Windows (Scoop) theme={null}
+      scoop bucket add infisical https://github.com/Infisical/scoop-infisical.git
+      scoop install infisical
+      ```
+    </CodeGroup>
+
+    ### Setup
+
+    <Steps>
+      <Step title="Get an authentication token">
+        Create a service token in the Infisical project settings:
+
+        ```bash theme={null}
+        export INFISICAL_TOKEN="st.xxx.yyy.zzz"
+
+        # Or store it encrypted with age for bootstrap
+        fnox set INFISICAL_TOKEN "st.xxx.yyy.zzz" --provider age
+        ```
+      </Step>
+
+      <Step title="Configure the provider">
+        ```toml theme={null}
+        [providers]
+        infisical = { type = "infisical", project_id = "your-project-id", environment = "dev", path = "/" }
+        ```
+
+        All fields are optional — if omitted, the Infisical CLI uses its own defaults.
+      </Step>
+
+      <Step title="Reference secrets">
+        ```toml theme={null}
+        [secrets]
+        DATABASE_PASSWORD = { provider = "infisical", value = "DATABASE_PASSWORD" }
+        API_KEY           = { provider = "infisical", value = "API_KEY" }
+        ```
+      </Step>
+    </Steps>
+
+    ### Configuration
+
+    ```toml theme={null}
+    [providers]
+    infisical = { type = "infisical", project_id = "abc123", environment = "dev", path = "/" }
+    ```
+
+    | Field         | Required | Description                                                            |
+    | ------------- | -------- | ---------------------------------------------------------------------- |
+    | `type`        | Yes      | Must be `"infisical"`                                                  |
+    | `project_id`  | No       | Infisical project ID (defaults to CLI default project)                 |
+    | `environment` | No       | Environment slug: `"dev"`, `"staging"`, `"prod"` (defaults to `"dev"`) |
+    | `path`        | No       | Secret path within the project (defaults to `"/"`)                     |
+
+    ### Multi-environment example
+
+    ```toml theme={null}
+    [providers]
+    infisical = { type = "infisical", project_id = "abc123", environment = "dev", path = "/" }
+
+    [profiles.staging.providers]
+    infisical = { type = "infisical", project_id = "abc123", environment = "staging", path = "/" }
+
+    [profiles.production.providers]
+    infisical = { type = "infisical", project_id = "abc123", environment = "prod", path = "/" }
+    ```
+  </Tab>
+
+  <Tab title="Doppler">
+    ## Doppler
+
+    Doppler is a developer-friendly cloud secrets platform with a project/config model that maps naturally to environments.
+
+    ### Prerequisites
+
+    * [Doppler account](https://www.doppler.com/)
+    * [Doppler CLI](https://docs.doppler.com/docs/cli) installed
+
+    ### Installation
+
+    <CodeGroup>
+      ```bash macOS theme={null}
+      brew install dopplerhq/cli/doppler
+      ```
+
+      ```bash Linux theme={null}
+      curl -sLf --retry 3 --tlsv1.2 --proto "=https" \
+        'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key' | \
+        sudo gpg --dearmor -o /usr/share/keyrings/doppler-archive-keyring.gpg
+      echo "deb [signed-by=/usr/share/keyrings/doppler-archive-keyring.gpg] \
+        https://packages.doppler.com/public/cli/deb/debian any-version main" | \
+        sudo tee /etc/apt/sources.list.d/doppler-cli.list
+      sudo apt-get update && sudo apt-get install -y doppler
+      ```
+    </CodeGroup>
+
+    ### Setup
+
+    <Steps>
+      <Step title="Authenticate">
+        ```bash theme={null}
+        # Interactive login (local development)
+        doppler login
+
+        # Service token (CI/CD)
+        export DOPPLER_TOKEN="dp.st.prd.xxxx"
+        ```
+      </Step>
+
+      <Step title="Configure the provider">
+        ```toml theme={null}
+        [providers]
+        doppler = { type = "doppler", project = "my-project", config = "prd" }
+        ```
+
+        All fields are optional — if omitted, the Doppler CLI uses defaults from `doppler setup`.
+      </Step>
+
+      <Step title="Reference secrets">
+        ```toml theme={null}
+        [secrets]
+        DATABASE_URL = { provider = "doppler", value = "DATABASE_URL" }
+        API_KEY      = { provider = "doppler", value = "API_KEY" }
+        ```
+      </Step>
+    </Steps>
+
+    ### Configuration
+
+    ```toml theme={null}
+    [providers]
+    doppler = { type = "doppler", project = "my-project", config = "prd" }
+    ```
+
+    | Field     | Required | Description                                                             |
+    | --------- | -------- | ----------------------------------------------------------------------- |
+    | `type`    | Yes      | Must be `"doppler"`                                                     |
+    | `project` | No       | Doppler project name (defaults to `doppler setup` value)                |
+    | `config`  | No       | Config/environment name (e.g. `"dev"`, `"stg"`, `"prd"`)                |
+    | `token`   | No       | Service token. Falls back to `FNOX_DOPPLER_TOKEN` then `DOPPLER_TOKEN`. |
+
+    ### Token resolution order
+
+    1. `token` field in provider config
+    2. `FNOX_DOPPLER_TOKEN` environment variable
+    3. `DOPPLER_TOKEN` environment variable
+    4. Interactive login session (from `doppler login`)
+
+    ### Multi-environment example
+
+    ```toml theme={null}
+    [providers]
+    doppler = { type = "doppler", project = "my-app", config = "dev" }
+
+    [profiles.staging.providers]
+    doppler = { type = "doppler", project = "my-app", config = "stg" }
+
+    [profiles.production.providers]
+    doppler = { type = "doppler", project = "my-app", config = "prd" }
+    ```
+  </Tab>
+</Tabs>
+
+
+# Quick Start
+Source: https://www.mintlify.com/jdx/fnox/quickstart
+
+Get fnox installed and your first secret encrypted and loaded in under 5 minutes.
+
+## 1. Install fnox
+
+<CodeGroup>
+  ```bash mise (recommended) theme={null}
+  mise use -g fnox
+  ```
+
+  ```bash cargo theme={null}
+  cargo install fnox
+  ```
+</CodeGroup>
+
+Verify the installation:
+
+```bash theme={null}
+fnox --version
+```
+
+## 2. Initialize your project
+
+```bash theme={null}
+cd your-project
+fnox init
+```
+
+This creates a `fnox.toml` configuration file in the current directory.
+
+## 3. Set a secret
+
+```bash theme={null}
+# Prompts interactively (recommended for sensitive values)
+fnox set DATABASE_URL
+
+# Or pass the value directly
+fnox set DATABASE_URL "postgresql://localhost/mydb"
+```
+
+<Warning>
+  Passing secrets as CLI arguments exposes them in shell history and `ps` output. For sensitive values, use the interactive prompt or pipe from stdin.
+</Warning>
+
+## 4. Get a secret
+
+```bash theme={null}
+fnox get DATABASE_URL
+```
+
+## 5. Run commands with secrets loaded
+
+```bash theme={null}
+fnox exec -- npm start
+fnox exec -- python app.py
+fnox exec -- ./my-script.sh
+```
+
+Secrets are injected as environment variables into the subprocess. Nothing leaks into your current shell.
+
+## 6. Add encryption (recommended)
+
+By default, `fnox set` stores a plain-text default value. For real secrets, encrypt them with [age](https://github.com/FiloSottile/age):
+
+<Steps>
+  <Step title="Install age and generate a key">
+    ```bash theme={null}
+    # macOS
+    brew install age
+
+    # Ubuntu / Debian
+    sudo apt install age
+
+    # Generate a key pair
+    mkdir -p ~/.config/fnox
+    age-keygen -o ~/.config/fnox/age.txt
+    ```
+
+    Note your public key from the output:
+
+    ```
+    # public key: age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p
+    ```
+  </Step>
+
+  <Step title="Configure the age provider">
+    Add the provider to `fnox.toml` using your public key:
+
+    ```toml fnox.toml theme={null}
+    [providers.age]
+    type = "age"
+    recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"]
+    ```
+  </Step>
+
+  <Step title="Export your private key">
+    ```bash theme={null}
+    export FNOX_AGE_KEY=$(grep "AGE-SECRET-KEY" ~/.config/fnox/age.txt)
+    ```
+
+    Add this to your shell profile (`~/.bashrc`, `~/.zshrc`) so it persists.
+  </Step>
+
+  <Step title="Encrypt a secret">
+    ```bash theme={null}
+    fnox set DATABASE_URL "postgresql://prod.example.com/db" --provider age
+    ```
+
+    fnox writes the ciphertext into `fnox.toml`:
+
+    ```toml theme={null}
+    [secrets]
+    DATABASE_URL = { provider = "age", value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+..." }
+    ```
+
+    This file is now safe to commit to git.
+  </Step>
+</Steps>
+
+## 7. Enable shell integration (optional)
+
+Auto-load secrets when you `cd` into a directory:
+
+```bash theme={null}
+# Add to your shell profile
+echo 'eval "$(fnox activate bash)"' >> ~/.bashrc   # bash
+echo 'eval "$(fnox activate zsh)"' >> ~/.zshrc      # zsh
+```
+
+Now secrets load automatically:
+
+```bash theme={null}
+~/projects $ cd my-app
+fnox: +3 DATABASE_URL, API_KEY, JWT_SECRET
+~/projects/my-app $
+```
+
+## Next steps
+
+<CardGroup>
+  <Card title="How it works" icon="gears" href="/guides/how-it-works">
+    Understand secret resolution order and the execution model.
+  </Card>
+
+  <Card title="Providers" icon="plug" href="/providers/overview">
+    Explore all 15+ supported secret backends.
+  </Card>
+
+  <Card title="Shell integration" icon="terminal" href="/guides/shell-integration">
+    Deep dive into shell integration for bash, zsh, fish, and nushell.
+  </Card>
+
+  <Card title="Profiles" icon="layer-group" href="/guides/profiles">
+    Manage dev, staging, and production secrets in one config file.
+  </Card>
+</CardGroup>
+
+
+# CLI Reference
+Source: https://www.mintlify.com/jdx/fnox/reference/cli
+
+Complete reference for all fnox commands and flags.
+
+**Usage**: `fnox [FLAGS] <COMMAND>`
+
+**Version**: 1.20.0
+
+## Global flags
+
+These flags apply to every command.
+
+| Flag                   | Short | Description                                                  | Default     |
+| ---------------------- | ----- | ------------------------------------------------------------ | ----------- |
+| `--config <PATH>`      | `-c`  | Path to the config file (searches parent directories)        | `fnox.toml` |
+| `--profile <NAME>`     | `-P`  | Profile to use (or `FNOX_PROFILE` env var)                   | `default`   |
+| `--if-missing <VALUE>` |       | What to do if a secret is missing: `error`, `warn`, `ignore` |             |
+| `--no-defaults`        |       | Do not merge top-level secrets into the selected profile     |             |
+| `--no-color`           |       | Disable colored output                                       |             |
+| `--verbose`            | `-v`  | Enable verbose logging                                       |             |
+
+***
+
+## Core commands
+
+<AccordionGroup>
+  <Accordion title="fnox init — Initialize a config file">
+    **Usage**: `fnox init [FLAGS]`
+
+    **Aliases**: `i`
+
+    Initialize a new `fnox.toml` in the current directory. Runs an interactive wizard by default to help you choose a provider.
+
+    | Flag            | Short | Description                                                      |
+    | --------------- | ----- | ---------------------------------------------------------------- |
+    | `--global`      | `-g`  | Initialize the global config file (`~/.config/fnox/config.toml`) |
+    | `--force`       | `-f`  | Overwrite an existing config file                                |
+    | `--skip-wizard` |       | Create a minimal config without the interactive wizard           |
+
+    ```bash theme={null}
+    # Initialize project config
+    fnox init
+
+    # Initialize global config
+    fnox init --global
+
+    # Non-interactive minimal config
+    fnox init --skip-wizard
+    ```
+  </Accordion>
+
+  <Accordion title="fnox set — Store a secret">
+    **Usage**: `fnox set [FLAGS] <KEY> [VALUE]`
+
+    **Aliases**: `s`
+
+    Store a secret value. If `VALUE` is omitted, fnox reads from stdin when piped, or prompts interactively with hidden input.
+
+    <Warning>
+      Passing secrets as CLI arguments exposes them in shell history and `ps` output. Prefer stdin or the interactive prompt for sensitive values.
+    </Warning>
+
+    | Flag                   | Short | Description                                                 |
+    | ---------------------- | ----- | ----------------------------------------------------------- |
+    | `--provider <NAME>`    | `-p`  | Provider to store the secret with                           |
+    | `--description <TEXT>` | `-d`  | Description of the secret                                   |
+    | `--key-name <NAME>`    | `-k`  | Key name in the provider if different from the env var name |
+    | `--default <VALUE>`    |       | Default value if the secret is not found                    |
+    | `--if-missing <VALUE>` |       | Behavior when missing: `error`, `warn`, `ignore`            |
+    | `--base64-encode`      |       | Base64-encode the value before storing                      |
+    | `--global`             | `-g`  | Save to the global config file                              |
+    | `--dry-run`            | `-n`  | Show what would be done without making changes              |
+
+    ```bash theme={null}
+    # Interactive prompt (recommended for sensitive values)
+    fnox set DATABASE_URL
+
+    # From stdin
+    echo "postgresql://..." | fnox set DATABASE_URL
+
+    # With provider and description
+    fnox set API_KEY --provider age --description "Third-party API key"
+
+    # Save to global config
+    fnox set PERSONAL_TOKEN "abc123" --global
+    ```
+  </Accordion>
+
+  <Accordion title="fnox get — Retrieve a secret">
+    **Usage**: `fnox get [--base64-decode] <KEY>`
+
+    Print a single secret value to stdout.
+
+    | Flag              | Description                             |
+    | ----------------- | --------------------------------------- |
+    | `--base64-decode` | Base64-decode the value before printing |
+
+    ```bash theme={null}
+    fnox get DATABASE_URL
+
+    # Use in a script
+    DB_URL=$(fnox get DATABASE_URL)
+
+    # Decode a base64-encoded secret
+    fnox get CERT_DATA --base64-decode
+    ```
+  </Accordion>
+
+  <Accordion title="fnox exec — Run a command with secrets">
+    **Usage**: `fnox exec [COMMAND]…`
+
+    **Aliases**: `x`
+
+    Execute a command with all resolved secrets injected as environment variables. Separate fnox flags from the command with `--`.
+
+    ```bash theme={null}
+    # Basic usage
+    fnox exec -- npm start
+
+    # With profile
+    fnox exec --profile production -- ./deploy.sh
+
+    # Without inheriting top-level secrets
+    fnox exec --profile production --no-defaults -- ./deploy.sh
+
+    # Inline for a single command
+    fnox exec -- env | grep DATABASE
+    ```
+  </Accordion>
+
+  <Accordion title="fnox list — List all secrets">
+    **Usage**: `fnox list [FLAGS]`
+
+    **Aliases**: `ls`, `secrets`
+
+    List all secrets defined in the current config.
+
+    | Flag        | Short | Description                                              |
+    | ----------- | ----- | -------------------------------------------------------- |
+    | `--values`  | `-V`  | Show resolved secret values                              |
+    | `--full`    | `-f`  | Show full provider keys without truncation               |
+    | `--sources` | `-s`  | Show the source config file where each secret is defined |
+
+    ```bash theme={null}
+    fnox list
+
+    # Show values (requires provider access)
+    fnox list --values
+
+    # Show with source file paths
+    fnox list --sources
+    ```
+  </Accordion>
+
+  <Accordion title="fnox remove — Remove a secret">
+    **Usage**: `fnox remove [-g --global] [-n --dry-run] <KEY>`
+
+    **Aliases**: `rm`, `delete`
+
+    Remove a secret from the config file.
+
+    | Flag        | Short | Description                                       |
+    | ----------- | ----- | ------------------------------------------------- |
+    | `--global`  | `-g`  | Remove from the global config file                |
+    | `--dry-run` | `-n`  | Show what would be removed without making changes |
+
+    ```bash theme={null}
+    fnox remove OLD_API_KEY
+
+    # Preview removal
+    fnox remove OLD_API_KEY --dry-run
+
+    # Remove from global config
+    fnox remove PERSONAL_TOKEN --global
+    ```
+  </Accordion>
+</AccordionGroup>
+
+***
+
+## Shell integration
+
+<AccordionGroup>
+  <Accordion title="fnox activate — Enable shell integration">
+    **Usage**: `fnox activate [--no-hook-env] [SHELL]`
+
+    Output shell activation code that installs a hook to automatically load secrets when you `cd` into a project. Pipe the output to `eval`.
+
+    | Argument / Flag | Description                                             |
+    | --------------- | ------------------------------------------------------- |
+    | `[SHELL]`       | Shell to generate code for: `bash`, `zsh`, `fish`, `nu` |
+    | `--no-hook-env` | Don't automatically invoke `hook-env` (for testing)     |
+
+    ```bash theme={null}
+    # bash
+    eval "$(fnox activate bash)"
+
+    # zsh
+    eval "$(fnox activate zsh)"
+
+    # fish
+    fnox activate fish | source
+
+    # Add to shell profile for permanent activation
+    echo 'eval "$(fnox activate bash)"' >> ~/.bashrc
+    ```
+  </Accordion>
+
+  <Accordion title="fnox deactivate — Disable shell integration">
+    **Usage**: `fnox deactivate`
+
+    Disable fnox shell integration in the current shell session and unset any injected secrets.
+  </Accordion>
+</AccordionGroup>
+
+***
+
+## Provider management
+
+<AccordionGroup>
+  <Accordion title="fnox provider — Manage providers">
+    **Usage**: `fnox provider <SUBCOMMAND>`
+
+    Defaults to listing providers when called without a subcommand.
+
+    **Subcommands**: `add`, `list`, `remove`, `test`
+  </Accordion>
+
+  <Accordion title="fnox provider add — Add a provider">
+    **Usage**: `fnox provider add [-g --global] [--vault <VAULT>] <PROVIDER> <PROVIDER_TYPE>`
+
+    **Aliases**: `a`, `set`
+
+    Add a new provider to the config. `PROVIDER` is your chosen name; `PROVIDER_TYPE` is the backend type.
+
+    | Flag             | Short | Description                                                    |
+    | ---------------- | ----- | -------------------------------------------------------------- |
+    | `--global`       | `-g`  | Add to the global config file                                  |
+    | `--vault <NAME>` |       | Default Proton Pass vault name (only valid with `proton-pass`) |
+
+    **Available provider types**: `1password`, `age`, `aws`, `aws-kms`, `aws-ps`, `azure-kms`, `azure-sm`, `gcp`, `gcp-kms`, `fido2`, `bitwarden`, `bitwarden-sm`, `doppler`, `infisical`, `keepass`, `keychain`, `password-store`, `passwordstate`, `plain`, `proton-pass`, `vault`, `yubikey`
+
+    ```bash theme={null}
+    fnox provider add age age
+    fnox provider add aws aws-sm
+    fnox provider add prod-vault vault
+    fnox provider add keys keychain --global
+    ```
+  </Accordion>
+
+  <Accordion title="fnox provider list — List providers">
+    **Usage**: `fnox provider list`
+
+    **Aliases**: `ls`
+
+    List all providers configured in the current config.
+
+    ```bash theme={null}
+    fnox provider list
+    ```
+  </Accordion>
+
+  <Accordion title="fnox provider remove — Remove a provider">
+    **Usage**: `fnox provider remove [-g --global] <PROVIDER>`
+
+    **Aliases**: `rm`, `delete`
+
+    Remove a provider from the config.
+
+    | Flag       | Short | Description                        |
+    | ---------- | ----- | ---------------------------------- |
+    | `--global` | `-g`  | Remove from the global config file |
+
+    ```bash theme={null}
+    fnox provider remove old-provider
+    ```
+  </Accordion>
+
+  <Accordion title="fnox provider test — Test a provider connection">
+    **Usage**: `fnox provider test [-a --all] [PROVIDER]`
+
+    **Aliases**: `t`
+
+    Test connectivity and authentication for a provider.
+
+    | Flag    | Short | Description                   |
+    | ------- | ----- | ----------------------------- |
+    | `--all` | `-a`  | Test all configured providers |
+
+    ```bash theme={null}
+    fnox provider test aws
+    fnox provider test --all
+    ```
+  </Accordion>
+</AccordionGroup>
+
+***
+
+## Leases
+
+Leases create short-lived ephemeral credentials from a secret backend.
+
+<AccordionGroup>
+  <Accordion title="fnox lease create — Create a lease">
+    **Usage**: `fnox lease create [FLAGS] [BACKEND_NAME]`
+
+    Create a short-lived credential lease. If `BACKEND_NAME` is omitted, creates leases for all configured lease backends.
+
+    | Flag                    | Short | Description                                  | Default      |
+    | ----------------------- | ----- | -------------------------------------------- | ------------ |
+    | `--duration <DURATION>` | `-d`  | Lease duration (e.g. `15m`, `1h`, `2h30m`)   |              |
+    | `--format <FORMAT>`     | `-f`  | Output format: `shell`, `json`, `env`        | `shell`      |
+    | `--label <LABEL>`       | `-l`  | Label for the lease (e.g. session purpose)   | `fnox-lease` |
+    | `--all`                 | `-a`  | Create leases for all configured backends    |              |
+    | `--interactive`         | `-i`  | Prompt interactively for missing credentials |              |
+
+    ```bash theme={null}
+    fnox lease create
+    fnox lease create my-backend --duration 1h
+    fnox lease create --format json
+    ```
+  </Accordion>
+
+  <Accordion title="fnox lease list — List leases">
+    **Usage**: `fnox lease list [--active] [--expired]`
+
+    List tracked leases.
+
+    | Flag        | Description                                        |
+    | ----------- | -------------------------------------------------- |
+    | `--active`  | Show only active (non-expired, non-revoked) leases |
+    | `--expired` | Show only expired leases                           |
+
+    ```bash theme={null}
+    fnox lease list
+    fnox lease list --active
+    ```
+  </Accordion>
+
+  <Accordion title="fnox lease revoke — Revoke a lease">
+    **Usage**: `fnox lease revoke <LEASE_ID>`
+
+    Revoke a specific lease by its ID.
+
+    ```bash theme={null}
+    fnox lease revoke abc123
+    ```
+  </Accordion>
+
+  <Accordion title="fnox lease cleanup — Clean up expired leases">
+    **Usage**: `fnox lease cleanup`
+
+    Revoke all expired leases that require manual cleanup.
+
+    ```bash theme={null}
+    fnox lease cleanup
+    ```
+  </Accordion>
+</AccordionGroup>
+
+***
+
+## Profiles
+
+<AccordionGroup>
+  <Accordion title="fnox profiles — List profiles">
+    **Usage**: `fnox profiles`
+
+    List all profiles defined in the current config.
+
+    ```bash theme={null}
+    fnox profiles
+    # default (active)
+    # staging
+    # production
+    ```
+  </Accordion>
+</AccordionGroup>
+
+***
+
+## Utilities
+
+<AccordionGroup>
+  <Accordion title="fnox check — Check secret configuration">
+    **Usage**: `fnox check [-a --all]`
+
+    **Aliases**: `c`
+
+    Check that all required secrets are defined and accessible.
+
+    | Flag    | Short | Description                                                                      |
+    | ------- | ----- | -------------------------------------------------------------------------------- |
+    | `--all` | `-a`  | Check all secrets, including those with `if_missing=warn` or `if_missing=ignore` |
+
+    ```bash theme={null}
+    fnox check
+    fnox check --all
+    ```
+  </Accordion>
+
+  <Accordion title="fnox scan — Scan for secrets in source code">
+    **Usage**: `fnox scan [FLAGS]`
+
+    Scan a repository for hard-coded or plaintext secrets.
+
+    | Flag                 | Short | Description                                   | Default |
+    | -------------------- | ----- | --------------------------------------------- | ------- |
+    | `--dir <DIR>`        | `-d`  | Directory to scan                             | `.`     |
+    | `--ignore <PATTERN>` | `-i`  | Skip files matching this pattern (repeatable) |         |
+    | `--quiet`            | `-q`  | Show only files with potential secrets        |         |
+
+    ```bash theme={null}
+    fnox scan
+    fnox scan --dir ./src --ignore "*.test.ts"
+    fnox scan --quiet
+    ```
+  </Accordion>
+
+  <Accordion title="fnox doctor — Diagnostic information">
+    **Usage**: `fnox doctor`
+
+    **Aliases**: `dr`
+
+    Show diagnostic information about the current fnox state: loaded config files, active profile, provider status, and resolved secrets.
+
+    ```bash theme={null}
+    fnox doctor
+    ```
+  </Accordion>
+
+  <Accordion title="fnox edit — Edit the config file">
+    **Usage**: `fnox edit`
+
+    Open the current `fnox.toml` in your `$EDITOR`.
+
+    ```bash theme={null}
+    fnox edit
+    EDITOR=code fnox edit
+    ```
+  </Accordion>
+
+  <Accordion title="fnox tui — Interactive dashboard">
+    **Usage**: `fnox tui`
+
+    Launch an interactive terminal UI for browsing and managing secrets.
+
+    ```bash theme={null}
+    fnox tui
+    ```
+  </Accordion>
+
+  <Accordion title="fnox sync — Sync remote secrets to local encryption">
+    **Usage**: `fnox sync [FLAGS] [KEYS]…`
+
+    Sync secrets from remote providers (e.g. AWS Secrets Manager) into a local encryption provider (e.g. age). Useful for working offline or creating encrypted backups.
+
+    | Flag                | Short | Description                                                 |
+    | ------------------- | ----- | ----------------------------------------------------------- |
+    | `--provider <NAME>` | `-p`  | Target encryption provider (defaults to `default_provider`) |
+    | `--source <NAME>`   | `-s`  | Only sync secrets from this source provider                 |
+    | `--filter <REGEX>`  |       | Only sync secrets matching this pattern                     |
+    | `--global`          | `-g`  | Write to the global config file                             |
+    | `--local-file`      |       | Write overrides to `fnox.local.toml` instead of `fnox.toml` |
+    | `--force`           | `-f`  | Skip confirmation prompt                                    |
+    | `--dry-run`         | `-n`  | Show what would be done without making changes              |
+
+    ```bash theme={null}
+    # Sync all secrets to default local provider
+    fnox sync
+
+    # Sync specific keys
+    fnox sync DATABASE_URL JWT_SECRET
+
+    # Preview
+    fnox sync --dry-run
+
+    # From a specific source provider
+    fnox sync --source aws --provider age
+    ```
+  </Accordion>
+</AccordionGroup>
+
+***
+
+## Import / Export
+
+<AccordionGroup>
+  <Accordion title="fnox import — Import secrets">
+    **Usage**: `fnox import <FLAGS> [FORMAT]`
+
+    **Aliases**: `im`
+
+    Import secrets from a file or stdin into the config. The `--provider` flag is required to specify where to store the imported secrets.
+
+    | Argument   | Description                                  | Default |
+    | ---------- | -------------------------------------------- | ------- |
+    | `[FORMAT]` | Source format: `env`, `json`, `yaml`, `toml` | `env`   |
+
+    | Flag                | Short | Description                                                     |
+    | ------------------- | ----- | --------------------------------------------------------------- |
+    | `--provider <NAME>` | `-p`  | Provider for encrypting/storing imported secrets (**required**) |
+    | `--input <PATH>`    | `-i`  | Source file (default: stdin)                                    |
+    | `--filter <REGEX>`  |       | Only import secrets matching this pattern                       |
+    | `--prefix <PREFIX>` |       | Prefix to prepend to imported secret names                      |
+    | `--global`          | `-g`  | Import to the global config file                                |
+    | `--force`           | `-f`  | Skip confirmation prompts                                       |
+    | `--dry-run`         | `-n`  | Show what would be imported without making changes              |
+
+    ```bash theme={null}
+    # Import a .env file
+    fnox import --provider age --input .env
+
+    # Import from stdin
+    cat secrets.env | fnox import --provider age
+
+    # Import JSON with a name prefix
+    fnox import json --provider aws --input secrets.json --prefix myapp/
+
+    # Preview
+    fnox import --provider age --input .env --dry-run
+    ```
+  </Accordion>
+
+  <Accordion title="fnox export — Export secrets">
+    **Usage**: `fnox export [FLAGS]`
+
+    **Aliases**: `ex`
+
+    Export resolved secrets to stdout or a file.
+
+    | Flag                | Short | Description                                  | Default |
+    | ------------------- | ----- | -------------------------------------------- | ------- |
+    | `--format <FORMAT>` | `-f`  | Output format: `env`, `json`, `yaml`, `toml` | `env`   |
+    | `--output <PATH>`   | `-o`  | Output file (default: stdout)                |         |
+    | `--dry-run`         | `-n`  | Show what would be exported without writing  |         |
+
+    ```bash theme={null}
+    # Export as .env to stdout
+    fnox export
+
+    # Export as JSON to a file
+    fnox export --format json --output secrets.json
+
+    # Export YAML for staging profile
+    fnox export --profile staging --format yaml
+    ```
+  </Accordion>
+</AccordionGroup>
+
+***
+
+## Encryption
+
+<AccordionGroup>
+  <Accordion title="fnox reencrypt — Re-encrypt secrets">
+    **Usage**: `fnox reencrypt [FLAGS] [KEYS]…`
+
+    Re-encrypt secrets with the current provider configuration. Use this after rotating recipients or keys.
+
+    | Flag                | Short | Description                                    |
+    | ------------------- | ----- | ---------------------------------------------- |
+    | `--provider <NAME>` | `-p`  | Only re-encrypt secrets from this provider     |
+    | `--filter <REGEX>`  |       | Only re-encrypt secrets matching this pattern  |
+    | `--force`           | `-f`  | Skip confirmation prompt                       |
+    | `--dry-run`         | `-n`  | Show what would be done without making changes |
+
+    ```bash theme={null}
+    # Re-encrypt everything
+    fnox reencrypt
+
+    # Re-encrypt specific keys
+    fnox reencrypt DATABASE_URL JWT_SECRET
+
+    # Preview
+    fnox reencrypt --dry-run
+    ```
+  </Accordion>
+</AccordionGroup>
+
+***
+
+## Other commands
+
+<AccordionGroup>
+  <Accordion title="fnox mcp — Start an MCP server">
+    **Usage**: `fnox mcp`
+
+    Start a Model Context Protocol (MCP) server that exposes secrets to AI agents in a controlled, access-gated way.
+
+    ```bash theme={null}
+    fnox mcp
+    ```
+  </Accordion>
+
+  <Accordion title="fnox completion — Generate shell completions">
+    **Usage**: `fnox completion <SHELL>`
+
+    Generate shell completion scripts.
+
+    ```bash theme={null}
+    # bash
+    fnox completion bash >> ~/.bash_completion
+
+    # zsh
+    fnox completion zsh > ~/.zsh/completions/_fnox
+
+    # fish
+    fnox completion fish > ~/.config/fish/completions/fnox.fish
+    ```
+  </Accordion>
+
+  <Accordion title="fnox config-files — List loaded config files">
+    **Usage**: `fnox config-files`
+
+    List all config files that would be loaded for the current directory and profile.
+
+    ```bash theme={null}
+    fnox config-files
+    # /home/user/.config/fnox/config.toml
+    # /home/user/projects/myapp/fnox.toml
+    # /home/user/projects/myapp/fnox.local.toml
+    ```
+  </Accordion>
+
+  <Accordion title="fnox version — Show version">
+    **Usage**: `fnox version`
+
+    **Aliases**: `v`
+
+    Print version information.
+
+    ```bash theme={null}
+    fnox version
+    # fnox 1.20.0
+    ```
+  </Accordion>
+</AccordionGroup>
+
+
+# Configuration Reference
+Source: https://www.mintlify.com/jdx/fnox/reference/configuration
+
+Complete reference for the fnox.toml configuration file.
+
+## JSON schema
+
+A JSON Schema is available for IDE autocompletion and validation:
+
+```
+https://fnox.jdx.dev/schema.json
+```
+
+### Editor setup
+
+<Tabs>
+  <Tab title="VS Code">
+    Install [Even Better TOML](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml), then add the schema directive at the top of your `fnox.toml`:
+
+    ```toml theme={null}
+    #:schema https://fnox.jdx.dev/schema.json
+
+    [providers]
+    age = { type = "age", recipients = ["age1..."] }
+    ```
+  </Tab>
+
+  <Tab title="JetBrains IDEs">
+    Go to **Settings > Languages & Frameworks > Schemas and DTDs > JSON Schema Mappings** and add:
+
+    * **Schema URL**: `https://fnox.jdx.dev/schema.json`
+    * **File pattern**: `fnox*.toml`
+  </Tab>
+</Tabs>
+
+## File loading order
+
+fnox looks for and merges configuration files in this order (lowest to highest priority):
+
+1. **Global config** — `~/.config/fnox/config.toml` (or `$FNOX_CONFIG_DIR/config.toml`)
+2. **Parent directories** — `fnox.toml` files found searching upward from the current directory
+3. **Local config** — `fnox.toml` in the current directory
+4. **Profile-specific file** — `fnox.$FNOX_PROFILE.toml` alongside each `fnox.toml`
+5. **Local overrides** — `fnox.local.toml` alongside each `fnox.toml`
+6. **CLI flag** — path specified with `-c, --config`
+
+Later entries override earlier ones. The global config is always loaded, even when a `root = true` directive stops parent directory recursion.
+
+### Global configuration
+
+The global config file stores machine-wide secrets and providers that apply to all projects.
+
+**Location**: `~/.config/fnox/config.toml` (customizable via `FNOX_CONFIG_DIR`)
+
+```bash theme={null}
+# Initialize global config
+fnox init --global
+
+# Add a secret to global config
+fnox set MY_TOKEN "secret-value" --global
+
+# Add a provider to global config
+fnox provider add aws aws-sm --global
+```
+
+Use the global config for personal API tokens used across multiple projects, machine-specific credentials, and default providers available everywhere.
+
+## Basic structure
+
+```toml theme={null}
+# Top-level settings
+if_missing = "warn"
+import = ["./shared/secrets.toml"]
+
+[providers]
+PROVIDER_NAME = { type = "PROVIDER_TYPE" }
+
+[secrets]
+SECRET_NAME = { provider = "PROVIDER_NAME", value = "...", default = "...", if_missing = "error", description = "..." }
+
+[profiles.PROFILE_NAME]
+# same structure as top-level
+```
+
+## Top-level settings
+
+### `if_missing`
+
+Global default behavior when a secret cannot be resolved.
+
+| Value      | Behavior                               |
+| ---------- | -------------------------------------- |
+| `"error"`  | Fail and exit with an error            |
+| `"warn"`   | Print a warning and continue (default) |
+| `"ignore"` | Silently skip the missing secret       |
+
+```toml theme={null}
+if_missing = "error"
+```
+
+**Priority:** Lowest. Overridden by secret-level `if_missing`, `FNOX_IF_MISSING`, and `--if-missing`.
+
+### `imports`
+
+List of config files to import. Paths are relative to the current config file. Imported files are merged in order; later imports override earlier ones.
+
+```toml theme={null}
+import = ["./shared/base.toml", "./envs/dev.toml"]
+```
+
+## Provider configuration
+
+```toml theme={null}
+[providers.PROVIDER_NAME]
+type = "PROVIDER_TYPE"
+# provider-specific fields
+```
+
+### `auth_command`
+
+Override the authentication command for a provider instance. When provider authentication fails in a TTY, fnox prompts to run this command. Each provider type has a built-in default (e.g. `bw login` for Bitwarden, `op signin` for 1Password). Set to `""` to disable auth prompting entirely.
+
+```toml theme={null}
+[providers]
+# Use rbw instead of the default bw CLI
+rbw = { type = "bitwarden", backend = "rbw", auth_command = "rbw unlock" }
+
+# Custom AWS SSO login profile
+aws = { type = "aws-sm", region = "us-east-1", auth_command = "aws sso login --profile myprofile" }
+
+# Disable auth prompting for this provider
+vault = { type = "vault", address = "https://vault.example.com", auth_command = "" }
+```
+
+### Provider types
+
+<AccordionGroup>
+  <Accordion title="age — Age encryption">
+    Secrets are encrypted in `fnox.toml` using [age](https://age-encryption.org). Recipients can be age keys or SSH keys.
+
+    ```toml theme={null}
+    [providers.age]
+    type = "age"
+    recipients = [
+      "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p",
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGQs..."
+    ]
+    ```
+  </Accordion>
+
+  <Accordion title="aws-sm — AWS Secrets Manager">
+    ```toml theme={null}
+    [providers]
+    aws = { type = "aws-sm", region = "us-east-1", prefix = "myapp/" }
+    ```
+
+    `prefix` is optional. Secrets are stored in AWS Secrets Manager; `value` in `[secrets]` is the secret name.
+  </Accordion>
+
+  <Accordion title="aws-kms — AWS KMS">
+    Secrets are encrypted with an AWS KMS key and stored as ciphertext in `fnox.toml`.
+
+    ```toml theme={null}
+    [providers]
+    kms = { type = "aws-kms", key_id = "arn:aws:kms:us-east-1:123456789012:key/...", region = "us-east-1" }
+    ```
+  </Accordion>
+
+  <Accordion title="azure-sm — Azure Key Vault Secrets">
+    ```toml theme={null}
+    [providers]
+    azure = { type = "azure-sm", vault_url = "https://myapp-vault.vault.azure.net/", prefix = "myapp/" }
+    ```
+  </Accordion>
+
+  <Accordion title="azure-kms — Azure Key Vault Keys">
+    ```toml theme={null}
+    [providers]
+    azurekms = { type = "azure-kms", vault_url = "https://myapp-vault.vault.azure.net/", key_name = "encryption-key" }
+    ```
+  </Accordion>
+
+  <Accordion title="gcp-sm — GCP Secret Manager">
+    ```toml theme={null}
+    [providers]
+    gcp = { type = "gcp-sm", project = "my-project-id", prefix = "myapp/" }
+    ```
+  </Accordion>
+
+  <Accordion title="gcp-kms — GCP Cloud KMS">
+    ```toml theme={null}
+    [providers.gcpkms]
+    type     = "gcp-kms"
+    project  = "my-project-id"
+    location = "us-central1"
+    keyring  = "fnox-keyring"
+    key      = "fnox-key"
+    ```
+  </Accordion>
+
+  <Accordion title="1password — 1Password">
+    ```toml theme={null}
+    [providers]
+    onepass = { type = "1password", vault = "Development", account = "my.1password.com" }
+    ```
+
+    `account` is optional.
+  </Accordion>
+
+  <Accordion title="bitwarden — Bitwarden">
+    ```toml theme={null}
+    [providers]
+    bitwarden = { type = "bitwarden", collection = "collection-id", organization_id = "org-id" }
+    ```
+
+    Both `collection` and `organization_id` are optional.
+  </Accordion>
+
+  <Accordion title="vault — HashiCorp Vault">
+    ```toml theme={null}
+    [providers]
+    vault = { type = "vault", address = "https://vault.example.com:8200", path = "secret/myapp", token = "hvs.CAESIJ..." }
+    ```
+
+    `token` is optional; use `VAULT_TOKEN` environment variable instead.
+  </Accordion>
+
+  <Accordion title="keychain — OS keychain">
+    ```toml theme={null}
+    [providers]
+    keychain = { type = "keychain", service = "fnox", prefix = "myapp/" }
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Secret configuration
+
+```toml theme={null}
+[secrets]
+SECRET_NAME = { provider = "PROVIDER_NAME", value = "...", default = "...", if_missing = "error", description = "..." }
+```
+
+### Fields
+
+<AccordionGroup>
+  <Accordion title="provider">
+    The provider to use for this secret. Required unless you are using only `default` (plain text).
+
+    ```toml theme={null}
+    [secrets]
+    DATABASE_URL = { provider = "age", value = "encrypted..." }
+    ```
+  </Accordion>
+
+  <Accordion title="value">
+    The provider-specific reference for the secret:
+
+    * **Encryption providers** (`age`, `aws-kms`, etc.) — encrypted ciphertext stored in the config file
+    * **Remote providers** (`aws-sm`, `1password`, etc.) — the secret name or reference in the remote store
+
+    ```toml theme={null}
+    [secrets]
+    # Encrypted ciphertext (age)
+    DATABASE_URL = { provider = "age", value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC..." }
+
+    # Remote reference (AWS Secrets Manager)
+    DATABASE_URL = { provider = "aws", value = "database-url" }
+    ```
+  </Accordion>
+
+  <Accordion title="default">
+    Fallback value used when the secret cannot be resolved. Useful for non-sensitive defaults and local development.
+
+    ```toml theme={null}
+    [secrets]
+    DATABASE_URL = { provider = "age", value = "encrypted...", default = "postgresql://localhost/dev" }
+    ```
+  </Accordion>
+
+  <Accordion title="if_missing">
+    Per-secret override for missing-secret behavior. Accepts `"error"`, `"warn"`, or `"ignore"`. Overrides the top-level `if_missing` setting but is itself overridden by `FNOX_IF_MISSING` and `--if-missing`.
+
+    ```toml theme={null}
+    [secrets]
+    DATABASE_URL  = { provider = "aws", value = "database-url", if_missing = "error" }
+    ANALYTICS_KEY = { provider = "aws", value = "analytics-key", if_missing = "ignore" }
+    ```
+  </Accordion>
+
+  <Accordion title="description">
+    Human-readable description shown in `fnox list` output.
+
+    ```toml theme={null}
+    [secrets]
+    DATABASE_URL = { provider = "age", value = "encrypted...", description = "Production database connection string" }
+    ```
+  </Accordion>
+
+  <Accordion title="as_file">
+    When `true`, write the secret to a temporary file and inject the file path as the environment variable instead of the raw value. Useful for credentials that must exist on disk.
+
+    ```toml theme={null}
+    [secrets]
+    GOOGLE_APPLICATION_CREDENTIALS = { provider = "age", value = "encrypted...", as_file = true }
+    ```
+  </Accordion>
+
+  <Accordion title="env">
+    Set `env = false` to prevent this secret from being injected as an environment variable in subprocesses. The secret is still resolved and available via `fnox get`.
+
+    ```toml theme={null}
+    [secrets]
+    INTERNAL_TOKEN = { provider = "age", value = "encrypted...", env = false }
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Profile configuration
+
+Profiles let you define environment-specific secrets and providers in a single config file.
+
+```toml theme={null}
+[profiles.PROFILE_NAME]
+if_missing = "error"  # profile-specific default
+
+[profiles.PROFILE_NAME.providers]
+PROVIDER_NAME = { type = "PROVIDER_TYPE" }
+
+[profiles.PROFILE_NAME.secrets]
+SECRET_NAME = { provider = "PROVIDER_NAME", value = "..." }
+```
+
+### Profile inheritance
+
+Profiles inherit all top-level secrets and providers. You only need to define values that differ:
+
+```toml theme={null}
+# Top-level (inherited by all profiles)
+[secrets]
+LOG_LEVEL    = { default = "info" }
+DATABASE_URL = { provider = "age", value = "encrypted-dev..." }
+
+# Production profile — only override what changes
+[profiles.production.secrets]
+DATABASE_URL = { provider = "aws", value = "prod-db" }
+# LOG_LEVEL="info" still inherited from top level
+```
+
+### `--no-defaults` flag
+
+To use only profile-specific secrets without inheriting from the top level:
+
+```bash theme={null}
+fnox exec --profile production --no-defaults -- ./deploy.sh
+```
+
+## Local overrides
+
+Create `fnox.local.toml` alongside `fnox.toml` to override values locally without touching the shared config. Add it to `.gitignore`.
+
+```toml theme={null}
+# fnox.local.toml
+[secrets]
+DATABASE_URL = { default = "postgresql://localhost/mylocal" }
+DEBUG_MODE   = { default = "true" }
+```
+
+```gitignore theme={null}
+fnox.local.toml
+```
+
+## Profile-specific config files
+
+Create `fnox.<profile>.toml` files that are automatically loaded when `FNOX_PROFILE` matches:
+
+```
+project/
+├── fnox.toml              # base config (committed)
+├── fnox.production.toml   # production overrides (committed)
+├── fnox.staging.toml      # staging overrides (committed)
+└── fnox.local.toml        # personal overrides (gitignored)
+```
+
+```bash theme={null}
+# Load fnox.toml only
+fnox exec -- npm start
+
+# Load fnox.toml + fnox.production.toml
+FNOX_PROFILE=production fnox exec -- ./deploy.sh
+```
+
+<Note>
+  `fnox.$FNOX_PROFILE.toml` files apply on top of `fnox.toml`'s default-profile secrets — they are separate from the `[profiles.xxx]` sections inside `fnox.toml`. `fnox.default.toml` is never loaded.
+</Note>
+
+## Hierarchical configuration
+
+fnox searches parent directories for `fnox.toml` files:
+
+```
+project/
+├── fnox.toml          # root config
+└── services/
+    └── api/
+        └── fnox.toml  # API config — inherits from root
+```
+
+Merge order for a project with a parent config (lowest to highest priority):
+
+1. Global config (`~/.config/fnox/config.toml`)
+2. Root `fnox.toml`
+3. Root `fnox.$FNOX_PROFILE.toml`
+4. Root `fnox.local.toml`
+5. Child `fnox.toml`
+6. Child `fnox.$FNOX_PROFILE.toml`
+7. Child `fnox.local.toml`
+
+## Complete example
+
+```toml theme={null}
+# Global settings
+if_missing = "warn"
+import     = ["./shared/common.toml"]
+
+# Providers
+[providers]
+age = { type = "age", recipients = ["age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"] }
+aws = { type = "aws-sm", region = "us-east-1", prefix = "myapp/" }
+
+# Default profile secrets
+[secrets]
+DATABASE_URL = { provider = "age", value = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNjcnlwdC...", default = "postgresql://localhost/dev", description = "Database connection string" }
+JWT_SECRET   = { provider = "age", value = "encrypted...", if_missing = "error" }
+LOG_LEVEL    = { default = "info" }
+
+# Production profile
+[profiles.production]
+if_missing = "error"
+
+[profiles.production.providers]
+aws = { type = "aws-sm", region = "us-east-1", prefix = "myapp-prod/" }
+
+[profiles.production.secrets]
+DATABASE_URL = { provider = "aws", value = "database-url", description = "Production database" }
+JWT_SECRET   = { provider = "aws", value = "jwt-secret" }
+# LOG_LEVEL inherited from top level
+```
+
+
+# Environment Variables
+Source: https://www.mintlify.com/jdx/fnox/reference/environment
+
+Complete reference for all FNOX_* environment variables and provider-specific variables.
+
+## Core configuration
+
+### `FNOX_PROFILE`
+
+The active profile name. Must consist of alphanumeric characters, dashes, underscores, or dots. Path separators and control characters are rejected.
+
+|             |                                               |
+| ----------- | --------------------------------------------- |
+| **Default** | `default`                                     |
+| **Values**  | Any valid profile name defined in `fnox.toml` |
+
+```bash theme={null}
+export FNOX_PROFILE=production
+fnox exec -- ./deploy.sh
+```
+
+### `FNOX_CONFIG_DIR`
+
+Path to the directory containing the global config file (`config.toml`). Must be an absolute path; relative paths are ignored.
+
+|             |                                                        |
+| ----------- | ------------------------------------------------------ |
+| **Default** | `~/.config/fnox` (or `$XDG_CONFIG_HOME/fnox` on Linux) |
+
+```bash theme={null}
+export FNOX_CONFIG_DIR=/opt/fnox
+fnox get DATABASE_URL
+```
+
+### `FNOX_NO_DEFAULTS`
+
+When set to `true`, skip merging top-level secrets into the selected profile. Equivalent to passing `--no-defaults` on every command.
+
+|             |                 |
+| ----------- | --------------- |
+| **Default** | `false`         |
+| **Values**  | `true`, `false` |
+
+```bash theme={null}
+export FNOX_NO_DEFAULTS=true
+fnox exec --profile production -- ./deploy.sh
+```
+
+## Age encryption keys
+
+### `FNOX_AGE_KEY`
+
+Age private key provided directly as a string. Use this in CI/CD environments where you inject the key from a secret manager.
+
+|            |                       |
+| ---------- | --------------------- |
+| **Format** | `AGE-SECRET-KEY-1...` |
+
+```bash theme={null}
+export FNOX_AGE_KEY="AGE-SECRET-KEY-1ABCDEFGHIJKLMNOPQRSTUVWXYZ..."
+fnox get DATABASE_URL
+```
+
+<Tip>
+  To load the age key from a file instead of an inline string, set `FNOX_AGE_KEY` to the file's contents:
+
+  ```bash theme={null}
+  export FNOX_AGE_KEY=$(grep "AGE-SECRET-KEY" ~/.config/fnox/age.txt)
+  ```
+
+  Alternatively, configure `key_file` directly in the provider config in `fnox.toml`:
+
+  ```toml theme={null}
+  [providers.age]
+  type = "age"
+  key_file = "~/.ssh/id_ed25519"
+  recipients = ["age1..."]
+  ```
+</Tip>
+
+## Missing secret behavior
+
+### `FNOX_IF_MISSING`
+
+Runtime override for missing-secret behavior. Overrides config file settings but is overridden by the `--if-missing` CLI flag.
+
+| Value    | Behavior                                               |
+| -------- | ------------------------------------------------------ |
+| `error`  | Fail and exit with an error                            |
+| `warn`   | Print a warning and continue (default system behavior) |
+| `ignore` | Silently skip the missing secret                       |
+
+```bash theme={null}
+# Strict mode for deployment scripts
+export FNOX_IF_MISSING=error
+fnox exec -- ./deploy.sh
+
+# Lenient mode for optional secrets
+FNOX_IF_MISSING=ignore fnox exec -- npm test
+```
+
+### `FNOX_IF_MISSING_DEFAULT`
+
+Base default when no other configuration specifies missing-secret behavior. This has the lowest priority of all configuration methods.
+
+|             |                           |
+| ----------- | ------------------------- |
+| **Default** | `warn`                    |
+| **Values**  | `error`, `warn`, `ignore` |
+
+Only applies when all of the following are unset: `--if-missing` flag, `FNOX_IF_MISSING`, secret-level `if_missing`, and top-level `if_missing` in config.
+
+```bash theme={null}
+# Make error mode the global default across all projects
+echo 'export FNOX_IF_MISSING_DEFAULT=error' >> ~/.bashrc
+```
+
+## Shell integration
+
+### `FNOX_SHELL_OUTPUT`
+
+Controls how much output the shell hook prints when loading secrets.
+
+| Value    | Output                                          |
+| -------- | ----------------------------------------------- |
+| `none`   | Silent — no output                              |
+| `normal` | Secret count and names (default)                |
+| `debug`  | Verbose: config path, profile, resolved secrets |
+
+```bash theme={null}
+# Silence shell integration output
+export FNOX_SHELL_OUTPUT=none
+
+# Default output
+export FNOX_SHELL_OUTPUT=normal
+cd my-app
+# fnox: +3 DATABASE_URL, API_KEY, JWT_SECRET
+
+# Debug output
+export FNOX_SHELL_OUTPUT=debug
+cd my-app
+# fnox: Loading config from /path/to/fnox.toml
+# fnox: Active profile: default
+# fnox: Resolved 3 secrets
+# fnox: +3 DATABASE_URL, API_KEY, JWT_SECRET
+```
+
+### `FNOX_PROMPT_AUTH`
+
+Whether to prompt for authentication when a provider's auth fails in a TTY. Disable this in non-interactive or automated contexts.
+
+|             |                                        |
+| ----------- | -------------------------------------- |
+| **Default** | `true`                                 |
+| **Values**  | `true`, `false`, `1`, `0`, `yes`, `no` |
+
+```bash theme={null}
+export FNOX_PROMPT_AUTH=false
+fnox exec -- ./automated-script.sh
+```
+
+## Provider-specific variables
+
+### AWS
+
+Used by `aws-sm`, `aws-kms`, and `aws-ps` providers.
+
+```bash theme={null}
+export AWS_ACCESS_KEY_ID="AKIA..."
+export AWS_SECRET_ACCESS_KEY="..."
+export AWS_REGION="us-east-1"
+export AWS_PROFILE="myapp"
+```
+
+### Azure
+
+Used by `azure-sm` and `azure-kms` providers.
+
+```bash theme={null}
+export AZURE_CLIENT_ID="..."
+export AZURE_CLIENT_SECRET="..."
+export AZURE_TENANT_ID="..."
+```
+
+### Google Cloud
+
+Used by `gcp-sm` and `gcp-kms` providers.
+
+```bash theme={null}
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account-key.json"
+```
+
+### 1Password
+
+Used by the `1password` provider. Enables non-interactive (service account) authentication.
+
+```bash theme={null}
+export OP_SERVICE_ACCOUNT_TOKEN="ops_..."
+```
+
+### Bitwarden
+
+Used by the `bitwarden` provider. Provides an already-unlocked session key.
+
+```bash theme={null}
+export BW_SESSION="..."
+```
+
+### HashiCorp Vault
+
+Used by the `vault` provider. `FNOX_`-prefixed variables take precedence over the standard Vault variables.
+
+```bash theme={null}
+export VAULT_ADDR="https://vault.example.com:8200"
+export VAULT_TOKEN="hvs.CAESIJ..."
+```
+
+### Editor
+
+Used by `fnox edit` to open the config file.
+
+```bash theme={null}
+export EDITOR=vim
+```
+
+**Default:** system default editor (`$VISUAL`, then `vi` or `nano`).
+
+## Priority order
+
+When the same setting is configured in multiple places, fnox resolves it in this order (highest to lowest):
+
+1. **CLI flags** — `--profile`, `--if-missing`, `--no-defaults`
+2. **Environment variables** — `FNOX_PROFILE`, `FNOX_IF_MISSING`, `FNOX_NO_DEFAULTS`
+3. **Secret-level config** — `if_missing` in `[secrets]`
+4. **Top-level config** — `if_missing` at the top of `fnox.toml`
+5. **`FNOX_IF_MISSING_DEFAULT`** — base default env var
+6. **Built-in defaults** — hardcoded behavior (`warn`)
+
+## Usage examples
+
+<Tabs>
+  <Tab title="Development">
+    ```bash theme={null}
+    # ~/.bashrc or ~/.zshrc
+
+    export FNOX_PROFILE=default
+    export FNOX_AGE_KEY_FILE=~/.ssh/id_ed25519
+    export FNOX_SHELL_OUTPUT=normal
+    export FNOX_IF_MISSING=warn
+
+    # Enable shell integration
+    eval "$(fnox activate bash)"
+    ```
+  </Tab>
+
+  <Tab title="Production server">
+    ```bash theme={null}
+    # CI/CD or production server environment
+
+    export FNOX_PROFILE=production
+    export FNOX_IF_MISSING=error
+
+    # AWS credentials (or use IAM role)
+    export AWS_REGION=us-east-1
+
+    # Age key injected from a secure secret store
+    export FNOX_AGE_KEY="${CI_SECRET_AGE_KEY}"
+    ```
+  </Tab>
+
+  <Tab title="GitHub Actions">
+    ```yaml theme={null}
+    # .github/workflows/deploy.yml
+    env:
+      FNOX_PROFILE: production
+      FNOX_IF_MISSING: error
+      FNOX_AGE_KEY: ${{ secrets.FNOX_AGE_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    ```
+  </Tab>
+</Tabs>
+
+

--- a/docs/research/mintlify-cache/jdx/fnox/llms.txt
+++ b/docs/research/mintlify-cache/jdx/fnox/llms.txt
@@ -1,0 +1,31 @@
+# Fnox
+
+## Docs
+
+- [CI/CD Integration](https://www.mintlify.com/jdx/fnox/guides/ci-cd.md): Run fnox in GitHub Actions and other CI pipelines to securely inject secrets at deploy time.
+- [Hierarchical Configuration](https://www.mintlify.com/jdx/fnox/guides/hierarchical-config.md): Merge fnox.toml files across parent directories for monorepos and multi-service projects.
+- [How It Works](https://www.mintlify.com/jdx/fnox/guides/how-it-works.md): Understand fnox's two storage modes, secret resolution order, and execution flow.
+- [Credential Leases](https://www.mintlify.com/jdx/fnox/guides/leases.md): Vend short-lived cloud credentials from AWS, GCP, Azure, Vault, and more using fnox leases.
+- [MCP Server](https://www.mintlify.com/jdx/fnox/guides/mcp.md): Use fnox as a session-scoped secret broker for AI agents via the Model Context Protocol.
+- [Profiles](https://www.mintlify.com/jdx/fnox/guides/profiles.md): Manage secrets for multiple environments in a single fnox.toml using profiles.
+- [Real-World Example](https://www.mintlify.com/jdx/fnox/guides/real-world-example.md): Build a complete multi-environment secret setup with age encryption, AWS Secrets Manager, shell integration, and CI/CD.
+- [Shell Integration](https://www.mintlify.com/jdx/fnox/guides/shell-integration.md): Automatically load and unload secrets when you cd into and out of project directories.
+- [Installation](https://www.mintlify.com/jdx/fnox/installation.md): Install fnox using mise, cargo, or from source.
+- [What is Fnox?](https://www.mintlify.com/jdx/fnox/introduction.md): Fnox is a CLI secret manager that supports encrypted secrets in git and remote cloud providers.
+- [Age Encryption](https://www.mintlify.com/jdx/fnox/providers/age.md): Encrypt secrets with age and store the ciphertext directly in fnox.toml. Supports native age keys and SSH keys — no extra key management needed.
+- [AWS KMS](https://www.mintlify.com/jdx/fnox/providers/aws-kms.md): Encrypt secrets with AWS Key Management Service and store the ciphertext in fnox.toml. Combines git-based version control with AWS-managed keys and IAM access control.
+- [AWS Parameter Store](https://www.mintlify.com/jdx/fnox/providers/aws-ps.md): Store secrets in AWS Systems Manager Parameter Store. Hierarchical paths, free standard tier, and IAM access control make it a cost-effective alternative to Secrets Manager.
+- [AWS Secrets Manager](https://www.mintlify.com/jdx/fnox/providers/aws-sm.md): Store secrets remotely in AWS Secrets Manager. fnox.toml contains only name references — secrets never touch the filesystem or version control.
+- [Azure Providers](https://www.mintlify.com/jdx/fnox/providers/azure.md): Use Azure Key Vault for encryption (azure-kms) or remote secret storage (azure-sm). Both providers authenticate with Azure credentials and integrate with Azure RBAC.
+- [Google Cloud Providers](https://www.mintlify.com/jdx/fnox/providers/gcp.md): Use GCP Cloud KMS for encryption (gcp-kms) or GCP Secret Manager for remote storage (gcp-sm). Both providers authenticate via Application Default Credentials.
+- [HashiCorp Vault](https://www.mintlify.com/jdx/fnox/providers/hashicorp-vault.md): Integrate with self-hosted or HCP HashiCorp Vault for advanced secret management with dynamic secrets, fine-grained policies, and audit logging.
+- [Local Storage Providers](https://www.mintlify.com/jdx/fnox/providers/local-storage.md): Store secrets locally using the OS keychain, a KeePass database, password-store (pass), or plain text defaults. Best for personal projects and local development.
+- [Providers Overview](https://www.mintlify.com/jdx/fnox/providers/overview.md): Choose the right secret storage provider for your project. fnox supports encryption, cloud storage, password managers, and local storage backends.
+- [Password Managers](https://www.mintlify.com/jdx/fnox/providers/password-managers.md): Integrate fnox with 1Password, Bitwarden, Bitwarden Secrets Manager, Infisical, or Doppler. Secrets live in your existing password manager or cloud secrets service.
+- [Quick Start](https://www.mintlify.com/jdx/fnox/quickstart.md): Get fnox installed and your first secret encrypted and loaded in under 5 minutes.
+- [CLI Reference](https://www.mintlify.com/jdx/fnox/reference/cli.md): Complete reference for all fnox commands and flags.
+- [Configuration Reference](https://www.mintlify.com/jdx/fnox/reference/configuration.md): Complete reference for the fnox.toml configuration file.
+- [Environment Variables](https://www.mintlify.com/jdx/fnox/reference/environment.md): Complete reference for all FNOX_* environment variables and provider-specific variables.
+
+
+Built with [Mintlify](https://mintlify.com).

--- a/docs/research/mintlify-cache/jdx/hk/llms-full.txt
+++ b/docs/research/mintlify-cache/jdx/hk/llms-full.txt
@@ -1,0 +1,3975 @@
+# Benchmarks
+Source: https://www.mintlify.com/jdx/hk/benchmarks
+
+Performance comparison of hk, lefthook, pre-commit, and prek running 10 linters on a synthetic project.
+
+These benchmarks compare hk, lefthook, pre-commit, and prek running 10 linters on a synthetic project.
+
+hk is the only tool that runs linters in parallel **and** safely. See [Why hk?](/why-hk) for background on how hk achieves this with file-level read/write locks.
+
+## Setup
+
+The benchmark uses a synthetic project with **\~6,000 files** across multiple languages:
+
+* 4,000 Python, 500 JavaScript/TypeScript, 500 JSON, 500 Shell, 250 YAML, 200 CSS, 200 Markdown
+
+### Linters
+
+Ten linters with overlapping file coverage are configured:
+
+| Linter              | Files              | How hk avoids write locks                              |
+| ------------------- | ------------------ | ------------------------------------------------------ |
+| prettier            | `*.{js,ts,css,md}` | `check_list_files` — only locks files that need fixing |
+| eslint              | `*.{js,ts}`        | Falls back to write lock (no diff or list mode)        |
+| black               | `*.py`             | `check_diff` — hk applies the diff itself              |
+| ruff check          | `*.py`             | Check only — read lock                                 |
+| ruff format         | `*.py`             | `check_diff` — hk applies the diff itself              |
+| jq                  | `*.json`           | `check_diff`                                           |
+| yq                  | `*.{yml,yaml}`     | `check_diff`                                           |
+| shfmt               | `*.{sh,bash}`      | `check_diff`                                           |
+| trailing-whitespace | `**/*` (all files) | `check_diff` via `hk util` (built-in Rust)             |
+| newlines            | `**/*` (all files) | `check_diff` via `hk util` (built-in Rust)             |
+
+`trailing-whitespace` and `newlines` use `**/*` globs — they overlap with every other linter. This is the most adversarial case for parallel execution.
+
+### Why other tools run sequentially
+
+<Note>
+  lefthook supports `parallel: true`, but it has no file-level coordination. If two parallel jobs modify the same file, the last writer wins and the other's changes are silently lost. For a fair and **correct** comparison, lefthook is run in its safe sequential mode — the only mode that avoids race conditions. pre-commit and prek always run hooks sequentially.
+</Note>
+
+## Results
+
+hk's parallel execution produces a significant speedup over sequential tools. The exact numbers depend on hardware (number of cores, I/O speed) and the mix of linters, but you can expect hk to be several times faster on a multi-core machine when linters are I/O or CPU bound.
+
+Key points from the benchmark:
+
+* **All files (\~1,750 matched files, 10 linters)** — hk's parallelism provides the largest advantage because the total work is spread across cores simultaneously.
+* **Staged changes (\~50 files)** — speedup is smaller but still meaningful; hk avoids unnecessary work through smart file filtering.
+
+To see live benchmark numbers, run the benchmarks locally using the steps below.
+
+## Reproducing the benchmarks
+
+Everything is in the `benchmark/` directory of the hk repository.
+
+### Prerequisites
+
+```bash theme={null}
+mise use hyperfine lefthook prettier eslint shfmt jq yq
+uv tool install pre-commit prek black ruff
+```
+
+### Generate and run
+
+<Steps>
+  <Step title="Generate a synthetic project">
+    ```bash theme={null}
+    benchmark/generate-project.sh /tmp/hk-bench
+    ```
+
+    You can customize the file counts with environment variables:
+
+    ```bash theme={null}
+    NUM_JS=500 NUM_PY=500 benchmark/generate-project.sh /tmp/hk-bench
+    ```
+  </Step>
+
+  <Step title="Run the benchmarks">
+    ```bash theme={null}
+    benchmark/run.sh /tmp/hk-bench
+    ```
+
+    Customize the number of runs and warmup iterations:
+
+    ```bash theme={null}
+    RUNS=20 WARMUP=3 benchmark/run.sh /tmp/hk-bench
+    ```
+  </Step>
+
+  <Step title="Review the results">
+    Results are saved as JSON in `benchmark/results/`. A chart image and data file are also generated in `docs/public/` for the documentation site.
+  </Step>
+</Steps>
+
+
+# Built-in linters
+Source: https://www.mintlify.com/jdx/hk/builtins
+
+120+ pre-configured linters and formatters available through the Builtins module — ready to use with a single import.
+
+hk ships with over 120 pre-configured linters and formatters through the `Builtins` module. Each builtin is a production-ready `Step` definition you can use as-is or customize with Pkl's amend syntax.
+
+## Importing and using builtins
+
+Add the `Builtins` import to your `hk.pkl`, then reference builtins by name:
+
+```pkl hk.pkl theme={null}
+amends "package://github.com/jdx/hk/releases/download/v1.41.0/hk@1.41.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.41.0/hk@1.41.0#/Builtins.pkl"
+
+hooks {
+    ["pre-commit"] {
+        fix = true
+        stash = "git"
+        steps {
+            ["prettier"] = Builtins.prettier
+            ["eslint"] = Builtins.eslint
+            ["cargo-fmt"] = Builtins.cargo_fmt
+            ["gitleaks"] = Builtins.gitleaks
+        }
+    }
+}
+```
+
+## Customizing builtins
+
+Use Pkl's amend syntax — `(Builtins.name) { ... }` — to override any property while keeping the rest of the builtin's defaults.
+
+<AccordionGroup>
+  <Accordion title="Override glob patterns">
+    ```pkl theme={null}
+    ["prettier"] = (Builtins.prettier) {
+        // restrict to only JS/TS files in src/
+        glob = List("src/**/*.js", "src/**/*.ts")
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="Toggle batch processing">
+    ```pkl theme={null}
+    ["eslint"] = (Builtins.eslint) {
+        batch = false  // disable parallel batching
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="Add environment variables">
+    ```pkl theme={null}
+    ["prettier"] = (Builtins.prettier) {
+        env {
+            ["PRETTIER_CONFIG"] = ".prettierrc.json"
+        }
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="Add dependencies">
+    ```pkl theme={null}
+    ["eslint"] = (Builtins.eslint) {
+        // run after prettier completes
+        depends = "prettier"
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="Workspace-specific configuration">
+    ```pkl theme={null}
+    ["cargo_clippy"] = (Builtins.cargo_clippy) {
+        // only run in directories with Cargo.toml
+        workspace_indicator = "Cargo.toml"
+        check = "cargo clippy --manifest-path {{workspace}}/Cargo.toml"
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="Profile-based configuration">
+    ```pkl theme={null}
+    ["mypy"] = (Builtins.mypy) {
+        // only run when the "python" profile is active
+        profiles = List("python")
+    }
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Available builtins
+
+### JavaScript / TypeScript
+
+| Builtin                      | Description                                                                    |
+| ---------------------------- | ------------------------------------------------------------------------------ |
+| `Builtins.prettier`          | Opinionated code formatter (JS, TS, CSS, HTML, JSON, YAML, Markdown, and more) |
+| `Builtins.eslint`            | Pluggable JavaScript linter                                                    |
+| `Builtins.biome`             | Fast formatter and linter (JS, TS, JSON)                                       |
+| `Builtins.tsc`               | TypeScript type checker                                                        |
+| `Builtins.deno`              | Deno formatter and linter                                                      |
+| `Builtins.deno_check`        | Deno type checker                                                              |
+| `Builtins.standard_js`       | JavaScript Standard Style linter                                               |
+| `Builtins.xo`                | Opinionated ESLint wrapper                                                     |
+| `Builtins.knip`              | Find unused exports, files, and dependencies                                   |
+| `Builtins.knip_strict`       | Knip with stricter settings                                                    |
+| `Builtins.ox_lint`           | Fast JavaScript linter written in Rust                                         |
+| `Builtins.sort_package_json` | Keep `package.json` keys sorted                                                |
+| `Builtins.stylelint`         | CSS/SCSS/Less linter                                                           |
+| `Builtins.astro`             | Astro formatter                                                                |
+
+### Python
+
+| Builtin                            | Description                              |
+| ---------------------------------- | ---------------------------------------- |
+| `Builtins.black`                   | Opinionated Python formatter             |
+| `Builtins.ruff`                    | Fast Python linter                       |
+| `Builtins.ruff_format`             | Fast Python formatter (ruff's formatter) |
+| `Builtins.mypy`                    | Static type checker for Python           |
+| `Builtins.pylint`                  | Python linter                            |
+| `Builtins.flake8`                  | Python style guide enforcer              |
+| `Builtins.isort`                   | Python import sorter                     |
+| `Builtins.python_check_ast`        | Check Python files for valid AST         |
+| `Builtins.python_debug_statements` | Detect leftover debug statements         |
+| `Builtins.ty`                      | Extremely fast Python type checker       |
+
+### Rust
+
+| Builtin                 | Description                                |
+| ----------------------- | ------------------------------------------ |
+| `Builtins.cargo_fmt`    | Rust code formatter                        |
+| `Builtins.cargo_clippy` | Rust linter                                |
+| `Builtins.cargo_check`  | Rust compiler check (without clippy)       |
+| `Builtins.rustfmt`      | Rust formatter (direct rustfmt invocation) |
+
+### Go
+
+| Builtin                  | Description              |
+| ------------------------ | ------------------------ |
+| `Builtins.go_fmt`        | Go formatter             |
+| `Builtins.go_fumpt`      | Stricter Go formatter    |
+| `Builtins.go_imports`    | Go import organizer      |
+| `Builtins.go_vet`        | Go static analysis       |
+| `Builtins.golangci_lint` | Go meta-linter           |
+| `Builtins.go_sec`        | Go security checker      |
+| `Builtins.staticcheck`   | Go static analysis tool  |
+| `Builtins.revive`        | Go linter                |
+| `Builtins.go_lines`      | Go line length checker   |
+| `Builtins.gomod_tidy`    | Keep `go.mod` tidy       |
+| `Builtins.go_vuln_check` | Go vulnerability checker |
+
+### Ruby
+
+| Builtin                 | Description                       |
+| ----------------------- | --------------------------------- |
+| `Builtins.rubocop`      | Ruby linter and formatter         |
+| `Builtins.standard_rb`  | Ruby Standard Style linter        |
+| `Builtins.reek`         | Ruby code smell detector          |
+| `Builtins.fasterer`     | Ruby performance suggestions      |
+| `Builtins.brakeman`     | Ruby on Rails security scanner    |
+| `Builtins.sorbet`       | Ruby type checker                 |
+| `Builtins.bundle_audit` | Bundler dependency security audit |
+| `Builtins.erb`          | ERB template linter               |
+
+### Shell
+
+| Builtin               | Description            |
+| --------------------- | ---------------------- |
+| `Builtins.shellcheck` | Shell script analyzer  |
+| `Builtins.shfmt`      | Shell script formatter |
+
+### Lua
+
+| Builtin             | Description         |
+| ------------------- | ------------------- |
+| `Builtins.selene`   | Lua linter          |
+| `Builtins.luacheck` | Lua static analysis |
+| `Builtins.stylua`   | Lua formatter       |
+
+### Nix
+
+| Builtin                   | Description                   |
+| ------------------------- | ----------------------------- |
+| `Builtins.nix_fmt`        | Nix formatter                 |
+| `Builtins.alejandra`      | Opinionated Nix formatter     |
+| `Builtins.nixpkgs_format` | nixpkgs code formatter        |
+| `Builtins.deadnix`        | Find and remove dead Nix code |
+| `Builtins.nixf_diagnose`  | Nix language diagnostics      |
+| `Builtins.nil`            | Nix language server linting   |
+
+### Elixir
+
+| Builtin                | Description              |
+| ---------------------- | ------------------------ |
+| `Builtins.mix_fmt`     | Elixir code formatter    |
+| `Builtins.mix_compile` | Elixir compilation check |
+| `Builtins.mix_test`    | Run Elixir tests         |
+
+### Kotlin / Java / Swift
+
+| Builtin                       | Description                 |
+| ----------------------------- | --------------------------- |
+| `Builtins.ktlint`             | Kotlin linter and formatter |
+| `Builtins.google_java_format` | Java formatter              |
+| `Builtins.swiftlint`          | Swift linter                |
+
+### Terraform / Infrastructure
+
+| Builtin              | Description         |
+| -------------------- | ------------------- |
+| `Builtins.terraform` | Terraform formatter |
+| `Builtins.tf_lint`   | Terraform linter    |
+| `Builtins.tofu`      | OpenTofu formatter  |
+| `Builtins.hclfmt`    | HCL formatter       |
+
+### Data formats
+
+| Builtin                 | Description              |
+| ----------------------- | ------------------------ |
+| `Builtins.taplo`        | TOML linter              |
+| `Builtins.taplo_format` | TOML formatter           |
+| `Builtins.tombi`        | TOML linter              |
+| `Builtins.tombi_format` | TOML formatter           |
+| `Builtins.yamllint`     | YAML linter              |
+| `Builtins.yamlfmt`      | YAML formatter           |
+| `Builtins.jq`           | JSON formatter via jq    |
+| `Builtins.yq`           | YAML/JSON processor      |
+| `Builtins.xmllint`      | XML linter               |
+| `Builtins.sql_fluff`    | SQL linter and formatter |
+| `Builtins.pkl`          | Pkl linter               |
+| `Builtins.pkl_format`   | Pkl formatter            |
+
+### Documentation
+
+| Builtin                  | Description                                     |
+| ------------------------ | ----------------------------------------------- |
+| `Builtins.markdown_lint` | Markdown linter                                 |
+| `Builtins.rumdl`         | Fast Markdown linter (Rust)                     |
+| `Builtins.vale`          | Prose style checker                             |
+| `Builtins.lychee`        | Link checker                                    |
+| `Builtins.asciidoctor`   | AsciiDoc processor check                        |
+| `Builtins.mdschema`      | JSON Schema validation for Markdown frontmatter |
+
+### GitHub Actions / CI
+
+| Builtin                     | Description                                |
+| --------------------------- | ------------------------------------------ |
+| `Builtins.actionlint`       | GitHub Actions workflow linter             |
+| `Builtins.ghalint_action`   | GitHub Actions linter (action files)       |
+| `Builtins.ghalint_workflow` | GitHub Actions linter (workflow files)     |
+| `Builtins.zizmor`           | GitHub Actions security analyzer           |
+| `Builtins.pinact`           | Pin GitHub Actions to specific commit SHAs |
+| `Builtins.pinact_update`    | Update pinned GitHub Actions               |
+
+### Docker / Containers
+
+| Builtin             | Description           |
+| ------------------- | --------------------- |
+| `Builtins.hadolint` | Dockerfile linter     |
+| `Builtins.dclint`   | Docker Compose linter |
+
+### C / C++
+
+| Builtin                 | Description       |
+| ----------------------- | ----------------- |
+| `Builtins.clang_format` | C/C++ formatter   |
+| `Builtins.cpp_lint`     | C++ style checker |
+| `Builtins.cmake_format` | CMake formatter   |
+
+### Secrets and security
+
+| Builtin                       | Description                         |
+| ----------------------------- | ----------------------------------- |
+| `Builtins.gitleaks`           | Secret scanner for Git repositories |
+| `Builtins.betterleaks`        | Enhanced secret scanner             |
+| `Builtins.detect_private_key` | Detect committed private keys       |
+
+### General / special purpose
+
+| Builtin                                    | Description                                                      |
+| ------------------------------------------ | ---------------------------------------------------------------- |
+| `Builtins.trailing_whitespace`             | Detect and remove trailing whitespace                            |
+| `Builtins.newlines`                        | Ensure files end with a newline                                  |
+| `Builtins.check_merge_conflict`            | Detect merge conflict markers                                    |
+| `Builtins.check_conventional_commit`       | Validate conventional commit messages                            |
+| `Builtins.check_added_large_files`         | Prevent large files from being committed                         |
+| `Builtins.check_case_conflict`             | Detect files that would conflict on case-insensitive filesystems |
+| `Builtins.check_symlinks`                  | Check for broken symlinks                                        |
+| `Builtins.check_executables_have_shebangs` | Ensure executable scripts have shebangs                          |
+| `Builtins.no_commit_to_branch`             | Prevent direct commits to protected branches                     |
+| `Builtins.mixed_line_ending`               | Detect mixed line endings                                        |
+| `Builtins.byte_order_marker`               | Detect byte order markers                                        |
+| `Builtins.fix_byte_order_marker`           | Remove byte order markers                                        |
+| `Builtins.check_byte_order_marker`         | Check for byte order markers                                     |
+| `Builtins.fix_smart_quotes`                | Replace smart quotes with straight quotes                        |
+| `Builtins.editorconfig-checker`            | Validate files against `.editorconfig`                           |
+| `Builtins.typos`                           | Fast spell checker for source code                               |
+| `Builtins.dprint`                          | Pluggable code formatter                                         |
+| `Builtins.contextlint`                     | Context-aware linter                                             |
+| `Builtins.err_check`                       | Error handling checker                                           |
+| `Builtins.ryl`                             | General-purpose linter                                           |
+| `Builtins.mise`                            | Validate `mise.toml` configuration                               |
+| `Builtins.buf_lint`                        | Protobuf linter                                                  |
+| `Builtins.buf_format`                      | Protobuf formatter                                               |
+| `Builtins.vacuum`                          | OpenAPI linter                                                   |
+| `Builtins.just_format`                     | Justfile formatter                                               |
+| `Builtins.php_cs`                          | PHP coding standards fixer                                       |
+
+## Creating custom steps
+
+When no builtin exists for your tool, define a step directly:
+
+```pkl hk.pkl theme={null}
+amends "package://github.com/jdx/hk/releases/download/v1.41.0/hk@1.41.0#/Config.pkl"
+
+hooks {
+    ["pre-commit"] {
+        steps {
+            ["custom-tool"] {
+                glob = List("**/*.custom")
+                check = "custom-tool --check {{files}}"
+                fix = "custom-tool --fix {{files}}"
+                batch = true
+            }
+        }
+    }
+}
+```
+
+You can also extract shared steps as local variables to reuse across hooks:
+
+```pkl hk.pkl theme={null}
+amends "package://github.com/jdx/hk/releases/download/v1.41.0/hk@1.41.0#/Config.pkl"
+
+local linters = new Mapping<String, Step> {
+    ["my-linter"] {
+        glob = List("**/*.go")
+        check = "my-linter {{files}}"
+        fix = "my-linter --fix {{files}}"
+    }
+}
+
+hooks {
+    ["pre-commit"] {
+        fix = true
+        steps = linters
+    }
+    ["check"] {
+        steps = linters
+    }
+}
+```
+
+
+# hk check
+Source: https://www.mintlify.com/jdx/hk/cli/check
+
+Run linters in read-only check mode against staged or specified files.
+
+**Usage**: `hk check [FLAGS] [FILES]…`
+
+**Alias**: `c`
+
+`hk check` runs all configured linter steps in check mode — no files are modified. It is equivalent to running the `check` hook defined in your `hk.pkl`. By default it operates on staged files only; use `--all` to check every file in the repository.
+
+<Tip>
+  Use `hk check --all` in CI pipelines to validate the entire codebase. Use `hk check --pr` to check only the files changed in the current pull request branch.
+</Tip>
+
+## Arguments
+
+<ParamField type="string[]">
+  One or more specific files to check. Conflicts with `--all`, `--fix`, and `--check`.
+</ParamField>
+
+## Flags
+
+<ParamField type="boolean">
+  Run on all files in the repository instead of just staged files.
+</ParamField>
+
+<ParamField type="boolean">
+  Force check mode — run the check command even if fix mode is the default. Overrides `--fix`.
+</ParamField>
+
+<ParamField type="string[]">
+  Exclude files that would otherwise have been selected. Can be specified multiple times.
+
+  ```bash theme={null}
+  hk check --exclude "vendor/**" --exclude "*.generated.go"
+  ```
+</ParamField>
+
+<ParamField type="boolean">
+  Force fix mode — run the fix command instead of the check command. This is the default behavior unless `HK_FIX=0`. Overrides `--check`.
+</ParamField>
+
+<ParamField type="string[]">
+  Run on files matching these glob patterns. Can be specified multiple times.
+
+  ```bash theme={null}
+  hk check --glob "src/**/*.ts" --glob "tests/**/*.ts"
+  ```
+</ParamField>
+
+<ParamField type="boolean">
+  Print the execution plan instead of running steps. Shows which steps will run and on which files.
+</ParamField>
+
+<ParamField type="string[]">
+  Run only specific named steps. Can be specified multiple times.
+
+  ```bash theme={null}
+  hk check --step eslint --step prettier
+  ```
+</ParamField>
+
+<ParamField type="boolean">
+  Abort on the first step failure. Opposite of `--no-fail-fast`.
+</ParamField>
+
+<ParamField type="boolean">
+  Continue running remaining steps even after a failure. Opposite of `--fail-fast`.
+</ParamField>
+
+<ParamField type="string">
+  Start git reference for determining which files to check. Requires `--to-ref`.
+
+  ```bash theme={null}
+  hk check --from-ref main --to-ref HEAD
+  ```
+</ParamField>
+
+<ParamField type="string">
+  End git reference for determining which files to check. Requires `--from-ref`.
+</ParamField>
+
+<ParamField type="boolean">
+  Check only files changed in the current PR or branch. This is a shortcut for `--from-ref DEFAULT_BRANCH --to-ref HEAD`. Conflicts with `--all`, `--files`, `--from-ref`, `--glob`, and `--to-ref`.
+</ParamField>
+
+<ParamField type="string[]">
+  Skip specific named steps. Can be specified multiple times.
+
+  ```bash theme={null}
+  hk check --skip-step slow-linter
+  ```
+</ParamField>
+
+<ParamField type="boolean">
+  Enable auto-staging of files that were modified by fix steps. Overrides `--no-stage`.
+</ParamField>
+
+<ParamField type="boolean">
+  Disable auto-staging of files modified by fix steps. Overrides `--stage`.
+</ParamField>
+
+<ParamField type="string">
+  Stash method to use when running as a git hook. Controls how unstaged changes are preserved during the run.
+
+  | Value        | Description                                              |
+  | ------------ | -------------------------------------------------------- |
+  | `git`        | Use `git stash` to save and restore unstaged changes.    |
+  | `patch-file` | Save unstaged changes to a patch file and reapply after. |
+  | `none`       | Do not stash — run against the working tree as-is.       |
+</ParamField>
+
+<ParamField type="boolean">
+  Display statistics about which files match each configured step.
+</ParamField>
+
+## Examples
+
+<CodeGroup>
+  ```bash Check staged files theme={null}
+  hk check
+  ```
+
+  ```bash Check all files theme={null}
+  hk check --all
+  ```
+
+  ```bash Check PR diff theme={null}
+  hk check --pr
+  ```
+
+  ```bash Check specific files theme={null}
+  hk check src/main.rs src/lib.rs
+  ```
+
+  ```bash Check with a ref range theme={null}
+  hk check --from-ref v1.0.0 --to-ref HEAD
+  ```
+
+  ```bash Run only specific steps theme={null}
+  hk check --step rustfmt --step clippy
+  ```
+
+  ```bash Preview the plan without running theme={null}
+  hk check --all --plan
+  ```
+
+  ```bash Check only TypeScript files theme={null}
+  hk check --glob "**/*.ts"
+  ```
+</CodeGroup>
+
+
+# hk config
+Source: https://www.mintlify.com/jdx/hk/cli/config
+
+Inspect and introspect the effective merged hk configuration.
+
+**Usage**: `hk config <SUBCOMMAND>`
+
+**Alias**: `cfg`
+
+`hk config` provides subcommands for inspecting hk's effective configuration. Configuration is merged from multiple sources in the following precedence order (highest to lowest):
+
+1. CLI flags
+2. Environment variables
+3. Git config (repository-local)
+4. User config (`~/.config/hk/config.pkl`)
+5. Git config (global)
+6. Project config (`hk.pkl`)
+7. Built-in defaults
+
+## Subcommands
+
+### hk config dump
+
+**Usage**: `hk config dump [--format <FORMAT>]`
+
+Prints the effective merged configuration from all sources. Useful for debugging which values are active at runtime.
+
+<ParamField type="string">
+  Output format. Accepted values: `json`, `toml`.
+</ParamField>
+
+```bash theme={null}
+# Dump as JSON (default)
+hk config dump
+
+# Dump as TOML
+hk config dump --format toml
+```
+
+Example output:
+
+```json theme={null}
+{
+  "jobs": 8,
+  "fail_fast": false,
+  "stage": true,
+  "warnings": [],
+  "exclude": [],
+  "skip_steps": [],
+  "skip_hooks": [],
+  "enabled_profiles": [],
+  "disabled_profiles": []
+}
+```
+
+***
+
+### hk config get
+
+**Usage**: `hk config get <KEY>`
+
+Returns the current value of a single configuration key.
+
+<ParamField type="string">
+  The configuration key to retrieve. Available keys:
+
+  `jobs`, `enabled_profiles`, `disabled_profiles`, `fail_fast`, `display_skip_reasons`, `warnings`, `exclude`, `skip_steps`, `skip_hooks`, `stage`
+</ParamField>
+
+```bash theme={null}
+hk config get jobs
+# 8
+
+hk config get fail_fast
+# false
+
+hk config get skip_steps
+# []
+```
+
+***
+
+### hk config sources
+
+**Usage**: `hk config sources`
+
+Lists all configuration sources in order of precedence, showing which sources are active and where each one is located on disk.
+
+```bash theme={null}
+hk config sources
+```
+
+Example output:
+
+```
+Configuration sources (highest to lowest precedence):
+  1. CLI flags
+  2. Environment variables
+  3. Git config (local): /home/user/project/.git/config
+  4. User config: /home/user/.hkrc.pkl
+  5. Git config (global): /home/user/.gitconfig
+  6. Project config: /home/user/project/hk.pkl
+  7. Built-in defaults
+```
+
+***
+
+### hk config explain
+
+**Usage**: `hk config explain <KEY>`
+
+Shows the resolved value for a configuration key, its source, and the full precedence chain showing every layer that could affect it.
+
+<ParamField type="string">
+  The configuration key to explain.
+</ParamField>
+
+```bash theme={null}
+hk config explain jobs
+```
+
+Example output:
+
+```
+Key: jobs
+Value: 4
+Source: environment variable (HK_JOBS=4)
+
+Precedence chain:
+  CLI flag:            (not set)
+  HK_JOBS env var:     4  ← active
+  Git config (local):  (not set)
+  User config:         (not set)
+  Git config (global): (not set)
+  Project config:      (not set)
+  Built-in default:    8
+```
+
+## Examples
+
+<CodeGroup>
+  ```bash Dump full config as JSON theme={null}
+  hk config dump
+  ```
+
+  ```bash Dump full config as TOML theme={null}
+  hk config dump --format toml
+  ```
+
+  ```bash Get a specific key theme={null}
+  hk config get jobs
+  ```
+
+  ```bash List all config sources theme={null}
+  hk config sources
+  ```
+
+  ```bash Explain where a value comes from theme={null}
+  hk config explain fail_fast
+  ```
+</CodeGroup>
+
+
+# hk fix
+Source: https://www.mintlify.com/jdx/hk/cli/fix
+
+Run linters and auto-fix issues in staged or specified files.
+
+**Usage**: `hk fix [FLAGS] [FILES]…`
+
+**Alias**: `f`
+
+`hk fix` runs all configured linter steps in fix mode — tools that support auto-fixing will modify files in place. It is equivalent to running the `fix` hook defined in your `hk.pkl`. By default it operates on staged files only; use `--all` to fix every file in the repository.
+
+<Note>
+  When `hk fix` is invoked as a git hook (e.g. during `git commit`), hk automatically stashes unstaged changes before running, then restores them afterward. This ensures linters only see staged content. The stash method can be controlled with `--stash`.
+</Note>
+
+## Arguments
+
+<ParamField type="string[]">
+  One or more specific files to fix. Conflicts with `--all`, `--fix`, and `--check`.
+</ParamField>
+
+## Flags
+
+<ParamField type="boolean">
+  Run on all files in the repository instead of just staged files.
+</ParamField>
+
+<ParamField type="boolean">
+  Force check mode — run the check command instead of the fix command. Overrides `--fix`.
+</ParamField>
+
+<ParamField type="string[]">
+  Exclude files that would otherwise have been selected. Can be specified multiple times.
+
+  ```bash theme={null}
+  hk fix --exclude "vendor/**" --exclude "*.generated.go"
+  ```
+</ParamField>
+
+<ParamField type="boolean">
+  Force fix mode — run the fix command instead of the check command. This is the default behavior unless `HK_FIX=0`. Overrides `--check`.
+</ParamField>
+
+<ParamField type="string[]">
+  Run on files matching these glob patterns. Can be specified multiple times.
+
+  ```bash theme={null}
+  hk fix --glob "src/**/*.ts" --glob "tests/**/*.ts"
+  ```
+</ParamField>
+
+<ParamField type="boolean">
+  Print the execution plan instead of running steps. Shows which steps will run and on which files.
+</ParamField>
+
+<ParamField type="string[]">
+  Run only specific named steps. Can be specified multiple times.
+
+  ```bash theme={null}
+  hk fix --step prettier --step eslint
+  ```
+</ParamField>
+
+<ParamField type="boolean">
+  Abort on the first step failure. Opposite of `--no-fail-fast`.
+</ParamField>
+
+<ParamField type="boolean">
+  Continue running remaining steps even after a failure. Opposite of `--fail-fast`.
+</ParamField>
+
+<ParamField type="string">
+  Start git reference for determining which files to fix. Requires `--to-ref`.
+
+  ```bash theme={null}
+  hk fix --from-ref main --to-ref HEAD
+  ```
+</ParamField>
+
+<ParamField type="string">
+  End git reference for determining which files to fix. Requires `--from-ref`.
+</ParamField>
+
+<ParamField type="boolean">
+  Fix only files changed in the current PR or branch. Shortcut for `--from-ref DEFAULT_BRANCH --to-ref HEAD`. Conflicts with `--all`, `--files`, `--from-ref`, `--glob`, and `--to-ref`.
+</ParamField>
+
+<ParamField type="string[]">
+  Skip specific named steps. Can be specified multiple times.
+
+  ```bash theme={null}
+  hk fix --skip-step slow-formatter
+  ```
+</ParamField>
+
+<ParamField type="boolean">
+  Enable auto-staging of files that were modified by fix steps. Overrides `--no-stage`.
+</ParamField>
+
+<ParamField type="boolean">
+  Disable auto-staging of files modified by fix steps. Overrides `--stage`.
+</ParamField>
+
+<ParamField type="string">
+  Stash method to use when running as a git hook. Controls how unstaged changes are preserved during the run.
+
+  | Value        | Description                                              |
+  | ------------ | -------------------------------------------------------- |
+  | `git`        | Use `git stash` to save and restore unstaged changes.    |
+  | `patch-file` | Save unstaged changes to a patch file and reapply after. |
+  | `none`       | Do not stash — run against the working tree as-is.       |
+</ParamField>
+
+<ParamField type="boolean">
+  Display statistics about which files match each configured step.
+</ParamField>
+
+## Examples
+
+<CodeGroup>
+  ```bash Fix staged files theme={null}
+  hk fix
+  ```
+
+  ```bash Fix all files theme={null}
+  hk fix --all
+  ```
+
+  ```bash Fix PR diff theme={null}
+  hk fix --pr
+  ```
+
+  ```bash Fix specific files theme={null}
+  hk fix src/main.rs src/lib.rs
+  ```
+
+  ```bash Fix with a ref range theme={null}
+  hk fix --from-ref v1.0.0 --to-ref HEAD
+  ```
+
+  ```bash Run only specific steps theme={null}
+  hk fix --step prettier --step rustfmt
+  ```
+
+  ```bash Skip a slow step theme={null}
+  hk fix --all --skip-step heavy-formatter
+  ```
+
+  ```bash Fix only Go files theme={null}
+  hk fix --glob "**/*.go"
+  ```
+</CodeGroup>
+
+
+# hk init
+Source: https://www.mintlify.com/jdx/hk/cli/init
+
+Generate an hk.pkl configuration file in the project root.
+
+**Usage**: `hk init [FLAGS]`
+
+`hk init` generates a new `hk.pkl` configuration file in the current directory. It scans your project for recognizable files (e.g. `Cargo.toml`, `package.json`, `go.mod`, `.python-version`) and automatically selects appropriate built-in linter definitions. If no project files are detected it generates a minimal template you can customize.
+
+By default, `hk init` configures three hooks: `pre-commit`, `check`, and `fix`.
+
+## Flags
+
+<ParamField type="boolean">
+  Overwrite an existing `hk.pkl` file. Without this flag, `hk init` warns and exits if `hk.pkl` already exists.
+</ParamField>
+
+<ParamField type="boolean">
+  Interactive mode. Displays detected project files, then lets you manually select which built-in linters and which hooks to include.
+</ParamField>
+
+<ParamField type="boolean">
+  Also generate a `mise.toml` file that configures hk and pkl as project tools.
+
+  Set `HK_MISE=1` to make this the default behavior for all `hk init` invocations.
+</ParamField>
+
+## What gets generated
+
+### hk.pkl (auto-detected example)
+
+When hk detects a Rust project, the generated file might look like:
+
+```pkl hk.pkl theme={null}
+amends "package://github.com/jdx/hk/releases/download/v1.41.0/hk@1.41.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.41.0/hk@1.41.0#/Builtins.pkl"
+
+hooks {
+  ["pre-commit"] {
+    steps {
+      ["cargo-fmt"] = Builtins.cargo_fmt
+      ["cargo-clippy"] = Builtins.cargo_clippy
+    }
+  }
+  ["check"] {
+    steps {
+      ["cargo-fmt"] = Builtins.cargo_fmt
+      ["cargo-clippy"] = Builtins.cargo_clippy
+    }
+  }
+  ["fix"] {
+    fix = true
+    steps {
+      ["cargo-fmt"] = Builtins.cargo_fmt
+    }
+  }
+}
+```
+
+### hk.pkl (default template)
+
+When no project files are detected:
+
+```pkl hk.pkl theme={null}
+amends "package://github.com/jdx/hk/releases/download/v1.41.0/hk@1.41.0#/Config.pkl"
+
+hooks {
+  ["pre-commit"] {
+    steps {
+      // Add your steps here
+    }
+  }
+  ["check"] {
+    steps {
+      // Add your steps here
+    }
+  }
+  ["fix"] {
+    fix = true
+    steps {
+      // Add your steps here
+    }
+  }
+}
+```
+
+### mise.toml (with --mise)
+
+```toml mise.toml theme={null}
+[tools]
+hk = "latest"
+pkl = "latest"
+
+[tasks.pre-commit]
+run = "hk run pre-commit"
+```
+
+## Examples
+
+<CodeGroup>
+  ```bash Auto-detect and generate theme={null}
+  hk init
+  ```
+
+  ```bash Overwrite an existing config theme={null}
+  hk init --force
+  ```
+
+  ```bash Interactive mode theme={null}
+  hk init --interactive
+  ```
+
+  ```bash Generate hk.pkl and mise.toml theme={null}
+  hk init --mise
+  ```
+
+  ```bash Force regenerate with mise theme={null}
+  hk init --force --mise
+  ```
+</CodeGroup>
+
+## Typical setup workflow
+
+<Steps>
+  <Step title="Generate the config">
+    ```bash theme={null}
+    hk init
+    ```
+
+    hk scans the project and writes `hk.pkl`.
+  </Step>
+
+  <Step title="Review hk.pkl">
+    Open `hk.pkl` and confirm the detected linters are correct. Add or remove steps as needed.
+  </Step>
+
+  <Step title="Install the git hooks">
+    ```bash theme={null}
+    hk install
+    ```
+
+    This writes hook scripts into `.git/hooks/` so hk runs automatically on commit.
+  </Step>
+</Steps>
+
+
+# hk install
+Source: https://www.mintlify.com/jdx/hk/cli/install
+
+Install git hooks from hk.pkl into .git/hooks/.
+
+**Usage**: `hk install [--mise]`
+
+**Alias**: `i`
+
+`hk install` writes hook scripts into your repository's `.git/hooks/` directory so that hk runs automatically when git triggers a hook event. It reads `hk.pkl` to determine which hooks to install (e.g. `pre-commit`, `pre-push`, `commit-msg`).
+
+In a git worktree that has a per-worktree `core.hooksPath` configured, hooks are installed to that worktree-local directory. Otherwise they go to the shared hooks directory.
+
+## Flags
+
+<ParamField type="boolean">
+  Generate hook scripts that invoke hk via `mise x` instead of calling `hk` directly. This ensures tools managed by mise are available when hooks run, even if mise is not activated in the current shell session.
+
+  Set `HK_MISE=1` to make this the default for all `hk install` invocations.
+</ParamField>
+
+## What gets installed
+
+For each hook name defined in `hk.pkl`, hk writes a shell script at `.git/hooks/<hook-name>`. For example, if your `hk.pkl` defines a `pre-commit` hook, hk writes `.git/hooks/pre-commit`:
+
+```bash .git/hooks/pre-commit theme={null}
+#!/bin/sh
+hk run pre-commit "$@"
+```
+
+With `--mise`, the script uses `mise x` to ensure tools are resolved:
+
+```bash .git/hooks/pre-commit (with --mise) theme={null}
+#!/bin/sh
+mise x -- hk run pre-commit "$@"
+```
+
+## Uninstalling hooks
+
+To remove hk's hooks from `.git/hooks/`, run:
+
+```bash theme={null}
+hk uninstall
+```
+
+This deletes the hook scripts that hk previously installed. It does not remove `hk.pkl`.
+
+## Examples
+
+<CodeGroup>
+  ```bash Standard install theme={null}
+  hk install
+  ```
+
+  ```bash Install with mise support theme={null}
+  hk install --mise
+  ```
+
+  ```bash Remove installed hooks theme={null}
+  hk uninstall
+  ```
+</CodeGroup>
+
+## Typical setup workflow
+
+<Steps>
+  <Step title="Create hk.pkl">
+    ```bash theme={null}
+    hk init
+    ```
+  </Step>
+
+  <Step title="Install hooks">
+    ```bash theme={null}
+    hk install
+    ```
+
+    Hook scripts are written to `.git/hooks/`.
+  </Step>
+
+  <Step title="Verify">
+    ```bash theme={null}
+    ls -la .git/hooks/
+    ```
+
+    You should see executable scripts for each hook defined in `hk.pkl`.
+  </Step>
+</Steps>
+
+<Note>
+  Commit `hk.pkl` to your repository so your team can run `hk install` after cloning to get the same hooks.
+</Note>
+
+
+# CLI overview
+Source: https://www.mintlify.com/jdx/hk/cli/overview
+
+Reference for the hk command-line interface and its global flags.
+
+`hk` is a high-performance git hook manager written in Rust. It runs linters, formatters, and other checks concurrently against your staged or changed files, and installs those checks as git hooks so they run automatically on commit and push.
+
+**Usage**: `hk [FLAGS] <SUBCOMMAND>`
+
+**Version**: 1.41.0
+
+## Global flags
+
+These flags are available on every `hk` subcommand.
+
+<ParamField type="number">
+  Number of jobs to run in parallel. Defaults to the number of logical CPU cores.
+</ParamField>
+
+<ParamField type="string[]">
+  Profiles to enable or disable. Prefix a profile name with `!` to disable it.
+
+  ```bash theme={null}
+  hk check --profile slow --profile !fast
+  ```
+</ParamField>
+
+<ParamField type="boolean">
+  Shorthand for `--profile=slow`. Enables steps tagged with the `slow` profile.
+</ParamField>
+
+<ParamField type="boolean">
+  Enables verbose output. Can be repeated for more verbosity (e.g. `-vv`).
+</ParamField>
+
+<ParamField type="boolean">
+  Disables the live progress display.
+</ParamField>
+
+<ParamField type="boolean">
+  Suppresses informational output. Errors are still shown.
+</ParamField>
+
+<ParamField type="boolean">
+  Suppresses all output, including errors.
+</ParamField>
+
+<ParamField type="boolean">
+  Enables tracing spans and performance diagnostics.
+</ParamField>
+
+<ParamField type="boolean">
+  Output in JSON format where supported.
+</ParamField>
+
+## Subcommands
+
+<CardGroup>
+  <Card title="hk check" icon="circle-check" href="/cli/check">
+    Run linters in read-only check mode against staged or specified files.
+  </Card>
+
+  <Card title="hk fix" icon="wrench" href="/cli/fix">
+    Run linters and auto-fix issues in staged or specified files.
+  </Card>
+
+  <Card title="hk run" icon="play" href="/cli/run">
+    Explicitly run a named git hook (pre-commit, pre-push, commit-msg, prepare-commit-msg).
+  </Card>
+
+  <Card title="hk init" icon="file-plus" href="/cli/init">
+    Generate an `hk.pkl` configuration file in the project root.
+  </Card>
+
+  <Card title="hk install" icon="download" href="/cli/install">
+    Install git hooks from `hk.pkl` into `.git/hooks/`.
+  </Card>
+
+  <Card title="hk validate" icon="shield-check" href="/cli/validate">
+    Validate the `hk.pkl` configuration file for errors.
+  </Card>
+
+  <Card title="hk config" icon="sliders" href="/cli/config">
+    Inspect and introspect the effective merged configuration.
+  </Card>
+
+  <Card title="hk util" icon="toolbox" href="/cli/util">
+    Built-in Rust-native utility commands for common file checks and fixes.
+  </Card>
+</CardGroup>
+
+### Additional subcommands
+
+| Command                 | Description                                                |
+| ----------------------- | ---------------------------------------------------------- |
+| `hk builtins`           | List all available built-in linter definitions.            |
+| `hk cache clear`        | Clear the hk cache.                                        |
+| `hk completion <SHELL>` | Generate shell completion scripts.                         |
+| `hk migrate pre-commit` | Migrate an existing `.pre-commit-config.yaml` to `hk.pkl`. |
+| `hk test`               | Run built-in step tests defined in `hk.pkl`.               |
+| `hk uninstall`          | Remove hk git hooks from `.git/hooks/`.                    |
+| `hk version`            | Print the hk version.                                      |
+
+
+# hk run
+Source: https://www.mintlify.com/jdx/hk/cli/run
+
+Explicitly run a named git hook without committing.
+
+**Usage**: `hk run [FLAGS] [FILES]… <SUBCOMMAND>`
+
+**Alias**: `r`
+
+`hk run` lets you manually trigger a specific git hook by name. This is useful for testing hook behavior, running hooks in CI, or invoking hooks outside of a git operation. hk itself calls these subcommands when it is invoked by git.
+
+## Subcommands
+
+### hk run pre-commit
+
+**Usage**: `hk run pre-commit [FLAGS] [FILES]…`
+
+**Alias**: `pc`
+
+Runs the `pre-commit` hook. This is the hook git triggers before creating a commit. It operates on staged files by default.
+
+```bash theme={null}
+# Run pre-commit hook against staged files
+hk run pre-commit
+
+# Run pre-commit hook against all files
+hk run pre-commit --all
+
+# Run pre-commit hook against specific files
+hk run pre-commit src/main.rs
+```
+
+### hk run pre-push
+
+**Usage**: `hk run pre-push [FLAGS] [ARGS]…`
+
+**Alias**: `pp`
+
+Runs the `pre-push` hook. This is the hook git triggers before pushing to a remote. Accepts optional `REMOTE` and `URL` arguments to simulate git's invocation.
+
+```bash theme={null}
+# Run pre-push hook
+hk run pre-push
+
+# Simulate a push to a specific remote
+hk run pre-push origin https://github.com/example/repo.git
+```
+
+### hk run commit-msg
+
+**Usage**: `hk run commit-msg [FLAGS] <COMMIT_MSG_FILE> [FILES]…`
+
+**Alias**: `cm`
+
+Runs the `commit-msg` hook. This is the hook git triggers to validate the commit message. Requires the path to the commit message file as an argument.
+
+```bash theme={null}
+# Run commit-msg hook (git passes .git/COMMIT_EDITMSG)
+hk run commit-msg .git/COMMIT_EDITMSG
+
+# Test with a custom message file
+hk run commit-msg /tmp/my-commit-message.txt
+```
+
+### hk run prepare-commit-msg
+
+**Usage**: `hk run prepare-commit-msg [FLAGS] <ARGS>…`
+
+**Alias**: `pcm`
+
+Runs the `prepare-commit-msg` hook. This hook fires before the commit message editor opens. Accepts the commit message file, an optional source (`message`, `template`, `merge`), and an optional SHA for amendments.
+
+```bash theme={null}
+# Run prepare-commit-msg hook
+hk run prepare-commit-msg .git/COMMIT_EDITMSG
+
+# Specify source type
+hk run prepare-commit-msg .git/COMMIT_EDITMSG merge
+
+# Specify source and SHA (for --amend)
+hk run prepare-commit-msg .git/COMMIT_EDITMSG commit abc1234
+```
+
+## Flags
+
+All `hk run` subcommands accept the same flags as [`hk check`](/cli/check) and [`hk fix`](/cli/fix).
+
+<ParamField type="boolean">
+  Run on all files instead of just staged files.
+</ParamField>
+
+<ParamField type="boolean">
+  Force check mode. Overrides `--fix`.
+</ParamField>
+
+<ParamField type="string[]">
+  Exclude files that would otherwise have been selected. Can be specified multiple times.
+</ParamField>
+
+<ParamField type="boolean">
+  Force fix mode. This is the default unless `HK_FIX=0`. Overrides `--check`.
+</ParamField>
+
+<ParamField type="string[]">
+  Run on files matching these glob patterns. Can be specified multiple times.
+</ParamField>
+
+<ParamField type="boolean">
+  Print the execution plan instead of running steps.
+</ParamField>
+
+<ParamField type="string[]">
+  Run only specific named steps. Can be specified multiple times.
+</ParamField>
+
+<ParamField type="boolean">
+  Abort on the first step failure.
+</ParamField>
+
+<ParamField type="boolean">
+  Continue after failures.
+</ParamField>
+
+<ParamField type="string">
+  Start git reference for file selection. Requires `--to-ref`.
+</ParamField>
+
+<ParamField type="string">
+  End git reference for file selection. Requires `--from-ref`.
+</ParamField>
+
+<ParamField type="boolean">
+  Run against files changed in the current PR branch.
+</ParamField>
+
+<ParamField type="string[]">
+  Skip specific named steps. Can be specified multiple times.
+</ParamField>
+
+<ParamField type="boolean">
+  Enable auto-staging of files modified by fix steps.
+</ParamField>
+
+<ParamField type="boolean">
+  Disable auto-staging of files modified by fix steps.
+</ParamField>
+
+<ParamField type="string">
+  Stash method (`git`, `patch-file`, or `none`) for preserving unstaged changes.
+</ParamField>
+
+<ParamField type="boolean">
+  Display statistics about files matching each step.
+</ParamField>
+
+## Examples
+
+<CodeGroup>
+  ```bash Run pre-commit on staged files theme={null}
+  hk run pre-commit
+  ```
+
+  ```bash Run pre-commit on all files in CI theme={null}
+  hk run pre-commit --all
+  ```
+
+  ```bash Validate a commit message theme={null}
+  hk run commit-msg .git/COMMIT_EDITMSG
+  ```
+
+  ```bash Run pre-push against PR diff theme={null}
+  hk run pre-push --pr
+  ```
+
+  ```bash Dry-run: see the plan without executing theme={null}
+  hk run pre-commit --all --plan
+  ```
+</CodeGroup>
+
+
+# hk util
+Source: https://www.mintlify.com/jdx/hk/cli/util
+
+Built-in Rust-native utility commands for common file checks and fixes.
+
+**Usage**: `hk util <SUBCOMMAND>`
+
+`hk util` provides a collection of built-in, dependency-free utility commands implemented directly in Rust. These commands are suitable for use as step commands in `hk.pkl` without requiring any external tools to be installed.
+
+They are designed to be drop-in replacements for the most common [pre-commit](https://pre-commit.com/) hooks.
+
+## Using util commands in hk.pkl
+
+Reference `hk util` commands directly in your step definitions:
+
+```pkl hk.pkl theme={null}
+amends "package://github.com/jdx/hk/releases/download/v1.41.0/hk@1.41.0#/Config.pkl"
+
+hooks {
+  ["pre-commit"] {
+    steps {
+      ["no-commit-to-main"] {
+        check = "hk util no-commit-to-branch --branch main --branch master"
+      }
+      ["eof-fixer"] {
+        glob = List("**/*")
+        fix = "hk util end-of-file-fixer --fix {{files}}"
+        check = "hk util end-of-file-fixer {{files}}"
+      }
+      ["large-files"] {
+        glob = List("**/*")
+        check = "hk util check-added-large-files --maxkb 1000 {{files}}"
+      }
+    }
+  }
+}
+```
+
+## Subcommands
+
+<AccordionGroup>
+  <Accordion title="check-added-large-files">
+    **Usage**: `hk util check-added-large-files [--maxkb <MAXKB>] <FILES>…`
+
+    Check that no files exceed a maximum size. Fails if any file is larger than the threshold.
+
+    <ParamField type="number">
+      Maximum allowed file size in kilobytes.
+    </ParamField>
+
+    <ParamField type="string[]">
+      Files to check.
+    </ParamField>
+
+    ```bash theme={null}
+    # Check with default 500 KB limit
+    hk util check-added-large-files src/assets/logo.png
+
+    # Check with a custom limit
+    hk util check-added-large-files --maxkb 1000 dist/bundle.js
+    ```
+  </Accordion>
+
+  <Accordion title="check-byte-order-marker">
+    **Usage**: `hk util check-byte-order-marker [-d --diff] <FILES>…`
+
+    Check for UTF-8 byte order markers (BOM). BOMs are unnecessary in UTF-8 and can cause issues in some tools.
+
+    <ParamField type="boolean">
+      Output a diff showing where BOMs were found.
+    </ParamField>
+
+    <ParamField type="string[]">
+      Files to check.
+    </ParamField>
+
+    ```bash theme={null}
+    hk util check-byte-order-marker src/main.py
+    hk util check-byte-order-marker --diff src/**/*.py
+    ```
+  </Accordion>
+
+  <Accordion title="check-case-conflict">
+    **Usage**: `hk util check-case-conflict <FILES>…`
+
+    Check for files whose names conflict on case-insensitive filesystems (e.g. macOS, Windows). Detects pairs like `Readme.md` and `README.md`.
+
+    <ParamField type="string[]">
+      Files to check.
+    </ParamField>
+
+    ```bash theme={null}
+    hk util check-case-conflict src/**/*
+    ```
+  </Accordion>
+
+  <Accordion title="check-conventional-commit">
+    **Usage**: `hk util check-conventional-commit [--allowed-types… <ALLOWED_TYPES>] <COMMIT_MSG_FILE>`
+
+    Validate that a commit message follows the [Conventional Commits](https://www.conventionalcommits.org/) specification.
+
+    <ParamField type="string[]">
+      Comma-separated list of allowed commit types. Can be specified multiple times.
+    </ParamField>
+
+    <ParamField type="string">
+      Path to the file containing the commit message to validate.
+    </ParamField>
+
+    ```bash theme={null}
+    # Validate with default allowed types
+    hk util check-conventional-commit .git/COMMIT_EDITMSG
+
+    # Validate with custom allowed types
+    hk util check-conventional-commit \
+      --allowed-types feat \
+      --allowed-types fix \
+      --allowed-types chore \
+      .git/COMMIT_EDITMSG
+    ```
+  </Accordion>
+
+  <Accordion title="check-executables-have-shebangs">
+    **Usage**: `hk util check-executables-have-shebangs <FILES>…`
+
+    Check that all executable files have a shebang line (`#!`) as their first line.
+
+    <ParamField type="string[]">
+      Files to check.
+    </ParamField>
+
+    ```bash theme={null}
+    hk util check-executables-have-shebangs bin/* scripts/*
+    ```
+  </Accordion>
+
+  <Accordion title="check-merge-conflict">
+    **Usage**: `hk util check-merge-conflict [--assume-in-merge] <FILES>…`
+
+    Check for unresolved merge conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`).
+
+    <ParamField type="boolean">
+      Run the check even when not currently in a merge state.
+    </ParamField>
+
+    <ParamField type="string[]">
+      Files to check.
+    </ParamField>
+
+    ```bash theme={null}
+    hk util check-merge-conflict src/**/*.rs
+    hk util check-merge-conflict --assume-in-merge src/conflicted.rs
+    ```
+  </Accordion>
+
+  <Accordion title="check-symlinks">
+    **Usage**: `hk util check-symlinks <FILES>…`
+
+    Check for broken symbolic links — symlinks that point to a path that does not exist.
+
+    <ParamField type="string[]">
+      Files to check.
+    </ParamField>
+
+    ```bash theme={null}
+    hk util check-symlinks **/*
+    ```
+  </Accordion>
+
+  <Accordion title="detect-private-key">
+    **Usage**: `hk util detect-private-key <FILES>…`
+
+    Scan files for private key material (PEM blocks, SSH keys, etc.) and fail if any is found.
+
+    <ParamField type="string[]">
+      Files to scan.
+    </ParamField>
+
+    ```bash theme={null}
+    hk util detect-private-key **/*
+    ```
+  </Accordion>
+
+  <Accordion title="end-of-file-fixer">
+    **Usage**: `hk util end-of-file-fixer [-d --diff] [-f --fix] <FILES>…`
+
+    Check that files end with exactly one newline, and optionally fix them.
+
+    <ParamField type="boolean">
+      Output a diff of the change. Cannot be used with `--fix`.
+    </ParamField>
+
+    <ParamField type="boolean">
+      Fix files to end with exactly one newline.
+    </ParamField>
+
+    <ParamField type="string[]">
+      Files to check or fix.
+    </ParamField>
+
+    ```bash theme={null}
+    # Check only
+    hk util end-of-file-fixer src/**/*.rs
+
+    # Show diff
+    hk util end-of-file-fixer --diff src/**/*.rs
+
+    # Fix in place
+    hk util end-of-file-fixer --fix src/**/*.rs
+    ```
+  </Accordion>
+
+  <Accordion title="fix-byte-order-marker">
+    **Usage**: `hk util fix-byte-order-marker <FILES>…`
+
+    Remove UTF-8 byte order markers from files.
+
+    <ParamField type="string[]">
+      Files to fix.
+    </ParamField>
+
+    ```bash theme={null}
+    hk util fix-byte-order-marker src/**/*.py
+    ```
+  </Accordion>
+
+  <Accordion title="fix-smart-quotes">
+    **Usage**: `hk util fix-smart-quotes [--check] [-d --diff] <FILES>…`
+
+    Replace UTF-8 smart (curly) quotes with their ASCII equivalents.
+
+    <ParamField type="boolean">
+      Check for smart quotes without modifying files.
+    </ParamField>
+
+    <ParamField type="boolean">
+      Output a diff of the change. Implies `--check`.
+    </ParamField>
+
+    <ParamField type="string[]">
+      Files to check or fix.
+    </ParamField>
+
+    ```bash theme={null}
+    # Fix in place (default behavior)
+    hk util fix-smart-quotes docs/**/*.md
+
+    # Check without fixing
+    hk util fix-smart-quotes --check docs/**/*.md
+
+    # Show diff
+    hk util fix-smart-quotes --diff docs/**/*.md
+    ```
+  </Accordion>
+
+  <Accordion title="mixed-line-ending">
+    **Usage**: `hk util mixed-line-ending [-d --diff] [-f --fix] <FILES>…`
+
+    Detect files that contain mixed line endings (both CRLF and LF), and optionally normalize them to LF.
+
+    <ParamField type="boolean">
+      Output a diff of the change. Cannot be used with `--fix`.
+    </ParamField>
+
+    <ParamField type="boolean">
+      Normalize line endings to LF.
+    </ParamField>
+
+    <ParamField type="string[]">
+      Files to check or fix.
+    </ParamField>
+
+    ```bash theme={null}
+    # Check for mixed line endings
+    hk util mixed-line-ending src/**/*.ts
+
+    # Fix mixed line endings
+    hk util mixed-line-ending --fix src/**/*.ts
+    ```
+  </Accordion>
+
+  <Accordion title="no-commit-to-branch">
+    **Usage**: `hk util no-commit-to-branch [--branch… <BRANCH>]`
+
+    Prevent commits directly to protected branches. Exits with an error if the current branch matches any of the specified names.
+
+    <ParamField type="string[]">
+      Branch names to protect. Defaults to `main` and `master`. Can be specified multiple times.
+    </ParamField>
+
+    ```bash theme={null}
+    # Protect main and master (default)
+    hk util no-commit-to-branch
+
+    # Protect a custom set of branches
+    hk util no-commit-to-branch --branch main --branch develop --branch production
+    ```
+  </Accordion>
+
+  <Accordion title="python-check-ast">
+    **Usage**: `hk util python-check-ast <FILES>…`
+
+    Parse Python files and check for syntax errors by validating their abstract syntax tree (AST). Does not require Python to be installed — parsing is done in Rust.
+
+    <ParamField type="string[]">
+      Python files to check.
+    </ParamField>
+
+    ```bash theme={null}
+    hk util python-check-ast src/**/*.py
+    ```
+  </Accordion>
+
+  <Accordion title="python-debug-statements">
+    **Usage**: `hk util python-debug-statements <FILES>…`
+
+    Check Python files for debug statements (`import pdb`, `breakpoint()`, `import ipdb`, etc.) that should not be committed.
+
+    <ParamField type="string[]">
+      Python files to check.
+    </ParamField>
+
+    ```bash theme={null}
+    hk util python-debug-statements src/**/*.py
+    ```
+  </Accordion>
+
+  <Accordion title="trailing-whitespace">
+    **Usage**: `hk util trailing-whitespace [-d --diff] [-f --fix] <FILES>…`
+
+    Check for trailing whitespace on lines, and optionally remove it.
+
+    <ParamField type="boolean">
+      Output a diff of the change. Cannot be used with `--fix`.
+    </ParamField>
+
+    <ParamField type="boolean">
+      Remove trailing whitespace from lines.
+    </ParamField>
+
+    <ParamField type="string[]">
+      Files to check or fix.
+    </ParamField>
+
+    ```bash theme={null}
+    # Check only
+    hk util trailing-whitespace src/**/*.rs
+
+    # Show diff
+    hk util trailing-whitespace --diff src/**/*.rs
+
+    # Fix in place
+    hk util trailing-whitespace --fix src/**/*.rs
+    ```
+  </Accordion>
+</AccordionGroup>
+
+
+# hk validate
+Source: https://www.mintlify.com/jdx/hk/cli/validate
+
+Validate the hk.pkl configuration file for errors.
+
+**Usage**: `hk validate`
+
+`hk validate` parses and validates your `hk.pkl` configuration file, reporting any errors or misconfigurations. It exits with a non-zero status if the configuration is invalid, making it safe to use in CI.
+
+## What it checks
+
+* The `hk.pkl` file exists and is valid Pkl syntax.
+* The file correctly amends the hk `Config.pkl` schema.
+* All referenced built-in names exist in `Builtins.pkl`.
+* Step fields (`check`, `fix`, `glob`, `batch`, etc.) have the correct types.
+* Hook names are valid git hook names or recognized custom hooks (`check`, `fix`).
+
+## Example output
+
+When the configuration is valid:
+
+```bash theme={null}
+$ hk validate
+✓ hk.pkl is valid
+```
+
+When the configuration has errors:
+
+```bash theme={null}
+$ hk validate
+error: unknown builtin 'esint' in step 'eslint'
+  --> hk.pkl:8:22
+  |
+8 |       ["eslint"] = Builtins.esint
+  |                             ^^^^^ did you mean 'eslint'?
+```
+
+## When to use
+
+<Tip>
+  Run `hk validate` in CI before any hook steps to catch configuration regressions early — for example, after a developer edits `hk.pkl` and opens a pull request.
+</Tip>
+
+```yaml .github/workflows/ci.yml (example) theme={null}
+- name: Validate hk config
+  run: hk validate
+```
+
+You can also run it locally after editing `hk.pkl` to confirm the changes are correct before committing:
+
+```bash theme={null}
+hk validate && git add hk.pkl && git commit -m "chore: update hk.pkl"
+```
+
+
+# Configuration
+Source: https://www.mintlify.com/jdx/hk/configuration
+
+How hk layers configuration from built-in defaults up through CLI flags, and a full reference for every setting.
+
+hk builds its effective configuration by layering sources from lowest to highest precedence:
+
+| Precedence  | Source                                                | Scope                     |
+| ----------- | ----------------------------------------------------- | ------------------------- |
+| 1 (lowest)  | Built-in defaults                                     | All projects              |
+| 2           | [hkrc](#hkrc) (`~/.config/hk/config.pkl`)             | All projects (user-level) |
+| 3           | [Project config](#hkpkl) (`hk.pkl` or `hk.local.pkl`) | Single project            |
+| 4           | [Git config](#git-configuration) (global, then local) | Per-repo                  |
+| 5           | [Environment variables](#settings-reference) (`HK_*`) | Per-invocation            |
+| 6 (highest) | [CLI flags](#settings-reference)                      | Per-invocation            |
+
+Higher layers override lower. For hooks and steps, layers are **additive** — hkrc can define hooks the project doesn't have, but the project's definition wins on collision.
+
+## `hk.pkl`
+
+hk is configured via `hk.pkl`, written in [Pkl](https://pkl-lang.org/) from Apple. By default, hk uses the pkl CLI to evaluate configuration. Set `HK_PKL_BACKEND=pklr` to use the built-in evaluator instead — no pkl CLI required.
+
+### Config file paths
+
+hk searches for config files in the following order (first match wins):
+
+| Precedence | Path                   | Purpose                                           |
+| ---------- | ---------------------- | ------------------------------------------------- |
+| 1          | `hk.local.pkl`         | Local overrides — do not commit to source control |
+| 2          | `.config/hk.local.pkl` | Local overrides nested under `.config/`           |
+| 3          | `hk.pkl`               | Standard project config                           |
+| 4          | `.config/hk.pkl`       | Standard project config nested under `.config/`   |
+
+hk walks up from the current directory to `/`, checking each directory for these files. The first file found is used.
+
+<Note>
+  Set `HK_FILE` to override the search and point hk at a specific path.
+</Note>
+
+Unlike mise, hk does not merge multiple config files or support `conf.d/` directories. Local overrides use Pkl's `amends` mechanism instead (see [`hk.local.pkl`](#hklocalpkl)).
+
+### Example
+
+Here is a complete `hk.pkl` showing hooks, steps, and builtins:
+
+```pkl hk.pkl theme={null}
+amends "package://github.com/jdx/hk/releases/download/v1.41.0/hk@1.41.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.41.0/hk@1.41.0#/Builtins.pkl"
+
+local linters = new Mapping<String, Step> {
+    // linters can be manually defined
+    ["eslint"] {
+        // filter staged files to those matching these globs; skip if none match
+        glob = List("*.js", "*.ts")
+        // read-only check command
+        check = "eslint {{files}}"
+        // fix command that modifies files in place
+        fix = "eslint --fix {{files}}"
+    }
+    // linters can also come from the Builtins library
+    ["prettier"] = Builtins.prettier
+}
+
+hooks {
+    ["pre-commit"] {
+        fix = true       // run the fix command to auto-modify files
+        stash = "git"    // stash unstaged changes before running fix steps
+        steps = linters
+    }
+    ["pre-push"] {
+        steps = linters
+    }
+    // "fix" and "check" are special hooks for `hk fix` and `hk check` commands
+    ["fix"] {
+        fix = true
+        steps = linters
+    }
+    ["check"] {
+        steps = linters
+        // optional: run a report after the hook finishes; HK_REPORT_JSON contains timing JSON
+        report = #"node scripts/upload-timings.js <<<"$HK_REPORT_JSON""#
+    }
+}
+```
+
+The first line (`amends`) is critical — it imports the base configuration schema for type-checking and base classes.
+
+### `hk.local.pkl`
+
+If `hk.local.pkl` exists it is used instead of `hk.pkl`. It is intended for local developer overrides and should not be committed to source control.
+
+The first line should amend `./hk.pkl`:
+
+```pkl hk.local.pkl theme={null}
+amends "./hk.pkl"
+import "./hk.pkl" as repo_config
+
+hooks = (repo_config.hooks) {
+    ["pre-commit"] {
+        (steps) {
+            ["custom-step"] = new Step {
+                check = "my-custom-check"
+            }
+        }
+    }
+}
+```
+
+## Step groups
+
+A `Group` is a collection of steps executed in parallel. All steps in a group must finish before the next group starts, and no step from the next group starts until the current group is complete.
+
+```pkl theme={null}
+hooks {
+    ["pre-commit"] {
+        steps {
+            ["build"] = new Group {
+                steps = new Mapping<String, Step> {
+                    ["ts"] = new Step {
+                        fix = "tsc -b"
+                    }
+                    ["rs"] = new Step {
+                        fix = "cargo build"
+                    }
+                }
+            }
+            // these steps run in parallel after "build" finishes
+            ["lint"] = new Group {
+                steps = new Mapping<String, Step> {
+                    ["prettier"] = new Step {
+                        check = "prettier --check {{files}}"
+                    }
+                    ["eslint"] = new Step {
+                        check = "eslint {{files}}"
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+Use `depends` and read/write locks for finer-grained ordering instead of groups where possible.
+
+## Git status in conditions and templates
+
+hk exposes the current git status to both condition expressions and Tera templates via a `git` object, so you can avoid shelling out in conditions.
+
+**Available fields:**
+
+* `git.staged_files`, `git.unstaged_files`, `git.untracked_files`, `git.modified_files`
+* Staged classifications: `git.staged_added_files`, `git.staged_modified_files`, `git.staged_deleted_files`, `git.staged_renamed_files`, `git.staged_copied_files`
+* Unstaged classifications: `git.unstaged_modified_files`, `git.unstaged_deleted_files`, `git.unstaged_renamed_files`
+
+<Tabs>
+  <Tab title="In conditions">
+    ```pkl theme={null}
+    // Run only if there are any staged files
+    condition = "git.staged_files != []"
+
+    // Run only if a Cargo.toml file is staged
+    condition = #"any(git.staged_files, {hasSuffix(#, "Cargo.toml")})"#
+
+    // Added or Renamed (AR):
+    condition = "(git.staged_added_files != []) || (git.staged_renamed_files != [])"
+
+    // Renamed or Deleted (RD):
+    condition = "(git.staged_renamed_files != []) || (git.staged_deleted_files != [])"
+    ```
+  </Tab>
+
+  <Tab title="In templates">
+    ```pkl theme={null}
+    check = "echo staged: {{ git.staged_files }}"
+    ```
+  </Tab>
+</Tabs>
+
+These lists contain repository-relative paths for files currently in each state.
+
+## `hkrc`
+
+<Warning>
+  `.hkrc.pkl` and `--hkrc` are deprecated and will be removed in hk v2.
+
+  * **Per-project overrides:** use `hk.local.pkl` in the project root.
+  * **Global user config:** use `~/.config/hk/config.pkl`.
+</Warning>
+
+The `hkrc` is a global configuration file applied to all projects. hk discovers it in this order (first match wins):
+
+| Precedence | Path                      | Purpose                                 |
+| ---------- | ------------------------- | --------------------------------------- |
+| 1          | `.hkrc.pkl` (CWD)         | Per-directory override **(deprecated)** |
+| 2          | `~/.hkrc.pkl`             | Home directory **(deprecated)**         |
+| 3          | `~/.config/hk/config.pkl` | XDG config directory **(recommended)**  |
+
+The hkrc file uses the same format as `hk.pkl`. It is merged with the project config using **project wins** semantics:
+
+* **Settings** (`jobs`, `fail_fast`, etc.): project config overrides hkrc.
+* **Environment variables**: hkrc values are set first; project config can override them.
+* **Hooks/steps**: additive — hkrc can add hooks and steps the project doesn't define, but when both define the same step, the project's definition wins.
+
+### Managing global hook preferences
+
+<AccordionGroup>
+  <Accordion title="Run your own linters on every project">
+    Add steps to your hkrc. hk merges them into every project's hooks:
+
+    ```pkl ~/.config/hk/config.pkl theme={null}
+    amends "package://github.com/jdx/hk/releases/download/v1.41.0/hk@1.41.0#/Config.pkl"
+
+    hooks {
+        ["pre-commit"] {
+            steps {
+                ["gitleaks"] { check = "gitleaks git --staged" }
+            }
+        }
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="Skip steps you don't want from a project">
+    hkrc can't remove project steps — project wins on collision. To skip a step, use git config (persists) or an env var (one session):
+
+    ```bash theme={null}
+    # Skip a step permanently in this repo
+    git config --local hk.skipSteps "slow-linter,noisy-formatter"
+
+    # Skip for one run
+    HK_SKIP_STEPS=slow-linter hk run pre-commit
+    ```
+  </Accordion>
+
+  <Accordion title="Completely replace a project's hooks locally">
+    Create `hk.local.pkl` in the project root and add it to `.gitignore`:
+
+    ```pkl hk.local.pkl theme={null}
+    amends "./hk.pkl"
+    import "./hk.pkl" as upstream
+
+    hooks = (upstream.hooks) {
+        ["pre-commit"] {
+            steps {
+                // keep only the steps you want
+                ["gitleaks"] = upstream.hooks["pre-commit"].steps["gitleaks"]
+            }
+        }
+    }
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Settings reference
+
+Settings are sourced from multiple places; higher precedence overrides lower. List settings (`exclude`, `skip_steps`, `skip_hooks`, `hide_warnings`) use **union semantics** — values from all sources are combined.
+
+| Precedence  | Source                         | Example                                 |
+| ----------- | ------------------------------ | --------------------------------------- |
+| 1 (highest) | CLI flags                      | `hk check --fail-fast`                  |
+| 2           | Environment variables (`HK_*`) | `HK_JOBS=8 hk check`                    |
+| 3           | Git config (local repo)        | `git config --local hk.jobs 4`          |
+| 4           | Git config (global/system)     | `git config --global hk.failFast false` |
+| 5           | Project config (`hk.pkl`)      | `jobs = 4` in `hk.pkl`                  |
+| 6           | User rc (hkrc)                 | `jobs = 4` in `~/.config/hk/config.pkl` |
+| 7 (lowest)  | Built-in defaults              | `jobs = 0` (auto, CPU cores)            |
+
+<AccordionGroup>
+  <Accordion title="jobs">
+    **Type:** `UInt` | **Default:** `0` (auto-detect from CPU cores)
+
+    **Env var:** `HK_JOBS` | **Git config:** `hk.jobs`
+
+    The number of parallel processes hk uses to run steps concurrently. Set to `0` to let hk choose based on available CPU cores.
+
+    ```pkl theme={null}
+    jobs = 4
+    ```
+  </Accordion>
+
+  <Accordion title="fail_fast">
+    **Type:** `Boolean` | **Default:** `true`
+
+    **Env var:** `HK_FAIL_FAST` | **Git config:** `hk.failFast`
+
+    When `true`, hk stops remaining steps as soon as one fails. When `false`, hk continues and reports all failures at the end.
+
+    ```pkl theme={null}
+    fail_fast = false
+    ```
+  </Accordion>
+
+  <Accordion title="exclude">
+    **Type:** `String | List<String> | Regex` | **Default:** `(empty)`
+
+    **Env var:** `HK_EXCLUDE` | **Git config:** `hk.exclude`
+
+    Global exclude patterns applied to all hooks and steps. Simple directory names automatically match their contents. Values from all sources are unioned together.
+
+    ```pkl theme={null}
+    exclude = List("node_modules", "dist", "**/*.min.js")
+    ```
+  </Accordion>
+
+  <Accordion title="skip_steps">
+    **Type:** `List<String>` | **Default:** `(empty)`
+
+    **Env var:** `HK_SKIP_STEPS` | **Git config:** `hk.skipSteps`
+
+    Step names to skip when running hooks. Values from all sources are unioned together.
+
+    ```pkl theme={null}
+    skip_steps = List("slow-test")
+    ```
+  </Accordion>
+
+  <Accordion title="skip_hooks">
+    **Type:** `List<String>` | **Default:** `(empty)`
+
+    **Env var:** `HK_SKIP_HOOKS` | **Git config:** `hk.skipHook`
+
+    Hook names to skip entirely. Values from all sources are unioned together.
+
+    ```pkl theme={null}
+    skip_hooks = List("pre-push")
+    ```
+  </Accordion>
+
+  <Accordion title="profiles">
+    **Type:** `List<String>` | **Default:** `(empty)`
+
+    **Env var:** `HK_PROFILE` | **Git config:** `hk.profile`
+
+    Profiles to enable or disable. Steps opt in to profiles via `step.profiles`. Prefix a profile name with `!` to explicitly disable it.
+
+    ```pkl theme={null}
+    profiles = List("ci", "slow")
+    ```
+  </Accordion>
+
+  <Accordion title="stage">
+    **Type:** `Boolean` | **Default:** `true` (on hooks with `fix = true`)
+
+    **Env var:** `HK_STAGE`
+
+    When `true`, hk automatically stages files modified by fix commands. Set to `false` to apply fixes without re-staging (useful with `fail_on_fix = true` to force review).
+
+    ```pkl theme={null}
+    stage = false
+    ```
+  </Accordion>
+
+  <Accordion title="default_branch">
+    **Type:** `String` | **Default:** auto-detected
+
+    The default branch to compare against when hk needs a reference. Supports local branch names (`main`) and remote-qualified refs (`origin/main`).
+
+    ```pkl theme={null}
+    default_branch = "origin/main"
+    ```
+  </Accordion>
+
+  <Accordion title="stash_backup_count">
+    **Type:** `UInt` | **Default:** `20`
+
+    Number of backup patch files to keep per repository when using git stash. Set to `0` to disable patch backup creation.
+
+    ```pkl theme={null}
+    stash_backup_count = 5
+    ```
+  </Accordion>
+
+  <Accordion title="walk_ignore">
+    **Type:** `Boolean` | **Default:** `true`
+
+    When `true`, hk respects `.gitignore` and other ignore files when walking directories.
+
+    ```pkl theme={null}
+    walk_ignore = false
+    ```
+  </Accordion>
+
+  <Accordion title="warnings / hide_warnings">
+    **Type:** `List<String>` | **Default:** `(empty)`
+
+    **Git config:** `hk.warnings` / `hk.hideWarnings`
+
+    `warnings` controls which warning categories are shown (available tag: `missing-profiles`). `hide_warnings` suppresses specific warnings. Values from all sources are unioned together.
+
+    ```pkl theme={null}
+    warnings = List("missing-profiles")
+    hide_warnings = List("missing-profiles")
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Git configuration
+
+hk can be configured through git config. All keys use the `hk.` prefix:
+
+```bash theme={null}
+# Set number of parallel jobs
+git config --local hk.jobs 5
+
+# Disable fail-fast behavior
+git config --local hk.failFast false
+
+# Add profiles
+git config --local hk.profile slow
+git config --local --add hk.profile fast
+
+# Add exclude patterns (union semantics)
+git config --local hk.exclude "node_modules"
+git config --local --add hk.exclude "**/*.min.js"
+
+# Skip specific steps
+git config --local hk.skipSteps "slow-test,flaky-test"
+
+# Skip entire hooks
+git config --local hk.skipHook "pre-push"
+
+# Configure warnings
+git config --local hk.warnings "missing-profiles"
+git config --local hk.hideWarnings "missing-profiles"
+```
+
+Git config supports both multi-value entries (multiple keys with the same name) and comma-separated values in a single entry.
+
+## User configuration
+
+User-specific defaults live in `~/.config/hk/config.pkl`:
+
+```pkl ~/.config/hk/config.pkl theme={null}
+amends "package://github.com/jdx/hk/releases/download/v1.41.0/hk@1.41.0#/Config.pkl"
+
+jobs = 4
+fail_fast = false
+exclude = List("node_modules", "dist", "build")
+skip_steps = List("slow-test")
+skip_hooks = List("pre-push")
+```
+
+## Configuration introspection
+
+Use the `hk config` commands to inspect your active configuration:
+
+```bash theme={null}
+# Show effective configuration (all sources merged)
+hk config dump
+
+# Get a specific configuration value
+hk config get exclude
+hk config get skip_steps
+
+# Show configuration source precedence
+hk config sources
+```
+
+
+# Environment variables
+Source: https://www.mintlify.com/jdx/hk/environment-variables
+
+Full reference for all HK_* environment variables used to configure hk.
+
+Environment variables can be used to configure hk. They apply to the current command or, when exported, to all commands in the session.
+
+## Core
+
+<ParamField type="string">
+  The configuration file to use.
+
+  ```bash theme={null}
+  HK_FILE=my-hk.pkl hk check
+  ```
+</ParamField>
+
+<ParamField type="bool">
+  If set to `false`, hk will not run fix steps. Use this to enforce check-only mode.
+
+  ```bash theme={null}
+  HK_FIX=false hk check
+  ```
+</ParamField>
+
+<ParamField type="usize">
+  The number of steps to run in parallel. Defaults to the number of logical CPU cores on the machine.
+
+  ```bash theme={null}
+  HK_JOBS=4 hk check
+  ```
+</ParamField>
+
+<ParamField type="string[] (comma-separated)">
+  The profile(s) to activate when running hooks. Steps that require a profile not in this list are skipped.
+
+  ```bash theme={null}
+  HK_PROFILE=ci,slow hk check
+  ```
+</ParamField>
+
+## Git integration
+
+<ParamField type="git | patch-file | none">
+  Controls how unstaged changes are stashed before hooks run.
+
+  * `git` — use `git stash` to stash unstaged changes
+  * `patch-file` — use an hk-generated patch file (typically faster, avoids `index is locked` errors)
+  * `none` — do not stash; faster but may accidentally stage unstaged changes if they overlap with staged files that are fixed
+
+  ```bash theme={null}
+  HK_STASH=patch-file hk run pre-commit
+  ```
+</ParamField>
+
+<ParamField type="bool">
+  If `true`, untracked files are also stashed along with unstaged changes. Set to `false` to leave untracked files in the working tree during hook execution.
+</ParamField>
+
+<ParamField type="bool">
+  If `false`, hk shells out to git commands instead of using the embedded libgit2 library. This can improve performance when `fsmonitor` is active or when libgit2 has trouble with a repository layout.
+</ParamField>
+
+## Paths
+
+<ParamField type="path">
+  The directory where hk stores cached data.
+</ParamField>
+
+<ParamField type="path">
+  The directory where hk stores runtime state, including the default log file.
+</ParamField>
+
+<ParamField type="path">
+  The file path for log output. Set to a custom path to redirect logs.
+
+  ```bash theme={null}
+  HK_LOG_FILE=/tmp/my-hk.log hk check
+  ```
+</ParamField>
+
+## Logging
+
+<ParamField type="trace | debug | info | warn | error">
+  The minimum log level for console output.
+
+  ```bash theme={null}
+  HK_LOG=debug hk check
+  ```
+</ParamField>
+
+<ParamField type="trace | debug | info | warn | error">
+  The minimum log level written to the log file. Defaults to the same level as `HK_LOG`. Set this independently to capture detailed logs in the file without verbose console output.
+
+  ```bash theme={null}
+  HK_LOG=warn HK_LOG_FILE_LEVEL=trace hk check
+  ```
+</ParamField>
+
+<ParamField type="1 | text | json">
+  Enables tracing output for performance analysis. `1` and `text` produce human-readable hierarchical output. `json` produces newline-delimited JSON (JSONL) suitable for programmatic analysis.
+
+  ```bash theme={null}
+  HK_TRACE=text hk check
+  HK_TRACE=json hk check > trace.jsonl
+  ```
+</ParamField>
+
+<ParamField type="bool">
+  Controls whether per-step output summaries are printed in plain text mode. By default, summaries are only shown when hk renders progress bars. Set to `true` to force summaries to appear in text (non-TTY) mode.
+
+  ```bash theme={null}
+  HK_SUMMARY_TEXT=1 hk check
+  ```
+</ParamField>
+
+## Skipping
+
+<ParamField type="string[] (comma-separated)">
+  A list of step names to skip when running pre-commit and pre-push hooks. All skip sources (env var, git config, user config) are unioned together.
+
+  ```bash theme={null}
+  HK_SKIP_STEPS=lint,typecheck hk run pre-commit
+  ```
+
+  This can also be configured via:
+
+  * Git config: `git config hk.skipSteps "lint,typecheck"`
+  * User config (`.hkrc.pkl`): `skip_steps = List("lint", "typecheck")`
+</ParamField>
+
+<ParamField type="string[] (comma-separated)">
+  A list of hook names to skip entirely. Unlike `HK_SKIP_STEPS`, this skips the entire hook and all of its steps.
+
+  ```bash theme={null}
+  HK_SKIP_HOOK=pre-commit hk run pre-commit
+  ```
+
+  This can also be configured via:
+
+  * Git config: `git config hk.skipHook "pre-commit"`
+  * User config (`.hkrc.pkl`): `skip_hooks = List("pre-commit")`
+</ParamField>
+
+## Performance
+
+<ParamField type="bool">
+  When `true`, hk runs check commands first, then runs fix commands only for steps that failed and whose files overlap with other steps. This allows maximum parallelism: multiple check commands can run concurrently against the same file, while fix commands — which may write to files — are serialized only when necessary.
+
+  When `false`, hk uses simpler logic that always runs fix commands serially for overlapping files.
+</ParamField>
+
+<ParamField type="bool">
+  If `true`, hk stops executing remaining steps after the first step fails.
+</ParamField>
+
+## Output
+
+<ParamField type="string[] (comma-separated)">
+  A list of warning tags to suppress. Available tags:
+
+  * `missing-profiles` — suppresses warnings about steps being skipped due to missing profiles
+
+  ```bash theme={null}
+  HK_HIDE_WARNINGS=missing-profiles hk check
+  ```
+
+  Warning categories can also be opted into in `hk.pkl` or `.hkrc.pkl`:
+
+  ```pkl theme={null}
+  warnings = List("missing-profiles")
+  ```
+</ParamField>
+
+<ParamField type="bool">
+  If `true`, hk clears the progress output once the hook finishes successfully. Errors are always shown regardless of this setting.
+</ParamField>
+
+<ParamField type="path">
+  If set to a file path, hk writes a JSON timing report at the end of the run. The report includes total wall time and per-step wall time. Overlapping parallel intervals are merged so time is not double-counted.
+
+  ```bash theme={null}
+  HK_TIMING_JSON=/tmp/hk-timing.json hk check
+  ```
+
+  The `steps` object maps step names to:
+
+  * `wall_time_ms` — merged wall time in milliseconds
+  * `profiles` — (optional) profiles required by the step; omitted if none
+
+  Example output:
+
+  ```json theme={null}
+  {
+    "total": { "wall_time_ms": 12456 },
+    "steps": {
+      "lint": { "wall_time_ms": 4321, "profiles": ["ci", "fast"] },
+      "fmt": { "wall_time_ms": 2100 },
+      "typecheck": { "wall_time_ms": 6035 }
+    }
+  }
+  ```
+
+  When a hook-level `report` command is configured in `hk.pkl`, hk also sets `HK_REPORT_JSON` to the same timing JSON content in memory and executes the command after the hook finishes. This lets custom scripts post-process or upload timing data without reading a file.
+</ParamField>
+
+## Misc
+
+<ParamField type="bool">
+  When `true`:
+
+  * `hk install` uses `mise x` to execute hooks, so mise tools are available without activating mise in the shell
+  * `hk init` generates a `mise.toml` file with hk configured
+
+  ```bash theme={null}
+  HK_MISE=true hk install
+  ```
+</ParamField>
+
+<ParamField type="string[] (comma-separated)">
+  Glob patterns to exclude from processing. These are unioned with exclude patterns from git config, user config, and project config. Supports both directory names and glob patterns.
+
+  ```bash theme={null}
+  # Exclude specific directories
+  HK_EXCLUDE=node_modules,dist hk check
+
+  # Exclude using glob patterns
+  HK_EXCLUDE="**/*.min.js,**/*.map" hk check
+  ```
+</ParamField>
+
+<ParamField type="pklr | pkl">
+  Controls which backend evaluates `hk.pkl` configuration files.
+
+  * `pklr` — use the built-in Rust Pkl evaluator ([pklr](https://github.com/jdx/pklr)). No external pkl CLI required. This is experimental and may not support every Pkl feature yet.
+  * `pkl` — use the external `pkl` CLI (the default). Install it with `mise use -g pkl`.
+
+  ```bash theme={null}
+  # Use the built-in evaluator (no pkl CLI needed)
+  HK_PKL_BACKEND=pklr hk check
+  ```
+
+  See [Pkl configuration language](/pkl-introduction) for details.
+</ParamField>
+
+
+# Hooks
+Source: https://www.mintlify.com/jdx/hk/hooks
+
+How hk executes git hooks, the read/write locking model, and a reference for every supported hook type and step property.
+
+hk wraps git hooks and runs their configured steps as fast as possible using a read/write locking model. Each step declares whether it reads or writes files, and hk schedules them concurrently while preventing conflicting operations from overlapping.
+
+## Hook execution flow
+
+When a hook runs with `fix = true`, hk performs the following sequence:
+
+<Steps>
+  <Step title="Stash unstaged changes">
+    Unstaged and untracked changes are stashed so the linters only see staged content. Disable with `stash = "none"`.
+  </Step>
+
+  <Step title="Gather files">
+    hk collects the list of staged files (or all files when running `hk run pre-commit --all`) and filters them against each step's `glob` patterns.
+  </Step>
+
+  <Step title="Run steps in parallel">
+    Steps run concurrently up to `HK_JOBS` at a time. hk creates per-file read/write locks based on each step's glob patterns:
+
+    * **Check steps** acquire read locks — multiple check steps on the same file run simultaneously.
+    * **Fix steps** acquire write locks — a fix step blocks other steps on the same file until it completes.
+    * If `check_first = true` (the default), hk runs the check command first with read locks. Only if it fails does hk acquire write locks and run the fix command.
+    * If `check_list_files` is defined, hk uses its output to acquire write locks only for files that actually need fixing.
+    * If `check_diff` is defined, hk attempts to apply the diff output directly with `git apply` instead of running the fix command.
+    * `exclusive = true` steps wait for all previous steps to finish and block later steps from starting.
+  </Step>
+
+  <Step title="Stage modified files">
+    Files modified by fix steps that match the step's `stage` globs (defaults to the step's `glob`) are added to the git index.
+  </Step>
+
+  <Step title="Unstash">
+    The stashed changes are restored.
+  </Step>
+</Steps>
+
+When `fix = false`, hk only runs check steps and skips the locking machinery entirely.
+
+## Supported hooks
+
+<AccordionGroup>
+  <Accordion title="pre-commit">
+    Runs before `git commit` creates the commit. This is the most common hook — use it for formatting and linting staged files.
+
+    ```pkl theme={null}
+    hooks {
+        ["pre-commit"] {
+            fix = true
+            stash = "git"
+            steps {
+                ["cargo-fmt"] {
+                    glob = "**/*.rs"
+                    check_first = true
+                    check = "cargo fmt --check"
+                    fix = "cargo fmt"
+                }
+                ["cargo-clippy"] {
+                    glob = "**/*.rs"
+                    check_first = true
+                    check = "cargo clippy"
+                    fix = "cargo clippy --fix --allow-dirty --allow-staged"
+                }
+            }
+        }
+    }
+    ```
+
+    You can also use prelint and postlint bookend steps with `exclusive = true` to sequence work:
+
+    ```pkl theme={null}
+    hooks {
+        ["pre-commit"] {
+            fix = true
+            stash = "git"
+            steps {
+                ["prelint"] {
+                    check = "mise run prelint"
+                    exclusive = true
+                }
+                ...linters
+                ["postlint"] {
+                    check = "mise run postlint"
+                    exclusive = true
+                }
+            }
+        }
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="prepare-commit-msg">
+    Runs before the commit message editor opens. Useful for rendering a default commit message template.
+
+    The `{{commit_msg_file}}` template variable contains the path to the commit message file.
+
+    ```pkl theme={null}
+    hooks {
+        ["prepare-commit-msg"] {
+            steps {
+                ["render-commit-msg"] {
+                    check = "echo 'default commit message' > {{commit_msg_file}}"
+                }
+            }
+        }
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="commit-msg">
+    Runs after the commit message is created. Useful for validating that commit messages follow a convention.
+
+    The `{{commit_msg_file}}` template variable contains the path to the commit message file.
+
+    ```pkl theme={null}
+    hooks {
+        ["commit-msg"] {
+            steps {
+                ["validate-commit-msg"] {
+                    check = "grep -q '^(fix|feat|chore):' {{commit_msg_file}} || exit 1"
+                }
+            }
+        }
+    }
+    ```
+
+    You can also use `Builtins.check_conventional_commit` for this:
+
+    ```pkl theme={null}
+    import "package://github.com/jdx/hk/releases/download/v1.41.0/hk@1.41.0#/Builtins.pkl"
+
+    hooks {
+        ["commit-msg"] {
+            steps {
+                ["check-conventional-commit"] = Builtins.check_conventional_commit
+            }
+        }
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="pre-push">
+    Runs before `git push`. Use it for slower checks that are too expensive to run on every commit.
+
+    ```pkl theme={null}
+    hooks {
+        ["pre-push"] {
+            steps = linters
+        }
+    }
+    ```
+
+    Because `fix` is not set (defaults to `false`), hk runs only check steps and skips all write locking — making pre-push faster than pre-commit.
+  </Accordion>
+
+  <Accordion title="fix and check (special hooks)">
+    `fix` and `check` are not git hooks — they are special hooks for the `hk fix` and `hk check` commands. Define them to enable manual linting runs outside of git.
+
+    ```pkl theme={null}
+    hooks {
+        ["fix"] {
+            fix = true
+            steps = linters
+        }
+        ["check"] {
+            steps = linters
+            // optional: upload timing data after the run
+            report = #"node scripts/upload-timings.js <<<"$HK_REPORT_JSON""#
+        }
+    }
+    ```
+
+    Run them with:
+
+    ```bash theme={null}
+    hk fix          # run fix steps on all files
+    hk check        # run check steps on all files
+    hk check --all  # check every file, not just staged ones
+    ```
+  </Accordion>
+</AccordionGroup>
+
+hk also supports all other standard git hooks. See the [git documentation](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) for the full list.
+
+## Step properties
+
+Steps are configured as entries in a `Mapping<String, Step>` inside a hook's `steps` field. Every property is optional unless noted.
+
+<AccordionGroup>
+  <Accordion title="check">
+    A read-only command to validate files. Should exit non-zero if there are errors. Runs with read locks; multiple check steps can run simultaneously on the same file.
+
+    ```pkl theme={null}
+    check = "eslint {{files}}"
+    ```
+
+    **Template variables:** `{{files}}`, `{{workspace}}`, `{{workspace_indicator}}`, `{{workspace_files}}`
+  </Accordion>
+
+  <Accordion title="fix">
+    A command that modifies files in place. Runs with write locks. When `check_first = true` (the default), hk only runs fix if the check command fails first.
+
+    ```pkl theme={null}
+    fix = "eslint --fix {{files}}"
+    ```
+  </Accordion>
+
+  <Accordion title="check_diff">
+    A command that outputs a unified diff of what would be changed. hk attempts to apply it with `git apply` instead of running the fix command — more efficient for tools like `black`, `ruff`, and `shfmt`.
+
+    ```pkl theme={null}
+    check_diff = "black --check --diff {{files}}"
+    ```
+  </Accordion>
+
+  <Accordion title="check_list_files">
+    A command that returns the list of files that need fixing. Used with `check_first` to acquire write locks only for files that actually need changes.
+
+    ```pkl theme={null}
+    check_list_files = "prettier --list-different {{files}}"
+    ```
+  </Accordion>
+
+  <Accordion title="glob">
+    File patterns (glob or regex) the step runs on. Only staged files matching these patterns are passed to the step. If unset, the step always runs.
+
+    ```pkl theme={null}
+    glob = List("**/*.js", "**/*.ts")
+    ```
+  </Accordion>
+
+  <Accordion title="batch">
+    **Default:** `false`
+
+    When `true`, hk splits the file list into batches and runs them in parallel. Useful for single-threaded tools like eslint and prettier.
+
+    ```pkl theme={null}
+    batch = true
+    ```
+  </Accordion>
+
+  <Accordion title="check_first">
+    **Default:** `true`
+
+    When `true`, hk runs the check command first with read locks. If it fails, hk acquires write locks and runs the fix command. Set to `false` to always run fix directly — avoid this when possible as it hurts parallelism.
+
+    ```pkl theme={null}
+    check_first = false
+    ```
+  </Accordion>
+
+  <Accordion title="exclusive">
+    **Default:** `false`
+
+    When `true`, this step waits for all previous steps to complete before starting, and no subsequent steps start until this one finishes. Useful for bookend steps that must run in isolation.
+
+    ```pkl theme={null}
+    exclusive = true
+    ```
+  </Accordion>
+
+  <Accordion title="depends">
+    A step name or list of step names that must complete before this step starts.
+
+    ```pkl theme={null}
+    depends = List("prettier")
+    // or a single string:
+    depends = "prettier"
+    ```
+  </Accordion>
+
+  <Accordion title="profiles">
+    A list of profile names that must be active for this step to run. Prefix with `!` to disable the step when a profile is active.
+
+    ```pkl theme={null}
+    profiles = List("slow")         // only run when "slow" profile is active
+    profiles = List("!slow")        // skip when "slow" profile is active
+    ```
+
+    Enable profiles with `HK_PROFILE=slow` or via `git config hk.profile slow`.
+  </Accordion>
+
+  <Accordion title="workspace_indicator">
+    When set, hk groups files by the nearest parent directory containing this filename, then runs the step once per matching workspace.
+
+    ```pkl theme={null}
+    workspace_indicator = "Cargo.toml"
+    check = "cargo clippy --manifest-path {{workspace_indicator}}"
+    ```
+
+    Additional template variables become available: `{{workspace}}`, `{{workspace_indicator}}`, `{{workspace_files}}`.
+  </Accordion>
+
+  <Accordion title="env">
+    Environment variables scoped to this step.
+
+    ```pkl theme={null}
+    env {
+        ["NODE_ENV"] = "production"
+    }
+    ```
+  </Accordion>
+
+  <Accordion title="condition / step_condition">
+    An [expr](https://github.com/jdx/expr-rs) expression that controls whether the step runs.
+
+    * `condition` is evaluated per job (once per batch or workspace).
+    * `step_condition` is evaluated once for the entire step.
+
+    ```pkl theme={null}
+    condition = "git.staged_files != []"
+    step_condition = "exec('test -f .eslintrc.json')"
+    ```
+  </Accordion>
+
+  <Accordion title="dir">
+    Run the step's commands in this directory instead of the repository root.
+
+    ```pkl theme={null}
+    dir = "frontend"
+    ```
+  </Accordion>
+
+  <Accordion title="prefix">
+    Prepend this string to all step commands.
+
+    ```pkl theme={null}
+    prefix = "bun run"
+    ```
+  </Accordion>
+
+  <Accordion title="stage">
+    Glob patterns of files to stage after running a fix command. Defaults to the step's `glob` when staging is enabled.
+
+    ```pkl theme={null}
+    stage = List("*.js", "*.ts")
+    ```
+  </Accordion>
+
+  <Accordion title="stomp">
+    **Default:** `false`
+
+    When `true`, hk acquires a write lock immediately instead of attempting a read lock first. Use for tools that have their own internal locking.
+
+    ```pkl theme={null}
+    stomp = true
+    ```
+  </Accordion>
+
+  <Accordion title="output_summary">
+    **Default:** `"stderr"`
+
+    Controls which output stream is captured and printed after the hook run.
+
+    * `"stderr"` — capture only stderr (default)
+    * `"stdout"` — capture only stdout
+    * `"combined"` — capture both streams interleaved
+    * `"hide"` — suppress all output for this step
+
+    ```pkl theme={null}
+    output_summary = "combined"
+    ```
+  </Accordion>
+</AccordionGroup>
+
+
+# Introduction
+Source: https://www.mintlify.com/jdx/hk/introduction
+
+hk is a high-performance git hook manager that runs linters in parallel using file-level read/write locks — safely, without race conditions.
+
+hk manages your git hooks and project lints with an emphasis on **performance**. Unlike other hook managers that shell out to linters sequentially, hk maintains a read/write lock for every file being linted and runs as many linters concurrently as possible.
+
+<Note>
+  hk is a single Rust binary with no runtime dependencies. The built-in `pklr` evaluator means you don't even need the pkl CLI installed.
+</Note>
+
+## What makes hk different
+
+Most git hook managers — pre-commit, prek, lefthook — work by shelling out to linters one after another. Running 10 linters sequentially means your commit time is the *sum* of every linter's runtime. hk runs them in parallel, making commit time closer to the *slowest* single linter.
+
+Safe parallelism requires coordination. If two linters both try to rewrite the same file at the same time, one will silently overwrite the other's changes. hk prevents this with **file-level read/write locks**: multiple linters can read the same file simultaneously, but a linter that needs to write first acquires an exclusive lock.
+
+Beyond speed, hk adds:
+
+* **Smart stashing** — a three-way merge strategy ensures your unstaged work-in-progress is never clobbered by fixers during a commit.
+* **120+ built-in linter configs** — Prettier, ESLint, Ruff, Cargo Clippy, Golangci-lint, and more, ready to drop in with a single line of Pkl.
+* **Type-safe Pkl configuration** — Apple's [Pkl](https://pkl-lang.org/) language gives you schema validation and IDE autocomplete instead of stringly-typed YAML.
+* **Secure plugin model** — builtins are Pkl config files in the hk repository, not third-party code downloaded from external git repos.
+
+## Feature comparison
+
+| Feature                    | hk                 | pre-commit         | lefthook       | prek               |
+| -------------------------- | ------------------ | ------------------ | -------------- | ------------------ |
+| Parallel execution         | File-locked        | No                 | Unsafe         | No                 |
+| Language                   | Rust               | Python             | Go             | Rust               |
+| Requires Python            | No                 | Yes                | No             | Often              |
+| Config format              | Pkl                | YAML               | YAML           | YAML               |
+| Built-in linter configs    | [120+](/builtins)  | —                  | —              | —                  |
+| Plugin model               | Pkl config (local) | Git repos (remote) | Shell commands | Git repos (remote) |
+| `check_diff` support       | Yes                | No                 | No             | No                 |
+| `check_list_files` support | Yes                | No                 | No             | No                 |
+| Stash management           | Yes                | Partial            | No             | Partial            |
+| Dependency resolution      | Yes                | No                 | No             | No                 |
+| Batched execution          | Yes                | No                 | No             | No                 |
+
+<Tip>
+  See [Benchmarks](/benchmarks) for reproducible performance numbers comparing hk against pre-commit, lefthook, and prek on a synthetic 6,000-file project with 10 overlapping linters.
+</Tip>
+
+## Next steps
+
+<CardGroup>
+  <Card title="Quick start" icon="rocket" href="/quickstart">
+    Install hk and configure your first project in under 5 minutes.
+  </Card>
+
+  <Card title="Why hk?" icon="bolt" href="/why-hk">
+    Deep dive into parallel execution, smart stashing, and how hk compares to alternatives.
+  </Card>
+
+  <Card title="Configuration" icon="gear" href="/configuration">
+    Learn how to write `hk.pkl` with hooks, steps, globs, and builtins.
+  </Card>
+
+  <Card title="Built-in linters" icon="list-check" href="/builtins">
+    Browse 120+ pre-configured linters and formatters ready to use instantly.
+  </Card>
+</CardGroup>
+
+
+# Logging and debugging
+Source: https://www.mintlify.com/jdx/hk/logging
+
+Control log levels, enable tracing, generate timing reports, and debug common issues with hk.
+
+hk provides several ways to control logging output and diagnose problems during execution.
+
+## Log levels
+
+hk supports standard log levels that control how much information is displayed:
+
+| Level   | What you see                                                 |
+| ------- | ------------------------------------------------------------ |
+| `error` | Only error messages                                          |
+| `warn`  | Warnings and errors (console default)                        |
+| `info`  | Informational messages, warnings, and errors                 |
+| `debug` | Debug information including file operations and step details |
+| `trace` | All internal operations — very verbose                       |
+
+## Setting log levels
+
+### CLI flags
+
+The `-v` / `--verbose` flag is the quickest way to raise the log level for a single command:
+
+```bash theme={null}
+# debug level — shows which files are being checked or fixed
+hk check -v
+hk fix --verbose
+
+# trace level — shows all internal operations
+hk check -vv
+```
+
+* `-v` or `--verbose` sets the level to `debug`
+* `-vv` sets the level to `trace`
+
+### Environment variable
+
+Use `HK_LOG` to set the level for a command or for the entire session:
+
+```bash theme={null}
+# Single command
+HK_LOG=debug hk check
+HK_LOG=trace hk fix
+
+# Entire session
+export HK_LOG=debug
+hk check
+hk fix
+```
+
+### Log file output
+
+By default hk writes logs to `~/.local/state/hk/hk.log`. You can redirect the file or set an independent level for it:
+
+```bash theme={null}
+# Redirect to a custom path
+HK_LOG_FILE=/tmp/my-hk.log hk check
+
+# Capture trace logs in the file without cluttering the console
+HK_LOG=warn HK_LOG_FILE_LEVEL=trace hk check
+```
+
+`HK_LOG_FILE_LEVEL` defaults to the value of `HK_LOG` when not set.
+
+## Quiet and silent modes
+
+```bash theme={null}
+# Suppress all non-error output
+hk check --quiet
+hk check -q
+
+# Suppress all output — rely on exit codes only
+hk check --silent
+```
+
+## Tracing and performance diagnostics
+
+hk includes built-in tracing for detailed execution tracking and performance analysis.
+
+### Enabling tracing
+
+Use the `--trace` flag or the `HK_TRACE` environment variable:
+
+```bash theme={null}
+# Console trace output (text mode)
+hk check --trace
+HK_TRACE=1 hk check
+HK_TRACE=text hk check
+
+# JSON/JSONL output for programmatic analysis
+HK_TRACE=json hk check > trace.jsonl
+hk check --trace --json > trace.jsonl
+```
+
+### Trace output formats
+
+**Text mode** — human-readable hierarchical output with timing:
+
+```
+  0.123s INFO Starting check
+  0.456s ├─ lint::eslint
+  0.789s │  ├─ Running eslint on 45 files
+  1.234s │  └─ Complete (478ms)
+  1.567s └─ Complete (1.444s)
+```
+
+**JSON mode** — newline-delimited JSON (JSONL), suitable for piping to `jq` or other tools:
+
+```json theme={null}
+{"type":"meta","span_schema_version":1,"hk_version":"1.12.1","pid":12345}
+{"type":"span_start","ts_ns":123456,"id":"span_0","name":"check","attrs":{}}
+{"type":"span_start","ts_ns":456789,"id":"span_1","name":"lint","attrs":{"step":"eslint"},"parent_id":"span_0"}
+{"type":"span_end","ts_ns":789012,"id":"span_1"}
+{"type":"span_end","ts_ns":1234567,"id":"span_0"}
+```
+
+### Performance timing reports
+
+`HK_TIMING_JSON` writes a structured JSON report at the end of a run. Overlapping parallel intervals are merged so time is not double-counted:
+
+```bash theme={null}
+HK_TIMING_JSON=/tmp/timing.json hk check
+cat /tmp/timing.json | jq .
+```
+
+Example report:
+
+```json theme={null}
+{
+  "total": { "wall_time_ms": 12456 },
+  "steps": {
+    "lint": { "wall_time_ms": 4321, "profiles": ["ci", "fast"] },
+    "fmt": { "wall_time_ms": 2100 },
+    "typecheck": { "wall_time_ms": 6035 }
+  }
+}
+```
+
+`steps` maps each step name to:
+
+* `wall_time_ms` — merged wall time in milliseconds
+* `profiles` — (optional) profiles required by the step; omitted when none
+
+## Common debugging scenarios
+
+<AccordionGroup>
+  <Accordion title="Debugging step execution">
+    To see which files are being processed by each step:
+
+    ```bash theme={null}
+    # Debug level shows file operations
+    HK_LOG=debug hk check
+
+    # Trace level shows every internal operation
+    HK_LOG=trace hk check
+    ```
+
+    To see exactly which steps would run without executing them, use `--plan`:
+
+    ```bash theme={null}
+    hk check --plan
+    ```
+  </Accordion>
+
+  <Accordion title="Debugging configuration issues">
+    Validate your configuration:
+
+    ```bash theme={null}
+    hk validate
+    ```
+
+    Check which steps are loaded and their file matches with `--plan`:
+
+    ```bash theme={null}
+    hk check --all --plan
+    ```
+  </Accordion>
+
+  <Accordion title="Debugging performance issues">
+    Generate a timing report to identify slow steps:
+
+    ```bash theme={null}
+    HK_TIMING_JSON=/tmp/timing.json hk check
+    cat /tmp/timing.json | jq .
+    ```
+
+    Use tracing for a step-by-step execution timeline:
+
+    ```bash theme={null}
+    hk check --trace
+    ```
+
+    For machine-readable analysis, capture JSONL output:
+
+    ```bash theme={null}
+    HK_TRACE=json hk check > trace.jsonl
+    jq 'select(.type == "span_end")' trace.jsonl
+    ```
+  </Accordion>
+
+  <Accordion title="Debugging configuration issues">
+    Validate your configuration with verbose output:
+
+    ```bash theme={null}
+    hk validate -v
+    ```
+
+    Check which steps are loaded and their file matches:
+
+    ```bash theme={null}
+    hk check --all --plan
+    ```
+
+    Debug a specific profile:
+
+    ```bash theme={null}
+    HK_LOG=debug hk check --profile slow
+    ```
+  </Accordion>
+
+  <Accordion title="Debugging git hook issues">
+    Test a hook directly with debug output:
+
+    ```bash theme={null}
+    HK_LOG=debug hk run pre-commit
+    ```
+
+    Check whether hooks are installed correctly:
+
+    ```bash theme={null}
+    ls -la .git/hooks/
+    ```
+
+    If you suspect stash behavior is causing issues, switch to patch-file mode and add debug logging:
+
+    ```bash theme={null}
+    HK_STASH=patch-file HK_LOG=debug hk run pre-commit
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Tips
+
+<Tip>
+  Start with `-v`. For most debugging, `hk check -v` provides enough detail without overwhelming output.
+</Tip>
+
+<Tip>
+  Use log files for trace-level detail. Set `HK_LOG_FILE_LEVEL=trace` to capture a full trace to disk while keeping the console clean.
+</Tip>
+
+<Tip>
+  Pipe JSON trace output to `jq` for filtering and analysis. For example, `jq 'select(.type == "span_end")' trace.jsonl` shows only completed spans.
+</Tip>
+
+<Tip>
+  Debug specific profiles with `HK_LOG=debug hk check --profile slow` to narrow down which steps in that profile are misbehaving.
+</Tip>
+
+
+# mise integration
+Source: https://www.mintlify.com/jdx/hk/mise-integration
+
+How to use hk alongside mise-en-place for tool management, task running, environment variables, and automated hook installation.
+
+Most git hook managers provide features that hk's sister project, [mise-en-place](https://github.com/jdx/mise), already covers well. Using hk and mise together gives you the best of both: hk handles the git lifecycle and linting, while mise manages tool versions, tasks, and environment variables.
+
+To opt in to all mise-specific features at once, set:
+
+```bash theme={null}
+export HK_MISE=1
+```
+
+<Info>
+  Setting `HK_MISE=1` wraps your git hooks with `mise x`. This ensures mise sets up the correct environment and tool versions before running hk, even for developers who haven't activated mise in their shell.
+</Info>
+
+## `hk init --mise`
+
+The `--mise` flag on `hk init` generates a `mise.toml` in the repository root. It installs hk and defines a `pre-commit` task so developers can run `mise run pre-commit` as a consistent project action alongside other mise tasks.
+
+```bash theme={null}
+hk init --mise
+```
+
+## `hk install --mise`
+
+The `--mise` flag on `hk install` wraps each git hook script with `mise x`, so the mise environment (tool versions, PATH shims, env vars) is available when hooks fire:
+
+```bash theme={null}
+hk install --mise
+```
+
+This is useful for teams where some developers have not activated mise in their shell — the hooks will still work correctly because `mise x` sets up the environment each time.
+
+## Tool management
+
+mise's tool management lets you pin the exact version of every tool used by `hk.pkl` in a single `mise.toml`:
+
+```bash theme={null}
+mise use hk
+mise use pkl
+mise use npm:prettier
+mise use jq
+```
+
+This creates (or updates) `mise.toml`, which you commit to the repository:
+
+```toml mise.toml theme={null}
+[tools]
+hk = "latest"
+pkl = "latest"
+"npm:prettier" = "latest"
+jq = "latest"
+```
+
+See the [mise dev tools docs](https://mise.jdx.dev/dev-tools/) for the full list of supported tool registries and version pinning options.
+
+## Task management
+
+[mise tasks](https://mise.jdx.dev/tasks/) can be called directly inside hk steps. This gives you access to task features like dependency management, option parsing, and parallel execution.
+
+```pkl hk.pkl theme={null}
+amends "package://github.com/jdx/hk/releases/download/v1.41.0/hk@1.41.0#/Config.pkl"
+
+hooks {
+    ["pre-commit"] {
+        fix = true
+        stash = "git"
+        steps {
+            ["prelint"] {
+                check = "mise run prelint"
+                exclusive = true  // ensure this finishes before other steps start
+            }
+            // ... more steps ...
+            ["postlint"] {
+                check = "mise run postlint"
+                exclusive = true  // wait for all previous steps to finish
+            }
+        }
+    }
+}
+```
+
+## Environment variables
+
+Define an `[env]` section in `mise.toml` to inject environment variables into every hook run:
+
+```toml mise.toml theme={null}
+[env]
+PRETTIER_CONFIG = ".prettierrc.json"
+NODE_ENV = "development"
+```
+
+When hooks run with `mise x` (via `hk install --mise` or `HK_MISE=1`), these variables are set automatically. mise has much richer environment variable support — see the [mise environments docs](https://mise.jdx.dev/environments/) for path manipulation, templating, and more.
+
+## Recommended setup
+
+The recommended approach is to use `mise.toml` as the single source of truth for tools and environment, and use hk only for the git lifecycle. Set `HK_MISE=1` in `mise.toml` and use a `postinstall` hook to automate hook installation for your whole team:
+
+```toml mise.toml theme={null}
+[tools]
+hk = "latest"
+pkl = "latest"
+# add other tools here: prettier, actionlint, etc.
+
+[env]
+HK_MISE = "1"
+
+[hooks]
+# automatically install/update hooks whenever tools are installed
+postinstall = "hk install --mise"
+```
+
+With this setup:
+
+<Steps>
+  <Step title="Developer clones the repo">
+    A new team member clones the repository.
+  </Step>
+
+  <Step title="Developer runs `mise install`">
+    mise installs all pinned tools and then runs the `postinstall` hook.
+  </Step>
+
+  <Step title="Hooks are installed automatically">
+    `hk install --mise` installs git hooks wrapped with `mise x`. No manual hook installation needed.
+  </Step>
+
+  <Step title="Hooks run in the correct environment">
+    When the developer commits or pushes, hooks fire with the full mise environment — correct tool versions, PATH shims, and env vars — regardless of whether mise is activated in their shell.
+  </Step>
+</Steps>
+
+
+# Pkl configuration language
+Source: https://www.mintlify.com/jdx/hk/pkl-introduction
+
+An introduction to Pkl — the configuration language hk uses — covering syntax, imports, amending, caching, and how to test your config.
+
+hk uses [Pkl](https://pkl-lang.org/) from Apple as its configuration language. Pkl is a statically-typed, schema-validated configuration language designed for building safe, composable configs. This page covers the Pkl concepts you need to write and maintain `hk.pkl` files.
+
+## Why Pkl?
+
+* **Built-in schema validation** — your editor can display type errors in your config, not just syntax errors.
+* **Native imports** — Pkl can import other Pkl files from the filesystem or HTTP URLs, so hk doesn't need its own import system.
+* **Amend / compose** — you can create shared objects and override specific fields without duplicating the rest. This makes patterns like local overrides clean and explicit.
+* **Static but expressive** — Pkl is comprehensive enough that hk doesn't need a plugin system. Shared, cached Pkl files keep evaluation fast.
+
+## Downsides
+
+Pkl is a young language with some rough edges worth knowing about:
+
+* Editor / syntax-highlighting support is still maturing (though it's backed by Apple, so it's improving quickly).
+* `List(a, b, c)` instead of `[a, b, c]` — the list literal syntax is unusual.
+* The `amends` model can be confusing at first.
+* The `default` behavior in mappings has some surprising edge cases.
+* Caching means env vars embedded in `hk.pkl` won't cause a re-evaluation when they change.
+
+AI tools (Cursor, Copilot, etc.) handle Pkl well — you can ask them to write or explain Pkl snippets for you.
+
+## Dependencies
+
+hk supports two Pkl backends:
+
+<Tabs>
+  <Tab title="pklr (built-in, recommended)">
+    hk includes a built-in Pkl evaluator called [pklr](https://github.com/jdx/pklr). Enable it with:
+
+    ```bash theme={null}
+    export HK_PKL_BACKEND=pklr
+    ```
+
+    No external Pkl installation required. pklr is experimental and may not support every Pkl feature yet, but it will eventually become the default backend.
+  </Tab>
+
+  <Tab title="pkl CLI">
+    The default backend uses the `pkl` CLI. Install it with mise:
+
+    ```bash theme={null}
+    mise use -g pkl
+    ```
+
+    If you run into issues with pklr, unset `HK_PKL_BACKEND` to fall back to the pkl CLI.
+  </Tab>
+</Tabs>
+
+## Basic syntax
+
+### Types
+
+```pkl theme={null}
+my_string = "hello"
+my_number = 1
+my_boolean = true
+list_of_strings = List("a", "b", "c")
+```
+
+### Mappings
+
+Mappings are key-value pairs, like objects or dictionaries in other languages:
+
+```pkl theme={null}
+my_mapping = new Mapping<String, String> {
+    ["key"] = "value"
+    ["another"] = "value2"
+}
+```
+
+### Listings and lists
+
+Use `List(...)` for simple ordered collections of scalar values:
+
+```pkl theme={null}
+my_list = List("a", "b", "c")
+```
+
+Use `new Listing<T>` for ordered collections of complex objects:
+
+```pkl theme={null}
+my_listing = new Listing<Step> {
+    new Step {
+        check = "make lint"
+    }
+    new Step {
+        check = "make format"
+    }
+}
+```
+
+### Local variables
+
+hk will reject any top-level property it doesn't recognize. Use the `local` keyword for intermediate variables:
+
+```pkl theme={null}
+local my_step = new Step {
+    check = "make lint"
+}
+```
+
+### Amending objects
+
+Amend an existing object to override specific fields while keeping the rest:
+
+```pkl theme={null}
+local make_lint = new Step {
+    check = "make lint"
+}
+
+local linters = new Mapping<String, Step> {
+    ["proj-a"] = (make_lint) {
+        dir = "proj_a"
+    }
+    ["proj-b"] = (make_lint) {
+        dir = "proj_b"
+    }
+}
+```
+
+This is equivalent to copying the object and changing only the `dir` field in each copy. The amend syntax `(object) { overrides }` is used extensively with builtins:
+
+```pkl theme={null}
+["prettier"] = (Builtins.prettier) {
+    glob = List("src/**/*.js", "src/**/*.ts")
+}
+```
+
+### Comments
+
+```pkl theme={null}
+// Single-line comment
+/*
+  Multi-line comment
+*/
+/// Doc comment (not currently used by hk)
+```
+
+### Classes
+
+You won't usually define your own classes in an hk config, but you will instantiate classes provided by `Config.pkl`:
+
+```pkl theme={null}
+local step = new Step {
+    glob = "**/*.rs"
+    check = "cargo fmt --check"
+    fix = "cargo fmt"
+}
+```
+
+## The `amends` line
+
+Every `hk.pkl` must start with an `amends` declaration. This line points at the base schema, which provides type checking and base class definitions:
+
+```pkl theme={null}
+amends "package://github.com/jdx/hk/releases/download/v1.41.0/hk@1.41.0#/Config.pkl"
+```
+
+The `amends` line means "this file extends and overrides values from that file." It is what lets your config be validated against the schema — your IDE can show errors for wrong property names or types.
+
+For `hk.local.pkl`, amend the project's `hk.pkl` instead:
+
+```pkl theme={null}
+amends "./hk.pkl"
+```
+
+## Imports
+
+Import other Pkl files to reference their values:
+
+```pkl theme={null}
+// Import the Builtins module
+import "package://github.com/jdx/hk/releases/download/v1.41.0/hk@1.41.0#/Builtins.pkl"
+
+// Import a local file
+import "./shared-steps.pkl" as shared
+
+// Import a remote file
+import "https://example.com/shared-config.pkl" as remote
+```
+
+Imported modules are referenced by their alias (or by their filename stem if no alias is given).
+
+## Caching
+
+hk caches the evaluated output of each `hk.pkl` file until the file is modified. This makes repeated hook runs fast.
+
+<Warning>
+  Do not embed environment variables directly inside `hk.pkl` as dynamic values — the cache will not invalidate when those env vars change. Use the `env` block inside steps or hooks instead, or pass values via `HK_*` environment variables at runtime.
+</Warning>
+
+## Testing your config
+
+Use `pkl eval` to see exactly what hk will receive from your config file, without running hk:
+
+```bash theme={null}
+$ pkl eval hk.pkl
+hooks {
+  ["pre-commit"] {
+    fix = true
+    steps {
+      ["prelint"] {
+        command = "lint"
+        args = ["--fix"]
+      }
+    }
+  }
+}
+```
+
+This is especially useful when using dynamic features like amending or local variables — you can verify the output before running any linters.
+
+You can also validate the config through hk itself:
+
+```bash theme={null}
+hk validate
+```
+
+If you use the built-in step test framework, run tests with:
+
+```bash theme={null}
+hk test                       # run all step tests
+hk test --step prettier       # run only prettier's tests
+hk test --name "formats json" # run a test by name
+hk test --list                # list tests without running them
+```
+
+## Full example
+
+Putting it all together — a complete `hk.pkl` using builtins, local variables, amending, and multiple hooks:
+
+```pkl hk.pkl theme={null}
+amends "package://github.com/jdx/hk/releases/download/v1.41.0/hk@1.41.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.41.0/hk@1.41.0#/Builtins.pkl"
+
+// Define linters as a local variable to share across hooks
+local linters = new Mapping<String, Step> {
+    ["actionlint"] = Builtins.actionlint
+    ["cargo-fmt"] = Builtins.cargo_fmt
+    ["cargo-clippy"] = (Builtins.cargo_clippy) {
+        profiles = List("slow")
+        check = "cargo clippy --manifest-path {{workspace_indicator}} --quiet -- -D warnings"
+    }
+    ["cargo-check"] = (Builtins.cargo_check) {
+        profiles = List("!slow")
+    }
+    ["prettier"] = (Builtins.prettier) {
+        glob = List("*.js", "*.ts", "*.yml", "*.yaml")
+    }
+    ["newlines"] = Builtins.newlines
+    ["trailing-whitespace"] = Builtins.trailing_whitespace
+}
+
+hooks = new {
+    ["pre-commit"] {
+        fix = true
+        stash = "git"
+        steps = new {
+            ["prelint"] {
+                check = "mise run prelint"
+                exclusive = true
+            }
+            ...linters
+            ["postlint"] {
+                check = "echo postlint"
+                exclusive = true
+            }
+        }
+    }
+    ["pre-push"] {
+        steps = linters
+    }
+    ["check"] {
+        steps = linters
+    }
+    ["fix"] {
+        fix = true
+        steps = linters
+    }
+}
+
+warnings = List("missing-profiles")
+```
+
+
+# Quick start
+Source: https://www.mintlify.com/jdx/hk/quickstart
+
+Install hk and set up your first project with parallel linting in under 5 minutes.
+
+## Get up and running
+
+<Steps>
+  <Step title="Install hk">
+    The recommended way to install hk is with [mise-en-place](https://github.com/jdx/mise):
+
+    <CodeGroup>
+      ```bash mise (recommended) theme={null}
+      mise use hk
+      hk --version
+      ```
+
+      ```bash brew theme={null}
+      brew install hk
+      ```
+
+      ```bash cargo theme={null}
+      cargo install hk
+      ```
+
+      ```bash aqua theme={null}
+      aqua g -i jdx/hk
+      ```
+    </CodeGroup>
+
+    <Tip>
+      mise-en-place integrates well with hk. Features common in similar git hook managers — dependency management, task dependencies, and env vars — can be provided by mise. See [mise integration](/mise-integration) for details.
+    </Tip>
+
+    <Tip>
+      By default hk uses the pkl CLI to evaluate configuration. Set `HK_PKL_BACKEND=pklr` to use the built-in Rust evaluator instead, which removes the pkl CLI dependency entirely. This is experimental — see [Pkl introduction](/pkl-introduction) for details.
+    </Tip>
+  </Step>
+
+  <Step title="Initialize your project">
+    Inside a git repository, run `hk init` to generate a `hk.pkl` configuration file:
+
+    ```bash theme={null}
+    hk init
+    ```
+
+    This creates a `hk.pkl` file in the root of your repository.
+  </Step>
+
+  <Step title="Configure your linters">
+    Edit `hk.pkl` to define your hooks and steps. Here's an example that uses the built-in ESLint and Prettier configs, with pre- and post-lint tasks:
+
+    ```pkl hk.pkl theme={null}
+    amends "package://github.com/jdx/hk/releases/download/v1.41.0/hk@1.41.0#/Config.pkl"
+    import "package://github.com/jdx/hk/releases/download/v1.41.0/hk@1.41.0#/Builtins.pkl"
+
+    local linters = new Mapping<String, Step> {
+        // linters can be manually defined
+        ["eslint"] {
+            // files to run the linter on — if no files match, the step is skipped
+            glob = List("*.js", "*.ts")
+            // a command that returns non-zero to fail the check
+            check = "eslint {{files}}"
+        }
+        // linters can also be specified with the builtins pkl library
+        ["prettier"] = Builtins.prettier
+        // with pkl, builtins can be extended:
+        ["prettier-yaml"] = (Builtins.prettier) {
+            glob = List("*.yaml", "*.yml")
+        }
+    }
+
+    hooks {
+        ["pre-commit"] {
+            fix = true    // runs the "fix" step of linters to modify files
+            stash = "git" // stashes unstaged changes when running fix steps
+            steps {
+                ["prelint"] {
+                    check = "mise run prelint"
+                    exclusive = true // blocks other steps from starting until this one finishes
+                }
+                ...linters
+                ["postlint"] {
+                    check = "mise run postlint"
+                    exclusive = true
+                }
+            }
+        }
+    }
+    ```
+
+    The `...linters` spread operator expands all entries from the `linters` mapping directly into `steps`. hk runs all non-exclusive steps in parallel using file-level read/write locks.
+
+    See [configuration](/configuration) for the full reference.
+  </Step>
+
+  <Step title="Install the git hooks">
+    Run `hk install` to wire up the hooks defined in `hk.pkl` to your repository's `.git/hooks/` directory:
+
+    ```bash theme={null}
+    hk install
+    ```
+
+    From now on, `git commit` will automatically trigger the `pre-commit` hook and run your linters in parallel.
+  </Step>
+
+  <Step title="Check and fix code manually">
+    You can run linters outside of a git commit at any time.
+
+    Run linters in check-only mode against modified files:
+
+    ```bash theme={null}
+    hk check
+    ```
+
+    Run linters and auto-fix issues in modified files:
+
+    ```bash theme={null}
+    hk fix
+    ```
+
+    <Tip>
+      Use `hk check --all` in CI to lint every file in the repository, or `hk check --from-ref main --to-ref HEAD` to lint only files that have changed since the `main` branch. Use `hk check --pr` as a shortcut for checking only PR diff files.
+    </Tip>
+
+    To explicitly trigger a hook without going through git — useful for local testing:
+
+    ```bash theme={null}
+    hk run pre-commit
+    ```
+  </Step>
+</Steps>
+
+## Next steps
+
+<CardGroup>
+  <Card title="Configuration" icon="gear" href="/configuration">
+    Full reference for `hk.pkl` — hooks, steps, globs, stashing, and more.
+  </Card>
+
+  <Card title="Built-in linters" icon="list-check" href="/builtins">
+    Browse 120+ pre-configured linters ready to drop into your `hk.pkl`.
+  </Card>
+
+  <Card title="Why hk?" icon="bolt" href="/why-hk">
+    Learn how parallel execution and smart stashing work under the hood.
+  </Card>
+
+  <Card title="CLI reference" icon="terminal" href="/cli/overview">
+    Full reference for all hk commands and flags.
+  </Card>
+</CardGroup>
+
+
+# Why hk?
+Source: https://www.mintlify.com/jdx/hk/why-hk
+
+How hk's parallel execution model, smart stashing, and secure builtins make it faster and safer than pre-commit, lefthook, prek, and husky.
+
+Tools like pre-commit, prek, and lefthook work by shelling out to linters one at a time. That means if two linters try to modify the same file at the same time, there will be a race condition — so they don't even try. hk solves this at the core and unlocks safe parallelism.
+
+## Parallel execution with file-level locking
+
+hk maintains a **read/write lock for every file being linted**. A linter that only reads a file acquires a shared read lock — multiple linters can hold read locks on the same file simultaneously. A linter that needs to write a file acquires an exclusive write lock — it waits for any readers to finish, then runs alone.
+
+This means linters with non-overlapping file sets always run in parallel. Linters with overlapping files run in parallel where possible, and coordinate only when they would genuinely conflict.
+
+### How hk avoids write locks
+
+hk goes further by actively avoiding write locks through linter-specific integration:
+
+**ruff** — has diff output, which is ideal. hk runs `ruff format --diff` to get a patch without touching any files. hk holds only a read lock while running ruff, then applies the diff itself later. If multiple linters edited the same lines, it re-runs ruff to resolve conflicts.
+
+**prettier** — supports `--list-different`, which returns the names of files that need formatting without modifying them. hk uses this to run the check phase with only read locks across all targeted files, then narrows the set before running `prettier --write` on just the files that need it.
+
+For linters with no diff or list mode (eslint is the main example), hk falls back to a write lock on all targeted files. Other linters that don't touch the same files still run in parallel. You can also use the `check_first` option to run a check pass first and only invoke the fix on failing files.
+
+<Note>
+  This integration work is why hk ships a large library of [builtins](/builtins) — you get the benefits without having to configure each linter's lock strategy yourself.
+</Note>
+
+## Smart stashing
+
+Here's a scenario every developer hits: you have a file with some changes staged and other changes you're still working on. Your pre-commit hook runs a formatter — and suddenly your unstaged work-in-progress gets formatted and staged along with everything else. Your careful partial commit is ruined.
+
+hk solves this with a **three-way merge stash strategy**:
+
+1. **Before hooks run** — hk snapshots your working tree and stashes only the unstaged changes (the diff between your worktree and your index). Your working tree now matches your staged content exactly.
+2. **Hooks run** — linters and fixers see only what you're actually committing. If prettier reformats a file, it reformats the staged version, not your work-in-progress.
+3. **After hooks run** — hk does a three-way merge to combine the fixer's changes with your unstaged work. If the fixer changed line 5 and your unstaged changes are on line 20, both are preserved. If there's a conflict, your unstaged changes take priority — hk never destroys your in-progress work.
+
+This works even with partially staged hunks in a single file. If you `git add -p` to stage just one function, hk will lint that function, apply fixes to it, and leave your other unstaged changes untouched.
+
+Other tools either don't stash at all (lefthook), or do basic stashing that can lose changes when fixers and unstaged edits touch the same lines (pre-commit, prek).
+
+## Built-in utilities
+
+hk ships fast **Rust-native utilities** for common checks: trailing whitespace removal, end-of-file newline fixing, and merge conflict detection. These run as part of the hk binary itself — no extra tools to install, and no subprocess overhead. They use `check_diff` mode so they always run in parallel with other linters.
+
+## Plugin security
+
+pre-commit and prek download hook implementations from external git repositories. Each hook repo contains its own environment setup, dependencies, and entry points — you're running code pulled from third-party repos on every commit.
+
+hk builtins are just [Pkl](https://pkl-lang.org/) config files hosted in the [hk repository](https://github.com/jdx/hk/tree/main/pkl/builtins) and fetched via the `import` statement in your `hk.pkl`. They define how to invoke linters that are already on your system — they don't download or execute third-party code. You can read exactly what each builtin does in a few lines of Pkl:
+
+```pkl theme={null}
+// This is an entire hk builtin.
+prettier = new Config.Step {
+  glob = List("**/*.js", "**/*.ts", "**/*.css", "**/*.json", "**/*.md")
+  check = "prettier --check {{ files }}"
+  check_list_files = "prettier --list-different {{ files }}"
+  fix = "prettier --write {{ files }}"
+}
+```
+
+Compare that to pre-commit:
+
+```yaml theme={null}
+# pre-commit: hooks are downloaded from external git repos
+repos:
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+```
+
+## Comparisons
+
+<AccordionGroup>
+  <Accordion title="vs pre-commit">
+    [pre-commit](https://pre-commit.com/) is the most popular hook manager. It's written in Python and requires Python as a runtime dependency.
+
+    * Runs hooks **sequentially** — hook B waits for hook A to finish completely before starting.
+    * Downloads hook code from external git repos, running third-party code on every commit.
+    * Requires Python on every developer's machine.
+    * Configuration is YAML with no schema validation.
+
+    hk gets its speed from parallelism. Running 10 linters in parallel is fundamentally faster than running them one at a time, regardless of how fast the manager itself is.
+  </Accordion>
+
+  <Accordion title="vs prek">
+    [prek](https://github.com/j178/prek) is pre-commit reimplemented in Rust. It's faster than pre-commit at startup but follows the same execution model:
+
+    * Still runs hooks **sequentially** — same fundamental bottleneck as pre-commit.
+    * Still downloads hook code from external git repos.
+    * prek itself doesn't require Python, but Python-based hooks (which are most of the pre-commit ecosystem) still need Python at runtime — prek manages it automatically via uv.
+    * prek does have some built-in Rust-native hooks for common checks, similar to hk's `hk util` commands.
+
+    The core difference: prek is a faster *runner* of the same sequential model. hk is a different model entirely.
+  </Accordion>
+
+  <Accordion title="vs lefthook">
+    [lefthook](https://github.com/evilmartians/lefthook) is a hook manager written in Go. It's the closest to hk in philosophy — it supports parallel execution.
+
+    The problem: lefthook has **no file-level coordination**. If two parallel jobs modify the same file, you get a race condition — the last writer wins and the other's changes are silently discarded. In practice you either accept the risk or configure your hooks to have non-overlapping file patterns, which defeats the purpose of built-in parallelism.
+
+    Other differences:
+
+    * lefthook has no built-in linter definitions — you write raw shell commands in YAML.
+    * lefthook does not stash unstaged changes before running fix hooks, which can cause in-progress work to be accidentally staged.
+    * lefthook uses YAML; hk uses [Pkl](https://pkl-lang.org/) for type-safe, composable configuration.
+  </Accordion>
+
+  <Accordion title="vs husky + lint-staged">
+    [husky](https://github.com/typicode/husky) (\~35k stars) and [lint-staged](https://github.com/lint-staged/lint-staged) (\~14k stars) are the most popular combination in the JavaScript ecosystem.
+
+    husky is intentionally minimal — it just wires up git hooks to scripts. lint-staged handles the actual linting orchestration. lint-staged runs tasks matched to *different* glob patterns in parallel, but tasks targeting the *same* glob run sequentially. There's no file-level coordination, so if two tasks touch the same file through different globs, you get a race condition.
+
+    Both require Node.js. If your project isn't a JavaScript project, you're adding a Node.js runtime dependency purely for your hook manager.
+  </Accordion>
+</AccordionGroup>
+
+## Feature comparison
+
+| Feature                    | hk                 | pre-commit         | lefthook       | prek               |
+| -------------------------- | ------------------ | ------------------ | -------------- | ------------------ |
+| Parallel execution         | File-locked        | No                 | Unsafe         | No                 |
+| Language                   | Rust               | Python             | Go             | Rust               |
+| Requires Python            | No                 | Yes                | No             | Often              |
+| Config format              | Pkl                | YAML               | YAML           | YAML               |
+| Built-in linter configs    | [120+](/builtins)  | —                  | —              | —                  |
+| Plugin model               | Pkl config (local) | Git repos (remote) | Shell commands | Git repos (remote) |
+| `check_diff` support       | Yes                | No                 | No             | No                 |
+| `check_list_files` support | Yes                | No                 | No             | No                 |
+| Stash management           | Yes                | Partial            | No             | Partial            |
+| Dependency resolution      | Yes                | No                 | No             | No                 |
+| Batched execution          | Yes                | No                 | No             | No                 |
+
+See [Benchmarks](/benchmarks) for reproducible performance numbers — hk, lefthook, pre-commit, and prek running 10 linters on a synthetic 6,000-file project.
+
+Ready to try it? [Get started](/quickstart).
+
+

--- a/docs/research/mintlify-cache/jdx/hk/llms.txt
+++ b/docs/research/mintlify-cache/jdx/hk/llms.txt
@@ -1,0 +1,27 @@
+# hk
+
+## Docs
+
+- [Benchmarks](https://www.mintlify.com/jdx/hk/benchmarks.md): Performance comparison of hk, lefthook, pre-commit, and prek running 10 linters on a synthetic project.
+- [Built-in linters](https://www.mintlify.com/jdx/hk/builtins.md): 120+ pre-configured linters and formatters available through the Builtins module — ready to use with a single import.
+- [hk check](https://www.mintlify.com/jdx/hk/cli/check.md): Run linters in read-only check mode against staged or specified files.
+- [hk config](https://www.mintlify.com/jdx/hk/cli/config.md): Inspect and introspect the effective merged hk configuration.
+- [hk fix](https://www.mintlify.com/jdx/hk/cli/fix.md): Run linters and auto-fix issues in staged or specified files.
+- [hk init](https://www.mintlify.com/jdx/hk/cli/init.md): Generate an hk.pkl configuration file in the project root.
+- [hk install](https://www.mintlify.com/jdx/hk/cli/install.md): Install git hooks from hk.pkl into .git/hooks/.
+- [CLI overview](https://www.mintlify.com/jdx/hk/cli/overview.md): Reference for the hk command-line interface and its global flags.
+- [hk run](https://www.mintlify.com/jdx/hk/cli/run.md): Explicitly run a named git hook without committing.
+- [hk util](https://www.mintlify.com/jdx/hk/cli/util.md): Built-in Rust-native utility commands for common file checks and fixes.
+- [hk validate](https://www.mintlify.com/jdx/hk/cli/validate.md): Validate the hk.pkl configuration file for errors.
+- [Configuration](https://www.mintlify.com/jdx/hk/configuration.md): How hk layers configuration from built-in defaults up through CLI flags, and a full reference for every setting.
+- [Environment variables](https://www.mintlify.com/jdx/hk/environment-variables.md): Full reference for all HK_* environment variables used to configure hk.
+- [Hooks](https://www.mintlify.com/jdx/hk/hooks.md): How hk executes git hooks, the read/write locking model, and a reference for every supported hook type and step property.
+- [Introduction](https://www.mintlify.com/jdx/hk/introduction.md): hk is a high-performance git hook manager that runs linters in parallel using file-level read/write locks — safely, without race conditions.
+- [Logging and debugging](https://www.mintlify.com/jdx/hk/logging.md): Control log levels, enable tracing, generate timing reports, and debug common issues with hk.
+- [mise integration](https://www.mintlify.com/jdx/hk/mise-integration.md): How to use hk alongside mise-en-place for tool management, task running, environment variables, and automated hook installation.
+- [Pkl configuration language](https://www.mintlify.com/jdx/hk/pkl-introduction.md): An introduction to Pkl — the configuration language hk uses — covering syntax, imports, amending, caching, and how to test your config.
+- [Quick start](https://www.mintlify.com/jdx/hk/quickstart.md): Install hk and set up your first project with parallel linting in under 5 minutes.
+- [Why hk?](https://www.mintlify.com/jdx/hk/why-hk.md): How hk's parallel execution model, smart stashing, and secure builtins make it faster and safer than pre-commit, lefthook, prek, and husky.
+
+
+Built with [Mintlify](https://mintlify.com).

--- a/docs/research/mintlify-cache/jdx/mise-action/llms-full.txt
+++ b/docs/research/mintlify-cache/jdx/mise-action/llms-full.txt
@@ -1,0 +1,1066 @@
+# Cache key templates
+Source: https://www.mintlify.com/jdx/mise-action/caching/cache-key-templates
+
+Customize the cache key using template variables and conditional logic.
+
+The `cache_key` input accepts a Handlebars template string. You can use it to build a cache key from any combination of built-in variables, environment variables, and conditional logic — giving you precise control over when caches are invalidated.
+
+## Default cache key
+
+When `cache_key` is not set, the action uses this template:
+
+```text theme={null}
+{{cache_key_prefix}}-{{platform}}{{#if version}}-{{version}}{{/if}}{{#if mise_env}}-{{mise_env}}{{/if}}{{#if install_args_hash}}-{{install_args_hash}}{{/if}}-{{#if file_hash}}{{file_hash}}{{else}}no-config{{/if}}
+```
+
+A typical resolved key looks like:
+
+```text theme={null}
+mise-v1-linux-x64-2026.3.10-a3f8c2d1e4b5...
+```
+
+If no mise config files are found in the repository, the key ends with `-no-config` instead of a hash.
+
+## Available template variables
+
+| Variable                | Description                                                       |
+| ----------------------- | ----------------------------------------------------------------- |
+| `{{cache_key_prefix}}`  | The value of `cache_key_prefix` (default: `mise-v1`)              |
+| `{{platform}}`          | Target platform, e.g. `linux-x64`, `macos-arm64`, `windows-x64`   |
+| `{{version}}`           | The mise version from the `version` input                         |
+| `{{file_hash}}`         | Hash of all mise configuration files found in the repository      |
+| `{{mise_env}}`          | Value of the `MISE_ENV` environment variable                      |
+| `{{install_args_hash}}` | SHA256 hash of the sorted tool names from `install_args`          |
+| `{{default}}`           | The fully resolved default cache key (useful as a base to extend) |
+| `{{env.VAR_NAME}}`      | Any environment variable, e.g. `{{env.NODE_ENV}}`                 |
+
+## Conditional logic
+
+Use Handlebars `{{#if}}` blocks to include segments only when a variable is non-empty:
+
+```text theme={null}
+{{cache_key_prefix}}-{{platform}}{{#if version}}-{{version}}{{/if}}
+```
+
+The `-{{version}}` segment is omitted entirely when no `version` input is provided.
+
+## Examples
+
+### Include only the platform and file hash
+
+Use this when you always want a minimal key without the mise version:
+
+```yaml theme={null}
+- uses: jdx/mise-action@v4
+  with:
+    cache_key: "mise-v1-{{platform}}-{{file_hash}}"
+```
+
+### Key on specific tools from `install_args`
+
+When you pass specific tools via `install_args`, the `install_args_hash` encodes them as a SHA256 of the sorted tool list:
+
+```yaml theme={null}
+- uses: jdx/mise-action@v4
+  with:
+    cache_key: "mise-v1-{{platform}}-{{install_args_hash}}-{{file_hash}}"
+    install_args: "node@24 python@3.14"
+```
+
+### Extend the default key
+
+Use `{{default}}` to start from the standard key and append extra segments. This preserves all the default invalidation logic while adding your own:
+
+```yaml theme={null}
+- uses: jdx/mise-action@v4
+  with:
+    cache_key: "{{default}}-custom-suffix"
+    install_args: "node@24 python@3.14"
+```
+
+### Use an environment variable
+
+Scope the cache to a specific environment using any variable from the runner environment:
+
+```yaml theme={null}
+- uses: jdx/mise-action@v4
+  with:
+    cache_key: "{{default}}-{{env.NODE_ENV}}"
+```
+
+<Tip>
+  `{{env.VAR_NAME}}` reads directly from the runner's environment at the time the cache key is computed. You can reference any variable set in a previous step or in your workflow's `env` block.
+</Tip>
+
+## Simple prefix-only customization
+
+If you only want to change the prefix to force cache invalidation, use `cache_key_prefix` instead of writing a full template:
+
+```yaml theme={null}
+- uses: jdx/mise-action@v4
+  with:
+    cache_key_prefix: "mise-v2"
+```
+
+This is equivalent to overriding the `{{cache_key_prefix}}` variable across the entire default template without having to copy the template yourself.
+
+<Warning>
+  Setting `cache_key` overrides the complete cache key and ignores `cache_key_prefix` and all other automatic key components. Use `{{default}}` inside your template if you want to retain the default logic.
+</Warning>
+
+
+# Caching overview
+Source: https://www.mintlify.com/jdx/mise-action/caching/overview
+
+How mise-action caches the mise binary and installed tools to speed up your workflows.
+
+Caching is enabled by default. On a cache hit, the action skips downloading and installing everything and restores the entire mise data directory directly from GitHub's cache — so your workflow starts executing tool commands almost immediately.
+
+<Note>
+  The cache covers the entire mise data directory, including the mise binary itself and all installed tools. Cache hits are very fast because nothing needs to be downloaded or compiled.
+</Note>
+
+## What gets cached
+
+The action caches the mise data directory (defaults to `~/.local/share/mise`). This includes:
+
+* The mise binary
+* All tools installed by `mise install`
+
+## Cache key
+
+The cache key is content-addressable. By default it is computed from:
+
+* **Platform** — the OS and architecture (e.g., `linux-x64`, `macos-arm64`)
+* **mise version** — when a specific version is pinned
+* **`MISE_ENV`** — the value of the `MISE_ENV` environment variable, if set
+* **Install args hash** — a SHA256 hash of the tools passed to `install_args`, sorted
+* **Config file hash** — a hash of all mise configuration files found in the repository
+
+The following file patterns are included in the config file hash:
+
+```text theme={null}
+**/.config/mise/config.toml
+**/.config/mise/config.lock
+**/.config/mise/config.*.toml
+**/.config/mise/config.*.lock
+**/.config/mise.toml
+**/.config/mise.lock
+**/.config/mise.*.toml
+**/.config/mise.*.lock
+**/.mise/config.toml
+**/.mise/config.lock
+**/.mise/config.*.toml
+**/.mise/config.*.lock
+**/mise/config.toml
+**/mise/config.lock
+**/mise/config.*.toml
+**/mise/config.*.lock
+**/.mise.toml
+**/.mise.lock
+**/.mise.*.toml
+**/.mise.*.lock
+**/mise.toml
+**/mise.lock
+**/mise.*.toml
+**/mise.*.lock
+**/.tool-versions
+```
+
+Any change to one of these files produces a new cache key, so stale tools are never restored from cache.
+
+## `cache-hit` output
+
+The action exposes a `cache-hit` boolean output you can use in later steps:
+
+```yaml theme={null}
+- uses: jdx/mise-action@v4
+  id: mise
+
+- run: echo "Cache hit: ${{ steps.mise.outputs.cache-hit }}"
+```
+
+## Disable caching
+
+Set `cache: false` to skip both reading from and writing to the cache entirely:
+
+```yaml theme={null}
+- uses: jdx/mise-action@v4
+  with:
+    cache: false
+```
+
+## Read-only cache
+
+Set `cache_save: false` to restore from the cache but never write back to it. This is useful for pull requests, where you want fast reads but want to avoid polluting the cache with short-lived branches:
+
+```yaml theme={null}
+- uses: jdx/mise-action@v4
+  with:
+    cache_save: ${{ github.ref_name == 'main' }}
+```
+
+With this configuration, only runs on `main` save a new cache entry. All other runs still benefit from cache hits.
+
+## Change the cache key prefix
+
+If you need to force-invalidate all existing caches without changing your config files, update `cache_key_prefix`:
+
+```yaml theme={null}
+- uses: jdx/mise-action@v4
+  with:
+    cache_key_prefix: "mise-v2"
+```
+
+The default prefix is `mise-v1`. Changing it produces a brand new set of cache keys, so all runners start with a cold cache.
+
+
+# Inputs
+Source: https://www.mintlify.com/jdx/mise-action/configuration/inputs
+
+All available inputs for the jdx/mise-action GitHub Action.
+
+Use these inputs in the `with:` block of your workflow step to configure how the action installs and runs mise.
+
+```yaml theme={null}
+- uses: jdx/mise-action@v4
+  with:
+    version: 2026.3.10
+    install: true
+    install_args: "node python"
+    cache: true
+    cache_key_prefix: "mise-v1"
+    experimental: false
+    log_level: info
+    working_directory: app
+    reshim: false
+    add_shims_to_path: true
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    fetch_from_github: true
+    env: true
+```
+
+## Installation
+
+<ParamField type="string">
+  The version of mise to install. If not specified, the action uses the latest release. Accepts version strings such as `2026.3.10`. A `v` prefix (e.g. `v2026.3.10`) is automatically stripped.
+
+  <Note>
+    Versions from 2024 are downloaded as a bare binary rather than a compressed archive. Versions from 2025 onward use `.tar.zst` (if zstd is available) or `.tar.gz`.
+  </Note>
+</ParamField>
+
+<ParamField type="string">
+  The expected SHA256 checksum of the downloaded mise binary. When provided, the action verifies the download matches this value and fails if there is a mismatch.
+</ParamField>
+
+<ParamField type="string">
+  The directory that mise will be installed to. Defaults to `$HOME/.local/share/mise`, or `$XDG_DATA_HOME/mise` if `$XDG_DATA_HOME` is set, or `$MISE_DATA_DIR` if `$MISE_DATA_DIR` is set.
+</ParamField>
+
+<ParamField type="string">
+  When `true` (the default), the action downloads the mise binary from GitHub releases. When `false` and using the latest version, it fetches from `mise.jdx.dev` instead.
+</ParamField>
+
+<ParamField type="string">
+  GitHub token for API authentication. Used to avoid rate limits when installing GitHub-hosted tools. Defaults to the automatic GitHub token provided by the runner. Set this explicitly if you encounter rate limit errors.
+</ParamField>
+
+<ParamField type="string">
+  Deprecated. Use `working_directory` instead.
+</ParamField>
+
+## Tool configuration
+
+<ParamField type="string">
+  When present, this value is written to `.tool-versions` before mise runs. Use this to define tool versions inline in your workflow without committing a `.tool-versions` file to your repository. See [tool versions](/configuration/tool-versions) for format details.
+</ParamField>
+
+<ParamField type="string">
+  When present, this value is written to `mise.toml` before mise runs. Use this to define tool versions and environment variables inline in your workflow without committing a `mise.toml` file to your repository. See [tool versions](/configuration/tool-versions) for format details.
+</ParamField>
+
+<ParamField type="string">
+  When `true`, the action runs `mise install` after setting up mise. Set to `false` to skip tool installation, for example when you only need mise itself available on `PATH`.
+</ParamField>
+
+<ParamField type="string">
+  Additional arguments passed to `mise install`. For example, set `install_args: "bun"` to install only the `bun` tool instead of everything defined in your config file.
+</ParamField>
+
+## Caching
+
+<ParamField type="string">
+  When `true`, the action reads from and writes to the GitHub Actions cache for the mise data directory. Set to `false` to disable all caching.
+</ParamField>
+
+<ParamField type="string">
+  When `true`, the action saves the mise data directory to the cache after a successful install. Set to `false` to read from the cache but never write to it.
+</ParamField>
+
+<ParamField type="string">
+  The prefix used when constructing the default cache key. Change this value to force a full cache invalidation without altering any other configuration.
+</ParamField>
+
+<ParamField type="string">
+  Overrides the entire cache key, ignoring all other cache key inputs. Supports Handlebars template variables:
+
+  | Variable                | Description                                                  |
+  | ----------------------- | ------------------------------------------------------------ |
+  | `{{version}}`           | The mise version from the `version` input                    |
+  | `{{cache_key_prefix}}`  | The value of `cache_key_prefix`                              |
+  | `{{platform}}`          | The target platform, e.g. `linux-x64` or `macos-arm64`       |
+  | `{{file_hash}}`         | Hash of all mise configuration files in the repository       |
+  | `{{mise_env}}`          | The value of the `MISE_ENV` environment variable             |
+  | `{{install_args_hash}}` | SHA256 hash of the sorted tools from `install_args`          |
+  | `{{default}}`           | The processed default cache key (useful for adding a suffix) |
+  | `{{env.VAR_NAME}}`      | Any environment variable by name                             |
+
+  Conditional logic is supported using Handlebars syntax, for example `{{#if version}}...{{/if}}`.
+
+  ```yaml theme={null}
+  cache_key: "mise-{{platform}}-{{version}}-{{file_hash}}"
+  ```
+</ParamField>
+
+## Runtime behavior
+
+<ParamField type="string">
+  When `true`, sets the `MISE_EXPERIMENTAL` environment variable to enable experimental mise features.
+</ParamField>
+
+<ParamField type="string">
+  The log level passed to mise via the `MISE_LOG_LEVEL` environment variable. Accepted values are `error`, `warn`, `info`, `debug`, and `trace`.
+</ParamField>
+
+<ParamField type="string">
+  The directory that mise runs in. Defaults to the current working directory of the runner.
+</ParamField>
+
+<ParamField type="string">
+  When `true`, runs `mise reshim -f` after setting up mise. Use this if downstream steps rely on shims being regenerated.
+</ParamField>
+
+<ParamField type="string">
+  When `true`, adds the mise shims directory to `PATH` so shim-based tool invocation (e.g., calling `node` directly) works in subsequent steps. The mise binary directory is always added to `PATH` regardless of this setting. Set to `false` if you want to call tools only via `mise exec --` or manage shims manually.
+</ParamField>
+
+<ParamField type="string">
+  When `true`, automatically loads mise environment variables (from the `[env]` section of `mise.toml`) into `GITHUB_ENV` so they are available in subsequent steps. Note that `PATH` modifications are not included.
+</ParamField>
+
+
+# Outputs
+Source: https://www.mintlify.com/jdx/mise-action/configuration/outputs
+
+Outputs produced by the jdx/mise-action GitHub Action.
+
+The action exposes one output you can reference in subsequent steps using the `steps.<id>.outputs` context.
+
+## Available outputs
+
+<ResponseField name="cache-hit" type="boolean">
+  Indicates whether a cache entry was found for the current cache key. The value is `true` when the mise data directory was restored from cache and `false` when the action performed a fresh install.
+</ResponseField>
+
+## Using the output
+
+Give the action step an `id` and then reference `steps.<id>.outputs.cache-hit` in any subsequent step:
+
+```yaml theme={null}
+- uses: jdx/mise-action@v4
+  id: mise
+
+- run: echo "Cache hit: ${{ steps.mise.outputs.cache-hit }}"
+```
+
+You can also use the output in a conditional to skip work that is only needed on a cache miss:
+
+```yaml theme={null}
+- uses: jdx/mise-action@v4
+  id: mise
+  with:
+    cache_save: false
+
+- name: Warm the cache
+  if: steps.mise.outputs.cache-hit != 'true'
+  run: echo "No cache found, tools were freshly installed."
+```
+
+<Note>
+  The `cache-hit` output is always set. When you disable caching with `cache: false`, the output is set to `false`.
+</Note>
+
+
+# Tool versions
+Source: https://www.mintlify.com/jdx/mise-action/configuration/tool-versions
+
+Configure which tools mise installs using .tool-versions or mise.toml.
+
+mise reads tool versions from configuration files in your repository. You can either commit these files alongside your code or write them inline in your workflow using the `tool_versions` and `mise_toml` action inputs.
+
+## Configuration file formats
+
+<Tabs>
+  <Tab title="mise.toml (recommended)">
+    `mise.toml` is the recommended format. It supports richer configuration including pinned versions, version ranges, environment variables, and per-directory settings.
+
+    ```toml theme={null}
+    [tools]
+    node = "22"
+    python = "3.13"
+    bun = "1.2"
+    shellcheck = "0.11.0"
+    ```
+
+    Place `mise.toml` in the root of your repository or in any directory that mise should read.
+  </Tab>
+
+  <Tab title=".tool-versions (legacy)">
+    `.tool-versions` is the asdf-compatible format. Each line contains a tool name followed by one or more versions separated by spaces.
+
+    ```text theme={null}
+    node 22.0.0
+    python 3.13.0
+    bun 1.2.0
+    shellcheck 0.11.0
+    ```
+
+    Place `.tool-versions` in the root of your repository. mise reads this file automatically and treats it as equivalent to `mise.toml`.
+  </Tab>
+</Tabs>
+
+## Environment variables in mise.toml
+
+`mise.toml` supports an `[env]` section for defining environment variables that mise exports into the shell environment. When the `env` input is `true` (the default), the action reads these variables using `mise env` and writes them to `GITHUB_ENV` so they are available in all subsequent steps.
+
+```toml theme={null}
+[tools]
+node = "22"
+python = "3.13"
+
+[env]
+NODE_ENV = "test"
+DATABASE_URL = "postgres://localhost/myapp_test"
+```
+
+<Note>
+  `PATH` modifications from `mise env` are not exported to `GITHUB_ENV`. The action handles `PATH` separately by adding the mise bin and shims directories directly.
+</Note>
+
+<Tip>
+  On mise versions 2025.8.17 and later, the action uses `mise env --redacted` to detect sensitive values and automatically masks them in GitHub Actions logs via `core.setSecret`. On older versions it falls back to `mise env --dotenv` without masking.
+</Tip>
+
+## Inline configuration with action inputs
+
+Instead of committing configuration files to your repository, you can write them inline in your workflow using the `tool_versions` or `mise_toml` inputs. The action writes the value to the appropriate file before running `mise install`.
+
+Use `tool_versions` to write a `.tool-versions` file:
+
+```yaml theme={null}
+- uses: jdx/mise-action@v4
+  with:
+    tool_versions: |
+      node 22.0.0
+      python 3.13.0
+      shellcheck 0.11.0
+```
+
+Use `mise_toml` to write a `mise.toml` file:
+
+```yaml theme={null}
+- uses: jdx/mise-action@v4
+  with:
+    mise_toml: |
+      [tools]
+      node = "22"
+      python = "3.13"
+      shellcheck = "0.11.0"
+
+      [env]
+      NODE_ENV = "test"
+```
+
+<Warning>
+  When you use `tool_versions` or `mise_toml`, the action overwrites any existing `.tool-versions` or `mise.toml` file in the working directory. If your repository already contains these files, use the committed versions instead of the inline inputs to avoid conflicts.
+</Warning>
+
+## Which files does mise read?
+
+The action caches the mise data directory using a hash derived from all mise configuration files it finds in the repository. The following patterns are searched:
+
+* `mise.toml`, `.mise.toml`, `mise.*.toml`
+* `mise.lock`, `.mise.lock`, `mise.*.lock`
+* `.config/mise/config.toml`, `.config/mise/config.*.toml`
+* `.mise/config.toml`, `.mise/config.*.toml`
+* `.tool-versions`
+
+If any of these files change, the cache key changes and mise performs a fresh install on the next run.
+
+
+# GitHub API rate limits
+Source: https://www.mintlify.com/jdx/mise-action/guides/github-rate-limits
+
+Understand why the action uses MISE_GITHUB_TOKEN and how to avoid hitting rate limits when installing GitHub-hosted tools.
+
+When mise installs tools hosted on GitHub — such as `node`, `bun`, `gh`, and others — it calls the GitHub Releases API to resolve versions and download binaries. Unauthenticated requests to that API are limited to **60 requests per hour** per IP address. In a busy CI environment, this limit can be reached quickly, causing tool installations to fail.
+
+## How the action handles authentication
+
+The action accepts a `github_token` input and exports it as the `MISE_GITHUB_TOKEN` environment variable so mise can authenticate its API calls.
+
+```yaml theme={null}
+- uses: jdx/mise-action@v4
+  with:
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+<Note>
+  The `github_token` input defaults to `${{ github.token }}`, which is the automatically generated token GitHub provides to every workflow run. In most cases you don't need to set it explicitly — authentication is already in place.
+</Note>
+
+## Why `MISE_GITHUB_TOKEN` instead of `GITHUB_TOKEN`
+
+The action deliberately sets `MISE_GITHUB_TOKEN` rather than `GITHUB_TOKEN`. This avoids interfering with downstream tools and steps that inspect `GITHUB_TOKEN` for their own purposes. Keeping the two variables separate prevents unexpected side effects in the rest of your workflow.
+
+## What to do if you hit rate limits
+
+If you see errors like `403` or `rate limit exceeded` during tool installation, check the following:
+
+1. **Confirm the token is being passed.** The default `${{ github.token }}` is injected automatically, but some configurations (such as reusable workflows or restricted permissions) may prevent it from reaching the action. Pass it explicitly:
+
+   ```yaml theme={null}
+   - uses: jdx/mise-action@v4
+     with:
+       github_token: ${{ secrets.GITHUB_TOKEN }}
+   ```
+
+2. **Check workflow permissions.** The token must have at least read access to public repositories. For private repositories, ensure `contents: read` is granted in your workflow's `permissions` block.
+
+3. **Use caching.** Enabling the cache (on by default) means tools only need to be downloaded once. Subsequent runs restore from cache and make no API calls.
+
+<Tip>
+  If you are running many parallel jobs, each job makes its own API calls. Make sure caching is enabled so that a warm cache eliminates most GitHub API requests across the board.
+</Tip>
+
+
+# Monorepos
+Source: https://www.mintlify.com/jdx/mise-action/guides/monorepos
+
+Configure mise-action for monorepos where each subdirectory has its own tool configuration.
+
+In a monorepo, different packages or applications may require different tool versions. The action supports this through the `working_directory` input, which tells mise to look for configuration files (`.mise.toml`, `.tool-versions`, etc.) in a specific subdirectory instead of the repository root.
+
+## Pointing mise at a subdirectory
+
+Set `working_directory` to the path of the subdirectory you want mise to use as its working context:
+
+```yaml theme={null}
+- uses: actions/checkout@v4
+- uses: jdx/mise-action@v4
+  with:
+    working_directory: apps/api
+```
+
+Mise will read the configuration from `apps/api/.mise.toml` (or `apps/api/.tool-versions`) and install the tools defined there.
+
+## Running against multiple subdirectories with a matrix
+
+Use a matrix strategy to run the action against several subdirectories in parallel. Each matrix entry gets its own separate cache based on the configuration files found in that directory.
+
+```yaml theme={null}
+strategy:
+  matrix:
+    dir: [apps/frontend, apps/api, apps/worker]
+steps:
+  - uses: actions/checkout@v4
+  - uses: jdx/mise-action@v4
+    with:
+      working_directory: ${{ matrix.dir }}
+```
+
+<Tip>
+  Cache keys are derived from a hash of all mise configuration files found in the workspace. Because each subdirectory has a different `.mise.toml` or `.tool-versions`, each matrix entry naturally produces a different cache key and gets its own isolated cache.
+</Tip>
+
+## Differentiating cache keys explicitly
+
+If you need even finer-grained cache control — for example, when the same configuration files exist at multiple levels of the tree — you can use the `cache_key` input with template variables to make each entry's cache key unique.
+
+The `{{env.VAR_NAME}}` template syntax lets you reference any environment variable in the cache key:
+
+```yaml theme={null}
+strategy:
+  matrix:
+    dir: [apps/frontend, apps/api, apps/worker]
+steps:
+  - uses: actions/checkout@v4
+  - uses: jdx/mise-action@v4
+    with:
+      working_directory: ${{ matrix.dir }}
+      cache_key: "mise-v1-{{platform}}-${{ matrix.dir }}-{{file_hash}}"
+```
+
+This produces a distinct cache key per directory, per platform, and per configuration file hash — giving you full control over cache invalidation.
+
+<Note>
+  If you are using `mise_toml` or `tool_versions` inputs to write configuration inline (rather than reading from committed files), the `file_hash` portion of the default cache key will be empty. In that case, use `cache_key` with a custom template that incorporates something that changes when your inline config changes, such as a hash of the workflow file itself.
+</Note>
+
+
+# Platform support
+Source: https://www.mintlify.com/jdx/mise-action/guides/platforms
+
+Run mise-action on Linux, macOS, and Windows runners, including Alpine containers.
+
+The action works across all major GitHub Actions runner platforms. Platform detection is automatic — you don't need to configure anything different per OS in most cases.
+
+## Supported platforms
+
+| Platform              | Architecture                       | Binary format                               |
+| --------------------- | ---------------------------------- | ------------------------------------------- |
+| Linux (glibc)         | x64, arm64, armv7                  | `.tar.zst` (if zstd available) or `.tar.gz` |
+| Linux (musl / Alpine) | x64, arm64, armv7                  | `.tar.zst` (if zstd available) or `.tar.gz` |
+| macOS                 | x64 (Intel), arm64 (Apple Silicon) | `.tar.zst` (if zstd available) or `.tar.gz` |
+| Windows               | x64                                | `.zip`                                      |
+
+The action detects the correct binary target automatically using Node's `process.platform` and `process.arch`. On Linux, it also detects musl by inspecting the output of `ldd --version` — if that output contains the string `musl`, a musl-linked binary is downloaded instead of a glibc one.
+
+<Note>
+  Windows uses a `.zip` archive. On Linux and macOS, `.tar.zst` is preferred when `zstd` is available on the runner, falling back to `.tar.gz` otherwise.
+</Note>
+
+## Running on Ubuntu and macOS
+
+No extra configuration is needed for standard GitHub-hosted runners.
+
+```yaml theme={null}
+strategy:
+  matrix:
+    include:
+      - name: ubuntu
+        runs-on: ubuntu-latest
+      - name: macos
+        runs-on: macos-latest
+      - name: windows
+        runs-on: windows-latest
+jobs:
+  test:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v4
+```
+
+## Running in Alpine containers
+
+Alpine Linux uses musl libc instead of glibc. The action detects this automatically and downloads the musl binary. However, Alpine images are minimal and ship without `curl` or `bash`, both of which the action requires. You must install them before the action runs.
+
+```yaml theme={null}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container: alpine:latest
+    steps:
+      - name: Install requirements
+        run: apk add --no-cache curl bash
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v4
+```
+
+<Warning>
+  If you skip the `apk add` step, the action will fail because `curl` is unavailable to download the mise binary.
+</Warning>
+
+## Windows notes
+
+The action works correctly in PowerShell and cmd on Windows runners. However, mise shims may not function as expected inside MINGW environments such as Git Bash for Windows.
+
+<Note>
+  If you run steps with `shell: bash` on Windows (which uses MINGW), avoid relying on shims. Use `mise exec --` to run tools directly instead:
+
+  ```yaml theme={null}
+  - run: mise exec -- node --version
+    shell: bash
+  ```
+</Note>
+
+The shims directory is still added to `PATH` by default (`add_shims_to_path: true`), but resolving executables through those shims may not work in MINGW. Standard PowerShell and cmd shells are unaffected.
+
+
+# Troubleshooting
+Source: https://www.mintlify.com/jdx/mise-action/guides/troubleshooting
+
+Solutions for common issues with mise-action, including cache misses, rate limits, checksum failures, and platform-specific problems.
+
+<AccordionGroup>
+  <Accordion title="Cache not being hit">
+    The cache key is built from a hash of your mise configuration files (`.mise.toml`, `.tool-versions`, and related files). If the cache is never restored, check the following:
+
+    * **Configuration files are committed.** The cache key hash is computed from files on disk in your repository. If your config exists only as an inline `mise_toml` or `tool_versions` input, the file hash component will be empty and the key will differ from what you expect.
+
+    * **`cache_key_prefix` has not changed.** The default prefix is `mise-v1`. If you or a team member changed it, all existing caches are invalidated. Check your workflow history for changes to this input.
+
+    * **Set `cache_key` explicitly** to pin the cache to a known key and rule out template variable issues:
+
+      ```yaml theme={null}
+      - uses: jdx/mise-action@v4
+        with:
+          cache_key: "mise-v1-debug-${{ runner.os }}"
+      ```
+
+    * **Check the Actions cache tab** in your repository's GitHub UI to confirm whether a matching cache entry exists.
+  </Accordion>
+
+  <Accordion title="GitHub API rate limits">
+    When installing tools hosted on GitHub (such as `node`, `bun`, or `gh`), mise calls the GitHub Releases API. Without authentication, this is limited to 60 requests per hour.
+
+    Ensure `github_token` is being passed to the action:
+
+    ```yaml theme={null}
+    - uses: jdx/mise-action@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+    ```
+
+    The default value is `${{ github.token }}`, so authentication is active in most workflows. If you are using a reusable workflow or a restricted permissions setup, the token may not be available automatically — pass it explicitly in that case.
+
+    See the [GitHub API rate limits guide](/guides/github-rate-limits) for more detail.
+  </Accordion>
+
+  <Accordion title="SHA256 mismatch">
+    If you provide the `sha256` input and the action fails with a message like `SHA256 mismatch: expected X, got Y`, the checksum you supplied does not match the downloaded binary.
+
+    The `sha256` input must exactly match the SHA256 hash of the mise binary for the specific version and platform you are targeting. Get the correct hash from the [mise GitHub releases page](https://github.com/jdx/mise/releases) — each release publishes a checksums file alongside the binaries.
+
+    <Warning>
+      The hash is platform-specific. A hash for `linux-x64` will not match on `macos-arm64`. If you use `sha256` in a matrix workflow, you need a separate hash per platform or you must remove the `sha256` input from cross-platform jobs.
+    </Warning>
+  </Accordion>
+
+  <Accordion title="Tools not found after the action runs">
+    If subsequent steps cannot find tools that mise installed, check the following:
+
+    * **`add_shims_to_path` is true (the default).** If you set it to `false`, the mise shims directory is not added to `PATH`. The mise binary directory is always on `PATH` regardless, but shim-based tool invocation (e.g., calling `node` directly) will not work. Set it back to `true` or call tools via `mise exec --`.
+    * **`install` is true (the default).** If `install: false` is set, mise is configured but `mise install` is not run, so no tools are downloaded.
+    * **`install_args` is scoped correctly.** If you pass `install_args: "node"`, only `node` is installed. Other tools defined in your config file are skipped. Remove `install_args` to install everything, or extend it to include all required tools.
+    * **Check the action's log output.** The action runs `mise ls` after installation. Expand that step in the Actions log to see which tools were installed and whether any failed.
+  </Accordion>
+
+  <Accordion title="Alpine or musl container failing">
+    Alpine Linux does not include `curl` or `bash` by default. The action uses both to download the mise binary. You must install them before the action runs:
+
+    ```yaml theme={null}
+    jobs:
+      test:
+        runs-on: ubuntu-latest
+        container: alpine:latest
+        steps:
+          - name: Install requirements
+            run: apk add --no-cache curl bash
+          - uses: actions/checkout@v4
+          - uses: jdx/mise-action@v4
+    ```
+
+    The action automatically detects musl via `ldd --version` and downloads the correct musl-linked mise binary, so no additional configuration is needed beyond installing the prerequisites.
+  </Accordion>
+
+  <Accordion title="Windows shim issues">
+    Mise shims may not resolve correctly when running steps with `shell: bash` on Windows, which uses a MINGW environment (Git Bash). This is a known limitation of how MINGW resolves executables.
+
+    Use `mise exec --` to run tools directly instead of relying on shims:
+
+    ```yaml theme={null}
+    - run: mise exec -- node --version
+      shell: bash
+    ```
+
+    Steps using PowerShell or cmd on Windows are unaffected — shims work correctly in those shells.
+  </Accordion>
+
+  <Accordion title="Environment variables not propagating">
+    Variables defined in the `[env]` section of your `mise.toml` are exported to `GITHUB_ENV` by the action, making them available to all subsequent steps.
+
+    This behaviour is controlled by the `env` input, which defaults to `true`. If environment variables are missing in later steps, confirm that `env` has not been set to `false` in your workflow.
+
+    ```yaml theme={null}
+    - uses: jdx/mise-action@v4
+      with:
+        env: true  # default — exports [env] vars to GITHUB_ENV
+    ```
+
+    <Note>
+      `PATH` modifications made by mise are handled separately via `core.addPath` and are not part of the `GITHUB_ENV` export. The mise bin directory is always added to `PATH`. The shims directory is added to `PATH` only when `add_shims_to_path` is `true` (the default).
+    </Note>
+  </Accordion>
+
+  <Accordion title="Enabling debug logging">
+    To see detailed output from the action, set `log_level` to `debug`:
+
+    ```yaml theme={null}
+    - uses: jdx/mise-action@v4
+      with:
+        log_level: debug
+    ```
+
+    This sets `MISE_LOG_LEVEL=debug`, which causes mise to emit verbose output for every command it runs.
+
+    You can also enable GitHub Actions' built-in debug mode by setting the `ACTIONS_STEP_DEBUG` secret to `true` in your repository. When GitHub's debug mode is active, the action automatically runs mise commands at debug log level as well.
+  </Accordion>
+</AccordionGroup>
+
+
+# Introduction
+Source: https://www.mintlify.com/jdx/mise-action/introduction
+
+A GitHub Action that installs and configures mise, the polyglot runtime manager, with intelligent caching and cross-platform support.
+
+## What is mise-action?
+
+`mise-action` is a GitHub Action that sets up [mise](https://mise.jdx.dev) in your CI/CD workflows. mise is a polyglot runtime manager that lets you pin and install tools like Node.js, Python, Go, Bun, and hundreds more — all from a single `.mise.toml` or `.tool-versions` file.
+
+With `mise-action`, you get:
+
+* **Zero-config tool installation** — mise reads your existing config files automatically
+* **Smart caching** — tools are cached between runs using GitHub Actions cache
+* **Cross-platform support** — works on Linux (glibc and musl), macOS, and Windows
+* **Environment variable export** — variables from `mise.toml` are exported to your workflow
+* **Version pinning** — pin mise itself to a specific version with optional SHA256 verification
+
+<CardGroup>
+  <Card title="Quickstart" icon="rocket" href="/quickstart">
+    Get mise running in your workflow in under 5 minutes
+  </Card>
+
+  <Card title="All Inputs" icon="sliders" href="/configuration/inputs">
+    Full reference for every action input parameter
+  </Card>
+
+  <Card title="Caching" icon="database" href="/caching/overview">
+    Understand how caching works and how to customize it
+  </Card>
+
+  <Card title="Troubleshooting" icon="wrench" href="/guides/troubleshooting">
+    Solutions to common problems
+  </Card>
+</CardGroup>
+
+## How it works
+
+When `mise-action` runs in your workflow, it:
+
+1. Writes any inline `tool_versions` or `mise_toml` content to config files
+2. Restores mise and installed tools from the GitHub Actions cache (if available)
+3. Downloads the mise binary (if not already cached or installed)
+4. Configures environment variables (`MISE_YES`, `MISE_TRUSTED_CONFIG_PATHS`, `MISE_GITHUB_TOKEN`, etc.)
+5. Runs `mise install` to install all tools defined in your config
+6. Saves the updated cache (if `cache_save` is true and cache was not already hit)
+7. Runs `mise ls` to log installed tools
+8. Exports environment variables from `mise.toml` `[env]` section to `GITHUB_ENV`
+
+## Basic example
+
+```yaml theme={null}
+name: CI
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v4
+      - run: node --version  # uses version from .mise.toml or .tool-versions
+```
+
+This is all you need if you have a `.mise.toml` or `.tool-versions` file in your repository. mise-action reads it automatically and installs the declared tools.
+
+## Supported platforms
+
+| Platform      | Architecture      | Notes                   |
+| ------------- | ----------------- | ----------------------- |
+| Linux (glibc) | x64, arm64, armv7 | Default on most runners |
+| Linux (musl)  | x64, arm64, armv7 | Alpine containers       |
+| macOS         | x64, arm64        | Intel and Apple Silicon |
+| Windows       | x64               | PowerShell compatible   |
+
+
+# Quickstart
+Source: https://www.mintlify.com/jdx/mise-action/quickstart
+
+Get mise running in your GitHub Actions workflow in minutes
+
+Add `jdx/mise-action` to your workflow to install and configure [mise](https://mise.jdx.dev) with caching enabled by default.
+
+<Steps>
+  <Step title="Add a tool config file to your repo">
+    mise reads your pinned tools from a `.mise.toml` or `.tool-versions` file at the root of your repository. Create one before adding the action.
+
+    <Tabs>
+      <Tab title=".mise.toml">
+        ```toml .mise.toml theme={null}
+        [tools]
+        node = "22"
+        bun = "1"
+        ```
+      </Tab>
+
+      <Tab title=".tool-versions">
+        ```text .tool-versions theme={null}
+        node 22.0.0
+        bun 1.0.0
+        ```
+      </Tab>
+    </Tabs>
+
+    <Tip>
+      Both formats are supported. `.mise.toml` also lets you declare environment variables and other mise settings.
+    </Tip>
+  </Step>
+
+  <Step title="Add the action to your workflow">
+    In most cases, a single step is all you need. The action reads your config file automatically, installs the declared tools, and caches everything for future runs.
+
+    ```yaml .github/workflows/ci.yml theme={null}
+    name: CI
+    on: [push, pull_request]
+
+    jobs:
+      test:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v4
+          - uses: jdx/mise-action@v4
+          - run: node --version
+          - run: bun --version
+    ```
+
+    <Note>
+      Caching is enabled by default. Installed tools are restored from the GitHub Actions cache on subsequent runs, making repeat builds significantly faster.
+    </Note>
+  </Step>
+
+  <Step title="(Optional) Pass config inline">
+    If you don't want to commit a config file to your repository, you can write it inline using the `mise_toml` or `tool_versions` input. The action writes the value to the appropriate file before installing tools.
+
+    <Tabs>
+      <Tab title="mise_toml input">
+        ```yaml .github/workflows/ci.yml theme={null}
+        - uses: jdx/mise-action@v4
+          with:
+            mise_toml: |
+              [tools]
+              shellcheck = "0.11.0"
+        ```
+      </Tab>
+
+      <Tab title="tool_versions input">
+        ```yaml .github/workflows/ci.yml theme={null}
+        - uses: jdx/mise-action@v4
+          with:
+            tool_versions: |
+              shellcheck 0.11.0
+        ```
+      </Tab>
+    </Tabs>
+  </Step>
+
+  <Step title="Run your workflow">
+    Push your changes. The action will install mise, restore the cache if available, install your tools, and export environment variables from your `mise.toml` to the rest of the workflow.
+
+    On the first run the cache is cold and tools are downloaded. Subsequent runs restore from cache and complete much faster.
+  </Step>
+</Steps>
+
+## Complete example: lint and test
+
+This is a realistic two-job workflow using `jdx/mise-action@v4`. It mirrors the pattern used in the action's own test suite.
+
+```yaml .github/workflows/ci.yml theme={null}
+name: CI
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v4
+        with:
+          mise_toml: |
+            [tools]
+            shellcheck = "0.11.0"
+      - run: shellcheck scripts/*.sh
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jdx/mise-action@v4
+      # Tools are read from .mise.toml or .tool-versions in the repo root
+      - run: node ./my_app.js
+```
+
+## Common inputs
+
+The most frequently used inputs are shown below. For the complete list, see [All inputs](/configuration/inputs).
+
+<CodeGroup>
+  ```yaml Pin a specific mise version theme={null}
+  - uses: jdx/mise-action@v4
+    with:
+      version: 2026.3.10
+  ```
+
+  ```yaml Install only specific tools theme={null}
+  - uses: jdx/mise-action@v4
+    with:
+      install_args: "bun"
+  ```
+
+  ```yaml Disable caching theme={null}
+  - uses: jdx/mise-action@v4
+    with:
+      cache: false
+  ```
+
+  ```yaml Custom cache key prefix theme={null}
+  - uses: jdx/mise-action@v4
+    with:
+      cache_key_prefix: "mise-v2"
+  ```
+</CodeGroup>
+
+<Note>
+  The action automatically passes `${{ github.token }}` to mise as `MISE_GITHUB_TOKEN` to avoid GitHub API rate limits when installing tools hosted on GitHub. You don't need to configure this explicitly unless you need a different token.
+</Note>
+
+## Next steps
+
+<CardGroup>
+  <Card title="All inputs" icon="sliders" href="/configuration/inputs">
+    Full reference for every input parameter, including version pinning, SHA256 verification, and reshim.
+  </Card>
+
+  <Card title="Caching" icon="database" href="/caching/overview">
+    Understand how the cache key is built and how to customize or invalidate it.
+  </Card>
+
+  <Card title="Cache key templates" icon="key" href="/caching/cache-key-templates">
+    Use Handlebars template variables to construct a fully custom cache key.
+  </Card>
+
+  <Card title="GitHub rate limits" icon="github" href="/guides/github-rate-limits">
+    Avoid installation failures caused by unauthenticated GitHub API requests.
+  </Card>
+</CardGroup>
+
+

--- a/docs/research/mintlify-cache/jdx/mise-action/llms.txt
+++ b/docs/research/mintlify-cache/jdx/mise-action/llms.txt
@@ -1,0 +1,22 @@
+# mise-action
+
+## Docs
+
+- [Cache key templates](https://www.mintlify.com/jdx/mise-action/caching/cache-key-templates.md): Customize the cache key using template variables and conditional logic.
+- [Caching overview](https://www.mintlify.com/jdx/mise-action/caching/overview.md): How mise-action caches the mise binary and installed tools to speed up your workflows.
+- [Inputs](https://www.mintlify.com/jdx/mise-action/configuration/inputs.md): All available inputs for the jdx/mise-action GitHub Action.
+- [Outputs](https://www.mintlify.com/jdx/mise-action/configuration/outputs.md): Outputs produced by the jdx/mise-action GitHub Action.
+- [Tool versions](https://www.mintlify.com/jdx/mise-action/configuration/tool-versions.md): Configure which tools mise installs using .tool-versions or mise.toml.
+- [GitHub API rate limits](https://www.mintlify.com/jdx/mise-action/guides/github-rate-limits.md): Understand why the action uses MISE_GITHUB_TOKEN and how to avoid hitting rate limits when installing GitHub-hosted tools.
+- [Monorepos](https://www.mintlify.com/jdx/mise-action/guides/monorepos.md): Configure mise-action for monorepos where each subdirectory has its own tool configuration.
+- [Platform support](https://www.mintlify.com/jdx/mise-action/guides/platforms.md): Run mise-action on Linux, macOS, and Windows runners, including Alpine containers.
+- [Troubleshooting](https://www.mintlify.com/jdx/mise-action/guides/troubleshooting.md): Solutions for common issues with mise-action, including cache misses, rate limits, checksum failures, and platform-specific problems.
+- [Introduction](https://www.mintlify.com/jdx/mise-action/introduction.md): A GitHub Action that installs and configures mise, the polyglot runtime manager, with intelligent caching and cross-platform support.
+- [Quickstart](https://www.mintlify.com/jdx/mise-action/quickstart.md): Get mise running in your GitHub Actions workflow in minutes
+
+## OpenAPI Specs
+
+- [openapi](https://www.mintlify.com/jdx/mise-action/api-reference/openapi.json)
+
+
+Built with [Mintlify](https://mintlify.com).

--- a/docs/research/mintlify-cache/jdx/mise-env-fnox/llms-full.txt
+++ b/docs/research/mintlify-cache/jdx/mise-env-fnox/llms-full.txt
@@ -1,0 +1,350 @@
+# Environment-specific configuration
+Source: https://www.mintlify.com/jdx/mise-env-fnox/configuration/environments
+
+Use mise environment blocks to load different fnox profiles in development, staging, and production.
+
+mise supports environment-specific config blocks via `[env.<name>]` sections in `mise.toml`. You can combine this with the fnox-env plugin to load a different fnox profile for each environment.
+
+## Example
+
+The following configuration loads the `dev` profile by default and switches to `production` or `staging` when the corresponding mise environment is active:
+
+```toml mise.toml theme={null}
+[plugins]
+fnox-env = "https://github.com/jdx/mise-env-fnox"
+
+[env]
+_.fnox-env = { tools = true, profile = "dev" }
+
+[env.production]
+_.fnox-env = { tools = true, profile = "production" }
+
+[env.staging]
+_.fnox-env = { tools = true, profile = "staging" }
+```
+
+## Activating an environment
+
+Set the `MISE_ENV` variable to select which environment block mise uses:
+
+```bash theme={null}
+# Development (default)
+mise env
+
+# Production
+MISE_ENV=production mise env
+
+# Staging
+MISE_ENV=staging mise env
+```
+
+<Tip>
+  Keep your fnox profile names consistent with your mise environment names. For example, if your mise environment is `staging`, name the corresponding fnox profile `staging` in `fnox.toml`. This makes the mapping obvious and reduces configuration errors.
+</Tip>
+
+
+# Configuration options
+Source: https://www.mintlify.com/jdx/mise-env-fnox/configuration/options
+
+Reference for all options available when configuring the mise-env-fnox plugin.
+
+All options are set inline in the `[env]` section of your `mise.toml` file, directly on the `_.fnox-env` directive. There is no separate configuration block.
+
+## Options
+
+<ParamField type="boolean">
+  Use mise-managed tool paths when invoking fnox. Set this to `true` if fnox is installed via mise; otherwise mise will not resolve the binary from its toolchain.
+</ParamField>
+
+<ParamField type="string">
+  The fnox profile to load secrets from. If not set, the `--profile` flag is omitted and fnox uses its own default profile.
+</ParamField>
+
+<ParamField type="string">
+  Path to the fnox binary. Useful when fnox is not on your `PATH` or you need to point to a specific installation.
+</ParamField>
+
+## Full example
+
+```toml mise.toml theme={null}
+[plugins]
+fnox-env = "https://github.com/jdx/mise-env-fnox"
+
+[env]
+_.fnox-env = { tools = true, profile = "production", fnox_bin = "/usr/local/bin/fnox" }
+```
+
+<Note>
+  Options are passed inline with the env directive, not in a separate config block. Any option you omit falls back to its default value.
+</Note>
+
+
+# Caching
+Source: https://www.mintlify.com/jdx/mise-env-fnox/guides/caching
+
+How mise-env-fnox uses mise's environment caching to avoid re-fetching secrets on every shell activation.
+
+The plugin returns `cacheable: true` on every response, which allows mise to cache your secrets to disk and skip calling `fnox export` on subsequent shell activations. This can significantly reduce startup time, especially when your secrets provider is slow or rate-limited.
+
+## Enabling caching
+
+Caching is opt-in. Set the `MISE_ENV_CACHE` environment variable before mise activates your environment:
+
+```bash theme={null}
+export MISE_ENV_CACHE=1
+```
+
+Add this to your shell's startup file (e.g. `~/.bashrc`, `~/.zshrc`) to enable it permanently.
+
+## What caching does
+
+When caching is active:
+
+* **Secrets are cached encrypted on disk.** mise stores the resolved environment variables locally so `fnox export` is not called on every new shell.
+* **Cache is automatically invalidated when `fnox.toml` changes.** The plugin registers your `fnox.toml` path as a watch file. mise detects modifications to that file and discards the cache, triggering a fresh fetch on the next activation.
+* **Cache is scoped to your shell session for security.** Cached secrets are not shared across unrelated sessions.
+
+## When the cache is not used
+
+If no `fnox.toml` is found in the current directory or any parent directory, the plugin returns an empty result immediately — there is nothing to cache, and `fnox export` is never called.
+
+## Tradeoff: upstream secret changes
+
+Cache invalidation is based on `fnox.toml` file changes, not on changes made to secrets in your upstream provider. If you rotate a secret or update a value directly in your secrets provider without modifying `fnox.toml`, the cached value will remain until you either:
+
+* Touch or edit `fnox.toml` to trigger invalidation, or
+* Disable caching (`unset MISE_ENV_CACHE`) and re-activate your environment.
+
+<Warning>
+  If you rotate a secret upstream, the old cached value will continue to be used until the cache is invalidated. Make sure to touch your `fnox.toml` or clear the cache after rotating credentials.
+</Warning>
+
+<Tip>
+  Caching is most useful in CI environments where shell activation happens frequently across many steps, and in projects that use slow secrets providers (such as cloud KMS or remote vaults). For local development with a fast provider, the performance difference is minimal.
+</Tip>
+
+
+# How it works
+Source: https://www.mintlify.com/jdx/mise-env-fnox/guides/how-it-works
+
+A step-by-step walkthrough of the secret resolution lifecycle when mise activates your project with mise-env-fnox.
+
+When mise activates your project, it calls the plugin's `MiseEnv` hook. The hook discovers your fnox configuration, fetches secrets from your configured providers, and exports them as environment variables in your shell — all before your prompt appears.
+
+<Steps>
+  <Step title="mise calls the MiseEnv hook">
+    mise invokes `PLUGIN:MiseEnv(ctx)` in the plugin. The hook receives the options you set in `mise.toml` (such as `profile` and `fnox_bin`) via the `ctx.options` table.
+  </Step>
+
+  <Step title="Plugin runs `fnox config-files` to locate fnox.toml">
+    The plugin executes `fnox config-files` to discover the path(s) to your `fnox.toml` file, searching the current directory and parent directories.
+
+    ```lua theme={null}
+    local function get_config_files(fnox_bin)
+        local ok, output = pcall(function()
+            return cmd.exec(fnox_bin .. " config-files")
+        end)
+        ...
+    end
+    ```
+  </Step>
+
+  <Step title="If no config files are found, the plugin exits silently">
+    If `fnox config-files` returns no paths, the plugin returns an empty result with no environment variables and no error. Your shell environment is unchanged.
+
+    ```lua theme={null}
+    if #config_files == 0 then
+        return {cacheable = true, watch_files = {}, env = {}}
+    end
+    ```
+  </Step>
+
+  <Step title="Plugin runs `fnox export --format json`">
+    The plugin constructs and runs the export command. If a `profile` option is configured, it appends the `--profile` flag.
+
+    ```lua theme={null}
+    local command = fnox_bin .. " export --format json"
+    if profile then
+        command = command .. " --profile " .. profile
+    end
+    ```
+  </Step>
+
+  <Step title="Plugin parses the JSON response">
+    The JSON output from `fnox export` is decoded and the `secrets` map is extracted. Each key-value pair in `secrets` becomes an environment variable.
+
+    ```lua theme={null}
+    local decode_ok, data = pcall(json.decode, output)
+    ...
+    local secrets = data.secrets or {}
+
+    local env_vars = {}
+    for key, value in pairs(secrets) do
+        table.insert(env_vars, {key = key, value = value})
+    end
+    ```
+
+    The expected JSON structure from `fnox export --format json` looks like:
+
+    ```json theme={null}
+    {
+      "secrets": {
+        "DATABASE_URL": "postgres://...",
+        "API_KEY": "sk-..."
+      }
+    }
+    ```
+  </Step>
+
+  <Step title="Secrets are exported as environment variables">
+    The plugin returns the collected environment variables to mise, which sets them in your shell session before your prompt appears. No manual `export` or `.env` sourcing is required.
+  </Step>
+
+  <Step title="fnox.toml is registered as a watch file">
+    The plugin returns `watch_files` containing the path(s) to your `fnox.toml`. mise monitors these files and invalidates the environment cache whenever they change, ensuring stale secrets are never served.
+  </Step>
+</Steps>
+
+## Secret redaction
+
+The plugin returns `redact: true`, which tells mise to hide secret values in its output. You will see the variable names in `mise env` output but not their values.
+
+## Error handling
+
+If `fnox config-files` or `fnox export` fails, the plugin prints a warning prefixed with `[fnox]` but does not abort the environment load. mise continues activating your environment, and the affected secrets are simply omitted.
+
+```lua theme={null}
+if not ok then
+    print("[fnox] warning: `" .. command .. "` failed: " .. tostring(output))
+    return {cacheable = true, watch_files = config_files, env = {}}
+end
+```
+
+<Note>
+  Warnings are printed to stdout during environment activation. If secrets are missing unexpectedly, check your terminal output for `[fnox] warning:` messages.
+</Note>
+
+
+# Installation
+Source: https://www.mintlify.com/jdx/mise-env-fnox/installation
+
+Add the mise-env-fnox plugin to your project's mise.toml to start loading fnox secrets as environment variables.
+
+mise-env-fnox is installed by declaring it as a plugin in your project's `mise.toml`. mise downloads and manages the plugin automatically.
+
+<Steps>
+  <Step title="Declare the plugin in mise.toml">
+    Add the plugin under `[plugins]` and activate it under `[env]`:
+
+    ```toml mise.toml theme={null}
+    [plugins]
+    fnox-env = "https://github.com/jdx/mise-env-fnox"
+
+    [env]
+    _.fnox-env = { tools = true }
+    ```
+
+    <Note>
+      `tools = true` is required when fnox is installed via mise. It tells the plugin to run fnox using mise-managed tool paths rather than relying on whatever is in your system `PATH`.
+    </Note>
+  </Step>
+
+  <Step title="Ensure fnox.toml exists">
+    The plugin searches for `fnox.toml` starting from the current directory and walking up to parent directories. If no config file is found, the plugin returns an empty environment and exits silently.
+
+    Make sure your project has a `fnox.toml` configured with at least one secret before proceeding.
+  </Step>
+
+  <Step title="Activate your environment">
+    Run any mise command. mise calls the plugin automatically and exports your secrets as environment variables:
+
+    ```bash theme={null}
+    mise env
+    ```
+
+    You do not need to run the plugin manually. mise handles invocation every time it activates your project environment.
+  </Step>
+</Steps>
+
+## Examples
+
+### Default profile
+
+Use the default fnox profile:
+
+```toml mise.toml theme={null}
+[plugins]
+fnox-env = "https://github.com/jdx/mise-env-fnox"
+
+[env]
+_.fnox-env = { tools = true }
+```
+
+### Custom profile
+
+Load secrets from a specific fnox profile by setting the `profile` option:
+
+```toml mise.toml theme={null}
+[plugins]
+fnox-env = "https://github.com/jdx/mise-env-fnox"
+
+[env]
+_.fnox-env = { tools = true, profile = "production" }
+```
+
+<Tip>
+  You can use mise's built-in environment system to switch profiles automatically. See [Configuration options](/configuration/options) for the full list of available options, and [Environment-specific profiles](/configuration/environments) to set different profiles for dev, staging, and production.
+</Tip>
+
+
+# Introduction
+Source: https://www.mintlify.com/jdx/mise-env-fnox/introduction
+
+mise-env-fnox is a mise env plugin that loads fnox secrets as environment variables into your development environment.
+
+mise-env-fnox is a [mise](https://mise.jdx.dev) env plugin that connects to [fnox](https://github.com/jdx/fnox) and automatically exports your secrets as environment variables whenever mise activates your project environment.
+
+<Warning>
+  The author of this plugin is uncertain whether it's a good idea. fnox was built as a separate CLI for a reason. Evaluate whether this integration fits your workflow before adopting it in production.
+</Warning>
+
+## What is mise?
+
+[mise](https://mise.jdx.dev) is a dev tools manager. It manages language runtimes, CLI tools, and environment variables on a per-project basis. When you enter a project directory, mise activates the environment defined in your `mise.toml`.
+
+## What is fnox?
+
+[fnox](https://github.com/jdx/fnox) is a secrets manager. It resolves secrets from configured providers and exposes them through a CLI. Projects configure fnox through a `fnox.toml` file.
+
+## What mise-env-fnox does
+
+When mise activates your environment, this plugin runs `fnox export` and injects the resulting secrets as environment variables into your shell. You don't write `export` commands and you don't store secrets in plaintext `.env` files.
+
+The plugin:
+
+* Searches for `fnox.toml` in the current directory and parent directories
+* Runs `fnox export --format json` (with an optional `--profile` flag)
+* Exports each secret as an environment variable
+* Watches `fnox.toml` for changes to invalidate the cache
+* Redacts secret values from mise output
+
+## Prerequisites
+
+Before installing the plugin, you need:
+
+* **mise** installed and configured, version **0.3.0 or later** (the plugin's minimum required runtime version). See the [mise docs](https://mise.jdx.dev) to get started.
+* **fnox** installed and configured with a `fnox.toml` in your project directory (or a parent directory). If fnox is installed via mise, set `tools = true` in the plugin config.
+
+## Next steps
+
+<CardGroup>
+  <Card title="Installation" icon="download" href="/installation">
+    Add the plugin to your mise.toml and start loading secrets.
+  </Card>
+
+  <Card title="Configuration options" icon="sliders" href="/configuration/options">
+    Customize the fnox binary path, profile, and tool resolution.
+  </Card>
+</CardGroup>
+
+

--- a/docs/research/mintlify-cache/jdx/mise-env-fnox/llms.txt
+++ b/docs/research/mintlify-cache/jdx/mise-env-fnox/llms.txt
@@ -1,0 +1,17 @@
+# mise-env-fnox
+
+## Docs
+
+- [Environment-specific configuration](https://www.mintlify.com/jdx/mise-env-fnox/configuration/environments.md): Use mise environment blocks to load different fnox profiles in development, staging, and production.
+- [Configuration options](https://www.mintlify.com/jdx/mise-env-fnox/configuration/options.md): Reference for all options available when configuring the mise-env-fnox plugin.
+- [Caching](https://www.mintlify.com/jdx/mise-env-fnox/guides/caching.md): How mise-env-fnox uses mise's environment caching to avoid re-fetching secrets on every shell activation.
+- [How it works](https://www.mintlify.com/jdx/mise-env-fnox/guides/how-it-works.md): A step-by-step walkthrough of the secret resolution lifecycle when mise activates your project with mise-env-fnox.
+- [Installation](https://www.mintlify.com/jdx/mise-env-fnox/installation.md): Add the mise-env-fnox plugin to your project's mise.toml to start loading fnox secrets as environment variables.
+- [Introduction](https://www.mintlify.com/jdx/mise-env-fnox/introduction.md): mise-env-fnox is a mise env plugin that loads fnox secrets as environment variables into your development environment.
+
+## OpenAPI Specs
+
+- [openapi](https://www.mintlify.com/jdx/mise-env-fnox/api-reference/openapi.json)
+
+
+Built with [Mintlify](https://mintlify.com).

--- a/docs/research/mintlify-cache/jdx/mise/llms-full.txt
+++ b/docs/research/mintlify-cache/jdx/mise/llms-full.txt
@@ -1,0 +1,5436 @@
+# mise activate
+Source: https://www.mintlify.com/jdx/mise/cli/activate
+
+Initialize mise in your current shell session by adding it to your shell's rc file.
+
+## Synopsis
+
+```sh theme={null}
+mise activate [FLAGS] [SHELL_TYPE]
+```
+
+Initializes mise in the current shell session.
+
+Add this to your shell's rc file (e.g., `~/.zshrc`, `~/.bashrc`, `~/.config/fish/config.fish`, or `$PROFILE` for PowerShell) so it takes effect for every new session. Without this, activation only applies to the current session.
+
+Mise works by updating your `PATH` and environment variables each time your prompt runs. Use [`--shims`](#--shims) instead for non-interactive setups like CI/CD or IDEs.
+
+<Note>
+  Customize the status output shown when changing directories using `status` settings.
+</Note>
+
+## Shell type
+
+The shell to generate the activation script for. If omitted, mise will attempt to detect your shell automatically.
+
+| Value    | Shell      |
+| -------- | ---------- |
+| `bash`   | Bash       |
+| `zsh`    | Zsh        |
+| `fish`   | Fish       |
+| `nu`     | Nushell    |
+| `xonsh`  | Xonsh      |
+| `elvish` | Elvish     |
+| `pwsh`   | PowerShell |
+
+## Flags
+
+| Flag            | Description                                                                                                                                                                                                     |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-q, --quiet`   | Suppress non-error messages.                                                                                                                                                                                    |
+| `--no-hook-env` | Do not automatically call `hook-env`. Useful for debugging — run `eval "$(mise activate --no-hook-env)"` then call `mise hook-env` manually to inspect output without modifying your environment.               |
+| `--shims`       | Use shims instead of modifying `PATH`. Equivalent to prepending `$HOME/.local/share/mise/shims` to `PATH`. Does not support all features of `mise activate`. See [shims vs PATH](/dev-tools/shims) for details. |
+
+## Examples
+
+<Tabs>
+  <Tab title="bash">
+    ```sh theme={null}
+    eval "$(mise activate bash)"
+    ```
+  </Tab>
+
+  <Tab title="zsh">
+    ```sh theme={null}
+    eval "$(mise activate zsh)"
+    ```
+  </Tab>
+
+  <Tab title="fish">
+    ```sh theme={null}
+    mise activate fish | source
+    ```
+  </Tab>
+
+  <Tab title="xonsh">
+    ```sh theme={null}
+    execx($(mise activate xonsh))
+    ```
+  </Tab>
+
+  <Tab title="PowerShell">
+    ```powershell theme={null}
+    (&mise activate pwsh) | Out-String | Invoke-Expression
+    ```
+  </Tab>
+</Tabs>
+
+### Adding to your rc file
+
+If `mise` is already on your `PATH`:
+
+```sh theme={null}
+echo 'eval "$(mise activate zsh)"' >> ~/.zshrc
+```
+
+If `mise` is not yet on your `PATH`, specify the full path:
+
+```sh theme={null}
+echo 'eval "$(/path/to/mise activate zsh)"' >> ~/.zshrc
+```
+
+
+# mise config
+Source: https://www.mintlify.com/jdx/mise/cli/config
+
+Manage mise.toml config files — list, get, and set configuration values.
+
+## Synopsis
+
+```sh theme={null}
+mise config [FLAGS] <SUBCOMMAND>
+```
+
+**Aliases:** `cfg`
+
+Manages mise config files. Without a subcommand, runs `mise config ls`.
+
+## Flags
+
+| Flag                | Description                        |
+| ------------------- | ---------------------------------- |
+| `-J, --json`        | Output in JSON format.             |
+| `--no-header`       | Do not print the table header row. |
+| `--tracked-configs` | List all tracked config files.     |
+
+## Subcommands
+
+### `mise config ls`
+
+```sh theme={null}
+mise config ls [FLAGS]
+```
+
+Lists config files currently in use, along with the tools each one defines.
+
+| Flag                | Description                        |
+| ------------------- | ---------------------------------- |
+| `-J, --json`        | Output in JSON format.             |
+| `--no-header`       | Do not print the table header row. |
+| `--tracked-configs` | List all tracked config files.     |
+
+```sh theme={null}
+$ mise config ls
+Path                        Tools
+~/.config/mise/config.toml  pitchfork
+~/src/mise/mise.toml        actionlint, bun, cargo-binstall, cargo:cargo-edit, cargo:cargo-insta
+```
+
+### `mise config get`
+
+```sh theme={null}
+mise config get [-f --file <FILE>] [KEY]
+```
+
+Displays the value of a key in a `mise.toml` file. Uses dotted key notation to access nested values.
+
+| Flag                | Description                                                                |
+| ------------------- | -------------------------------------------------------------------------- |
+| `-f, --file <FILE>` | Path to the `mise.toml` file to read. Defaults to the nearest `mise.toml`. |
+
+```sh theme={null}
+$ mise config get tools.python
+3.12
+```
+
+### `mise config set`
+
+```sh theme={null}
+mise config set [-f --file <FILE>] [-t --type <TYPE>] <KEY> [VALUE]
+```
+
+Sets the value of a key in a `mise.toml` file. Accepts `KEY=VALUE` syntax or separate `KEY VALUE` arguments.
+
+| Flag                | Description                                                                                   |
+| ------------------- | --------------------------------------------------------------------------------------------- |
+| `-f, --file <FILE>` | Path to the `mise.toml` file to edit. Defaults to the nearest `mise.toml`.                    |
+| `-t, --type <TYPE>` | Force the value type: `infer` (default), `string`, `integer`, `float`, `bool`, `list`, `set`. |
+
+```sh theme={null}
+$ mise config set tools.python 3.12
+$ mise config set settings.always_keep_download true
+$ mise config set env.TEST_ENV_VAR ABC
+$ mise config set settings.disable_tools --type list node,rust
+
+# Type for settings keys is inferred automatically
+$ mise config set settings.jobs 4
+```
+
+## Examples
+
+```sh theme={null}
+$ mise config ls
+Path                        Tools
+~/.config/mise/config.toml  pitchfork
+~/src/mise/mise.toml        actionlint, bun, cargo-binstall, cargo:cargo-edit, cargo:cargo-insta
+```
+
+
+# mise doctor
+Source: https://www.mintlify.com/jdx/mise/cli/doctor
+
+Check your mise installation for configuration problems and display diagnostic information.
+
+**Usage:** `mise doctor [-J --json]`
+
+**Alias:** `dr`
+
+Run diagnostic checks on your mise installation. Identifies common issues like missing plugins, `PATH` problems, shell configuration errors, and outdated versions.
+
+Always run `mise doctor` first when troubleshooting.
+
+## Flags
+
+| Flag         | Description                       |
+| ------------ | --------------------------------- |
+| `-J, --json` | Output diagnostics in JSON format |
+
+## Subcommands
+
+### `mise doctor path`
+
+```bash theme={null}
+mise doctor path [-f --full]
+```
+
+Display the current `PATH` as seen by mise, one entry per line. Use `--full` to show additional path details.
+
+```bash theme={null}
+mise doctor path
+mise doctor path --full
+```
+
+## Examples
+
+```bash theme={null}
+# Run all checks
+mise doctor
+
+# JSON output for scripting
+mise doctor --json
+
+# Check PATH configuration
+mise doctor path
+```
+
+## Example output
+
+```
+mise doctor
+[OK] mise version: 2026.4.5
+[OK] shell: zsh
+[OK] mise shims dir: /home/user/.local/share/mise/shims
+[WARN] plugin node is not installed
+[OK] config files loaded: /home/user/project/mise.toml
+```
+
+<Tip>
+  When filing a bug report, always include the output of `mise doctor`. It provides essential information about your environment.
+</Tip>
+
+
+# mise env
+Source: https://www.mintlify.com/jdx/mise/cli/env
+
+Export mise environment variables for use in a single shell session or script.
+
+**Usage:** `mise env [FLAGS] [TOOL@VERSION]…`
+
+**Alias:** `e`
+
+Export environment variables that mise would set, without permanently activating mise. Useful for scripts, one-off sessions, or environments where `mise activate` isn't available.
+
+## Arguments
+
+| Argument          | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `[TOOL@VERSION]…` | Additional tools to include, e.g. `node@22` |
+
+## Flags
+
+| Flag                  | Description                                                                  |
+| --------------------- | ---------------------------------------------------------------------------- |
+| `-D, --dotenv`        | Output in `.env` file format                                                 |
+| `-J, --json`          | Output in JSON format                                                        |
+| `--json-extended`     | JSON format with additional metadata (source, tool)                          |
+| `-s, --shell <SHELL>` | Shell syntax to use (`bash`, `zsh`, `fish`, `nu`, `xonsh`, `elvish`, `pwsh`) |
+| `--redacted`          | Only show redacted environment variables                                     |
+| `--values`            | Only show variable values (no export statements)                             |
+
+## Examples
+
+```bash theme={null}
+# Activate mise for one shell session
+eval "$(mise env -s bash)"
+eval "$(mise env -s zsh)"
+mise env -s fish | source
+execx($(mise env -s xonsh))
+
+# Get env vars in JSON format
+mise env --json
+
+# Get env vars in dotenv format for use with other tools
+mise env --dotenv > .env.local
+
+# Include an extra tool
+mise env node@22 --json
+```
+
+## Use in scripts
+
+For scripts that need mise tools without activating mise:
+
+```bash theme={null}
+#!/usr/bin/env bash
+eval "$(mise env -s bash)"
+node ./app.js
+```
+
+<Tip>
+  If you only need to run a single command, `mise exec` is simpler than `mise env`. Use `mise env` when you need the environment variables exported for a whole script or session.
+</Tip>
+
+
+# mise exec
+Source: https://www.mintlify.com/jdx/mise/cli/exec
+
+Execute a command with mise-managed tools active, without modifying the current shell session.
+
+**Usage:** `mise exec [FLAGS] [TOOL@VERSION]… [-- COMMAND]…`
+
+**Alias:** `x`
+
+Execute a command with specified tool versions active. Use this to run one-off commands without permanently activating tools in your shell or modifying `mise.toml`.
+
+Tools from `mise.toml` are loaded automatically, but you can override specific tools with the `TOOL@VERSION` arguments.
+
+## Arguments
+
+| Argument          | Description                                   |
+| ----------------- | --------------------------------------------- |
+| `[TOOL@VERSION]…` | Tools to activate, e.g. `node@22 python@3.12` |
+| `[-- COMMAND]…`   | Command to run                                |
+
+## Flags
+
+| Flag                | Description                                                        |
+| ------------------- | ------------------------------------------------------------------ |
+| `-c, --command <C>` | Command string to execute (alternative to `-- COMMAND`)            |
+| `-j, --jobs <JOBS>` | Number of jobs to run in parallel (default: 4)                     |
+| `--raw`             | Pipe stdin/stdout/stderr directly to tool process; sets `--jobs=1` |
+| `--fresh-env`       | Bypass environment cache and recompute                             |
+| `--no-prepare`      | Skip automatic dependency preparation                              |
+
+### Sandboxing (experimental)
+
+| Flag                    | Description                                                                       |
+| ----------------------- | --------------------------------------------------------------------------------- |
+| `--deny-all`            | Block reads, writes, network, and env vars                                        |
+| `--deny-env`            | Block env var inheritance (only PATH, HOME, USER, SHELL, TERM, LANG pass through) |
+| `--deny-net`            | Block all network access                                                          |
+| `--deny-read`           | Block filesystem reads (system libs and tool dirs still accessible)               |
+| `--deny-write`          | Block all filesystem writes                                                       |
+| `--allow-env… <VAR>`    | Allow specific env var (implies `--deny-env` for everything else)                 |
+| `--allow-net… <HOST>`   | Allow network to specific host (implies `--deny-net` for everything else)         |
+| `--allow-read… <PATH>`  | Allow reads from specific path (implies `--deny-read` for everything else)        |
+| `--allow-write… <PATH>` | Allow writes to specific path (implies `--deny-write` for everything else)        |
+
+## Examples
+
+```bash theme={null}
+# Run a script with node@22
+mise exec node@22 -- node ./app.js
+
+# Shorter alias
+mise x node@22 -- node ./app.js
+
+# Multiple tools
+mise exec node@22 python@3.12 -- node ./app.js
+
+# Command as string
+mise exec node@22 python@3.12 --command "node -v && python -V"
+
+# Run in a different directory
+mise x -C /path/to/project node@22 -- node ./app.js
+```
+
+<Tip>
+  If you have `mise activate` in your shell's rc file, tools are already active for interactive use. Use `mise exec` for scripts, CI, or one-off commands where you want explicit tool versions without changing the shell environment.
+</Tip>
+
+
+# mise install
+Source: https://www.mintlify.com/jdx/mise/cli/install
+
+Install tool versions without modifying any config file.
+
+## Synopsis
+
+```sh theme={null}
+mise install [FLAGS] [TOOL@VERSION]…
+```
+
+**Alias:** `mise i`
+
+## Description
+
+`mise install` downloads and installs one or more tool versions to `~/.local/share/mise/installs/<PLUGIN>/<VERSION>`.
+
+Installing a tool does **not** activate it — it will not appear on `PATH` until it is referenced in a config file or used via [`mise exec`](/cli/exec). To install and activate in one step, use [`mise use`](/cli/use) instead.
+
+By default, tools are installed in parallel. Pass `--jobs=1` or set `MISE_JOBS=1` to disable parallel installation.
+
+<Tip>
+  Run `mise install` with no arguments to install all tools specified across your config files.
+</Tip>
+
+## Arguments
+
+<ParamField type="string">
+  One or more tools to install, for example `node@20.0.0` or `node@20`. If no version is provided, mise installs the version specified in the nearest config file.
+</ParamField>
+
+## Flags
+
+<ParamField type="boolean">
+  Force reinstall even if the tool version is already installed. Requires a tool argument.
+</ParamField>
+
+<ParamField type="number">
+  Number of installation jobs to run in parallel. Also configurable via `MISE_JOBS`.
+</ParamField>
+
+<ParamField type="boolean">
+  Show what would be installed without actually installing anything.
+</ParamField>
+
+<ParamField type="boolean">
+  Print plugin output including download, configuration, and compilation details. Can be specified multiple times for more output.
+</ParamField>
+
+<ParamField type="string">
+  Only install versions released before this date. Accepts absolute dates like `2024-06-01` or relative durations like `90d` or `1y`.
+</ParamField>
+
+<ParamField type="boolean">
+  Like `--dry-run`, but exits with code `1` if there are tools to install. Useful in scripts to check whether installation is needed.
+</ParamField>
+
+<ParamField type="boolean">
+  Pipe stdin/stdout/stderr directly from the plugin to the terminal. Sets `--jobs=1`.
+</ParamField>
+
+<ParamField type="string">
+  **Experimental.** Install tools to a shared directory at the specified path instead of the default install location. May require elevated permissions.
+</ParamField>
+
+<ParamField type="boolean">
+  **Experimental.** Install tools to the system-wide shared directory (`/usr/local/share/mise/installs`, or the path set by `MISE_SYSTEM_DATA_DIR`). May require elevated permissions (e.g. `sudo`).
+</ParamField>
+
+## Examples
+
+```sh theme={null}
+mise install node@20.0.0  # Install a specific node version
+mise install node@20      # Install the latest node 20.x release
+mise install node         # Install the version from mise.toml
+mise install              # Install all tools listed in config files
+```
+
+
+# mise ls
+Source: https://www.mintlify.com/jdx/mise/cli/ls
+
+List installed and active tool versions managed by mise.
+
+**Usage:** `mise ls [FLAGS] [TOOL]…`
+
+**Alias:** `list`
+
+List tools that mise knows about — installed versions, active versions from config files, and missing versions.
+
+## Arguments
+
+| Argument  | Description                     |
+| --------- | ------------------------------- |
+| `[TOOL]…` | Filter output to specific tools |
+
+## Flags
+
+| Flag                | Description                                                         |
+| ------------------- | ------------------------------------------------------------------- |
+| `-c, --current`     | Only show versions currently specified in a `mise.toml`             |
+| `-g, --global`      | Only show versions from the global `mise.toml`                      |
+| `-i, --installed`   | Only show installed versions (hide tools defined but not installed) |
+| `-l, --local`       | Only show versions from the local `mise.toml`                       |
+| `-m, --missing`     | Show tools that are defined but not installed                       |
+| `-J, --json`        | Output in JSON format                                               |
+| `--outdated`        | Show whether each version is outdated                               |
+| `--all-sources`     | Show all config sources for each tool                               |
+| `--no-header`       | Suppress table header                                               |
+| `--prefix <PREFIX>` | Filter to versions starting with this prefix                        |
+
+## Examples
+
+```bash theme={null}
+# List all known tools
+mise ls
+
+# List only currently active tools
+mise ls --current
+
+# List only installed tools
+mise ls --installed
+
+# Find tools that need installation
+mise ls --missing
+
+# List a specific tool
+mise ls node
+
+# Check for outdated versions
+mise ls --outdated
+
+# JSON output for scripting
+mise ls --json
+```
+
+## Output format
+
+```
+Tool    Version    Config Source        Requested  Missing
+node    22.3.0     ~/project/mise.toml  22         false
+python  3.12.0     ~/project/mise.toml  3.12       false
+go      missing    ~/project/mise.toml  1.22       true
+```
+
+Tools with `Missing = true` need to be installed with `mise install`.
+
+
+# mise plugins
+Source: https://www.mintlify.com/jdx/mise/cli/plugins
+
+Manage mise plugins for extending tool support.
+
+**Usage:** `mise plugins [FLAGS] <SUBCOMMAND>`
+
+**Alias:** `p`
+
+Manage plugins that extend mise with support for additional tools.
+
+<Note>
+  For most tools, plugins are no longer needed — use the [aqua](/dev-tools/backends) or [github](/dev-tools/backends) backends instead. See [Plugins guide](/guides/plugins) for when to use plugins.
+</Note>
+
+## Flags
+
+| Flag         | Description                                     |
+| ------------ | ----------------------------------------------- |
+| `-c, --core` | Include built-in core plugins (normally hidden) |
+| `-u, --urls` | Show the git URL for each plugin                |
+| `--user`     | List user-installed plugins (default behavior)  |
+
+## Subcommands
+
+### `mise plugins install`
+
+```bash theme={null}
+mise plugins install <NAME> [GIT_URL]
+```
+
+Install a plugin by name (from the registry) or by providing a git URL:
+
+```bash theme={null}
+# Install from registry
+mise plugins install node
+
+# Install from a git URL
+mise plugins install java https://github.com/halcyon/asdf-java.git
+```
+
+### `mise plugins ls`
+
+```bash theme={null}
+mise plugins ls [--outdated] [--urls]
+```
+
+List installed plugins. Use `--urls` to show source URLs.
+
+```bash theme={null}
+mise plugins ls
+mise plugins ls --urls
+```
+
+### `mise plugins ls-remote`
+
+```bash theme={null}
+mise plugins ls-remote [--urls] [--only-names]
+```
+
+List all plugins available in the remote registry.
+
+### `mise plugins update`
+
+```bash theme={null}
+mise plugins update [PLUGIN]…
+```
+
+Update installed plugins to their latest versions:
+
+```bash theme={null}
+mise plugins update           # update all
+mise plugins update node      # update specific plugin
+```
+
+### `mise plugins uninstall`
+
+```bash theme={null}
+mise plugins uninstall [PLUGIN]…
+```
+
+Remove installed plugins:
+
+```bash theme={null}
+mise plugins uninstall node
+```
+
+### `mise plugins link`
+
+```bash theme={null}
+mise plugins link <NAME> [DIR]
+```
+
+Link a local plugin directory for development:
+
+```bash theme={null}
+mise plugins link my-plugin ~/dev/mise-plugin-my-plugin
+```
+
+## Examples
+
+```bash theme={null}
+# List installed plugins
+mise plugins ls
+
+# Install a plugin from registry
+mise plugins install java https://github.com/halcyon/asdf-java.git
+
+# Use the installed tool
+mise use java@21
+
+# Update all plugins
+mise plugins update
+
+# Show remote plugin list
+mise plugins ls-remote | head -20
+```
+
+
+# mise prune
+Source: https://www.mintlify.com/jdx/mise/cli/prune
+
+Remove unused tool versions to free up disk space.
+
+**Usage:** `mise prune [FLAGS] [TOOL]…`
+
+Delete tool versions that are no longer referenced by any active `mise.toml` config file. Mise tracks which config files it has used in `~/.local/state/mise/tracked-configs`.
+
+Versions installed only via environment variables (`MISE_<PLUGIN>_VERSION`) or command-line overrides (`mise exec <tool>@<version>`) are also considered prunable.
+
+## Arguments
+
+| Argument  | Description                     |
+| --------- | ------------------------------- |
+| `[TOOL]…` | Prune only these specific tools |
+
+## Flags
+
+| Flag             | Description                                                        |
+| ---------------- | ------------------------------------------------------------------ |
+| `-n, --dry-run`  | Show what would be removed without deleting anything               |
+| `--dry-run-code` | Like `--dry-run` but exits with code 1 if there are tools to prune |
+| `--configs`      | Prune only tracked config links pointing to non-existent files     |
+| `--tools`        | Prune only unused tool versions                                    |
+
+## Examples
+
+```bash theme={null}
+# Preview what would be removed
+mise prune --dry-run
+
+# Remove all unused versions
+mise prune
+
+# Prune only node versions
+mise prune node
+
+# Check in scripts (exits 1 if prunable tools exist)
+mise prune --dry-run-code && echo "Nothing to prune"
+```
+
+```
+$ mise prune --dry-run
+rm -rf ~/.local/share/mise/versions/node/20.0.0
+rm -rf ~/.local/share/mise/versions/node/20.0.1
+```
+
+## Listing prunable tools
+
+Before pruning, you can see what would be removed:
+
+```bash theme={null}
+mise ls --prunable
+```
+
+<Tip>
+  Run `mise prune --dry-run` first to verify what will be removed before actually deleting anything.
+</Tip>
+
+
+# mise run
+Source: https://www.mintlify.com/jdx/mise/cli/run
+
+Run project tasks defined in mise.toml or as shell scripts.
+
+**Usage:** `mise run [FLAGS] [TASK] [ARGS]…`
+
+**Alias:** `r`
+
+Run one or more tasks defined in `mise.toml` or as standalone scripts. Tasks may have dependencies, source file checks, and parallel execution.
+
+See [Running Tasks](/tasks/running-tasks) for a full guide.
+
+## Flags
+
+| Flag                      | Description                                                             |
+| ------------------------- | ----------------------------------------------------------------------- |
+| `-c, --continue-on-error` | Continue running tasks even if one fails                                |
+| `-C, --cd <CD>`           | Change to this directory before executing                               |
+| `-f, --force`             | Run even if outputs are up to date                                      |
+| `-j, --jobs <JOBS>`       | Number of tasks to run in parallel (default: 4)                         |
+| `-n, --dry-run`           | Print tasks in execution order without running them                     |
+| `-r, --raw`               | Connect stdin/stdout/stderr directly to task processes; sets `--jobs=1` |
+| `--timings`               | Show elapsed time for each task                                         |
+| `--no-timings`            | Hide elapsed time                                                       |
+| `--interleave`            | Print stdout/stderr directly without line-prefix buffering              |
+| `--output <OUTPUT>`       | Output mode: `prefix`, `interleave`                                     |
+| `--shell <SHELL>`         | Shell to use for running tasks                                          |
+
+## Examples
+
+```bash theme={null}
+# Run a single task
+mise run build
+mise r build           # shorter alias
+
+# Run with arguments
+mise run test -- --nocapture
+mise run build --release
+
+# Run multiple tasks in sequence with different args
+mise run build arg1 ::: test arg2
+
+# Run in parallel with 8 jobs
+mise run --jobs 8 lint test
+
+# Dry run — see what would execute
+mise run --dry-run test
+
+# Force re-run even if outputs are fresh
+mise run --force build
+
+# Continue past failures
+mise run --continue-on-error lint test build
+```
+
+## Task definition
+
+Define tasks in `mise.toml`:
+
+```toml mise.toml theme={null}
+[tasks.build]
+run = "cargo build"
+description = "Build the project"
+
+[tasks.test]
+run = "cargo test"
+depends = ["build"]
+sources = ["src/**/*.rs"]
+outputs = ["target/debug/myapp"]
+```
+
+Or as files in `mise-tasks/`, `.mise/tasks/`, `mise/tasks/`:
+
+```bash mise-tasks/build theme={null}
+#!/usr/bin/env bash
+#MISE description="Build the project"
+cargo build
+```
+
+
+# mise upgrade
+Source: https://www.mintlify.com/jdx/mise/cli/upgrade
+
+Upgrade installed tools to newer versions within the range specified in mise.toml.
+
+**Usage:** `mise upgrade [FLAGS] [TOOL@VERSION]…`
+
+**Alias:** `up`
+
+Upgrade installed tools to newer versions. By default, stays within the version range specified in `mise.toml` (e.g., `node = "22"` upgrades to the latest `22.x.x`). Use `--bump` to upgrade to the latest available version and update `mise.toml`.
+
+## Arguments
+
+| Argument          | Description                                |
+| ----------------- | ------------------------------------------ |
+| `[TOOL@VERSION]…` | Tools to upgrade (upgrades all if omitted) |
+
+## Flags
+
+| Flag                    | Description                                                                     |
+| ----------------------- | ------------------------------------------------------------------------------- |
+| `-i, --interactive`     | Show a multiselect menu to choose which tools to upgrade                        |
+| `-j, --jobs <JOBS>`     | Number of parallel jobs (default: 4)                                            |
+| `-l, --bump`            | Upgrade to latest available version and update `mise.toml`                      |
+| `-n, --dry-run`         | Print what would be done without doing it                                       |
+| `--dry-run-code`        | Like `--dry-run` but exits with code 1 if there are outdated tools              |
+| `-x, --exclude… <TOOL>` | Exclude specific tools from upgrading                                           |
+| `--before <DATE>`       | Only upgrade to versions released before this date (e.g. `2024-06-01` or `90d`) |
+| `--local`               | Only upgrade tools defined in local (project) config, skip global config        |
+| `--raw`                 | Pipe stdin/stdout/stderr directly to tool processes; sets `--jobs=1`            |
+
+## Examples
+
+```bash theme={null}
+# Upgrade node within the range in mise.toml
+mise upgrade node
+
+# Upgrade node to latest and bump mise.toml
+mise upgrade node --bump
+
+# Upgrade all tools
+mise upgrade
+
+# Upgrade all tools and bump versions in mise.toml
+mise upgrade --bump
+
+# Preview what would be upgraded
+mise upgrade --dry-run
+
+# Upgrade node and python
+mise upgrade node python
+
+# Upgrade all except go
+mise upgrade --exclude go
+
+# Interactive upgrade with menu
+mise upgrade --interactive
+
+# Only upgrade project-local tools
+mise upgrade --local
+```
+
+## Version bumping
+
+When using `--bump`, mise preserves the same precision as what's in `mise.toml`:
+
+| `mise.toml` before | Latest available | `mise.toml` after (`--bump`) |
+| ------------------ | ---------------- | ---------------------------- |
+| `node = "20"`      | 22.1.0           | `node = "22"`                |
+| `node = "20.0.0"`  | 22.1.0           | `node = "22.1.0"`            |
+| `node = "20.0"`    | 22.1.0           | `node = "22.1"`              |
+
+<Tip>
+  Use `mise ls --outdated` to see which tools have newer versions available before running upgrade.
+</Tip>
+
+
+# mise use
+Source: https://www.mintlify.com/jdx/mise/cli/use
+
+Install a tool and add it to mise.toml.
+
+## Synopsis
+
+```sh theme={null}
+mise use [FLAGS] [TOOL@VERSION]…
+```
+
+**Alias:** `mise u`
+
+## Description
+
+`mise use` installs a tool version and writes it to a `mise.toml` config file so it stays active inside the current directory. If the version is already installed, it skips installation unless `--force` is passed.
+
+By default the command targets the lowest-precedence config file in the current directory (usually `mise.toml`). Use the flags below to write to a different file instead.
+
+**Config file selection order:**
+
+1. `--global` — writes to `~/.config/mise/config.toml`
+2. `--path <PATH>` — writes to the specified file or directory
+3. `--env <ENV>` — writes to `mise.<env>.toml`
+4. `MISE_DEFAULT_CONFIG_FILENAME` — uses the filename set by this env var
+5. `MISE_OVERRIDE_CONFIG_FILENAMES` — uses the first entry in this list
+6. Otherwise — `mise.toml` in the current directory, or the global config if cwd is the home directory
+
+<Note>
+  Run `mise use` with no arguments to open an interactive tool selector.
+</Note>
+
+## Arguments
+
+<ParamField type="string">
+  One or more tools to install and add to the config file. For example: `node@20`, `cargo:ripgrep@latest`, `npm:prettier@3`. If no version is provided, it defaults to `@latest`.
+
+  Tool options can be passed inline:
+
+  ```sh theme={null}
+  mise use ubi:BurntSushi/ripgrep[exe=rg]
+  ```
+</ParamField>
+
+## Flags
+
+<ParamField type="string">
+  Create or modify an environment-specific config file such as `.mise.<env>.toml`.
+</ParamField>
+
+<ParamField type="boolean">
+  Force reinstall even if the tool version is already installed. Requires a tool argument.
+</ParamField>
+
+<ParamField type="boolean">
+  Write the tool version to the global config file (`~/.config/mise/config.toml`) instead of the local one.
+</ParamField>
+
+<ParamField type="number">
+  Number of installation jobs to run in parallel. Also configurable via `MISE_JOBS`.
+</ParamField>
+
+<ParamField type="boolean">
+  Show what would be installed and which config file would be modified, without making any changes.
+</ParamField>
+
+<ParamField type="string">
+  Path to a config file or directory. If a directory is given, mise searches it for a config file using the same rules as above.
+</ParamField>
+
+<ParamField type="string">
+  Only install versions released before this date. Accepts absolute dates like `2024-06-01` or relative durations like `90d` or `1y`.
+</ParamField>
+
+<ParamField type="boolean">
+  Like `--dry-run`, but exits with code `1` if there are changes to make. Useful in scripts to check whether tools need to be added or removed.
+</ParamField>
+
+<ParamField type="boolean">
+  Save a fuzzy version to the config file. For example, `mise use --fuzzy node@20` writes `20` rather than `20.0.0`. This is the default unless `MISE_PIN=1`.
+</ParamField>
+
+<ParamField type="boolean">
+  Save the exact resolved version to the config file. For example, `mise use --pin node@20` writes `20.0.0`. Set `MISE_PIN=1` to make this the default.
+</ParamField>
+
+<ParamField type="boolean">
+  Pipe stdin/stdout/stderr directly from the plugin to the terminal. Sets `--jobs=1`.
+</ParamField>
+
+<ParamField type="string">
+  Remove the specified plugin(s) from the config file. Aliases: `--rm`, `--unset`.
+</ParamField>
+
+## Examples
+
+```sh theme={null}
+# Open the interactive tool selector
+mise use
+
+# Set node 20.x in mise.toml of the current directory (writes fuzzy version, e.g. 20)
+mise use node@20
+
+# Set node 20.x in the global config, pinned to the exact version (e.g. 20.0.0)
+mise use -g --pin node@20
+
+# Write to .mise.local.toml (not intended to be committed)
+mise use --env local node@20
+
+# Write to .mise.staging.toml (active when MISE_ENV=staging)
+mise use --env staging node@20
+```
+
+
+# Config Environments
+Source: https://www.mintlify.com/jdx/mise/configuration/environments
+
+Use environment-specific mise.toml files for development, production, and other profiles.
+
+Mise supports separate configuration files for different environments like `development`, `production`, or `ci`. This lets you define different tools, environment variables, and tasks per environment.
+
+## Enabling an environment
+
+Set the `MISE_ENV` environment variable to activate a profile:
+
+```bash theme={null}
+MISE_ENV=development mise install
+MISE_ENV=production mise run deploy
+```
+
+Or pass it as a CLI flag:
+
+```bash theme={null}
+mise -E development install
+mise --env development install
+```
+
+## Environment-specific config files
+
+When `MISE_ENV=development` is set, mise looks for files like:
+
+```
+mise.development.toml
+mise.development.local.toml
+```
+
+These are loaded in addition to the standard `mise.toml`, with environment-specific files taking higher precedence.
+
+### Full priority order (highest to lowest)
+
+```
+mise.{MISE_ENV}.local.toml
+mise.local.toml
+mise.{MISE_ENV}.toml
+mise.toml
+```
+
+## Setting MISE\_ENV persistently
+
+Use a `.miserc.toml` file to commit the environment choice to version control:
+
+```toml .miserc.toml theme={null}
+env = ["development"]
+```
+
+Mise reads `.miserc.toml` very early, before other config files are discovered. It searches for this file in the current directory up to root, then the global config directory.
+
+<Note>
+  `MISE_ENV` cannot be set in `mise.toml` itself — it determines which config files to load.
+</Note>
+
+## Multiple environments
+
+Specify multiple environments with comma separation:
+
+```bash theme={null}
+MISE_ENV=ci,test mise install
+```
+
+The last specified environment has the highest precedence.
+
+## Local overrides
+
+Local config files (`mise.local.toml`, `mise.{MISE_ENV}.local.toml`) are intended for machine-specific overrides and should not be committed to version control:
+
+```bash theme={null}
+# .gitignore
+mise.local.toml
+mise.*.local.toml
+```
+
+## Example: development vs CI
+
+```toml mise.development.toml theme={null}
+[tools]
+node = "22"
+
+[env]
+NODE_ENV = "development"
+DEBUG = "app:*"
+```
+
+```toml mise.ci.toml theme={null}
+[tools]
+node = "22"
+
+[env]
+NODE_ENV = "test"
+CI = "true"
+```
+
+## Checking active configs
+
+```bash theme={null}
+mise config ls    # list active config files in load order
+mise config       # same
+```
+
+
+# Configuration overview
+Source: https://www.mintlify.com/jdx/mise/configuration/overview
+
+How mise loads and merges configuration from mise.toml files across system, global, and project scopes.
+
+Mise is configured through `mise.toml` files. These files declare tool versions, environment variables, tasks, and settings. Mise walks up the directory tree to collect all relevant config files, then merges them so that more specific (closer to your working directory) settings override broader ones.
+
+## Config file locations
+
+Mise looks for config files in the following locations within each directory it searches. Files are listed in **order of precedence** — a file higher in this list overrides files below it:
+
+| File                         | Purpose                                                    |
+| ---------------------------- | ---------------------------------------------------------- |
+| `mise.local.toml`            | Local overrides, should not be committed to source control |
+| `mise.toml`                  | Primary project config                                     |
+| `mise/config.toml`           | Alternative location                                       |
+| `.mise/config.toml`          | Dotfile alternative                                        |
+| `.config/mise.toml`          | Groups config into a common directory                      |
+| `.config/mise/config.toml`   | Full XDG-style path                                        |
+| `.config/mise/conf.d/*.toml` | Fragment files, loaded alphabetically                      |
+
+<Note>
+  Files prefixed with `mise` can also be written as dotfiles. For example, `mise.toml` and `.mise.toml` are equivalent, as are `mise/config.toml` and `.mise/config.toml`.
+</Note>
+
+Run `mise config` (or `mise cfg`) to see exactly which files mise has loaded in your current directory, in precedence order.
+
+## Configuration hierarchy
+
+Configuration is collected from three scopes and merged together:
+
+<Steps>
+  <Step title="System config">
+    `/etc/mise/config.toml` applies to all users on the machine. Use this for organization-wide defaults on shared systems.
+
+    ```
+    /etc/mise/
+    ├── config.toml          # System-wide defaults
+    ├── config.<env>.toml    # Env-specific system config
+    └── conf.d/*.toml        # Fragment files
+    ```
+  </Step>
+
+  <Step title="Global config">
+    `~/.config/mise/config.toml` applies to all your projects. Set global tool versions here using `mise use -g`.
+
+    ```
+    ~/.config/mise/
+    ├── config.toml              # Your global defaults
+    ├── config.<env>.toml        # Env-specific user config
+    ├── config.local.toml        # Local user overrides
+    └── conf.d/*.toml            # Fragment files
+    ```
+  </Step>
+
+  <Step title="Project config">
+    `mise.toml` files in your project directories apply only to that directory and its subdirectories.
+
+    ```
+    ~/work/
+    ├── mise.toml                    # Work-wide settings
+    └── myproject/
+        ├── mise.toml                # Project config
+        ├── mise.local.toml          # Local overrides (git-ignored)
+        ├── mise.<env>.toml          # Env-specific project config
+        └── backend/
+            └── mise.toml            # Service-specific config
+    ```
+  </Step>
+</Steps>
+
+More specific configs (closer to your current directory) take precedence over broader ones. The full merged result is what mise uses.
+
+## Merge behavior by section
+
+Different sections of `mise.toml` merge differently:
+
+<AccordionGroup>
+  <Accordion title="[tools] — additive with overrides">
+    Tool versions merge across configs. A project config can override or extend tools from a global config:
+
+    ```toml theme={null}
+    # Global config: node@18, python@3.11
+    # Project config: node@20, go@1.21
+    # Result: node@20, python@3.11, go@1.21
+    ```
+  </Accordion>
+
+  <Accordion title="[env] — additive with overrides">
+    Environment variables merge across configs, with more specific values overriding broader ones:
+
+    ```toml theme={null}
+    # Global config: NODE_ENV=development
+    # Project config: NODE_ENV=production, API_URL=localhost
+    # Result: NODE_ENV=production, API_URL=localhost
+    ```
+  </Accordion>
+
+  <Accordion title="[tasks] — replaced per task">
+    Each task definition completely replaces any task with the same name from a parent config:
+
+    ```toml theme={null}
+    # Global config: [tasks.test] = "npm test"
+    # Project config: [tasks.test] = "yarn test"
+    # Result: "yarn test" — the global definition is replaced entirely
+    ```
+  </Accordion>
+
+  <Accordion title="[settings] — additive with overrides">
+    Settings from multiple configs combine, with more specific settings overriding broader ones:
+
+    ```toml theme={null}
+    # Global config: experimental = true
+    # Project config: jobs = 4
+    # Result: experimental = true, jobs = 4
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## A full mise.toml example
+
+```toml mise.toml theme={null}
+[tools]
+node = '24'
+python = '3.12'
+
+[env]
+NODE_ENV = 'development'
+
+[tasks.dev]
+run = 'npm run dev'
+
+[tasks.test]
+run = 'pytest'
+
+[settings]
+jobs = 4
+```
+
+## Config sections
+
+### `[tools]`
+
+Declares the tool versions required for this project. See [Dev tools](/dev-tools/overview) for full details.
+
+```toml mise.toml theme={null}
+[tools]
+node = '24'
+python = '3.12'
+ruby = 'latest'
+
+# With options
+node = { version = '22', postinstall = 'corepack enable' }
+```
+
+### `[env]`
+
+Sets environment variables when you enter this directory. See [Environments](/environments/overview) for full details.
+
+```toml mise.toml theme={null}
+[env]
+NODE_ENV = 'development'
+DATABASE_URL = 'postgres://localhost/mydb'
+```
+
+### `[tasks]`
+
+Defines runnable tasks for this project. See [Tasks](/tasks/overview) for full details.
+
+```toml mise.toml theme={null}
+[tasks.build]
+run = 'npm run build'
+
+[tasks.test]
+run = 'pytest tests/'
+depends = ['build']
+```
+
+### `[settings]`
+
+Overrides mise settings for this project scope. See [Settings](/configuration/settings) for the full list.
+
+```toml mise.toml theme={null}
+[settings]
+jobs = 4
+verbose = false
+```
+
+### `[plugins]`
+
+Specifies custom plugin repository URLs. This affects only new plugin installations.
+
+```toml mise.toml theme={null}
+[plugins]
+elixir = 'https://github.com/my-org/mise-elixir.git'
+node = 'https://github.com/my-org/mise-node.git#DEADBEEF'
+```
+
+### `[tool_alias]`
+
+Defines version aliases for tools.
+
+```toml mise.toml theme={null}
+[tool_alias.node.versions]
+my_custom_node = '20'
+```
+
+This makes `mise install node@my_custom_node` install Node 20.x.
+
+### `[shell_alias]`
+
+Defines shell aliases that activate when you enter this directory and deactivate when you leave.
+
+```toml mise.toml theme={null}
+[shell_alias]
+ll = 'ls -la'
+gs = 'git status'
+```
+
+## Global config
+
+Your global config at `~/.config/mise/config.toml` applies to all directories:
+
+```toml ~/.config/mise/config.toml theme={null}
+[tools]
+node = 'lts'
+python = ['3.10', '3.11']
+
+[settings]
+idiomatic_version_file_enable_tools = ['node']
+always_keep_download = false
+jobs = 4
+verbose = false
+```
+
+## Minimum mise version
+
+Specify the minimum mise version required for a config file:
+
+```toml mise.toml theme={null}
+# Hard minimum — errors if unmet
+min_version = '2024.11.1'
+
+# Soft minimum — warns if unmet, continues anyway
+min_version = { soft = '2024.11.1' }
+
+# Both
+min_version = { hard = '2024.11.1', soft = '2024.9.0' }
+```
+
+## Write target
+
+When commands like `mise use`, `mise set`, or `mise unuse` write to a config file, they use the **lowest precedence file in the highest precedence directory**:
+
+* If both `mise.toml` and `mise.local.toml` exist, writes go to `mise.toml`
+* If only `mise.local.toml` exists, writes go to `mise.local.toml`
+
+```sh theme={null}
+# With both mise.toml and mise.local.toml present
+mise use node@22          # writes to mise.toml
+mise use --env local node@20  # writes to mise.local.toml
+```
+
+## `.tool-versions` compatibility
+
+Mise is compatible with asdf's `.tool-versions` format. You can use these files in any directory where mise looks for config:
+
+```text .tool-versions theme={null}
+node 20.0.0
+ruby 3
+shellcheck latest
+jq 1.6
+erlang ref:master
+go prefix:1.19
+```
+
+<Info>
+  `.tool-versions` is less flexible than `mise.toml`. If you're starting a new project, use `mise.toml` instead.
+</Info>
+
+### Idiomatic version files
+
+Mise also reads language-specific version files when enabled. These let other tools like `nvm` or `rbenv` read the same version specification:
+
+| Tool      | Files                                     |
+| --------- | ----------------------------------------- |
+| node      | `.nvmrc`, `.node-version`, `package.json` |
+| python    | `.python-version`, `.python-versions`     |
+| ruby      | `.ruby-version`, `Gemfile`                |
+| go        | `.go-version`                             |
+| java      | `.java-version`, `.sdkmanrc`              |
+| terraform | `.terraform-version`, `main.tf`           |
+
+Idiomatic version files are disabled by default. Enable them per-tool:
+
+```sh theme={null}
+mise settings add idiomatic_version_file_enable_tools python
+```
+
+Or in your config:
+
+```toml ~/.config/mise/config.toml theme={null}
+[settings]
+idiomatic_version_file_enable_tools = ['node', 'python']
+```
+
+## Version scopes
+
+Both `mise.toml` and `.tool-versions` support version scopes:
+
+| Scope     | Example                          | Meaning                            |
+| --------- | -------------------------------- | ---------------------------------- |
+| `ref:`    | `ref:master`                     | Compile from a VCS ref             |
+| `prefix:` | `prefix:1.20`                    | Latest version matching the prefix |
+| `path:`   | `path:/opt/homebrew/opt/node@20` | Use a custom compiled version      |
+| `sub-`    | `sub-2:lts`                      | Two versions behind LTS            |
+
+## JSON schema
+
+Mise publishes a JSON schema for `mise.toml` at `https://mise.jdx.dev/schema/mise.json`. Many editors can use this for autocompletion and validation.
+
+## Special keys
+
+The `[_]` table is reserved for metadata that mise never parses. Use it for comments or documentation within `mise.toml` that should be ignored by mise:
+
+```toml mise.toml theme={null}
+[_]
+maintainer = 'Alice'
+docs = 'https://internal.example.com/mise-setup'
+```
+
+
+# Settings
+Source: https://www.mintlify.com/jdx/mise/configuration/settings
+
+Global settings for mise, configurable via mise.toml, environment variables, or the mise settings command.
+
+Mise settings control global behavior. You can configure them in three ways:
+
+```bash theme={null}
+# Via CLI
+mise settings set jobs 8
+
+# Via environment variable
+MISE_JOBS=8 mise install
+
+# Via ~/.config/mise/config.toml
+```
+
+```toml ~/.config/mise/config.toml theme={null}
+[settings]
+jobs = 8
+```
+
+## Viewing settings
+
+```bash theme={null}
+mise settings          # list all settings and values
+mise settings get jobs # get a specific setting
+mise settings set jobs 8
+mise settings unset jobs
+```
+
+## Key settings reference
+
+### Tool installation
+
+| Setting                | Env var                     | Default | Description                                            |
+| ---------------------- | --------------------------- | ------- | ------------------------------------------------------ |
+| `jobs`                 | `MISE_JOBS`                 | `4`     | Number of tools to install in parallel                 |
+| `auto_install`         | `MISE_AUTO_INSTALL`         | `true`  | Automatically install missing tools                    |
+| `always_keep_download` | `MISE_ALWAYS_KEEP_DOWNLOAD` | `false` | Keep downloaded tool archives after install            |
+| `always_keep_install`  | `MISE_ALWAYS_KEEP_INSTALL`  | `false` | Keep install directory even on failed installs         |
+| `raw`                  | `MISE_RAW`                  | `false` | Connect stdin/stdout/stderr directly to tool processes |
+
+### Behavior
+
+| Setting                  | Env var                       | Default | Description                               |
+| ------------------------ | ----------------------------- | ------- | ----------------------------------------- |
+| `verbose`                | `MISE_VERBOSE`                | `false` | Show extra output                         |
+| `quiet`                  | `MISE_QUIET`                  | `false` | Suppress non-error output                 |
+| `color`                  | `MISE_COLOR`                  | `true`  | Use colored output                        |
+| `yes`                    | `MISE_YES`                    | `false` | Auto-confirm all prompts                  |
+| `not_found_auto_install` | `MISE_NOT_FOUND_AUTO_INSTALL` | `true`  | Install tools when a command is not found |
+
+### Caching
+
+| Setting                       | Env var                            | Default | Description                                 |
+| ----------------------------- | ---------------------------------- | ------- | ------------------------------------------- |
+| `cache_prune_age`             | `MISE_CACHE_PRUNE_AGE`             | `30d`   | Delete cache files older than this duration |
+| `fetch_remote_versions_cache` | `MISE_FETCH_REMOTE_VERSIONS_CACHE` | `1h`    | How long to cache remote version lists      |
+
+### Security
+
+| Setting                | Env var                     | Default | Description                                          |
+| ---------------------- | --------------------------- | ------- | ---------------------------------------------------- |
+| `paranoid`             | `MISE_PARANOID`             | `false` | Enable extra security checks (checksum verification) |
+| `trusted_config_paths` | `MISE_TRUSTED_CONFIG_PATHS` | `[]`    | Paths to trust without prompting                     |
+
+### Shell & PATH
+
+| Setting     | Env var          | Default                     | Description              |
+| ----------- | ---------------- | --------------------------- | ------------------------ |
+| `shims_dir` | `MISE_SHIMS_DIR` | `~/.local/share/mise/shims` | Directory for shims      |
+| `data_dir`  | `MISE_DATA_DIR`  | `~/.local/share/mise`       | Directory for mise data  |
+| `cache_dir` | `MISE_CACHE_DIR` | `~/.cache/mise`             | Directory for mise cache |
+
+### Task runner
+
+| Setting       | Env var            | Default  | Description                                       |
+| ------------- | ------------------ | -------- | ------------------------------------------------- |
+| `task_output` | `MISE_TASK_OUTPUT` | `prefix` | Task output mode: `prefix`, `interleave`, `quiet` |
+
+## Example: common configuration
+
+```toml ~/.config/mise/config.toml theme={null}
+[settings]
+jobs = 8
+auto_install = true
+verbose = false
+paranoid = true
+trusted_config_paths = ["/home/me/work"]
+```
+
+<Tip>
+  Run `mise settings` to see the full list of available settings with their current values and descriptions.
+</Tip>
+
+
+# Templates
+Source: https://www.mintlify.com/jdx/mise/configuration/templates
+
+Use Tera templates in mise.toml to dynamically generate configuration values.
+
+Mise uses the [Tera](https://keats.github.io/tera/) template engine to allow dynamic values in `mise.toml` configuration files. Templates let you reference environment variables, run shell commands, inspect the system, and more.
+
+## Where templates are supported
+
+Templates work in most `mise.toml` string values, including:
+
+* `[env]` values
+* `[tools]` version strings
+* `[tasks]` run scripts
+* `.tool-versions` files
+
+<Note>
+  The `mise.toml` file itself must be valid TOML — only string values inside it are templated.
+</Note>
+
+## Template syntax
+
+Tera uses three delimiter types:
+
+| Syntax      | Purpose                      |
+| ----------- | ---------------------------- |
+| `{{ ... }}` | Expressions — output a value |
+| `{% ... %}` | Statements — control flow    |
+| `{# ... #}` | Comments                     |
+
+## Built-in variables
+
+### `env`
+
+Access environment variables:
+
+```toml mise.toml theme={null}
+[env]
+HOME_BIN = "{{ env.HOME }}/bin"
+NODE_VERSION = "{{ get_env(name='NODE_VERSION', default='22') }}"
+```
+
+### `cwd`
+
+The current working directory:
+
+```toml mise.toml theme={null}
+[env]
+PROJECT_NAME = "{{ cwd | basename }}"
+```
+
+## Built-in functions
+
+### `get_env(name, default)`
+
+Read an environment variable with an optional default:
+
+```toml mise.toml theme={null}
+[tools]
+node = "{{ get_env(name='NODE_VERSION', default='22') }}"
+```
+
+### `exec(command)`
+
+Run a shell command and use its output:
+
+```toml mise.toml theme={null}
+[env]
+GIT_BRANCH = "{{ exec(command='git rev-parse --abbrev-ref HEAD') }}"
+```
+
+### `arch()`
+
+Returns the system architecture (`x86_64`, `aarch64`, etc.):
+
+```toml mise.toml theme={null}
+[env]
+ARCH = "{{ arch() }}"
+```
+
+### `os()`
+
+Returns the OS name (`linux`, `macos`, `windows`):
+
+```toml mise.toml theme={null}
+[tools]
+# Use different tool versions per OS
+python = "{% if os() == 'macos' %}3.12{% else %}3.11{% endif %}"
+```
+
+### `os_family()`
+
+Returns the OS family (`unix` or `windows`).
+
+### `num_cpus()`
+
+Returns the number of logical CPUs:
+
+```toml mise.toml theme={null}
+[tasks.build]
+run = "make -j{{ num_cpus() }}"
+```
+
+## Filters
+
+Apply Tera filters with `|`:
+
+```toml mise.toml theme={null}
+[env]
+# basename: get last path component
+DIR_NAME = "{{ cwd | basename }}"
+
+# upper/lower: change case
+UPPER = "{{ env.project | upper }}"
+```
+
+Standard Tera string filters are available: `upper`, `lower`, `trim`, `replace`, `truncate`, `basename`, `dirname`, and many more.
+
+## Conditionals
+
+```toml mise.toml theme={null}
+[env]
+PLATFORM = "{% if os() == 'macos' %}darwin{% elif os() == 'windows' %}win32{% else %}linux{% endif %}"
+```
+
+## Full example
+
+```toml mise.toml theme={null}
+[env]
+PROJECT_NAME = "{{ cwd | basename }}"
+NODE_ENV = "{{ get_env(name='NODE_ENV', default='development') }}"
+GIT_SHA = "{{ exec(command='git rev-parse --short HEAD') }}"
+
+[tools]
+node = "{{ get_env(name='NODE_VERSION', default='22') }}"
+python = "{{ get_env(name='PYTHON_VERSION', default='3.12') }}"
+
+[tasks.build]
+run = "make -j{{ num_cpus() }} build"
+```
+
+
+# Aliases
+Source: https://www.mintlify.com/jdx/mise/dev-tools/aliases
+
+Create short names for tool versions and redirect tool backends using aliases in mise.toml.
+
+Mise supports two kinds of aliases: **backend aliases**, which redirect a tool name to a different backend, and **version aliases**, which give friendly names to specific versions.
+
+<Note>
+  The `[alias]` key has been renamed to `[tool_alias]` to distinguish it from `[shell_alias]`. The old `[alias]` key still works but is deprecated. For shell command aliases like `alias ll='ls -la'`, see [Shell aliases](/configuration/overview).
+</Note>
+
+## Backend aliases
+
+Backend aliases let you redirect a tool name to a different backend. For example, you can change `node` from its default `core:node` to a custom asdf plugin:
+
+```toml ~/.config/mise/config.toml theme={null}
+[tool_alias]
+node = 'asdf:company/our-custom-node'
+erlang = 'asdf:https://github.com/company/our-custom-erlang'
+```
+
+After adding this, running `mise use node@20` will use your custom backend instead of the built-in core backend.
+
+This is useful when:
+
+* Your organization maintains a fork of a tool plugin
+* You need to pin a specific backend for compliance or reproducibility reasons
+* You want to use a private plugin for a commonly named tool
+
+## Version aliases
+
+Version aliases let you assign friendly names to specific versions. One common use case is defining aliases for LTS versions:
+
+```toml ~/.config/mise/config.toml theme={null}
+[tool_alias.node.versions]
+my_custom_20 = '20'
+```
+
+After adding this, you can use the alias in any config file:
+
+```toml mise.toml theme={null}
+[tools]
+node = "my_custom_20"
+```
+
+This makes it easier to update multiple projects at once — change the alias definition once in your global config, and all projects that reference it pick up the update.
+
+## Plugin-provided aliases
+
+Plugins can supply their own version aliases via a `bin/list-aliases` script. Here is an example showing Node.js LTS aliases:
+
+```bash bin/list-aliases theme={null}
+#!/usr/bin/env bash
+
+echo "lts-hydrogen 18"
+echo "lts-gallium 16"
+echo "lts-fermium 14"
+```
+
+Each line contains the alias name and the version it maps to, separated by a space. Plugin-provided aliases work the same way as user-defined aliases: you can reference them anywhere you specify a version.
+
+<Info>
+  Plugin-provided aliases are mise-specific and don't affect asdf. Plugin authors can add this script without impacting asdf users.
+</Info>
+
+## Template aliases
+
+Alias values support [Tera templates](/configuration/templates), which means you can use dynamic expressions:
+
+```toml ~/.config/mise/config.toml theme={null}
+[tool_alias.node.versions]
+current = "{{exec(command='node --version')}}"
+```
+
+This resolves the alias to whatever `node --version` returns at the time mise evaluates the config.
+
+## Global vs project aliases
+
+**Global aliases** go in `~/.config/mise/config.toml` and apply across all your projects:
+
+```toml ~/.config/mise/config.toml theme={null}
+[tool_alias.node.versions]
+lts = "22"
+```
+
+**Project aliases** can also be defined in a project's `mise.toml`. They take precedence over global aliases for that project:
+
+```toml mise.toml theme={null}
+[tool_alias.node.versions]
+project-node = "20.11.0"
+
+[tools]
+node = "project-node"
+```
+
+This lets teams pin a canonical version name in the project config without hardcoding a version number in every place the tool is referenced.
+
+
+# Backends
+Source: https://www.mintlify.com/jdx/mise/dev-tools/backends
+
+All the package ecosystems mise can install tools from, and how to choose between them.
+
+Backends are the package managers and ecosystems that mise uses to install tools. Each backend handles a different installation method. When you run `mise use`, mise determines the appropriate backend from the tool name prefix, the registry, or explicit selection.
+
+## How backend selection works
+
+Mise resolves which backend to use in this order:
+
+1. **Explicit prefix** — `mise use aqua:golangci/golangci-lint`
+2. **Environment variable override** — `MISE_BACKENDS_<TOOL>` (see below)
+3. **Registry lookup** — `mise use golangci-lint` checks the registry for the default backend
+4. **Core tools** — `mise use node` uses the built-in core backend
+5. **Fallback** — if no match, mise suggests available backends
+
+You typically don't need to think about backend selection. The [mise registry](https://github.com/jdx/mise/blob/main/registry/) defines sensible defaults for hundreds of tools.
+
+### Override with an environment variable
+
+Convert the tool name to `SHOUTY_SNAKE_CASE` and set `MISE_BACKENDS_<TOOL>`:
+
+```bash theme={null}
+# Use vfox backend for php instead of the registry default
+export MISE_BACKENDS_PHP='vfox:mise-plugins/vfox-php'
+mise install php@latest
+```
+
+### Disable specific backends
+
+```toml ~/.config/mise/config.toml theme={null}
+[settings]
+disable_backends = ["asdf", "vfox"]
+```
+
+## Capabilities comparison
+
+| Feature               | Core | npm/pipx/cargo | aqua | github | Tool Plugins (vfox) | asdf (legacy) |
+| --------------------- | ---- | -------------- | ---- | ------ | ------------------- | ------------- |
+| Speed                 | ✅    | ⚠️             | ✅    | ✅      | ⚠️                  | ⚠️            |
+| Security              | ✅    | ⚠️             | ✅    | ⚠️     | ⚠️                  | ⚠️            |
+| Windows support       | ✅    | ✅              | ✅    | ✅      | ✅                   | ❌             |
+| Env var support       | ✅    | ❌              | ❌    | ❌      | ✅                   | ✅             |
+| Custom scripts        | ✅    | ❌              | ❌    | ❌      | ✅                   | ✅             |
+| Security attestations | ❌    | ❌              | ✅    | ❌      | ✅                   | ❌             |
+| Multi-tool plugins    | ❌    | ❌              | ❌    | ❌      | ✅                   | ❌             |
+
+## Available backends
+
+<AccordionGroup>
+  <Accordion title="Core (built-in)">
+    Core tools are built directly into mise in Rust for the best performance and reliability. They require no external dependencies and have the deepest integration with mise features.
+
+    **Examples:** `node`, `python`, `ruby`, `go`, `java`, `terraform`
+
+    ```toml mise.toml theme={null}
+    [tools]
+    node = "24"
+    python = "3.12"
+    go = "1.22"
+    ```
+
+    Use core tools whenever they are available for your tool. They offer the fastest installation, zero startup overhead, and the best integration with mise features like environment variables and hooks.
+  </Accordion>
+
+  <Accordion title="aqua">
+    Aqua is a registry-based backend with strong security features. Mise has a built-in reimplementation of aqua — you do not need to install the aqua CLI.
+
+    **Syntax:** `aqua:<owner>/<repo>`
+
+    ```sh theme={null}
+    mise use -g aqua:BurntSushi/ripgrep
+    rg --version
+    # ripgrep 14.1.1
+    ```
+
+    ```toml mise.toml theme={null}
+    [tools]
+    "aqua:BurntSushi/ripgrep" = "latest"
+    ```
+
+    Aqua tools are sourced from the [aqua registry](https://github.com/aquaproj/aqua-registry), which is compiled into the mise binary at release. The registry defines which assets to download and how to verify them.
+
+    **Security verification** — aqua natively supports multiple verification methods, all implemented in Rust without external tools:
+
+    * GitHub artifact attestations
+    * Cosign signature verification
+    * SLSA provenance verification
+    * Minisign verification
+    * SHA256/SHA512 checksum verification
+
+    **When to use aqua:**
+
+    * The tool is in the [aqua registry](https://github.com/aquaproj/aqua-registry)
+    * You want comprehensive security verification
+    * You need Windows support
+    * You're installing pre-compiled binaries
+
+    **Tool option: `symlink_bins`**
+
+    Some tools bundle extra executables you may not want on `PATH`. For example, `aws-cli` bundles Python:
+
+    ```toml mise.toml theme={null}
+    [tools]
+    aws-cli = { version = "latest", symlink_bins = true }
+    ```
+
+    This creates a filtered `.mise-bins` directory exposing only the binaries defined in the aqua registry for that package.
+
+    <Note>
+      To see which tools default to aqua, run `mise registry | grep aqua:`.
+    </Note>
+  </Accordion>
+
+  <Accordion title="github">
+    The github backend downloads release assets directly from GitHub repositories. It is ideal for tools that distribute pre-built binaries through GitHub releases.
+
+    **Syntax:** `github:<owner>/<repo>`
+
+    ```sh theme={null}
+    mise use -g github:BurntSushi/ripgrep
+    rg --version
+    # ripgrep 14.1.1
+    ```
+
+    ```toml mise.toml theme={null}
+    [tools]
+    "github:BurntSushi/ripgrep" = "latest"
+    ```
+
+    **Asset autodetection** — when no `asset_pattern` is specified, mise automatically selects the best asset for your platform based on OS, architecture, libc variant, and archive format.
+
+    **Tool options:**
+
+    ```toml mise.toml theme={null}
+    # Match a specific asset name pattern
+    "github:cli/cli" = { version = "latest", asset_pattern = "gh_*_linux_x64.tar.gz" }
+
+    # Custom version prefix for release tags
+    "github:user/repo" = { version = "latest", version_prefix = "release-" }
+
+    # Verify checksum
+    "github:owner/repo" = { version = "1.0.0", checksum = "sha256:a1b2c3d4e5f6789..." }
+
+    # Rename the downloaded binary
+    "github:docker/compose" = { version = "2.29.1", bin = "docker-compose" }
+
+    # Filter which binaries are exposed on PATH
+    "github:jgm/pandoc" = { version = "latest", filter_bins = "pandoc" }
+    ```
+
+    **Platform-specific patterns:**
+
+    ```toml mise.toml theme={null}
+    [tools."github:cli/cli"]
+    version = "latest"
+
+    [tools."github:cli/cli".platforms]
+    linux-x64 = { asset_pattern = "gh_*_linux_x64.tar.gz" }
+    macos-arm64 = { asset_pattern = "gh_*_macOS_arm64.tar.gz" }
+    ```
+
+    **When to use github:**
+
+    * The tool publishes pre-built binaries on GitHub releases
+    * You want zero configuration (no registry setup required)
+    * The tool follows standard release tarball conventions
+  </Accordion>
+
+  <Accordion title="cargo">
+    The cargo backend installs Rust crates from [crates.io](https://crates.io/). It requires `cargo` to be installed.
+
+    **Syntax:** `cargo:<crate-name>`
+
+    ```sh theme={null}
+    mise use -g cargo:eza
+    eza --version
+    # eza - A modern, maintained replacement for ls
+    # v0.17.1 [+git]
+    ```
+
+    ```toml mise.toml theme={null}
+    [tools]
+    "cargo:eza" = "latest"
+    ```
+
+    **Installing cargo** — either via rustup or mise:
+
+    ```sh theme={null}
+    # Via rustup
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+    # Via mise
+    mise use -g rust
+    ```
+
+    **Install from a Git repository:**
+
+    ```sh theme={null}
+    # Specific tag
+    mise use cargo:https://github.com/username/demo@tag:<release_tag>
+
+    # Latest from a branch
+    mise use cargo:https://github.com/username/demo@branch:<branch_name>
+
+    # Specific commit
+    mise use cargo:https://github.com/username/demo@rev:<commit_hash>
+    ```
+
+    **Tool options:**
+
+    ```toml mise.toml theme={null}
+    # Install with additional features
+    "cargo:cargo-edit" = { version = "latest", features = "add" }
+
+    # Disable default features
+    "cargo:cargo-edit" = { version = "latest", default-features = false }
+
+    # Select specific binary when multiple are available
+    "cargo:https://github.com/username/demo" = { version = "tag:v1.0.0", bin = "demo" }
+
+    # Select specific crate from a Git repo
+    "cargo:https://github.com/username/demo" = { version = "tag:v1.0.0", crate = "demo" }
+    ```
+
+    **When to use cargo:**
+
+    * The tool is a Rust crate distributed on crates.io
+    * You need to build from source with specific features
+    * The tool isn't available as a pre-compiled binary
+  </Accordion>
+
+  <Accordion title="npm">
+    The npm backend installs packages from [npmjs.org](https://npmjs.org/). It requires `npm` (or `bun` / `pnpm`) to be installed.
+
+    **Syntax:** `npm:<package-name>`
+
+    ```sh theme={null}
+    mise use -g npm:prettier
+    prettier --version
+    # 3.1.0
+    ```
+
+    ```toml mise.toml theme={null}
+    [tools]
+    "npm:prettier" = "latest"
+    ```
+
+    **Installing node/npm via mise:**
+
+    ```sh theme={null}
+    mise use -g node
+    # or for bun/pnpm
+    mise use -g bun
+    mise use -g pnpm
+    ```
+
+    **When to use npm:**
+
+    * The tool is a Node.js CLI package
+    * The tool is primarily distributed through npm
+    * You want to manage Node.js tooling alongside your runtimes
+  </Accordion>
+
+  <Accordion title="pipx (Python)">
+    The pipx backend installs Python CLI tools in isolated environments via [pipx](https://pipx.pypa.io/).
+
+    **Syntax:** `pipx:<package-name>`
+
+    ```toml mise.toml theme={null}
+    [tools]
+    "pipx:black" = "latest"
+    "pipx:poetry" = "latest"
+    ```
+
+    Mise automatically handles the dependency chain — pipx depends on Python and uv, and mise installs them in the right order.
+
+    **When to use pipx:**
+
+    * Installing Python CLI tools
+    * The tool is distributed on PyPI
+    * You want isolated Python tool environments
+  </Accordion>
+
+  <Accordion title="go">
+    The go backend installs tools from Go module paths.
+
+    **Syntax:** `go:<module-path>`
+
+    ```toml mise.toml theme={null}
+    [tools]
+    "go:github.com/golangci/golangci-lint/cmd/golangci-lint" = "latest"
+    ```
+
+    Requires Go to be installed (can be managed by mise itself).
+
+    **When to use go:**
+
+    * The tool is distributed as a Go module
+    * No pre-built binary is available through aqua or github
+  </Accordion>
+
+  <Accordion title="asdf (legacy)">
+    <Warning>
+      asdf plugins are considered legacy. For new tools, prefer [vfox plugins](/guides/plugins) which are written in Lua, work cross-platform including Windows, and have access to built-in modules for HTTP, JSON, HTML parsing, and more.
+    </Warning>
+
+    The asdf backend provides compatibility with the asdf plugin ecosystem. Plugins are typically Bash scripts and generally do not work on Windows.
+
+    **Syntax:** `asdf:<plugin-name>`
+
+    ```toml mise.toml theme={null}
+    [tools]
+    "asdf:postgres" = "latest"
+    ```
+
+    Mise actively migrates tools away from asdf toward aqua and github backends where possible. asdf plugins remain useful when a tool has a complex installation process or needs to export environment variables.
+
+    | Feature               | asdf plugins | vfox plugins |
+    | --------------------- | ------------ | ------------ |
+    | Language              | Bash         | Lua          |
+    | Windows support       | ❌            | ✅            |
+    | Built-in HTTP         | ❌            | ✅            |
+    | Built-in JSON         | ❌            | ✅            |
+    | Security attestations | ❌            | ✅            |
+    | Post-install hooks    | ❌            | ✅            |
+  </Accordion>
+
+  <Accordion title="vfox (tool plugins)">
+    The vfox backend supports tool plugins written in Lua. These plugins are cross-platform and have access to built-in modules for HTTP, JSON, HTML parsing, archive extraction, and more.
+
+    **Syntax:** `vfox:<owner>/<plugin-name>`
+
+    ```toml mise.toml theme={null}
+    [tools]
+    "vfox:mise-plugins/vfox-php" = "8.3"
+    ```
+
+    Use vfox plugins when a tool requires complex installation logic, needs to export environment variables like `JAVA_HOME`, or needs cross-platform support including Windows.
+  </Accordion>
+
+  <Accordion title="http">
+    The http backend downloads tools directly from arbitrary URLs.
+
+    **Syntax:** `http:<url>`
+
+    ```toml mise.toml theme={null}
+    [tools."http:my-tool"]
+    version = "1.0.0"
+
+    [tools."http:my-tool".platforms]
+    macos-x64 = { url = "https://example.com/my-tool-macos-x64.tar.gz", checksum = "sha256:abc123" }
+    linux-x64 = { url = "https://example.com/my-tool-linux-x64.tar.gz", checksum = "sha256:def456" }
+    ```
+
+    Use the http backend for tools with custom download URLs not covered by github or aqua.
+  </Accordion>
+
+  <Accordion title="ubi (deprecated)">
+    <Warning>
+      The ubi backend is deprecated. Use the [github backend](#github) instead. Replace `ubi:owner/repo` with `github:owner/repo`.
+    </Warning>
+
+    Ubi was a zero-configuration installer for GitHub and GitLab repositories. The github backend supersedes it with more features and better support.
+  </Accordion>
+</AccordionGroup>
+
+## Backend dependencies
+
+Some backends depend on other tools being installed first. Mise handles this automatically:
+
+| Backend | Requires     |
+| ------- | ------------ |
+| `npm`   | Node.js      |
+| `pipx`  | pipx, Python |
+| `cargo` | Rust / cargo |
+| `gem`   | Ruby         |
+| `go`    | Go           |
+
+## Forcing a specific backend
+
+Override the default backend for a tool explicitly in `mise.toml`:
+
+```toml mise.toml theme={null}
+[tools]
+"core:node" = "20"     # Explicitly use core backend
+"aqua:yarn" = "latest" # Use aqua instead of registry default
+```
+
+## Backend-specific settings
+
+Some backends support additional configuration options:
+
+```toml mise.toml theme={null}
+[tools]
+python = { version = "3.12", virtualenv = ".venv" }  # Core backend
+black = { version = "latest", python = "3.12" }      # pipx backend
+```
+
+
+# Dev tools overview
+Source: https://www.mintlify.com/jdx/mise/dev-tools/overview
+
+How mise manages tool versions, resolves configurations, and switches between runtimes automatically.
+
+Mise manages installations of programming language runtimes and other tools for local development. It can manage multiple versions of Node.js, Python, Ruby, Go, and hundreds more on the same machine, automatically switching between them based on the directory you're in.
+
+## How mise resolves tools
+
+When you enter a directory or run a command, mise follows this process:
+
+<Steps>
+  <Step title="Configuration discovery">
+    Mise walks up the directory tree looking for configuration files (`mise.toml`, `.tool-versions`, etc.) and merges them hierarchically. A project config overrides a workspace config, which overrides your global config.
+
+    ```
+    ~/.config/mise/config.toml      # Global defaults
+    ~/work/mise.toml                # Work-specific tools
+    ~/work/project/mise.toml        # Project-specific overrides
+    ~/work/project/.tool-versions   # Legacy asdf compatibility
+    ```
+  </Step>
+
+  <Step title="Version resolution">
+    Mise resolves version specifications like `node@latest` or `python@3` to specific versions using registries and cached version lists.
+  </Step>
+
+  <Step title="Backend selection">
+    Mise chooses the appropriate [backend](/dev-tools/backends) to handle each tool — core, aqua, asdf, cargo, npm, etc.
+  </Step>
+
+  <Step title="Installation check">
+    Mise verifies whether the required tool versions are installed, automatically installing missing ones.
+  </Step>
+
+  <Step title="Environment setup">
+    Mise configures your `PATH` and environment variables to point at the resolved tool versions.
+
+    ```sh theme={null}
+    # After mise activation in a project with node@20
+    echo $PATH
+    # /home/user/.local/share/mise/installs/node/20.11.0/bin:/usr/local/bin:/usr/bin:/bin
+    ```
+  </Step>
+</Steps>
+
+## The `[tools]` section
+
+Declare which tools and versions a project requires in a `mise.toml` file:
+
+```toml mise.toml theme={null}
+[tools]
+node = "24"
+python = "3"
+ruby = "latest"
+```
+
+Run `mise install` after editing to install any new tools. Or use `mise use` to install and update the config in one step:
+
+```sh theme={null}
+mise use node@24
+```
+
+Mise is also compatible with asdf `.tool-versions` files and idiomatic version files like `.node-version` and `.ruby-version`.
+
+### Version specification syntax
+
+| Syntax        | Meaning                                  |
+| ------------- | ---------------------------------------- |
+| `"24"`        | Latest patch release of major version 24 |
+| `"24.0.0"`    | Exact version                            |
+| `"latest"`    | Latest stable release                    |
+| `"lts"`       | Latest LTS release (where supported)     |
+| `"prefix:24"` | Latest matching the prefix `24`          |
+
+### Multiple tools
+
+You can declare as many tools as your project needs:
+
+```toml mise.toml theme={null}
+[tools]
+node = "24"
+python = "3.12"
+go = "1.22"
+ruby = "3.3"
+java = "21"
+terraform = "1.9"
+```
+
+## Tool options
+
+Tool options let you customize how individual tools are installed and configured.
+
+### Table format
+
+```toml mise.toml theme={null}
+[tools."http:my-tool"]
+version = "1.0.0"
+
+[tools."http:my-tool".platforms]
+macos-x64 = { url = "https://example.com/my-tool-macos-x64.tar.gz", checksum = "sha256:abc123" }
+linux-x64 = { url = "https://example.com/my-tool-linux-x64.tar.gz", checksum = "sha256:def456" }
+```
+
+### Dotted notation
+
+```toml mise.toml theme={null}
+[tools."http:my-tool"]
+version = "1.0.0"
+platforms.macos-x64.url = "https://example.com/my-tool-macos-x64.tar.gz"
+platforms.linux-x64.url = "https://example.com/my-tool-linux-x64.tar.gz"
+simple_option = "value"
+```
+
+### Postinstall commands
+
+Run a command immediately after a tool finishes installing:
+
+```toml mise.toml theme={null}
+[tools]
+node = { version = "22", postinstall = "corepack enable" }
+```
+
+The tool's bin path is on `PATH` during the command, and `MISE_TOOL_INSTALL_PATH` points to the install directory.
+
+## OS-specific tools
+
+Restrict tools to specific operating systems with the `os` field:
+
+```toml mise.toml theme={null}
+[tools]
+# Only install on Linux and macOS
+ripgrep = { version = "latest", os = ["linux", "macos"] }
+
+# Only install on Windows
+"npm:windows-terminal" = { version = "latest", os = ["windows"] }
+
+# Works with other options
+"cargo:usage-cli" = {
+    version = "latest",
+    os = ["linux", "macos"],
+    install_env = { RUST_BACKTRACE = "1" }
+}
+```
+
+Accepted values: `"linux"`, `"macos"`, `"windows"`.
+
+## Tool dependencies
+
+Use `depends` to declare explicit installation ordering between tools:
+
+```toml mise.toml theme={null}
+[tools]
+python = "3.12.11"
+"pipx:ruff" = { version = "latest", depends = ["python"] }
+```
+
+The `depends` field accepts a single string or an array:
+
+```toml mise.toml theme={null}
+[tools]
+# Single dependency
+"pipx:ruff" = { version = "latest", depends = "python" }
+
+# Multiple dependencies
+"pipx:ruff" = { version = "latest", depends = ["python", "pipx"] }
+```
+
+<Note>
+  Backends like `pipx` already declare automatic dependencies (e.g., `pipx` depends on `python` and `uv`). Use `depends` only to add extra ordering constraints specific to your setup.
+</Note>
+
+## Key commands
+
+### `mise use`
+
+Installs a tool, sets it as active, and updates the config file:
+
+```sh theme={null}
+cd my-project
+mise use node@24
+# mise node@24.x.x ✓ installed
+# mise ~/my-project/mise.toml tools: node@24.x.x
+
+which node
+# ~/.local/share/installs/node/24.x.x/bin/node
+```
+
+Use `-g` to update your global config instead:
+
+```sh theme={null}
+mise use -g node@24
+```
+
+### `mise install`
+
+Downloads and installs tools without modifying any config file:
+
+```sh theme={null}
+mise install node@20.0.0   # Install a specific version
+mise install node@20       # Install latest matching this prefix
+mise install node          # Install the version from mise.toml
+mise install               # Install all tools in config files
+```
+
+### `mise exec` / `mise x`
+
+Run a one-off command with specific tools loaded:
+
+```sh theme={null}
+mise x python@3.12 -- ./myscript.py
+```
+
+Or use tools already specified in `mise.toml`:
+
+```sh theme={null}
+mise use node@20
+mise x -- node -v
+# 20.x.x
+```
+
+<Tip>
+  Create an alias for frequently used exec commands: `alias mx="mise x --"`
+</Tip>
+
+## Auto-install
+
+Mise can install missing tools automatically. All auto-install behaviors are enabled by default.
+
+| Trigger                                  | Setting                  | Default |
+| ---------------------------------------- | ------------------------ | ------- |
+| `mise x` or `mise r` runs a missing tool | `exec_auto_install`      | `true`  |
+| Task runs a missing tool                 | `task_auto_install`      | `true`  |
+| Shell command not found                  | `not_found_auto_install` | `true`  |
+
+<Tip>
+  Disable auto-install for specific tools with `auto_install_disable_tools` in your settings.
+</Tip>
+
+## Caching and performance
+
+Mise uses caching to minimize overhead:
+
+* **Version lists** — cached daily to avoid repeated API calls
+* **Installation artifacts** — cached downloads to speed up reinstalls
+* **Environment resolution** — cached setups for faster shell prompts
+* **Plugin metadata** — cached plugin information for quicker operations
+
+Mise modifies `PATH` ahead of time so tools are called directly with zero overhead. Running `which node` returns the real binary path, not a shim.
+
+<Info>
+  After activating, mise calls `mise hook-env` each time your prompt is displayed to update environment variables. It exits early when nothing has changed, so the cost is negligible.
+</Info>
+
+
+# Shims
+Source: https://www.mintlify.com/jdx/mise/dev-tools/shims
+
+What shims are, how they compare to PATH activation, and when to use them — especially for IDEs and non-interactive environments.
+
+Mise provides three ways to load tools and environment variables into your shell:
+
+* **`mise activate`** (PATH activation) — updates `PATH` and env vars every time your prompt is displayed
+* **`mise activate --shims`** — places lightweight wrapper scripts on `PATH` that intercept tool calls
+* **`mise exec` / `mise run`** — loads the mise environment on demand for a single command or task
+
+## PATH activation
+
+With `mise activate`, mise hooks into your shell prompt and updates `PATH` and other environment variables each time it's displayed.
+
+```sh theme={null}
+# Add to your shell rc file
+eval "$(mise activate zsh)"
+
+# When you cd into a project, tools load automatically
+cd my-project
+node -v  # uses the version from mise.toml
+```
+
+After activation, `PATH` looks like this for a project with `python@3.13`:
+
+```sh theme={null}
+echo $PATH
+# /home/user/.local/share/mise/installs/python/3.13.0/bin:/usr/local/bin:/usr/bin:/bin
+```
+
+Mise modifies `PATH` ahead of time, so tool binaries are called directly with zero overhead. Running `which node` returns the real binary path.
+
+<Info>
+  This is the method used when you add `eval "$(mise activate bash)"` to your `~/.bashrc`.
+</Info>
+
+## Shims
+
+When using shims, mise places small wrapper executables in a directory on your `PATH`. Each shim intercepts calls to a tool and loads the appropriate mise environment before running it.
+
+```sh theme={null}
+ls -l ~/.local/share/mise/shims/node
+# [...] ~/.local/share/mise/shims/node -> ~/.local/bin/mise
+```
+
+Shims are created automatically when you install a tool:
+
+```sh theme={null}
+mise use -g node@20
+npm install -g prettier@3.1.0
+
+~/.local/share/mise/shims/node -v
+# v20.0.0
+~/.local/share/mise/shims/prettier -v
+# 3.1.0
+```
+
+The default shims directory is `~/.local/share/mise/shims` (Windows: `%LOCALAPPDATA%\mise\shims`).
+
+<Warning>
+  `mise activate --shims` does not support all features of `mise activate`. See [shims vs PATH](#shims-vs-path) for details.
+</Warning>
+
+## Setting up shims
+
+The recommended setup uses shims for non-interactive sessions and PATH activation for interactive shells:
+
+<Tabs>
+  <Tab title="bash">
+    ```sh theme={null}
+    # Non-interactive sessions (e.g. scripts, IDEs)
+    echo 'eval "$(mise activate bash --shims)"' >> ~/.bash_profile
+
+    # Interactive sessions
+    echo 'eval "$(mise activate bash)"' >> ~/.bashrc
+    ```
+  </Tab>
+
+  <Tab title="zsh">
+    ```sh theme={null}
+    # Non-interactive sessions
+    echo 'eval "$(mise activate zsh --shims)"' >> ~/.zprofile
+
+    # Interactive sessions
+    echo 'eval "$(mise activate zsh)"' >> ~/.zshrc
+    ```
+  </Tab>
+
+  <Tab title="fish">
+    ```sh theme={null}
+    echo 'mise activate fish --shims | source' >> ~/.config/fish/config.fish
+    echo 'mise activate fish | source' >> ~/.config/fish/config.fish
+    ```
+  </Tab>
+</Tabs>
+
+<Note>
+  `mise activate` automatically removes the shims directory from `PATH`, so it's safe to call `mise activate --shims` in your profile file and then `mise activate` in your interactive rc file.
+</Note>
+
+Alternatively, add the shims directory directly to `PATH` without using `mise activate`:
+
+```sh theme={null}
+export PATH="$HOME/.local/share/mise/shims:$PATH"
+```
+
+### Refreshing shims
+
+Mise automatically runs a reshim whenever a tool is installed, updated, or removed. You can force a refresh manually:
+
+```sh theme={null}
+mise reshim
+```
+
+This only creates or removes shim files. Use it if `~/.local/share/mise/shims` is missing an entry it should have.
+
+<Warning>
+  Do not add custom executables to the mise shims directory — mise will delete them on the next reshim.
+</Warning>
+
+## Shims vs PATH
+
+| Feature                            | PATH activation    | Shims                               |
+| ---------------------------------- | ------------------ | ----------------------------------- |
+| Environment variables in mise.toml | Available in shell | Only available to mise tools        |
+| Hooks (`cd`, `enter`, `exit`)      | ✅                  | ❌ (only `preinstall`/`postinstall`) |
+| `which <tool>` shows real path     | ✅                  | ❌ (shows the shim)                  |
+| Works in non-interactive shells    | ❌                  | ✅                                   |
+| Works in IDEs and scripts          | ❌                  | ✅                                   |
+
+In general, use PATH activation (`mise activate`) for interactive shells and shims for non-interactive environments like IDEs and CI scripts.
+
+### Environment variables and shims
+
+With PATH activation, env vars set in `mise.toml` are available directly in the shell:
+
+```sh theme={null}
+mise set NODE_ENV=production
+echo $NODE_ENV
+# production   ← works only with mise activate
+```
+
+With shims, env vars are only loaded when a shim is called:
+
+```sh theme={null}
+mise set NODE_ENV=production
+node -p process.env.NODE_ENV
+# production   ← works with both activate and shims
+```
+
+To get mise env vars without a shim, use `mise exec`:
+
+```sh theme={null}
+mise set NODE_ENV=production
+mise x -- bash -c "echo \$NODE_ENV"
+# production
+```
+
+### Hooks and shims
+
+The hooks `cd`, `enter`, `exit`, and `watch_files` only trigger with `mise activate`. The `preinstall` and `postinstall` hooks still work with shims because they don't require shell integration.
+
+### `which` and shims
+
+With PATH activation, `which node` returns the real binary path:
+
+```sh theme={null}
+which node
+# ~/.mise/installs/node/20/bin/node
+```
+
+With shims, `which node` points to the shim. Use `mise which` to find the real location:
+
+```sh theme={null}
+mise which node
+# ~/.local/share/mise/installs/node/20.11.0/bin/node
+```
+
+### Performance
+
+The performance difference between shims and PATH activation is negligible for most users. With `mise activate`, mise runs on every prompt display. With shims, mise runs on every shim invocation.
+
+If you're calling a shim in a tight loop from a script, the cost adds up:
+
+```sh theme={null}
+for i in {1..500}; do
+    node script.js  # pays the mise startup cost each iteration
+done
+```
+
+For this reason, shims work better for scripts that call subprocesses from within a shim: mise sets up `PATH` when the outer shim is called, and the subprocess inherits it without triggering another mise lookup.
+
+## Using shims in an IDE
+
+IDEs launch non-interactive processes that don't source your `~/.zshrc` or `~/.bashrc`. Shims solve this because the shims directory is in `PATH` regardless of how the process was started.
+
+<Steps>
+  <Step title="Add shims to your PATH activation profile">
+    Add `mise activate --shims` to your non-interactive profile file (e.g., `~/.zprofile` or `~/.bash_profile`), not just your interactive rc file. This ensures the IDE inherits the shims directory.
+  </Step>
+
+  <Step title="Verify the shims directory is on PATH in the IDE">
+    Check that `~/.local/share/mise/shims` appears in the IDE's terminal `PATH`. If not, add it explicitly to your IDE's environment settings.
+  </Step>
+
+  <Step title="Install tools before opening the IDE">
+    Run `mise install` in your project directory before opening it in the IDE to ensure all shims exist.
+  </Step>
+</Steps>
+
+## Using shims in rc files
+
+If you need mise tools inside a shell rc file (which runs non-interactively), you have two options:
+
+<CodeGroup>
+  ```sh hook-env theme={null}
+  eval "$(mise activate zsh)"
+  eval "$(mise hook-env -s zsh)"
+  node some_script.js
+  ```
+
+  ```sh shims theme={null}
+  eval "$(mise activate zsh --shims)"  # should be first
+  eval "$(mise activate zsh)"
+  node some_script.js
+  ```
+</CodeGroup>
+
+## Neither shims nor PATH
+
+For ad-hoc or scripted use, `mise exec`, `mise run`, and `mise en` load the mise environment explicitly without requiring any shell integration:
+
+```sh theme={null}
+mise x python@3.12 -- ./myscript.py
+mise r some_task_that_uses_NODE_ENV
+```
+
+This approach is useful when you want precise control over when and how mise is loaded, or when working on mise itself and need to avoid conflicts with your development version.
+
+<Tip>
+  Alias frequently used commands: `alias mx="mise x --"` and `alias mr="mise r"`.
+</Tip>
+
+
+# Environments overview
+Source: https://www.mintlify.com/jdx/mise/environments/overview
+
+Set, unset, and dynamically generate environment variables for your projects using mise.
+
+Mise manages environment variables for different project directories, similar to [direnv](https://github.com/direnv/direnv). When you enter a project directory, mise automatically activates the environment variables defined for that project.
+
+## Setting environment variables
+
+Declare environment variables in the `[env]` section of `mise.toml`:
+
+```toml mise.toml theme={null}
+[env]
+NODE_ENV = 'production'
+```
+
+You can also use the CLI to get and set vars without editing the file directly:
+
+```sh theme={null}
+mise set NODE_ENV=development
+
+mise set
+# key       value        source
+# NODE_ENV  development  mise.toml
+
+mise unset NODE_ENV
+```
+
+To unset a variable that was set in a parent config, assign it to `false`:
+
+```toml mise.toml theme={null}
+[env]
+NODE_ENV = false # unset a previously set NODE_ENV
+```
+
+## Using environment variables
+
+Environment variables are available in `mise exec`, `mise run`, and — when mise is activated in your shell — any command you run after `cd`-ing into the project directory.
+
+```sh theme={null}
+mise set MY_VAR=123
+mise exec -- echo $MY_VAR
+# 123
+```
+
+You can combine tools and environment variables in the same config:
+
+```sh theme={null}
+mise use node@24
+mise set MY_VAR=123
+cat mise.toml
+# [tools]
+# node = '24'
+# [env]
+# MY_VAR = '123'
+mise exec -- node --eval 'console.log(process.env.MY_VAR)'
+# 123
+```
+
+## Directives (`env._`)
+
+The `env._` key holds special directives for sourcing env vars from files, scripts, and paths. Because nested env vars don't make sense in TOML, mise uses the `_` key as a namespace for these directives.
+
+### Load a dotenv file (`env._.file`)
+
+Load variables from a `.env`, `.env.json`, or `.env.yaml` file:
+
+```toml mise.toml theme={null}
+[env]
+_.file = '.env'
+```
+
+Multiple files and formats are supported:
+
+```toml mise.toml theme={null}
+[env]
+_.file = [
+    '.env.json',
+    '/User/bob/.env',
+    { path = ".secrets.yaml", redact = true }
+]
+```
+
+<Info>
+  File loading uses the [dotenvy](https://crates.io/crates/dotenvy) crate. If you encounter parsing issues, the problem likely originates there.
+</Info>
+
+You can also set `MISE_ENV_FILE=.env` to automatically load a dotenv file in any directory.
+
+### Extend PATH (`env._.path`)
+
+Add directories to `PATH` without overwriting it:
+
+```toml mise.toml theme={null}
+[env]
+_.path = './bin'
+```
+
+Multiple paths are supported, including references to env vars:
+
+```toml mise.toml theme={null}
+[env]
+_.path = [
+    "~/.local/share/bin",
+    "{{config_root}}/node_modules/.bin",
+    "tools/bin",
+]
+```
+
+Relative paths resolve against `config_root` — the project root directory containing your `mise.toml`.
+
+To add a path after tools have set their env vars, use `tools = true`:
+
+```toml mise.toml theme={null}
+[env]
+_.path = { path = ["{{env.GEM_HOME}}/bin"], tools = true }
+```
+
+### Source a bash script (`env._.source`)
+
+Source an external bash script and pull its exported variables into the environment:
+
+```toml mise.toml theme={null}
+[env]
+_.source = "./script.sh"
+```
+
+<Warning>
+  The sourced file must be a bash script. The shebang is ignored — mise always sources the file using `source ./script.sh` in bash.
+</Warning>
+
+Multiple sources with options:
+
+```toml mise.toml theme={null}
+[env]
+_.source = [
+    './scripts/base.sh',
+    '/User/bob/env.sh',
+    { path = ".secrets.sh", redact = true }
+]
+```
+
+### Multiple directives
+
+TOML doesn't allow duplicate keys, so you can't write two `_.source` entries in the same `[env]` table. Use `[[env]]` (array of tables) instead:
+
+```toml mise.toml theme={null}
+[[env]]
+_.source = "./script_1.sh"
+[[env]]
+_.source = "./script_2.sh"
+```
+
+## Templates
+
+Environment variable values support [Tera](https://keats.github.io/tera/) templates. This lets you reference other env vars or compute values dynamically:
+
+```toml mise.toml theme={null}
+[env]
+MY_PROJ_LIB = "{{config_root}}/lib"
+LD_LIBRARY_PATH = "/some/path:{{env.MY_PROJ_LIB}}"
+```
+
+Variables are resolved in order, so you can reference earlier-defined variables in later ones.
+
+## Shell-style variable expansion
+
+As a simpler alternative to Tera templates, enable `env_shell_expand` to use `$VAR` syntax:
+
+```toml mise.toml theme={null}
+[settings]
+env_shell_expand = true
+
+[env]
+MY_PROJ_LIB = "{{config_root}}/lib"
+LD_LIBRARY_PATH = "$MY_PROJ_LIB:$LD_LIBRARY_PATH"
+```
+
+Supported syntax:
+
+| Syntax            | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `$VAR`            | Expands to the value of `VAR`               |
+| `${VAR}`          | Same, useful before alphanumeric characters |
+| `${VAR:-default}` | Uses `default` if `VAR` is unset or empty   |
+| `${VAR:-}`        | Expands to empty string if `VAR` is unset   |
+
+<Tip>
+  Shell expansion will become the default in the 2026.7.0 release. Set `env_shell_expand = true` now to opt in early, or `env_shell_expand = false` to preserve the current behavior.
+</Tip>
+
+## Lazy evaluation (after tools)
+
+By default, env vars resolve before tools so you can use them to configure tool installation. To reference env vars produced by tools, set `tools = true`:
+
+```toml mise.toml theme={null}
+[env]
+MY_VAR = { value = "tools path: {{env.PATH}}", tools = true }
+_.path = { path = ["{{env.GEM_HOME}}/bin"], tools = true }
+NODE_VERSION = { value = "{{ tools.node.version }}", tools = true }
+```
+
+## Required variables
+
+Mark a variable as required to ensure it is explicitly set before running commands:
+
+```toml mise.toml theme={null}
+[env]
+DATABASE_URL = { required = true }
+API_KEY = {
+  required = "Get your API key from https://example.com/api-keys",
+}
+```
+
+When a required variable is missing, mise shows the help text in the error message. Variables can be satisfied by a pre-existing environment variable or by a later config file such as `mise.local.toml`.
+
+<Info>
+  Shell activation (`hook-env`) warns about missing required variables but continues — it doesn't break your shell setup.
+</Info>
+
+## Redactions
+
+Mark variables as sensitive to prevent them from appearing in logs:
+
+```toml mise.toml theme={null}
+[env]
+SECRET = { value = "my_secret", redact = true }
+_.file = { path = ".env.json", redact = true }
+```
+
+You can also use glob patterns to redact multiple variables at once:
+
+```toml mise.toml theme={null}
+redactions = ["SECRET_*", "*_TOKEN", "PASSWORD"]
+
+[env]
+SECRET_KEY = "sensitive_value"
+API_TOKEN = "token_123"
+```
+
+<Warning>
+  Redactions work by intercepting task output line-by-line, so they require a non-`raw` output mode. Tasks with `raw = true` bypass this interception.
+</Warning>
+
+Use `mise env --redacted` to inspect redacted values. In CI, mask them explicitly:
+
+```bash theme={null}
+# GitHub Actions
+for value in $(mise env --redacted --values); do
+  echo "::add-mask::$value"
+done
+```
+
+<Note>
+  [mise-action](https://github.com/jdx/mise-action) automatically redacts values marked with `redact = true` or matching patterns in the `redactions` array.
+</Note>
+
+## `config_root`
+
+`config_root` is the canonical project root that mise uses when resolving relative paths in config files. Relative paths in `env._` directives always resolve against `config_root`.
+
+| Config file                                 | `config_root` |
+| ------------------------------------------- | ------------- |
+| `~/src/foo/.config/mise/conf.d/config.toml` | `~/src/foo`   |
+| `~/src/foo/.config/mise/config.toml`        | `~/src/foo`   |
+| `~/src/foo/.mise/config.toml`               | `~/src/foo`   |
+| `~/src/foo/mise.toml`                       | `~/src/foo`   |
+
+```toml mise.toml theme={null}
+[env]
+# Both are equivalent and resolve against config_root
+_.path = ["tools/bin", "{{config_root}}/tools/bin"]
+
+# Relative source path resolves against config_root
+_.source = "scripts/env.sh"
+```
+
+
+# Secrets
+Source: https://www.mintlify.com/jdx/mise/environments/secrets
+
+Manage sensitive environment variables securely using SOPS, age encryption, or external secret managers.
+
+Mise provides several approaches for handling sensitive environment variables. Choose the one that fits your security requirements and team workflow.
+
+<CardGroup>
+  <Card title="SOPS" icon="file-lock" href="#sops">
+    Encrypt entire env files. Integrates with age. Good for committing encrypted secrets to version control.
+  </Card>
+
+  <Card title="Direct age" icon="key" href="#direct-age-encryption">
+    Encrypt individual values inline in `mise.toml`. No extra files required.
+  </Card>
+
+  <Card title="fnox" icon="shield" href="#fnox">
+    Full-featured external secret manager with remote storage. Recommended for team environments.
+  </Card>
+</CardGroup>
+
+## SOPS
+
+<Warning>
+  SOPS support is experimental. Behavior may change in future releases.
+</Warning>
+
+Mise reads [sops](https://getsops.io)-encrypted files and makes their values available as environment variables via `env._.file`. Currently, only age encryption is supported as the sops backend.
+
+**Supported file formats:** `.env.json`, `.env.yaml`, `.env.toml`
+
+### Setup
+
+<Steps>
+  <Step title="Install tools">
+    ```sh theme={null}
+    mise use -g sops age
+    ```
+  </Step>
+
+  <Step title="Generate an age key">
+    ```sh theme={null}
+    age-keygen -o ~/.config/mise/age.txt
+    # Public key: age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p
+    ```
+
+    Note the public key — you'll need it in the next step.
+  </Step>
+
+  <Step title="Create and encrypt your env file">
+    Create `.env.json` with your secrets:
+
+    ```json .env.json theme={null}
+    {
+      "AWS_ACCESS_KEY_ID": "[REDACTED-AWSKEY-DOCS-EXAMPLE]",
+      "AWS_SECRET_ACCESS_KEY": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    }
+    ```
+
+    Encrypt it in-place:
+
+    ```sh theme={null}
+    sops encrypt -i --age "<public key>" .env.json
+    ```
+
+    The `-i` flag overwrites the file with its encrypted version. The encrypted file is safe to commit.
+  </Step>
+
+  <Step title="Reference the file in mise.toml">
+    ```toml mise.toml theme={null}
+    [env]
+    _.file = ".env.json"
+    ```
+
+    Mise automatically detects and decrypts sops-encrypted files.
+  </Step>
+</Steps>
+
+### Key configuration
+
+Set the age key file for sops decryption using mise-specific or standard SOPS variables:
+
+| Variable                 | Description                                |
+| ------------------------ | ------------------------------------------ |
+| `MISE_SOPS_AGE_KEY`      | Age private key content (highest priority) |
+| `MISE_SOPS_AGE_KEY_FILE` | Path to age private key file               |
+| `SOPS_AGE_KEY_FILE`      | Standard SOPS variable (fallback)          |
+| `SOPS_AGE_KEY`           | Standard SOPS variable (fallback)          |
+
+Mise checks these in the order listed. If none are set, it falls back to `~/.config/mise/age.txt`.
+
+<Tip>
+  Set `SOPS_AGE_KEY_FILE=~/.config/mise/age.txt` to use the same key file with the `sops` CLI for manual editing.
+</Tip>
+
+### Redacting sops secrets
+
+Mark secrets from a sops file as sensitive so they are hidden from output:
+
+```toml mise.toml theme={null}
+[env]
+_.file = { path = ".env.json", redact = true }
+```
+
+Work with redacted values:
+
+```bash theme={null}
+mise env --redacted
+mise env --redacted --values
+```
+
+**Masking in GitHub Actions:**
+
+```yaml theme={null}
+- name: Mask secrets
+  run: |
+    for value in $(mise env --redacted --values); do
+      echo "::add-mask::$value"
+    done
+- name: Use secrets safely
+  run: |
+    mise exec -- ./deploy.sh
+```
+
+***
+
+## Direct age encryption
+
+<Warning>
+  Direct age encryption is experimental. Flags and behavior may change in future releases.
+</Warning>
+
+Encrypt individual environment variable values directly inside `mise.toml` using [age](https://github.com/FiloSottile/age). Mise has built-in age support — you don't need to install the `age` CLI separately.
+
+By default, mise uses your SSH key (`~/.ssh/id_ed25519` or `~/.ssh/id_rsa`) if one exists.
+
+### Quick start
+
+<Steps>
+  <Step title="Optionally generate an age key">
+    Skip this if you want to use your existing SSH key.
+
+    ```bash theme={null}
+    age-keygen -o ~/.config/mise/age.txt
+    # Note the public key output for encryption
+    ```
+  </Step>
+
+  <Step title="Encrypt a value">
+    ```bash theme={null}
+    mise set --age-encrypt --prompt DB_PASSWORD
+    # Enter value for DB_PASSWORD: [hidden input]
+    ```
+
+    <Tip>
+      Use `--prompt` to avoid exposing the value in your shell history. Alternatively: `mise set --age-encrypt DB_PASSWORD="password123"`.
+    </Tip>
+  </Step>
+
+  <Step title="Verify the stored value">
+    Encrypted values are stored in `mise.toml`:
+
+    ```toml mise.toml theme={null}
+    [env]
+    DB_PASSWORD = { age = { value = "<base64>" } }
+    ```
+  </Step>
+
+  <Step title="Use the variable">
+    Decryption happens automatically when mise resolves the environment:
+
+    ```bash theme={null}
+    mise env  # Variables are decrypted automatically
+    ```
+  </Step>
+</Steps>
+
+### CLI flags
+
+| Flag                              | Description                                               |
+| --------------------------------- | --------------------------------------------------------- |
+| `--age-encrypt`                   | Enable age encryption for the value                       |
+| `--age-recipient <KEY>`           | x25519 recipient (repeatable)                             |
+| `--age-ssh-recipient <PATH\|KEY>` | SSH public key or path to `.pub`/private key (repeatable) |
+| `--age-key-file <PATH>`           | Use recipients from an age identity file                  |
+| `--prompt`                        | Prompt for the value to avoid shell history exposure      |
+
+### Decryption identities
+
+Mise looks for decryption identities in this order:
+
+1. `MISE_AGE_KEY` environment variable — raw `AGE-SECRET-KEY-...` lines or identity file payload
+2. `settings.age.identity_files` — list of paths
+3. `settings.age.key_file` — single path
+4. `~/.config/mise/age.txt` — default key file if it exists
+5. SSH identities from `settings.age.ssh_identity_files` and defaults (`~/.ssh/id_ed25519`, `~/.ssh/id_rsa`)
+
+Decrypted values are always marked as redacted. If no identities are found or decryption fails, mise returns the encrypted value as-is.
+
+### Storage format
+
+Encrypted values are stored as base64 with a `format` field:
+
+* `format = "raw"` — uncompressed ciphertext (for small values)
+* `format = "zstd"` — zstd-compressed ciphertext (used when ciphertext exceeds 1 KB)
+
+***
+
+## fnox
+
+[fnox](https://github.com/jdx/fnox) is a full-featured secret manager that integrates with remote storage backends (1Password, AWS Secrets Manager) and remote encryption (AWS KMS). It is a separate project by the same author as mise.
+
+There is no direct integration between fnox and mise — you configure fnox independently, and it sets environment variables that mise picks up like any other variables in your shell.
+
+fnox is recommended for team environments where secrets need to be shared securely and audited.
+
+
+# Getting started
+Source: https://www.mintlify.com/jdx/mise/getting-started
+
+Install mise, activate your shell, and start managing tools, environment variables, and tasks.
+
+## Install and activate mise
+
+<Steps>
+  <Step title="Install mise">
+    The fastest way to install mise on Linux or macOS is with the install script:
+
+    ```sh theme={null}
+    curl https://mise.run | sh
+    ```
+
+    By default, mise installs to `~/.local/bin`. Verify the installation:
+
+    ```sh theme={null}
+    ~/.local/bin/mise --version
+    # mise 2024.x.x
+    ```
+
+    For other platforms and package managers, see [Installing mise](/installing-mise).
+  </Step>
+
+  <Step title="Activate mise in your shell">
+    Add the activation line to your shell's config file, then restart your shell session:
+
+    <Tabs>
+      <Tab title="bash">
+        ```sh theme={null}
+        echo 'eval "$(~/.local/bin/mise activate bash)"' >> ~/.bashrc
+        ```
+      </Tab>
+
+      <Tab title="zsh">
+        ```sh theme={null}
+        echo 'eval "$(~/.local/bin/mise activate zsh)"' >> ~/.zshrc
+        ```
+      </Tab>
+
+      <Tab title="fish">
+        ```sh theme={null}
+        echo '~/.local/bin/mise activate fish | source' >> ~/.config/fish/config.fish
+        ```
+      </Tab>
+
+      <Tab title="PowerShell">
+        ```powershell theme={null}
+        (&mise activate pwsh) | Out-String | Invoke-Expression
+        ```
+
+        Add the line above to your PowerShell profile (`$PROFILE`).
+      </Tab>
+    </Tabs>
+
+    After restarting your shell, run `mise doctor` to verify the setup:
+
+    ```sh theme={null}
+    mise doctor
+    ```
+
+    <Tip>
+      `mise activate` updates your `PATH` and environment every time your prompt runs. This is the recommended approach for interactive shells. Alternatively, use [shims](/dev-tools/shims) for CI/CD, IDEs, and scripts.
+    </Tip>
+  </Step>
+
+  <Step title="Install and use tools">
+    Install a tool at a specific version and set it as your global default:
+
+    ```sh theme={null}
+    mise use --global node@24
+    node -v
+    # v24.x.x
+    ```
+
+    For a one-off command without installing permanently, use `mise exec`:
+
+    ```sh theme={null}
+    mise exec node@24 -- node -v
+    # mise node@24.x.x ✓ installed
+    # v24.x.x
+    ```
+
+    Running `mise use --global node@24` updates your global config:
+
+    ```toml ~/.config/mise/config.toml theme={null}
+    [tools]
+    node = "24"
+    ```
+  </Step>
+
+  <Step title="Set environment variables">
+    Define environment variables in a project's `mise.toml`. They load automatically when mise is activated:
+
+    ```toml mise.toml theme={null}
+    [env]
+    NODE_ENV = "production"
+    ```
+
+    ```sh theme={null}
+    echo "node env: $NODE_ENV"
+    # node env: production
+    ```
+  </Step>
+
+  <Step title="Run tasks">
+    Define tasks in `mise.toml` and run them with `mise run`:
+
+    ```toml mise.toml theme={null}
+    [tasks]
+    hello = "echo hello from mise"
+    ```
+
+    ```sh theme={null}
+    mise run hello
+    # hello from mise
+    ```
+
+    <Tip>
+      Mise automatically installs all tools from `mise.toml` before running a task.
+    </Tip>
+  </Step>
+</Steps>
+
+## Using backends
+
+Mise can install tools from multiple package ecosystems. Use `mise use` with the backend prefix:
+
+```sh theme={null}
+# Install claude-code from npm
+mise use --global npm:@anthropic-ai/claude-code
+claude --version
+
+# Install black from PyPI via pipx
+mise use --global pipx:black
+black --version
+
+# Install ripgrep from GitHub releases
+mise use --global github:BurntSushi/ripgrep
+rg --version
+```
+
+After running all three, your config will include:
+
+```toml ~/.config/mise/config.toml theme={null}
+[tools]
+"npm:@anthropic-ai/claude-code" = "latest"
+"pipx:black" = "latest"
+"github:BurntSushi/ripgrep" = "latest"
+```
+
+See [backends](/dev-tools/backends) for all supported ecosystems.
+
+## Trusting config files
+
+When you or a teammate adds a `mise.toml` to a project, mise prompts you to trust it before loading any env directives or hooks:
+
+```
+mise ~/my-project/mise.toml is not trusted. Trust it? [y/n]
+```
+
+To trust the file, run:
+
+```sh theme={null}
+mise trust
+```
+
+<Note>
+  This is a security measure — config files can execute arbitrary code via `[env]` directives, hooks, and tasks. `mise use` automatically trusts the file it creates, so you will only see this prompt when pulling a config someone else wrote or editing `mise.toml` by hand.
+</Note>
+
+## Shell feature compatibility
+
+Not all shells support every mise feature:
+
+| Feature                         | Bash | Zsh | Fish | Nushell | Elvish | Xonsh | PowerShell |
+| ------------------------------- | ---- | --- | ---- | ------- | ------ | ----- | ---------- |
+| `mise activate`                 | Yes  | Yes | Yes  | Yes     | Yes    | Yes   | Yes        |
+| `mise shell`                    | Yes  | Yes | Yes  | Yes     | Yes    | Yes   | Yes        |
+| Shell aliases (`[shell_alias]`) | Yes  | Yes | Yes  | No      | No     | Yes   | No         |
+| `chpwd` hook                    | Yes  | Yes | Yes  | Yes     | Yes    | Yes   | Yes        |
+
+## Next steps
+
+<CardGroup>
+  <Card title="Installing mise" icon="download" href="/installing-mise">
+    All installation methods: brew, apt, dnf, cargo, winget, and more.
+  </Card>
+
+  <Card title="Dev tools" icon="wrench" href="/dev-tools/overview">
+    Manage hundreds of tools across multiple backends.
+  </Card>
+
+  <Card title="Environments" icon="leaf" href="/environments/overview">
+    Load `.env` files and manage per-project environment variables.
+  </Card>
+
+  <Card title="Tasks" icon="list-check" href="/tasks/overview">
+    Define tasks with dependencies, file watching, and parallel execution.
+  </Card>
+</CardGroup>
+
+<Warning>
+  Many tools in mise require the GitHub API. Unauthenticated requests can be rate limited — if you see 4xx errors, see [GitHub API rate limits](/guides/troubleshooting#github-api-rate-limits) for how to configure authentication.
+</Warning>
+
+
+# Continuous integration
+Source: https://www.mintlify.com/jdx/mise/guides/continuous-integration
+
+Use mise in CI pipelines to provision reproducible tool environments across GitHub Actions, GitLab CI, Xcode Cloud, and any other CI system.
+
+Mise works in any CI environment that can run shell commands. Pin your tools to specific versions in `mise.toml` to ensure reproducible builds across every run.
+
+## Any CI provider
+
+Install mise and run `mise install` as part of your pipeline setup:
+
+```yaml theme={null}
+script: |
+  curl https://mise.run | sh
+  mise install
+```
+
+To run commands through the tools mise installed, use `mise x`:
+
+```yaml theme={null}
+script: |
+  mise x -- npm test
+```
+
+Alternatively, add the [shims](/dev-tools/shims) directory to `PATH` if your CI provider supports it.
+
+### Bootstrapping without curl
+
+Use `mise generate bootstrap` to generate a self-contained installer script that you can commit to your repository. This avoids calling `curl` at runtime:
+
+```shell theme={null}
+mise generate bootstrap -l -w
+```
+
+Add `.mise/` to your `.gitignore` and commit `./bin/mise`. You can now use `./bin/mise` in CI without a network dependency on the installer:
+
+```yaml theme={null}
+script: |
+  ./bin/mise install
+  ./bin/mise x -- npm test
+```
+
+## GitHub Actions
+
+The [mise-action](https://github.com/jdx/mise-action) handles installation, caching, and tool setup for you:
+
+```yaml theme={null}
+name: test
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: jdx/mise-action@v3
+        with:
+          version: 2024.12.14 # [default: latest] mise version to install
+          install: true        # [default: true] run `mise install`
+          cache: true          # [default: true] cache mise using GitHub's cache
+          experimental: true   # [default: false] enable experimental features
+          # automatically write this mise.toml file
+          mise_toml: |
+            [tools]
+            shellcheck = "0.9.0"
+          # or, if you prefer .tool-versions:
+          tool_versions: |
+            shellcheck 0.9.0
+      - run: shellcheck scripts/*.sh
+```
+
+<Tip>
+  The `cache: true` option caches installed tools between runs using GitHub's built-in cache. Tool caches are keyed on `mise.toml` and `mise.lock` so they invalidate automatically when your tool versions change.
+</Tip>
+
+<Note>
+  If you hit GitHub API rate limits when installing tools, configure a `GITHUB_TOKEN`. See the [GitHub tokens](/dev-tools/backends) documentation for details.
+</Note>
+
+## GitLab CI
+
+### Using a Docker image with mise pre-installed
+
+Build a Docker image with mise included, then cache the mise data directory:
+
+<AccordionGroup>
+  <Accordion title="Example Dockerfile">
+    ```dockerfile theme={null}
+    FROM debian:12-slim
+
+    RUN apt-get update  \
+        && apt-get -y --no-install-recommends install  \
+          sudo curl git ca-certificates build-essential \
+        && rm -rf /var/lib/apt/lists/*
+
+    RUN curl https://mise.run | MISE_VERSION=v... MISE_INSTALL_PATH=/usr/local/bin/mise sh
+    ```
+  </Accordion>
+</AccordionGroup>
+
+Configure your job to cache the mise data directory keyed on your config files:
+
+```yaml theme={null}
+build-job:
+  stage: build
+  image: mise-debian-slim # Use the image you created
+  variables:
+    MISE_DATA_DIR: $CI_PROJECT_DIR/.mise/mise-data
+  cache:
+    - key:
+        prefix: mise-
+        files: ["mise.toml", "mise.lock"] # mise.lock is optional, only if using `lockfile = true`
+      paths:
+        - $MISE_DATA_DIR
+  script:
+    - mise install
+    - mise exec --command 'npm build'
+```
+
+### Using the bootstrap script
+
+Use the [bootstrap approach](#bootstrapping-without-curl) to avoid a custom Docker image entirely. Use any generic Debian image and let `./bin/mise` handle the rest:
+
+<AccordionGroup>
+  <Accordion title="Example Dockerfile (generic)">
+    ```dockerfile theme={null}
+    FROM debian:12-slim
+
+    RUN apt-get update  \
+        && apt-get -y --no-install-recommends install sudo curl git ca-certificates build-essential \
+        && rm -rf /var/lib/apt/lists/*
+    ```
+  </Accordion>
+</AccordionGroup>
+
+```yaml theme={null}
+.mise-cache: &mise-cache
+  key:
+    prefix: mise-
+    files: ["mise.toml", "./bin/mise"]
+  paths:
+    - .mise/installs
+    - .mise/mise-2025.1.3
+
+build-job:
+  stage: build
+  image: my-debian-slim-image
+  cache:
+    - <<: *mise-cache
+      policy: pull-push
+  script:
+    - ./bin/mise install
+    - ./bin/mise exec --command 'npm build'
+```
+
+## Xcode Cloud
+
+Add a `ci_post_clone.sh` [build script](https://developer.apple.com/documentation/xcode/writing-custom-build-scripts) to install mise and activate your tools before the build runs:
+
+```bash theme={null}
+#!/bin/sh
+curl https://mise.run | sh
+export PATH="$HOME/.local/bin:$PATH"
+
+mise install # Installs the tools in mise.toml
+eval "$(mise activate bash --shims)" # Adds the activated tools to $PATH
+
+swiftlint {args}
+```
+
+
+# Hooks
+Source: https://www.mintlify.com/jdx/mise/guides/hooks
+
+Automatically execute scripts on directory changes, tool installation, and other mise lifecycle events.
+
+Hooks let you automatically run scripts when mise lifecycle events occur. Configure them in `mise.toml` under the `[hooks]` section.
+
+<Note>
+  Most hooks require `mise activate` to be installed in your shell. The `preinstall` and `postinstall` hooks are exceptions and work without activation.
+</Note>
+
+## Hook types
+
+### `enter`
+
+Runs once when you enter a project directory (not on subsequent `cd` within the project):
+
+```toml mise.toml theme={null}
+[hooks]
+enter = "echo 'Welcome to the project!'"
+```
+
+### `leave`
+
+Runs when you leave the project directory:
+
+```toml mise.toml theme={null}
+[hooks]
+leave = "echo 'Leaving the project'"
+```
+
+### `cd`
+
+Runs every time the directory changes, including within the project:
+
+```toml mise.toml theme={null}
+[hooks]
+cd = "echo 'Directory changed'"
+```
+
+### `preinstall`
+
+Runs before tools are installed. Works without `mise activate`:
+
+```toml mise.toml theme={null}
+[hooks]
+preinstall = "echo 'About to install tools'"
+```
+
+### `postinstall`
+
+Runs after tools are installed. Receives `MISE_INSTALLED_TOOLS` as a JSON array:
+
+```toml mise.toml theme={null}
+[hooks]
+postinstall = '''
+echo "Installed: $MISE_INSTALLED_TOOLS"
+# Output: [{"name":"node","version":"22.0.0"},{"name":"python","version":"3.12.0"}]
+'''
+```
+
+## Per-tool postinstall
+
+Individual tools can define postinstall scripts that run immediately after that tool is installed:
+
+```toml mise.toml theme={null}
+[tools]
+node = { version = "22", postinstall = "npm install -g pnpm" }
+python = { version = "3.12", postinstall = "pip install pipx" }
+```
+
+Tool postinstall scripts receive:
+
+* `MISE_TOOL_NAME` — tool name (e.g., `node`)
+* `MISE_TOOL_VERSION` — installed version (e.g., `22.3.0`)
+* `MISE_TOOL_INSTALL_PATH` — install directory path
+
+## Using tasks as hooks
+
+Instead of inline shell scripts, reference a mise task:
+
+```toml mise.toml theme={null}
+[tasks.setup]
+run = "npm install"
+description = "Install project dependencies"
+
+[hooks]
+enter = { task = "setup" }
+```
+
+## Multi-line hooks
+
+Use TOML multi-line strings for complex hook scripts:
+
+```toml mise.toml theme={null}
+[hooks]
+enter = '''
+  echo "Entering project: $(basename $PWD)"
+  if [ ! -d node_modules ]; then
+    echo "Running npm install..."
+    npm install
+  fi
+'''
+```
+
+## Example: auto-install dependencies
+
+```toml mise.toml theme={null}
+[tools]
+node = "22"
+
+[hooks]
+enter = '''
+  if [ -f package.json ] && [ ! -d node_modules ]; then
+    npm install
+  fi
+'''
+
+postinstall = "echo 'Tools ready: $MISE_INSTALLED_TOOLS'"
+```
+
+
+# IDE Integration
+Source: https://www.mintlify.com/jdx/mise/guides/ide-integration
+
+Configure VS Code, IntelliJ, and other editors to use tools managed by mise.
+
+IDEs launch differently from interactive shells — they often don't source your shell's `rc` file, so `mise activate` may not run. This guide explains how to make IDEs use the correct tool versions.
+
+## The recommended approach: shims in PATH
+
+The most reliable solution is to add the mise shims directory to your shell's **login profile** (not the interactive `rc` file). IDEs like VS Code and IntelliJ typically read login profiles on startup.
+
+<Tabs>
+  <Tab title="zsh">
+    ```zsh ~/.zprofile theme={null}
+    eval "$($HOME/.local/bin/mise activate zsh --shims)"
+    ```
+  </Tab>
+
+  <Tab title="bash">
+    ```bash ~/.bash_profile theme={null}
+    eval "$($HOME/.local/bin/mise activate bash --shims)"
+    ```
+  </Tab>
+
+  <Tab title="fish">
+    ```fish ~/.config/fish/config.fish theme={null}
+    if status is-interactive
+      mise activate fish | source
+    else
+      mise activate fish --shims | source
+    end
+    ```
+  </Tab>
+</Tabs>
+
+After updating your profile, restart the IDE.
+
+<Warning>
+  On macOS, do not use `/bin/bash` as your default shell. Use `zsh` instead.
+</Warning>
+
+## Finding your default shell
+
+Your IDE uses your system's default shell to read the login profile.
+
+<Tabs>
+  <Tab title="macOS">
+    ```bash theme={null}
+    dscl . -read /Users/$USER UserShell
+    ```
+  </Tab>
+
+  <Tab title="Linux">
+    ```bash theme={null}
+    getent passwd $USER | cut -d: -f7
+    ```
+  </Tab>
+</Tabs>
+
+## VS Code
+
+After adding shims to your login profile, VS Code will automatically pick up mise-managed tools when launched from the terminal or Finder.
+
+To help VS Code find the correct interpreter, you can also set paths explicitly in your workspace settings:
+
+```json .vscode/settings.json theme={null}
+{
+  "python.defaultInterpreterPath": "${env:HOME}/.local/share/mise/shims/python",
+  "typescript.tsdk": "node_modules/typescript/lib"
+}
+```
+
+If VS Code doesn't read your login profile, enable it:
+
+```json VS Code settings.json theme={null}
+{
+  "terminal.integrated.shellArgs.osx": ["-l"]
+}
+```
+
+## IntelliJ / JetBrains
+
+In IntelliJ-based IDEs, configure the SDK path to point to the mise shim:
+
+1. Open **Project Structure** → **SDKs**
+2. Add a new SDK and set the path to the shim, e.g.: `~/.local/share/mise/shims/java`
+
+Alternatively, use `mise where <tool>` to get the exact install path:
+
+```bash theme={null}
+mise where node
+# /home/user/.local/share/mise/installs/node/22.0.0
+```
+
+## Neovim / Vim
+
+If you launch Neovim from a terminal with `mise activate`, tools are available automatically. For other launch methods, add shims to your profile as above.
+
+## Finding tool paths manually
+
+Use these commands to get exact paths for IDE configuration:
+
+```bash theme={null}
+# Path to the tool's binary
+mise which node
+# /home/user/.local/share/mise/installs/node/22.0.0/bin/node
+
+# Path to the tool's install directory
+mise where node
+# /home/user/.local/share/mise/installs/node/22.0.0
+
+# Path to the shim (works for any tool)
+echo ~/.local/share/mise/shims/node
+```
+
+<Tip>
+  Shim paths (`~/.local/share/mise/shims/node`) are stable across version changes, making them ideal for IDE configuration. The shim resolves to the correct version based on the current directory.
+</Tip>
+
+
+# Plugins
+Source: https://www.mintlify.com/jdx/mise/guides/plugins
+
+Extend mise with plugins for additional tools and environment management.
+
+Plugins extend mise with support for additional tools and environment variable management.
+
+<Note>
+  For most tools, plugins are no longer necessary. The [aqua](/dev-tools/backends) and [github](/dev-tools/backends) backends cover hundreds of tools without requiring manual plugin installation. Prefer those when possible.
+</Note>
+
+## When to use plugins
+
+Use plugins when:
+
+* The tool needs to set environment variables globally (e.g., Java's `JAVA_HOME`)
+* The tool has a complex installation process not handled by aqua/github
+* You need to use a legacy asdf plugin
+
+## Managing plugins
+
+```bash theme={null}
+# List installed plugins
+mise plugins ls
+mise plugins ls --urls   # include git URLs
+
+# Install a plugin
+mise plugins install node
+mise plugins install my-plugin https://github.com/user/mise-plugin-name
+
+# Update plugins
+mise plugins update
+mise plugins update node  # update specific plugin
+
+# Remove a plugin
+mise plugins uninstall node
+```
+
+## asdf plugin compatibility
+
+Mise is compatible with asdf plugins. You can install any plugin from the asdf ecosystem:
+
+```bash theme={null}
+# Install an asdf plugin by URL
+mise plugins install java https://github.com/halcyon/asdf-java.git
+```
+
+Then use it like any other tool:
+
+```bash theme={null}
+mise use java@21
+```
+
+## vfox plugins
+
+Mise also supports [vfox](https://vfox.lhan.me/) plugins, which use a Lua-based API:
+
+```bash theme={null}
+mise plugins install vfox:version-fox/vfox-nodejs
+mise use vfox:nodejs@22
+```
+
+## Tool plugins format
+
+Plugins installed with the `plugin:tool` format allow a single plugin to manage multiple tools:
+
+```bash theme={null}
+mise plugins install my-plugin https://github.com/user/my-plugin
+mise use my-plugin:some-tool@1.0.0
+```
+
+## Plugin-provided environment variables
+
+Plugins can inject environment variables when their tool is active. For example, the Java plugin sets `JAVA_HOME`:
+
+```bash theme={null}
+mise use java@21
+# Automatically sets JAVA_HOME=/path/to/java/21
+```
+
+## Finding plugins
+
+Browse available plugins:
+
+```bash theme={null}
+# List all plugins available in the registry
+mise plugins ls-remote
+```
+
+Or search the [mise plugin registry](https://github.com/mise-plugins/registry).
+
+<Warning>
+  For security reasons, new tools using the asdf plugin backend are no longer accepted into the mise registry unless aqua/github backends are not viable options. Prefer aqua or github backends for new tools.
+</Warning>
+
+
+# Troubleshooting
+Source: https://www.mintlify.com/jdx/mise/guides/troubleshooting
+
+Diagnose and fix common issues with mise tool management, shell activation, and environment setup.
+
+## Run mise doctor first
+
+```bash theme={null}
+mise doctor
+```
+
+This checks your mise installation for common problems and prints actionable warnings.
+
+## Enable debug output
+
+```bash theme={null}
+MISE_DEBUG=1 mise install
+MISE_TRACE=1 mise install   # even more verbose
+```
+
+Write logs to a file:
+
+```bash theme={null}
+MISE_LOG_FILE_LEVEL=debug MISE_LOG_FILE=/tmp/mise.log mise install
+```
+
+## `mise activate` not working
+
+`mise activate` should only be used in interactive shell `rc` files (`~/.zshrc`, `~/.bashrc`, `~/.config/fish/config.fish`). It does **not** work in login profiles (`~/.profile`, `~/.zprofile`).
+
+For non-interactive environments (IDEs, scripts, CI), use one of:
+
+* `mise exec -- <command>` to run a single command with mise tools
+* `mise env` to export environment variables
+* Add shims to `PATH` via `~/.zprofile` / `~/.bash_profile`
+
+See [IDE Integration](/guides/ide-integration) for IDE-specific setup.
+
+## Wrong tool version is being used
+
+If the wrong version is active, mise may not be first in `PATH`. Verify with:
+
+```bash theme={null}
+mise ls node         # check what version mise thinks is active
+which node           # check what node is on PATH
+mise doctor          # look for PATH warnings
+```
+
+If the version says "missing", install it:
+
+```bash theme={null}
+mise install
+```
+
+## Slow shell prompts
+
+`mise activate` hooks into your prompt to check for environment changes. Profile it:
+
+```bash theme={null}
+# Deactivate first to avoid interference
+mise deactivate
+
+# Measure hook-env timing
+MISE_TIMINGS=1 mise hook-env -s zsh 2>&1 >/dev/null
+MISE_TIMINGS=2 mise hook-env -s zsh 2>&1 >/dev/null  # more detail
+```
+
+Common causes:
+
+* Expensive `_.source` scripts in `mise.toml` (re-run on every prompt)
+* Many tools or plugins
+* Network-dependent env directives
+
+Consider using [shims](/dev-tools/shims) to move the cost from every prompt to every tool invocation.
+
+## Tool installation fails
+
+Try the `--raw` flag to connect stdin/stdout/stderr directly to the terminal:
+
+```bash theme={null}
+mise install node --raw
+```
+
+This helps if the plugin is trying to prompt for input.
+
+Also try clearing the cache:
+
+```bash theme={null}
+mise cache clean
+```
+
+## Permission errors
+
+Make sure `~/.local/share/mise` and `~/.local/bin` are writable:
+
+```bash theme={null}
+ls -la ~/.local/share/mise
+ls -la ~/.local/bin/mise
+```
+
+## Tool not found / command not found
+
+If mise shows "not found" for a tool that should be installed:
+
+```bash theme={null}
+mise ls --missing          # list tools defined but not installed
+mise install               # install all missing tools
+mise which node            # verify the tool path
+```
+
+## Resetting mise
+
+Clear the cache:
+
+```bash theme={null}
+mise cache clean
+```
+
+Remove everything except config:
+
+```bash theme={null}
+mise implode
+```
+
+## GitHub API rate limits
+
+Many tools are hosted on GitHub, and mise uses the GitHub API to list versions. Unauthenticated requests are rate-limited and may produce `403 Forbidden` errors, especially in CI.
+
+Mise checks these sources in order:
+
+| Priority | Source                                  |
+| -------- | --------------------------------------- |
+| 1        | `MISE_GITHUB_TOKEN` env var             |
+| 2        | `GITHUB_API_TOKEN` env var              |
+| 3        | `GITHUB_TOKEN` env var                  |
+| 4        | `credential_command` setting            |
+| 5        | `~/.config/mise/github_tokens.toml`     |
+| 6        | gh CLI token (`~/.config/gh/hosts.yml`) |
+
+Set a token via environment variable (no scopes required):
+
+```bash theme={null}
+export MISE_GITHUB_TOKEN="[REDACTED-GHTOKEN-DOCS-EXAMPLE]"
+```
+
+Or store it in a config file:
+
+```toml ~/.config/mise/github_tokens.toml theme={null}
+[tokens."github.com"]
+token = "[REDACTED-GHTOKEN-DOCS-EXAMPLE]"
+```
+
+In GitHub Actions, `GITHUB_TOKEN` is available automatically — mise picks it up with no extra config.
+
+Debug which token mise is using:
+
+```bash theme={null}
+mise github token           # check resolved token (masked)
+mise github token --unmask  # show full token
+```
+
+## Getting more help
+
+* Run `mise doctor` and include the output in bug reports
+* Check `mise --version` and update with `mise self-update`
+* File issues at [github.com/jdx/mise](https://github.com/jdx/mise)
+
+
+# Installing mise
+Source: https://www.mintlify.com/jdx/mise/installing-mise
+
+All installation methods for mise: curl, brew, apt, dnf, cargo, winget, scoop, and more.
+
+If you are new to mise, follow the [Getting started](/getting-started) guide first.
+
+## Recommended methods by platform
+
+| Platform              | Recommended    | Alternative     |
+| --------------------- | -------------- | --------------- |
+| macOS                 | Homebrew       | mise.run        |
+| Linux (Debian/Ubuntu) | apt            | mise.run        |
+| Linux (Fedora/RHEL)   | dnf            | mise.run        |
+| Linux (Arch)          | pacman         | mise.run        |
+| Linux (Alpine)        | apk            | mise.run        |
+| Windows               | Scoop          | winget          |
+| Any (Rust users)      | cargo binstall | cargo install   |
+| CI/Docker             | mise.run       | GitHub Releases |
+
+<Tip>
+  Package managers (apt, dnf, brew, pacman, etc.) update mise when you update system packages. Other methods can be updated with `mise self-update`.
+</Tip>
+
+## Installation methods
+
+<Tabs>
+  <Tab title="mise.run (curl)">
+    ```sh theme={null}
+    curl https://mise.run | sh
+    ```
+
+    Mise installs to `~/.local/bin` by default. To specify a different path:
+
+    ```sh theme={null}
+    curl https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise sh
+    ```
+
+    For a streamlined setup that also configures shell activation, use the shell-specific endpoints:
+
+    <CodeGroup>
+      ```sh zsh theme={null}
+      curl https://mise.run/zsh | sh
+      # Installs mise and adds activation to ~/.zshrc
+      ```
+
+      ```sh bash theme={null}
+      curl https://mise.run/bash | sh
+      # Installs mise and adds activation to ~/.bashrc
+      ```
+
+      ```sh fish theme={null}
+      curl https://mise.run/fish | sh
+      # Installs mise and adds activation to ~/.config/fish/config.fish
+      ```
+    </CodeGroup>
+
+    **Installer options:**
+
+    * `MISE_DEBUG=1` — enable debug logging
+    * `MISE_QUIET=1` — disable non-error output
+    * `MISE_INSTALL_PATH=/some/path` — change the binary path (default: `~/.local/bin/mise`)
+    * `MISE_VERSION=v2025.12.0` — install a specific version
+
+    To verify the install script hasn't been tampered with:
+
+    ```sh theme={null}
+    gpg --keyserver hkps://keys.openpgp.org --recv-keys 24853EC9F655CE80B48E6C3A8B81C9D17413A06D
+    curl https://mise.jdx.dev/install.sh.sig | gpg --decrypt > install.sh
+    # ensure the above is signed with the mise release key
+    sh ./install.sh
+    ```
+
+    **Supported platforms:** `macos-x64`, `macos-arm64`, `linux-x64`, `linux-x64-musl`, `linux-arm64`, `linux-arm64-musl`, `linux-armv6`, `linux-armv6-musl`, `linux-armv7`, `linux-armv7-musl`
+  </Tab>
+
+  <Tab title="Homebrew">
+    ```sh theme={null}
+    brew install mise
+    ```
+
+    [Homebrew formula](https://formulae.brew.sh/formula/mise)
+  </Tab>
+
+  <Tab title="apt (Debian/Ubuntu)">
+    On Ubuntu 26.04+, mise is available via a PPA:
+
+    ```sh theme={null}
+    sudo add-apt-repository -y ppa:jdxcode/mise
+    sudo apt update -y
+    sudo apt install -y mise
+    ```
+
+    For older Ubuntu/Debian versions:
+
+    ```sh theme={null}
+    sudo apt update -y && sudo apt install -y curl
+    sudo install -dm 755 /etc/apt/keyrings
+    curl -fSs https://mise.jdx.dev/gpg-key.pub | sudo tee /etc/apt/keyrings/mise-archive-keyring.asc 1> /dev/null
+    echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.asc] https://mise.jdx.dev/deb stable main" | sudo tee /etc/apt/sources.list.d/mise.list
+    sudo apt update -y
+    sudo apt install -y mise
+    ```
+  </Tab>
+
+  <Tab title="dnf (Fedora/RHEL)">
+    For Fedora 41+, RHEL 9+, CentOS Stream 9+:
+
+    ```sh theme={null}
+    dnf copr enable jdxcode/mise
+    dnf install mise
+    ```
+
+    For RHEL 8, CentOS Stream 8, Amazon Linux 2 (yum):
+
+    ```sh theme={null}
+    yum install -y yum-utils
+    yum-config-manager --add-repo https://mise.jdx.dev/rpm/mise.repo
+    yum install -y mise
+    ```
+  </Tab>
+
+  <Tab title="Windows">
+    **Scoop (recommended):**
+
+    ```sh theme={null}
+    scoop install mise
+    ```
+
+    Scoop automatically adds shims to `PATH`. [Scoop manifest](https://github.com/ScoopInstaller/Main/blob/master/bucket/mise.json)
+
+    **winget:**
+
+    ```sh theme={null}
+    winget install jdx.mise
+    ```
+
+    **Chocolatey:**
+
+    <Warning>
+      The Chocolatey version is currently outdated.
+    </Warning>
+
+    ```sh theme={null}
+    choco install mise
+    ```
+
+    **Manual:** Download the latest release from [GitHub](https://github.com/jdx/mise/releases) and add the binary to your `PATH`. If your shell does not support `mise activate`, add `%LOCALAPPDATA%\mise\shims` to `PATH`.
+  </Tab>
+
+  <Tab title="Other">
+    **pacman (Arch Linux):**
+
+    ```sh theme={null}
+    sudo pacman -S mise
+    ```
+
+    [Arch package](https://archlinux.org/packages/extra/x86_64/mise/)
+
+    **apk (Alpine Linux):**
+
+    ```sh theme={null}
+    apk add mise
+    ```
+
+    **MacPorts:**
+
+    ```sh theme={null}
+    sudo port install mise
+    ```
+
+    **zypper (openSUSE):**
+
+    ```sh theme={null}
+    sudo wget https://mise.jdx.dev/rpm/mise.repo -O /etc/zypp/repos.d/mise.repo
+    sudo zypper refresh
+    sudo zypper install mise
+    ```
+
+    **Snap (beta):**
+
+    ```sh theme={null}
+    sudo snap install mise --classic --beta
+    ```
+
+    **npm:**
+
+    ```sh theme={null}
+    npm install -g @jdxcode/mise
+    ```
+
+    Useful for JS projects that want to set up mise via `package.json`. For a one-off test:
+
+    ```sh theme={null}
+    npx @jdxcode/mise exec python@3.11 -- python some_script.py
+    ```
+
+    **nix:**
+
+    ```sh theme={null}
+    nix-env -iA mise
+    ```
+
+    <Tip>
+      NixOS compiles mise from source by default. For precompiled binaries, enable [nix-ld](https://github.com/Mic92/nix-ld) and disable `all_compile`.
+    </Tip>
+
+    **Cargo:**
+
+    ```sh theme={null}
+    cargo install --locked mise
+    ```
+
+    Or faster with [cargo-binstall](https://github.com/cargo-bins/cargo-binstall):
+
+    ```sh theme={null}
+    cargo install cargo-binstall
+    cargo binstall mise
+    ```
+
+    **GitHub Releases:**
+
+    ```sh theme={null}
+    curl -L https://github.com/jdx/mise/releases/download/v2025.12.0/mise-v2025.12.0-linux-x64 > /usr/local/bin/mise
+    chmod +x /usr/local/bin/mise
+    ```
+
+    **Docker:** See the [mise Docker docs](https://mise.jdx.dev/installing-mise.html) for tips on using mise with Docker.
+  </Tab>
+</Tabs>
+
+## Shell activation
+
+After installing mise, add the activation line to your shell's config file and restart your session:
+
+<Tabs>
+  <Tab title="bash">
+    ```sh theme={null}
+    echo 'eval "$(mise activate bash)"' >> ~/.bashrc
+    ```
+  </Tab>
+
+  <Tab title="zsh">
+    ```sh theme={null}
+    echo 'eval "$(mise activate zsh)"' >> "${ZDOTDIR-$HOME}/.zshrc"
+    ```
+  </Tab>
+
+  <Tab title="fish">
+    ```sh theme={null}
+    echo 'mise activate fish | source' >> ~/.config/fish/config.fish
+    ```
+
+    <Tip>
+      For Homebrew installs, mise is automatically activated with fish. See `MISE_FISH_AUTO_ACTIVATE` for more information.
+    </Tip>
+  </Tab>
+
+  <Tab title="PowerShell">
+    ```powershell theme={null}
+    echo '(&mise activate pwsh) | Out-String | Invoke-Expression' >> $HOME\Documents\PowerShell\Microsoft.PowerShell_profile.ps1
+    ```
+
+    <Warning>
+      See [about\_Profiles](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles) to find your actual profile location. You may need to create the parent directory first.
+    </Warning>
+  </Tab>
+
+  <Tab title="Nushell">
+    Nushell does not support `eval`. Append to `env.nu` and `config.nu`:
+
+    ```nushell theme={null}
+    '
+    let mise_path = $nu.default-config-dir | path join mise.nu
+    ^mise activate nu | save $mise_path --force
+    ' | save $nu.env-path --append
+    "\nuse ($nu.default-config-dir | path join mise.nu)" | save $nu.config-path --append
+    ```
+  </Tab>
+
+  <Tab title="Xonsh">
+    Add to `~/.config/xonsh/rc.xsh`:
+
+    ```sh theme={null}
+    echo 'execx($(~/bin/mise activate xonsh))' >> ~/.config/xonsh/rc.xsh
+    ```
+
+    Or use a pure Python import for faster startup. Add to `~/.config/xonsh/mise.py`:
+
+    ```python theme={null}
+    from pathlib import Path
+    from xonsh.built_ins import XSH
+
+    ctx = XSH.ctx
+    mise_init = subprocess.run([Path('~/bin/mise').expanduser(),'activate','xonsh'],capture_output=True,encoding="UTF-8").stdout
+    XSH.builtins.execx(mise_init,'exec',ctx,filename='mise')
+    ```
+
+    Then `import mise` in `~/.config/xonsh/rc.xsh`.
+  </Tab>
+
+  <Tab title="Elvish">
+    Add to your `rc.elv`:
+
+    ```shell theme={null}
+    var mise: = (ns [&])
+    eval (mise activate elvish | slurp) &ns=$mise: &on-end={|ns| set mise: = $ns }
+    mise:activate
+    ```
+
+    Optionally alias `mise` for seamless integration:
+
+    ```shell theme={null}
+    edit:add-var mise~ {|@args| mise:mise $@args }
+    ```
+  </Tab>
+</Tabs>
+
+## Autocompletion
+
+<Note>
+  Some installation methods automatically install autocompletion scripts.
+</Note>
+
+The `mise completion` command generates autocompletion scripts. First, install the `usage` tool if you don't have it:
+
+```sh theme={null}
+mise use -g usage
+```
+
+Then install the completion script for your shell:
+
+<CodeGroup>
+  ```sh bash theme={null}
+  # Requires bash-completion to be installed
+  mkdir -p ~/.local/share/bash-completion/completions/
+  mise completion bash --include-bash-completion-lib > ~/.local/share/bash-completion/completions/mise
+  ```
+
+  ```sh zsh theme={null}
+  # If you use oh-my-zsh, add the mise plugin to your .zshrc: plugins=(... mise)
+
+  # Otherwise, find where zsh searches for completions:
+  echo $fpath | tr ' ' '\n'
+
+  # For zsh installed via apt:
+  mkdir -p /usr/local/share/zsh/site-functions
+  mise completion zsh > /usr/local/share/zsh/site-functions/_mise
+  ```
+
+  ```sh fish theme={null}
+  mise completion fish > ~/.config/fish/completions/mise.fish
+  ```
+</CodeGroup>
+
+Then source your shell's rc file or restart your shell.
+
+## Self-update
+
+For installations that don't use a system package manager, you can update mise with:
+
+```sh theme={null}
+mise self-update
+```
+
+## Troubleshooting
+
+If you encounter issues after installation, run:
+
+```sh theme={null}
+mise doctor
+```
+
+This diagnoses common problems with your mise setup.
+
+## Uninstalling
+
+Use `mise implode` to remove the mise binary and all of its data:
+
+```sh theme={null}
+mise implode
+```
+
+To manually clean up, remove these directories:
+
+* `~/.local/share/mise` (or `MISE_DATA_DIR` / `XDG_DATA_HOME/mise`)
+* `~/.local/state/mise` (or `MISE_STATE_DIR` / `XDG_STATE_HOME/mise`)
+* `~/.config/mise` (or `MISE_CONFIG_DIR` / `XDG_CONFIG_HOME/mise`)
+* Linux: `~/.cache/mise` (or `MISE_CACHE_DIR` / `XDG_CACHE_HOME/mise`)
+* macOS: `~/Library/Caches/mise` (or `MISE_CACHE_DIR`)
+
+
+# Introduction
+Source: https://www.mintlify.com/jdx/mise/introduction
+
+Mise is a dev tools manager, environment manager, and task runner — all in one fast Rust binary.
+
+Mise (mise-en-place) is the front-end to your dev environment. It replaces version managers like `nvm`, `pyenv`, and `rbenv`; environment tools like `direnv`; and task runners like `make` — unified into a single configuration file.
+
+## What mise does
+
+<CardGroup>
+  <Card title="Dev tools manager" icon="code-branch">
+    Like [asdf](https://asdf-vm.com) — manage multiple versions of Node, Python, Go, Ruby, and [hundreds more](/dev-tools/overview). Tools are pinned per project and installed automatically.
+  </Card>
+
+  <Card title="Environment manager" icon="leaf">
+    Like [direnv](https://github.com/direnv/direnv) — define environment variables in `mise.toml` and they load automatically when you enter a project directory.
+  </Card>
+
+  <Card title="Task runner" icon="play">
+    Like [make](https://www.gnu.org/software/make/manual/make.html) — define tasks in `mise.toml` or as shell scripts, with dependency resolution and parallel execution.
+  </Card>
+</CardGroup>
+
+## Explore the docs
+
+<CardGroup>
+  <Card title="Getting started" icon="rocket" href="/getting-started">
+    Install mise and run your first tools in minutes.
+  </Card>
+
+  <Card title="Dev tools" icon="wrench" href="/dev-tools/overview">
+    Manage Node, Python, Go, Ruby, and hundreds of other tools.
+  </Card>
+
+  <Card title="Environments" icon="gear" href="/environments/overview">
+    Load per-project environment variables automatically.
+  </Card>
+
+  <Card title="Tasks" icon="list-check" href="/tasks/overview">
+    Define and run project tasks with dependency resolution.
+  </Card>
+</CardGroup>
+
+## Key features
+
+* **Single config file** — tools, environment variables, and tasks all live in `mise.toml`
+* **Per-project tool versions** — each project gets its own pinned versions, no conflicts
+* **Multiple backends** — install tools from npm, pipx, cargo, GitHub releases, aqua, and more
+* **Shell integration** — tools and env vars are loaded when you `cd` into a project directory
+* **ASDF compatible** — reads `.tool-versions` files and supports asdf plugins
+* **Fast** — written in Rust; activates in under 10ms
+
+## Example project config
+
+```toml mise.toml theme={null}
+[tools]
+terraform = "1"
+aws-cli = "2"
+
+[env]
+TF_WORKSPACE = "development"
+AWS_REGION = "us-west-2"
+AWS_PROFILE = "dev"
+
+[tasks.plan]
+description = "Run terraform plan with configured workspace"
+run = """
+terraform init
+terraform workspace select $TF_WORKSPACE
+terraform plan
+"""
+
+[tasks.deploy]
+description = "Deploy infrastructure after validation"
+depends = ["validate", "plan"]
+run = "terraform apply -auto-approve"
+```
+
+Run it with:
+
+```sh theme={null}
+mise install      # install tools specified in mise.toml
+mise run deploy   # run the deploy task
+```
+
+
+# File tasks
+Source: https://www.mintlify.com/jdx/mise/tasks/file-tasks
+
+Write mise tasks as standalone executable scripts with metadata headers, argument parsing, and multi-language support.
+
+File tasks are standalone executable scripts that mise discovers automatically. Place them in any of these directories:
+
+* `mise-tasks/`
+* `.mise-tasks/`
+* `mise/tasks/`
+* `.mise/tasks/`
+* `.config/mise/tasks/`
+
+Mise uses the filename as the task name. A file at `mise-tasks/build` becomes the `build` task.
+
+<Note>
+  If [`task_config.includes`](/configuration/settings) is set for the current config scope, mise searches only the paths listed there instead of the defaults above.
+</Note>
+
+## Basic example
+
+```bash mise-tasks/build theme={null}
+#!/usr/bin/env bash
+#MISE description="Build the CLI"
+cargo build
+```
+
+<Warning>
+  The file must be executable, otherwise mise will not detect it.
+
+  ```shell theme={null}
+  chmod +x mise-tasks/build
+  ```
+</Warning>
+
+File tasks have an advantage over TOML tasks for complex logic: editors can apply full syntax highlighting and linting to the script. Non-mise users can also run the script directly without needing mise installed.
+
+## Metadata headers
+
+Configure a file task by adding `#MISE` comment lines at the top of the file. All [task configuration](/tasks/toml-tasks) options are supported:
+
+```bash mise-tasks/build theme={null}
+#MISE description="Build the CLI"
+#MISE alias="b"
+#MISE sources=["Cargo.toml", "src/**/*.rs"]
+#MISE outputs=["target/debug/mycli"]
+#MISE env={RUST_BACKTRACE = "1"}
+#MISE depends=["lint", "test"]
+#MISE tools={rust="1.50.0"}
+```
+
+With the above file at `mise-tasks/build`, you can run it with `mise run build` or via its alias: `mise run b`.
+
+<Tip>
+  Some formatters automatically add a space after `#`, turning `#MISE` into `# MISE`. Mise intentionally ignores `# MISE` to prevent accidental configuration. Use `# [MISE]` as an alternative syntax that is formatter-safe.
+</Tip>
+
+## Shebangs
+
+The shebang line determines which interpreter runs the script. Use this to write file tasks in languages other than bash:
+
+<CodeGroup>
+  ```js mise-tasks/greet (node) theme={null}
+  #!/usr/bin/env node
+  //MISE description="Hello, World in Node.js"
+
+  console.log("Hello, World!");
+  ```
+
+  ```python mise-tasks/greet (python) theme={null}
+  #!/usr/bin/env python
+  #MISE description="Hello, World in Python"
+
+  print('Hello, World!')
+  ```
+
+  ```ts mise-tasks/greet (deno) theme={null}
+  #!/usr/bin/env -S deno run --allow-env
+  //MISE description="Hello, World in Deno"
+
+  console.log(`PATH, ${Deno.env.get("PATH")}`);
+  ```
+
+  ```powershell mise-tasks/greet (powershell) theme={null}
+  #!/usr/bin/env pwsh
+  #MISE description="Hello, World in PowerShell"
+
+  $current_directory = Get-Location
+  Write-Host "Hello from PowerShell, current directory is $current_directory"
+  ```
+</CodeGroup>
+
+## Editing tasks
+
+Open a file task in your `$EDITOR` with `mise tasks edit`. If the file does not exist, mise creates it:
+
+```shell theme={null}
+mise tasks edit build
+```
+
+## Task grouping
+
+Organize tasks into subdirectories. Mise automatically prefixes the task name with the directory path using `:` as a separator.
+
+Given this directory structure:
+
+```text theme={null}
+mise-tasks
+├── build
+└── test
+    ├── _default
+    ├── integration
+    └── units
+```
+
+Running `mise tasks` shows:
+
+```shell theme={null}
+$ mise tasks
+Name              Description  Source
+build                          ./mise-tasks/build
+test                           ./mise-tasks/test/_default
+test:integration               ./mise-tasks/test/integration
+test:units                     ./mise-tasks/test/units
+```
+
+## Arguments
+
+File tasks support the [usage spec](https://usage.jdx.dev) for argument parsing, validation, autocompletion, and help generation. Define arguments and flags with `#USAGE` comment lines (or `#MISE` for non-argument metadata):
+
+```bash mise-tasks/build theme={null}
+#!/usr/bin/env bash
+set -e
+
+#USAGE flag "-c --clean" help="Clean the build directory before building"
+#USAGE flag "-p --profile <profile>" help="Build with the specified profile" default="debug" {
+#USAGE   choices "debug" "release"
+#USAGE }
+#USAGE flag "-u --user <user>" help="The user to build for"
+#USAGE complete "user" run="mycli users"
+#USAGE arg "<target>" help="The target to build"
+
+if [ "${usage_clean:-false}" = "true" ]; then
+  cargo clean
+fi
+
+cargo build --profile "${usage_profile?}" --target "${usage_target?}"
+```
+
+Arguments are passed to the script as environment variables prefixed with `usage_`. See [task arguments](/tasks/toml-tasks#task-arguments) for the full variable syntax reference.
+
+<Tip>
+  The `usage` CLI is not required to run file tasks. It is only needed for shell completions to work. Install it with `mise use -g usage@latest`.
+</Tip>
+
+Use `--` to separate mise flags from task arguments:
+
+```shell theme={null}
+mise run -- build --profile release my-target
+```
+
+With `usage` installed, completions work automatically. For the example above:
+
+* `mise run -- build --profile <tab>` shows `debug` and `release`
+* `mise run -- build --user <tab>` shows completions from `mycli users`
+
+<Tip>
+  If completions are not working, run with `-v` to see debug output. For example, `mise run build -v` will print a `DEBUG failed to parse task file with usage` error if the usage spec is invalid.
+</Tip>
+
+### Node.js file task with arguments
+
+Arguments work the same way in non-bash scripts. Parsed values are available as `process.env.usage_*`:
+
+```js mise-tasks/greet theme={null}
+#!/usr/bin/env -S node
+//MISE description="Write a greeting to a file"
+//USAGE flag "-f --force" help="Overwrite existing <file>"
+//USAGE flag "-u --user <user>" help="User to run as"
+//USAGE arg "<output_file>" help="The file to write" default="file.txt" {
+//USAGE   choices "greeting.txt" "file.txt"
+//USAGE }
+
+const fs = require("fs");
+
+const { usage_user, usage_force, usage_output_file } = process.env;
+
+if (usage_force === "true") {
+  fs.rmSync(usage_output_file, { force: true });
+}
+
+const user = usage_user ?? "world";
+fs.appendFileSync(usage_output_file, `Hello, ${user}\n`);
+console.log(`Greeting written to ${usage_output_file}`);
+```
+
+Run it:
+
+```shell theme={null}
+mise run greet greeting.txt --user Alice
+# Greeting written to greeting.txt
+```
+
+If you pass an invalid argument, mise returns an error:
+
+```shell theme={null}
+mise run greet invalid.txt --user Alice
+# [greet] ERROR
+#   0: Invalid choice for arg output_file: invalid.txt, expected one of greeting.txt, file.txt
+```
+
+## Working directory
+
+By default, mise sets the working directory to the directory containing `mise.toml`. Override it with `#MISE dir`:
+
+```bash mise-tasks/build theme={null}
+#!/usr/bin/env bash
+#MISE dir="{{cwd}}"
+```
+
+You can also access the original working directory via the `MISE_ORIGINAL_CWD` environment variable:
+
+```bash mise-tasks/build theme={null}
+#!/usr/bin/env bash
+cd "$MISE_ORIGINAL_CWD"
+```
+
+## Running tasks directly
+
+Run a script directly by passing its path. The path must start with `/` or `./`:
+
+```shell theme={null}
+mise run ./path/to/script.sh
+```
+
+
+# Tasks overview
+Source: https://www.mintlify.com/jdx/mise/tasks/overview
+
+Define and run project tasks in mise — from simple one-liners to complex dependency graphs.
+
+Mise includes a task runner similar to [make](https://www.gnu.org/software/make/manual/make.html). You can define tasks in `mise.toml` files or as standalone shell scripts. Tasks launched with mise automatically inherit the mise environment — your tools and env vars from `mise.toml` are all available.
+
+Highlights of the mise task runner:
+
+* Dependencies run in parallel by default, with no extra configuration
+* Last-modified checking skips tasks when inputs haven't changed
+* `mise watch` rebuilds automatically when source files change
+* File tasks are real shell scripts with full syntax highlighting and linting support in editors
+
+## Two ways to define tasks
+
+<CardGroup>
+  <Card title="TOML tasks" icon="file-code" href="/tasks/toml-tasks">
+    Define tasks directly in `mise.toml`. Good for simple commands, dependency graphs, and tasks that benefit from being co-located with tool and env config.
+  </Card>
+
+  <Card title="File tasks" icon="file" href="/tasks/file-tasks">
+    Write tasks as standalone executable scripts in a `mise-tasks/` directory. Good for complex logic, multi-language scripts, and tasks that benefit from full editor support.
+  </Card>
+</CardGroup>
+
+<Card title="Running tasks" icon="play" href="/tasks/running-tasks">
+  Learn how to run tasks, pass arguments, run tasks in parallel, watch for file changes, and control output modes.
+</Card>
+
+### When to use TOML tasks
+
+Use TOML tasks when:
+
+* The task is a short command or a simple sequence of commands
+* You want all your project config in one file
+* The task has dependencies you want mise to run in the right order
+
+```toml mise.toml theme={null}
+[tasks.build]
+description = 'Build the CLI'
+run = "cargo build"
+alias = 'b'
+
+[tasks.test]
+depends = ['build']
+run = "cargo test"
+```
+
+### When to use file tasks
+
+Use file tasks when:
+
+* The task contains significant logic that benefits from syntax highlighting and linting
+* You want non-mise users to be able to run the script directly
+* The task is written in a language other than bash (Node.js, Python, Deno, etc.)
+
+```bash mise-tasks/build theme={null}
+#!/usr/bin/env bash
+#MISE description="Build the CLI"
+cargo build
+```
+
+## Environment variables passed to tasks
+
+Mise sets the following environment variables in every task:
+
+| Variable            | Value                                                               |
+| ------------------- | ------------------------------------------------------------------- |
+| `MISE_ORIGINAL_CWD` | The directory you were in when you ran `mise run`                   |
+| `MISE_CONFIG_ROOT`  | The directory containing the `mise.toml` where the task was defined |
+| `MISE_PROJECT_ROOT` | The root of the project                                             |
+| `MISE_TASK_NAME`    | The name of the running task                                        |
+| `MISE_TASK_DIR`     | The directory containing the task script (file tasks only)          |
+| `MISE_TASK_FILE`    | The full path to the task script (file tasks only)                  |
+
+By default, tasks run from `MISE_CONFIG_ROOT`. To run in the user's current directory instead, set `dir = "{{cwd}}"` in the task definition or use `$MISE_ORIGINAL_CWD` inside the script.
+
+## Quick example
+
+```toml mise.toml theme={null}
+[tasks.ci]
+description = 'Run CI tasks'
+depends = ['build', 'lint', 'test']
+
+[tasks.build]
+description = 'Build the CLI'
+run = "cargo build"
+sources = ['Cargo.toml', 'src/**/*.rs']
+outputs = ['target/debug/mycli']
+
+[tasks.lint]
+description = 'Lint with clippy'
+env = { RUST_BACKTRACE = '1' }
+run = '''
+#!/usr/bin/env bash
+cargo clippy
+'''
+
+[tasks.test]
+description = 'Run automated tests'
+run = [
+    'cargo test',
+    './scripts/test-e2e.sh',
+]
+```
+
+Run the CI task:
+
+```sh theme={null}
+mise run ci
+```
+
+Mise resolves the dependency graph, runs what it can in parallel, and skips `build` if no source files have changed since the last run.
+
+
+# Running Tasks
+Source: https://www.mintlify.com/jdx/mise/tasks/running-tasks
+
+Run mise tasks from the command line with parallel execution, file watching, and dependency ordering.
+
+## Running a task
+
+Run a task with `mise run <task>` (or `mise r <task>`):
+
+```bash theme={null}
+mise run build
+mise run test
+mise r lint   # shorter alias
+```
+
+You can also run tasks directly if the name doesn't conflict with a mise command:
+
+```bash theme={null}
+mise build
+```
+
+<Note>
+  Prefer `mise run <task>` in scripts and documentation — mise may add built-in commands in the future that shadow task names.
+</Note>
+
+## Passing arguments
+
+Extra arguments after the task name are passed to the task script:
+
+```bash theme={null}
+mise run build --release
+mise run test -- --nocapture
+```
+
+If a task has multiple `run` commands, arguments are only passed to the last command.
+
+## Running multiple tasks
+
+Run multiple tasks in one command using the `:::` delimiter:
+
+```bash theme={null}
+mise run build arg1 arg2 ::: test arg3 arg4
+```
+
+## Parallel execution
+
+By default, mise runs up to 4 tasks in parallel. Configure with `--jobs`, the `jobs` setting, or `MISE_JOBS`:
+
+```bash theme={null}
+mise run --jobs 8 build test lint
+MISE_JOBS=8 mise run build
+```
+
+Output is printed line-by-line with a task label prefix to avoid interleaving. Use `--interleave` to print stdout/stderr directly:
+
+```bash theme={null}
+mise run --interleave build
+```
+
+## Dry run
+
+See what would run without executing:
+
+```bash theme={null}
+mise run --dry-run build test
+```
+
+## Task dependencies and ordering
+
+Define task dependencies in `mise.toml`:
+
+```toml mise.toml theme={null}
+[tasks.build]
+run = "cargo build"
+
+[tasks.test]
+run = "cargo test"
+depends = ["build"]
+```
+
+`test` will always run after `build` completes.
+
+## Task groups and wildcards
+
+Group tasks with `:` prefixes and use glob patterns:
+
+```bash theme={null}
+# Run all lint tasks
+mise run lint:*
+
+# Run all test tasks including nested
+mise run test:**:local
+```
+
+Available wildcard patterns:
+
+* `?` — any single character
+* `*` — 0 or more characters
+* `**` — 0 or more groups
+* `{a,b}` — matches any listed pattern
+
+## File change detection
+
+Skip tasks when outputs are up to date:
+
+```toml mise.toml theme={null}
+[tasks.build]
+run = "cargo build"
+sources = ["Cargo.toml", "src/**/*.rs"]
+outputs = ["target/debug/myapp"]
+```
+
+If `target/debug/myapp` is newer than all source files, the task is skipped. Use `--force` to override:
+
+```bash theme={null}
+mise run --force build
+```
+
+## Watching files
+
+Re-run a task automatically when sources change using `mise watch`:
+
+```bash theme={null}
+mise watch build
+```
+
+<Note>
+  `mise watch` uses `watchexec` under the hood. Install it with `mise use -g watchexec@latest`.
+</Note>
+
+## Default task
+
+If a task named `default` is defined, it runs when no task is specified:
+
+```bash theme={null}
+mise run
+```
+
+## Listing available tasks
+
+```bash theme={null}
+mise tasks
+mise tasks --hidden   # include tasks with hide=true
+mise tasks deps build # show dependencies of a task
+```
+
+
+# TOML tasks
+Source: https://www.mintlify.com/jdx/mise/tasks/toml-tasks
+
+Define tasks directly in mise.toml with dependencies, environment variables, sources, and argument parsing.
+
+Tasks can be defined in the `[tasks]` section of `mise.toml`. Simple tasks are one-liners; more detailed tasks get their own `[tasks.<name>]` table.
+
+## Basic syntax
+
+<CodeGroup>
+  ```toml One-liner theme={null}
+  [tasks]
+  build = "cargo build"
+  test = "cargo test"
+  lint = "cargo clippy"
+  ```
+
+  ```toml Full task theme={null}
+  [tasks.build]
+  description = 'Build the CLI'
+  run = "cargo build"
+  alias = 'b'
+  ```
+</CodeGroup>
+
+You can also add tasks from the CLI:
+
+```shell theme={null}
+mise tasks add pre-commit --depends "test" --depends "render" -- echo pre-commit
+```
+
+This adds to `mise.toml`:
+
+```toml mise.toml theme={null}
+[tasks.pre-commit]
+depends = ["test", "render"]
+run = "echo pre-commit"
+```
+
+## Task fields
+
+### `run`
+
+The command or commands to execute. Commands in an array run in series — if one fails, the rest are skipped.
+
+```toml mise.toml theme={null}
+[tasks.test]
+run = [
+    'cargo test',
+    './scripts/test-e2e.sh',
+]
+```
+
+Extra arguments passed to `mise run` are forwarded to the last command in the array.
+
+For Windows-specific commands, use `run_windows`:
+
+```toml mise.toml theme={null}
+[tasks.test]
+run = 'cargo test'
+run_windows = 'cargo test --features windows'
+```
+
+You can also mix scripts with task references, and pass optional `args` and `env` to referenced tasks:
+
+```toml mise.toml theme={null}
+[tasks.grouped]
+run = [
+  { task = "t1" },
+  { task = "build", args = ["--release"], env = { RUSTFLAGS = "-C opt-level=3" } },
+  { tasks = ["t2", "t3"] },  # run t2 and t3 in parallel
+  "echo end",
+]
+```
+
+### `description` and `alias`
+
+```toml mise.toml theme={null}
+[tasks.build]
+description = 'Build the CLI'
+run = "cargo build"
+alias = 'b'  # run with `mise run b`
+```
+
+The description appears in `mise tasks` output and `mise run` with no arguments.
+
+### `depends`
+
+Tasks that must complete before this task runs. Mise resolves the full dependency graph and runs tasks in parallel when possible.
+
+```toml mise.toml theme={null}
+[tasks.build]
+run = 'cargo build'
+
+[tasks.test]
+depends = ['build']
+run = 'cargo test'
+
+[tasks.ci]
+depends = ['build', 'lint', 'test']
+```
+
+Pass arguments and env vars to specific dependencies:
+
+```toml mise.toml theme={null}
+[tasks.deploy]
+depends = [
+  { task = "build", args = ["--release"], env = { RUSTFLAGS = "-C opt-level=3" } }
+]
+run = "./deploy.sh"
+```
+
+Forward parent task arguments to dependencies using `{{usage.*}}` templates:
+
+```toml mise.toml theme={null}
+[tasks.build]
+usage = 'arg "<app>"'
+run = 'echo "building {{usage.app}}"'
+
+[tasks.deploy]
+usage = 'arg "<app>"'
+depends = [{ task = "build", args = ["{{usage.app}}"] }]
+run = 'echo "deploying {{usage.app}}"'
+```
+
+### `depends_post`
+
+Like `depends`, but runs *after* the task completes:
+
+```toml mise.toml theme={null}
+[tasks.lint]
+run = "eslint ."
+depends_post = ["postlint"]
+
+[tasks.postlint]
+run = "echo 'linting complete'"
+```
+
+### `wait_for`
+
+Optional dependencies — if these tasks are already running, wait for them to finish before starting. Unlike `depends`, they are not added to the run list.
+
+```toml mise.toml theme={null}
+[tasks.lint]
+wait_for = ["render"]
+run = "eslint ."
+```
+
+### `env`
+
+Environment variables for this task only. These are not passed to `depends` tasks.
+
+```toml mise.toml theme={null}
+[tasks.lint]
+description = 'Lint with clippy'
+env = { RUST_BACKTRACE = '1' }
+run = '''
+#!/usr/bin/env bash
+cargo clippy
+'''
+```
+
+### `dir`
+
+The working directory for the task. Defaults to `config_root` (the project root containing `mise.toml`).
+
+```toml mise.toml theme={null}
+[tasks.test]
+dir = "{{cwd}}"
+run = "cargo test"
+```
+
+### `sources` and `outputs`
+
+Skip the task when outputs are newer than sources. Mise compares last-modified timestamps.
+
+```toml mise.toml theme={null}
+[tasks.build]
+description = 'Build the CLI'
+run = "cargo build"
+sources = ['Cargo.toml', 'src/**/*.rs']
+outputs = ['target/debug/mycli']
+```
+
+Use `outputs = { auto = true }` (the default when `sources` is defined) to have mise track an internal hash-based file instead of specifying output files manually:
+
+```toml mise.toml theme={null}
+[tasks.build]
+run = "cargo build"
+sources = ["Cargo.toml", "src/**/*.rs"]
+outputs = { auto = true }
+```
+
+### `hide` and `quiet`
+
+```toml mise.toml theme={null}
+[tasks.internal]
+hide = true          # exclude from `mise tasks` output
+run = "echo my internal task"
+
+[tasks.build]
+quiet = true         # suppress mise's own output (e.g., "[build] $ cargo build")
+run = "cargo build"
+```
+
+### `raw` and `interactive`
+
+```toml mise.toml theme={null}
+[tasks.repl]
+raw = true           # connect stdin/stdout/stderr directly; prevents parallel execution
+run = "node"
+
+[tasks.prompt]
+interactive = true   # like raw, but only blocks other interactive tasks
+run = "./scripts/setup.sh"
+```
+
+### `confirm`
+
+Show a confirmation prompt before the task's own `run` executes:
+
+```toml mise.toml theme={null}
+[tasks.release]
+confirm = 'Are you sure you want to cut a new release?'
+description = 'Cut a new release'
+file = 'scripts/release.sh'
+```
+
+<Warning>
+  `confirm` only guards the task's own `run`. Dependencies listed in `depends` run before the confirmation prompt. If you need confirmation before dependencies, add `confirm` to those tasks or use `run = [{ task = "..." }]` instead of `depends`.
+</Warning>
+
+### `tools`
+
+Override tool versions for a specific task:
+
+```toml mise.toml theme={null}
+[tasks.build]
+tools.rust = "1.50.0"
+run = "cargo build"
+```
+
+## Specifying the shell
+
+Tasks run with `sh -c` by default (or `cmd /c` on Windows), with `set -e` enabled for `sh`, `bash`, and `zsh`. Use a shebang to specify a different interpreter:
+
+```toml mise.toml theme={null}
+[tasks.lint]
+run = '''
+#!/usr/bin/env bash
+cargo clippy
+'''
+```
+
+Or set the `shell` property:
+
+```toml mise.toml theme={null}
+[tasks.lint]
+shell = 'bash -c'
+run = "cargo clippy"
+```
+
+You can use other runtimes via shebangs:
+
+<CodeGroup>
+  ```toml python theme={null}
+  [tools]
+  python = 'latest'
+
+  [tasks.python_task]
+  run = '''
+  #!/usr/bin/env python
+  for i in range(10):
+      print(i)
+  '''
+  ```
+
+  ```toml node theme={null}
+  [tools]
+  node = 'lts'
+
+  [tasks.node_task]
+  shell = 'node -e'
+  run = [
+    "console.log('First line')",
+    "console.log('Second line')",
+  ]
+  ```
+
+  ```toml deno theme={null}
+  [tools]
+  deno = 'latest'
+
+  [tasks.deno_task]
+  description = "A more complex task using Deno imports"
+  run = '''
+  #!/usr/bin/env -S deno run
+  import ProgressBar from "jsr:@deno-library/progress";
+  import { delay } from "jsr:@std/async";
+
+  if (!confirm('Start download?')) {
+      Deno.exit(1);
+  }
+
+  const progress = new ProgressBar({ title:  "downloading:", total: 100 });
+  let completed = 0;
+  async function download() {
+    while (completed <= 100) {
+      await progress.render(completed++);
+      await delay(10);
+    }
+  }
+  await download();
+  '''
+  ```
+
+  ```toml ruby theme={null}
+  [tools]
+  ruby = 'latest'
+
+  [tasks.ruby_task]
+  run = '''
+  #!/usr/bin/env ruby
+  puts 'Hello, ruby!'
+  '''
+  ```
+</CodeGroup>
+
+## Running an external file
+
+Point a task at a script file instead of inlining the command:
+
+```toml mise.toml theme={null}
+[tasks.release]
+description = 'Cut a new release'
+file = 'scripts/release.sh'
+```
+
+Remote files are also supported via HTTP or Git:
+
+<CodeGroup>
+  ```toml HTTP theme={null}
+  [tasks.build]
+  file = "https://example.com/build.sh"
+  ```
+
+  ```toml Git (SSH) theme={null}
+  [tasks.build]
+  file = "git::ssh://git@github.com/myorg/example.git//myfile?ref=v1.0.0"
+  ```
+
+  ```toml Git (HTTPS) theme={null}
+  [tasks.build]
+  file = "git::https://github.com/myorg/example.git//myfile?ref=v1.0.0"
+  ```
+</CodeGroup>
+
+Remote files are cached in `MISE_CACHE_DIR`. Clear the cache with `mise cache clear`, or disable caching with `MISE_TASK_REMOTE_NO_CACHE=true`.
+
+## Task arguments
+
+The recommended way to define task arguments is the `usage` field:
+
+```toml mise.toml theme={null}
+[tasks.test]
+usage = '''
+arg "<file>" help="Test file to run" default="all"
+flag "--format <format>" help="Output format" default="text"
+flag "-v --verbose" help="Enable verbose output"
+'''
+run = 'cargo test ${usage_file?} --format ${usage_format?}'
+```
+
+Arguments become environment variables prefixed with `usage_`. Use bash parameter expansion to access them safely:
+
+| Syntax                 | Use case                                       |
+| ---------------------- | ---------------------------------------------- |
+| `${usage_var?}`        | Args or flags with a default in the usage spec |
+| `${usage_var:-false}`  | Boolean flags without a default                |
+| `${usage_var:?}`       | Required args — error if empty                 |
+| `${usage_var:+--flag}` | Pass a flag only when the variable is set      |
+
+**Help output** is generated automatically:
+
+```shell theme={null}
+$ mise run test --help
+Usage: test <file> [OPTIONS]
+
+Arguments:
+  <file>  Test file to run [default: all]
+
+Options:
+  --format <format>  Output format [default: text]
+  -v, --verbose      Enable verbose output
+  -h, --help         Print help
+```
+
+## Vars
+
+Vars are shared values available across tasks but not passed as environment variables to scripts. Define them in `[vars]`:
+
+```toml mise.toml theme={null}
+[vars]
+e2e_args = '--headless'
+
+[tasks.test]
+run = './scripts/test-e2e.sh {{vars.e2e_args}}'
+```
+
+Tasks can override vars locally:
+
+```toml mise.toml theme={null}
+[tasks.test]
+vars = { e2e_args = "--headed" }
+run = './scripts/test-e2e.sh {{vars.e2e_args}}'
+```
+
+

--- a/docs/research/mintlify-cache/jdx/mise/llms.txt
+++ b/docs/research/mintlify-cache/jdx/mise/llms.txt
@@ -1,0 +1,45 @@
+# Mise
+
+## Docs
+
+- [mise activate](https://www.mintlify.com/jdx/mise/cli/activate.md): Initialize mise in your current shell session by adding it to your shell's rc file.
+- [mise config](https://www.mintlify.com/jdx/mise/cli/config.md): Manage mise.toml config files — list, get, and set configuration values.
+- [mise doctor](https://www.mintlify.com/jdx/mise/cli/doctor.md): Check your mise installation for configuration problems and display diagnostic information.
+- [mise env](https://www.mintlify.com/jdx/mise/cli/env.md): Export mise environment variables for use in a single shell session or script.
+- [mise exec](https://www.mintlify.com/jdx/mise/cli/exec.md): Execute a command with mise-managed tools active, without modifying the current shell session.
+- [mise install](https://www.mintlify.com/jdx/mise/cli/install.md): Install tool versions without modifying any config file.
+- [mise ls](https://www.mintlify.com/jdx/mise/cli/ls.md): List installed and active tool versions managed by mise.
+- [mise plugins](https://www.mintlify.com/jdx/mise/cli/plugins.md): Manage mise plugins for extending tool support.
+- [mise prune](https://www.mintlify.com/jdx/mise/cli/prune.md): Remove unused tool versions to free up disk space.
+- [mise run](https://www.mintlify.com/jdx/mise/cli/run.md): Run project tasks defined in mise.toml or as shell scripts.
+- [mise upgrade](https://www.mintlify.com/jdx/mise/cli/upgrade.md): Upgrade installed tools to newer versions within the range specified in mise.toml.
+- [mise use](https://www.mintlify.com/jdx/mise/cli/use.md): Install a tool and add it to mise.toml.
+- [Config Environments](https://www.mintlify.com/jdx/mise/configuration/environments.md): Use environment-specific mise.toml files for development, production, and other profiles.
+- [Configuration overview](https://www.mintlify.com/jdx/mise/configuration/overview.md): How mise loads and merges configuration from mise.toml files across system, global, and project scopes.
+- [Settings](https://www.mintlify.com/jdx/mise/configuration/settings.md): Global settings for mise, configurable via mise.toml, environment variables, or the mise settings command.
+- [Templates](https://www.mintlify.com/jdx/mise/configuration/templates.md): Use Tera templates in mise.toml to dynamically generate configuration values.
+- [Aliases](https://www.mintlify.com/jdx/mise/dev-tools/aliases.md): Create short names for tool versions and redirect tool backends using aliases in mise.toml.
+- [Backends](https://www.mintlify.com/jdx/mise/dev-tools/backends.md): All the package ecosystems mise can install tools from, and how to choose between them.
+- [Dev tools overview](https://www.mintlify.com/jdx/mise/dev-tools/overview.md): How mise manages tool versions, resolves configurations, and switches between runtimes automatically.
+- [Shims](https://www.mintlify.com/jdx/mise/dev-tools/shims.md): What shims are, how they compare to PATH activation, and when to use them — especially for IDEs and non-interactive environments.
+- [Environments overview](https://www.mintlify.com/jdx/mise/environments/overview.md): Set, unset, and dynamically generate environment variables for your projects using mise.
+- [Secrets](https://www.mintlify.com/jdx/mise/environments/secrets.md): Manage sensitive environment variables securely using SOPS, age encryption, or external secret managers.
+- [Getting started](https://www.mintlify.com/jdx/mise/getting-started.md): Install mise, activate your shell, and start managing tools, environment variables, and tasks.
+- [Continuous integration](https://www.mintlify.com/jdx/mise/guides/continuous-integration.md): Use mise in CI pipelines to provision reproducible tool environments across GitHub Actions, GitLab CI, Xcode Cloud, and any other CI system.
+- [Hooks](https://www.mintlify.com/jdx/mise/guides/hooks.md): Automatically execute scripts on directory changes, tool installation, and other mise lifecycle events.
+- [IDE Integration](https://www.mintlify.com/jdx/mise/guides/ide-integration.md): Configure VS Code, IntelliJ, and other editors to use tools managed by mise.
+- [Plugins](https://www.mintlify.com/jdx/mise/guides/plugins.md): Extend mise with plugins for additional tools and environment management.
+- [Troubleshooting](https://www.mintlify.com/jdx/mise/guides/troubleshooting.md): Diagnose and fix common issues with mise tool management, shell activation, and environment setup.
+- [Installing mise](https://www.mintlify.com/jdx/mise/installing-mise.md): All installation methods for mise: curl, brew, apt, dnf, cargo, winget, scoop, and more.
+- [Introduction](https://www.mintlify.com/jdx/mise/introduction.md): Mise is a dev tools manager, environment manager, and task runner — all in one fast Rust binary.
+- [File tasks](https://www.mintlify.com/jdx/mise/tasks/file-tasks.md): Write mise tasks as standalone executable scripts with metadata headers, argument parsing, and multi-language support.
+- [Tasks overview](https://www.mintlify.com/jdx/mise/tasks/overview.md): Define and run project tasks in mise — from simple one-liners to complex dependency graphs.
+- [Running Tasks](https://www.mintlify.com/jdx/mise/tasks/running-tasks.md): Run mise tasks from the command line with parallel execution, file watching, and dependency ordering.
+- [TOML tasks](https://www.mintlify.com/jdx/mise/tasks/toml-tasks.md): Define tasks directly in mise.toml with dependencies, environment variables, sources, and argument parsing.
+
+## OpenAPI Specs
+
+- [openapi](https://www.mintlify.com/jdx/mise/api-reference/openapi.json)
+
+
+Built with [Mintlify](https://mintlify.com).

--- a/docs/research/mintlify-cache/jdx/pitchfork/llms-full.txt
+++ b/docs/research/mintlify-cache/jdx/pitchfork/llms-full.txt
@@ -1,0 +1,4989 @@
+# pitchfork activate
+Source: https://www.mintlify.com/jdx/pitchfork/cli/activate
+
+Generate shell hook code that enables automatic daemon management when you change directories.
+
+## Synopsis
+
+```bash theme={null}
+pitchfork activate <shell>
+```
+
+## Description
+
+Generates shell integration code for your shell. When loaded, the hook runs `pitchfork cd` every time you change directories. This enables the `auto = ["start", "stop"]` feature in `pitchfork.toml`: daemons are started automatically when you enter a project directory and stopped when you leave.
+
+Supported shells: `bash`, `zsh`, `fish`.
+
+The generated code must be evaluated in your shell startup file — it is not a standalone script.
+
+## Arguments
+
+<ParamField type="string">
+  The shell to generate activation code for. Must be one of: `bash`, `zsh`, `fish`.
+</ParamField>
+
+## Setup
+
+<Tabs>
+  <Tab title="bash">
+    Add to `~/.bashrc`:
+
+    ```bash theme={null}
+    eval "$(pitchfork activate bash)"
+    ```
+  </Tab>
+
+  <Tab title="zsh">
+    Add to `~/.zshrc`:
+
+    ```bash theme={null}
+    eval "$(pitchfork activate zsh)"
+    ```
+  </Tab>
+
+  <Tab title="fish">
+    Add to `~/.config/fish/config.fish`:
+
+    ```fish theme={null}
+    pitchfork activate fish | source
+    ```
+  </Tab>
+</Tabs>
+
+## Examples
+
+```bash theme={null}
+# Print the bash activation code (inspect before adding to your shell config)
+pitchfork activate bash
+
+# Print the zsh activation code
+pitchfork activate zsh
+
+# Print the fish activation code
+pitchfork activate fish
+```
+
+## Notes
+
+<Note>
+  Without the shell hook, pitchfork's `auto = ["start", "stop"]` feature in `pitchfork.toml` will not work. The hook must be loaded in your shell for directory-based automatic daemon management.
+</Note>
+
+<Tip>
+  After adding the activation line to your shell config, restart your shell or source the config file to activate it immediately.
+</Tip>
+
+
+# pitchfork boot
+Source: https://www.mintlify.com/jdx/pitchfork/cli/boot
+
+Register or remove the pitchfork supervisor from automatic system boot startup.
+
+## Synopsis
+
+```bash theme={null}
+pitchfork boot <subcommand>
+```
+
+## Description
+
+Manages whether the pitchfork supervisor starts automatically when your system boots. Uses platform-specific mechanisms — **launchd** on macOS and **systemd** user services on Linux.
+
+## Subcommands
+
+### `pitchfork boot enable`
+
+Registers pitchfork to start automatically at boot. On macOS, this creates a LaunchAgent plist. On Linux, this creates a systemd user service unit.
+
+```bash theme={null}
+pitchfork boot enable
+```
+
+### `pitchfork boot disable`
+
+Removes the boot start registration. Pitchfork will no longer start automatically when the system boots. Running daemons are not affected.
+
+```bash theme={null}
+pitchfork boot disable
+```
+
+### `pitchfork boot status`
+
+Reports whether pitchfork is currently configured to start at boot.
+
+```bash theme={null}
+pitchfork boot status
+```
+
+## Examples
+
+```bash theme={null}
+# Register pitchfork to start on boot
+pitchfork boot enable
+
+# Remove pitchfork from boot startup
+pitchfork boot disable
+
+# Check the current boot start configuration
+pitchfork boot status
+```
+
+## Notes
+
+<Note>
+  `pitchfork boot enable` and `pitchfork boot disable` only control whether the **supervisor** starts at boot. Individual daemons with `boot_start = true` in their config are started by the supervisor once it is running.
+</Note>
+
+
+# pitchfork clean
+Source: https://www.mintlify.com/jdx/pitchfork/cli/clean
+
+Remove stopped and failed daemon entries from the pitchfork list.
+
+## Synopsis
+
+```bash theme={null}
+pitchfork clean
+pitchfork c
+```
+
+**Alias**: `c`
+
+## Description
+
+Removes entries for daemons that are no longer running from pitchfork's tracked state. This affects daemons with a `stopped`, `failed`, or `errored` status. Running daemons and their configurations in `pitchfork.toml` are not affected.
+
+Use `clean` to tidy up the output of `pitchfork list` after stopping daemons or after failed runs.
+
+## Examples
+
+```bash theme={null}
+# Remove all stopped and failed entries
+pitchfork clean
+
+# Using the alias
+pitchfork c
+```
+
+## Notes
+
+<Note>
+  `pitchfork clean` only removes entries from the in-memory and persisted daemon state. It does not delete log files or modify `pitchfork.toml`. Daemons removed by `clean` will reappear as `available` if they are still defined in config.
+</Note>
+
+
+# pitchfork completion
+Source: https://www.mintlify.com/jdx/pitchfork/cli/completion
+
+Generate tab-completion scripts for bash, zsh, or fish shells.
+
+## Synopsis
+
+```bash theme={null}
+pitchfork completion <shell>
+```
+
+## Description
+
+Generates tab-completion scripts for your shell. Completions are generated using the [`usage`](https://usage.jdx.dev) CLI tool, which must be installed and available on your `$PATH`.
+
+Supported shells: `bash`, `zsh`, `fish`.
+
+Redirect the output to the appropriate location for your shell to enable completions.
+
+## Arguments
+
+<ParamField type="string">
+  The shell to generate completions for. Must be one of: `bash`, `zsh`, `fish`.
+</ParamField>
+
+## Setup
+
+<Tabs>
+  <Tab title="bash">
+    ```bash theme={null}
+    pitchfork completion bash > ~/.local/share/bash-completion/completions/pitchfork
+    ```
+  </Tab>
+
+  <Tab title="zsh">
+    ```bash theme={null}
+    pitchfork completion zsh > ~/.zfunc/_pitchfork
+    ```
+
+    Make sure `~/.zfunc` is on your `$fpath`. Add the following to `~/.zshrc` if it isn't:
+
+    ```bash theme={null}
+    fpath=(~/.zfunc $fpath)
+    autoload -Uz compinit && compinit
+    ```
+  </Tab>
+
+  <Tab title="fish">
+    ```fish theme={null}
+    pitchfork completion fish > ~/.config/fish/completions/pitchfork.fish
+    ```
+  </Tab>
+</Tabs>
+
+## Examples
+
+```bash theme={null}
+# Generate and install bash completions
+pitchfork completion bash > ~/.local/share/bash-completion/completions/pitchfork
+
+# Generate and install zsh completions
+pitchfork completion zsh > ~/.zfunc/_pitchfork
+
+# Generate and install fish completions
+pitchfork completion fish > ~/.config/fish/completions/pitchfork.fish
+
+# Inspect the generated script before installing
+pitchfork completion bash
+```
+
+## Notes
+
+<Note>
+  The `usage` CLI tool must be installed for `pitchfork completion` to work. Install it with `cargo install usage-cli` or via `mise use -g usage`.
+</Note>
+
+
+# pitchfork config
+Source: https://www.mintlify.com/jdx/pitchfork/cli/config
+
+Manage and edit pitchfork.toml configuration files, including adding and removing daemon entries.
+
+## Synopsis
+
+```bash theme={null}
+pitchfork config [subcommand]
+pitchfork cfg [subcommand]
+```
+
+**Alias**: `cfg`
+
+## Description
+
+Without a subcommand, lists all `pitchfork.toml` files found in the filesystem hierarchy from the current directory upward. This includes project-level files (`pitchfork.toml`, `pitchfork.local.toml`, `.config/pitchfork.toml`) and user/system-level config files.
+
+Subcommands allow you to add and remove daemon entries directly from the command line without manually editing TOML files.
+
+## Subcommands
+
+### `pitchfork config add`
+
+Adds a new daemon entry to the nearest `pitchfork.toml` in the current directory hierarchy. Creates `pitchfork.toml` in the current directory if no project config file is found.
+
+**Usage**: `pitchfork config add [flags] <id> [args...]`
+
+**Alias**: `a`
+
+<ParamField type="string">
+  The daemon ID to add (e.g., `api` or `namespace/api`).
+</ParamField>
+
+<ParamField type="string[]">
+  Command and arguments to run as the daemon. An alternative to `--run`.
+</ParamField>
+
+<ParamField type="string">
+  The shell command string to run as the daemon.
+</ParamField>
+
+<ParamField type="string">
+  Number of restart attempts on failure. Use `"true"` for infinite retries, `"false"` or `"0"` to disable.
+</ParamField>
+
+<ParamField type="string[]">
+  Glob patterns to watch for file changes that trigger a daemon restart. Can be specified multiple times.
+</ParamField>
+
+<ParamField type="string">
+  Working directory for the daemon process.
+</ParamField>
+
+<ParamField type="string[]">
+  Environment variables in `KEY=value` format. Can be specified multiple times.
+</ParamField>
+
+<ParamField type="number">
+  Seconds to wait before considering the daemon ready.
+</ParamField>
+
+<ParamField type="string">
+  Regex pattern to match in daemon output to declare it ready.
+</ParamField>
+
+<ParamField type="string">
+  HTTP URL to poll for a 2xx response to declare the daemon ready.
+</ParamField>
+
+<ParamField type="number">
+  TCP port to check for readiness.
+</ParamField>
+
+<ParamField type="string">
+  Shell command to poll for readiness (exit code 0 = ready).
+</ParamField>
+
+<ParamField type="number[]">
+  Ports the daemon is expected to bind to. Can be specified multiple times or comma-separated.
+</ParamField>
+
+<ParamField type="flag">
+  Find an available port automatically if the expected port is in use.
+</ParamField>
+
+<ParamField type="string[]">
+  Daemon IDs that must be started before this daemon. Can be specified multiple times.
+</ParamField>
+
+<ParamField type="flag">
+  Start this daemon automatically when the pitchfork supervisor starts at boot.
+</ParamField>
+
+<ParamField type="flag">
+  Start this daemon automatically when you enter the project directory (requires shell hook).
+</ParamField>
+
+<ParamField type="flag">
+  Stop this daemon automatically when you leave the project directory (requires shell hook).
+</ParamField>
+
+<ParamField type="string">
+  Shell command to run when the daemon becomes ready.
+</ParamField>
+
+<ParamField type="string">
+  Shell command to run when the daemon fails.
+</ParamField>
+
+<ParamField type="string">
+  Shell command to run before each retry attempt.
+</ParamField>
+
+<ParamField type="string">
+  Shell command to run when the daemon is explicitly stopped by pitchfork.
+</ParamField>
+
+<ParamField type="string">
+  Shell command to run on any daemon termination (clean exit, crash, or stop).
+</ParamField>
+
+<ParamField type="string">
+  Cron schedule expression (6 fields: second minute hour day month weekday).
+</ParamField>
+
+<ParamField type="string">
+  Cron retrigger behavior when the previous run is still active. One of: `finish`, `always`, `success`, `fail`. Defaults to `finish`.
+</ParamField>
+
+***
+
+### `pitchfork config remove`
+
+Removes a daemon entry from the nearest project-level `pitchfork.toml`.
+
+**Usage**: `pitchfork config remove <id>`
+
+**Alias**: `rm`
+
+<ParamField type="string">
+  The daemon ID to remove (e.g., `api` or `namespace/api`).
+</ParamField>
+
+## Examples
+
+```bash theme={null}
+# List all pitchfork.toml files in scope
+pitchfork config
+
+# Add a daemon using positional args
+pitchfork config add api bun run server
+
+# Add a daemon with an explicit --run string
+pitchfork config add api --run 'npm start'
+
+# Add with arguments after --
+pitchfork config add api -- bun run server
+
+# Add with a retry policy
+pitchfork config add api --run 'npm start' --retry 3
+
+# Add with file watching
+pitchfork config add api --run 'npm start' --watch 'src/**/*.ts'
+
+# Add with auto start/stop on directory change
+pitchfork config add api --run 'npm start' --autostart --autostop
+
+# Add with a daemon dependency
+pitchfork config add worker --run './worker' --depends api
+
+# Remove a daemon from config
+pitchfork config remove api
+
+# Using the alias
+pitchfork cfg add api -- node server.js
+```
+
+## Notes
+
+<Note>
+  `pitchfork config add` writes to the nearest existing `pitchfork.toml` file in the current directory hierarchy. If none exists, it creates `pitchfork.toml` in the current directory.
+</Note>
+
+<Tip>
+  After adding a daemon with `pitchfork config add`, start it immediately with `pitchfork start <id>`.
+</Tip>
+
+
+# pitchfork disable
+Source: https://www.mintlify.com/jdx/pitchfork/cli/disable
+
+Prevent a daemon from being started manually or automatically until re-enabled.
+
+## Synopsis
+
+```bash theme={null}
+pitchfork disable <daemon>
+pitchfork d <daemon>
+```
+
+**Alias**: `d`
+
+## Description
+
+Disables a daemon to prevent it from being started manually or through automatic mechanisms such as the shell hook or `boot_start`. The daemon remains in the list with a `disabled` marker until you run `pitchfork enable` to restore it to normal operation.
+
+Disabling is useful for temporarily suspending a service without removing its configuration from `pitchfork.toml`.
+
+## Arguments
+
+<ParamField type="string">
+  The name of the daemon to disable, as defined in `pitchfork.toml`.
+</ParamField>
+
+## Examples
+
+```bash theme={null}
+# Disable a daemon
+pitchfork disable api
+
+# Using the alias
+pitchfork d api
+
+# Verify the daemon is marked as disabled
+pitchfork list
+```
+
+### Example output from `pitchfork list`
+
+```text theme={null}
+Name    PID    Status     Error
+api            stopped    disabled
+```
+
+## Notes
+
+<Note>
+  Disabling a daemon that is currently running does not stop it. Stop the daemon first with `pitchfork stop`, then disable it.
+</Note>
+
+<Tip>
+  Use `pitchfork enable` to restore a disabled daemon to its normal state.
+</Tip>
+
+
+# pitchfork enable
+Source: https://www.mintlify.com/jdx/pitchfork/cli/enable
+
+Re-enable a previously disabled daemon, allowing it to be started manually or automatically.
+
+## Synopsis
+
+```bash theme={null}
+pitchfork enable <daemon>
+pitchfork e <daemon>
+```
+
+**Alias**: `e`
+
+## Description
+
+Re-enables a daemon that was previously disabled with `pitchfork disable`. Once enabled, the daemon can be started manually with `pitchfork start` or automatically through the shell hook. Enabled is the default state for all daemons.
+
+## Arguments
+
+<ParamField type="string">
+  The name of the daemon to enable, as defined in `pitchfork.toml`.
+</ParamField>
+
+## Examples
+
+```bash theme={null}
+# Enable a disabled daemon
+pitchfork enable api
+
+# Using the alias
+pitchfork e api
+```
+
+## Notes
+
+<Note>
+  Enabling a daemon does not start it. Use `pitchfork start <daemon>` after enabling to start it immediately.
+</Note>
+
+
+# CLI reference
+Source: https://www.mintlify.com/jdx/pitchfork/cli/index
+
+Complete reference for all pitchfork commands, flags, and arguments.
+
+The `pitchfork` CLI manages background daemons from a `pitchfork.toml` file or on-the-fly. It communicates with a background supervisor process over a Unix socket, auto-starting the supervisor if it isn't already running.
+
+```bash theme={null}
+pitchfork <command> [options] [arguments]
+pitchfork --version
+pitchfork --help
+```
+
+**Version**: 2.3.0
+
+## Commands
+
+<CardGroup>
+  <Card title="start" icon="play" href="/cli/start">
+    Start one or more daemons defined in `pitchfork.toml`, waiting for each to be ready.
+  </Card>
+
+  <Card title="stop" icon="stop" href="/cli/stop">
+    Send a graceful stop signal to one or more running daemons.
+  </Card>
+
+  <Card title="restart" icon="rotate" href="/cli/restart">
+    Stop then start daemons, equivalent to `start --force`.
+  </Card>
+
+  <Card title="run" icon="circle-play" href="/cli/run">
+    Run a one-off command as a managed daemon without a config file.
+  </Card>
+
+  <Card title="list" icon="list" href="/cli/list">
+    Display a table of all tracked daemons and their statuses.
+  </Card>
+
+  <Card title="status" icon="circle-info" href="/cli/status">
+    Show detailed status for a single daemon.
+  </Card>
+
+  <Card title="logs" icon="file-lines" href="/cli/logs">
+    Display, filter, and follow log output from daemons.
+  </Card>
+
+  <Card title="tui" icon="display" href="/cli/tui">
+    Launch the interactive terminal dashboard.
+  </Card>
+
+  <Card title="activate" icon="bolt" href="/cli/activate">
+    Generate shell hook code for automatic daemon management on directory change.
+  </Card>
+
+  <Card title="boot" icon="power-off" href="/cli/boot">
+    Register or remove the pitchfork supervisor from system boot.
+  </Card>
+
+  <Card title="enable" icon="toggle-on" href="/cli/enable">
+    Re-enable a previously disabled daemon.
+  </Card>
+
+  <Card title="disable" icon="toggle-off" href="/cli/disable">
+    Prevent a daemon from starting or restarting.
+  </Card>
+
+  <Card title="clean" icon="broom" href="/cli/clean">
+    Remove stopped and failed daemon entries from the list.
+  </Card>
+
+  <Card title="wait" icon="hourglass" href="/cli/wait">
+    Block until a daemon stops, tailing its logs in real time.
+  </Card>
+
+  <Card title="config" icon="gear" href="/cli/config">
+    Manage and edit `pitchfork.toml` configuration files.
+  </Card>
+
+  <Card title="completion" icon="wand-magic-sparkles" href="/cli/completion">
+    Generate tab-completion scripts for bash, zsh, or fish.
+  </Card>
+</CardGroup>
+
+## Global usage
+
+```bash theme={null}
+# Show version
+pitchfork --version
+
+# Show help
+pitchfork --help
+
+# Show help for a specific command
+pitchfork start --help
+```
+
+<Note>
+  The supervisor process starts automatically the first time you run any pitchfork command that requires it. You don't need to start it manually.
+</Note>
+
+
+# pitchfork list
+Source: https://www.mintlify.com/jdx/pitchfork/cli/list
+
+Display a table of all tracked daemons with their PID, status, and error information.
+
+## Synopsis
+
+```bash theme={null}
+pitchfork list [flags]
+pitchfork ls [flags]
+```
+
+**Alias**: `ls`
+
+## Description
+
+Displays a table of all daemons pitchfork knows about. This includes:
+
+* **Active daemons** — daemons that have been started and are currently running, stopping, or stopped.
+* **Available daemons** — daemons defined in config files that have not yet been started.
+
+Each row shows the daemon's name, PID (if running), status, disabled indicator, and any error message.
+
+## Flags
+
+<ParamField type="flag">
+  Omit the column header row from the output. Useful when parsing output in scripts.
+</ParamField>
+
+## Examples
+
+```bash theme={null}
+# List all daemons
+pitchfork list
+
+# Using the alias
+pitchfork ls
+
+# Output without column headers (useful in scripts)
+pitchfork list --hide-header
+```
+
+### Example output
+
+```text theme={null}
+Name    PID    Status     Error
+api     12345  running
+worker         available
+db             errored    exit code 127
+redis   98765  running    disabled
+```
+
+## Notes
+
+<Note>
+  The `available` status means the daemon is defined in `pitchfork.toml` but has not been started yet. Use `pitchfork start <name>` to start it.
+</Note>
+
+<Tip>
+  Use `pitchfork clean` to remove stopped and failed entries from the list without affecting running daemons.
+</Tip>
+
+
+# pitchfork logs
+Source: https://www.mintlify.com/jdx/pitchfork/cli/logs
+
+Display, filter, and follow log output from one or more managed daemons.
+
+## Synopsis
+
+```bash theme={null}
+pitchfork logs [flags] [daemons...]
+pitchfork l [flags] [daemons...]
+```
+
+**Alias**: `l`
+
+## Description
+
+Shows logs from managed daemons. Log files are stored at `~/.local/state/pitchfork/logs/<daemon>/<daemon>.log` and include timestamps on every line.
+
+When viewing logs in an interactive terminal, pitchfork automatically uses a pager (controlled by the `$PAGER` environment variable, defaulting to `less`) if the output exceeds the terminal height.
+
+When multiple daemons are specified, logs from all of them are merged and sorted by timestamp.
+
+## Arguments
+
+<ParamField type="string[]">
+  One or more daemon IDs to show logs for. When omitted, logs from all known daemons are shown.
+</ParamField>
+
+## Flags
+
+<ParamField type="number">
+  Show only the last N lines. Does not apply when `--since` or `--until` is also used.
+</ParamField>
+
+<ParamField type="flag">
+  Follow logs in real time, printing new lines as they are written. Short form: `-t`. Also accepts `-f` or `--follow`.
+</ParamField>
+
+<ParamField type="string">
+  Show only log lines from this point in time. Short form: `-s`.
+
+  Accepted formats:
+
+  * Full datetime: `"2024-01-15 10:00:00"` or `"2024-01-15 10:00"`
+  * Time only (today's date): `"10:30:00"` or `"10:30"` — if in the future, yesterday is assumed
+  * Relative duration: `"5min"`, `"2h"`, `"1d"`
+</ParamField>
+
+<ParamField type="string">
+  Show only log lines up to this point in time. Short form: `-u`.
+
+  Accepted formats:
+
+  * Full datetime: `"2024-01-15 12:00:00"` or `"2024-01-15 12:00"`
+  * Time only (today's date): `"12:00:00"` or `"12:00"`
+</ParamField>
+
+<ParamField type="flag">
+  Delete log files for the specified daemon(s). Clears logs for all daemons when no daemon IDs are given. Short form: `-c`.
+</ParamField>
+
+<ParamField type="flag">
+  Output log lines without color or formatting. Disables the pager.
+</ParamField>
+
+<ParamField type="flag">
+  Disable the pager even when running in an interactive terminal.
+</ParamField>
+
+## Examples
+
+```bash theme={null}
+# Show all logs for 'api'
+pitchfork logs api
+
+# Show logs for multiple daemons, merged by timestamp
+pitchfork logs api worker
+
+# Show logs for all daemons
+pitchfork logs
+
+# Show the last 50 lines
+pitchfork logs api -n 50
+
+# Follow logs in real time
+pitchfork logs api --tail
+
+# Show logs since a specific datetime
+pitchfork logs api --since '2024-01-15 10:00:00'
+
+# Show logs since a time today
+pitchfork logs api --since '10:30:00'
+
+# Show logs in a time window
+pitchfork logs api --since '10:30' --until '12:00'
+
+# Show logs from the last 5 minutes
+pitchfork logs api --since 5min
+
+# Output raw lines (no color, no pager)
+pitchfork logs api --raw
+
+# Show last 100 raw lines
+pitchfork logs api --raw -n 100
+
+# Delete logs for 'api'
+pitchfork logs api --clear
+
+# Delete logs for all daemons
+pitchfork logs --clear
+```
+
+## Notes
+
+<Note>
+  Log files are stored at `~/.local/state/pitchfork/logs/<daemon-id>/<daemon-id>.log`. Each log line starts with a timestamp in `YYYY-MM-DD HH:MM:SS` format, enabling accurate time-range filtering.
+</Note>
+
+<Tip>
+  Combine `--since` and `--tail` to start following from a specific point in time: `pitchfork logs api --since 5min --tail`
+</Tip>
+
+
+# pitchfork restart
+Source: https://www.mintlify.com/jdx/pitchfork/cli/restart
+
+Stop then start one or more daemons, equivalent to running start --force.
+
+## Synopsis
+
+```bash theme={null}
+pitchfork restart [flags] [daemons...]
+```
+
+## Description
+
+Stops and then starts one or more daemons. This is equivalent to `pitchfork start --force` — the daemon is sent `SIGTERM`, and once it stops, it is started again from the `pitchfork.toml` configuration with full dependency resolution.
+
+You must provide at least one daemon ID or use `--all`.
+
+## Arguments
+
+<ParamField type="string[]">
+  One or more daemon IDs to restart.
+</ParamField>
+
+## Flags
+
+<ParamField type="flag">
+  Restart all currently running daemons. Short form: `-a`.
+</ParamField>
+
+<ParamField type="number">
+  Number of seconds to wait before considering the daemon ready after it restarts. Defaults to 3 seconds.
+</ParamField>
+
+<ParamField type="string">
+  Wait until the daemon's output matches this regex pattern before declaring it ready.
+</ParamField>
+
+<ParamField type="string">
+  Wait until the given HTTP URL responds with a 2xx status code before declaring the daemon ready.
+</ParamField>
+
+<ParamField type="number">
+  Wait until a TCP port is accepting connections before declaring the daemon ready.
+</ParamField>
+
+<ParamField type="string">
+  Run a shell command repeatedly until it exits with code 0, then declare the daemon ready.
+</ParamField>
+
+<ParamField type="flag">
+  Suppress the startup log output printed after the daemon becomes ready. Short form: `-q`.
+</ParamField>
+
+## Examples
+
+```bash theme={null}
+# Restart a single daemon
+pitchfork restart api
+
+# Restart multiple daemons
+pitchfork restart api worker
+
+# Restart all running daemons
+pitchfork restart --all
+
+# Restart and wait 5 seconds for the ready check
+pitchfork restart api --delay 5
+
+# Restart and wait for an HTTP health check
+pitchfork restart api --http http://localhost:3000/health
+
+# Restart and wait for a port to open
+pitchfork restart api --port 8080
+```
+
+## Notes
+
+<Note>
+  `pitchfork restart api` and `pitchfork start --force api` are equivalent. Both stop the running daemon before starting it again.
+</Note>
+
+
+# pitchfork run
+Source: https://www.mintlify.com/jdx/pitchfork/cli/run
+
+Run a one-off command as a managed daemon without a pitchfork.toml configuration file.
+
+## Synopsis
+
+```bash theme={null}
+pitchfork run [flags] <name> -- <command> [args...]
+pitchfork r [flags] <name> -- <command> [args...]
+```
+
+**Alias**: `r`
+
+## Description
+
+Runs an arbitrary command as a managed daemon tracked by the pitchfork supervisor. Unlike `pitchfork start`, this command does not require a `pitchfork.toml` file. The daemon is identified by the name you provide and can be monitored with `pitchfork status`, `pitchfork logs`, and other commands.
+
+The command to execute must be provided after `--`.
+
+## Arguments
+
+<ParamField type="string">
+  A name to assign to the daemon. Used to identify it in `pitchfork list`, `pitchfork logs`, and other commands.
+</ParamField>
+
+<ParamField type="string[]">
+  The command and its arguments to run as a daemon. Must follow `--` on the command line.
+</ParamField>
+
+## Flags
+
+<ParamField type="flag">
+  Stop the daemon if it is already running before starting it again. Short form: `-f`.
+</ParamField>
+
+<ParamField type="number">
+  Number of times to restart the daemon on a non-zero exit code. Set to `0` to disable retries.
+</ParamField>
+
+<ParamField type="number">
+  Number of seconds to wait before declaring the daemon ready. Defaults to 3 seconds. Short form: `-d`.
+</ParamField>
+
+<ParamField type="string">
+  Wait until the daemon's output matches this regex pattern before declaring it ready. Short form: `-o`.
+</ParamField>
+
+<ParamField type="string">
+  Wait until the given HTTP URL responds with a 2xx status code before declaring the daemon ready.
+</ParamField>
+
+<ParamField type="number">
+  Wait until a TCP port is accepting connections before declaring the daemon ready.
+</ParamField>
+
+<ParamField type="number[]">
+  Ports the daemon is expected to bind to. Can be specified multiple times or as a comma-separated list.
+</ParamField>
+
+<ParamField type="flag">
+  If the expected port is already in use, automatically find the next available port.
+</ParamField>
+
+<ParamField type="string">
+  Run a shell command repeatedly until it exits with code 0, then declare the daemon ready.
+</ParamField>
+
+<ParamField type="flag">
+  Suppress the startup log output printed after the daemon becomes ready. Short form: `-q`.
+</ParamField>
+
+## Examples
+
+```bash theme={null}
+# Run npm as a daemon named 'api'
+pitchfork run api -- npm run dev
+
+# Force-restart 'api' if it is already running
+pitchfork run api -f -- npm run dev
+
+# Restart up to 3 times on failure
+pitchfork run api --retry 3 -- ./server
+
+# Wait 5 seconds for the ready check
+pitchfork run api -d 5 -- ./server
+
+# Wait for a log output pattern
+pitchfork run api -o 'Listening' -- ./server
+
+# Wait for an HTTP health check
+pitchfork run api --http http://localhost:8080/health -- ./server
+
+# Wait for a TCP port
+pitchfork run api --port 8080 -- ./server
+```
+
+## Notes
+
+<Note>
+  `pitchfork run` registers the daemon globally (not tied to any project config). The daemon appears in `pitchfork list` and can be managed with all standard pitchfork commands.
+</Note>
+
+<Tip>
+  Use `pitchfork start` for daemons defined in `pitchfork.toml`. Use `pitchfork run` for quick one-off commands or ad-hoc services that don't need a config entry.
+</Tip>
+
+
+# pitchfork start
+Source: https://www.mintlify.com/jdx/pitchfork/cli/start
+
+Start one or more daemons defined in pitchfork.toml, waiting for each to be ready before returning.
+
+## Synopsis
+
+```bash theme={null}
+pitchfork start [flags] [daemons...]
+pitchfork s [flags] [daemons...]
+```
+
+**Alias**: `s`
+
+## Description
+
+Starts daemons defined in `pitchfork.toml` with a `[daemons.<name>]` section. The command blocks until each daemon is ready before returning.
+
+Pitchfork auto-starts the supervisor process if it isn't already running. When starting multiple daemons with dependencies, pitchfork resolves the dependency graph and starts them in the correct order.
+
+You must provide at least one daemon ID or one of `--all`, `--local`, or `--global`.
+
+## Arguments
+
+<ParamField type="string[]">
+  One or more daemon IDs defined in `pitchfork.toml` to start. Conflicts with `--all`, `--local`, and `--global`.
+</ParamField>
+
+## Flags
+
+<ParamField type="flag">
+  Start all daemons defined in the local `pitchfork.toml` file found in or above the current directory. Short form: `-l`. Alias: `--all-local`.
+</ParamField>
+
+<ParamField type="flag">
+  Start all daemons defined in the global config files (`~/.config/pitchfork/config.toml` and `/etc/pitchfork/config.toml`). Short form: `-g`. Alias: `--all-global`.
+</ParamField>
+
+<ParamField type="flag">
+  Start all daemons from both local and global configuration. Short form: `-a`.
+</ParamField>
+
+<ParamField type="flag">
+  Stop the daemon first if it is already running, then start it. Short form: `-f`.
+</ParamField>
+
+<ParamField type="number">
+  Number of seconds to wait before considering the daemon ready. Defaults to 3 seconds. Overrides the `ready_delay` value from config for this invocation.
+</ParamField>
+
+<ParamField type="string">
+  Wait until the daemon's stdout/stderr matches this regex pattern before declaring it ready. Overrides `ready_output` from config.
+</ParamField>
+
+<ParamField type="string">
+  Wait until the given HTTP URL responds with a 2xx status code before declaring the daemon ready. Overrides `ready_http` from config.
+</ParamField>
+
+<ParamField type="number">
+  Wait until a TCP port is accepting connections before declaring the daemon ready. Overrides `ready_port` from config.
+</ParamField>
+
+<ParamField type="string">
+  Run a shell command repeatedly until it exits with code 0, then declare the daemon ready. Overrides `ready_cmd` from config.
+</ParamField>
+
+<ParamField type="number[]">
+  Ports the daemon is expected to bind to. Can be specified multiple times. When combined with `--auto-bump-port`, pitchfork finds an available port if the expected one is already in use.
+</ParamField>
+
+<ParamField type="flag">
+  If the expected port is already in use, automatically find the next available port and pass it to the daemon.
+</ParamField>
+
+<ParamField type="flag">
+  Suppress the startup log output that is printed after the daemon becomes ready. Short form: `-q`.
+</ParamField>
+
+## Examples
+
+```bash theme={null}
+# Start a single daemon
+pitchfork start api
+
+# Start multiple daemons
+pitchfork start api worker
+
+# Start all local daemons defined in pitchfork.toml
+pitchfork start --local
+
+# Start all global daemons
+pitchfork start --global
+
+# Start all daemons (local and global)
+pitchfork start --all
+
+# Restart a daemon if it is already running
+pitchfork start api --force
+
+# Wait 5 seconds before marking the daemon ready
+pitchfork start api --delay 5
+
+# Wait for a specific log message before returning
+pitchfork start api --output 'Listening on'
+
+# Wait for an HTTP health check to pass
+pitchfork start api --http http://localhost:8080/health
+
+# Wait for a TCP port to open
+pitchfork start api --port 8080
+```
+
+## Notes
+
+<Note>
+  Ready check flags (`--delay`, `--output`, `--http`, `--port`, `--cmd`) override the equivalent `ready_*` fields from `pitchfork.toml` for that invocation only. They do not modify the config file.
+</Note>
+
+<Tip>
+  Use `pitchfork start --force` or `pitchfork restart` to restart a running daemon. Both are equivalent.
+</Tip>
+
+
+# pitchfork status
+Source: https://www.mintlify.com/jdx/pitchfork/cli/status
+
+Show detailed status information for a single daemon, including its PID and current state.
+
+## Synopsis
+
+```bash theme={null}
+pitchfork status <daemon>
+pitchfork stat <daemon>
+```
+
+**Alias**: `stat`
+
+## Description
+
+Shows the name, PID, and current status of a single daemon. The status reflects the daemon's last known state as recorded in pitchfork's state file.
+
+Possible status values: `running`, `stopped`, `failed`, `errored`, `waiting`, `stopping`.
+
+## Arguments
+
+<ParamField type="string">
+  The name of the daemon to inspect, as defined in `pitchfork.toml`.
+</ParamField>
+
+## Examples
+
+```bash theme={null}
+# Show status for a daemon named 'api'
+pitchfork status api
+
+# Using the alias
+pitchfork stat api
+```
+
+### Example output
+
+```text theme={null}
+Name: api
+PID: 12345
+Status: running
+```
+
+## Notes
+
+<Note>
+  If the daemon name is not found in the state file, `pitchfork status` exits with an error. Use `pitchfork list` to see all known daemons.
+</Note>
+
+
+# pitchfork stop
+Source: https://www.mintlify.com/jdx/pitchfork/cli/stop
+
+Send a graceful stop signal to one or more running daemons, escalating to SIGKILL if needed.
+
+## Synopsis
+
+```bash theme={null}
+pitchfork stop [flags] [daemons...]
+pitchfork kill [flags] [daemons...]
+```
+
+**Alias**: `kill`
+
+## Description
+
+Sends a stop signal to one or more running daemons using a two-step graceful shutdown strategy:
+
+1. Send `SIGTERM` and poll for up to \~3 seconds (starting at 10ms intervals, then 50ms).
+2. If the process is still running after that window, send `SIGKILL` to force termination.
+
+Most well-behaved processes exit immediately on `SIGTERM`. The escalation to `SIGKILL` ensures that stubborn processes are always terminated.
+
+When using `--all`, daemons are stopped in reverse dependency order — dependents are stopped before the daemons they depend on.
+
+You must provide at least one daemon ID or use `--all`.
+
+## Arguments
+
+<ParamField type="string[]">
+  One or more daemon IDs to stop. Cannot be combined with `--all`.
+</ParamField>
+
+## Flags
+
+<ParamField type="flag">
+  Stop all currently running daemons in reverse dependency order. Short form: `-a`. Cannot be combined with daemon ID arguments.
+</ParamField>
+
+## Examples
+
+```bash theme={null}
+# Stop a single daemon
+pitchfork stop api
+
+# Stop multiple daemons
+pitchfork stop api worker
+
+# Stop all running daemons in reverse dependency order
+pitchfork stop --all
+
+# Using the alias
+pitchfork kill api
+```
+
+## Notes
+
+<Note>
+  `--all` and explicit daemon IDs cannot be used together. Choose one or the other.
+</Note>
+
+<Tip>
+  Daemons stopped with `pitchfork stop` remain in the list with a `stopped` status. Use `pitchfork clean` to remove stopped entries from the list.
+</Tip>
+
+
+# pitchfork tui
+Source: https://www.mintlify.com/jdx/pitchfork/cli/tui
+
+Launch the interactive terminal dashboard to monitor daemons and view logs in real time.
+
+## Synopsis
+
+```bash theme={null}
+pitchfork tui
+```
+
+## Description
+
+Opens pitchfork's interactive terminal user interface (TUI). The TUI provides a live dashboard showing daemon statuses, streaming log output, and controls for starting and stopping daemons — all from within the terminal.
+
+## Examples
+
+```bash theme={null}
+pitchfork tui
+```
+
+## Notes
+
+<Tip>
+  Use the TUI for a live overview during development when you want to monitor multiple daemons and their logs in a single pane. For scripting and automation, use the individual commands like `pitchfork list` and `pitchfork logs`.
+</Tip>
+
+
+# pitchfork wait
+Source: https://www.mintlify.com/jdx/pitchfork/cli/wait
+
+Block until a daemon stops, tailing its logs in real time. Exits with the same code as the daemon.
+
+## Synopsis
+
+```bash theme={null}
+pitchfork wait <daemon>
+pitchfork w <daemon>
+```
+
+**Alias**: `w`
+
+## Description
+
+Blocks the current process until the specified daemon stops running. While waiting, the daemon's log output is streamed to the terminal in real time.
+
+When the daemon exits, `pitchfork wait` exits with the same status code as the daemon process. This makes it useful in scripts that need to synchronize on a daemon completing its work.
+
+## Arguments
+
+<ParamField type="string">
+  The name of the daemon to wait for, as defined in `pitchfork.toml` or started with `pitchfork run`.
+</ParamField>
+
+## Examples
+
+```bash theme={null}
+# Wait for the 'api' daemon to stop
+pitchfork wait api
+
+# Using the alias
+pitchfork w api
+
+# Run a command after the daemon stops
+pitchfork wait api && echo "api has stopped"
+
+# Use in a script to wait for a job daemon
+pitchfork run job -- ./run-migration.sh
+pitchfork wait job
+echo "migration finished with exit code $?"
+```
+
+## Notes
+
+<Note>
+  If the daemon is not currently running when you call `pitchfork wait`, the command exits immediately with a warning.
+</Note>
+
+<Tip>
+  `pitchfork wait` is designed for short-lived daemon processes (like migration scripts or build jobs started with `pitchfork run`). For long-running services, use `pitchfork logs --tail` instead.
+</Tip>
+
+
+# Architecture
+Source: https://www.mintlify.com/jdx/pitchfork/concepts/architecture
+
+A technical deep-dive into how Pitchfork is built.
+
+This page is for developers who want to understand Pitchfork's internals — how processes are managed, how state is stored, and how the different components fit together.
+
+## System overview
+
+```
+┌────────────────────────────────────────────────────────────┐
+│                         USER                                │
+│           pitchfork start/stop/status/run/logs              │
+└───────────────────────────┬────────────────────────────────┘
+                            │
+                            ▼
+┌────────────────────────────────────────────────────────────┐
+│                          CLI                                │
+│  • Reads pitchfork.toml configs                             │
+│  • Sends IPC requests                                       │
+└───────────────────────────┬────────────────────────────────┘
+                            │ Unix socket
+                            │ ~/.local/state/pitchfork/ipc/main.sock
+                            ▼
+┌────────────────────────────────────────────────────────────┐
+│                       SUPERVISOR                            │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐         │
+│  │ IPC Server  │  │  Interval   │  │    Cron     │         │
+│  │             │  │  Watcher    │  │   Watcher   │         │
+│  └──────┬──────┘  └──────┬──────┘  └──────┬──────┘         │
+│         │                │                │                 │
+│         └────────────────┼────────────────┘                 │
+│                          ▼                                  │
+│              ┌───────────────────────┐                      │
+│              │   Daemon management   │                      │
+│              │  • spawn processes    │                      │
+│              │  • monitor output     │                      │
+│              │  • handle retries     │                      │
+│              └───────────────────────┘                      │
+└────────────────────────────────────────────────────────────┘
+                            │
+             ┌──────────────┼──────────────┐
+             ▼              ▼              ▼
+        ┌─────────┐   ┌─────────┐   ┌─────────┐
+        │ Daemon  │   │ Daemon  │   │ Daemon  │
+        └─────────┘   └─────────┘   └─────────┘
+```
+
+## Components
+
+| Component  | Source              | Purpose                                                  |
+| ---------- | ------------------- | -------------------------------------------------------- |
+| CLI        | `src/cli/`          | User commands, config parsing, IPC client                |
+| Supervisor | `src/supervisor/`   | Background process, daemon management                    |
+| IPC        | `src/ipc/`          | Unix socket communication with MessagePack serialization |
+| State file | `src/state_file.rs` | Persistent TOML state with file locking                  |
+
+## Supervisor auto-start
+
+The supervisor is a long-lived background process. The CLI never manages daemons directly — it always delegates through IPC.
+
+When you run any Pitchfork command:
+
+1. The CLI checks whether the supervisor is listening at `~/.local/state/pitchfork/ipc/main.sock`.
+2. If the socket is absent, the CLI forks and exec's the supervisor in the background.
+3. The CLI then connects and sends its request.
+
+The supervisor continues running until explicitly stopped or the machine reboots, keeping all managed daemons alive independently of any terminal session.
+
+## IPC protocol
+
+The CLI and supervisor communicate over a Unix domain socket using **MessagePack** serialization (or JSON when the `PITCHFORK_IPC_JSON` environment variable is set, useful for debugging).
+
+Requests from the CLI include operations such as `Run`, `Stop`, `GetActiveDaemons`, and `UpdateShellDir`. The supervisor replies with typed responses like `DaemonStart`, `DaemonReady`, `DaemonFailed`, and `PortConflict`.
+
+## Background watchers
+
+The supervisor runs two background tasks continuously alongside the IPC server.
+
+### Interval watcher (every 10 seconds)
+
+* Refreshes process state — checks which PIDs are still alive.
+* Handles autostop — stops daemons when the shell that started them changes out of the project directory.
+* Retries failed daemons that have remaining retry attempts.
+* Checks resource limits (CPU and memory) for all running daemons.
+
+### Cron watcher (every 60 seconds)
+
+* Scans daemons with `cron` schedules.
+* Triggers execution according to the configured retrigger policy (`skip`, `queue`, or `restart`).
+
+### File watcher (event-driven)
+
+* Watches filesystem paths specified in a daemon's `watch` field.
+* Restarts the daemon when a matching file changes.
+
+## Daemon states
+
+| State      | Meaning                                                     |
+| ---------- | ----------------------------------------------------------- |
+| `Running`  | Process is alive and has passed its ready check (if any)    |
+| `Waiting`  | Process started; supervisor is polling the ready check      |
+| `Stopping` | SIGTERM sent; supervisor is waiting for the process to exit |
+| `Stopped`  | Process exited with code 0                                  |
+| `Errored`  | Process exited with a non-zero exit code                    |
+
+State transitions are always written to the state file before the supervisor acts on them, ensuring the on-disk record stays consistent even if the supervisor is interrupted.
+
+## State persistence
+
+All runtime state is stored in `~/.local/state/pitchfork/state.toml`. This file is read and written under an `fslock` file lock to prevent concurrent corruption when multiple CLI invocations run simultaneously.
+
+```toml theme={null}
+[daemons.myapp]
+id = "myapp"
+pid = 12345
+status = "running"
+dir = "/path/to/project"
+autostop = true
+retry = 2
+retry_count = 0
+
+[disabled]
+# Set of disabled daemon IDs
+
+[shell_dirs]
+# Map of shell_pid → working directory
+```
+
+The `shell_dirs` map is how autostop works: each interactive shell reports its current directory via `UpdateShellDir` IPC calls (installed by the shell hook), and the interval watcher stops daemons whose owning shell has left the project directory.
+
+## Process spawning
+
+When the supervisor receives a `Run` request:
+
+1. Checks whether the daemon is already running (PID exists and is alive).
+2. Prepends `exec` to the command to replace the shell process with the target binary directly, eliminating an unnecessary wrapper process.
+3. Creates the log file at `~/.local/share/pitchfork/logs/<namespace>--<name>/<namespace>--<name>.log`.
+4. Spawns the process with piped stdout and stderr.
+5. Records the PID in the state file.
+6. Starts a monitoring task that polls or waits for the ready check.
+
+## Process termination
+
+Pitchfork uses a two-phase graceful shutdown:
+
+<Steps>
+  <Step title="SIGTERM">
+    The supervisor sends SIGTERM to the process (and its children first). It then polls every 10 ms, waiting up to approximately 3 seconds for the process to exit voluntarily.
+  </Step>
+
+  <Step title="SIGKILL">
+    If the process has not exited after the grace period, the supervisor sends SIGKILL to force termination.
+  </Step>
+</Steps>
+
+This ensures well-behaved processes have time to flush buffers and close connections, while stubborn processes are always eventually cleaned up. Zombie processes are detected correctly and do not trigger unnecessary escalation.
+
+## Readiness detection
+
+When a ready check is configured, the supervisor keeps the daemon in the `Waiting` state until the check passes. The first check to succeed marks the daemon as `Running`.
+
+| Method       | Config key     | Trigger                                      |
+| ------------ | -------------- | -------------------------------------------- |
+| Delay        | `ready_delay`  | Wait N seconds; if still running, mark ready |
+| Output match | `ready_output` | A regex matches a line on stdout or stderr   |
+| HTTP         | `ready_http`   | An HTTP endpoint returns a 2xx response      |
+| Port         | `ready_port`   | A TCP port is accepting connections          |
+| Command      | `ready_cmd`    | A shell command exits with code 0            |
+
+```toml theme={null}
+[daemons.api]
+run = "npm run dev"
+ready_http = "http://localhost:3000/health"
+
+[daemons.worker]
+run = "./worker"
+ready_output = "Worker started"
+
+[daemons.db]
+run = "postgres -D ~/.local/share/postgres/data"
+ready_port = 5432
+```
+
+## Key source files
+
+| File                             | Purpose                                             |
+| -------------------------------- | --------------------------------------------------- |
+| `src/supervisor/mod.rs`          | Supervisor struct, startup, signal handling         |
+| `src/supervisor/lifecycle.rs`    | Daemon start/stop operations                        |
+| `src/supervisor/watchers.rs`     | Interval, cron, and file watcher tasks              |
+| `src/supervisor/autostop.rs`     | Autostop logic                                      |
+| `src/supervisor/retry.rs`        | Retry with backoff                                  |
+| `src/supervisor/ipc_handlers.rs` | IPC request dispatch                                |
+| `src/ipc/`                       | Unix socket client and server, MessagePack protocol |
+| `src/pitchfork_toml.rs`          | Config file parsing and merging                     |
+| `src/state_file.rs`              | Persistent state management                         |
+| `src/daemon.rs`                  | Daemon struct and ID validation                     |
+
+
+# How it works
+Source: https://www.mintlify.com/jdx/pitchfork/concepts/how-it-works
+
+A tour of the client-server architecture that powers Pitchfork.
+
+Pitchfork is built around a persistent **supervisor** process that runs in the background and manages all your daemons. Your CLI commands are thin clients that talk to the supervisor over a Unix socket — they never manage processes directly.
+
+## The big picture
+
+```
+You → CLI → IPC (Unix socket) → Supervisor → Your daemons
+```
+
+| Layer          | What it does                                                                                |
+| -------------- | ------------------------------------------------------------------------------------------- |
+| **CLI**        | Reads config files, resolves daemon IDs, sends requests to the supervisor                   |
+| **IPC**        | Unix domain socket at `~/.local/state/pitchfork/ipc/main.sock`, serialized with MessagePack |
+| **Supervisor** | Spawns and monitors processes, handles retries, cron, autostop                              |
+| **Daemons**    | Your actual background services (API server, database, worker, etc.)                        |
+
+## Supervisor auto-start
+
+You never need to start the supervisor manually. Whenever you run a Pitchfork command, the CLI checks whether the supervisor is already listening on the socket. If it is not, the CLI starts the supervisor in the background and then connects.
+
+<Note>
+  The supervisor continues running between commands. It keeps your daemons alive even after the terminal session that started them is closed.
+</Note>
+
+## What happens when you run `pitchfork start`
+
+<Steps>
+  <Step title="Config is loaded">
+    The CLI reads all `pitchfork.toml` files in the config hierarchy — system, user, and project — and merges them in order.
+  </Step>
+
+  <Step title="Supervisor is contacted">
+    The CLI connects to the supervisor's Unix socket. If the supervisor is not running, it is started automatically in the background first.
+  </Step>
+
+  <Step title="Run request is sent">
+    The CLI sends a `Run` IPC request containing the resolved daemon configuration (command, ready check, retry policy, etc.).
+  </Step>
+
+  <Step title="Process is spawned">
+    The supervisor checks whether the daemon is already running. If not, it prepends `exec` to the command (eliminating the shell wrapper), creates a log file, and spawns the process.
+  </Step>
+
+  <Step title="Readiness is checked">
+    If a ready check is configured (`ready_http`, `ready_port`, `ready_output`, `ready_delay`, or `ready_cmd`), the supervisor waits until the check passes before reporting the daemon as ready.
+  </Step>
+
+  <Step title="CLI returns">
+    Once the daemon is running (or ready), the supervisor sends a response and the CLI exits. The daemon keeps running in the background.
+  </Step>
+</Steps>
+
+## Daemon lifecycle
+
+A daemon moves through well-defined states during its lifetime:
+
+| State      | Meaning                                                              |
+| ---------- | -------------------------------------------------------------------- |
+| `Waiting`  | Process started; supervisor is waiting for a ready check to pass     |
+| `Running`  | Process is alive and ready                                           |
+| `Stopping` | SIGTERM has been sent; supervisor is waiting for the process to exit |
+| `Stopped`  | Process exited with code 0                                           |
+| `Errored`  | Process exited with a non-zero exit code                             |
+
+When a daemon exits unexpectedly, the supervisor retries it up to the configured `retry` count before marking it `Errored`.
+
+## Config hierarchy
+
+Pitchfork merges configuration from multiple files. Later entries override earlier ones:
+
+| Priority    | File                                        | Namespace |
+| ----------- | ------------------------------------------- | --------- |
+| 1 (lowest)  | `/etc/pitchfork/config.toml`                | `global`  |
+| 2           | `~/.config/pitchfork/config.toml`           | `global`  |
+| 3           | `.config/pitchfork.toml` (root → cwd)       | project   |
+| 4           | `.config/pitchfork.local.toml` (root → cwd) | project   |
+| 5           | `pitchfork.toml` (root → cwd)               | project   |
+| 6 (highest) | `pitchfork.local.toml` (root → cwd)         | project   |
+
+Project configs are discovered by walking from the filesystem root down to your current directory, so parent directories can provide shared defaults.
+
+<Tip>
+  Use `pitchfork.local.toml` for machine-specific overrides you do not want to commit to version control.
+</Tip>
+
+## Why this architecture?
+
+Splitting the CLI from the supervisor means your daemons stay running even when you close terminals, run commands from scripts, or switch directories. The supervisor is the single source of truth for process state, and all CLI commands simply read from or write to it.
+
+For a deeper technical dive, see [Architecture](/concepts/architecture).
+
+
+# Namespaces
+Source: https://www.mintlify.com/jdx/pitchfork/concepts/namespaces
+
+How Pitchfork keeps daemons from different projects from colliding.
+
+When you work across multiple projects, it is common for each one to define daemons with the same name — `api`, `worker`, `db`. Namespaces let Pitchfork manage all of them at the same time without ambiguity.
+
+## The problem namespaces solve
+
+Imagine two projects, each with a `pitchfork.toml` that defines an `api` daemon:
+
+```
+~/projects/
+├── frontend/
+│   └── pitchfork.toml    # [daemons.api]
+└── backend/
+    └── pitchfork.toml    # [daemons.api]
+```
+
+Without namespacing these would conflict. Pitchfork solves this by automatically qualifying every daemon ID with a **namespace** derived from its config file location.
+
+## Daemon ID formats
+
+Every daemon has two forms of ID:
+
+| Format       | Example        | When to use                  |
+| ------------ | -------------- | ---------------------------- |
+| Short ID     | `api`          | Inside the project directory |
+| Qualified ID | `frontend/api` | From anywhere; unambiguous   |
+
+## Namespace derivation rules
+
+| Config file location                        | Namespace used                           |
+| ------------------------------------------- | ---------------------------------------- |
+| `/etc/pitchfork/config.toml`                | `global`                                 |
+| `~/.config/pitchfork/config.toml`           | `global`                                 |
+| Project config with `namespace = "..."` set | The value you specified                  |
+| Project config without `namespace`          | Parent directory name of the config file |
+
+If the derived directory name is invalid (contains `--`, spaces, or non-ASCII characters), Pitchfork fails with a clear error and prompts you to set `namespace` explicitly:
+
+```toml theme={null}
+# pitchfork.toml
+namespace = "my-project"
+
+[daemons.api]
+run = "npm run dev"
+```
+
+## Using short IDs
+
+When you are inside a project directory, you can omit the namespace:
+
+```bash theme={null}
+cd ~/projects/frontend
+pitchfork start api        # starts frontend/api
+pitchfork status api       # shows status of frontend/api
+pitchfork logs api         # streams logs for frontend/api
+```
+
+Short ID resolution order:
+
+1. Prefer a daemon in the current directory's namespace.
+2. If not found locally, use a unique match from the merged config.
+3. If `global/<id>` exists in the merged config, use it.
+4. If no match is found, return a not-found error.
+5. If multiple namespaces match, return an ambiguity error and require the qualified form.
+
+## Using qualified IDs
+
+From any directory, use the `namespace/name` form:
+
+```bash theme={null}
+# From anywhere on the filesystem
+pitchfork start frontend/api
+pitchfork status backend/api
+pitchfork logs frontend/api
+pitchfork stop backend/api
+```
+
+Qualified IDs are parsed directly and work even when there is no `pitchfork.toml` in the current directory.
+
+## The `global` namespace
+
+Daemons defined in `~/.config/pitchfork/config.toml` or `/etc/pitchfork/config.toml` belong to the `global` namespace. These are typically long-lived services like databases that are not tied to a specific project:
+
+```toml theme={null}
+# ~/.config/pitchfork/config.toml
+
+[daemons.postgres]
+run = "postgres -D ~/.local/share/postgres/data"
+ready_port = 5432
+```
+
+```bash theme={null}
+pitchfork start global/postgres
+pitchfork logs global/redis
+```
+
+## Display behavior
+
+Pitchfork hides namespaces in output when they are unambiguous, and shows them when they are needed:
+
+<Tabs>
+  <Tab title="No conflict">
+    When only one daemon is named `api`:
+
+    ```
+    $ pitchfork list
+    api    12345  running
+    ```
+  </Tab>
+
+  <Tab title="Conflict">
+    When multiple daemons share the same short name:
+
+    ```
+    $ pitchfork list
+    frontend/api  12345  running
+    backend/api   12346  running
+    ```
+  </Tab>
+</Tabs>
+
+## Naming rules
+
+| Rule                          | Valid         | Invalid   |
+| ----------------------------- | ------------- | --------- |
+| No double dashes              | `my-app`      | `my--app` |
+| No slashes in short ID        | `api`         | `api/v2`  |
+| Single slash for qualified ID | `project/api` | `a/b/c`   |
+| No spaces                     | `my_app`      | `my app`  |
+| No parent references          | `myapp`       | `../etc`  |
+| ASCII only                    | `myapp123`    | `myäpp`   |
+
+The `--` sequence is reserved for internal path encoding — Pitchfork converts `namespace/daemon` to `namespace--daemon` when constructing filesystem paths (log directories, state entries). This conversion is transparent: you always use `/` in commands.
+
+## Path encoding
+
+| Daemon ID               | Log directory                  | Log file                     |
+| ----------------------- | ------------------------------ | ---------------------------- |
+| `frontend/api`          | `logs/frontend--api/`          | `frontend--api.log`          |
+| `my-project/web-server` | `logs/my-project--web-server/` | `my-project--web-server.log` |
+| `global/postgres`       | `logs/global--postgres/`       | `global--postgres.log`       |
+
+## Examples
+
+### Managing multiple projects
+
+```bash theme={null}
+# Start services in two separate projects
+cd ~/projects/frontend && pitchfork start api
+cd ~/projects/backend && pitchfork start api
+
+# See all running daemons with qualified names
+pitchfork list
+# frontend/api  12345  running
+# backend/api   12346  running
+
+# Stream logs for one specific project
+pitchfork logs frontend/api
+
+# Stop from anywhere
+pitchfork stop backend/api
+```
+
+### Working within a single project
+
+```bash theme={null}
+cd ~/projects/frontend
+
+# Short IDs resolve to this project's daemons
+pitchfork start api
+pitchfork logs api
+pitchfork stop api
+```
+
+
+# Your first project
+Source: https://www.mintlify.com/jdx/pitchfork/first-daemon
+
+Set up a pitchfork.toml with multiple daemons for a realistic development environment.
+
+This guide walks through configuring Pitchfork for a project with multiple services — a pattern you'll use for most real-world setups.
+
+<Steps>
+  <Step title="Create a pitchfork.toml">
+    In your project root, create `pitchfork.toml` and define your daemons:
+
+    ```toml pitchfork.toml theme={null}
+    [daemons.postgres]
+    run = "docker run --rm -p 5432:5432 -e POSTGRES_PASSWORD=dev postgres:16"
+    auto = ["start", "stop"]
+    ready_delay = 5
+
+    [daemons.redis]
+    run = "redis-server --port 6379"
+    auto = ["start", "stop"]
+    ready_delay = 2
+
+    [daemons.api]
+    run = "npm run dev:api"
+    auto = ["start", "stop"]
+    ready_output = "listening on"
+    depends = ["postgres", "redis"]
+    ```
+
+    This defines three daemons. The `api` daemon declares `depends` on `postgres` and `redis`, so Pitchfork starts those first and waits for them to be ready before starting the API.
+
+    <Tip>
+      The `auto = ["start", "stop"]` field enables the shell hook — daemons with this setting will start automatically when you enter the project directory and stop when you leave. See the [shell hook guide](/guides/shell-hook) for setup instructions.
+    </Tip>
+  </Step>
+
+  <Step title="Start all daemons">
+    From your project root, start everything at once:
+
+    ```bash theme={null}
+    pitchfork start --all
+    ```
+
+    Or start a specific subset:
+
+    ```bash theme={null}
+    pitchfork start postgres redis
+    ```
+
+    Pitchfork respects dependency ordering — it starts `postgres` and `redis` in parallel, waits for both to be ready, then starts `api`.
+  </Step>
+
+  <Step title="Check status">
+    List all daemons and their current state:
+
+    ```bash theme={null}
+    pitchfork list
+    ```
+
+    Output:
+
+    ```
+    NAME      PID    STATUS
+    api       12347  running
+    postgres  12345  running
+    redis     12346  running
+    ```
+
+    Get detailed status for a single daemon:
+
+    ```bash theme={null}
+    pitchfork status api
+    ```
+  </Step>
+
+  <Step title="View logs">
+    Tail logs for a specific daemon:
+
+    ```bash theme={null}
+    pitchfork logs api
+    ```
+
+    Follow logs in real-time:
+
+    ```bash theme={null}
+    pitchfork logs api --tail
+    ```
+
+    View logs from multiple daemons at once:
+
+    ```bash theme={null}
+    pitchfork logs api postgres
+    ```
+  </Step>
+
+  <Step title="Enable the shell hook">
+    With `auto = ["start", "stop"]` set in your config, daemons can start and stop automatically as you change directories. To enable this, add the activation line to your shell config:
+
+    ```bash theme={null}
+    # bash
+    echo 'eval "$(pitchfork activate bash)"' >> ~/.bashrc
+
+    # zsh
+    echo 'eval "$(pitchfork activate zsh)"' >> ~/.zshrc
+
+    # fish
+    echo 'pitchfork activate fish | source' >> ~/.config/fish/config.fish
+    ```
+
+    Reload your shell, then `cd` out of and back into the project directory — your daemons will start automatically.
+  </Step>
+</Steps>
+
+## Restart on changes
+
+If a daemon is already running, `pitchfork start` does nothing by default. Use `--force` to restart it:
+
+```bash theme={null}
+pitchfork start api --force
+```
+
+## Stop daemons
+
+Stop a specific daemon:
+
+```bash theme={null}
+pitchfork stop api
+```
+
+Stop all daemons defined in the current project's config:
+
+```bash theme={null}
+pitchfork stop api postgres redis
+```
+
+## Add ready checks
+
+Make Pitchfork wait until a daemon is truly ready before starting dependents. Three options are available:
+
+```toml pitchfork.toml theme={null}
+[daemons.api]
+run = "npm run dev:api"
+ready_http = "http://localhost:3000/health"  # wait for HTTP 200
+
+[daemons.redis]
+run = "redis-server"
+ready_output = "Ready to accept connections"  # wait for log output
+
+[daemons.postgres]
+run = "docker run --rm -p 5432:5432 -e POSTGRES_PASSWORD=dev postgres:16"
+ready_delay = 5  # wait a fixed number of seconds
+```
+
+See the [ready checks guide](/guides/ready-checks) for all options.
+
+## Enable auto-restart
+
+Have Pitchfork restart a daemon automatically if it crashes:
+
+```toml pitchfork.toml theme={null}
+[daemons.api]
+run = "npm run dev:api"
+retry = 3
+```
+
+The `retry` field sets the maximum number of restart attempts. See the [auto-restart guide](/guides/auto-restart) for details.
+
+## What's next
+
+<CardGroup>
+  <Card title="Shell hook" icon="hook" href="/guides/shell-hook">
+    Auto-start and auto-stop daemons when changing directories.
+  </Card>
+
+  <Card title="Ready checks" icon="heart-pulse" href="/guides/ready-checks">
+    Configure exactly when Pitchfork considers a daemon ready.
+  </Card>
+
+  <Card title="Auto-restart" icon="rotate" href="/guides/auto-restart">
+    Recover automatically from crashes with retry policies.
+  </Card>
+
+  <Card title="Configuration reference" icon="sliders" href="/reference/configuration">
+    Complete reference for all `pitchfork.toml` options.
+  </Card>
+</CardGroup>
+
+
+# Auto restart
+Source: https://www.mintlify.com/jdx/pitchfork/guides/auto-restart
+
+Configure pitchfork to automatically restart daemons when they crash.
+
+Pitchfork can automatically restart daemons that exit unexpectedly. Use the `retry` option to control how many times a daemon is retried before it is marked as failed.
+
+## Basic configuration
+
+```toml theme={null}
+[daemons.api]
+run = "npm run server:api"
+retry = 3  # retry up to 3 times on failure (4 total attempts)
+```
+
+Setting `retry = 3` means pitchfork will make 3 additional attempts after the first failure, for 4 total attempts.
+
+## Infinite retries
+
+Use `retry = true` for daemons that must always be running:
+
+```toml theme={null}
+[daemons.critical-worker]
+run = "npm run worker"
+retry = true  # retry forever until manually stopped
+```
+
+To disable retries explicitly (the default), use `retry = false` or `retry = 0`.
+
+## CLI override
+
+You can override the retry count from the command line:
+
+```bash theme={null}
+# Override for pitchfork run
+pitchfork run my-task --retry 3 -- ./my-script.sh
+
+# Override for pitchfork start (overrides pitchfork.toml)
+pitchfork start api --retry 5
+```
+
+## How retry works
+
+Pitchfork uses two different retry strategies depending on when the failure occurs.
+
+### Startup failures
+
+If the daemon fails before its ready check completes, pitchfork retries synchronously with exponential backoff:
+
+```
+$ pitchfork start api
+Daemon fails immediately
+Wait 1s... retry (attempt 1/3)
+Daemon fails again
+Wait 2s... retry (attempt 2/3)
+Daemon fails again
+Wait 4s... retry (attempt 3/3)
+All retries exhausted
+ERROR: daemon api failed with exit code 1
+```
+
+The backoff sequence is 1s, 2s, 4s, 8s, and so on. The `pitchfork start` command blocks until the daemon becomes ready or all retries are exhausted.
+
+**Typical causes:** waiting for a dependency, temporary port conflict, or resource constraints during startup.
+
+### Runtime crashes
+
+If the daemon crashes after successfully starting, the supervisor handles retries in the background:
+
+```
+$ pitchfork start api
+started api
+# daemon runs for a while...
+# daemon crashes unexpectedly
+# supervisor detects crash
+# waits 10 seconds... retry (attempt 1/3)
+# daemon starts successfully
+```
+
+Runtime retries happen every 10 seconds, independently of any CLI commands you're running.
+
+**Typical causes:** transient network issues, memory leaks causing periodic crashes, or external resource failures.
+
+## Example configurations
+
+**Service that might fail transiently:**
+
+```toml theme={null}
+[daemons.api]
+run = "npm run server"
+retry = 5
+ready_http = "http://localhost:3000/health"
+```
+
+**Database with startup retries:**
+
+```toml theme={null}
+[daemons.postgres]
+run = "postgres -D /var/lib/pgsql/data"
+retry = 3
+ready_output = "ready to accept connections"
+```
+
+**Mission-critical daemon that should never stay down:**
+
+```toml theme={null}
+[daemons.payment-processor]
+run = "./processor"
+retry = true
+ready_port = 9000
+```
+
+## Combine with ready checks
+
+Retry and ready checks work together. The ready check determines when a startup attempt is considered successful. If the daemon exits before the ready check passes, it counts as a startup failure and retry kicks in.
+
+```toml theme={null}
+[daemons.api]
+run = "npm run server"
+retry = 3
+ready_http = "http://localhost:3000/health"  # must pass for startup to succeed
+```
+
+## React to retries with lifecycle hooks
+
+Use lifecycle hooks to log, alert, or take action on each retry attempt or final failure. See the [Lifecycle hooks guide](/guides/lifecycle-hooks) for details.
+
+```toml theme={null}
+[daemons.api]
+run = "npm run server"
+retry = 3
+
+[daemons.api.hooks]
+on_retry = "echo 'retrying api (attempt $PITCHFORK_RETRY_COUNT)...'"
+on_fail  = "./scripts/alert-team.sh"
+```
+
+
+# Start on boot
+Source: https://www.mintlify.com/jdx/pitchfork/guides/boot-start
+
+Configure pitchfork to start automatically when your system boots using launchd on macOS or systemd on Linux.
+
+Configure pitchfork to start automatically when you log in, and mark individual daemons to launch alongside it.
+
+## Enable boot start
+
+<Steps>
+  <Step title="Register pitchfork with your system">
+    ```bash theme={null}
+    pitchfork boot enable
+    ```
+
+    On macOS, this creates a LaunchAgent. On Linux, this creates a systemd user service.
+    Pitchfork will start automatically at your next login.
+  </Step>
+
+  <Step title="Add boot daemons to your global config">
+    Open `~/.config/pitchfork/config.toml` and add the daemons you want to start at boot.
+    Set `boot_start = true` on each one:
+
+    ```toml theme={null}
+    [daemons.postgres]
+    run = "postgres -D /usr/local/var/postgres"
+    boot_start = true
+    ready_output = "ready to accept connections"
+    retry = true
+
+    [daemons.redis]
+    run = "redis-server"
+    boot_start = true
+    ready_port = 6379
+    ```
+
+    <Note>
+      Boot daemons should live in `~/.config/pitchfork/config.toml`, not in a project-level
+      `pitchfork.toml`. The supervisor runs from your home directory at login, so project
+      configs in subdirectories won't be loaded.
+    </Note>
+  </Step>
+
+  <Step title="Verify the setup">
+    Check that boot start is registered and that your daemons are listed:
+
+    ```bash theme={null}
+    pitchfork boot status
+    pitchfork list
+    ```
+  </Step>
+</Steps>
+
+## Disable boot start
+
+```bash theme={null}
+pitchfork boot disable
+```
+
+This removes the platform-specific registration. Pitchfork and its daemons will no longer start at login.
+
+## How it works by platform
+
+<CodeGroup>
+  ```text macOS (launchd) theme={null}
+  pitchfork boot enable  →  creates ~/Library/LaunchAgents/dev.jdx.pitchfork.plist
+  System login           →  launchd reads the plist and starts pitchfork
+  pitchfork supervisor   →  starts all daemons with boot_start = true
+  ```
+
+  ```text Linux (systemd) theme={null}
+  pitchfork boot enable  →  creates ~/.config/systemd/user/pitchfork.service
+                             and runs: systemctl --user enable --now pitchfork
+  System login           →  systemd user session starts pitchfork.service
+  pitchfork supervisor   →  starts all daemons with boot_start = true
+  ```
+</CodeGroup>
+
+The boot sequence is:
+
+1. System login triggers the platform init system.
+2. The init system launches the pitchfork supervisor.
+3. The supervisor reads your config and starts all daemons where `boot_start = true`.
+4. Daemons run in the background until you stop them or reboot.
+
+## The `boot_start` option
+
+Add `boot_start = true` to any daemon in your global config to include it in the boot sequence.
+Omitting the option or setting it to `false` means the daemon will not start at boot.
+
+```toml theme={null}
+[daemons.postgres]
+run = "postgres -D /usr/local/var/postgres"
+boot_start = true   # starts at boot
+
+[daemons.dev-server]
+run = "npm run dev"
+boot_start = false  # manual start only
+```
+
+## mise integration for boot daemons
+
+When pitchfork starts at login, your shell profile (`.zshrc`, `.bashrc`, etc.) has not been
+sourced, so tools installed via mise or Homebrew may not be on `PATH`.
+
+Enable mise integration to make sure your daemons can find their tools:
+
+```toml theme={null}
+# ~/.config/pitchfork/config.toml
+[settings.general]
+mise = true
+
+[daemons.api]
+run = "node server.js"
+boot_start = true
+```
+
+Or enable it per daemon:
+
+```toml theme={null}
+[daemons.api]
+run = "node server.js"
+boot_start = true
+mise = true
+```
+
+See the [mise integration guide](/guides/mise-integration) for details.
+
+
+# Container mode
+Source: https://www.mintlify.com/jdx/pitchfork/guides/container-mode
+
+Run pitchfork as PID 1 inside a Docker container with proper zombie reaping and signal forwarding.
+
+<Warning>
+  Container mode is an **experimental** feature. Its behavior may change in future releases and it
+  is not guaranteed to work in all environments. Use it at your own risk.
+</Warning>
+
+Container mode lets you use pitchfork as the entrypoint of a Docker container, handling the
+special responsibilities that come with running as PID 1.
+
+## The problem with PID 1 in Docker
+
+When a process runs as PID 1 inside a container, it becomes responsible for two things that a
+normal init system (like systemd) would handle automatically:
+
+**Zombie reaping** — When a child process exits, the kernel re-parents any of its orphaned
+children to PID 1. Without an explicit `waitpid` call, those processes accumulate as zombies in
+the process table indefinitely.
+
+**Signal forwarding** — The Linux kernel does not apply default signal handlers to PID 1. A bare
+`SIGTERM` sent by `docker stop` is silently ignored unless PID 1 explicitly catches it.
+
+Running pitchfork as a container entrypoint without container mode means orphaned processes from
+your daemons may pile up as zombies, and `docker stop` may hang or force-kill the container after
+its timeout.
+
+## Enable container mode
+
+<Tabs>
+  <Tab title="CLI flag (recommended)">
+    ```bash theme={null}
+    pitchfork supervisor run --container
+    ```
+  </Tab>
+
+  <Tab title="Environment variable">
+    ```bash theme={null}
+    PITCHFORK_CONTAINER=true pitchfork supervisor run
+    ```
+  </Tab>
+
+  <Tab title="Settings file">
+    ```toml theme={null}
+    [settings.supervisor]
+    container = true
+    ```
+  </Tab>
+</Tabs>
+
+The CLI flag and environment variable take priority over the settings file.
+
+## What container mode does
+
+When container mode is enabled, pitchfork makes two changes to its signal handling:
+
+1. **SIGCHLD handler** — pitchfork installs a handler that reaps all orphaned and zombie child
+   processes. Only processes *not* managed by the supervisor are reaped this way; managed daemons
+   are tracked and reaped by their own monitoring tasks.
+
+2. **SIGTERM / SIGINT routing** — pitchfork catches these signals and runs its normal graceful
+   shutdown sequence, stopping all managed daemons cleanly before the process exits. This ensures
+   `docker stop` works correctly.
+
+## Example Dockerfile
+
+```dockerfile theme={null}
+FROM debian:bookworm-slim
+
+# Install pitchfork
+COPY --from=ghcr.io/jdx/pitchfork:latest /usr/local/bin/pitchfork /usr/local/bin/pitchfork
+
+# Copy your application and config
+COPY pitchfork.toml /app/pitchfork.toml
+WORKDIR /app
+
+# Run pitchfork as PID 1 in container mode
+ENTRYPOINT ["pitchfork", "supervisor", "run", "--container"]
+```
+
+## Example pitchfork.toml for containers
+
+```toml theme={null}
+[settings.supervisor]
+container = true
+
+[daemons.api]
+run        = "node server.js"
+ready_http = "http://localhost:3000/health"
+retry      = true
+
+[daemons.worker]
+run     = "python worker.py"
+depends = ["api"]
+retry   = true
+```
+
+<Note>
+  Using `retry = true` in containers is recommended for daemons that should always be running.
+  If a daemon crashes, pitchfork will restart it automatically instead of leaving the container
+  in a degraded state.
+</Note>
+
+
+# File watching
+Source: https://www.mintlify.com/jdx/pitchfork/guides/file-watching
+
+Automatically restart daemons when source files change.
+
+The `watch` option lets you specify glob patterns for files that should trigger a daemon restart when they change. This is useful in development when you want your server to reload automatically after editing source files.
+
+## Basic configuration
+
+```toml theme={null}
+[daemons.api]
+run = "npm run dev"
+watch = ["src/**/*.ts", "package.json"]
+```
+
+Whenever a `.ts` file under `src/` or the `package.json` file changes, pitchfork automatically restarts the `api` daemon.
+
+## Glob pattern syntax
+
+Patterns follow standard glob syntax. They are resolved relative to the `pitchfork.toml` file that defines the daemon.
+
+| Pattern         | Matches                                          |
+| --------------- | ------------------------------------------------ |
+| `*.js`          | All `.js` files in the project root              |
+| `src/**/*.ts`   | All `.ts` files in `src/` and its subdirectories |
+| `package.json`  | A specific file                                  |
+| `lib/**/*.py`   | All `.py` files in `lib/` and its subdirectories |
+| `config/*.toml` | All `.toml` files in the `config/` directory     |
+
+## How it works
+
+<Steps>
+  <Step title="Pattern registration">
+    When the supervisor starts, it scans all daemon configs for `watch` patterns and registers the relevant directories for recursive filesystem watching.
+  </Step>
+
+  <Step title="Change detection">
+    The `notify` crate receives filesystem events. Events are debounced for 1 second to avoid rapid restarts during batch saves or editor auto-saves that write multiple files in quick succession.
+  </Step>
+
+  <Step title="Pattern matching">
+    Changed files are matched against each daemon's glob patterns.
+  </Step>
+
+  <Step title="Restart">
+    Any running daemon with a matching pattern is automatically restarted. Stopped daemons are not affected.
+  </Step>
+</Steps>
+
+<Note>
+  Only running daemons are restarted. If a daemon is stopped, file changes will not start it.
+</Note>
+
+## Examples
+
+### TypeScript API server
+
+```toml theme={null}
+[daemons.api]
+run = "npm run dev"
+watch = ["src/**/*.ts", "src/**/*.tsx", "package.json", "tsconfig.json"]
+ready_http = "http://localhost:3000/health"
+```
+
+### Python Flask app
+
+```toml theme={null}
+[daemons.flask]
+run = "flask run --reload"
+watch = ["app/**/*.py", "templates/**/*.html", "requirements.txt"]
+ready_port = 5000
+```
+
+### Go service
+
+```toml theme={null}
+[daemons.server]
+run = "go run ./cmd/server"
+watch = ["**/*.go", "go.mod", "go.sum"]
+ready_port = 8080
+```
+
+### Multi-service project
+
+```toml theme={null}
+[daemons.postgres]
+run = "postgres -D /var/lib/pgsql/data"
+ready_port = 5432
+# No watch — database doesn't need hot reload
+
+[daemons.api]
+run = "npm run dev"
+depends = ["postgres"]
+watch = ["src/**/*.ts", "package.json"]
+ready_http = "http://localhost:3000/health"
+
+[daemons.worker]
+run = "npm run worker"
+depends = ["postgres"]
+watch = ["src/worker/**/*.ts", "package.json"]
+```
+
+## Combining with other features
+
+### With ready checks
+
+Add a ready check so pitchfork waits for the daemon to be fully up after each file-triggered restart:
+
+```toml theme={null}
+[daemons.api]
+run = "npm run dev"
+watch = ["src/**/*.ts"]
+ready_http = "http://localhost:3000/health"
+```
+
+### With the shell hook
+
+Combine with `auto` for a fully automated development workflow:
+
+```toml theme={null}
+[daemons.api]
+run = "npm run dev"
+watch = ["src/**/*.ts"]
+auto = ["start", "stop"]
+```
+
+### With retry
+
+If the daemon might fail during a restart (for example, while a build step is in progress), add `retry`:
+
+```toml theme={null}
+[daemons.api]
+run = "npm run dev"
+watch = ["src/**/*.ts"]
+retry = 3
+```
+
+## Performance notes
+
+* **Debouncing:** Changes are debounced for 1 second. If you save multiple files in quick succession, only the final state triggers a restart.
+* **Directory watching:** Pitchfork watches the unique parent directories of your patterns recursively, not every individual file. This keeps the number of OS-level watch handles low.
+* **Specificity:** Use specific patterns like `src/**/*.ts` rather than `**/*` to avoid matching build artifacts in `node_modules`, `target`, or `.git`.
+
+## Troubleshooting
+
+**Files are not triggering a restart:**
+
+* Confirm the pattern matches your files (patterns are case-sensitive).
+* Make sure the daemon is running — use `pitchfork list` to check.
+* Check supervisor logs for watch registration messages.
+
+**Too many restarts:**
+
+* Tighten your glob patterns to exclude build output directories:
+
+  ```toml theme={null}
+  watch = ["src/**/*.ts"]  # only src/, not node_modules or dist
+  ```
+
+
+# Lifecycle hooks
+Source: https://www.mintlify.com/jdx/pitchfork/guides/lifecycle-hooks
+
+Run custom shell commands when daemons become ready, fail, retry, or stop.
+
+Lifecycle hooks let you run shell commands in response to daemon events. Use them to send alerts when a service goes down, clean up resources on exit, or log retry attempts for debugging.
+
+## Configuration
+
+Add a `[daemons.<name>.hooks]` section to your `pitchfork.toml`:
+
+```toml theme={null}
+[daemons.api]
+run = "npm run server"
+retry = 3
+ready_http = "http://localhost:3000/health"
+
+[daemons.api.hooks]
+on_ready = "curl -X POST https://alerts.example.com/ready"
+on_fail  = "./scripts/cleanup.sh"
+on_retry = "echo 'retrying api server...'"
+on_stop  = "./scripts/notify-stopped.sh"
+on_exit  = "./scripts/cleanup.sh"
+```
+
+## Hook events
+
+### `on_ready`
+
+Fires when the daemon passes its readiness check (delay, output match, HTTP, port, or command check).
+
+```toml theme={null}
+[daemons.api.hooks]
+on_ready = "curl -s -X POST https://slack.example.com/webhook -d '{\"text\": \"API is up\"}'"
+```
+
+### `on_fail`
+
+Fires when the daemon fails and all retries are exhausted. If `retry = 0`, fires immediately on the first failure.
+
+```toml theme={null}
+[daemons.api.hooks]
+on_fail = "./scripts/alert-team.sh"
+```
+
+The `PITCHFORK_EXIT_CODE` environment variable contains the exit code of the failed process.
+
+### `on_retry`
+
+Fires before each retry attempt.
+
+```toml theme={null}
+[daemons.api.hooks]
+on_retry = "echo 'Retrying api (attempt $PITCHFORK_RETRY_COUNT)...'"
+```
+
+### `on_stop`
+
+Fires when the daemon is explicitly stopped by pitchfork — via `pitchfork stop`, the shell hook leaving a directory, or supervisor shutdown.
+
+```toml theme={null}
+[daemons.api.hooks]
+on_stop = "./scripts/notify-stopped.sh"
+```
+
+### `on_exit`
+
+Fires on any daemon termination: intentional stop, clean exit, or crash. Also fires during supervisor shutdown.
+
+```toml theme={null}
+[daemons.infra.hooks]
+on_exit = "docker compose down --volumes"
+```
+
+<Warning>
+  For daemons with `retry > 0`, `on_exit` fires only after all retries are exhausted — not on each individual crash attempt. Use `on_retry` if you need to react to every failure.
+</Warning>
+
+## Environment variables
+
+All hooks receive these environment variables:
+
+| Variable                     | Description                                                                                                                                          |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PITCHFORK_DAEMON_ID`        | Fully-qualified daemon ID (`namespace/name`)                                                                                                         |
+| `PITCHFORK_DAEMON_NAMESPACE` | The daemon's namespace                                                                                                                               |
+| `PITCHFORK_RETRY_COUNT`      | Current retry attempt number (0 on first run)                                                                                                        |
+| `PITCHFORK_EXIT_CODE`        | Exit code of the process (`on_fail`, `on_stop`, `on_exit`). Set to `-1` for processes terminated by a signal (e.g. SIGTERM).                         |
+| `PITCHFORK_EXIT_REASON`      | Why the daemon stopped: `"stop"` (intentional), `"fail"` (non-zero exit), or `"exit"` (unexpected clean exit). Available in `on_stop` and `on_exit`. |
+
+Any custom `env` variables from the daemon config are also passed to hook commands.
+
+## Behavior
+
+* Hooks are **fire-and-forget** — they run in the background and never block the daemon or the supervisor.
+* Hook commands run in the daemon's working directory.
+* Errors in hooks are logged but do not affect the daemon.
+* Hooks re-read `pitchfork.toml` each time they fire, so config changes take effect without restarting.
+
+## Examples
+
+**Send a Slack alert on failure:**
+
+```toml theme={null}
+[daemons.api]
+run = "npm run server"
+retry = 3
+
+[daemons.api.hooks]
+on_fail = "curl -s -X POST $SLACK_WEBHOOK -d '{\"text\": \"API failed (exit $PITCHFORK_EXIT_CODE)\"}'"
+```
+
+**Log retry attempts to a file:**
+
+```toml theme={null}
+[daemons.worker]
+run = "python worker.py"
+retry = 5
+
+[daemons.worker.hooks]
+on_retry = "sh -c 'echo \"$(date): retry $PITCHFORK_RETRY_COUNT\" >> /var/log/worker-retries.log'"
+```
+
+**Acquire and release a lock around a daemon's lifecycle:**
+
+```toml theme={null}
+[daemons.processor]
+run = "./process-queue.sh"
+retry = 2
+
+[daemons.processor.hooks]
+on_ready = "./scripts/acquire-locks.sh"
+on_fail  = "./scripts/release-locks.sh"
+```
+
+**Tear down infrastructure whenever a daemon exits:**
+
+```toml theme={null}
+[daemons.infra]
+run = "docker compose up"
+
+[daemons.infra.hooks]
+on_exit = "docker compose down --volumes --remove-orphans"
+```
+
+**Log the exit reason from a shared script:**
+
+```toml theme={null}
+[daemons.api]
+run = "npm run server"
+
+[daemons.api.hooks]
+on_exit = "sh -c 'echo \"Daemon exited: reason=$PITCHFORK_EXIT_REASON code=$PITCHFORK_EXIT_CODE\" >> /var/log/api-exits.log'"
+```
+
+
+# Viewing logs
+Source: https://www.mintlify.com/jdx/pitchfork/guides/logs
+
+View, filter, tail, and manage daemon logs from the command line, TUI, or web UI.
+
+Pitchfork captures stdout and stderr from every daemon and stores them in
+`~/.local/state/pitchfork/logs/`. You can view logs from the CLI, the TUI, or the web UI.
+
+## Basic usage
+
+Show all logs for a daemon:
+
+```bash theme={null}
+pitchfork logs api
+```
+
+When output exceeds your terminal height, logs are automatically paged using `less` (or `$PAGER`
+if set), starting at the end of the file.
+
+Show logs for multiple daemons at once. Entries are interleaved and sorted by timestamp:
+
+```bash theme={null}
+pitchfork logs api worker database
+```
+
+Show all logs for all known daemons:
+
+```bash theme={null}
+pitchfork logs
+```
+
+## Following logs in real time
+
+```bash theme={null}
+pitchfork logs api --tail
+# aliases: --follow, -t, -f
+```
+
+Press `Ctrl+C` to stop following.
+
+## Limiting line count
+
+Show only the last N lines:
+
+```bash theme={null}
+pitchfork logs api -n 50
+pitchfork logs api -n 10
+```
+
+When combined with `--since` or `--until`, `-n` limits lines from the filtered results.
+
+## Filtering by time
+
+Use `--since` (`-s`) and `--until` (`-u`) to narrow logs to a time range.
+
+### Relative time
+
+```bash theme={null}
+# Logs from the last 5 minutes
+pitchfork logs api --since 5min
+
+# Logs from the last 2 hours
+pitchfork logs api --since 2h
+
+# Logs from the last day
+pitchfork logs api --since 1d
+```
+
+### Time only (today's date assumed)
+
+```bash theme={null}
+pitchfork logs api --since 10:30
+pitchfork logs api --since 14:30:00
+```
+
+If the given time is in the future, pitchfork assumes you meant yesterday.
+
+### Full datetime
+
+```bash theme={null}
+pitchfork logs api --since "2024-01-15 09:00:00"
+pitchfork logs api --until "2024-01-15 17:00:00"
+pitchfork logs api --since "2024-01-15 09:00" --until "2024-01-15 12:00"
+```
+
+### Combining with line limit
+
+```bash theme={null}
+# Last 20 lines from the past hour
+pitchfork logs api --since 1h -n 20
+```
+
+## Raw output
+
+Output log lines without color or formatting. Useful for piping to other tools:
+
+```bash theme={null}
+pitchfork logs api --raw
+
+# Pipe to grep
+pitchfork logs api --raw | grep ERROR
+
+# Save to a file
+pitchfork logs api --raw > api.log
+```
+
+## Disable pager
+
+Force direct output to stdout even when logs would normally trigger the pager:
+
+```bash theme={null}
+pitchfork logs api --no-pager
+```
+
+## Clearing logs
+
+Delete all logs for a specific daemon:
+
+```bash theme={null}
+pitchfork logs api --clear
+```
+
+Delete logs for all daemons:
+
+```bash theme={null}
+pitchfork logs --clear
+```
+
+## Supervisor logs
+
+View pitchfork's own internal logs:
+
+```bash theme={null}
+pitchfork logs pitchfork
+```
+
+## Log file location
+
+Logs are stored in:
+
+```text theme={null}
+~/.local/state/pitchfork/logs/<namespace>--<daemon>/
+```
+
+Each daemon has its own log directory using the `namespace--daemon` naming pattern. For example,
+a daemon named `api` in a project with namespace `myapp` has its logs at:
+
+```text theme={null}
+~/.local/state/pitchfork/logs/myapp--api/
+```
+
+Log files persist across restarts. Each daemon appends to the same log file, so you can see
+history from previous runs.
+
+## Log flush interval
+
+By default, log output is flushed to disk every 500 ms. You can adjust this in your settings:
+
+```toml theme={null}
+# ~/.config/pitchfork/config.toml
+[settings.supervisor]
+log_flush_interval = "1s"
+```
+
+Lower values make logs appear sooner in the UI at the cost of slightly higher I/O.
+
+## Viewing logs in the TUI and web UI
+
+You can also view live logs without leaving your terminal using the TUI, or from a browser using
+the web UI.
+
+* [Terminal UI (TUI)](/guides/tui) — `pitchfork tui`, then press `l` or `Enter` on a daemon.
+* [Web UI](/guides/web-ui) — select a daemon to see its real-time log stream.
+
+
+# mise integration
+Source: https://www.mintlify.com/jdx/pitchfork/guides/mise-integration
+
+Use mise with pitchfork to ensure the correct tool versions and environment variables are available to your daemons.
+
+[mise](https://mise.jdx.dev) is a polyglot tool version manager that handles installing and
+activating tools (Node, Python, Go, etc.) and environment variables per directory.
+
+When pitchfork and mise are used together, mise takes care of the environment and pitchfork
+handles process lifecycle.
+
+## Why mise integration is needed
+
+When you open a terminal, your shell profile (`.zshrc`, `.bashrc`, etc.) runs and activates mise,
+putting the right tool versions on `PATH`. Daemons started at boot or via cron don't have that
+luxury — they run without an interactive shell, so mise hooks are never sourced and tools aren't
+available.
+
+The built-in `mise = true` option solves this by wrapping daemon commands with `mise x --`, which
+activates the correct tool versions and environment variables before your daemon runs.
+
+## Enable mise globally
+
+Add this to `~/.config/pitchfork/config.toml` to enable mise for all daemons:
+
+```toml theme={null}
+[settings.general]
+mise = true
+```
+
+## Enable or disable mise per daemon
+
+Override the global setting for individual daemons in `pitchfork.toml`:
+
+```toml theme={null}
+[daemons.api]
+run  = "node server.js"
+mise = true   # use mise for this daemon
+
+[daemons.simple]
+run  = "echo hello"
+mise = false  # skip mise even if globally enabled
+```
+
+The per-daemon `mise` setting takes precedence over `general.mise`. If neither is set, mise is
+disabled by default.
+
+## How it works
+
+When `mise = true` is set, pitchfork wraps the daemon command before executing it:
+
+```text theme={null}
+# Without mise
+sh -c "exec node server.js"
+
+# With mise
+sh -c "exec /path/to/mise x -- node server.js"
+```
+
+`mise x --` reads your `mise.toml` or `.tool-versions` in the daemon's working directory and
+activates all tools and environment variables before running the command.
+
+## Custom mise binary path
+
+Pitchfork searches these locations automatically:
+
+* `~/.local/bin/mise`
+* `~/.cargo/bin/mise`
+* `/usr/local/bin/mise`
+* `/opt/homebrew/bin/mise`
+
+If mise is installed elsewhere, specify the path explicitly:
+
+```toml theme={null}
+# ~/.config/pitchfork/config.toml
+[settings.general]
+mise     = true
+mise_bin = "/opt/custom/bin/mise"
+```
+
+## Using mise tasks as daemon commands
+
+You can use mise tasks directly as daemon run commands. This gives you full control over tool
+installation, environment variables, and task dependencies:
+
+<CodeGroup>
+  ```toml pitchfork.toml theme={null}
+  [daemons.docs]
+  run = "mise run docs:dev"
+  ```
+
+  ```toml mise.toml theme={null}
+  [env]
+  NODE_ENV = "development"
+
+  [tools]
+  node = "20"
+
+  [tasks."docs:setup"]
+  run = "npm install"
+
+  [tasks."docs:dev"]
+  run = "node docs/index.js"
+  depends = ["docs:setup"]
+  ```
+</CodeGroup>
+
+When you run `pitchfork start docs`:
+
+1. Pitchfork calls `mise run docs:dev`.
+2. mise ensures Node 20 is installed.
+3. mise runs `docs:setup` (npm install) first.
+4. mise sets `NODE_ENV=development` and starts the server.
+5. Pitchfork monitors the process and handles restarts.
+
+## Example: full-stack app
+
+<CodeGroup>
+  ```toml pitchfork.toml theme={null}
+  [daemons.api]
+  run        = "mise run api:dev"
+  auto       = ["start", "stop"]
+  ready_http = "http://localhost:3000/health"
+
+  [daemons.frontend]
+  run          = "mise run frontend:dev"
+  auto         = ["start", "stop"]
+  ready_output = "ready in"
+  ```
+
+  ```toml mise.toml theme={null}
+  [tools]
+  node   = "20"
+  python = "3.11"
+
+  [env]
+  DATABASE_URL = "postgres://localhost/myapp"
+
+  [tasks."api:setup"]
+  run = "pip install -r requirements.txt"
+
+  [tasks."api:dev"]
+  run     = "uvicorn main:app --reload"
+  depends = ["api:setup"]
+
+  [tasks."frontend:setup"]
+  run = "npm install"
+
+  [tasks."frontend:dev"]
+  run     = "npm run dev"
+  depends = ["frontend:setup"]
+  ```
+</CodeGroup>
+
+## Summary of settings
+
+| Setting               | Scope      | Description                                 |
+| --------------------- | ---------- | ------------------------------------------- |
+| `general.mise`        | Global     | Wrap all daemon commands with `mise x --`.  |
+| `general.mise_bin`    | Global     | Explicit path to the mise binary.           |
+| `daemons.<name>.mise` | Per-daemon | Override the global setting for one daemon. |
+
+<Tip>
+  `mise = true` is especially important for daemons that use `boot_start = true`. Without it,
+  tools installed via mise won't be on `PATH` at login time. See the
+  [start on boot guide](/guides/boot-start) for a complete example.
+</Tip>
+
+
+# Ready checks
+Source: https://www.mintlify.com/jdx/pitchfork/guides/ready-checks
+
+Configure how pitchfork determines when a daemon is ready to accept requests.
+
+When you run `pitchfork start` or `pitchfork run`, the command waits until the daemon is "ready" before returning. This ensures dependent processes don't start before their dependencies are actually available — for example, your API server won't start until its database is accepting connections.
+
+## Check types
+
+Pitchfork supports five ready check strategies. You can set them in `pitchfork.toml` or override them from the CLI.
+
+| Check   | Config key     | CLI flag   | Ready when                                 |
+| ------- | -------------- | ---------- | ------------------------------------------ |
+| Delay   | `ready_delay`  | `--delay`  | Daemon runs for N seconds without crashing |
+| Output  | `ready_output` | `--output` | Pattern matches stdout/stderr              |
+| HTTP    | `ready_http`   | `--http`   | Endpoint returns a 2xx status              |
+| Port    | `ready_port`   | `--port`   | TCP connection to port succeeds            |
+| Command | `ready_cmd`    | `--cmd`    | Shell command exits with code 0            |
+
+If you configure multiple checks, the first one to succeed marks the daemon as ready.
+
+<Note>
+  If the daemon exits with a non-zero code before any check passes, `pitchfork start` exits with that same code.
+</Note>
+
+## Delay check
+
+Wait a fixed number of seconds after starting. If the daemon is still running at that point, it is considered ready. This is the default check, with a 3-second delay.
+
+<CodeGroup>
+  ```toml pitchfork.toml theme={null}
+  [daemons.myapp]
+  run = "node server.js"
+  ready_delay = 5  # wait 5 seconds (default: 3)
+  ```
+
+  ```bash CLI theme={null}
+  pitchfork start myapp --delay 5
+  pitchfork run myapp --delay 5 -- node server.js
+  ```
+</CodeGroup>
+
+**Best for:** Simple services where a short wait is enough to confirm the process didn't immediately crash.
+
+## Output check
+
+Wait until a specific pattern appears in the daemon's stdout or stderr. The pattern is a regular expression.
+
+<CodeGroup>
+  ```toml pitchfork.toml theme={null}
+  [daemons.database]
+  run = "postgres -D /var/lib/pgsql/data"
+  ready_output = "database system is ready to accept connections"
+
+  [daemons.webserver]
+  run = "python -m http.server 8080"
+  ready_output = "Serving HTTP on"
+  ```
+
+  ```bash CLI theme={null}
+  pitchfork start database --output "ready to accept connections"
+  pitchfork run myapp --output "Server listening" -- node server.js
+  ```
+</CodeGroup>
+
+**Best for:** Services that print a specific message when they finish starting up.
+
+## HTTP check
+
+Wait until an HTTP endpoint returns a 2xx status code. The check polls every 500ms with a 5-second timeout per request.
+
+<CodeGroup>
+  ```toml pitchfork.toml theme={null}
+  [daemons.api]
+  run = "python -m uvicorn main:app"
+  ready_http = "http://localhost:8000/health"
+
+  [daemons.webserver]
+  run = "node server.js"
+  ready_http = "http://localhost:3000/ready"
+  ```
+
+  ```bash CLI theme={null}
+  pitchfork start api --http http://localhost:8000/health
+  pitchfork run myapp --http http://localhost:8080/health -- node server.js
+  ```
+</CodeGroup>
+
+**Best for:** Web services with a dedicated health or readiness endpoint.
+
+## Port check
+
+Wait until the daemon is listening on a specific TCP port. The check polls every 500ms by attempting a connection to `127.0.0.1:<port>`.
+
+<CodeGroup>
+  ```toml pitchfork.toml theme={null}
+  [daemons.api]
+  run = "node server.js"
+  ready_port = 3000
+
+  [daemons.database]
+  run = "postgres -D /var/lib/pgsql/data"
+  ready_port = 5432
+  ```
+
+  ```bash CLI theme={null}
+  pitchfork start api --port 3000
+  pitchfork run myapp --port 8080 -- node server.js
+  ```
+</CodeGroup>
+
+**Best for:** Services that bind to a known port but don't expose a health endpoint.
+
+## Command check
+
+Wait until a shell command exits with code 0. The check polls every 500ms.
+
+<CodeGroup>
+  ```toml pitchfork.toml theme={null}
+  [daemons.database]
+  run = "postgres -D /var/lib/pgsql/data"
+  ready_cmd = "pg_isready -h localhost"
+
+  [daemons.api]
+  run = "node server.js"
+  ready_cmd = "curl -sf http://localhost:3000/health"
+  ```
+
+  ```bash CLI theme={null}
+  pitchfork start database --cmd "pg_isready -h localhost"
+  pitchfork run myapp --cmd "curl -sf http://localhost:3000/health" -- node server.js
+  ```
+</CodeGroup>
+
+**Best for:** Services that need custom readiness logic, or where you already have a CLI tool for checking readiness (like `pg_isready` for PostgreSQL or `redis-cli ping` for Redis).
+
+## Common patterns
+
+<AccordionGroup>
+  <Accordion title="PostgreSQL">
+    Use the output check to wait for PostgreSQL's startup message, or use `pg_isready` for a more robust check:
+
+    ```toml theme={null}
+    # Output check — watches for the startup log line
+    [daemons.postgres]
+    run = "postgres -D /var/lib/pgsql/data"
+    ready_output = "database system is ready to accept connections"
+    ```
+
+    ```toml theme={null}
+    # Command check — uses pg_isready utility
+    [daemons.postgres]
+    run = "postgres -D /var/lib/pgsql/data"
+    ready_cmd = "pg_isready -h localhost"
+    ```
+  </Accordion>
+
+  <Accordion title="Redis">
+    ```toml theme={null}
+    # Output check
+    [daemons.redis]
+    run = "redis-server"
+    ready_output = "Ready to accept connections"
+    ```
+
+    ```toml theme={null}
+    # Command check
+    [daemons.redis]
+    run = "redis-server"
+    ready_cmd = "redis-cli ping"
+    ```
+  </Accordion>
+
+  <Accordion title="Node.js">
+    ```toml theme={null}
+    [daemons.api]
+    run = "npm run start"
+    ready_http = "http://localhost:3000/health"
+    ```
+  </Accordion>
+
+  <Accordion title="Python FastAPI">
+    ```toml theme={null}
+    [daemons.api]
+    run = "uvicorn main:app"
+    ready_http = "http://localhost:8000/health"
+    ```
+  </Accordion>
+
+  <Accordion title="File-based readiness">
+    For scripts that signal readiness by creating a file:
+
+    ```toml theme={null}
+    [daemons.worker]
+    run = "./start-worker.sh"
+    ready_cmd = "test -f /tmp/worker.ready"
+    ```
+  </Accordion>
+</AccordionGroup>
+
+
+# Cron scheduling
+Source: https://www.mintlify.com/jdx/pitchfork/guides/scheduling
+
+Run daemons on a schedule using cron expressions.
+
+The `cron` option lets you run a daemon on a recurring schedule. This is useful for backups, data sync, health checks, and any other periodic task you'd otherwise manage with system cron or a separate scheduler.
+
+## Basic configuration
+
+```toml theme={null}
+[daemons.backup]
+run = "./scripts/backup.sh"
+cron = { schedule = "0 0 2 * * *", retrigger = "finish" }  # run at 2 AM daily
+```
+
+Start it like any other daemon:
+
+```bash theme={null}
+pitchfork start backup
+pitchfork start --all
+```
+
+Once started, the supervisor triggers the daemon according to its schedule. You can monitor it with:
+
+```bash theme={null}
+pitchfork list
+pitchfork logs backup
+```
+
+## Cron expression format
+
+Pitchfork uses a 6-field cron format, adding a **seconds** field at the start:
+
+```
+┌──────────── second (0-59)
+│ ┌────────── minute (0-59)
+│ │ ┌──────── hour (0-23)
+│ │ │ ┌────── day of month (1-31)
+│ │ │ │ ┌──── month (1-12)
+│ │ │ │ │ ┌── day of week (0-6, Sunday = 0)
+│ │ │ │ │ │
+* * * * * *
+```
+
+**Common examples:**
+
+| Expression       | Meaning                      |
+| ---------------- | ---------------------------- |
+| `0 0 * * * *`    | Every hour (on the hour)     |
+| `0 */5 * * * *`  | Every 5 minutes              |
+| `0 0 2 * * *`    | Daily at 2:00 AM             |
+| `0 0 0 * * 0`    | Weekly on Sunday at midnight |
+| `0 30 9 * * 1-5` | Weekdays at 9:30 AM          |
+
+## Retrigger modes
+
+The `retrigger` field controls what happens when the schedule fires while a previous run is still active.
+
+### `finish` (default)
+
+Only start a new run if the previous one has finished.
+
+```toml theme={null}
+[daemons.backup]
+run = "./backup.sh"
+cron = { schedule = "0 0 2 * * *", retrigger = "finish" }
+```
+
+**Use for:** Long-running tasks like database backups where overlapping runs would corrupt output or exhaust resources.
+
+### `always`
+
+Always start a new run, stopping the previous run if it is still active.
+
+```toml theme={null}
+[daemons.health-check]
+run = "curl -f http://localhost:8080/health"
+cron = { schedule = "0 */5 * * * *", retrigger = "always" }
+```
+
+**Use for:** Short health checks or monitoring tasks where you always want the freshest result.
+
+### `success`
+
+Only start a new run if the previous run succeeded (exited with code 0).
+
+```toml theme={null}
+[daemons.process-data]
+run = "./process.sh"
+cron = { schedule = "0 0 * * * *", retrigger = "success" }
+```
+
+**Use for:** Chained pipelines where a new run should only start if the previous one produced valid output.
+
+### `fail`
+
+Only start a new run if the previous run failed (non-zero exit code).
+
+```toml theme={null}
+[daemons.retry-task]
+run = "./flaky-task.sh"
+cron = { schedule = "0 */10 * * * *", retrigger = "fail" }
+```
+
+**Use for:** Built-in retry logic — keep re-running every 10 minutes until the task succeeds.
+
+## Examples
+
+**Hourly database sync:**
+
+```toml theme={null}
+[daemons.db-sync]
+run = "./scripts/sync-db.sh"
+cron = { schedule = "0 0 * * * *", retrigger = "finish" }
+```
+
+**Every 5 minutes metrics collection:**
+
+```toml theme={null}
+[daemons.metrics]
+run = "node scripts/collect-metrics.js"
+cron = { schedule = "0 */5 * * * *", retrigger = "always" }
+```
+
+**Weekday report at 9 AM:**
+
+```toml theme={null}
+[daemons.report]
+run = "python generate-report.py"
+cron = { schedule = "0 0 9 * * 1-5", retrigger = "success" }
+```
+
+## PATH and tool availability
+
+When running cron daemons via `pitchfork boot` (login daemon mode), tools managed by version managers like mise or pyenv may not be on `PATH` because interactive shell hooks haven't run.
+
+Use the `mise` option to wrap your command:
+
+```toml theme={null}
+[daemons.backup]
+run = "node scripts/backup.js"
+cron = { schedule = "0 0 2 * * *" }
+mise = true  # ensures Node is on PATH even in login daemon context
+```
+
+See the [mise integration guide](/guides/mise-integration) for details.
+
+
+# Shell hook
+Source: https://www.mintlify.com/jdx/pitchfork/guides/shell-hook
+
+Automatically start daemons when you enter a project directory and stop them when you leave.
+
+The shell hook watches your current directory and starts or stops daemons automatically as you navigate between projects. Once installed, running `cd ~/projects/myapp` is enough to bring your entire dev stack up.
+
+## Install the hook
+
+Add the shell hook to your shell's config file, then restart your shell.
+
+<Tabs>
+  <Tab title="Bash">
+    ```bash theme={null}
+    echo 'eval "$(pitchfork activate bash)"' >> ~/.bashrc
+    ```
+  </Tab>
+
+  <Tab title="Zsh">
+    ```bash theme={null}
+    echo 'eval "$(pitchfork activate zsh)"' >> ~/.zshrc
+    ```
+  </Tab>
+
+  <Tab title="Fish">
+    ```bash theme={null}
+    echo 'pitchfork activate fish | source' >> ~/.config/fish/config.fish
+    ```
+  </Tab>
+</Tabs>
+
+After adding the line, either restart your shell or source the config file:
+
+```bash theme={null}
+source ~/.bashrc   # or ~/.zshrc, or restart your terminal
+```
+
+## Configure daemons
+
+Add the `auto` option to any daemon in `pitchfork.toml` to enable auto start/stop for that daemon.
+
+```toml theme={null}
+[daemons.api]
+run = "npm run server:api"
+auto = ["start", "stop"]  # auto-start on enter, auto-stop on leave
+
+[daemons.database]
+run = "postgres -D /var/lib/pgsql/data"
+auto = ["start"]          # auto-start only, stays running when you leave
+
+[daemons.worker]
+run = "npm run worker"
+auto = ["stop"]           # manual start, auto-stops when you leave
+```
+
+### Auto options
+
+| Value               | Behavior                                           |
+| ------------------- | -------------------------------------------------- |
+| `["start"]`         | Daemon starts when you enter the project directory |
+| `["stop"]`          | Daemon stops when you leave the project directory  |
+| `["start", "stop"]` | Both auto-start and auto-stop                      |
+
+## How it works
+
+<Steps>
+  <Step title="You cd into a project">
+    The hook detects the directory change and finds a `pitchfork.toml` in the current or any parent directory. Any daemon with `auto = ["start", ...]` is started.
+  </Step>
+
+  <Step title="Pitchfork starts daemons">
+    Daemons start in the background. If you have ready checks configured, pitchfork waits until they pass before returning control to your prompt.
+  </Step>
+
+  <Step title="You cd away">
+    Daemons with `auto = [..., "stop"]` are marked for stopping. Pitchfork waits a few seconds before actually stopping them, in case you navigate back quickly.
+  </Step>
+
+  <Step title="Daemons stop">
+    If no terminal sessions remain inside the project directory, the daemons stop. Sessions in subdirectories of the project also count as "inside".
+  </Step>
+</Steps>
+
+<Tip>
+  You can still start daemons manually with `pitchfork start`. If they're configured with `auto = ["stop"]`, they'll auto-stop when you leave regardless of how they were started.
+</Tip>
+
+## Example workflow
+
+```bash theme={null}
+# Enter your project
+cd ~/projects/myapp
+# → api and worker start automatically
+
+# Do your work...
+
+# Leave the project
+cd ~
+# → after a short delay, api and worker stop
+#   (only if no other terminals are still in ~/projects/myapp)
+
+# Come back
+cd ~/projects/myapp
+# → api and worker start again
+```
+
+## Autostop delay
+
+Pitchfork waits before stopping daemons to handle cases where you briefly leave the directory (for example, running `cd /tmp && ls && cd -`). The delay is configurable in your settings:
+
+```toml theme={null}
+# ~/.config/pitchfork/config.toml
+[general]
+autostop_delay = 10  # seconds to wait before stopping (default: 3)
+```
+
+
+# Terminal UI (TUI)
+Source: https://www.mintlify.com/jdx/pitchfork/guides/tui
+
+Monitor and manage daemons from an interactive terminal dashboard with vim-style keybindings.
+
+Pitchfork includes a full-featured terminal UI for monitoring and managing daemons without leaving
+your terminal.
+
+## Launch the TUI
+
+```bash theme={null}
+pitchfork tui
+```
+
+The TUI connects to the supervisor automatically, starting it if it isn't already running.
+
+## Features
+
+### Dashboard view
+
+The main dashboard shows all your daemons at a glance:
+
+* Live status with color-coded states (running, stopped, failed)
+* CPU and memory usage per daemon
+* Fuzzy search to filter the list
+* Multi-select for batch operations
+* Sortable columns
+
+### Log viewer
+
+Select a daemon and press `l` or `Enter` to open its log viewer:
+
+* Real-time log streaming with auto-scroll (follow mode)
+* Search within logs
+* Expandable full-screen view
+* Vim-style navigation
+
+### Config editor
+
+Press `n` to create a new daemon or `E` to edit an existing one:
+
+* Form-based interface for all daemon options
+* Checkbox and dropdown fields for boolean/enum settings
+* Validation for required fields and formats
+* `Ctrl+s` to save, `D` to delete (in edit mode)
+
+## Keybindings
+
+### Dashboard
+
+| Key           | Action                             |
+| ------------- | ---------------------------------- |
+| `j` / `↓`     | Move down                          |
+| `k` / `↑`     | Move up                            |
+| `l` / `Enter` | View logs                          |
+| `i`           | View details                       |
+| `s`           | Start daemon                       |
+| `x`           | Stop daemon (with confirmation)    |
+| `r`           | Restart daemon                     |
+| `e`           | Enable daemon                      |
+| `d`           | Disable daemon (with confirmation) |
+| `/`           | Search/filter daemons              |
+| `Space`       | Toggle selection                   |
+| `Ctrl+a`      | Select all visible                 |
+| `c`           | Clear selection                    |
+| `a`           | Toggle showing available daemons   |
+| `S`           | Cycle sort column                  |
+| `o`           | Toggle sort order                  |
+| `R`           | Refresh                            |
+| `n`           | Create new daemon                  |
+| `E`           | Edit selected daemon config        |
+| `?`           | Show help                          |
+| `q` / `Esc`   | Quit                               |
+
+### Log viewer
+
+| Key         | Action                |
+| ----------- | --------------------- |
+| `j` / `↓`   | Scroll down           |
+| `k` / `↑`   | Scroll up             |
+| `Ctrl+d`    | Page down             |
+| `Ctrl+u`    | Page up               |
+| `g`         | Jump to top           |
+| `G`         | Jump to bottom        |
+| `f`         | Toggle follow mode    |
+| `e`         | Toggle expanded view  |
+| `/`         | Search in logs        |
+| `n`         | Next search match     |
+| `N`         | Previous search match |
+| `q` / `Esc` | Back to dashboard     |
+
+### Config editor
+
+| Key                     | Action                                        |
+| ----------------------- | --------------------------------------------- |
+| `Tab` / `j` / `↓`       | Next field                                    |
+| `Shift+Tab` / `k` / `↑` | Previous field                                |
+| `Enter`                 | Edit text field                               |
+| `Space`                 | Toggle checkbox / cycle option                |
+| `Ctrl+s`                | Save configuration                            |
+| `D`                     | Delete daemon (edit mode only)                |
+| `q` / `Esc`             | Cancel (prompts if there are unsaved changes) |
+
+## Multi-select operations
+
+Select multiple daemons with `Space`, then press `s`, `x`, `r`, `e`, or `d` to run that
+operation on all selected daemons at once. Use `Ctrl+a` to select everything visible or `c` to
+clear the selection.
+
+## Settings
+
+Adjust TUI behavior in your config file:
+
+```toml theme={null}
+# ~/.config/pitchfork/config.toml
+[settings.tui]
+refresh_rate = "2s"   # How often the daemon list updates (default: 2s)
+tick_rate   = "100ms" # Event loop / keyboard polling rate (default: 100ms)
+```
+
+| Setting            | Default | Description                                                                                                          |
+| ------------------ | ------- | -------------------------------------------------------------------------------------------------------------------- |
+| `refresh_rate`     | `2s`    | How often the daemon list and status are refreshed. Lower values are more responsive but use more CPU.               |
+| `tick_rate`        | `100ms` | How often the TUI checks for keyboard input and other events.                                                        |
+| `stat_history`     | `60`    | Number of CPU/memory samples to keep for graphs. At the default 2 s refresh rate, 60 samples ≈ 2 minutes of history. |
+| `message_duration` | `3s`    | How long status messages (e.g. "Daemon started") remain visible before clearing.                                     |
+
+<Tip>
+  If you have many daemons and notice the TUI using extra CPU, try increasing `refresh_rate` to
+  `"5s"` or `"10s"`.
+</Tip>
+
+
+# Web UI
+Source: https://www.mintlify.com/jdx/pitchfork/guides/web-ui
+
+Monitor and manage daemons from a browser with real-time log streaming and config editing.
+
+Pitchfork includes a built-in web interface for monitoring and managing daemons from any browser.
+
+## Enable the web UI
+
+The web UI is disabled by default. There are several ways to start it:
+
+<Tabs>
+  <Tab title="Settings file (persistent)">
+    Add this to `~/.config/pitchfork/config.toml` to start the web UI automatically every time
+    the supervisor starts:
+
+    ```toml theme={null}
+    [settings.web]
+    auto_start = true
+    bind_port  = 3120
+    ```
+
+    Then (re)start the supervisor in the background:
+
+    ```bash theme={null}
+    pitchfork supervisor run --force
+    ```
+  </Tab>
+
+  <Tab title="Environment variable (one-off)">
+    ```bash theme={null}
+    PITCHFORK_WEB_AUTO_START=true pitchfork supervisor run
+    ```
+  </Tab>
+
+  <Tab title="CLI flag">
+    ```bash theme={null}
+    pitchfork supervisor run --web-port 3120
+    ```
+  </Tab>
+</Tabs>
+
+Once the web UI is running, open it in your browser:
+
+```
+http://127.0.0.1:3120
+```
+
+If the configured port is already in use, pitchfork automatically tries the next 10 ports (e.g.
+3120, 3121, … up to 3129).
+
+## Features
+
+### Dashboard
+
+The dashboard gives you an overview of every daemon:
+
+* Name and current status (running, stopped, failed)
+* Process ID (PID)
+* Error messages for failed daemons
+
+### Daemon management
+
+Control daemons directly from your browser:
+
+* **Start** — launch a stopped daemon
+* **Stop** — gracefully stop a running daemon
+* **Restart** — stop and start a daemon
+* **Enable / Disable** — control whether a daemon can be started
+
+### Live logs
+
+Real-time log streaming for each daemon:
+
+* Select a daemon to view its log output
+* Logs update automatically as new lines arrive
+* Scroll through historical log entries
+
+### Config editing
+
+Edit `pitchfork.toml` files directly in the browser:
+
+* TOML syntax validation
+* Save changes without leaving the UI
+
+## Settings reference
+
+Configure the web UI in your settings file:
+
+```toml theme={null}
+# ~/.config/pitchfork/config.toml
+[settings.web]
+auto_start   = false        # start with supervisor (default: false)
+bind_address = "127.0.0.1"  # listen address (default: 127.0.0.1)
+bind_port    = 3120         # port (default: 3120)
+port_attempts = 10          # ports to try if default is taken (default: 10)
+log_lines    = 100          # initial log lines to show (default: 100)
+```
+
+| Setting         | Default     | Description                                                                         |
+| --------------- | ----------- | ----------------------------------------------------------------------------------- |
+| `auto_start`    | `false`     | Start the web UI automatically when the supervisor starts.                          |
+| `bind_address`  | `127.0.0.1` | IP address to listen on.                                                            |
+| `bind_port`     | `3120`      | Port for the web UI.                                                                |
+| `port_attempts` | `10`        | Number of consecutive ports to try if `bind_port` is in use.                        |
+| `log_lines`     | `100`       | Initial number of log lines to load when opening a daemon's logs.                   |
+| `base_path`     | `""`        | URL path prefix when serving behind a reverse proxy (e.g. `"ps"` serves at `/ps/`). |
+
+<Warning>
+  Changing `bind_address` to `0.0.0.0` exposes the web UI on all network interfaces. The web UI
+  has no authentication, so anyone on your network can view and control your daemons. Only change
+  this on trusted networks.
+</Warning>
+
+
+# Installation
+Source: https://www.mintlify.com/jdx/pitchfork/installation
+
+Install Pitchfork via mise, cargo, or a pre-built binary from GitHub Releases.
+
+## Install Pitchfork
+
+<CodeGroup>
+  ```bash mise (recommended) theme={null}
+  mise use -g pitchfork
+  ```
+
+  ```bash cargo theme={null}
+  cargo install pitchfork-cli
+  ```
+</CodeGroup>
+
+**mise** is the recommended installation method. It manages the binary for you and makes upgrades straightforward. If you don't have mise installed, see the [mise documentation](https://mise.jdx.dev).
+
+**cargo** installs from [crates.io](https://crates.io/crates/pitchfork-cli). You need the Rust toolchain installed.
+
+**GitHub Releases** — Download a pre-built binary for your platform directly from the [GitHub Releases page](https://github.com/jdx/pitchfork/releases). Extract the archive and place the `pitchfork` binary somewhere on your `PATH`.
+
+## Verify installation
+
+```bash theme={null}
+pitchfork --version
+```
+
+You should see output like:
+
+```
+pitchfork 2.3.0
+```
+
+## Shell completion
+
+Pitchfork provides tab completion for bash, zsh, and fish. Completion requires the [`usage`](https://usage.jdx.dev) CLI to be installed.
+
+<Steps>
+  <Step title="Install the usage CLI">
+    ```bash theme={null}
+    mise use -g usage
+    ```
+  </Step>
+
+  <Step title="Generate and install the completion script">
+    Choose the instructions for your shell:
+
+    **Bash**
+
+    ```bash theme={null}
+    mkdir -p ~/.local/share/bash-completion/completions
+    pitchfork completion bash > ~/.local/share/bash-completion/completions/pitchfork
+    ```
+
+    **Zsh**
+
+    ```bash theme={null}
+    mkdir -p ~/.zfunc
+    pitchfork completion zsh > ~/.zfunc/_pitchfork
+    ```
+
+    Then add the following line to your `~/.zshrc` if it isn't already there:
+
+    ```bash theme={null}
+    fpath=(~/.zfunc $fpath)
+    ```
+
+    **Fish**
+
+    ```bash theme={null}
+    pitchfork completion fish > ~/.config/fish/completions/pitchfork.fish
+    ```
+  </Step>
+
+  <Step title="Reload your shell">
+    Open a new terminal, or reload your shell configuration:
+
+    ```bash theme={null}
+    # bash
+    source ~/.bashrc
+
+    # zsh
+    source ~/.zshrc
+
+    # fish
+    source ~/.config/fish/config.fish
+    ```
+  </Step>
+</Steps>
+
+<Note>
+  Completion scripts are generated at install time. Re-run the generation command after upgrading Pitchfork to pick up any new commands or flags.
+</Note>
+
+## What's next
+
+<CardGroup>
+  <Card title="Quick start" icon="rocket" href="/quickstart">
+    Run your first daemon and learn the core commands.
+  </Card>
+
+  <Card title="Your first project" icon="folder-open" href="/first-daemon">
+    Set up a `pitchfork.toml` with multiple daemons.
+  </Card>
+</CardGroup>
+
+
+# Introduction
+Source: https://www.mintlify.com/jdx/pitchfork/introduction
+
+Pitchfork is a CLI for managing background daemons with a focus on developer experience.
+
+Pitchfork is a daemon manager built for developers. It handles the lifecycle of your background services — starting them once, waiting until they're ready, restarting them when they crash, and stopping them automatically when you leave your project directory.
+
+## Key features
+
+<CardGroup>
+  <Card title="Start once, use everywhere" icon="circle-check">
+    Pitchfork only starts a daemon if it's not already running — safe to call from any script or shell.
+  </Card>
+
+  <Card title="Auto start/stop" icon="arrows-rotate">
+    Shell hooks automatically start daemons when you `cd` into a project and stop them when you leave.
+  </Card>
+
+  <Card title="Ready checks" icon="heart-pulse">
+    Wait for a service to be truly ready via HTTP health check, port probe, output pattern, or a fixed delay.
+  </Card>
+
+  <Card title="Dependency ordering" icon="diagram-project">
+    Define dependencies between daemons and Pitchfork starts them in the correct order, in parallel where possible.
+  </Card>
+
+  <Card title="Restart on failure" icon="rotate">
+    Automatically restart daemons that crash, with configurable retry limits.
+  </Card>
+
+  <Card title="Cron scheduling" icon="clock">
+    Run recurring tasks on a cron schedule alongside your long-running services.
+  </Card>
+
+  <Card title="Project configuration" icon="file-code">
+    Define all your project's daemons in a single `pitchfork.toml` file at the project root.
+  </Card>
+
+  <Card title="Start on boot" icon="power-off">
+    Register daemons as system services that start automatically when your machine boots.
+  </Card>
+</CardGroup>
+
+## Use cases
+
+Pitchfork is designed for situations where you need background processes to stay out of your way:
+
+* **Development services** — Databases, API servers, and queue workers that need to run while you code.
+* **File synchronization** — Long-running `rsync` or `unison` processes that keep directories in sync.
+* **Background processes** — Any task you'd otherwise run with `mytask &` and then forget about.
+
+## How it works
+
+Pitchfork uses a client-server architecture. A lightweight supervisor process runs in the background and manages all your daemons. The `pitchfork` CLI communicates with the supervisor over a Unix socket. If the supervisor isn't running, the CLI starts it automatically.
+
+State is persisted to `~/.local/state/pitchfork/` so daemons survive terminal sessions. Logs are written to `~/.local/state/pitchfork/logs/`.
+
+## Get started
+
+<CardGroup>
+  <Card title="Installation" icon="download" href="/installation">
+    Install via mise, cargo, or a pre-built binary from GitHub Releases.
+  </Card>
+
+  <Card title="Quick start" icon="rocket" href="/quickstart">
+    Launch your first daemon and explore the core commands in under 5 minutes.
+  </Card>
+
+  <Card title="Your first project" icon="folder-open" href="/first-daemon">
+    Set up a `pitchfork.toml` with multiple daemons for a realistic dev environment.
+  </Card>
+
+  <Card title="CLI reference" icon="terminal" href="/cli/index">
+    Every command, subcommand, and flag with examples.
+  </Card>
+</CardGroup>
+
+
+# Quick start
+Source: https://www.mintlify.com/jdx/pitchfork/quickstart
+
+Get Pitchfork running and launch your first daemon in under 5 minutes.
+
+<Steps>
+  <Step title="Install Pitchfork">
+    ```bash theme={null}
+    mise use -g pitchfork
+    ```
+
+    Or with cargo:
+
+    ```bash theme={null}
+    cargo install pitchfork-cli
+    ```
+
+    See [Installation](/installation) for all methods including pre-built binaries.
+  </Step>
+
+  <Step title="Run your first daemon">
+    Start a background process with a single command:
+
+    ```bash theme={null}
+    pitchfork run myserver -- python -m http.server 8000
+    ```
+
+    This starts a Python HTTP server in the background, labeled `myserver`. It's an alternative to shell job control (`python -m http.server 8000 &`) — the process keeps running even after you close the terminal.
+  </Step>
+
+  <Step title="Check status">
+    List all running daemons:
+
+    ```bash theme={null}
+    pitchfork list
+    ```
+
+    Output:
+
+    ```
+    NAME       PID    STATUS
+    myserver   12345  running
+    ```
+  </Step>
+
+  <Step title="View logs">
+    See what the daemon has printed:
+
+    ```bash theme={null}
+    pitchfork logs myserver
+    ```
+
+    Follow logs in real-time:
+
+    ```bash theme={null}
+    pitchfork logs myserver --tail
+    ```
+
+    Logs are saved to `~/.local/state/pitchfork/logs/`.
+  </Step>
+
+  <Step title="Stop the daemon">
+    ```bash theme={null}
+    pitchfork stop myserver
+    ```
+  </Step>
+</Steps>
+
+## Interactive TUI
+
+For a richer monitoring experience, open the terminal UI:
+
+```bash theme={null}
+pitchfork tui
+```
+
+The TUI shows live status and logs for all daemons, with vim-style keybindings, fuzzy search, and a built-in config editor. See the [TUI guide](/guides/tui) for details.
+
+## What's next
+
+<CardGroup>
+  <Card title="Your first project" icon="folder-open" href="/first-daemon">
+    Create a `pitchfork.toml` and manage multiple daemons as a group.
+  </Card>
+
+  <Card title="Shell hook" icon="hook" href="/guides/shell-hook">
+    Auto-start daemons when you enter a project directory.
+  </Card>
+
+  <Card title="Ready checks" icon="heart-pulse" href="/guides/ready-checks">
+    Make Pitchfork wait until a daemon is truly ready before continuing.
+  </Card>
+
+  <Card title="CLI reference" icon="terminal" href="/cli/index">
+    Full reference for every command and flag.
+  </Card>
+</CardGroup>
+
+
+# Configuration reference
+Source: https://www.mintlify.com/jdx/pitchfork/reference/configuration
+
+Complete reference for pitchfork.toml — daemon definitions, naming rules, namespace derivation, and all configuration options.
+
+## Configuration hierarchy
+
+Pitchfork loads configuration files in precedence order. Later files override earlier ones:
+
+| Priority    | File                                                    | Namespace                |
+| ----------- | ------------------------------------------------------- | ------------------------ |
+| 1 (lowest)  | `/etc/pitchfork/config.toml`                            | `global`                 |
+| 2           | `~/.config/pitchfork/config.toml`                       | `global`                 |
+| 3           | `.config/pitchfork.toml` (project `.config/` dir)       | derived from project dir |
+| 4           | `.config/pitchfork.local.toml` (project `.config/` dir) | derived from project dir |
+| 5           | `pitchfork.toml` (project root)                         | derived from project dir |
+| 6 (highest) | `pitchfork.local.toml` (project root)                   | derived from project dir |
+
+Project configs are searched from the filesystem root up to the current directory, so configs in parent directories apply to all subdirectories. Within each directory, the precedence from lowest to highest is:
+
+1. `.config/pitchfork.toml`
+2. `.config/pitchfork.local.toml`
+3. `pitchfork.toml`
+4. `pitchfork.local.toml`
+
+<Tip>
+  Add `pitchfork.local.toml` to your `.gitignore`. It is designed for local overrides that should not be committed to version control.
+</Tip>
+
+## JSON Schema
+
+A JSON Schema is available for editor autocompletion and validation.
+
+**URL:** `https://pitchfork.jdx.dev/schema.json`
+
+<Tabs>
+  <Tab title="VS Code">
+    Install the [Even Better TOML](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml) extension, then add the schema comment at the top of your config file:
+
+    ```toml pitchfork.toml theme={null}
+    #:schema https://pitchfork.jdx.dev/schema.json
+
+    [daemons.api]
+    run = "npm run server"
+    ```
+  </Tab>
+
+  <Tab title="JetBrains IDEs">
+    Go to **Settings → Languages & Frameworks → Schemas and DTDs → JSON Schema Mappings** and add `https://pitchfork.jdx.dev/schema.json` mapped to `pitchfork.toml`.
+  </Tab>
+</Tabs>
+
+## File format
+
+Configuration files use TOML format. The top-level structure is:
+
+```toml pitchfork.toml theme={null}
+namespace = "my-project"   # optional — overrides derived namespace for this file
+
+[daemons.<daemon-name>]
+run = "command to execute"
+# ... additional options
+```
+
+### Daemon naming rules
+
+Daemon names must satisfy all of the following rules:
+
+| Rule                 | Valid      | Invalid            |
+| -------------------- | ---------- | ------------------ |
+| No double dashes     | `my-app`   | `my--app`          |
+| No slashes           | `api`      | `api/v2`           |
+| No spaces            | `my_app`   | `my app`           |
+| No parent references | `myapp`    | `..` or `foo..bar` |
+| ASCII only           | `myapp123` | `myäpp`            |
+
+The `--` sequence is reserved for internal namespace encoding. See the [Namespaces](/concepts/namespaces) concept page for details.
+
+### Namespace derivation
+
+The namespace assigned to daemons in a config file is determined as follows:
+
+* **Global config files** (`/etc/pitchfork/config.toml`, `~/.config/pitchfork/config.toml`) always use namespace `global`.
+* **Project config files** use the top-level `namespace = "..."` field if set; otherwise the parent directory name is used.
+* For `.config/pitchfork.toml` and `.config/pitchfork.local.toml`, the namespace derives from the `.config` directory's parent, not from `.config` itself.
+* If the derived directory name is invalid (contains `--`, spaces, non-ASCII characters, etc.) you must set a top-level `namespace`.
+* `pitchfork.local.toml` shares the namespace of its sibling `pitchfork.toml`. If both declare `namespace`, the values must match.
+
+```toml pitchfork.toml theme={null}
+# Explicitly override the namespace for all daemons in this file
+namespace = "frontend"
+
+[daemons.api]
+run = "npm run dev"
+```
+
+## Daemon options
+
+### `run`
+
+<ParamField type="string">
+  The shell command to execute for this daemon. Prepend with `exec` to avoid an extra shell process:
+
+  ```toml theme={null}
+  [daemons.api]
+  run = "exec node server.js"
+  ```
+</ParamField>
+
+### `dir`
+
+<ParamField type="string">
+  Working directory for the daemon process. Relative paths are resolved from the location of the `pitchfork.toml` file. When not set, defaults to the directory containing `pitchfork.toml`.
+
+  ```toml theme={null}
+  # Relative — resolved from pitchfork.toml location
+  [daemons.frontend]
+  run = "npm run dev"
+  dir = "frontend"
+
+  # Absolute
+  [daemons.api]
+  run = "npm run server"
+  dir = "/opt/myapp/api"
+  ```
+</ParamField>
+
+### `env`
+
+<ParamField type="object">
+  Environment variables to set for the daemon process. Values must be strings.
+
+  ```toml theme={null}
+  # Inline table
+  [daemons.api]
+  run = "npm run server"
+  env = { NODE_ENV = "development", PORT = "3000" }
+
+  # Section syntax (for many variables)
+  [daemons.worker.env]
+  DATABASE_URL = "postgres://localhost/mydb"
+  REDIS_URL = "redis://localhost:6379"
+  LOG_LEVEL = "debug"
+  ```
+</ParamField>
+
+### `retry`
+
+<ParamField type="number | boolean">
+  Number of times to retry the daemon after failure, or `true` for infinite retries.
+
+  * A number (e.g., `3`) retries that many times.
+  * `true` retries indefinitely.
+  * `false` or `0` disables retries.
+
+  ```toml theme={null}
+  [daemons.api]
+  run = "npm run server"
+  retry = 3       # retry up to 3 times
+
+  [daemons.critical]
+  run = "npm run worker"
+  retry = true    # retry forever
+  ```
+</ParamField>
+
+### `auto`
+
+<ParamField type="string[]">
+  Automatic start/stop behavior triggered by shell hook directory changes. Accepts an array containing `"start"`, `"stop"`, or both.
+
+  * `"start"` — start the daemon automatically when you enter the project directory.
+  * `"stop"` — stop the daemon automatically when you leave the project directory (respects `settings.general.autostop_delay`).
+
+  ```toml theme={null}
+  [daemons.api]
+  run = "npm run server"
+  auto = ["start", "stop"]
+  ```
+</ParamField>
+
+### `ready_delay`
+
+<ParamField type="number">
+  Number of seconds to wait after the process starts before marking it as ready. Use this as a simple fallback when no other readiness check is appropriate.
+
+  ```toml theme={null}
+  [daemons.api]
+  run = "npm run server"
+  ready_delay = 5
+  ```
+</ParamField>
+
+### `ready_output`
+
+<ParamField type="string">
+  A regex pattern to match against the daemon's stdout or stderr. The daemon is marked ready when a line matching the pattern is detected.
+
+  ```toml theme={null}
+  [daemons.postgres]
+  run = "postgres -D /var/lib/pgsql/data"
+  ready_output = "ready to accept connections"
+  ```
+</ParamField>
+
+### `ready_http`
+
+<ParamField type="string">
+  An HTTP URL to poll for readiness. The daemon is marked ready when the endpoint returns a 2xx response.
+
+  ```toml theme={null}
+  [daemons.api]
+  run = "npm run server"
+  ready_http = "http://localhost:3000/health"
+  ```
+</ParamField>
+
+### `ready_port`
+
+<ParamField type="number">
+  A TCP port to check for readiness. The daemon is marked ready when a connection to this port succeeds.
+
+  ```toml theme={null}
+  [daemons.api]
+  run = "npm run server"
+  ready_port = 3000
+  ```
+</ParamField>
+
+### `ready_cmd`
+
+<ParamField type="string">
+  A shell command to run periodically. The daemon is marked ready when the command exits with code `0`.
+
+  ```toml theme={null}
+  [daemons.postgres]
+  run = "postgres -D /var/lib/pgsql/data"
+  ready_cmd = "pg_isready -h localhost"
+
+  [daemons.redis]
+  run = "redis-server"
+  ready_cmd = "redis-cli ping"
+  ```
+</ParamField>
+
+### `depends`
+
+<ParamField type="string[]">
+  List of daemon names that must be started and ready before this daemon starts. Use short names for daemons in the same namespace, or qualified `namespace/name` IDs for cross-namespace dependencies.
+
+  ```toml theme={null}
+  [daemons.api]
+  run = "npm run server"
+  depends = ["postgres", "redis"]
+  ```
+
+  **Dependency behavior:**
+
+  * Running `pitchfork start api` automatically starts all dependencies first.
+  * Transitive dependencies are resolved (if `postgres` depends on `storage`, that starts too).
+  * Dependencies at the same level start in parallel.
+  * Already-running dependencies are skipped, not restarted.
+  * Circular dependencies are detected and reported as errors.
+  * Using `-f` only restarts the explicitly requested daemon, not its dependencies.
+</ParamField>
+
+### `watch`
+
+<ParamField type="string[]">
+  Glob patterns for files to watch. When a matching file changes, the daemon is automatically restarted. Patterns are resolved relative to the `pitchfork.toml` file. Only running daemons are restarted.
+
+  ```toml theme={null}
+  [daemons.api]
+  run = "npm run dev"
+  watch = ["src/**/*.ts", "package.json"]
+  ```
+
+  Changes are debounced (see `settings.supervisor.file_watch_debounce`) to avoid rapid restarts during bulk file operations like builds or checkouts.
+</ParamField>
+
+### `boot_start`
+
+<ParamField type="boolean">
+  Start this daemon automatically when the system boots (via the platform's native service manager). Set to `true` for daemons that should always be running, such as a shared database.
+
+  ```toml theme={null}
+  [daemons.postgres]
+  run = "postgres -D /var/lib/pgsql/data"
+  boot_start = true
+  ```
+</ParamField>
+
+### `hooks`
+
+<ParamField type="object">
+  Lifecycle hooks that run shell commands in response to daemon events. Hooks are fire-and-forget — they run in the background and do not block the daemon.
+
+  ```toml theme={null}
+  [daemons.api.hooks]
+  on_ready = "curl -X POST https://alerts.example.com/ready"
+  on_fail   = "./scripts/cleanup.sh"
+  on_retry  = "echo 'retrying...'"
+  on_stop   = "./scripts/notify-stop.sh"
+  on_exit   = "./scripts/record-exit.sh"
+  ```
+
+  | Hook       | When it runs                                                                           |
+  | ---------- | -------------------------------------------------------------------------------------- |
+  | `on_ready` | When the daemon passes its readiness check                                             |
+  | `on_fail`  | When the daemon fails and all retries are exhausted                                    |
+  | `on_retry` | Before each retry attempt                                                              |
+  | `on_stop`  | When the daemon is explicitly stopped by pitchfork                                     |
+  | `on_exit`  | On any termination: clean exit, crash, or stop (also fires during supervisor shutdown) |
+
+  Hook commands receive these environment variables: `PITCHFORK_DAEMON_ID`, `PITCHFORK_DAEMON_NAMESPACE`, `PITCHFORK_RETRY_COUNT`, `PITCHFORK_EXIT_CODE`, and (for `on_stop`/`on_exit`) `PITCHFORK_EXIT_REASON`. See [Lifecycle Hooks](/guides/lifecycle-hooks) for details.
+</ParamField>
+
+### `cron`
+
+<ParamField type="object">
+  Cron scheduling configuration for running the daemon on a schedule.
+
+  ```toml theme={null}
+  [daemons.backup]
+  run = "./backup.sh"
+  cron = { schedule = "0 0 2 * * *", retrigger = "finish" }
+  ```
+
+  | Field       | Type   | Description                                                              |
+  | ----------- | ------ | ------------------------------------------------------------------------ |
+  | `schedule`  | string | Cron expression with 6 fields: second, minute, hour, day, month, weekday |
+  | `retrigger` | string | What to do when the schedule fires while a previous run is active        |
+
+  **`retrigger` values:**
+
+  | Value                | Behavior                                                    |
+  | -------------------- | ----------------------------------------------------------- |
+  | `"finish"` (default) | Skip if previous run has not finished                       |
+  | `"always"`           | Always retrigger, stopping the previous run if still active |
+  | `"success"`          | Only retrigger if the previous run succeeded                |
+  | `"fail"`             | Only retrigger if the previous run failed                   |
+</ParamField>
+
+### `mise`
+
+<ParamField type="boolean">
+  When `true`, wraps this daemon's command with `mise x --` so that [mise](https://mise.jdx.dev) activates the correct tool versions, PATH entries, and environment variables before the daemon starts. When not set, falls back to the global `settings.general.mise` value.
+
+  ```toml theme={null}
+  [daemons.api]
+  run = "node server.js"
+  mise = true
+  ```
+
+  This is especially useful for daemons running via `pitchfork boot` (login daemon mode) where the interactive shell profile has not been sourced. See [mise Integration](/guides/mise-integration) for details.
+</ParamField>
+
+### `memory_limit`
+
+<ParamField type="string">
+  Maximum physical memory (RSS) for the daemon process. Accepts human-readable byte sizes. The supervisor monitors RSS at each interval tick and kills the process group if the limit is exceeded.
+
+  ```toml theme={null}
+  [daemons.worker]
+  run = "python worker.py"
+  memory_limit = "512MB"
+
+  [daemons.api]
+  run = "node server.js"
+  memory_limit = "2GiB"
+  ```
+
+  **Supported formats:** `"50MB"`, `"512MB"`, `"1GiB"`, `"256KiB"`. Both SI (MB, GB) and binary (MiB, GiB) units are accepted.
+
+  When the limit is exceeded, the process group is sent `SIGTERM` (then `SIGKILL` if unresponsive). The daemon is marked as `Errored`, so `retry` applies. For multi-process daemons (e.g. gunicorn, nginx workers), RSS is aggregated across the root process and all descendants.
+</ParamField>
+
+### `cpu_limit`
+
+<ParamField type="number">
+  Maximum CPU usage as a percentage of one CPU core. The supervisor monitors CPU at each interval tick. To avoid killing on transient spikes, the process is only killed after `settings.supervisor.cpu_violation_threshold` (default: `3`) consecutive samples exceed the limit.
+
+  ```toml theme={null}
+  [daemons.worker]
+  run = "python compute.py"
+  cpu_limit = 80     # 80% of one core
+
+  [daemons.batch]
+  run = "./run-batch.sh"
+  cpu_limit = 200    # up to 2 full cores (valid on multi-core systems)
+  ```
+
+  When the threshold is reached, the process group is sent `SIGTERM` (then `SIGKILL` if unresponsive). The daemon is marked as `Errored`, so `retry` applies. CPU usage is measured as a percentage of one core; for multi-process daemons, usage is aggregated across all descendants.
+</ParamField>
+
+## Complete example
+
+```toml pitchfork.toml theme={null}
+# Database — starts on boot, shared across the project
+[daemons.postgres]
+run = "postgres -D /var/lib/pgsql/data"
+ready_output = "ready to accept connections"
+boot_start = true
+retry = 3
+
+# Cache
+[daemons.redis]
+run = "redis-server"
+ready_output = "Ready to accept connections"
+
+# API server — depends on database and cache, hot reloads on changes
+[daemons.api]
+run = "npm run server"
+dir = "api"
+depends = ["postgres", "redis"]
+watch = ["src/**/*.ts", "package.json"]
+ready_http = "http://localhost:3000/health"
+auto = ["start", "stop"]
+retry = 5
+env = { NODE_ENV = "development", PORT = "3000" }
+memory_limit = "2GiB"
+cpu_limit = 200
+
+[daemons.api.hooks]
+on_ready = "curl -X POST https://alerts.example.com/ready"
+on_fail  = "./scripts/alert-failure.sh"
+
+# Frontend dev server in a subdirectory
+[daemons.frontend]
+run = "npm run dev"
+dir = "frontend"
+env = { PORT = "5173" }
+auto = ["start", "stop"]
+
+# Nightly backup via cron
+[daemons.backup]
+run = "./scripts/backup.sh"
+cron = { schedule = "0 0 2 * * *", retrigger = "finish" }
+```
+
+
+# Environment variables
+Source: https://www.mintlify.com/jdx/pitchfork/reference/environment-vars
+
+All environment variables that control pitchfork behavior. Environment variables override all file-based configuration.
+
+Environment variables have the highest configuration priority and override values from all `pitchfork.toml` and `config.toml` files.
+
+<Note>
+  The supervisor reads environment variables at startup. Changes take effect only after restarting the supervisor with `pitchfork supervisor run --force`.
+</Note>
+
+## Settings environment variables
+
+Every setting in `pitchfork.toml` has a corresponding environment variable. See the [Settings Reference](/reference/settings) for full descriptions of each setting.
+
+| Variable                            | Default           | Description                                                      |
+| ----------------------------------- | ----------------- | ---------------------------------------------------------------- |
+| `PITCHFORK_AUTOSTOP_DELAY`          | `1m`              | Delay before auto-stopping daemons when leaving a directory      |
+| `PITCHFORK_INTERVAL`                | `10s`             | Supervisor background task refresh interval                      |
+| `PITCHFORK_LOG`                     | `info`            | Console log level (`trace`, `debug`, `info`, `warn`, `error`)    |
+| `PITCHFORK_LOG_FILE_LEVEL`          | `info`            | Log file verbosity level                                         |
+| `PITCHFORK_MISE`                    | `false`           | Wrap all daemon commands with `mise x --` globally               |
+| `PITCHFORK_MISE_BIN`                | *(auto-detected)* | Explicit path to the `mise` binary                               |
+| `PITCHFORK_IPC_CONNECT_ATTEMPTS`    | `5`               | Number of connection retry attempts to the supervisor            |
+| `PITCHFORK_IPC_CONNECT_MIN_DELAY`   | `100ms`           | Minimum delay between connection retries                         |
+| `PITCHFORK_IPC_CONNECT_MAX_DELAY`   | `1s`              | Maximum delay between connection retries                         |
+| `PITCHFORK_IPC_REQUEST_TIMEOUT`     | `5s`              | Default timeout for IPC requests                                 |
+| `PITCHFORK_IPC_RATE_LIMIT`          | `100`             | Maximum IPC requests per second per connection                   |
+| `PITCHFORK_IPC_RATE_LIMIT_WINDOW`   | `1s`              | Rate limit sliding window duration                               |
+| `PITCHFORK_WEB_AUTO_START`          | `false`           | Automatically start web UI when supervisor starts                |
+| `PITCHFORK_WEB_BIND_ADDRESS`        | `127.0.0.1`       | Web server bind address                                          |
+| `PITCHFORK_WEB_BIND_PORT`           | `3120`            | Default web server port                                          |
+| `PITCHFORK_WEB_PORT_ATTEMPTS`       | `10`              | Number of ports to try if the default is in use                  |
+| `PITCHFORK_WEB_LOG_LINES`           | `100`             | Initial number of log lines shown in the web UI                  |
+| `PITCHFORK_WEB_PATH`                | *(none)*          | URL path prefix for the web UI                                   |
+| `PITCHFORK_WEB_SSE_POLL_INTERVAL`   | `500ms`           | Server-Sent Events poll interval for log streaming               |
+| `PITCHFORK_TUI_REFRESH_RATE`        | `2s`              | TUI daemon list refresh interval                                 |
+| `PITCHFORK_TUI_TICK_RATE`           | `100ms`           | TUI event loop tick rate                                         |
+| `PITCHFORK_TUI_STAT_HISTORY`        | `60`              | Number of stat samples to keep for TUI graphs                    |
+| `PITCHFORK_TUI_MESSAGE_DURATION`    | `3s`              | Duration to display status messages in the TUI                   |
+| `PITCHFORK_READY_CHECK_INTERVAL`    | `500ms`           | Interval between ready checks (HTTP, TCP, command)               |
+| `PITCHFORK_FILE_WATCH_DEBOUNCE`     | `1s`              | File watch debounce duration                                     |
+| `PITCHFORK_LOG_FLUSH_INTERVAL`      | `500ms`           | Daemon log buffer flush interval                                 |
+| `PITCHFORK_STOP_TIMEOUT`            | `5s`              | Maximum time to wait for a daemon to stop gracefully             |
+| `PITCHFORK_RESTART_DELAY`           | `100ms`           | Delay between stop and start during a restart                    |
+| `PITCHFORK_CRON_CHECK_INTERVAL`     | `10s`             | Interval for checking cron schedules                             |
+| `PITCHFORK_WATCH_INTERVAL`          | `10s`             | File watcher poll interval                                       |
+| `PITCHFORK_HTTP_CLIENT_TIMEOUT`     | `5s`              | Timeout for HTTP ready checks                                    |
+| `PITCHFORK_PORT_BUMP_ATTEMPTS`      | `10`              | Maximum port increment attempts when `auto_bump_port` is enabled |
+| `PITCHFORK_CONTAINER`               | `false`           | Enable container/PID 1 mode                                      |
+| `PITCHFORK_CPU_VIOLATION_THRESHOLD` | `3`               | Consecutive CPU-over-limit samples before killing a daemon       |
+
+## Web UI port shortcut
+
+In addition to the persistent `PITCHFORK_WEB_BIND_PORT` setting above, there is a one-shot variable for enabling the web UI on a specific port for a single invocation:
+
+| Variable             | Description                                                       |
+| -------------------- | ----------------------------------------------------------------- |
+| `PITCHFORK_WEB_PORT` | Enables the web UI on the specified port for this invocation only |
+
+```bash theme={null}
+# Enable web UI on port 19876 for this supervisor run only
+PITCHFORK_WEB_PORT=19876 pitchfork supervisor run --force
+```
+
+If the specified port is in use, pitchfork tries up to `web.port_attempts` consecutive ports.
+
+## Daemon process variables
+
+These variables are automatically set for every daemon process and its lifecycle hook commands. You do not configure them — pitchfork sets them for you.
+
+| Variable                     | Description                                                                               |
+| ---------------------------- | ----------------------------------------------------------------------------------------- |
+| `PITCHFORK_DAEMON_ID`        | Fully-qualified daemon identifier in `namespace/name` format (e.g., `my-project/api`)     |
+| `PITCHFORK_DAEMON_NAMESPACE` | The daemon's namespace component alone (e.g., `my-project`)                               |
+| `PITCHFORK_RETRY_COUNT`      | Current retry attempt number: `0` on the initial run, `1` on the first retry, etc.        |
+| `PITCHFORK_EXIT_CODE`        | Exit code from the daemon process. Available in `on_fail`, `on_stop`, and `on_exit` hooks |
+| `PITCHFORK_EXIT_REASON`      | Reason the daemon stopped. Available in `on_stop` and `on_exit` hooks                     |
+
+**`PITCHFORK_EXIT_REASON` values:**
+
+| Value  | Meaning                                                                                       |
+| ------ | --------------------------------------------------------------------------------------------- |
+| `stop` | Explicitly stopped by pitchfork (`pitchfork stop`, `auto = ["stop"]`, or supervisor shutdown) |
+| `exit` | Process exited on its own with exit code `0`                                                  |
+| `fail` | Process exited with a non-zero exit code                                                      |
+
+### Example usage in hooks
+
+```bash theme={null}
+# In a daemon script
+echo "I am daemon: $PITCHFORK_DAEMON_ID"
+
+if [ "$PITCHFORK_RETRY_COUNT" -gt 0 ]; then
+  echo "This is retry attempt $PITCHFORK_RETRY_COUNT"
+fi
+```
+
+```bash theme={null}
+# In an on_exit hook
+if [ "$PITCHFORK_EXIT_REASON" = "fail" ]; then
+  echo "Daemon $PITCHFORK_DAEMON_ID crashed with code $PITCHFORK_EXIT_CODE"
+fi
+```
+
+## Example: debug setup
+
+Start the supervisor with debug logging and the web UI enabled:
+
+```bash theme={null}
+PITCHFORK_LOG=debug PITCHFORK_WEB_PORT=19876 pitchfork supervisor run --force
+
+# View supervisor logs
+pitchfork logs pitchfork
+```
+
+
+# File locations
+Source: https://www.mintlify.com/jdx/pitchfork/reference/file-locations
+
+Where pitchfork stores configuration files, state, logs, and the IPC socket.
+
+## Configuration files
+
+Pitchfork searches for configuration in multiple locations and merges them in precedence order. Later files override earlier ones.
+
+| File                              | Purpose                                                             |
+| --------------------------------- | ------------------------------------------------------------------- |
+| `/etc/pitchfork/config.toml`      | System-wide configuration (namespace: `global`)                     |
+| `~/.config/pitchfork/config.toml` | User-wide configuration (namespace: `global`)                       |
+| `.config/pitchfork.toml`          | Project configuration (in project's `.config/` subdirectory)        |
+| `.config/pitchfork.local.toml`    | Project configuration (in project's `.config/` subdirectory)        |
+| `pitchfork.toml`                  | Project configuration (in project root)                             |
+| `pitchfork.local.toml`            | Local project overrides (highest precedence, typically git-ignored) |
+
+Project config files are searched from the filesystem root up to your current directory, so configs in parent directories apply to all subdirectories. Within each directory, precedence from lowest to highest is:
+
+1. `.config/pitchfork.toml`
+2. `.config/pitchfork.local.toml`
+3. `pitchfork.toml`
+4. `pitchfork.local.toml`
+
+<Tip>
+  The `.config/pitchfork.toml` placement mirrors [mise](https://mise.jdx.dev/configuration.html) behavior, letting you store project config in a centralized `.config/` directory if you prefer that layout.
+</Tip>
+
+## State directory
+
+Pitchfork stores all runtime data in `~/.local/state/pitchfork/`.
+
+| Path                                     | Purpose                                         |
+| ---------------------------------------- | ----------------------------------------------- |
+| `~/.local/state/pitchfork/state.toml`    | Persistent daemon state                         |
+| `~/.local/state/pitchfork/logs/`         | Daemon log files                                |
+| `~/.local/state/pitchfork/ipc/main.sock` | Unix socket for CLI-to-supervisor communication |
+
+### State file
+
+`~/.local/state/pitchfork/state.toml` tracks:
+
+* All known daemons and their current status
+* Enabled/disabled state for each daemon
+* Last run information
+
+The file is protected with file locking to allow safe concurrent access from multiple CLI commands.
+
+### Log files
+
+Each daemon writes logs to its own subdirectory. The path is derived from the daemon's qualified ID (`namespace/name`) by replacing the `/` with `--`:
+
+```
+~/.local/state/pitchfork/logs/<namespace>--<name>/<namespace>--<name>.log
+```
+
+**Examples:**
+
+| Daemon                          | Log path                                       |
+| ------------------------------- | ---------------------------------------------- |
+| `api` in project `myapp`        | `logs/myapp--api/myapp--api.log`               |
+| `postgres` in project `yourapp` | `logs/yourapp--postgres/yourapp--postgres.log` |
+| `postgres` in global config     | `logs/global--postgres/global--postgres.log`   |
+
+The `--` separator is the filesystem-safe encoding of the `/` in qualified daemon IDs. Because `--` is reserved for this encoding, project directory names that contain `--` (or other invalid namespace characters) require an explicit `namespace = "..."` override in `pitchfork.toml`. See [Namespaces](/concepts/namespaces) for details.
+
+### IPC socket
+
+`~/.local/state/pitchfork/ipc/main.sock`
+
+This Unix domain socket is how CLI commands communicate with the supervisor daemon. It is created when the supervisor starts and removed when it stops.
+
+## Boot start files
+
+When `boot_start = true` is set on a daemon, pitchfork registers with the platform's native service manager. The registration file location depends on your operating system:
+
+| Platform | Location                                                                          |
+| -------- | --------------------------------------------------------------------------------- |
+| macOS    | `~/Library/LaunchAgents/com.pitchfork.agent.plist`                                |
+| Linux    | `~/.config/systemd/user/pitchfork.service`                                        |
+| Windows  | Registry key at `HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run` |
+
+
+# Settings reference
+Source: https://www.mintlify.com/jdx/pitchfork/reference/settings
+
+All configurable settings for pitchfork, grouped by section. Set via pitchfork.toml, user config, or environment variables.
+
+Settings control the behavior of the pitchfork supervisor, web UI, TUI, and IPC. They can be configured in multiple places. Sources are applied in this order (later sources win):
+
+| Priority    | Source                                                            |
+| ----------- | ----------------------------------------------------------------- |
+| 1 (lowest)  | `/etc/pitchfork/config.toml` — `[settings]` section               |
+| 2           | `~/.config/pitchfork/config.toml` — `[settings]` section          |
+| 3           | `pitchfork.toml` or `pitchfork.local.toml` — `[settings]` section |
+| 4 (highest) | Environment variables                                             |
+
+## Configuring settings
+
+### In pitchfork.toml
+
+Add a `[settings]` section to any `pitchfork.toml` file:
+
+```toml pitchfork.toml theme={null}
+[daemons.myapp]
+run = "node server.js"
+
+[settings.general]
+autostop_delay = "5m"
+log_level = "debug"
+
+[settings.web]
+auto_start = true
+bind_address = "0.0.0.0"
+bind_port = 8080
+
+[settings.tui]
+refresh_rate = "1s"
+
+[settings.supervisor]
+file_watch_debounce = "2s"
+```
+
+### In user config
+
+For settings that apply to all projects, add a `[settings]` section to `~/.config/pitchfork/config.toml`:
+
+```toml ~/.config/pitchfork/config.toml theme={null}
+[settings.general]
+log_level = "info"
+
+[settings.web]
+auto_start = true
+```
+
+### Via environment variables
+
+Every setting has a corresponding environment variable that overrides all file configuration:
+
+```bash theme={null}
+export PITCHFORK_LOG=debug
+export PITCHFORK_WEB_AUTO_START=true
+export PITCHFORK_AUTOSTOP_DELAY=5m
+```
+
+## General settings
+
+<ParamField type="Duration">
+  How long to wait before stopping a daemon after you leave its directory (when using `auto = ["stop"]` with the shell hook).
+
+  This delay prevents unnecessary stop/start cycles when briefly switching directories.
+
+  **Env var:** `PITCHFORK_AUTOSTOP_DELAY`
+
+  ```toml theme={null}
+  [settings.general]
+  autostop_delay = "30s"   # wait 30 seconds before stopping
+  ```
+
+  Set to `"0s"` to stop daemons immediately when you leave the directory.
+</ParamField>
+
+<ParamField type="Duration">
+  How often the supervisor refreshes its internal state and checks daemon health, config file updates, and process synchronization.
+
+  **Env var:** `PITCHFORK_INTERVAL`
+
+  Lower values give more responsive status updates at the cost of more resource use.
+</ParamField>
+
+<ParamField type="string">
+  Verbosity of log output to the console. Accepted values: `trace`, `debug`, `info`, `warn`, `error`.
+
+  **Env var:** `PITCHFORK_LOG`
+
+  <Note>The supervisor reads this only at startup. Use `pitchfork supervisor run --force` to restart with new log settings.</Note>
+</ParamField>
+
+<ParamField type="string">
+  Verbosity of log output written to log files. Can be set independently from `log_level` to keep verbose logs on disk without cluttering the console.
+
+  **Env var:** `PITCHFORK_LOG_FILE_LEVEL`
+</ParamField>
+
+<ParamField type="boolean">
+  When `true`, wraps every daemon command globally with `mise x --` to activate mise-managed tool versions and environment variables.
+
+  **Env var:** `PITCHFORK_MISE`
+
+  Individual daemons can override this with `mise = true` or `mise = false` in their daemon configuration. Useful when pitchfork is started as a login item or boot daemon where the shell profile has not been sourced.
+</ParamField>
+
+<ParamField type="string">
+  Explicit path to the `mise` binary. When not set, pitchfork searches these locations in order:
+
+  * `~/.local/bin/mise`
+  * `~/.cargo/bin/mise`
+  * `/usr/local/bin/mise`
+  * `/opt/homebrew/bin/mise`
+
+  **Env var:** `PITCHFORK_MISE_BIN`
+</ParamField>
+
+## IPC settings
+
+Settings that control communication between the CLI and the supervisor daemon.
+
+<ParamField type="integer">
+  Number of times to retry connecting to the supervisor before giving up. Each attempt uses exponential backoff between `connect_min_delay` and `connect_max_delay`.
+
+  **Env var:** `PITCHFORK_IPC_CONNECT_ATTEMPTS`
+</ParamField>
+
+<ParamField type="Duration">
+  Initial delay between connection retry attempts. The actual delay increases exponentially up to `connect_max_delay`.
+
+  **Env var:** `PITCHFORK_IPC_CONNECT_MIN_DELAY`
+</ParamField>
+
+<ParamField type="Duration">
+  Maximum delay between connection retry attempts. Exponential backoff will not exceed this value.
+
+  **Env var:** `PITCHFORK_IPC_CONNECT_MAX_DELAY`
+</ParamField>
+
+<ParamField type="Duration">
+  Maximum time to wait for a response from the supervisor for most operations. Daemon start operations may use a longer timeout calculated from the daemon's `ready_delay` plus a buffer.
+
+  **Env var:** `PITCHFORK_IPC_REQUEST_TIMEOUT`
+</ParamField>
+
+<ParamField type="integer">
+  Maximum IPC requests per second per connection. Uses a sliding window algorithm to prevent local denial-of-service. Increase if you have automated tools making many rapid requests.
+
+  **Env var:** `PITCHFORK_IPC_RATE_LIMIT`
+</ParamField>
+
+<ParamField type="Duration">
+  The time window for rate limit calculations. `rate_limit` requests are allowed within each window.
+
+  **Env var:** `PITCHFORK_IPC_RATE_LIMIT_WINDOW`
+</ParamField>
+
+## Web settings
+
+Settings for the pitchfork web UI.
+
+<ParamField type="boolean">
+  When `true`, the web UI server starts automatically alongside the supervisor. By default the web UI must be started manually with `pitchfork web`.
+
+  **Env var:** `PITCHFORK_WEB_AUTO_START`
+</ParamField>
+
+<ParamField type="string">
+  IP address the web UI listens on.
+
+  **Env var:** `PITCHFORK_WEB_BIND_ADDRESS`
+
+  <Warning>
+    The default `127.0.0.1` allows only local connections. Setting this to `0.0.0.0` exposes the web UI to your entire network.
+  </Warning>
+</ParamField>
+
+<ParamField type="integer">
+  Port for the web UI. If this port is in use, pitchfork tries subsequent ports up to `port_attempts` times.
+
+  **Env var:** `PITCHFORK_WEB_BIND_PORT`
+</ParamField>
+
+<ParamField type="integer">
+  Number of consecutive ports to try if the configured port is occupied. With `bind_port = 3120` and `port_attempts = 10`, pitchfork tries 3120 through 3129.
+
+  **Env var:** `PITCHFORK_WEB_PORT_ATTEMPTS`
+</ParamField>
+
+<ParamField type="integer">
+  Number of log lines to display initially when viewing daemon logs in the web UI. More lines means more history visible but a slower initial load.
+
+  **Env var:** `PITCHFORK_WEB_LOG_LINES`
+</ParamField>
+
+<ParamField type="string">
+  URL path prefix for the web UI. Useful when running behind a reverse proxy that routes a path prefix to pitchfork.
+
+  **Env var:** `PITCHFORK_WEB_PATH`
+
+  For example, `base_path = "ps"` serves the web UI at `/ps/`. The `--web-path` CLI flag takes priority over this setting.
+</ParamField>
+
+<ParamField type="Duration">
+  How often the web UI polls for new log lines when streaming logs via Server-Sent Events. Lower values provide more real-time updates at the cost of more resource use.
+
+  **Env var:** `PITCHFORK_WEB_SSE_POLL_INTERVAL`
+</ParamField>
+
+## TUI settings
+
+Settings for the interactive terminal UI (`pitchfork tui`).
+
+<ParamField type="Duration">
+  How often the TUI refreshes the daemon list and status information.
+
+  **Env var:** `PITCHFORK_TUI_REFRESH_RATE`
+</ParamField>
+
+<ParamField type="Duration">
+  How often the TUI event loop checks for keyboard input and other events. Lower values improve input responsiveness but increase CPU use.
+
+  **Env var:** `PITCHFORK_TUI_TICK_RATE`
+</ParamField>
+
+<ParamField type="integer">
+  Number of CPU and memory stat samples to retain per daemon for graphs. With the default `refresh_rate` of `2s`, 60 samples represents approximately 2 minutes of history.
+
+  **Env var:** `PITCHFORK_TUI_STAT_HISTORY`
+</ParamField>
+
+<ParamField type="Duration">
+  How long status messages (such as "Daemon started") remain visible in the TUI before automatically clearing.
+
+  **Env var:** `PITCHFORK_TUI_MESSAGE_DURATION`
+</ParamField>
+
+## Supervisor settings
+
+Internal settings for the pitchfork supervisor daemon.
+
+<ParamField type="Duration">
+  How often to poll when checking if a daemon is ready using `ready_http`, `ready_port`, or `ready_cmd`. Lower values detect readiness faster at the cost of more resource use.
+
+  **Env var:** `PITCHFORK_READY_CHECK_INTERVAL`
+</ParamField>
+
+<ParamField type="Duration">
+  How long to wait after the last file change before triggering a daemon restart. This prevents rapid restart cycles when many files change at once (e.g., during a build or `git checkout`).
+
+  **Env var:** `PITCHFORK_FILE_WATCH_DEBOUNCE`
+</ParamField>
+
+<ParamField type="Duration">
+  How often daemon log output is flushed to disk. Lower values make logs appear faster in the UI.
+
+  **Env var:** `PITCHFORK_LOG_FLUSH_INTERVAL`
+</ParamField>
+
+<ParamField type="Duration">
+  Maximum time to wait for a daemon to exit gracefully after receiving `SIGTERM` before sending `SIGKILL`. Increase this for daemons that need time to flush data or close connections.
+
+  **Env var:** `PITCHFORK_STOP_TIMEOUT`
+</ParamField>
+
+<ParamField type="Duration">
+  Brief pause between stopping and starting a daemon during a restart. Helps ensure resources such as ports are fully released before the new process starts.
+
+  **Env var:** `PITCHFORK_RESTART_DELAY`
+</ParamField>
+
+<ParamField type="Duration">
+  How often the supervisor checks whether any cron-scheduled daemons should be triggered. The default of `10s` supports sub-minute cron schedules.
+
+  **Env var:** `PITCHFORK_CRON_CHECK_INTERVAL`
+</ParamField>
+
+<ParamField type="Duration">
+  How often the file watcher polls for filesystem changes when using `watch` patterns. Lower values detect changes faster but increase CPU and I/O use.
+
+  **Env var:** `PITCHFORK_WATCH_INTERVAL`
+</ParamField>
+
+<ParamField type="Duration">
+  Maximum time to wait for a response when polling `ready_http` endpoints during readiness checks. Increase if your services take a while to respond during startup.
+
+  **Env var:** `PITCHFORK_HTTP_CLIENT_TIMEOUT`
+</ParamField>
+
+<ParamField type="integer">
+  Maximum number of port increments to try when `auto_bump_port = true` is set on a daemon. With `port = [3000]` and `port_bump_attempts = 10`, pitchfork tries ports 3000 through 3009 before reporting failure.
+
+  **Env var:** `PITCHFORK_PORT_BUMP_ATTEMPTS`
+</ParamField>
+
+<ParamField type="boolean">
+  Enable container/PID 1 mode for running pitchfork inside Docker containers. When enabled, pitchfork installs a `SIGCHLD` handler to reap orphaned child processes and routes `SIGTERM`/`SIGINT` through the graceful shutdown sequence. Can also be set with the `--container` CLI flag on `pitchfork supervisor run`.
+
+  **Env var:** `PITCHFORK_CONTAINER`
+</ParamField>
+
+<ParamField type="integer">
+  Number of consecutive CPU-over-limit samples required before a daemon is killed. A single sample below the limit resets the counter. This prevents killing daemons during transient spikes (e.g., JIT warm-up).
+
+  **Env var:** `PITCHFORK_CPU_VIOLATION_THRESHOLD`
+
+  With the default `general.interval` of `10s`, a threshold of `3` means a daemon must exceed its `cpu_limit` for approximately 30 seconds before being killed.
+</ParamField>
+
+

--- a/docs/research/mintlify-cache/jdx/pitchfork/llms.txt
+++ b/docs/research/mintlify-cache/jdx/pitchfork/llms.txt
@@ -1,0 +1,51 @@
+# Pitchfork
+
+## Docs
+
+- [pitchfork activate](https://www.mintlify.com/jdx/pitchfork/cli/activate.md): Generate shell hook code that enables automatic daemon management when you change directories.
+- [pitchfork boot](https://www.mintlify.com/jdx/pitchfork/cli/boot.md): Register or remove the pitchfork supervisor from automatic system boot startup.
+- [pitchfork clean](https://www.mintlify.com/jdx/pitchfork/cli/clean.md): Remove stopped and failed daemon entries from the pitchfork list.
+- [pitchfork completion](https://www.mintlify.com/jdx/pitchfork/cli/completion.md): Generate tab-completion scripts for bash, zsh, or fish shells.
+- [pitchfork config](https://www.mintlify.com/jdx/pitchfork/cli/config.md): Manage and edit pitchfork.toml configuration files, including adding and removing daemon entries.
+- [pitchfork disable](https://www.mintlify.com/jdx/pitchfork/cli/disable.md): Prevent a daemon from being started manually or automatically until re-enabled.
+- [pitchfork enable](https://www.mintlify.com/jdx/pitchfork/cli/enable.md): Re-enable a previously disabled daemon, allowing it to be started manually or automatically.
+- [CLI reference](https://www.mintlify.com/jdx/pitchfork/cli/index.md): Complete reference for all pitchfork commands, flags, and arguments.
+- [pitchfork list](https://www.mintlify.com/jdx/pitchfork/cli/list.md): Display a table of all tracked daemons with their PID, status, and error information.
+- [pitchfork logs](https://www.mintlify.com/jdx/pitchfork/cli/logs.md): Display, filter, and follow log output from one or more managed daemons.
+- [pitchfork restart](https://www.mintlify.com/jdx/pitchfork/cli/restart.md): Stop then start one or more daemons, equivalent to running start --force.
+- [pitchfork run](https://www.mintlify.com/jdx/pitchfork/cli/run.md): Run a one-off command as a managed daemon without a pitchfork.toml configuration file.
+- [pitchfork start](https://www.mintlify.com/jdx/pitchfork/cli/start.md): Start one or more daemons defined in pitchfork.toml, waiting for each to be ready before returning.
+- [pitchfork status](https://www.mintlify.com/jdx/pitchfork/cli/status.md): Show detailed status information for a single daemon, including its PID and current state.
+- [pitchfork stop](https://www.mintlify.com/jdx/pitchfork/cli/stop.md): Send a graceful stop signal to one or more running daemons, escalating to SIGKILL if needed.
+- [pitchfork tui](https://www.mintlify.com/jdx/pitchfork/cli/tui.md): Launch the interactive terminal dashboard to monitor daemons and view logs in real time.
+- [pitchfork wait](https://www.mintlify.com/jdx/pitchfork/cli/wait.md): Block until a daemon stops, tailing its logs in real time. Exits with the same code as the daemon.
+- [Architecture](https://www.mintlify.com/jdx/pitchfork/concepts/architecture.md): A technical deep-dive into how Pitchfork is built.
+- [How it works](https://www.mintlify.com/jdx/pitchfork/concepts/how-it-works.md): A tour of the client-server architecture that powers Pitchfork.
+- [Namespaces](https://www.mintlify.com/jdx/pitchfork/concepts/namespaces.md): How Pitchfork keeps daemons from different projects from colliding.
+- [Your first project](https://www.mintlify.com/jdx/pitchfork/first-daemon.md): Set up a pitchfork.toml with multiple daemons for a realistic development environment.
+- [Auto restart](https://www.mintlify.com/jdx/pitchfork/guides/auto-restart.md): Configure pitchfork to automatically restart daemons when they crash.
+- [Start on boot](https://www.mintlify.com/jdx/pitchfork/guides/boot-start.md): Configure pitchfork to start automatically when your system boots using launchd on macOS or systemd on Linux.
+- [Container mode](https://www.mintlify.com/jdx/pitchfork/guides/container-mode.md): Run pitchfork as PID 1 inside a Docker container with proper zombie reaping and signal forwarding.
+- [File watching](https://www.mintlify.com/jdx/pitchfork/guides/file-watching.md): Automatically restart daemons when source files change.
+- [Lifecycle hooks](https://www.mintlify.com/jdx/pitchfork/guides/lifecycle-hooks.md): Run custom shell commands when daemons become ready, fail, retry, or stop.
+- [Viewing logs](https://www.mintlify.com/jdx/pitchfork/guides/logs.md): View, filter, tail, and manage daemon logs from the command line, TUI, or web UI.
+- [mise integration](https://www.mintlify.com/jdx/pitchfork/guides/mise-integration.md): Use mise with pitchfork to ensure the correct tool versions and environment variables are available to your daemons.
+- [Ready checks](https://www.mintlify.com/jdx/pitchfork/guides/ready-checks.md): Configure how pitchfork determines when a daemon is ready to accept requests.
+- [Cron scheduling](https://www.mintlify.com/jdx/pitchfork/guides/scheduling.md): Run daemons on a schedule using cron expressions.
+- [Shell hook](https://www.mintlify.com/jdx/pitchfork/guides/shell-hook.md): Automatically start daemons when you enter a project directory and stop them when you leave.
+- [Terminal UI (TUI)](https://www.mintlify.com/jdx/pitchfork/guides/tui.md): Monitor and manage daemons from an interactive terminal dashboard with vim-style keybindings.
+- [Web UI](https://www.mintlify.com/jdx/pitchfork/guides/web-ui.md): Monitor and manage daemons from a browser with real-time log streaming and config editing.
+- [Installation](https://www.mintlify.com/jdx/pitchfork/installation.md): Install Pitchfork via mise, cargo, or a pre-built binary from GitHub Releases.
+- [Introduction](https://www.mintlify.com/jdx/pitchfork/introduction.md): Pitchfork is a CLI for managing background daemons with a focus on developer experience.
+- [Quick start](https://www.mintlify.com/jdx/pitchfork/quickstart.md): Get Pitchfork running and launch your first daemon in under 5 minutes.
+- [Configuration reference](https://www.mintlify.com/jdx/pitchfork/reference/configuration.md): Complete reference for pitchfork.toml — daemon definitions, naming rules, namespace derivation, and all configuration options.
+- [Environment variables](https://www.mintlify.com/jdx/pitchfork/reference/environment-vars.md): All environment variables that control pitchfork behavior. Environment variables override all file-based configuration.
+- [File locations](https://www.mintlify.com/jdx/pitchfork/reference/file-locations.md): Where pitchfork stores configuration files, state, logs, and the IPC socket.
+- [Settings reference](https://www.mintlify.com/jdx/pitchfork/reference/settings.md): All configurable settings for pitchfork, grouped by section. Set via pitchfork.toml, user config, or environment variables.
+
+## OpenAPI Specs
+
+- [openapi](https://www.mintlify.com/jdx/pitchfork/api-reference/openapi.json)
+
+
+Built with [Mintlify](https://mintlify.com).

--- a/docs/research/mintlify-cache/jdx/pklr/llms-full.txt
+++ b/docs/research/mintlify-cache/jdx/pklr/llms-full.txt
@@ -1,0 +1,3135 @@
+# analyze_imports
+Source: https://www.mintlify.com/jdx/pklr/api/analyze-imports
+
+Extract all transitive local file dependencies from a Pkl file
+
+Statically analyze a `.pkl` file and return the paths of all local files it imports, including imports of those imports (transitive). This function does not evaluate the Pkl source — it only lexes it to extract import URIs.
+
+## `analyze_imports`
+
+```rust theme={null}
+pub fn analyze_imports(path: &Path) -> Result<Vec<std::path::PathBuf>>
+```
+
+<Note>
+  This function is synchronous. It does not require an async runtime.
+</Note>
+
+### Parameters
+
+<ParamField type="&Path">
+  Path to the root `.pkl` file to analyze. Import paths in the file are resolved relative to this
+  file's parent directory.
+</ParamField>
+
+### Return value
+
+Returns `Result<Vec<PathBuf>>` — a flat list of resolved absolute-or-relative `PathBuf`s for every local import found transitively. Each entry corresponds to an actual file on disk (or a glob-expanded match).
+
+***
+
+## Behavior
+
+### Handled import forms
+
+`analyze_imports` handles all import syntaxes that reference local files:
+
+| Import syntax                        | Behavior                                                          |
+| ------------------------------------ | ----------------------------------------------------------------- |
+| `import "relative/path.pkl"`         | Resolved relative to the importing file's directory               |
+| `import "file:///absolute/path.pkl"` | The `file://` prefix is stripped; path used as-is                 |
+| `import* "*.pkl"`                    | Glob pattern expanded to all matching files in the base directory |
+
+### What is NOT resolved
+
+<Warning>
+  `analyze_imports` only returns **local file** dependencies. The following import types are
+  silently ignored:
+
+  * `https://` and `http://` remote imports
+  * `package://` package imports
+
+  If your build system depends on remote assets, you must handle those separately.
+</Warning>
+
+### Use cases
+
+<CardGroup>
+  <Card title="Build system dependency tracking" icon="hammer">
+    Pass the returned paths as inputs to your build rule so it reruns whenever any transitive
+    dependency changes.
+  </Card>
+
+  <Card title="Hot-reload watching" icon="eye">
+    Watch the returned file list for changes and trigger re-evaluation when any dependency is
+    modified.
+  </Card>
+</CardGroup>
+
+***
+
+## Example
+
+```rust theme={null}
+use std::path::Path;
+use pklr::analyze_imports;
+
+fn main() -> pklr::Result<()> {
+    let path = Path::new("config/app.pkl");
+    let deps = analyze_imports(path)?;
+
+    println!("Dependencies of {}:", path.display());
+    for dep in &deps {
+        println!("  {}", dep.display());
+    }
+
+    Ok(())
+}
+```
+
+Example output for a file that imports two modules, one of which imports another:
+
+```
+Dependencies of config/app.pkl:
+  config/database.pkl
+  config/server.pkl
+  config/tls.pkl
+```
+
+***
+
+## Build system integration
+
+The following example shows how to use `analyze_imports` as the dependency discovery step in a simple build system or task runner:
+
+```rust theme={null}
+use std::path::{Path, PathBuf};
+use pklr::analyze_imports;
+
+/// Returns true if any dependency of `root` is newer than `output`.
+fn needs_rebuild(root: &Path, output: &Path) -> pklr::Result<bool> {
+    if !output.exists() {
+        return Ok(true);
+    }
+
+    let output_mtime = output.metadata()?.modified()?;
+
+    // Check the root file itself
+    let mut files: Vec<PathBuf> = vec![root.to_path_buf()];
+
+    // Add all transitive local dependencies
+    files.extend(analyze_imports(root)?);
+
+    for file in files {
+        if let Ok(meta) = file.metadata() {
+            if let Ok(mtime) = meta.modified() {
+                if mtime > output_mtime {
+                    return Ok(true);
+                }
+            }
+        }
+    }
+
+    Ok(false)
+}
+```
+
+<Tip>
+  To watch dependencies for hot-reload, call `analyze_imports` once at startup, register the
+  returned paths with a file watcher (such as `notify`), and re-call `analyze_imports` after each
+  change to pick up any newly added imports.
+</Tip>
+
+
+# Error
+Source: https://www.mintlify.com/jdx/pklr/api/error
+
+Error types returned by pklr
+
+All fallible pklr functions return `Result<T>`, which is a type alias for `std::result::Result<T, Error>`. The `Error` enum covers every failure mode from file I/O through lexing, parsing, evaluation, import resolution, and unsupported features.
+
+## `Result<T>`
+
+```rust theme={null}
+pub type Result<T> = std::result::Result<T, Error>;
+```
+
+***
+
+## `Error`
+
+```rust theme={null}
+#[derive(Debug, miette::Diagnostic, thiserror::Error)]
+pub enum Error {
+    Io(PathBuf, std::io::Error),
+    Lex { src: NamedSource<String>, span: miette::SourceOffset, message: String },
+    Parse { src: NamedSource<String>, span: miette::SourceOffset, message: String },
+    Eval(String),
+    ImportNotFound(String),
+    Unsupported(String),
+}
+```
+
+`Error` implements `miette::Diagnostic`, so `Lex` and `Parse` errors can be printed with full source context and highlighted spans when you use a miette-aware reporter.
+
+***
+
+## Variants
+
+<AccordionGroup>
+  <Accordion title="Error::Io(PathBuf, std::io::Error)">
+    A file could not be read from disk. The first field is the path that was attempted; the second
+    is the underlying `std::io::Error`.
+
+    **Display:** `IO error reading {path}: {io_error}`
+
+    ```rust theme={null}
+    // Returned by eval_to_json, eval_to_json_with_options, and analyze_imports
+    // when std::fs::read_to_string fails.
+    ```
+  </Accordion>
+
+  <Accordion title="Error::Lex { src, span, message }">
+    The lexer encountered a character or sequence it could not tokenize.
+
+    | Field     | Type                          | Description                                               |
+    | --------- | ----------------------------- | --------------------------------------------------------- |
+    | `src`     | `miette::NamedSource<String>` | Full source text with file name, for diagnostic rendering |
+    | `span`    | `miette::SourceOffset`        | Byte offset of the invalid token                          |
+    | `message` | `String`                      | Human-readable description of the problem                 |
+
+    **Display:** the `message` string
+
+    <Note>
+      `Lex` carries a `miette::NamedSource` so that tools using a miette error reporter (such as
+      `miette::GraphicalReportHandler`) can print the offending line with a caret pointing at the
+      exact character.
+    </Note>
+  </Accordion>
+
+  <Accordion title="Error::Parse { src, span, message }">
+    The parser received a valid token sequence that does not form a legal Pkl construct.
+
+    | Field     | Type                          | Description                                               |
+    | --------- | ----------------------------- | --------------------------------------------------------- |
+    | `src`     | `miette::NamedSource<String>` | Full source text with file name, for diagnostic rendering |
+    | `span`    | `miette::SourceOffset`        | Byte offset of the unexpected token                       |
+    | `message` | `String`                      | Human-readable description of the problem                 |
+
+    **Display:** the `message` string
+
+    <Note>
+      Like `Lex`, `Parse` carries a `NamedSource` for pretty miette diagnostics. Both variants
+      implement `miette::Diagnostic` via the derive macro.
+    </Note>
+  </Accordion>
+
+  <Accordion title="Error::Eval(String)">
+    A runtime error during evaluation: type mismatches, undefined variables, failed `read()`
+    calls, environment variable lookup failures, and similar runtime conditions.
+
+    **Display:** `Eval error: {message}`
+  </Accordion>
+
+  <Accordion title="Error::ImportNotFound(String)">
+    An `import` statement referenced a path or URI that could not be resolved to a module.
+
+    **Display:** `Import not found: {uri}`
+  </Accordion>
+
+  <Accordion title="Error::Unsupported(String)">
+    The Pkl source used a language feature that pklr does not yet implement.
+
+    **Display:** `Unsupported feature: {description}`
+  </Accordion>
+</AccordionGroup>
+
+***
+
+## Pattern matching example
+
+```rust theme={null}
+use std::path::Path;
+use pklr::{eval_to_json, Error};
+
+#[tokio::main]
+async fn main() {
+    match eval_to_json(Path::new("config.pkl")).await {
+        Ok(value) => {
+            println!("{}", serde_json::to_string_pretty(&value).unwrap());
+        }
+        Err(Error::Io(path, io_err)) => {
+            eprintln!("could not read {}: {}", path.display(), io_err);
+        }
+        Err(Error::Lex { message, .. }) => {
+            eprintln!("tokenization error: {message}");
+        }
+        Err(Error::Parse { message, .. }) => {
+            eprintln!("parse error: {message}");
+        }
+        Err(Error::Eval(msg)) => {
+            eprintln!("evaluation error: {msg}");
+        }
+        Err(Error::ImportNotFound(uri)) => {
+            eprintln!("import not found: {uri}");
+        }
+        Err(Error::Unsupported(feature)) => {
+            eprintln!("unsupported feature: {feature}");
+        }
+    }
+}
+```
+
+***
+
+## Pretty diagnostics with miette
+
+`Lex` and `Parse` errors implement `miette::Diagnostic`. Use `miette::GraphicalReportHandler` to render them with source context:
+
+```rust theme={null}
+use miette::GraphicalReportHandler;
+use pklr::Error;
+
+fn print_error(err: &Error) {
+    let mut out = String::new();
+    GraphicalReportHandler::new()
+        .render_report(&mut out, err)
+        .unwrap();
+    eprintln!("{out}");
+}
+```
+
+For `Io`, `Eval`, `ImportNotFound`, and `Unsupported` variants, standard `Display` formatting (`eprintln!("{err}")`) is sufficient.
+
+
+# EvalOptions
+Source: https://www.mintlify.com/jdx/pklr/api/eval-options
+
+Configuration options for the pkl evaluator
+
+`EvalOptions` is passed to [`eval_to_json_with_options`](/api/eval-to-json) to configure the HTTP client and URL rewrite rules used during evaluation. All fields are optional — use struct update syntax with `Default::default()` to set only what you need.
+
+## `EvalOptions`
+
+```rust theme={null}
+#[derive(Default)]
+pub struct EvalOptions {
+    pub client: Option<reqwest::Client>,
+    pub http_rewrites: Vec<String>,
+}
+```
+
+***
+
+## Fields
+
+<ParamField type="Option<reqwest::Client>">
+  Custom HTTP client used for all remote imports (`https://` and `http://` URIs). Useful for
+  configuring proxies, custom CA certificates, or connection timeouts. When `None`, a default
+  `reqwest::Client` is used.
+</ParamField>
+
+<ParamField type="Vec<String>">
+  HTTP URL rewrite rules in `"source_prefix=target_prefix"` format. Matches the behavior of the
+  `pkl` CLI's `--http-rewrite` flag: when a URL matches a source prefix, the prefix is replaced
+  with the corresponding target prefix. The longest matching prefix wins. An empty `Vec` means no
+  rewrites are applied.
+</ParamField>
+
+<Note>
+  `pklr` re-exports `reqwest` so you do not need a separate `reqwest` dependency in your
+  `Cargo.toml`. Use `pklr::reqwest::Client::builder()` to build a client.
+</Note>
+
+***
+
+## Rewrite rule format
+
+Each string in `http_rewrites` must contain exactly one `=` separating the source prefix from the target prefix:
+
+```
+https://example.com/modules=https://mirror.internal/modules
+```
+
+A request to `https://example.com/modules/config.pkl` is rewritten to `https://mirror.internal/modules/config.pkl`. Rules with a missing `=` or an empty source prefix are silently ignored with a message to stderr.
+
+<Tip>
+  When multiple rules could match the same URL, the rule with the longest source prefix wins.
+  This is consistent with the official `pkl` CLI behavior.
+</Tip>
+
+***
+
+## Examples
+
+### Default options
+
+Use `Default::default()` to pass zero configuration:
+
+```rust theme={null}
+use pklr::{eval_to_json_with_options, EvalOptions};
+use std::path::Path;
+
+#[tokio::main]
+async fn main() -> pklr::Result<()> {
+    let value = eval_to_json_with_options(
+        Path::new("config.pkl"),
+        EvalOptions::default(),
+    ).await?;
+    println!("{}", serde_json::to_string_pretty(&value)?);
+    Ok(())
+}
+```
+
+### Custom client with struct update syntax
+
+Set only the fields you care about and let `Default` fill in the rest:
+
+```rust theme={null}
+use pklr::{eval_to_json_with_options, EvalOptions, reqwest};
+use std::path::Path;
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() -> pklr::Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .expect("failed to build HTTP client");
+
+    let options = EvalOptions {
+        client: Some(client),
+        ..Default::default()
+    };
+
+    let value = eval_to_json_with_options(Path::new("config.pkl"), options).await?;
+    println!("{}", serde_json::to_string_pretty(&value)?);
+    Ok(())
+}
+```
+
+### Custom CA certificate
+
+Load a PEM-encoded CA bundle and use it for all HTTPS imports:
+
+```rust theme={null}
+use pklr::{eval_to_json_with_options, EvalOptions, reqwest};
+use std::path::Path;
+
+#[tokio::main]
+async fn main() -> pklr::Result<()> {
+    let pem = std::fs::read("/etc/ssl/certs/internal-ca.pem")
+        .expect("failed to read CA bundle");
+    let cert = reqwest::Certificate::from_pem(&pem)
+        .expect("failed to parse CA certificate");
+
+    let client = reqwest::Client::builder()
+        .add_root_certificate(cert)
+        .build()
+        .expect("failed to build HTTP client");
+
+    let options = EvalOptions {
+        client: Some(client),
+        http_rewrites: vec![
+            "https://pkl-lang.org=https://pkl-mirror.internal".to_string(),
+        ],
+    };
+
+    let value = eval_to_json_with_options(Path::new("config.pkl"), options).await?;
+    println!("{}", serde_json::to_string_pretty(&value)?);
+    Ok(())
+}
+```
+
+
+# eval_to_json
+Source: https://www.mintlify.com/jdx/pklr/api/eval-to-json
+
+Evaluate a Pkl file and return its contents as serde_json::Value
+
+Evaluate a `.pkl` file to a `serde_json::Value`. Three variants are available depending on how much control you need over the HTTP client and rewrite rules.
+
+<Tabs>
+  <Tab title="eval_to_json">
+    ## `eval_to_json`
+
+    The primary entry point. Uses a default HTTP client with no rewrites.
+
+    ```rust theme={null}
+    pub async fn eval_to_json(path: &Path) -> Result<serde_json::Value>
+    ```
+
+    ### Parameters
+
+    <ParamField type="&Path">
+      Path to the `.pkl` file to evaluate.
+    </ParamField>
+
+    ### Example
+
+    ```rust theme={null}
+    use std::path::Path;
+    use pklr::eval_to_json;
+
+    #[tokio::main]
+    async fn main() -> pklr::Result<()> {
+        let value = eval_to_json(Path::new("config.pkl")).await?;
+        println!("{}", serde_json::to_string_pretty(&value)?);
+        Ok(())
+    }
+    ```
+  </Tab>
+
+  <Tab title="eval_to_json_with_client">
+    ## `eval_to_json_with_client`
+
+    Accepts a custom `reqwest::Client` for proxy configuration, custom CA certificates, or other transport-level settings. Pass `None` to use the default client.
+
+    ```rust theme={null}
+    pub async fn eval_to_json_with_client(
+        path: &Path,
+        client: Option<reqwest::Client>,
+    ) -> Result<serde_json::Value>
+    ```
+
+    ### Parameters
+
+    <ParamField type="&Path">
+      Path to the `.pkl` file to evaluate.
+    </ParamField>
+
+    <ParamField type="Option<reqwest::Client>">
+      Custom HTTP client. Pass `None` to use the default client.
+    </ParamField>
+
+    ### Example
+
+    ```rust theme={null}
+    use std::path::Path;
+    use pklr::{eval_to_json_with_client, reqwest};
+
+    #[tokio::main]
+    async fn main() -> pklr::Result<()> {
+        let client = reqwest::Client::builder()
+            .danger_accept_invalid_certs(false)
+            .build()
+            .unwrap();
+
+        let value = eval_to_json_with_client(
+            Path::new("config.pkl"),
+            Some(client),
+        ).await?;
+
+        println!("{}", serde_json::to_string_pretty(&value)?);
+        Ok(())
+    }
+    ```
+
+    <Note>
+      `pklr` re-exports `reqwest` so you do not need a separate `reqwest` dependency in your `Cargo.toml`.
+    </Note>
+  </Tab>
+
+  <Tab title="eval_to_json_with_options">
+    ## `eval_to_json_with_options`
+
+    Full configuration via [`EvalOptions`](#evaloptions). Use this when you need both a custom HTTP client and HTTP URL rewrites.
+
+    ```rust theme={null}
+    pub async fn eval_to_json_with_options(
+        path: &Path,
+        options: EvalOptions,
+    ) -> Result<serde_json::Value>
+    ```
+
+    ### Parameters
+
+    <ParamField type="&Path">
+      Path to the `.pkl` file to evaluate.
+    </ParamField>
+
+    <ParamField type="EvalOptions">
+      Configuration struct. See [`EvalOptions`](#evaloptions) below.
+    </ParamField>
+
+    ### Example
+
+    ```rust theme={null}
+    use std::path::Path;
+    use pklr::{eval_to_json_with_options, EvalOptions, reqwest};
+
+    #[tokio::main]
+    async fn main() -> pklr::Result<()> {
+        let client = reqwest::Client::builder()
+            .build()
+            .unwrap();
+
+        let options = EvalOptions {
+            client: Some(client),
+            http_rewrites: vec![
+                "https://pkl.example.com=https://internal.mirror.example.com".to_string(),
+            ],
+        };
+
+        let value = eval_to_json_with_options(Path::new("config.pkl"), options).await?;
+        println!("{}", serde_json::to_string_pretty(&value)?);
+        Ok(())
+    }
+    ```
+  </Tab>
+</Tabs>
+
+***
+
+## EvalOptions
+
+Configuration struct passed to `eval_to_json_with_options`.
+
+```rust theme={null}
+#[derive(Default)]
+pub struct EvalOptions {
+    pub client: Option<reqwest::Client>,
+    pub http_rewrites: Vec<String>,
+}
+```
+
+<ParamField type="Option<reqwest::Client>">
+  Custom HTTP client used for all remote imports. Useful for proxy configuration, custom CA
+  certificates, or timeout settings. Defaults to `None`, which uses the default `reqwest` client.
+</ParamField>
+
+<ParamField type="Vec<String>">
+  HTTP URL rewrite rules in `"source_prefix=target_prefix"` format. Matches the behavior of the
+  `pkl` CLI's `--http-rewrite` flag: the longest matching prefix wins. Useful for redirecting
+  public Pkl module URLs to an internal mirror.
+</ParamField>
+
+### Rewrite rule format
+
+Each entry in `http_rewrites` must be a single string with exactly one `=` separating the source prefix from the target prefix:
+
+```
+https://example.com/modules=https://internal.mirror/modules
+```
+
+A request to `https://example.com/modules/foo.pkl` is rewritten to `https://internal.mirror/modules/foo.pkl`.
+
+<Tip>
+  When multiple rules could match, the longest source prefix wins. This mirrors the behavior of
+  the official `pkl` CLI.
+</Tip>
+
+***
+
+## Complete example
+
+The following shows a realistic setup with a custom HTTP client and URL rewrites:
+
+```rust theme={null}
+use std::path::Path;
+use std::time::Duration;
+use pklr::{eval_to_json_with_options, EvalOptions, reqwest};
+
+#[tokio::main]
+async fn main() -> pklr::Result<()> {
+    // Build a client with a custom timeout and CA bundle
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .expect("failed to build HTTP client");
+
+    let options = EvalOptions {
+        client: Some(client),
+        // Redirect public Pkl stdlib imports to an internal mirror
+        http_rewrites: vec![
+            "https://pkl-lang.org/package-docs=https://mirror.internal/pkl-docs".to_string(),
+            "https://raw.githubusercontent.com/apple/pkl=https://mirror.internal/pkl-github".to_string(),
+        ],
+    };
+
+    let path = Path::new("deploy/production.pkl");
+    let config = eval_to_json_with_options(path, options).await?;
+
+    println!("{}", serde_json::to_string_pretty(&config)?);
+    Ok(())
+}
+```
+
+<Warning>
+  `eval_to_json_with_options` reads the file at `path` synchronously before starting async
+  evaluation. Ensure the path exists and is readable before calling this function.
+</Warning>
+
+
+# Evaluator
+Source: https://www.mintlify.com/jdx/pklr/api/evaluator
+
+Low-level Pkl evaluator with full configuration control
+
+The `Evaluator` struct gives you direct control over every aspect of Pkl evaluation: the base path for local imports, the HTTP client used for remote imports, and URL rewrite rules. The top-level [`eval_to_json`](/api/eval-to-json) functions are convenience wrappers that construct and drive an `Evaluator` internally.
+
+## `Evaluator`
+
+```rust theme={null}
+pub struct Evaluator { /* private fields */ }
+```
+
+Use `Evaluator` directly when you need to reuse a single evaluator across multiple files, inspect the intermediate `Value` before converting to JSON, or apply `output.renderer.converters` transforms manually.
+
+***
+
+## Methods
+
+### `new`
+
+```rust theme={null}
+pub fn new() -> Self
+```
+
+Create a new `Evaluator` with default settings: base path set to `"."`, a default `reqwest::Client`, no HTTP rewrites, and a max import depth of 32.
+
+***
+
+### `set_base_path`
+
+```rust theme={null}
+pub fn set_base_path(&mut self, path: &Path)
+```
+
+Set the directory used to resolve relative imports. When you call [`eval_source`](#eval_source), any `import "relative/path.pkl"` in the source is resolved relative to this path.
+
+<ParamField type="&Path">
+  Directory to use as the base for relative import resolution. Typically the parent of the `.pkl`
+  file being evaluated.
+</ParamField>
+
+<Note>
+  `eval_to_json_with_options` automatically sets the base path to `path.parent()`. If you use
+  `Evaluator` directly, you must call `set_base_path` yourself before evaluating any file that
+  contains relative imports.
+</Note>
+
+***
+
+### `set_http_client`
+
+```rust theme={null}
+pub fn set_http_client(&mut self, client: reqwest::Client)
+```
+
+Replace the default HTTP client with a custom one. Use this to configure proxies, custom CA certificates, connection timeouts, or any other transport-level settings.
+
+<ParamField type="reqwest::Client">
+  A fully configured `reqwest::Client`. The evaluator takes ownership and uses this client for all
+  subsequent `https://` and `http://` import fetches.
+</ParamField>
+
+<Tip>
+  `pklr` re-exports `reqwest`, so you do not need a separate `reqwest` entry in your
+  `Cargo.toml`. Use `pklr::reqwest::Client::builder()` to build a client.
+</Tip>
+
+***
+
+### `set_http_rewrites`
+
+```rust theme={null}
+pub fn set_http_rewrites(&mut self, rules: &[String])
+```
+
+Install HTTP URL rewrite rules. When the evaluator fetches a remote URL, it checks each rule in order and replaces the longest matching source prefix with the corresponding target prefix. This mirrors the `--http-rewrite` flag of the `pkl` CLI.
+
+<ParamField type="&[String]">
+  Slice of rewrite rules. Each rule must be a string in `"source_prefix=target_prefix"` format.
+  Rules with a missing `=` or an empty source prefix are silently ignored with a warning to
+  stderr.
+</ParamField>
+
+Rules with a missing `=` or an empty source prefix are silently skipped with a message to stderr. When multiple rules match a URL, the one with the longest source prefix wins.
+
+***
+
+### `eval_source`
+
+```rust theme={null}
+pub async fn eval_source(&mut self, source: &str, path: &Path) -> Result<Value>
+```
+
+Lex, parse, and evaluate Pkl source text, returning the result as a [`Value`](/api/value).
+
+<ParamField type="&str">
+  The Pkl source text to evaluate.
+</ParamField>
+
+<ParamField type="&Path">
+  The path associated with this source. Used as the file name in error messages and as the key
+  in the import cache to prevent duplicate evaluation.
+</ParamField>
+
+**Returns** `Result<Value>` — the evaluated top-level object.
+
+<Warning>
+  Calling `eval_source` clears any previously registered `output.renderer.converters`. If the
+  evaluated module defines converters, call [`apply_converters`](#apply_converters) after
+  `eval_source` to apply them.
+</Warning>
+
+***
+
+### `apply_converters`
+
+```rust theme={null}
+pub async fn apply_converters(&mut self, value: Value) -> Result<Value>
+```
+
+Walk a `Value` tree and apply any `output.renderer.converters` that were registered during the most recent `eval_source` call. If no converters were defined, the value is returned unchanged.
+
+<ParamField type="Value">
+  The value tree to transform, typically the output of `eval_source`.
+</ParamField>
+
+**Returns** `Result<Value>` — the transformed value tree.
+
+***
+
+## Complete example
+
+The following example evaluates a Pkl file using `Evaluator` directly, applies any converters defined in the module, then converts the result to JSON.
+
+```rust theme={null}
+use std::path::Path;
+use std::time::Duration;
+use pklr::{Evaluator, reqwest};
+
+#[tokio::main]
+async fn main() -> pklr::Result<()> {
+    let path = Path::new("config/app.pkl");
+    let source = std::fs::read_to_string(path)
+        .map_err(|e| pklr::Error::Io(path.to_path_buf(), e))?;
+
+    // Build a client with a 10-second timeout
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("failed to build HTTP client");
+
+    let mut evaluator = Evaluator::new();
+    evaluator.set_base_path(path.parent().unwrap_or(Path::new(".")));
+    evaluator.set_http_client(client);
+    evaluator.set_http_rewrites(&[
+        "https://pkl-lang.org=https://mirror.internal/pkl".to_string(),
+    ]);
+
+    // Evaluate source → Value
+    let value = evaluator.eval_source(&source, path).await?;
+
+    // Apply output.renderer.converters if present
+    let value = evaluator.apply_converters(value).await?;
+
+    // Convert to serde_json::Value
+    let json = value.to_json();
+    println!("{}", serde_json::to_string_pretty(&json)?);
+
+    Ok(())
+}
+```
+
+
+# Value
+Source: https://www.mintlify.com/jdx/pklr/api/value
+
+The pklr runtime value type
+
+`Value` is the runtime representation of any Pkl value produced by evaluation. It maps directly onto Pkl's type system and can be converted to `serde_json::Value` via [`to_json`](#to_json).
+
+## `Value`
+
+```rust theme={null}
+#[derive(Debug, Clone, PartialEq, Default)]
+pub enum Value {
+    #[default]
+    Null,
+    Bool(bool),
+    Int(i64),
+    Float(f64),
+    String(String),
+    Object(IndexMap<String, Value>, Option<Arc<ObjectSource>>),
+    List(Vec<Value>),
+    Lambda(Vec<String>, Expr, IndexMap<String, Value>),
+}
+```
+
+***
+
+## Variants
+
+<AccordionGroup>
+  <Accordion title="Value::Null">
+    Represents Pkl's `null`. The default variant.
+
+    ```rust theme={null}
+    let v = Value::Null;
+    assert_eq!(v.to_json(), serde_json::Value::Null);
+    ```
+  </Accordion>
+
+  <Accordion title="Value::Bool(bool)">
+    A boolean value.
+
+    ```rust theme={null}
+    let v = Value::Bool(true);
+    assert_eq!(v.to_json(), serde_json::json!(true));
+    ```
+  </Accordion>
+
+  <Accordion title="Value::Int(i64)">
+    A 64-bit signed integer. Pkl integers that fit in `i64` are represented here.
+
+    ```rust theme={null}
+    let v = Value::Int(42);
+    assert_eq!(v.to_json(), serde_json::json!(42));
+    ```
+  </Accordion>
+
+  <Accordion title="Value::Float(f64)">
+    A 64-bit floating-point number.
+
+    <Warning>
+      `NaN` and `Infinity` are not representable in JSON. Both serialize to `null` via
+      `to_json`, because `serde_json` maps non-finite floats to `null`.
+    </Warning>
+
+    ```rust theme={null}
+    let v = Value::Float(3.14);
+    assert_eq!(v.to_json(), serde_json::json!(3.14));
+    ```
+  </Accordion>
+
+  <Accordion title="Value::String(String)">
+    A UTF-8 string.
+
+    ```rust theme={null}
+    let v = Value::String("hello".to_string());
+    assert_eq!(v.as_str(), Some("hello"));
+    ```
+  </Accordion>
+
+  <Accordion title="Value::Object(IndexMap<String, Value>, Option<Arc<ObjectSource>>)">
+    An ordered string-keyed map. Represents both Pkl objects and string-keyed Mappings. Key
+    insertion order is preserved via `IndexMap`.
+
+    The second field, `Option<Arc<ObjectSource>>`, stores the original AST entries and scope
+    needed for late-binding amendment. It is `None` for objects created from `serde_json::Value`
+    or after merging.
+
+    ```rust theme={null}
+    use indexmap::IndexMap;
+
+    let mut map = IndexMap::new();
+    map.insert("host".to_string(), Value::String("localhost".to_string()));
+    map.insert("port".to_string(), Value::Int(5432));
+
+    let v = Value::Object(map, None);
+    ```
+  </Accordion>
+
+  <Accordion title="Value::List(Vec<Value>)">
+    An ordered list of values. Represents Pkl `Listing` values.
+
+    ```rust theme={null}
+    let v = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
+    assert_eq!(v.to_json(), serde_json::json!([1, 2, 3]));
+    ```
+  </Accordion>
+
+  <Accordion title="Value::Lambda(...)">
+    A first-class function value: captured parameter names, body expression, and lexical scope.
+    Lambdas are not directly representable in JSON.
+
+    <Note>
+      `Lambda` serializes as the string `"<lambda>"` when `to_json` is called. You will not
+      normally encounter this variant unless you inspect `output.renderer.converters` entries
+      before they are applied.
+    </Note>
+  </Accordion>
+</AccordionGroup>
+
+***
+
+## Methods
+
+### `to_json`
+
+```rust theme={null}
+pub fn to_json(&self) -> serde_json::Value
+```
+
+Recursively convert this `Value` to a `serde_json::Value`.
+
+| `Value` variant  | JSON output                        |
+| ---------------- | ---------------------------------- |
+| `Null`           | `null`                             |
+| `Bool(b)`        | `true` / `false`                   |
+| `Int(n)`         | number                             |
+| `Float(f)`       | number (`NaN`/`Infinity` → `null`) |
+| `String(s)`      | string                             |
+| `Object(map, _)` | object (key order preserved)       |
+| `List(items)`    | array                              |
+| `Lambda(..)`     | `"<lambda>"`                       |
+
+***
+
+### `as_str`
+
+```rust theme={null}
+pub fn as_str(&self) -> Option<&str>
+```
+
+Return the inner string slice if the value is `Value::String`, otherwise `None`.
+
+```rust theme={null}
+let v = Value::String("world".to_string());
+assert_eq!(v.as_str(), Some("world"));
+
+let n = Value::Int(1);
+assert_eq!(n.as_str(), None);
+```
+
+***
+
+### `as_object_mut`
+
+```rust theme={null}
+pub fn as_object_mut(&mut self) -> Option<&mut IndexMap<String, Value>>
+```
+
+Return a mutable reference to the inner map if the value is `Value::Object`, otherwise `None`. Use this to add, remove, or update keys on an object in place.
+
+```rust theme={null}
+let mut v = Value::Object(indexmap::IndexMap::new(), None);
+if let Some(map) = v.as_object_mut() {
+    map.insert("injected".to_string(), Value::Bool(true));
+}
+```
+
+***
+
+### `merge`
+
+```rust theme={null}
+pub fn merge(&mut self, other: Value)
+```
+
+Merge `other` into `self`. For two `Object` values, keys from `other` are inserted into `self`, overwriting any existing keys with the same name. For all other combinations, `self` is replaced entirely by `other`.
+
+<ParamField type="Value">
+  The value to merge in. For objects, its keys win over existing keys in `self`.
+</ParamField>
+
+```rust theme={null}
+let mut base = Value::from(serde_json::json!({ "a": 1, "b": 2 }));
+let overlay = Value::from(serde_json::json!({ "b": 99, "c": 3 }));
+base.merge(overlay);
+// base is now { "a": 1, "b": 99, "c": 3 }
+```
+
+***
+
+## `From<serde_json::Value>`
+
+`Value` implements `From<serde_json::Value>`, so you can convert JSON values into the pklr
+runtime representation:
+
+```rust theme={null}
+impl From<serde_json::Value> for Value
+```
+
+| `serde_json::Value` | `Value`              |
+| ------------------- | -------------------- |
+| `Null`              | `Value::Null`        |
+| `Bool(b)`           | `Value::Bool(b)`     |
+| `Number` (integer)  | `Value::Int(i64)`    |
+| `Number` (other)    | `Value::Float(f64)`  |
+| `String(s)`         | `Value::String(s)`   |
+| `Array(a)`          | `Value::List(...)`   |
+| `Object(o)`         | `Value::Object(...)` |
+
+***
+
+## Pattern matching example
+
+Match on `Value` before converting to JSON to handle specific cases:
+
+```rust theme={null}
+use pklr::Value;
+
+fn describe(value: &Value) -> String {
+    match value {
+        Value::Null => "null".to_string(),
+        Value::Bool(b) => format!("bool: {b}"),
+        Value::Int(n) => format!("int: {n}"),
+        Value::Float(f) => format!("float: {f}"),
+        Value::String(s) => format!("string: {s:?}"),
+        Value::Object(map, _) => format!("object with {} keys", map.len()),
+        Value::List(items) => format!("list of {} items", items.len()),
+        Value::Lambda(..) => "<lambda>".to_string(),
+    }
+}
+
+// Convert to JSON only after inspecting the value
+let json = value.to_json();
+println!("{}", serde_json::to_string_pretty(&json)?);
+```
+
+
+# Error handling
+Source: https://www.mintlify.com/jdx/pklr/guides/error-handling
+
+Understanding and handling pklr errors
+
+All fallible pklr functions return `pklr::Result<T>`, a type alias for `std::result::Result<T, pklr::Error>`. The `Error` enum has one variant per failure category, each carrying enough context to diagnose the problem.
+
+## The `pklr::Result` type alias
+
+```rust theme={null}
+pub type Result<T> = std::result::Result<T, Error>;
+```
+
+Use `?` to propagate errors up the call stack, or match on the variant when you need to handle specific cases:
+
+```rust theme={null}
+async fn load_config(path: &Path) -> pklr::Result<serde_json::Value> {
+    let json = pklr::eval_to_json(path).await?;
+    Ok(json)
+}
+```
+
+## Error variants
+
+```rust theme={null}
+pub enum Error {
+    Io(PathBuf, std::io::Error),
+    Lex    { src: NamedSource<String>, span: SourceOffset, message: String },
+    Parse  { src: NamedSource<String>, span: SourceOffset, message: String },
+    Eval(String),
+    ImportNotFound(String),
+    Unsupported(String),
+}
+```
+
+<Accordion title="Error::Io — file read failures">
+  Returned when pklr cannot read a file from disk. The first field is the path that was attempted; the second is the underlying `std::io::Error`.
+
+  ```rust theme={null}
+  pklr::Error::Io(PathBuf, std::io::Error)
+  ```
+
+  Common causes: the file does not exist, the process lacks read permission, or the path is a directory.
+</Accordion>
+
+<Accordion title="Error::Lex — tokenization errors">
+  Returned when the Pkl source contains a character sequence that the lexer cannot tokenize — for example, an unclosed string literal or an invalid numeric literal.
+
+  ```rust theme={null}
+  pklr::Error::Lex { src, span, message }
+  ```
+
+  `src` is a `miette::NamedSource` containing the full source text and file name. `span` points to the byte offset of the problematic token. `message` describes the error in plain text.
+</Accordion>
+
+<Accordion title="Error::Parse — parsing errors">
+  Returned when the token stream is syntactically invalid — for example, a missing closing brace or an unexpected keyword.
+
+  ```rust theme={null}
+  pklr::Error::Parse { src, span, message }
+  ```
+
+  The fields are identical in shape to `Lex` and carry the same diagnostic context.
+</Accordion>
+
+<Accordion title="Error::Eval — evaluation errors">
+  Returned for runtime failures: type mismatches, division by zero, circular references that exceed the maximum import depth (32), failed HTTP requests, and similar conditions.
+
+  ```rust theme={null}
+  pklr::Error::Eval(String)
+  ```
+
+  The string contains a human-readable description of what went wrong.
+</Accordion>
+
+<Accordion title="Error::ImportNotFound — import resolution failures">
+  Returned when a local `import` or `amends` URI refers to a file that does not exist on disk.
+
+  ```rust theme={null}
+  pklr::Error::ImportNotFound(String)
+  ```
+
+  The string is the resolved absolute or relative path that was not found.
+</Accordion>
+
+<Accordion title="Error::Unsupported — unimplemented Pkl features">
+  Returned when the source uses a Pkl feature that pklr does not yet implement.
+
+  ```rust theme={null}
+  pklr::Error::Unsupported(String)
+  ```
+
+  The string names the unsupported feature.
+</Accordion>
+
+## Pattern matching on errors
+
+Match exhaustively to handle each variant:
+
+```rust theme={null}
+use pklr::Error;
+use std::path::Path;
+
+async fn evaluate(path: &Path) {
+    match pklr::eval_to_json(path).await {
+        Ok(json) => {
+            println!("{}", serde_json::to_string_pretty(&json).unwrap());
+        }
+        Err(Error::Io(path, e)) => {
+            eprintln!("could not read {}: {e}", path.display());
+        }
+        Err(Error::Lex { message, .. }) => {
+            eprintln!("tokenization error: {message}");
+        }
+        Err(Error::Parse { message, .. }) => {
+            eprintln!("parse error: {message}");
+        }
+        Err(Error::Eval(msg)) => {
+            eprintln!("evaluation error: {msg}");
+        }
+        Err(Error::ImportNotFound(uri)) => {
+            eprintln!("import not found: {uri}");
+        }
+        Err(Error::Unsupported(feature)) => {
+            eprintln!("unsupported feature: {feature}");
+        }
+    }
+}
+```
+
+## Handling missing files gracefully
+
+Check for `Error::Io` or `Error::ImportNotFound` when the file might not exist and a default is acceptable:
+
+```rust theme={null}
+use pklr::Error;
+use std::path::Path;
+
+async fn load_optional_config(path: &Path) -> pklr::Result<serde_json::Value> {
+    match pklr::eval_to_json(path).await {
+        Ok(json) => Ok(json),
+        Err(Error::Io(_, ref e)) if e.kind() == std::io::ErrorKind::NotFound => {
+            // File is absent — return an empty object as the default.
+            Ok(serde_json::Value::Object(Default::default()))
+        }
+        Err(e) => Err(e),
+    }
+}
+```
+
+## Pretty diagnostic output with miette
+
+`Error::Lex` and `Error::Parse` implement `miette::Diagnostic`. Printing them with the `{:?}` format activates miette's source-context rendering, which shows the relevant source snippet with a caret pointing at the error location:
+
+```rust theme={null}
+match pklr::eval_to_json(Path::new("config.pkl")).await {
+    Ok(json) => println!("{json}"),
+    Err(e)   => eprintln!("{e:?}"),  // miette pretty-print with source context
+}
+```
+
+Use `{}` (the `Display` format) for a single-line message without source context:
+
+```rust theme={null}
+Err(e) => eprintln!("pklr error: {e}"),
+```
+
+<Tip>
+  In binaries that use `miette`'s `fancy` feature, set the panic/error hook with `miette::set_hook` to get rich terminal output automatically for all reported errors.
+</Tip>
+
+## Propagating errors with `?`
+
+`pklr::Result` is a standard `std::result::Result`, so `?` works anywhere the enclosing function returns a compatible result type:
+
+```rust theme={null}
+use std::path::Path;
+
+async fn run() -> pklr::Result<()> {
+    let json = pklr::eval_to_json(Path::new("hk.pkl")).await?;
+    let branch = json["default_branch"]
+        .as_str()
+        .unwrap_or("main");
+    println!("branch: {branch}");
+    Ok(())
+}
+```
+
+To convert `pklr::Error` into `Box<dyn std::error::Error>` or `anyhow::Error`, pklr's `Error` type implements `std::error::Error`, so both conversions work with standard `From`/`Into` machinery.
+
+
+# Evaluating Pkl files
+Source: https://www.mintlify.com/jdx/pklr/guides/evaluating-files
+
+How to load and evaluate .pkl configuration files
+
+The primary output of pklr is a `serde_json::Value` produced by evaluating a `.pkl` source file. There are several entry points depending on how much control you need.
+
+## Simple path evaluation
+
+`eval_to_json` is the one-call entry point. Pass a `&Path` and get back a `serde_json::Value`:
+
+```rust theme={null}
+use pklr::eval_to_json;
+use std::path::Path;
+
+#[tokio::main]
+async fn main() -> pklr::Result<()> {
+    let json = eval_to_json(Path::new("config.pkl")).await?;
+    println!("{}", json);
+    Ok(())
+}
+```
+
+The function reads the file, resolves all imports relative to its parent directory, evaluates every expression, and returns the top-level object as JSON.
+
+### Accessing values
+
+`serde_json::Value` supports indexing by string key and by integer position:
+
+```rust theme={null}
+let json = eval_to_json(Path::new("config.pkl")).await?;
+
+// String field
+let host = json["host"].as_str().unwrap_or("localhost");
+
+// Nested object
+let db_url = json["database"]["url"].as_str().unwrap_or("");
+
+// List element
+let first_tag = json["tags"][0].as_str().unwrap_or("");
+
+// Numeric field
+let port = json["port"].as_u64().unwrap_or(8080);
+```
+
+When a key is missing, `serde_json::Value` returns `Value::Null` rather than panicking.
+
+## Using `Evaluator` directly
+
+For more control — setting a custom base path, reusing connection state across multiple files, or post-processing values before serializing to JSON — construct an `Evaluator` directly:
+
+```rust theme={null}
+use pklr::Evaluator;
+use std::path::Path;
+
+#[tokio::main]
+async fn main() -> pklr::Result<()> {
+    let mut evaluator = Evaluator::new();
+
+    // All relative imports in the source resolve against this directory.
+    evaluator.set_base_path(Path::new("/etc/myapp"));
+
+    let source = std::fs::read_to_string("config.pkl")?;
+    let value = evaluator.eval_source(&source, Path::new("config.pkl")).await?;
+
+    // value is pklr::Value — convert to serde_json::Value when ready.
+    let json = value.to_json();
+    println!("{}", json);
+
+    Ok(())
+}
+```
+
+### `set_base_path`
+
+`set_base_path` controls the directory used to resolve relative `import` and `amends` URIs. If you call `eval_to_json`, the base path is set automatically to the parent directory of the file you pass in. When calling `eval_source` manually, set it yourself so imports resolve correctly.
+
+```rust theme={null}
+// Resolve imports relative to /etc/myapp even if the source string
+// was read from elsewhere.
+evaluator.set_base_path(Path::new("/etc/myapp"));
+```
+
+## The `Value` enum
+
+`eval_source` returns `pklr::Value`, not `serde_json::Value`. `Value` is an enum with one variant per Pkl type:
+
+```rust theme={null}
+pub enum Value {
+    Null,
+    Bool(bool),
+    Int(i64),
+    Float(f64),
+    String(String),
+    Object(IndexMap<String, Value>, Option<Arc<ObjectSource>>),
+    List(Vec<Value>),
+    Lambda(Vec<String>, Expr, IndexMap<String, Value>),
+}
+```
+
+You can inspect the intermediate `Value` before converting:
+
+```rust theme={null}
+use pklr::{Value, Evaluator};
+use std::path::Path;
+
+async fn print_keys(path: &Path) -> pklr::Result<()> {
+    let source = std::fs::read_to_string(path)?;
+    let mut evaluator = Evaluator::new();
+    evaluator.set_base_path(path.parent().unwrap_or(Path::new(".")));
+
+    let value = evaluator.eval_source(&source, path).await?;
+
+    if let Value::Object(map, _) = &value {
+        for key in map.keys() {
+            println!("{key}");
+        }
+    }
+
+    Ok(())
+}
+```
+
+`Object` preserves insertion order via `IndexMap`, matching the order properties appear in the `.pkl` source.
+
+## Two-step: `eval_source` then `to_json`
+
+`eval_to_json` is implemented as a three-step pipeline you can replicate manually when you need an intermediate step:
+
+```rust theme={null}
+use pklr::Evaluator;
+use std::path::Path;
+
+#[tokio::main]
+async fn main() -> pklr::Result<()> {
+    let path = Path::new("config.pkl");
+    let source = std::fs::read_to_string(path)
+        .map_err(|e| pklr::Error::Io(path.to_path_buf(), e))?;
+
+    let mut evaluator = Evaluator::new();
+    evaluator.set_base_path(path.parent().unwrap_or(Path::new(".")));
+
+    // Step 1 — parse and evaluate to pklr::Value
+    let value = evaluator.eval_source(&source, path).await?;
+
+    // Step 2 — apply output.renderer.converters declared in the Pkl source
+    let value = evaluator.apply_converters(value).await?;
+
+    // Step 3 — serialize to serde_json::Value
+    let json = value.to_json();
+
+    println!("{}", serde_json::to_string_pretty(&json)?);
+    Ok(())
+}
+```
+
+## `apply_converters`
+
+`apply_converters` runs any converter lambdas declared in the Pkl source under `output.renderer.converters`. Converters map a Pkl class name to a transformation function, allowing type-specific post-processing before the value is serialized.
+
+<Note>
+  `eval_to_json` and `eval_to_json_with_options` call `apply_converters` for you. You only need to call it manually when using `eval_source` directly and the Pkl file may declare converters.
+</Note>
+
+```rust theme={null}
+// After eval_source, before to_json:
+let value = evaluator.apply_converters(value).await?;
+let json = value.to_json();
+```
+
+If no converters are declared in the source, `apply_converters` is a no-op and returns the value unchanged.
+
+## Complete example
+
+The following mirrors what the integration tests do — evaluate a source string with `amends`, local variables, and a nested object:
+
+```rust theme={null}
+use pklr::Evaluator;
+use std::path::Path;
+
+#[tokio::main]
+async fn main() -> pklr::Result<()> {
+    let mut ev = Evaluator::new();
+    let path = Path::new("hk.pkl");
+    let val = ev.eval_source(src, path).await?;
+    let json = val.to_json();
+
+    assert_eq!(json["default_branch"], "hello");
+    assert_eq!(json["hooks"]["pre-commit"]["fix"], true);
+    assert_eq!(json["warnings"][0], "missing-profiles");
+
+    Ok(())
+}
+```
+
+
+# HTTP and remote imports
+Source: https://www.mintlify.com/jdx/pklr/guides/http-remote-imports
+
+Fetching remote Pkl modules via HTTP, HTTPS, and package:// URIs
+
+pklr fetches remote Pkl modules over HTTP and HTTPS and resolves versioned release packages via `package://` URIs — no separate Pkl CLI binary required.
+
+## HTTP and HTTPS imports
+
+Any `import` or `amends` URI starting with `http://` or `https://` is fetched at evaluation time:
+
+```pkl theme={null}
+import "https://example.com/shared/config.pkl"
+```
+
+pklr sends a GET request, parses the response body as Pkl source, and evaluates it in the same way as a local file. The result is bound to the import alias (or the file stem of the URL if no `as` clause is given).
+
+## Package imports
+
+`package://` URIs reference a specific file inside a versioned release archive. The format is:
+
+```
+package://<host>/<owner>/<repo>/releases/download/<tag>/<name>@<version>#/<path>
+```
+
+For example, the integration tests use:
+
+```pkl theme={null}
+amends "pkg://github.com/jdx/hk/releases/download/v1.0.0/hk@1.0.0#/Config.pkl"
+```
+
+### How packages work
+
+When pklr encounters a `package://` URI it:
+
+<Steps>
+  <Step title="Derives the zip URL">
+    Constructs the download URL for the release zip from the URI. For GitHub releases this is the `.zip` asset attached to the tag.
+  </Step>
+
+  <Step title="Downloads and extracts the zip">
+    Fetches the zip archive via HTTP, extracts it to a temporary directory, and caches the extracted path keyed by zip URL. Subsequent imports from the same package reuse the already-extracted directory.
+  </Step>
+
+  <Step title="Evaluates the fragment path">
+    The fragment (`#/Config.pkl`) identifies the file inside the zip to evaluate. pklr reads that file from the temp directory and evaluates it as a local file.
+  </Step>
+</Steps>
+
+<Note>
+  Package extraction is per-`Evaluator` instance. Each new evaluator downloads and extracts packages fresh. Reuse an `Evaluator` across multiple evaluations to benefit from the extraction cache.
+</Note>
+
+## Using a custom HTTP client
+
+By default pklr creates a `reqwest::Client` with default settings. Pass a custom client to control proxy settings, CA certificates, timeouts, and connection pool behavior.
+
+pklr re-exports `reqwest` so you can build a client without adding it as a direct dependency:
+
+```rust theme={null}
+use pklr::{eval_to_json_with_client, reqwest};
+use std::path::Path;
+
+#[tokio::main]
+async fn main() -> pklr::Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap();
+
+    let json = eval_to_json_with_client(Path::new("config.pkl"), Some(client)).await?;
+    println!("{}", json);
+    Ok(())
+}
+```
+
+For proxy or custom CA certificate configuration, build the client with `reqwest::ClientBuilder` using `rustls-tls`:
+
+```toml Cargo.toml theme={null}
+[dependencies]
+pklr  = "0.4"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+```
+
+```rust theme={null}
+use pklr::{eval_to_json_with_options, EvalOptions, reqwest};
+use std::path::Path;
+
+#[tokio::main]
+async fn main() -> pklr::Result<()> {
+    let cert_pem = std::fs::read("internal-ca.pem")?;
+    let cert = reqwest::Certificate::from_pem(&cert_pem).unwrap();
+
+    let client = reqwest::Client::builder()
+        .add_root_certificate(cert)
+        .https_only(true)
+        .build()
+        .unwrap();
+
+    let options = EvalOptions {
+        client: Some(client),
+        ..Default::default()
+    };
+
+    let json = eval_to_json_with_options(Path::new("config.pkl"), options).await?;
+    println!("{}", json);
+    Ok(())
+}
+```
+
+### Setting the client on `Evaluator`
+
+When using `Evaluator` directly, call `set_http_client`:
+
+```rust theme={null}
+use pklr::{Evaluator, reqwest};
+use std::path::Path;
+
+let client = reqwest::Client::builder()
+    .timeout(std::time::Duration::from_secs(10))
+    .build()
+    .unwrap();
+
+let mut ev = Evaluator::new();
+ev.set_http_client(client);
+ev.set_base_path(Path::new("."));
+
+let source = std::fs::read_to_string("config.pkl")?;
+let value = ev.eval_source(&source, Path::new("config.pkl")).await?;
+```
+
+## HTTP URL rewrite rules
+
+Rewrite rules redirect HTTP requests from one URL prefix to another. The primary use case is routing package downloads through an internal mirror so builds work in air-gapped or proxy-restricted environments.
+
+### Rule format
+
+Each rule is a `"source_prefix=target_prefix"` string, matching the format of the Pkl CLI's `--http-rewrite` flag:
+
+```
+https://github.com/=https://mirror.internal.example.com/github/
+```
+
+When pklr fetches a URL that starts with `source_prefix`, the prefix is replaced with `target_prefix`. If multiple rules match, the **longest matching prefix wins**.
+
+### Setting rewrites via `EvalOptions`
+
+```rust theme={null}
+use pklr::{eval_to_json_with_options, EvalOptions};
+use std::path::Path;
+
+#[tokio::main]
+async fn main() -> pklr::Result<()> {
+    let options = EvalOptions {
+        http_rewrites: vec![
+            // Route all GitHub downloads to an internal mirror.
+            "https://github.com/=https://mirror.internal.example.com/github/".to_string(),
+            // A more specific rule for a particular org takes precedence.
+            "https://github.com/jdx/=https://artifacts.internal.example.com/jdx/".to_string(),
+        ],
+        ..Default::default()
+    };
+
+    // package:// imports in config.pkl will be fetched from the internal mirror.
+    let json = eval_to_json_with_options(Path::new("config.pkl"), options).await?;
+    println!("{}", json);
+    Ok(())
+}
+```
+
+### Setting rewrites on `Evaluator`
+
+```rust theme={null}
+use pklr::eval::Evaluator;
+use std::path::Path;
+
+let mut ev = Evaluator::new();
+ev.set_http_rewrites(&[
+    "https://github.com/=https://mirror.internal.example.com/github/".to_string(),
+]);
+```
+
+<Warning>
+  Malformed rules (missing `=`) and rules with an empty source prefix are logged to stderr and ignored. A rule like `"=https://mirror.example.com"` has an empty source prefix and will be discarded.
+</Warning>
+
+## HTTP caching
+
+Each `Evaluator` instance maintains an in-memory cache of fetched HTTP sources, keyed by the (possibly rewritten) URL. Within a single evaluation, the same URL is never fetched twice. This cache covers both plain HTTP imports and the package zip downloads.
+
+The cache is not shared across `Evaluator` instances. Create a single `Evaluator` and reuse it across multiple `eval_source` calls to maximize cache hits when evaluating several files that share remote dependencies.
+
+
+# Imports and amends
+Source: https://www.mintlify.com/jdx/pklr/guides/imports-and-amends
+
+Resolving imports, amends, and extends in Pkl files
+
+Pkl files can pull in other modules using `import`, `amends`, and `extends`. pklr resolves all three automatically during evaluation.
+
+## How `import` works
+
+An `import` statement binds a module to a name in the current scope. After evaluation the bound name holds the imported module's top-level object as a `pklr::Value`:
+
+```pkl imports.pkl theme={null}
+import "pkl/Builtins.pkl"
+import "shared/steps.pkl" as SharedSteps
+```
+
+pklr binds `Builtins` to the value of `pkl/Builtins.pkl` and `SharedSteps` to the value of `shared/steps.pkl`. The binding name is either the explicit alias (the `as` clause) or the file stem of the imported path.
+
+### Local file imports
+
+Relative paths resolve against the evaluator's base path. The base path is set automatically by `eval_to_json` (parent of the file you pass) and can be set manually with `set_base_path` when using `Evaluator` directly:
+
+```pkl theme={null}
+// hk.pkl — both imports resolve relative to the directory that contains hk.pkl
+import "pkl/Builtins.pkl"
+import "shared/lint-steps.pkl"
+```
+
+```rust theme={null}
+use pklr::Evaluator;
+use std::path::Path;
+
+let mut ev = Evaluator::new();
+ev.set_base_path(Path::new("/home/user/project"));
+
+let source = std::fs::read_to_string("hk.pkl")?;
+let value = ev.eval_source(&source, Path::new("hk.pkl")).await?;
+```
+
+If the imported file does not exist on disk, pklr returns `Error::ImportNotFound`.
+
+### Glob imports
+
+The `import*` syntax imports every file that matches a pattern and binds them as an object keyed by relative path:
+
+```pkl theme={null}
+import* "steps/*.pkl" as AllSteps
+```
+
+pklr expands the glob against the base path and evaluates each matching file. Each entry in `AllSteps` is keyed by the relative path of the matched file (e.g., `"steps/lint.pkl"`).
+
+<Note>
+  Glob patterns using the `://` scheme (HTTP, package) bind an empty mapping — only local file globs are expanded.
+</Note>
+
+## How `amends` works
+
+`amends` loads a base module and merges the current module's properties on top of it. The result is a single object containing all properties from the base, overridden by any properties declared in the amending file:
+
+```pkl config.pkl theme={null}
+amends "base/Config.pkl"
+
+// Override a single field — all other fields come from base/Config.pkl.
+fail_fast = false
+```
+
+`amends` also injects the class definitions from the base module into the current scope, so you can instantiate types like `Step` or `Group` declared in the base:
+
+```pkl hk.pkl theme={null}
+amends "pkl/Config.pkl"
+import "pkl/Builtins.pkl"
+
+local linters = new Mapping<String, Step | Group> {
+    ["dbg"] = new Step {
+        glob = "**/*.rs"
+        check = "! rg -e 'dbg!' {{files}}"
+    }
+}
+```
+
+Here `Step` is defined in `pkl/Config.pkl` and is available because `hk.pkl` amends it.
+
+### `amends` with package URIs
+
+`amends` accepts the same URI schemes as `import` including `package://`:
+
+```pkl theme={null}
+// amends a module from a versioned GitHub release package
+amends "package://github.com/jdx/hk/releases/download/v1.39.0/hk@1.39.0#/Config.pkl"
+```
+
+pklr downloads the release zip, extracts it to a temporary directory, and evaluates the specified entry file as the base module.
+
+## How `extends` works
+
+`extends` is similar to `amends` but is used on class bodies rather than modules. When pklr encounters an `extends` clause it loads the named class as the prototype and merges the current class definition on top of it.
+
+## The `analyze_imports` function
+
+`analyze_imports` extracts all transitive local file dependencies from a Pkl file without evaluating it. This is useful for build systems and watch tools that need to know which files to invalidate when a dependency changes:
+
+```rust theme={null}
+use pklr::analyze_imports;
+use std::path::Path;
+
+fn main() -> pklr::Result<()> {
+    let deps = analyze_imports(Path::new("hk.pkl"))?;
+    for dep in deps {
+        println!("{}", dep.display());
+    }
+    Ok(())
+}
+```
+
+`analyze_imports` uses the lexer and the fast `collect_imports` parser pass — it does not evaluate any expressions. It expands glob patterns to real files on disk and returns the results as `Vec<PathBuf>`.
+
+<Note>
+  `analyze_imports` only returns **local file** dependencies. HTTP, package, and `pkl:` standard-library imports are skipped.
+</Note>
+
+The underlying `collect_imports` function is also available directly from the parser if you already have tokens:
+
+```rust theme={null}
+use pklr::lexer::lex;
+use pklr::parser::collect_imports;
+
+let src = r#"
+amends "pkl/Config.pkl"
+import "pkl/Builtins.pkl"
+"#;
+
+let tokens = lex(src)?;
+let imports = collect_imports(&tokens);
+// imports == ["pkl/Config.pkl", "pkl/Builtins.pkl"]
+```
+
+`collect_imports` includes both `import` and `amends` URIs.
+
+## Import caching
+
+Each `Evaluator` instance keeps an in-memory cache of evaluated files keyed by canonical path. When the same file is imported from multiple places in the graph, it is evaluated exactly once:
+
+```
+hk.pkl
+  imports pkl/Builtins.pkl   ← evaluated, cached
+  imports shared/steps.pkl   ← evaluated, cached
+    imports pkl/Builtins.pkl ← cache hit, no re-evaluation
+```
+
+Before a file begins evaluating, pklr inserts an empty-object placeholder into the cache. If a circular import is encountered, the placeholder is returned instead of looping infinitely. The placeholder is replaced with the real value once evaluation completes.
+
+## Real-world example: the hk.pkl fixture
+
+The project's own `hk.pkl` config demonstrates `amends`, `import`, spread (`...`), and local variables together:
+
+```pkl tests/fixtures/hk.pkl theme={null}
+// amends "package://github.com/jdx/hk/releases/download/v1.39.0/hk@1.39.0#/Config.pkl"
+amends "pkl/Config.pkl"
+import "pkl/Builtins.pkl"
+
+local linters = new Mapping<String, Step | Group> {
+    ["actionlint"] = Builtins.actionlint
+    ["cargo-fmt"]  = Builtins.cargo_fmt
+    ["dbg"] = new Step {
+        glob  = "**/*.rs"
+        check = "! rg -e 'dbg!' {{files}}"
+    }
+}
+
+hooks = new {
+    ["pre-commit"] {
+        fix   = true
+        stash = "git"
+        steps = new {
+            ["prelint"] {
+                check     = "mise run prelint"
+                exclusive = true
+            }
+            ...linters
+        }
+    }
+    ["pre-push"] {
+        steps = linters
+    }
+}
+
+warnings = List("missing-profiles")
+```
+
+The `...linters` spread inlines all entries from the `linters` mapping into the `steps` object.
+
+
+# Installation
+Source: https://www.mintlify.com/jdx/pklr/installation
+
+Add pklr to your Rust project
+
+## Add to Cargo.toml
+
+Add pklr and Tokio to your `[dependencies]`:
+
+```toml Cargo.toml theme={null}
+[dependencies]
+pklr  = "0.4"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+```
+
+If you only need the single-threaded Tokio runtime, `rt` is sufficient instead of `rt-multi-thread`. The `macros` feature enables `#[tokio::main]`.
+
+<Note>
+  The current release is **0.4.0**. Check [crates.io/crates/pklr](https://crates.io/crates/pklr) for the latest version.
+</Note>
+
+## MSRV
+
+pklr requires **Rust 1.88** or later. To enforce this in your own project, set `rust-version` in your `Cargo.toml`:
+
+```toml Cargo.toml theme={null}
+[package]
+name         = "my-app"
+version      = "0.1.0"
+edition      = "2024"
+rust-version = "1.88"
+```
+
+## Runtime requirement
+
+All public evaluation functions in pklr are `async`. You must run them inside a Tokio runtime. The simplest setup is the `#[tokio::main]` macro:
+
+```rust src/main.rs theme={null}
+#[tokio::main]
+async fn main() -> pklr::Result<()> {
+    let json = pklr::eval_to_json(std::path::Path::new("config.pkl")).await?;
+    println!("{}", json);
+    Ok(())
+}
+```
+
+If you are calling pklr from a synchronous context, create a runtime manually:
+
+```rust theme={null}
+let rt  = tokio::runtime::Runtime::new().unwrap();
+let json = rt.block_on(pklr::eval_to_json(std::path::Path::new("config.pkl")))?;
+```
+
+## Dependencies
+
+pklr brings in the following crates:
+
+| Crate             | Purpose                                            |
+| ----------------- | -------------------------------------------------- |
+| `indexmap`        | Ordered map for preserving Pkl object key order    |
+| `miette`          | Rich error diagnostics with source context         |
+| `serde_json`      | JSON output type (`serde_json::Value`)             |
+| `thiserror`       | Error type derive macros                           |
+| `async-recursion` | Recursive async evaluation support                 |
+| `reqwest`         | HTTP/HTTPS and `package://` remote import fetching |
+| `tokio`           | Async runtime                                      |
+| `zip`             | Extracting Pkl package archives                    |
+
+### reqwest re-export
+
+pklr re-exports `reqwest` as `pklr::reqwest`. If you need to build a custom HTTP client (for proxy settings, CA certificates, or timeouts) you can use it directly without adding `reqwest` as a separate dependency:
+
+```toml Cargo.toml theme={null}
+[dependencies]
+pklr  = "0.4"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+# No separate reqwest needed — use pklr::reqwest
+```
+
+```rust theme={null}
+let client = pklr::reqwest::Client::builder()
+    .timeout(std::time::Duration::from_secs(30))
+    .build()
+    .unwrap();
+
+let options = pklr::EvalOptions {
+    client: Some(client),
+    ..Default::default()
+};
+
+let json = pklr::eval_to_json_with_options(
+    std::path::Path::new("config.pkl"),
+    options,
+).await?;
+```
+
+## Feature flags
+
+pklr has no optional Cargo feature flags. All capabilities are included by default.
+
+## Verify the installation
+
+Add a smoke test to confirm everything compiles and links:
+
+```rust src/main.rs theme={null}
+#[tokio::main]
+async fn main() {
+    println!("pklr ready");
+}
+```
+
+```bash theme={null}
+cargo build
+```
+
+If the build succeeds, pklr is installed correctly.
+
+
+# Introduction
+Source: https://www.mintlify.com/jdx/pklr/introduction
+
+What pklr is and why you'd use it
+
+pklr is a pure Rust parser and evaluator for [Apple's Pkl configuration language](https://pkl-lang.org/). It reads `.pkl` files and produces `serde_json::Value` output — no external binary, no CLI, no subprocess.
+
+## What pklr does
+
+Pkl is a programmable configuration language with types, classes, imports, and expressions. pklr brings that evaluation capability directly into your Rust process. You call an async function, pass a file path, and get back JSON.
+
+```rust theme={null}
+use pklr::eval_to_json;
+
+let json = eval_to_json(std::path::Path::new("config.pkl")).await?;
+println!("{}", json["host"]);
+```
+
+## Architecture
+
+pklr is a classic three-stage interpreter written entirely in Rust:
+
+```
+Source (.pkl) → lexer.rs → parser.rs → eval.rs → value.rs → serde_json::Value
+```
+
+* **Lexer** (`src/lexer.rs`) — Tokenizes source text. Handles 80+ token kinds including string literals (double-quoted, triple-quoted multiline, custom delimiters like `#"..."#`), number formats (decimal, hex, octal, binary), and all Pkl operators.
+* **Parser** (`src/parser.rs`) — Builds an AST from tokens. Key types are `Module` (top-level file), `Entry` (property, generator, spread), and `Expr` (all expression forms).
+* **Evaluator** (`src/eval.rs`) — Walks the AST with a scope chain. Two-pass: collects `local` variables first, then evaluates non-local entries. Max recursion depth of 32.
+* **Value** (`src/value.rs`) — The `Value` enum (`Null`, `Bool`, `Int`, `Float`, `String`, `Object`, `List`). Uses `IndexMap` for ordered object keys. Converts to `serde_json::Value`.
+
+## Supported features
+
+* String interpolation, lambdas, and higher-order methods (`map`, `filter`, `fold`)
+* Local variables (`local x = ...`)
+* Object literals, amendment, and spread (`...`)
+* `import` and `amends` resolution for local files
+* HTTP, HTTPS, and `package://` remote imports
+* `read()` and `read?()` resource readers (`file://`, `env:`, `http://`)
+* Class definitions, `extends`, and `super`
+* Type aliases (`typealias`) and type expressions (`is`, `as`)
+* Built-in functions: `List()`, `Map()`, `Set()`
+* `output.renderer.converters` support
+* Property modifiers: `local`, `hidden`, `const`, `abstract`, `fixed`
+* Rich error diagnostics with source context via [miette](https://crates.io/crates/miette)
+
+## When to use pklr
+
+Use pklr when you want to evaluate Pkl configuration files from within a Rust application without shelling out to the `pkl` CLI. Common use cases include:
+
+* Build tools and task runners that read `.pkl` config files
+* Applications that ship Pkl as their configuration format
+* Any context where spawning a subprocess is undesirable or impossible
+
+## Requirements
+
+<Note>
+  pklr requires **Rust 1.88** (MSRV) and the **Tokio** async runtime. All public evaluation functions are `async`.
+</Note>
+
+## Next steps
+
+<CardGroup>
+  <Card title="Quickstart" icon="bolt" href="/quickstart">
+    Evaluate your first Pkl file in minutes.
+  </Card>
+
+  <Card title="Installation" icon="box" href="/installation">
+    Add pklr to your Cargo project.
+  </Card>
+
+  <Card title="Evaluating files" icon="file" href="/guides/evaluating-files">
+    Learn the full evaluation API.
+  </Card>
+
+  <Card title="API reference" icon="code" href="/api/eval-to-json">
+    Browse all public functions and types.
+  </Card>
+</CardGroup>
+
+
+# Classes and modules
+Source: https://www.mintlify.com/jdx/pklr/language/classes-and-modules
+
+Defining classes and working with modules
+
+## Class definitions
+
+Define a class with `class Name { }`. Each property has a type annotation and an optional default value:
+
+```pkl theme={null}
+class Person {
+    name: String
+    age:  Int = 0
+}
+```
+
+Instantiate a class with `new ClassName { }`. Properties without defaults must be supplied; properties with defaults can be omitted:
+
+```pkl theme={null}
+x = new Person {
+    name = "Alice"
+}
+```
+
+```json theme={null}
+{ "x": { "name": "Alice", "age": 0 } }
+```
+
+## Instantiation with `new`
+
+Instantiate with any combination of overrides:
+
+```pkl theme={null}
+class Config {
+    debug: Boolean = false
+    port:  Int     = 8080
+    host:  String  = "localhost"
+}
+
+x = new Config {
+    debug = true
+}
+```
+
+```json theme={null}
+{ "x": { "debug": true, "port": 8080, "host": "localhost" } }
+```
+
+## Open classes
+
+By default, a class rejects any property not declared in its definition. Mark it `open` to allow extra properties:
+
+```pkl theme={null}
+open class Config {
+    port: Int = 8080
+}
+
+x = new Config {
+    port = 9090
+    host = "localhost"
+}
+```
+
+```json theme={null}
+{ "x": { "port": 9090, "host": "localhost" } }
+```
+
+A non-`open` class produces a runtime error if you add an undeclared property:
+
+```pkl theme={null}
+class Config { port: Int = 8080 }
+
+// Fails: "non-open class Config does not allow property 'host'"
+x = new Config { port = 9090, host = "localhost" }
+```
+
+## Class inheritance with `extends`
+
+Use `extends` to inherit all properties and defaults from a parent class:
+
+```pkl theme={null}
+class Animal {
+    name: String = "unknown"
+    legs: Int    = 4
+}
+
+class Dog extends Animal {
+    breed: String = "mixed"
+}
+
+x = new Dog { name = "Rex" }
+```
+
+```json theme={null}
+{ "x": { "name": "Rex", "legs": 4, "breed": "mixed" } }
+```
+
+A child class can override a parent's default:
+
+```pkl theme={null}
+class Base       { port: Int = 8080; host: String = "localhost" }
+class Production extends Base { port: Int = 443; tls: Boolean = true }
+
+x = new Production {}
+```
+
+```json theme={null}
+{ "x": { "port": 443, "host": "localhost", "tls": true } }
+```
+
+## Type annotations
+
+Property types are declared with `: TypeName`. Use `?` for nullable types and `|` for union types:
+
+```pkl theme={null}
+class Step {
+    name:    String
+    timeout: Int?                    = null
+    glob:    String | List<String>   = List()
+}
+```
+
+## Modifiers
+
+Modifiers appear before the property name or type annotation:
+
+| Modifier   | Effect                                                           |
+| ---------- | ---------------------------------------------------------------- |
+| `local`    | Not serialized; available only within the current scope          |
+| `hidden`   | Not serialized; accessible to other properties in the same scope |
+| `const`    | Cannot be overridden in an `amends` file                         |
+| `fixed`    | Signals semantic immutability; evaluated normally                |
+| `abstract` | Parses without error; may have a default value                   |
+| `open`     | On a class: allows extra properties when instantiated            |
+| `external` | Must be assigned a value before the module is evaluated          |
+
+```pkl theme={null}
+hidden  secret  = "abc123"
+const   version = 1
+fixed   build   = 42
+
+derived = secret + "-derived"
+```
+
+```json theme={null}
+{ "derived": "abc123-derived", "version": 1, "build": 42 }
+```
+
+## Module amends
+
+`amends "path.pkl"` at the top of a file applies the current file's properties on top of the base module:
+
+```pkl theme={null}
+amends "base.pkl"
+
+name = "override"
+// version and enabled are inherited from base.pkl
+```
+
+<Note>
+  `const` properties in the base file cannot be overridden by an amending file.
+</Note>
+
+## Module extends
+
+`extends "path.pkl"` is similar to `amends` but also makes the base module's class definitions available as constructors in the child module:
+
+```pkl theme={null}
+extends "base_module.pkl"
+
+default_name = "extended"
+extra        = "new property"
+x = new Config { debug = true }
+```
+
+## `this` and `outer`
+
+`this` refers to the current object. In a nested object, `this` refers to the inner object:
+
+```pkl theme={null}
+data {
+    x = 1
+    y = this.x + 1
+}
+```
+
+```json theme={null}
+{ "data": { "x": 1, "y": 2 } }
+```
+
+`outer` accesses the enclosing object's scope from a nested body:
+
+```pkl theme={null}
+local prefix = "test"
+
+data {
+    local before = "\(prefix)-data"
+    inner {
+        name = outer.before
+    }
+}
+```
+
+```json theme={null}
+{ "data": { "inner": { "name": "test-data" } } }
+```
+
+## `super`
+
+Inside a child class, `super.field` reads the parent class's default for that field:
+
+```pkl theme={null}
+class Base  { greeting: String = "hello" }
+class Child extends Base {
+    greeting: String = super.greeting + " world"
+}
+
+x = new Child {}
+```
+
+```json theme={null}
+{ "x": { "greeting": "hello world" } }
+```
+
+## Type aliases
+
+`typealias` defines an alias for an existing type. When the alias resolves to a class, it acts as an alternative constructor:
+
+```pkl theme={null}
+class Server { host: String = "localhost"; port: Int = 8080 }
+
+typealias Srv = Server
+
+x = new Srv { port = 3000 }
+```
+
+```json theme={null}
+{ "x": { "host": "localhost", "port": 3000 } }
+```
+
+Type aliases can include constraints (evaluated with `is` / `as`):
+
+```pkl theme={null}
+typealias PositiveInt = Int(this > 0)
+
+a = 42 is PositiveInt   // true
+b = -1 is PositiveInt   // false
+```
+
+## Type constraints with `is` / `as`
+
+Use inline constraints with a predicate in parentheses after the type name. Inside the constraint `this` refers to the value being tested:
+
+```pkl theme={null}
+local x = 8080
+local s = "hi"
+
+a = x is Int(this >= 1 && this <= 65535)   // true
+b = s is String(length <= 5)               // true
+c = s is String(!isEmpty)                  // true
+```
+
+`as` casts the value or fails:
+
+```pkl theme={null}
+result = 42 as Int(this > 0)   // 42
+// -1 as Int(this > 0) fails: "cannot cast"
+```
+
+
+# Expressions
+Source: https://www.mintlify.com/jdx/pklr/language/expressions
+
+Operators, control flow, and lambdas in Pkl
+
+## Arithmetic
+
+| Operator | Name             | Example   | Result                                     |
+| -------- | ---------------- | --------- | ------------------------------------------ |
+| `+`      | addition         | `2 + 3`   | `5`                                        |
+| `-`      | subtraction      | `10 - 3`  | `7`                                        |
+| `*`      | multiplication   | `4 * 5`   | `20`                                       |
+| `/`      | division         | `10 / 3`  | `3` (integer when both operands are `Int`) |
+| `~/`     | integer division | `7 ~/ 2`  | `3`                                        |
+| `**`     | exponentiation   | `2 ** 10` | `1024`                                     |
+| `%`      | modulo           | `10 % 3`  | `1`                                        |
+
+```pkl theme={null}
+intDiv = 7 ~/ 2
+power  = 2 ** 10
+mod    = 10 % 3
+```
+
+```json theme={null}
+{ "intDiv": 3, "power": 1024, "mod": 1 }
+```
+
+Standard precedence applies: `**` binds tightest, then `*`/`/`/`~/`/`%`, then `+`/`-`. `**` is right-associative:
+
+```pkl theme={null}
+a = 2 + 3 * 4     // 14
+b = (2 + 3) * 4   // 20
+c = 2 ** 3 ** 2   // 512  (right-associative: 2 ** 9)
+```
+
+<Warning>
+  Integer division by zero (`1 / 0`, `7 ~/ 0`, `1 % 0`) is a runtime error. Integer exponentiation with a negative exponent (`2 ** -1`) is also an error; use float operands (`2.0 ** -1.0`) instead.
+</Warning>
+
+## Comparison
+
+```pkl theme={null}
+a = 1 == 1   // true
+b = 1 != 2   // true
+c = 1 < 2    // true
+d = 2 > 1    // true
+```
+
+All six comparison operators are supported: `==`, `!=`, `<`, `<=`, `>`, `>=`.
+
+## Logical
+
+```pkl theme={null}
+a = true && false   // false
+b = true || false   // true
+c = !false          // true
+```
+
+## Null-safe operators
+
+### `??` — null coalescing
+
+Returns the left side if it is not `null`; otherwise returns the right side:
+
+```pkl theme={null}
+a = "hello" ?? "default"
+b = null    ?? "default"
+```
+
+```json theme={null}
+{ "a": "hello", "b": "default" }
+```
+
+### `?.` — null-safe access
+
+Accesses a field only when the receiver is not `null`. Returns `null` if the receiver is `null`:
+
+```pkl theme={null}
+local x = null
+result = x?.name ?? "default"
+```
+
+```json theme={null}
+{ "result": "default" }
+```
+
+### `!!` — non-null assertion
+
+Asserts the value is not `null`. Fails with "non-null assertion failed" if it is:
+
+```pkl theme={null}
+local x = 42
+y = x!!   // 42
+```
+
+## Pipe operator `|>`
+
+`|>` passes a value as the sole argument to a single-parameter function:
+
+```pkl theme={null}
+local double = (x) -> x * 2
+local addOne = (x) -> x + 1
+
+result = 5 |> double |> addOne
+```
+
+```json theme={null}
+{ "result": 11 }
+```
+
+<Note>
+  The pipe operator only works with single-parameter lambdas. Using it with a multi-parameter function is a runtime error.
+</Note>
+
+## If-else expressions
+
+`if`/`else` is an expression, not a statement:
+
+```pkl theme={null}
+local n = 10
+x = if (n > 5) "big" else "small"
+```
+
+```json theme={null}
+{ "x": "big" }
+```
+
+## Let expressions
+
+`let` binds a name to a value within a scoped expression:
+
+```pkl theme={null}
+x = let (a = 1) let (b = 2) a + b
+```
+
+```json theme={null}
+{ "x": 3 }
+```
+
+## Lambda expressions
+
+Write lambdas as `(params) -> body`. Call them with `.apply(…)` or pass them to higher-order methods:
+
+```pkl theme={null}
+local double = (x) -> x * 2
+local add    = (a, b) -> a + b
+
+r1 = double.apply(5)
+r2 = add.apply(3, 4)
+```
+
+```json theme={null}
+{ "r1": 10, "r2": 7 }
+```
+
+Lambdas capture their enclosing scope (closure):
+
+```pkl theme={null}
+local multiplier = 3
+local mul        = (x) -> x * multiplier
+
+result = mul.apply(5)
+```
+
+```json theme={null}
+{ "result": 15 }
+```
+
+Lambdas are commonly used with list methods:
+
+```pkl theme={null}
+local items = List(1, 2, 3, 4, 5)
+
+doubled = items.map((n) -> n * 2)
+evens   = items.filter((n) -> n > 2)
+sum     = items.fold(0, (acc, n) -> acc + n)
+```
+
+```json theme={null}
+{
+  "doubled": [2, 4, 6, 8, 10],
+  "evens":   [3, 4, 5],
+  "sum":     15
+}
+```
+
+## `read()` and `read?()`
+
+`read("uri")` reads a resource and returns it as a string. `read?("uri")` returns `null` instead of failing when the resource is unavailable.
+
+```pkl theme={null}
+x = read("env:PKLR_TEST_VAR")
+```
+
+```json theme={null}
+{ "x": "hello_pklr" }
+```
+
+`read?` is useful for optional configuration:
+
+```pkl theme={null}
+host = read?("env:DEFINITELY_NOT_SET") ?? "localhost"
+```
+
+```json theme={null}
+{ "host": "localhost" }
+```
+
+Use `read()` inside string interpolation:
+
+```pkl theme={null}
+x = "hello \(read("env:PKLR_NAME"))"
+```
+
+## `is` / `as` type operators
+
+`expr is Type` checks whether the value matches the type:
+
+```pkl theme={null}
+local x = 42
+
+a = x is Int       // true
+b = x is Number    // true (Int is a subtype of Number)
+c = x is String    // false
+d = x is Any       // true
+```
+
+Nullable and union types:
+
+```pkl theme={null}
+local n = null
+
+a = n is Null      // true
+b = n is String?   // true
+c = n is String    // false
+
+local y = 42
+d = y is String|Int   // true
+```
+
+`expr as Type` returns the value if it matches or fails with "cannot cast":
+
+```pkl theme={null}
+result = 42 as Int      // 42
+// "hello" as Int fails: "cannot cast"
+
+local x = null
+safe = x as String?     // null — nullable cast never fails
+```
+
+### Constrained types
+
+Both `is` and `as` accept inline constraints. Inside a constraint, `this` refers to the value being tested and value-properties like `length` are in scope:
+
+```pkl theme={null}
+local x = 8080
+local s = "hi"
+
+a = x is Int(this >= 1 && this <= 65535)   // true
+b = s is String(length <= 5)               // true
+c = s is String(!isEmpty)                  // true
+```
+
+Type aliases can encapsulate constraints:
+
+```pkl theme={null}
+typealias PositiveInt = Int(this > 0)
+
+a = 42 is PositiveInt    // true
+b = -1 is PositiveInt    // false
+```
+
+
+# Objects and mappings
+Source: https://www.mintlify.com/jdx/pklr/language/objects-and-mappings
+
+Pkl objects, mappings, lists, and sets
+
+## Property assignment
+
+Assign named properties with `=` inside a block:
+
+```pkl theme={null}
+server {
+    host  = "localhost"
+    port  = 8080
+    debug = false
+}
+```
+
+```json theme={null}
+{
+  "server": { "host": "localhost", "port": 8080, "debug": false }
+}
+```
+
+## Nested objects
+
+Objects can nest arbitrarily:
+
+```pkl theme={null}
+outer {
+    inner {
+        value = 42
+    }
+}
+```
+
+```json theme={null}
+{ "outer": { "inner": { "value": 42 } } }
+```
+
+## Dynamic string keys
+
+Use bracket notation for keys that are not valid identifiers or are computed at runtime:
+
+```pkl theme={null}
+data {
+    ["my-key"] = "value"
+}
+```
+
+```json theme={null}
+{ "data": { "my-key": "value" } }
+```
+
+A bracket entry can have a nested body instead of a `=` value:
+
+```pkl theme={null}
+data {
+    ["my-key"] {
+        nested = true
+    }
+}
+```
+
+```json theme={null}
+{ "data": { "my-key": { "nested": true } } }
+```
+
+## `new Mapping {}`
+
+Use `new Mapping` to create an explicit mapping:
+
+```pkl theme={null}
+x = new Mapping {
+    ["a"] = 1
+    ["b"] = 2
+}
+```
+
+```json theme={null}
+{ "x": { "a": 1, "b": 2 } }
+```
+
+`Mapping` and `Listing` accept optional generic type parameters:
+
+```pkl theme={null}
+x = new Mapping<String, String> {
+    ["a"] = "hello"
+    ["b"] = "world"
+}
+```
+
+## Lists
+
+Create a list with `List()` or a `new Listing {}` body:
+
+```pkl theme={null}
+nums    = List(1, 2, 3)
+strings = new Listing {
+    "a"
+    "b"
+    "c"
+}
+```
+
+```json theme={null}
+{
+  "nums": [1, 2, 3],
+  "strings": ["a", "b", "c"]
+}
+```
+
+Concatenate two lists with `+`:
+
+```pkl theme={null}
+combined = List(1, 2) + List(3, 4)
+```
+
+```json theme={null}
+{ "combined": [1, 2, 3, 4] }
+```
+
+## Sets
+
+`Set()` deduplicates its arguments, preserving the order of first occurrence:
+
+```pkl theme={null}
+nums    = Set(1, 2, 3, 2, 1)
+letters = Set("b", "a", "c", "a")
+```
+
+```json theme={null}
+{
+  "nums": [1, 2, 3],
+  "letters": ["b", "a", "c"]
+}
+```
+
+<Note>
+  Sets serialize as JSON arrays. There is no dedicated JSON set type.
+</Note>
+
+## Spread operator
+
+Use `...expr` to merge all entries from another object or mapping into the current body:
+
+```pkl theme={null}
+local base = new Mapping {
+    ["a"] = 1
+    ["b"] = 2
+}
+
+x {
+    ...base
+    ["c"] = 3
+}
+```
+
+```json theme={null}
+{ "x": { "a": 1, "b": 2, "c": 3 } }
+```
+
+## Local variables
+
+`local` variables are scoped to the current module or object and are never written to the output:
+
+```pkl theme={null}
+local greeting = "hello"
+local message  = greeting + " world"
+
+x = message
+```
+
+```json theme={null}
+{ "x": "hello world" }
+```
+
+<Tip>
+  Use `local` for intermediate values. Use `hidden` when you want a property that belongs to an object's structure but should not appear in the serialized output.
+</Tip>
+
+## Object amendment
+
+Amend an existing object with `(base) { … }`. Properties in the body override matching keys; all others are inherited. Dependent properties are re-evaluated (late binding).
+
+```pkl theme={null}
+local base = new Mapping {
+    ["check"] = "echo hello"
+    ["fix"]   = "echo fix"
+}
+
+x = (base) {
+    ["check"] = "echo override"
+}
+```
+
+```json theme={null}
+{ "x": { "check": "echo override", "fix": "echo fix" } }
+```
+
+Late binding works for named properties too:
+
+```pkl theme={null}
+local base = new {
+    name     = "world"
+    greeting = "Hello, \(name)!"
+}
+
+result = (base) {
+    name = "Pkl"
+}
+```
+
+```json theme={null}
+{ "result": { "name": "Pkl", "greeting": "Hello, Pkl!" } }
+```
+
+
+# Primitives
+Source: https://www.mintlify.com/jdx/pklr/language/primitives
+
+Pkl primitive types supported by pklr
+
+## Integers
+
+Pkl integers are 64-bit signed values. You can write them in decimal, hexadecimal, octal, or binary. Use underscores anywhere as a readability separator.
+
+```pkl theme={null}
+decimal     = 42
+negative    = -7
+hex         = 0xFF
+octal       = 0o77
+binary      = 0b1010
+underscored = 1_000_000
+```
+
+```json theme={null}
+{
+  "decimal": 42,
+  "negative": -7,
+  "hex": 255,
+  "octal": 63,
+  "binary": 10,
+  "underscored": 1000000
+}
+```
+
+## Floats
+
+Floats support a decimal point and scientific notation (`e` exponent).
+
+```pkl theme={null}
+basic      = 1.5
+scientific = 1e3
+```
+
+```json theme={null}
+{
+  "basic": 1.5,
+  "scientific": 1000.0
+}
+```
+
+## NaN and Infinity
+
+Pkl provides `NaN`, `Infinity`, and `-Infinity` as built-in identifiers.
+
+```pkl theme={null}
+notANumber = NaN
+positive   = Infinity
+negative   = -Infinity
+```
+
+```json theme={null}
+{
+  "notANumber": null,
+  "positive": null,
+  "negative": null
+}
+```
+
+<Warning>
+  JSON has no representation for `NaN` or `Infinity`. pklr serializes all three as `null` when converting to JSON.
+</Warning>
+
+`NaN` follows IEEE 754 semantics — it is not equal to itself:
+
+```pkl theme={null}
+check = NaN == NaN
+```
+
+```json theme={null}
+{ "check": false }
+```
+
+## Booleans
+
+```pkl theme={null}
+yes = true
+no  = false
+```
+
+```json theme={null}
+{ "yes": true, "no": false }
+```
+
+## Null
+
+```pkl theme={null}
+x = null
+```
+
+```json theme={null}
+{ "x": null }
+```
+
+## Strings
+
+### Basic strings
+
+Strings are double-quoted and support standard escape sequences (`\n`, `\t`, `\\`, `\"`) and Unicode escapes (`\u{…}`).
+
+```pkl theme={null}
+greeting = "hello world"
+escaped  = "a\nb\tc"
+unicode  = "\u{26} \u{E9} \u{1F600}"
+```
+
+```json theme={null}
+{
+  "greeting": "hello world",
+  "escaped": "a\nb\tc",
+  "unicode": "& é 😀"
+}
+```
+
+<Warning>
+  Unicode escapes require curly braces: `\u{41}` is valid, `\u0041` is not.
+</Warning>
+
+### Multiline strings
+
+Triple-quoted strings (`"""…"""`) strip the indentation that aligns the closing `"""`.
+
+```pkl theme={null}
+x = """
+  hello
+  world
+  """
+```
+
+```json theme={null}
+{ "x": "hello\nworld\n" }
+```
+
+### String interpolation
+
+Embed any expression inside `\(…)`:
+
+```pkl theme={null}
+local name = "world"
+greeting   = "hello \(name)"
+math       = "2 + 2 = \(2 + 2)"
+```
+
+```json theme={null}
+{
+  "greeting": "hello world",
+  "math": "2 + 2 = 4"
+}
+```
+
+### String concatenation
+
+Use `+` to join strings:
+
+```pkl theme={null}
+full = "hello" + " " + "world"
+```
+
+```json theme={null}
+{ "full": "hello world" }
+```
+
+
+# Quickstart
+Source: https://www.mintlify.com/jdx/pklr/quickstart
+
+Evaluate your first Pkl file in minutes
+
+<Steps>
+  <Step title="Add pklr to Cargo.toml">
+    Open your project's `Cargo.toml` and add pklr and Tokio:
+
+    ```toml Cargo.toml theme={null}
+    [dependencies]
+    pklr  = "0.4"
+    tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+    ```
+  </Step>
+
+  <Step title="Create a Pkl config file">
+    Create a file called `config.pkl` in your project root:
+
+    ```pkl config.pkl theme={null}
+    host = "localhost"
+    port = 8080
+    tags = List("web", "api", "production")
+    database {
+      url      = "postgres://localhost/myapp"
+      poolSize = 10
+    }
+    ```
+  </Step>
+
+  <Step title="Evaluate the file from Rust">
+    In `src/main.rs`, call `eval_to_json` and print the result:
+
+    ```rust src/main.rs theme={null}
+    use pklr::eval_to_json;
+    use std::path::Path;
+
+    #[tokio::main]
+    async fn main() -> pklr::Result<()> {
+        let json = eval_to_json(Path::new("config.pkl")).await?;
+
+        println!("host: {}", json["host"]);
+        println!("port: {}", json["port"]);
+        println!("tags: {}", json["tags"]);
+        println!("db:   {}", json["database"]["url"]);
+
+        Ok(())
+    }
+    ```
+
+    Run it:
+
+    ```bash theme={null}
+    cargo run
+    ```
+  </Step>
+
+  <Step title="Check the output">
+    You should see:
+
+    ```
+    host: "localhost"
+    port: 8080
+    tags: ["web","api","production"]
+    db:   "postgres://localhost/myapp"
+    ```
+
+    The full JSON value from `eval_to_json` looks like this:
+
+    ```json theme={null}
+    {
+      "host": "localhost",
+      "port": 8080,
+      "tags": ["web", "api", "production"],
+      "database": {
+        "url": "postgres://localhost/myapp",
+        "poolSize": 10
+      }
+    }
+    ```
+  </Step>
+
+  <Step title="Handle errors">
+    `eval_to_json` returns `pklr::Result<serde_json::Value>`. The `?` operator propagates any parse or evaluation error. pklr errors include source context from [miette](https://crates.io/crates/miette), so they print with the relevant source snippet.
+
+    To handle errors explicitly:
+
+    ```rust theme={null}
+    match eval_to_json(Path::new("config.pkl")).await {
+        Ok(json) => println!("{}", json),
+        Err(e)   => eprintln!("failed to evaluate config: {e}"),
+    }
+    ```
+  </Step>
+</Steps>
+
+## Advanced: configure the evaluator
+
+For proxy support, custom CA certificates, or HTTP URL rewrites, use `eval_to_json_with_options` with an `EvalOptions` value.
+
+```rust theme={null}
+use pklr::{eval_to_json_with_options, EvalOptions};
+use std::path::Path;
+
+#[tokio::main]
+async fn main() -> pklr::Result<()> {
+    // Build a custom reqwest client — pklr re-exports reqwest so you don't
+    // need a separate dependency.
+    let client = pklr::reqwest::Client::builder()
+        .danger_accept_invalid_certs(false)
+        .build()
+        .unwrap();
+
+    let options = EvalOptions {
+        client: Some(client),
+        // Rewrite internal registry URLs — longest matching prefix wins.
+        http_rewrites: vec![
+            "https://registry.example.com=https://mirror.internal.example.com".to_string(),
+        ],
+    };
+
+    let json = eval_to_json_with_options(Path::new("config.pkl"), options).await?;
+    println!("{}", json);
+
+    Ok(())
+}
+```
+
+<Tip>
+  `pklr::reqwest` is a re-export of the `reqwest` crate. You can use it to build a custom `Client` without adding `reqwest` as a direct dependency in your `Cargo.toml`.
+</Tip>
+
+## Next steps
+
+<CardGroup>
+  <Card title="Installation" icon="box" href="/installation">
+    Dependency details, MSRV, and feature flags.
+  </Card>
+
+  <Card title="Evaluating files" icon="file" href="/guides/evaluating-files">
+    Full evaluation API and advanced usage.
+  </Card>
+
+  <Card title="Imports and amends" icon="link" href="/guides/imports-and-amends">
+    Resolve local file imports and module amendment.
+  </Card>
+
+  <Card title="Error handling" icon="triangle-alert" href="/guides/error-handling">
+    Work with pklr's error types and diagnostics.
+  </Card>
+</CardGroup>
+
+

--- a/docs/research/mintlify-cache/jdx/pklr/llms.txt
+++ b/docs/research/mintlify-cache/jdx/pklr/llms.txt
@@ -1,0 +1,28 @@
+# pklr
+
+## Docs
+
+- [analyze_imports](https://www.mintlify.com/jdx/pklr/api/analyze-imports.md): Extract all transitive local file dependencies from a Pkl file
+- [Error](https://www.mintlify.com/jdx/pklr/api/error.md): Error types returned by pklr
+- [EvalOptions](https://www.mintlify.com/jdx/pklr/api/eval-options.md): Configuration options for the pkl evaluator
+- [eval_to_json](https://www.mintlify.com/jdx/pklr/api/eval-to-json.md): Evaluate a Pkl file and return its contents as serde_json::Value
+- [Evaluator](https://www.mintlify.com/jdx/pklr/api/evaluator.md): Low-level Pkl evaluator with full configuration control
+- [Value](https://www.mintlify.com/jdx/pklr/api/value.md): The pklr runtime value type
+- [Error handling](https://www.mintlify.com/jdx/pklr/guides/error-handling.md): Understanding and handling pklr errors
+- [Evaluating Pkl files](https://www.mintlify.com/jdx/pklr/guides/evaluating-files.md): How to load and evaluate .pkl configuration files
+- [HTTP and remote imports](https://www.mintlify.com/jdx/pklr/guides/http-remote-imports.md): Fetching remote Pkl modules via HTTP, HTTPS, and package:// URIs
+- [Imports and amends](https://www.mintlify.com/jdx/pklr/guides/imports-and-amends.md): Resolving imports, amends, and extends in Pkl files
+- [Installation](https://www.mintlify.com/jdx/pklr/installation.md): Add pklr to your Rust project
+- [Introduction](https://www.mintlify.com/jdx/pklr/introduction.md): What pklr is and why you'd use it
+- [Classes and modules](https://www.mintlify.com/jdx/pklr/language/classes-and-modules.md): Defining classes and working with modules
+- [Expressions](https://www.mintlify.com/jdx/pklr/language/expressions.md): Operators, control flow, and lambdas in Pkl
+- [Objects and mappings](https://www.mintlify.com/jdx/pklr/language/objects-and-mappings.md): Pkl objects, mappings, lists, and sets
+- [Primitives](https://www.mintlify.com/jdx/pklr/language/primitives.md): Pkl primitive types supported by pklr
+- [Quickstart](https://www.mintlify.com/jdx/pklr/quickstart.md): Evaluate your first Pkl file in minutes
+
+## OpenAPI Specs
+
+- [openapi](https://www.mintlify.com/jdx/pklr/api-reference/openapi.json)
+
+
+Built with [Mintlify](https://mintlify.com).

--- a/docs/research/mintlify-cache/knowsuchagency/mcp2cli/llms-full.txt
+++ b/docs/research/mintlify-cache/knowsuchagency/mcp2cli/llms-full.txt
@@ -1,0 +1,2653 @@
+# Authentication
+Source: https://www.mintlify.com/knowsuchagency/mcp2cli/features/authentication
+
+Static headers, OAuth PKCE, and client credentials — all modes supported
+
+mcp2cli supports three authentication methods across all modes (`--mcp`, `--spec`, `--graphql`, `--mcp-stdio`). You can combine static headers with OAuth flags if your setup requires it.
+
+## Static headers
+
+Pass any HTTP header with `--auth-header KEY:VALUE`. The flag is repeatable, so you can send multiple headers in a single call.
+
+```bash theme={null}
+mcp2cli --mcp https://mcp.example.com/sse --auth-header "x-api-key:sk-..." --list
+mcp2cli --spec ./spec.json --auth-header "Authorization:Bearer tok_..." create-item --name "Test"
+```
+
+Header values support `env:` and `file:` prefixes to avoid exposing secrets in process listings:
+
+```bash theme={null}
+# Read from an environment variable
+mcp2cli --mcp https://mcp.example.com/sse \
+  --auth-header "Authorization:env:MY_API_TOKEN" \
+  --list
+
+# Read from a file
+mcp2cli --mcp https://mcp.example.com/sse \
+  --auth-header "Authorization:file:/run/secrets/api_token" \
+  --list
+```
+
+## OAuth
+
+mcp2cli handles token acquisition, caching, and refresh automatically for OAuth-protected APIs.
+
+<Tabs>
+  <Tab title="Authorization code + PKCE">
+    Add `--oauth` to trigger the browser-based authorization code flow with PKCE. mcp2cli opens your default browser, waits for the callback, and caches the resulting token in `~/.cache/mcp2cli/oauth/`.
+
+    ```bash theme={null}
+    # MCP server
+    mcp2cli --mcp https://mcp.example.com/sse --oauth --list
+
+    # OpenAPI spec
+    mcp2cli --spec https://api.example.com/openapi.json --oauth --list
+
+    # GraphQL endpoint
+    mcp2cli --graphql https://api.example.com/graphql --oauth --list
+
+    # With specific scopes
+    mcp2cli --graphql https://api.example.com/graphql --oauth --oauth-scope "read write" users
+    ```
+
+    <Note>
+      When using a local spec file, mcp2cli cannot infer the server URL for OAuth discovery. Pass `--base-url` to provide it:
+
+      ```bash theme={null}
+      mcp2cli --spec ./openapi.json --base-url https://api.example.com --oauth --list
+      ```
+    </Note>
+  </Tab>
+
+  <Tab title="Client credentials">
+    For machine-to-machine flows where no browser is available, pass `--oauth-client-id` and `--oauth-client-secret`. mcp2cli detects that both are present and uses the client credentials grant automatically.
+
+    ```bash theme={null}
+    mcp2cli --spec https://api.example.com/openapi.json \
+      --oauth-client-id "my-client-id" \
+      --oauth-client-secret "my-secret" \
+      list-pets
+    ```
+
+    Both values support `env:` and `file:` prefixes:
+
+    ```bash theme={null}
+    # Works with secret managers that inject env vars
+    fnox exec -- mcp2cli --mcp https://mcp.example.com/sse \
+      --oauth-client-id "env:OAUTH_CLIENT_ID" \
+      --oauth-client-secret "env:OAUTH_CLIENT_SECRET" \
+      --list
+    ```
+  </Tab>
+</Tabs>
+
+## OAuth options reference
+
+<AccordionGroup>
+  <Accordion title="--oauth-flow">
+    Force a specific OAuth grant type. Accepts `auto` (default), `authorization_code`, or `client_credentials`.
+
+    * **`auto`**: uses client credentials when both `--oauth-client-id` and `--oauth-client-secret` are present; otherwise uses authorization code + PKCE.
+    * **`authorization_code`**: always use the browser-based PKCE flow, even when a `--oauth-client-secret` is also provided. Required for confidential-client servers like Slack.
+    * **`client_credentials`**: always use client credentials. Requires both `--oauth-client-id` and `--oauth-client-secret`.
+
+    ```bash theme={null}
+    # Force authorization_code even with a client secret (e.g. Slack)
+    mcp2cli --spec https://api.example.com/openapi.json \
+      --oauth-client-id "my-id" \
+      --oauth-client-secret "my-secret" \
+      --oauth-flow authorization_code \
+      --list
+    ```
+  </Accordion>
+
+  <Accordion title="--oauth-scope">
+    Request specific OAuth scopes. Pass a space-separated string.
+
+    ```bash theme={null}
+    mcp2cli --graphql https://api.example.com/graphql --oauth --oauth-scope "read write" users
+    ```
+  </Accordion>
+
+  <Accordion title="--oauth-client-name">
+    Set the client name used during dynamic client registration. Defaults to `"mcp2cli"`.
+
+    ```bash theme={null}
+    mcp2cli --mcp https://mcp.example.com/sse --oauth --oauth-client-name "my-agent" --list
+    ```
+  </Accordion>
+
+  <Accordion title="--oauth-redirect-uri">
+    Override the default loopback callback URL. The URI must use `http://` and include an explicit port. The host must be a loopback address (`localhost`, `127.0.0.1`, or `::1`).
+
+    ```bash theme={null}
+    mcp2cli --mcp https://mcp.example.com/sse \
+      --oauth \
+      --oauth-redirect-uri "http://localhost:3334/oauth/callback" \
+      --list
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Token storage
+
+OAuth tokens are cached per server in `~/.cache/mcp2cli/oauth/`, keyed by a SHA-256 hash of the server URL. Subsequent calls reuse cached tokens and refresh them automatically when they expire. No manual token management is needed.
+
+<Tip>
+  Use the `env:` prefix for `--oauth-client-id` and `--oauth-client-secret` values to keep secrets out of shell history and process listings.
+</Tip>
+
+
+# Bake mode
+Source: https://www.mintlify.com/knowsuchagency/mcp2cli/features/bake-mode
+
+Save connection settings as named tools — no more repeated flags
+
+Bake mode lets you save a source (`--spec`, `--mcp`, or `--mcp-stdio`) along with auth flags, cache settings, and tool filters as a named configuration. You then invoke that configuration with a `@NAME` prefix instead of repeating all flags on every call.
+
+<Note>
+  GraphQL sources (`--graphql`) are not supported by bake mode. Use the other source types (`--spec`, `--mcp`, `--mcp-stdio`) to take advantage of baking.
+</Note>
+
+## Creating a baked tool
+
+```bash theme={null}
+mcp2cli bake create NAME [options]
+```
+
+Provide exactly one source flag and any options you want to persist:
+
+```bash theme={null}
+# OpenAPI spec with method and tool filters
+mcp2cli bake create petstore \
+  --spec https://api.example.com/spec.json \
+  --exclude "delete-*,update-*" \
+  --methods GET,POST \
+  --cache-ttl 7200
+
+# MCP stdio server with include/exclude filters
+mcp2cli bake create mygit \
+  --mcp-stdio "npx @mcp/github" \
+  --include "search-*,list-*" \
+  --exclude "delete-*"
+```
+
+<Note>
+  Names must match `[a-z][a-z0-9-]*`. Use `--force` to overwrite an existing baked tool.
+</Note>
+
+## Using a baked tool
+
+Prefix the name with `@` to run a baked tool. All saved flags are injected automatically:
+
+```bash theme={null}
+mcp2cli @petstore --list
+mcp2cli @petstore list-pets --limit 10
+mcp2cli @mygit search-repos --query "rust"
+```
+
+Every flag you can pass to a normal invocation still works — `--list`, `--sort`, `--top`, `--compact`, `--jq`, `--head`, and so on.
+
+## Managing baked tools
+
+<Steps>
+  <Step title="List all baked tools">
+    ```bash theme={null}
+    mcp2cli bake list
+    ```
+
+    Prints a table with each tool's name, source type, and source URL or command.
+  </Step>
+
+  <Step title="Show a tool's config">
+    ```bash theme={null}
+    mcp2cli bake show petstore
+    ```
+
+    Prints the stored JSON config. Literal auth header values are masked (first 4 characters shown, rest replaced with `****`); `env:` and `file:` references are shown as-is.
+  </Step>
+
+  <Step title="Update settings">
+    ```bash theme={null}
+    mcp2cli bake update petstore --cache-ttl 3600
+    ```
+
+    Only the flags you pass are updated. Supported fields: `--cache-ttl`, `--include`, `--exclude`, `--methods`, `--description`, `--base-url`, `--transport`.
+  </Step>
+
+  <Step title="Remove a baked tool">
+    ```bash theme={null}
+    mcp2cli bake remove petstore
+    ```
+
+    Deletes the config and also removes any installed wrapper script at `~/.local/bin/petstore`.
+  </Step>
+</Steps>
+
+## Installing a wrapper script
+
+`bake install` creates a standalone shell script so you can call the tool by name without the `mcp2cli @` prefix:
+
+```bash theme={null}
+# Install to ~/.local/bin/petstore
+mcp2cli bake install petstore
+
+# Install to a custom directory
+mcp2cli bake install petstore --dir ./scripts/
+```
+
+The generated wrapper contains:
+
+```sh theme={null}
+#!/bin/sh
+exec mcp2cli @petstore "$@"
+```
+
+<Tip>
+  Make sure `~/.local/bin` is in your `PATH`. mcp2cli prints a note if it isn't when you run `bake install` without `--dir`.
+</Tip>
+
+## Filtering tools
+
+Three flags let you control which operations are exposed when using a baked tool:
+
+| Flag        | Description                                 | Example              |
+| ----------- | ------------------------------------------- | -------------------- |
+| `--include` | Comma-separated glob whitelist              | `"list-*,get-*"`     |
+| `--exclude` | Comma-separated glob blacklist              | `"delete-*,admin-*"` |
+| `--methods` | Comma-separated HTTP methods (OpenAPI only) | `"GET,POST"`         |
+
+Filters are applied in order: methods → include → exclude. MCP commands are not affected by `--methods`.
+
+## Config file location
+
+Baked configs are stored at `~/.config/mcp2cli/baked.json`. Override the directory with the `MCP2CLI_CONFIG_DIR` environment variable:
+
+```bash theme={null}
+MCP2CLI_CONFIG_DIR=/etc/mcp2cli mcp2cli bake list
+```
+
+
+# Caching
+Source: https://www.mintlify.com/knowsuchagency/mcp2cli/features/caching
+
+Specs and tool lists are cached locally to speed up repeated calls
+
+mcp2cli caches fetched specs and MCP tool lists on disk so that repeated calls don't pay the network round-trip cost. The cache is stored at `~/.cache/mcp2cli/` by default.
+
+## Default behavior
+
+* Remote OpenAPI specs and GraphQL schemas are cached after the first fetch.
+* MCP HTTP/SSE tool lists are cached after the first connection.
+* The default TTL is **3600 seconds** (1 hour). Entries older than the TTL are treated as missing and re-fetched.
+* Local file specs (`--spec ./api.yaml`) are **never cached**.
+
+## Controlling the cache
+
+<AccordionGroup>
+  <Accordion title="--refresh — bypass the cache">
+    Force a fresh fetch regardless of TTL. The new result is written back to the cache.
+
+    ```bash theme={null}
+    mcp2cli --spec https://api.example.com/spec.json --refresh --list
+    ```
+  </Accordion>
+
+  <Accordion title="--cache-ttl SECONDS — custom TTL">
+    Override the default 1-hour TTL for this invocation. Useful for specs that change frequently or rarely.
+
+    ```bash theme={null}
+    # Cache for 24 hours
+    mcp2cli --spec https://api.example.com/spec.json --cache-ttl 86400 --list
+
+    # Cache for 10 minutes
+    mcp2cli --spec https://api.example.com/spec.json --cache-ttl 600 --list
+    ```
+
+    When baking a tool, `--cache-ttl` is persisted in the config and applied on every invocation of that baked tool.
+  </Accordion>
+
+  <Accordion title="--cache-key KEY — custom cache key">
+    Use a fixed string as the cache key instead of the auto-generated hash. Useful when you want to share a cache entry across multiple invocations that differ only in auth headers.
+
+    ```bash theme={null}
+    mcp2cli --spec https://api.example.com/spec.json --cache-key my-api --list
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Cache key generation
+
+When no `--cache-key` is provided, mcp2cli generates a key by hashing the source URL and auth headers with SHA-256 and taking the first 16 hex characters. This means two calls to the same URL with different auth headers get separate cache entries.
+
+## Cache directory
+
+Override the cache directory with the `MCP2CLI_CACHE_DIR` environment variable:
+
+```bash theme={null}
+MCP2CLI_CACHE_DIR=/tmp/my-cache mcp2cli --spec ./spec.json --list
+```
+
+Each cache entry is a JSON file named `<key>.json` inside the cache directory.
+
+## Cache file layout
+
+```
+~/.cache/mcp2cli/
+├── a3f1c9d2e4b7f012.json   # cached OpenAPI spec
+├── 8c2d5e1a9b3f7240.json   # cached MCP tool list
+├── usage.json               # usage tracking data
+└── oauth/
+    └── <hash>/
+        ├── tokens.json      # cached OAuth tokens
+        └── client.json      # registered client info
+```
+
+<Note>
+  OAuth tokens are cached separately in `~/.cache/mcp2cli/oauth/` and are not affected by `--refresh` or `--cache-ttl`. See [Authentication](/features/authentication) for details.
+</Note>
+
+
+# Output control
+Source: https://www.mintlify.com/knowsuchagency/mcp2cli/features/output-control
+
+Filter, format, and truncate output for humans and LLM agents
+
+mcp2cli gives you several flags to shape how results are printed. They work across all modes and can be combined.
+
+## Formatting
+
+<CardGroup>
+  <Card title="--pretty" icon="indent">
+    Pretty-print JSON with 2-space indentation. Also enabled automatically when stdout is a TTY.
+
+    ```bash theme={null}
+    mcp2cli --spec ./spec.json --pretty list-pets
+    ```
+  </Card>
+
+  <Card title="--raw" icon="code">
+    Print the raw response body without any JSON parsing. Useful when the response is not JSON or you want the exact bytes.
+
+    ```bash theme={null}
+    mcp2cli --spec ./spec.json --raw get-data
+    ```
+  </Card>
+</CardGroup>
+
+## Filtering with jq
+
+`--jq EXPR` pipes the output through [jq](https://jqlang.github.io/jq/) with the given expression. jq must be installed and available on your `PATH`.
+
+```bash theme={null}
+# Extract a single field from each record
+mcp2cli --spec ./spec.json list-pets --jq '.[].name'
+
+# Count matching records
+mcp2cli --spec ./spec.json list-pets --jq '[.[] | select(.status == "available")] | length'
+```
+
+<Note>
+  If jq is not installed, mcp2cli exits with an error and prints the install URL. Get jq at [https://jqlang.github.io/jq/](https://jqlang.github.io/jq/).
+</Note>
+
+## Truncating arrays
+
+`--head N` limits array output to the first N records before any other processing. Scalars and objects pass through unchanged.
+
+```bash theme={null}
+# First 5 records
+mcp2cli --spec ./spec.json list-records --head 5
+
+# Preview first 3, then apply a jq filter
+mcp2cli --spec ./spec.json list-records --head 3 --jq '.'
+```
+
+## TOON encoding
+
+`--toon` encodes the output in [TOON format](https://github.com/toon-format/toon), which uses 40–60% fewer tokens than JSON for large uniform arrays. This is useful when feeding mcp2cli output directly to an LLM agent.
+
+```bash theme={null}
+mcp2cli --mcp https://mcp.example.com/sse --toon list-tags
+```
+
+TOON requires the `@toon-format/cli` npm package:
+
+```bash theme={null}
+npm install -g @toon-format/cli
+```
+
+<Warning>
+  If the TOON CLI is not installed, mcp2cli prints a warning to stderr and falls back to normal JSON output rather than failing.
+</Warning>
+
+## Pipe-friendly output
+
+When stdout is not a TTY (e.g. piped to another command), mcp2cli outputs compact JSON automatically. You don't need `--pretty` for human-readable output in a terminal — it's already the default there.
+
+```bash theme={null}
+# Compact JSON when piped
+mcp2cli --spec ./spec.json list-pets | jq '.[] | .name'
+```
+
+## Combining flags
+
+`--head`, `--jq`, `--pretty`, and `--raw` can be combined. Processing order is: `--head` → `--jq` → `--pretty`.
+
+```bash theme={null}
+# Truncate to 3 records, then apply a jq filter
+mcp2cli --spec ./spec.json list-records --head 3 --jq '.[].id'
+```
+
+<Warning>
+  `--jq` and `--toon` are mutually exclusive. Passing both flags will exit with an error.
+</Warning>
+
+
+# Usage tracking
+Source: https://www.mintlify.com/knowsuchagency/mcp2cli/features/usage-tracking
+
+mcp2cli tracks tool invocations to rank --list output and reduce tokens
+
+mcp2cli records every successful tool call locally and uses that data to sort `--list` output. The most-used tools rise to the top, so LLM agents spending tokens on tool discovery see the most relevant results first.
+
+All data stays on your machine. Nothing is sent to any server.
+
+## How it works
+
+After each successful invocation, mcp2cli increments a call count and updates a `last_used` timestamp for that tool and source. When you run `--list` on a source that has usage data, results are sorted by call frequency by default.
+
+Usage data is stored in `~/.cache/mcp2cli/usage.json`:
+
+```json theme={null}
+{
+  "a3f1c9d2e4b7f012": {
+    "list-pets": { "count": 42, "last_used": "2026-04-06T10:30:00+00:00" },
+    "create-pet": { "count": 7, "last_used": "2026-04-05T14:22:10+00:00" }
+  }
+}
+```
+
+The top-level keys are 16-character SHA-256 hashes derived from the source URL or command.
+
+## Sorting --list output
+
+Use `--sort` to control how `--list` orders tools:
+
+| Mode      | Behavior                                               |
+| --------- | ------------------------------------------------------ |
+| `usage`   | Most-called first. **Default when usage data exists.** |
+| `recent`  | Most-recently-used first.                              |
+| `alpha`   | Alphabetical by tool name.                             |
+| `default` | Original insertion order from the spec or server.      |
+
+```bash theme={null}
+# Most-used tools first (auto when usage data exists)
+mcp2cli @myapi --list
+
+# Most recently used first
+mcp2cli @myapi --list --sort recent
+
+# Alphabetical
+mcp2cli @myapi --list --sort alpha
+```
+
+## Reducing token cost
+
+Two flags help cut the token cost of `--list` when working with large APIs:
+
+<CardGroup>
+  <Card title="--top N" icon="list-ol">
+    Show only the top N tools instead of the full list.
+
+    ```bash theme={null}
+    mcp2cli @myapi --list --top 10
+    ```
+  </Card>
+
+  <Card title="--compact" icon="align-justify">
+    Print tool names only, space-separated, with no descriptions.
+
+    ```bash theme={null}
+    mcp2cli @myapi --list --compact
+    ```
+  </Card>
+</CardGroup>
+
+Combine them for the smallest possible output:
+
+```bash theme={null}
+mcp2cli @myapi --list --top 10 --compact
+```
+
+For a real-world API with 96 tools:
+
+* Default `--list`: \~1,400 tokens
+* `--top 10 --compact`: \~20 tokens
+
+## Effective sort when no usage data exists
+
+When mcp2cli has no usage data for a source (e.g., the first time you connect), `--list` preserves insertion order from the spec or server. Explicit `--sort` flags still work regardless of whether usage data exists — `alpha` sorting, for example, requires no history.
+
+
+# AI agent skill
+Source: https://www.mintlify.com/knowsuchagency/mcp2cli/guides/ai-agent-skill
+
+Teach Claude Code, Cursor, and Codex to use mcp2cli with a single install command
+
+The mcp2cli skill is an installable instruction set that teaches AI coding agents how to use mcp2cli. Once installed, your agent can discover tools, call any MCP server or OpenAPI endpoint, and generate new skills from APIs — without you having to explain the CLI in every conversation.
+
+## Install the skill
+
+<Steps>
+  <Step title="Run the install command">
+    Install the mcp2cli skill into your agent's skill directory:
+
+    ```bash theme={null}
+    npx skills add knowsuchagency/mcp2cli --skill mcp2cli
+    ```
+
+    This works with Claude Code, Cursor, and Codex. The skill is added to `.claude/skills/` (or the equivalent directory for your agent) and is automatically picked up on the next session.
+  </Step>
+
+  <Step title="Verify the install">
+    Ask your agent to list available tools from any MCP server:
+
+    ```
+    List the tools available at https://mcp.example.com/sse
+    ```
+
+    The agent will run `mcp2cli --mcp https://mcp.example.com/sse --list` without needing you to explain the flags.
+  </Step>
+</Steps>
+
+## What the skill teaches
+
+The skill gives your agent working knowledge of mcp2cli's full interface — modes, flags, output control, and token efficiency strategies. Specifically, the agent learns to:
+
+<CardGroup>
+  <Card title="Discover tools" icon="magnifying-glass">
+    Run `--list`, `--search`, and `--compact` to find the right tool without wasting tokens on full schema output.
+  </Card>
+
+  <Card title="Call any source" icon="plug">
+    Connect to MCP servers (HTTP/SSE or stdio), OpenAPI specs, and GraphQL endpoints without writing code.
+  </Card>
+
+  <Card title="Handle auth" icon="lock">
+    Use `env:` and `file:` prefixes to pass credentials safely. Understand OAuth flows and token caching.
+  </Card>
+
+  <Card title="Generate skills" icon="wand-magic-sparkles">
+    Discover, test, and bake a new API into a reusable skill without manual documentation.
+  </Card>
+</CardGroup>
+
+## Prompts to try after installing
+
+Once the skill is installed, your agent understands mcp2cli's interface and can act on natural-language requests:
+
+<AccordionGroup>
+  <Accordion title="Discover tools on an MCP server">
+    ```
+    List the tools available at https://mcp.example.com/sse
+    ```
+
+    The agent runs:
+
+    ```bash theme={null}
+    mcp2cli --mcp https://mcp.example.com/sse --list
+    ```
+
+    For a more token-efficient result, it may use `--top` and `--compact`:
+
+    ```bash theme={null}
+    mcp2cli --mcp https://mcp.example.com/sse --list --top 10 --compact
+    ```
+  </Accordion>
+
+  <Accordion title="Call a specific tool">
+    ```
+    Call the search tool with query 'test' using mcp2cli
+    ```
+
+    The agent inspects the tool's parameters first, then calls it:
+
+    ```bash theme={null}
+    mcp2cli --mcp https://mcp.example.com/sse search --help
+    mcp2cli --mcp https://mcp.example.com/sse search --query "test"
+    ```
+  </Accordion>
+
+  <Accordion title="Interact with an OpenAPI endpoint">
+    ```
+    List available pets from https://petstore3.swagger.io/api/v3/openapi.json
+    ```
+
+    The agent fetches and caches the spec, then calls the right operation:
+
+    ```bash theme={null}
+    mcp2cli --spec https://petstore3.swagger.io/api/v3/openapi.json --list
+    mcp2cli --spec https://petstore3.swagger.io/api/v3/openapi.json find-pets-by-status --status available
+    ```
+  </Accordion>
+
+  <Accordion title="Create a baked tool for an API">
+    ```
+    Create a baked tool for the Petstore API
+    ```
+
+    The agent discovers the spec, bakes a named config, and installs a wrapper:
+
+    ```bash theme={null}
+    mcp2cli bake create petstore --spec https://petstore3.swagger.io/api/v3/openapi.json
+    mcp2cli @petstore --list
+    ```
+  </Accordion>
+
+  <Accordion title="Generate a new skill from an API">
+    ```
+    Create a skill for https://api.example.com/openapi.json
+    ```
+
+    The agent runs the full skill-generation workflow: discover all commands, inspect parameters, test edge cases, bake the connection, install the wrapper, and write a `SKILL.md` with usage patterns and gotchas discovered during testing.
+  </Accordion>
+</AccordionGroup>
+
+## Why this matters
+
+Without the skill, an agent discovering tools from a large MCP server must read the full tool schema on every turn. A server with 96 tools produces roughly 1,400 tokens of schema overhead per request — most of it redundant.
+
+The skill teaches the agent to use mcp2cli's token-efficient discovery flags instead:
+
+| Command                     | Tokens (96 tools) |
+| --------------------------- | ----------------- |
+| `--list` (default)          | \~1,400           |
+| `--list --top 10`           | \~150             |
+| `--list --top 10 --compact` | \~20              |
+
+The agent no longer needs to see full JSON schemas to decide which tool to call. It reads the compact list, picks a tool, inspects only that tool's `--help`, and calls it. See [Token efficiency](/guides/token-efficiency) for the full breakdown.
+
+<Tip>
+  After installing, tell your agent to use `--top 10 --compact` for initial tool discovery and only fetch the full `--help` for the specific tool it intends to call. This keeps token usage low even on servers with hundreds of tools.
+</Tip>
+
+
+# Secrets management
+Source: https://www.mintlify.com/knowsuchagency/mcp2cli/guides/secrets-management
+
+Pass credentials securely using env: and file: prefixes
+
+Passing secrets as literal CLI arguments is a common security mistake. Arguments are visible in process listings (`ps aux`), shell history, and log output. mcp2cli provides `env:` and `file:` prefixes that resolve secrets at runtime from environment variables or files — so the credential never appears in the command line.
+
+## The problem with literal secrets
+
+```bash theme={null}
+# Don't do this — the token is visible in ps aux and .bash_history
+mcp2cli --mcp https://mcp.example.com/sse --auth-header "Authorization:sk-abc123..." --list
+```
+
+Anyone with access to process listings on the same machine can read the token. Shell history persists it across sessions.
+
+## Secret prefixes
+
+mcp2cli supports two prefixes for any secret-valued flag:
+
+| Prefix                 | Behavior                                                                                                           |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `env:VAR_NAME`         | Reads the value from the named environment variable. Exits with an error if the variable is not set.               |
+| `file:/path/to/secret` | Reads the value from the file at the given path. Trailing newlines are stripped. Exits if the file does not exist. |
+| *(literal)*            | Passed as-is. Use for non-secret values or when you accept the risk.                                               |
+
+### Supported flags
+
+The following flags support `env:` and `file:` prefixes:
+
+* `--auth-header` values (the part after the colon)
+* `--oauth-client-id`
+* `--oauth-client-secret`
+
+## Examples
+
+<Tabs>
+  <Tab title="Environment variable">
+    Set the secret in your shell environment, then reference it with `env:`:
+
+    ```bash theme={null}
+    export MY_API_TOKEN="sk-abc123..."
+
+    mcp2cli --mcp https://mcp.example.com/sse \
+      --auth-header "Authorization:env:MY_API_TOKEN" \
+      --list
+    ```
+
+    The value of `MY_API_TOKEN` is resolved at runtime. The literal string `env:MY_API_TOKEN` is what appears in the process listing.
+  </Tab>
+
+  <Tab title="File">
+    Write the secret to a file with restricted permissions, then reference it with `file:`:
+
+    ```bash theme={null}
+    echo "sk-abc123..." > /run/secrets/api_key
+    chmod 600 /run/secrets/api_key
+
+    mcp2cli --mcp https://mcp.example.com/sse \
+      --auth-header "Authorization:file:/run/secrets/api_key" \
+      --list
+    ```
+
+    Trailing newlines are stripped automatically. Works well with Docker secrets mounted at `/run/secrets/`.
+  </Tab>
+
+  <Tab title="OAuth credentials">
+    Both `--oauth-client-id` and `--oauth-client-secret` accept the same prefixes:
+
+    ```bash theme={null}
+    mcp2cli --mcp https://mcp.example.com/sse \
+      --oauth-client-secret "file:/run/secrets/client_secret" \
+      --oauth-client-id "my-client-id" \
+      --list
+    ```
+
+    Client IDs are not always secret, but client secrets always are. Use `file:` or `env:` for the secret.
+  </Tab>
+</Tabs>
+
+## Integration with secret managers
+
+Any tool that injects environment variables before running a command works seamlessly with the `env:` prefix. mcp2cli reads the variable after the secret manager has populated it.
+
+<CodeGroup>
+  ```bash Vault (via envconsul) theme={null}
+  envconsul -config=./envconsul.hcl -- \
+    mcp2cli --mcp https://mcp.example.com/sse \
+      --oauth-client-id "env:OAUTH_CLIENT_ID" \
+      --oauth-client-secret "env:OAUTH_CLIENT_SECRET" \
+      --list
+  ```
+
+  ```bash Doppler theme={null}
+  doppler run -- \
+    mcp2cli --spec https://api.example.com/spec.json \
+      --auth-header "Authorization:env:API_TOKEN" \
+      --list
+  ```
+
+  ```bash 1Password CLI theme={null}
+  op run --env-file=.env -- \
+    mcp2cli --mcp https://mcp.example.com/sse \
+      --auth-header "x-api-key:env:MY_API_KEY" \
+      --list
+  ```
+
+  ```bash fnox theme={null}
+  fnox exec -- mcp2cli --mcp https://mcp.example.com/sse \
+    --oauth-client-id "env:OAUTH_CLIENT_ID" \
+    --oauth-client-secret "env:OAUTH_CLIENT_SECRET" \
+    --list
+  ```
+</CodeGroup>
+
+## Bake mode and secrets
+
+When you create a baked tool with `bake create`, the `env:` and `file:` prefixes are stored as-is in `~/.config/mcp2cli/baked.json`. The reference is stored, not the resolved value.
+
+```bash theme={null}
+mcp2cli bake create myapi \
+  --spec https://api.example.com/spec.json \
+  --auth-header "Authorization:env:MY_API_TOKEN"
+```
+
+The baked config stores `"Authorization:env:MY_API_TOKEN"`. Each time you invoke `mcp2cli @myapi`, the value of `MY_API_TOKEN` is resolved fresh from the environment.
+
+`bake show` masks secret values in its output — the literal `env:` or `file:` reference is shown, never the resolved credential:
+
+```bash theme={null}
+mcp2cli bake show myapi
+```
+
+<Note>
+  Because the `env:` reference is stored rather than the resolved value, rotating a secret requires only updating the environment variable — not editing the baked config.
+</Note>
+
+## Implementation reference
+
+The resolution logic lives in `resolve_secret` in `src/mcp2cli/__init__.py`:
+
+```python theme={null}
+def resolve_secret(value: str) -> str:
+    """Resolve a secret value from env var, file, or literal.
+
+    Supports:
+      env:VAR_NAME   — read from environment variable
+      file:/path     — read from file (trailing newline stripped)
+      literal value  — returned as-is
+    """
+    if value.startswith("env:"):
+        var = value[4:]
+        resolved = os.environ.get(var)
+        if resolved is None:
+            print(f"Error: environment variable {var!r} is not set", file=sys.stderr)
+            sys.exit(1)
+        return resolved
+    if value.startswith("file:"):
+        path = Path(value[5:])
+        if not path.exists():
+            print(f"Error: secret file not found: {path}", file=sys.stderr)
+            sys.exit(1)
+        return path.read_text().rstrip("\n")
+    return value
+```
+
+If the environment variable is not set or the file does not exist, mcp2cli exits immediately with a descriptive error — it never silently uses an empty string.
+
+<Warning>
+  Avoid passing raw secrets as literal CLI arguments. Even in a controlled environment, literals end up in shell history, CI logs, and process snapshots. Use `env:` or `file:` prefixes instead.
+</Warning>
+
+
+# Token efficiency
+Source: https://www.mintlify.com/knowsuchagency/mcp2cli/guides/token-efficiency
+
+How mcp2cli saves 96–99% of tokens wasted on tool schemas
+
+Every time an LLM agent calls a tool, the tool schema travels with the request. A server with 96 tools produces roughly 1,400 tokens of schema overhead — per turn. Across a multi-step workflow, schema tokens dominate total cost while carrying almost no information the model doesn't already have.
+
+mcp2cli moves tool discovery to the CLI layer. The model sees one compact line per tool instead of a full JSON object. The schema is never sent.
+
+## The problem in numbers
+
+A standard MCP or OpenAPI tool schema includes the tool name, description, every parameter name, type, and description, plus any enum values or nested objects. For a server with 96 tools:
+
+| Discovery method                    | Approximate tokens |
+| ----------------------------------- | ------------------ |
+| Full JSON schema (all 96 tools)     | \~50,000+          |
+| `mcp2cli --list` (default)          | \~1,400            |
+| `mcp2cli --list --top 10`           | \~150              |
+| `mcp2cli --list --top 10 --compact` | \~20               |
+
+The reduction from raw schema to `--list --top 10 --compact` is **96–99%** on large servers.
+
+## Discovery strategies
+
+Use these flags in combination to match your token budget to the task.
+
+### Default list
+
+```bash theme={null}
+mcp2cli @myapi --list
+```
+
+Prints one tool per line with a truncated description. Sorted by call frequency when usage data exists — the tools you use most appear first automatically. At \~1,400 tokens for 96 tools, this is the richest output short of reading raw schemas.
+
+### Top N tools
+
+```bash theme={null}
+mcp2cli @myapi --list --top 10
+```
+
+Caps output to the N most relevant tools. Combined with usage-aware sorting, `--top 10` surfaces the tools you're most likely to need. Use this when you have a rough idea of the task but want to scan options.
+
+### Compact names only
+
+```bash theme={null}
+mcp2cli @myapi --list --compact
+```
+
+Prints tool names space-separated on a single line, no descriptions. Useful when the agent already knows what tool it's looking for and just needs to confirm the exact name.
+
+### Minimum footprint
+
+```bash theme={null}
+mcp2cli @myapi --list --top 10 --compact
+```
+
+\~20 tokens for 10 tool names. Use this for initial discovery at the start of an agentic workflow, then fetch full `--help` for the one tool you intend to call.
+
+```bash theme={null}
+mcp2cli @myapi search --help
+```
+
+### Inspect a specific tool
+
+```bash theme={null}
+mcp2cli @myapi search --help
+```
+
+Shows only the flags for a single tool. Costs a fraction of listing all tools, and gives the agent everything it needs to construct a correct call.
+
+<Tip>
+  The recommended pattern for agents: start with `--list --top 10 --compact`, pick a tool, then run `<tool> --help`. Total discovery cost: \~50 tokens instead of \~1,400.
+</Tip>
+
+## Usage-aware ranking
+
+mcp2cli tracks every tool invocation locally in `~/.cache/mcp2cli/usage.json`. After the first few calls to a source, `--list` automatically sorts by call frequency — the tools you use most appear first.
+
+```bash theme={null}
+# Sort by most frequently called (default when usage data exists)
+mcp2cli @myapi --list
+
+# Sort by most recently called
+mcp2cli @myapi --list --sort recent
+
+# Alphabetical
+mcp2cli @myapi --list --sort alpha
+
+# Preserve original server order
+mcp2cli @myapi --list --sort default
+```
+
+You can also search by name or description substring without listing everything:
+
+```bash theme={null}
+mcp2cli @myapi --search "task"
+```
+
+`--search` implies `--list` and works across all modes.
+
+## Output control for large responses
+
+Discovery tokens are only part of the cost. Tool responses can also be large. mcp2cli provides three mechanisms to reduce response size before it reaches the model.
+
+### TOON encoding
+
+```bash theme={null}
+mcp2cli --mcp https://mcp.example.com/sse --toon list-tags
+```
+
+TOON (Token-Oriented Object Notation) encodes large uniform arrays in a compact columnar format. For typical tabular API responses, TOON uses **40–60% fewer tokens than JSON**. It requires the `@toon-format/cli` package:
+
+```bash theme={null}
+npm install -g @toon-format/cli
+```
+
+<Note>
+  TOON is most effective for arrays of objects with repeated structure (e.g. lists of records, search results). For single objects or scalar values it falls back to normal JSON output.
+</Note>
+
+### Truncation with `--head`
+
+```bash theme={null}
+# Preview the first 5 records from a large dataset
+mcp2cli @myapi list-records --head 5
+
+# Preview then filter
+mcp2cli @myapi list-records --head 3 --jq '.'
+```
+
+`--head N` slices JSON arrays to the first N elements before returning output. Use it to inspect large datasets without loading the full response into context. Especially useful when records contain large fields (e.g. geometry polygons, embedded blobs).
+
+### Filtering with `--jq`
+
+```bash theme={null}
+# Extract only names from a list
+mcp2cli @myapi list-pets --jq '.[].name'
+
+# Count results
+mcp2cli @myapi list-pets --jq 'length'
+
+# Filter by condition
+mcp2cli @myapi list-pets --jq '[.[] | select(.status == "available")] | length'
+```
+
+`--jq` pipes JSON output through [jq](https://jqlang.github.io/jq/) before returning it. The model sees only the filtered result. Requires `jq` to be installed.
+
+<Tip>
+  Prefer `--jq` over writing a Python script to process JSON. It's more token-efficient, avoids script overhead, and the expression is readable inline.
+</Tip>
+
+## Bake mode and tool filtering
+
+When you bake a connection, you can filter which tools are included at load time with `--include` and `--exclude`. The agent only ever sees the relevant subset.
+
+```bash theme={null}
+# Only expose read operations
+mcp2cli bake create myapi-readonly \
+  --spec https://api.example.com/spec.json \
+  --methods GET \
+  --exclude "delete-*,update-*"
+
+# Use the filtered view
+mcp2cli @myapi-readonly --list
+```
+
+Filtering at bake time is the most aggressive reduction: tools excluded from the baked config never appear in `--list` output and cannot be called accidentally.
+
+See [Bake mode](/features/bake-mode) for full filtering options.
+
+## Recommended workflow for agents
+
+<Steps>
+  <Step title="Initial discovery">
+    Start with the minimum footprint to see what's available:
+
+    ```bash theme={null}
+    mcp2cli @myapi --list --top 10 --compact
+    ```
+  </Step>
+
+  <Step title="Inspect a specific tool">
+    Once you've identified the right tool, get its full parameter list:
+
+    ```bash theme={null}
+    mcp2cli @myapi search --help
+    ```
+  </Step>
+
+  <Step title="Call and filter">
+    Call the tool and filter the response to only what the agent needs:
+
+    ```bash theme={null}
+    mcp2cli @myapi search --query "test" --jq '.[].name' --head 10
+    ```
+  </Step>
+</Steps>
+
+This pattern keeps per-turn token cost well under 100 tokens for discovery, regardless of how many tools the server exposes.
+
+
+# Installation
+Source: https://www.mintlify.com/knowsuchagency/mcp2cli/installation
+
+Install mcp2cli using uv or run it directly with uvx
+
+## Requirements
+
+* Python >= 3.10
+* [uv](https://docs.astral.sh/uv/) (recommended) or pip
+
+mcp2cli version **2.7.0** depends on:
+
+* `mcp >= 1.0`
+* `httpx`
+* `pyyaml`
+
+These are installed automatically.
+
+## Install mcp2cli
+
+<Tabs>
+  <Tab title="Run without installing">
+    Use `uvx` to run mcp2cli directly without installing it. `uvx` downloads and caches the package in an isolated environment on first run:
+
+    ```bash theme={null}
+    uvx mcp2cli --help
+    ```
+
+    This is the fastest way to try mcp2cli. Subsequent runs use the cached environment.
+  </Tab>
+
+  <Tab title="Install globally">
+    Install mcp2cli as a persistent global tool using `uv tool install`:
+
+    ```bash theme={null}
+    uv tool install mcp2cli
+    ```
+
+    After installing, the `mcp2cli` command is available in your shell without the `uvx` prefix.
+  </Tab>
+</Tabs>
+
+## Verify the installation
+
+Check that mcp2cli is available and confirm the version:
+
+```bash theme={null}
+mcp2cli --version
+```
+
+You should see output like:
+
+```
+mcp2cli 2.7.0
+```
+
+## AI agent skill
+
+mcp2cli ships with an installable [skill](https://skills.sh) that teaches AI coding agents (Claude Code, Cursor, Codex) how to use it. Install it with:
+
+```bash theme={null}
+npx skills add knowsuchagency/mcp2cli --skill mcp2cli
+```
+
+Once installed, your agent can discover and call any MCP server or OpenAPI endpoint — and even generate new skills from APIs.
+
+<Note>
+  The skill requires Node.js and npx. It does not affect the mcp2cli Python installation.
+</Note>
+
+See the [AI agent skill guide](/guides/ai-agent-skill) for usage examples.
+
+
+# Introduction
+Source: https://www.mintlify.com/knowsuchagency/mcp2cli/introduction
+
+What mcp2cli is and why it exists
+
+mcp2cli turns any MCP server, OpenAPI spec, or GraphQL endpoint into a fully dynamic command-line interface — at runtime, with zero code generation. Point it at an API and start calling tools in seconds.
+
+## The problem
+
+When LLM agents call tools, they send the full tool schema on every turn. A server with 96 tools produces roughly 1,400 tokens of schema overhead — per request. That overhead is wasted: the agent already knows what tools exist. Across an agentic workflow, **96–99% of tokens consumed by tool discovery are redundant**.
+
+mcp2cli moves tool discovery to the CLI layer. Instead of passing schemas to the model, you call the tool directly from the terminal. The model sees only the result.
+
+## What mcp2cli does
+
+* Introspects APIs at runtime — no SDK, no codegen, no build step
+* Generates typed subcommands dynamically from specs and tool definitions
+* Passes arguments as CLI flags and returns structured output
+* Tracks invocations locally to rank tools by usage, reducing `--list` token cost further
+* Supports OAuth, bake mode for reusable configs, and TOON output for token-efficient encoding
+
+## Supported sources
+
+<CardGroup>
+  <Card title="MCP HTTP/SSE" icon="server" href="/modes/mcp-http">
+    Connect to any MCP server over HTTP or SSE transport using `--mcp`
+  </Card>
+
+  <Card title="MCP stdio" icon="square-terminal" href="/modes/mcp-stdio">
+    Spawn and communicate with local MCP servers over stdin/stdout using `--mcp-stdio`
+  </Card>
+
+  <Card title="OpenAPI" icon="file-code" href="/modes/openapi">
+    Turn any OpenAPI 3.x spec (JSON or YAML, local or remote) into a CLI using `--spec`
+  </Card>
+
+  <Card title="GraphQL" icon="diagram-project" href="/modes/graphql">
+    Introspect and call any GraphQL endpoint using `--graphql`
+  </Card>
+</CardGroup>
+
+## Key capabilities
+
+**Bake mode** — save connection settings (URL, auth headers, OAuth config) as a named tool so you never repeat flags:
+
+```bash theme={null}
+mcp2cli bake create petstore --spec https://petstore3.swagger.io/api/v3/openapi.json
+mcp2cli @petstore --list
+```
+
+**Usage-aware ranking** — mcp2cli tracks which tools you call and ranks `--list` output by frequency. Combined with `--top` and `--compact`, a list of 96 tools shrinks from \~1,400 tokens to \~20:
+
+```bash theme={null}
+mcp2cli @myapi --list --top 10 --compact
+```
+
+**OAuth** — authorization code + PKCE and client credentials flows are built in, with automatic token caching and refresh.
+
+**Token-efficient output** — `--toon` encodes large uniform arrays in a compact format that uses 40–60% fewer tokens than JSON.
+
+**Output control** — filter with `--jq`, truncate with `--head`, pretty-print with `--pretty`, or get raw bytes with `--raw`.
+
+## AI agent skill
+
+mcp2cli ships with an installable [skill](https://skills.sh) that teaches AI coding agents (Claude Code, Cursor, Codex) how to use it. Once installed, your agent can discover and call any MCP server or OpenAPI endpoint without manual prompting.
+
+```bash theme={null}
+npx skills add knowsuchagency/mcp2cli --skill mcp2cli
+```
+
+See the [AI agent skill guide](/guides/ai-agent-skill) for details.
+
+
+# GraphQL
+Source: https://www.mintlify.com/knowsuchagency/mcp2cli/modes/graphql
+
+Introspect and call any GraphQL endpoint — queries and mutations
+
+Use `--graphql` to point mcp2cli at a GraphQL endpoint. mcp2cli runs the introspection query, discovers every query and mutation, builds typed subcommands for each, and auto-generates selection sets — no SDL parsing or code generation required.
+
+## Connect and list operations
+
+Pass the endpoint URL to `--graphql` and add `--list` to see all available queries and mutations grouped by operation type:
+
+```bash theme={null}
+mcp2cli --graphql https://api.example.com/graphql --list
+```
+
+Output is grouped into `queries:` and `mutations:` sections so you can quickly identify what is available.
+
+## Call a query
+
+Subcommand names are the kebab-case version of the GraphQL field names. Pass arguments as typed flags derived from the field's arguments in the schema:
+
+```bash theme={null}
+mcp2cli --graphql https://api.example.com/graphql users --limit 10
+```
+
+## Call a mutation
+
+Mutations are called the same way as queries. mcp2cli determines the operation type from the schema:
+
+```bash theme={null}
+mcp2cli --graphql https://api.example.com/graphql create-user --name "Alice" --email "alice@example.com"
+```
+
+Run any subcommand with `--help` to see its flags and argument types:
+
+```bash theme={null}
+mcp2cli --graphql https://api.example.com/graphql create-user --help
+```
+
+## Auto-generated selection sets
+
+mcp2cli builds selection sets automatically from the return type reported by the introspection schema. You do not need to write GraphQL documents or parse an SDL file — just point and run.
+
+The generated document looks like:
+
+```
+query($limit: Int) { users(limit: $limit) { id name email createdAt } }
+```
+
+Variables are declared with the correct GraphQL types derived from the schema's type system.
+
+## Override the selection set
+
+Use `--fields` to replace the auto-generated selection set with your own space-separated field list:
+
+```bash theme={null}
+mcp2cli --graphql https://api.example.com/graphql users --fields "id name email"
+```
+
+<Tip>
+  Use `--fields` when the default selection set includes fields you don't need, or when you want to request nested fields that the auto-generator doesn't traverse into.
+</Tip>
+
+## Name collision handling
+
+When a query and a mutation share the same field name, mcp2cli prefixes the subcommand name to avoid collisions:
+
+* The query becomes `query-{name}`
+* The mutation becomes `mutation-{name}`
+
+<Note>
+  This only applies when there is an actual collision between a query field name and a mutation field name. In all other cases, the plain kebab-case name is used.
+</Note>
+
+## Search operations
+
+Use `--search PATTERN` to filter the list of operations by name or description. The match is case-insensitive and substring-based. `--search` implies `--list`:
+
+```bash theme={null}
+mcp2cli --graphql https://api.example.com/graphql --search "user"
+```
+
+## Authentication
+
+Pass one or more HTTP headers with `--auth-header KEY:VALUE`:
+
+```bash theme={null}
+mcp2cli --graphql https://api.example.com/graphql --auth-header "Authorization:Bearer tok_..." users
+```
+
+Values support `env:` and `file:` prefixes to avoid exposing secrets in process listings:
+
+```bash theme={null}
+mcp2cli --graphql https://api.example.com/graphql \
+  --auth-header "Authorization:env:GRAPHQL_TOKEN" \
+  users
+```
+
+## Example commands
+
+<CodeGroup>
+  ```bash List operations theme={null}
+  mcp2cli --graphql https://api.example.com/graphql --list
+  ```
+
+  ```bash Call a query theme={null}
+  mcp2cli --graphql https://api.example.com/graphql users --limit 10
+  ```
+
+  ```bash Call a mutation theme={null}
+  mcp2cli --graphql https://api.example.com/graphql create-user --name "Alice" --email "alice@example.com"
+  ```
+
+  ```bash Override selection set theme={null}
+  mcp2cli --graphql https://api.example.com/graphql users --fields "id name email"
+  ```
+
+  ```bash With authentication theme={null}
+  mcp2cli --graphql https://api.example.com/graphql --auth-header "Authorization:Bearer tok_..." users
+  ```
+</CodeGroup>
+
+
+# MCP HTTP/SSE
+Source: https://www.mintlify.com/knowsuchagency/mcp2cli/modes/mcp-http
+
+Connect to MCP servers over HTTP or Server-Sent Events
+
+Use `--mcp` to connect to an MCP server exposed over HTTP. mcp2cli discovers all available tools from the server, turns each one into a subcommand, and routes your call back over the same connection.
+
+## Connect and list tools
+
+Pass the server URL to `--mcp` and add `--list` to see every tool the server exposes:
+
+```bash theme={null}
+mcp2cli --mcp https://mcp.example.com/sse --list
+```
+
+Each tool appears as a subcommand name alongside its description. The list reflects what the live server reports — no static config required.
+
+## Call a tool
+
+Subcommand names are the kebab-case version of the tool names reported by the server. Pass arguments as typed flags:
+
+```bash theme={null}
+mcp2cli --mcp https://mcp.example.com/sse search --query "test"
+```
+
+Run any subcommand with `--help` to see its flags and descriptions:
+
+```bash theme={null}
+mcp2cli --mcp https://mcp.example.com/sse search --help
+```
+
+## Transport modes
+
+mcp2cli supports three transport modes for MCP HTTP connections. Use `--transport` to control which one is used.
+
+| Value            | Behaviour                                                    |
+| ---------------- | ------------------------------------------------------------ |
+| `auto` (default) | Tries streamable HTTP first; falls back to SSE if that fails |
+| `streamable`     | Forces streamable HTTP transport only                        |
+| `sse`            | Forces SSE transport only                                    |
+
+<Note>
+  Use `--transport sse` to skip the streamable HTTP probe when you know the server only speaks SSE. This avoids an extra round-trip on the first connection.
+</Note>
+
+```bash theme={null}
+mcp2cli --mcp https://mcp.example.com/sse --transport sse --list
+```
+
+## Authentication
+
+Pass one or more HTTP headers with `--auth-header KEY:VALUE`. The flag is repeatable:
+
+```bash theme={null}
+mcp2cli --mcp https://mcp.example.com/sse --auth-header "x-api-key:sk-..." \
+  query --sql "SELECT 1"
+```
+
+To avoid exposing secrets in process listings, use the `env:` or `file:` prefix in the value:
+
+```bash theme={null}
+mcp2cli --mcp https://mcp.example.com/sse \
+  --auth-header "Authorization:env:MY_API_TOKEN" \
+  --list
+```
+
+`env:MY_API_TOKEN` reads the value from the `MY_API_TOKEN` environment variable at runtime. `file:/run/secrets/token` reads from a file path.
+
+## Search tools
+
+Use `--search PATTERN` to filter tools by name or description. The match is case-insensitive and substring-based. `--search` implies `--list`, so you do not need both flags:
+
+```bash theme={null}
+mcp2cli --mcp https://mcp.example.com/sse --search "task"
+```
+
+<Tip>
+  `--search` works across all modes — `--mcp`, `--mcp-stdio`, `--spec`, and `--graphql`.
+</Tip>
+
+## Resources and prompts
+
+MCP servers can expose [Resources](https://modelcontextprotocol.io/docs/concepts/resources) and [Prompts](https://modelcontextprotocol.io/docs/concepts/prompts) in addition to tools. mcp2cli supports all three:
+
+```bash theme={null}
+# List resources
+mcp2cli --mcp https://mcp.example.com/sse --list-resources
+
+# Read a resource by URI
+mcp2cli --mcp https://mcp.example.com/sse --read-resource "file:///data/report.txt"
+
+# List prompt templates
+mcp2cli --mcp https://mcp.example.com/sse --list-prompts
+
+# Get a prompt by name
+mcp2cli --mcp https://mcp.example.com/sse --get-prompt summarize --prompt-arg "topic=AI"
+```
+
+## Persistent sessions
+
+Use `--session-start` to keep the MCP server process alive between calls, avoiding reconnection overhead on every invocation:
+
+```bash theme={null}
+# Start a named session
+mcp2cli --mcp https://mcp.example.com/sse --session-start myserver
+
+# Call tools through the session
+mcp2cli --session myserver search --query "test"
+mcp2cli --session myserver --list
+
+# Stop the session when done
+mcp2cli --session-stop myserver
+```
+
+## Example commands
+
+<CodeGroup>
+  ```bash List tools theme={null}
+  mcp2cli --mcp https://mcp.example.com/sse --list
+  ```
+
+  ```bash Call a tool theme={null}
+  mcp2cli --mcp https://mcp.example.com/sse search --query "test"
+  ```
+
+  ```bash With authentication theme={null}
+  mcp2cli --mcp https://mcp.example.com/sse --auth-header "x-api-key:sk-..." \
+    query --sql "SELECT 1"
+  ```
+
+  ```bash Force SSE transport theme={null}
+  mcp2cli --mcp https://mcp.example.com/sse --transport sse --list
+  ```
+
+  ```bash Search tools theme={null}
+  mcp2cli --mcp https://mcp.example.com/sse --search "task"
+  ```
+</CodeGroup>
+
+
+# MCP stdio
+Source: https://www.mintlify.com/knowsuchagency/mcp2cli/modes/mcp-stdio
+
+Spawn and talk to local MCP servers over stdin/stdout
+
+Use `--mcp-stdio` to launch a local MCP server as a subprocess and communicate with it over stdin/stdout. mcp2cli spawns the process, performs the MCP handshake, and exposes every tool as a subcommand — no network required.
+
+## Spawn a server and list tools
+
+Pass the shell command that starts your MCP server as a quoted string:
+
+```bash theme={null}
+mcp2cli --mcp-stdio "npx @modelcontextprotocol/server-filesystem /tmp" --list
+```
+
+mcp2cli spawns the command, waits for it to become ready, then prints every tool the server reports. The server process is terminated when mcp2cli exits.
+
+## Call a tool
+
+After listing, call any tool by name (kebab-cased) with its arguments as flags:
+
+```bash theme={null}
+mcp2cli --mcp-stdio "npx @modelcontextprotocol/server-filesystem /tmp" \
+  read-file --path /tmp/hello.txt
+```
+
+Run any subcommand with `--help` to see its available flags:
+
+```bash theme={null}
+mcp2cli --mcp-stdio "npx @modelcontextprotocol/server-filesystem /tmp" \
+  read-file --help
+```
+
+## Pass environment variables
+
+Use `--env KEY=VALUE` to inject environment variables into the server process. The flag is repeatable:
+
+```bash theme={null}
+mcp2cli --mcp-stdio "node server.js" --env API_KEY=sk-... --env DEBUG=1 \
+  search --query "test"
+```
+
+<Note>
+  To avoid exposing secrets in process listings, you can pass them via the env vars of the parent shell rather than inlining them in the `--env` value. Any environment variable already set in your shell is automatically inherited by the subprocess.
+</Note>
+
+## Search tools
+
+Use `--search PATTERN` to filter tools by name or description without listing everything. The match is case-insensitive and substring-based:
+
+```bash theme={null}
+mcp2cli --mcp-stdio "npx @modelcontextprotocol/server-filesystem /tmp" \
+  --search "read"
+```
+
+## Resources and prompts
+
+If the spawned MCP server exposes Resources or Prompts, you can access them the same way as with HTTP servers:
+
+```bash theme={null}
+# List resources
+mcp2cli --mcp-stdio "npx @modelcontextprotocol/server-filesystem /tmp" --list-resources
+
+# Read a resource by URI
+mcp2cli --mcp-stdio "npx @modelcontextprotocol/server-filesystem /tmp" \
+  --read-resource "file:///tmp/hello.txt"
+
+# List prompt templates
+mcp2cli --mcp-stdio "node server.js" --list-prompts
+```
+
+## Persistent sessions
+
+Use `--session-start` to keep the stdio server process running between calls. This avoids the overhead of re-spawning and re-initializing the server on every invocation:
+
+```bash theme={null}
+# Start a named session
+mcp2cli --mcp-stdio "npx @modelcontextprotocol/server-filesystem /tmp" \
+  --session-start myfs
+
+# Call tools through the session
+mcp2cli --session myfs read-file --path /tmp/hello.txt
+
+# Stop the session
+mcp2cli --session-stop myfs
+```
+
+## Example commands
+
+<CodeGroup>
+  ```bash List tools theme={null}
+  mcp2cli --mcp-stdio "npx @modelcontextprotocol/server-filesystem /tmp" --list
+  ```
+
+  ```bash Call a tool theme={null}
+  mcp2cli --mcp-stdio "npx @modelcontextprotocol/server-filesystem /tmp" \
+    read-file --path /tmp/hello.txt
+  ```
+
+  ```bash With environment variables theme={null}
+  mcp2cli --mcp-stdio "node server.js" --env API_KEY=sk-... --env DEBUG=1 \
+    search --query "test"
+  ```
+</CodeGroup>
+
+
+# OpenAPI
+Source: https://www.mintlify.com/knowsuchagency/mcp2cli/modes/openapi
+
+Turn any OpenAPI 3.x spec into a CLI — local or remote, JSON or YAML
+
+Use `--spec` to point mcp2cli at an OpenAPI 3.x spec. mcp2cli fetches and parses the spec, turns every operation into a subcommand, and maps path, query, header, and body parameters to typed CLI flags — no code generation required.
+
+## Supported spec formats
+
+mcp2cli accepts specs in JSON or YAML format, from a URL or a local file path.
+
+<Tabs>
+  <Tab title="Remote URL">
+    ```bash theme={null}
+    mcp2cli --spec https://petstore3.swagger.io/api/v3/openapi.json --list
+    ```
+
+    Remote specs are cached in `~/.cache/mcp2cli/` with a 1-hour TTL by default. Use `--refresh` to bypass the cache.
+  </Tab>
+
+  <Tab title="Local file">
+    ```bash theme={null}
+    mcp2cli --spec ./api.yaml --base-url http://localhost:8000 --list
+    ```
+
+    Local files are never cached. You must provide `--base-url` when using a local spec, because mcp2cli cannot infer the server URL from a file path.
+  </Tab>
+</Tabs>
+
+## Override the base URL
+
+When the spec's `servers` block points to the wrong host (or is absent), use `--base-url` to override it:
+
+```bash theme={null}
+mcp2cli --spec ./openapi.json --base-url https://api.example.com list-pets --status available
+```
+
+## List all operations
+
+Add `--list` to print every subcommand with a short description:
+
+```bash theme={null}
+mcp2cli --spec https://petstore3.swagger.io/api/v3/openapi.json --list
+```
+
+## Call an operation
+
+Subcommand names are derived from the `operationId` field in the spec, converted to kebab-case. If an operation has no `operationId`, mcp2cli generates a name from the HTTP method and path.
+
+Pass arguments as typed flags matching the operation's parameters:
+
+```bash theme={null}
+mcp2cli --spec ./openapi.json --base-url https://api.example.com list-pets --status available
+```
+
+Run any subcommand with `--help` to see all its flags:
+
+```bash theme={null}
+mcp2cli --spec ./openapi.json list-pets --help
+```
+
+## Parameter locations
+
+Parameters from all locations in the spec become CLI flags:
+
+| OpenAPI location         | CLI flag source  |
+| ------------------------ | ---------------- |
+| `path`                   | `--{param-name}` |
+| `query`                  | `--{param-name}` |
+| `header`                 | `--{param-name}` |
+| `requestBody` properties | `--{prop-name}`  |
+
+<Note>
+  `$ref` resolution happens automatically. mcp2cli dereferences the entire spec before extracting commands, so you do not need to pre-process the spec.
+</Note>
+
+## POST and PUT with JSON body from stdin
+
+For operations with a request body, you can pipe JSON directly from stdin using `--stdin`:
+
+```bash theme={null}
+echo '{"name": "Fido", "tag": "dog"}' | mcp2cli --spec ./spec.json create-pet --stdin
+```
+
+Individual body properties can also be passed as flags when the spec defines them as top-level properties of the request body schema.
+
+## Authentication
+
+Pass one or more HTTP headers with `--auth-header KEY:VALUE`:
+
+```bash theme={null}
+mcp2cli --spec ./spec.json --auth-header "Authorization:Bearer tok_..." create-item --name "Test"
+```
+
+The flag is repeatable. Values support `env:` and `file:` prefixes to avoid exposing secrets in process listings:
+
+```bash theme={null}
+mcp2cli --spec ./spec.json \
+  --auth-header "Authorization:env:API_TOKEN" \
+  list-pets
+```
+
+## Example commands
+
+<CodeGroup>
+  ```bash List from remote spec theme={null}
+  mcp2cli --spec https://petstore3.swagger.io/api/v3/openapi.json --list
+  ```
+
+  ```bash Call an endpoint theme={null}
+  mcp2cli --spec ./openapi.json --base-url https://api.example.com list-pets --status available
+  ```
+
+  ```bash With authentication theme={null}
+  mcp2cli --spec ./spec.json --auth-header "Authorization:Bearer tok_..." create-item --name "Test"
+  ```
+
+  ```bash POST body from stdin theme={null}
+  echo '{"name": "Fido", "tag": "dog"}' | mcp2cli --spec ./spec.json create-pet --stdin
+  ```
+
+  ```bash Local YAML spec theme={null}
+  mcp2cli --spec ./api.yaml --base-url http://localhost:8000 --list
+  ```
+</CodeGroup>
+
+
+# Quickstart
+Source: https://www.mintlify.com/knowsuchagency/mcp2cli/quickstart
+
+Call your first API in under 60 seconds
+
+<Steps>
+  <Step title="Install mcp2cli">
+    Run mcp2cli directly with `uvx` — no installation required:
+
+    ```bash theme={null}
+    uvx mcp2cli --help
+    ```
+
+    Or install it globally so you can call `mcp2cli` without the `uvx` prefix:
+
+    ```bash theme={null}
+    uv tool install mcp2cli
+    ```
+
+    See [Installation](/installation) for full details and requirements.
+  </Step>
+
+  <Step title="List operations from an API">
+    Point mcp2cli at the Petstore OpenAPI spec and list all available operations:
+
+    ```bash theme={null}
+    mcp2cli --spec https://petstore3.swagger.io/api/v3/openapi.json --list
+    ```
+
+    mcp2cli fetches and caches the spec, then prints every operation as a subcommand with a short description. The same `--list` flag works across all modes: `--mcp`, `--mcp-stdio`, `--spec`, and `--graphql`.
+
+    <Tip>
+      Use `--search` to filter tools by name or description without scrolling through the full list:
+
+      ```bash theme={null}
+      mcp2cli --spec https://petstore3.swagger.io/api/v3/openapi.json --search "pet"
+      ```
+    </Tip>
+  </Step>
+
+  <Step title="Call an operation">
+    Subcommands are generated from the spec. Pass arguments as typed flags:
+
+    ```bash theme={null}
+    mcp2cli --spec ./openapi.json --base-url https://api.example.com list-pets --status available
+    ```
+
+    Run `<subcommand> --help` to see all flags for a specific operation:
+
+    ```bash theme={null}
+    mcp2cli --spec ./openapi.json list-pets --help
+    ```
+  </Step>
+
+  <Step title="Bake settings for reuse">
+    Tired of repeating `--spec` and auth flags on every call? Bake them into a named configuration:
+
+    ```bash theme={null}
+    mcp2cli bake create petstore --spec https://petstore3.swagger.io/api/v3/openapi.json
+    ```
+
+    Then call the baked tool with the `@` prefix — no connection flags needed:
+
+    ```bash theme={null}
+    mcp2cli @petstore --list
+    mcp2cli @petstore list-pets --status available
+    ```
+
+    Baked configs are stored in `~/.config/mcp2cli/baked.json`.
+  </Step>
+</Steps>
+
+## Explore the modes
+
+<CardGroup>
+  <Card title="MCP HTTP/SSE" icon="server" href="/modes/mcp-http">
+    Connect to MCP servers over HTTP or SSE
+  </Card>
+
+  <Card title="MCP stdio" icon="square-terminal" href="/modes/mcp-stdio">
+    Spawn local MCP servers over stdin/stdout
+  </Card>
+
+  <Card title="OpenAPI" icon="file-code" href="/modes/openapi">
+    Turn any OpenAPI 3.x spec into a CLI
+  </Card>
+
+  <Card title="GraphQL" icon="diagram-project" href="/modes/graphql">
+    Introspect and call any GraphQL endpoint
+  </Card>
+</CardGroup>
+
+
+# Bake commands
+Source: https://www.mintlify.com/knowsuchagency/mcp2cli/reference/bake-commands
+
+Save and manage named connection configurations
+
+Bake mode lets you save connection settings — URL, auth headers, OAuth config, transport, and filters — as a named tool. Once baked, you run the tool with a simple `@name` prefix instead of repeating flags on every call.
+
+```bash theme={null}
+# Without bake
+mcp2cli --spec https://petstore3.swagger.io/api/v3/openapi.json \
+  --auth-header "Authorization:Bearer tok_..." \
+  --cache-ttl 7200 \
+  list-pets --status available
+
+# With bake
+mcp2cli @petstore list-pets --status available
+```
+
+Configs are stored in `~/.config/mcp2cli/baked.json`. Override the directory with the `MCP2CLI_CONFIG_DIR` environment variable.
+
+<Note>
+  Baked tool names must match the pattern `[a-z][a-z0-9-]*` — lowercase letters, digits, and hyphens only, starting with a letter.
+</Note>
+
+***
+
+## bake create
+
+Save a connection configuration as a named tool.
+
+**Syntax**
+
+```bash theme={null}
+mcp2cli bake create NAME [options]
+```
+
+**Source options** (mutually exclusive, one required)
+
+<ParamField type="URL|FILE">
+  OpenAPI spec URL or local file path to bake.
+</ParamField>
+
+<ParamField type="URL">
+  MCP server URL (HTTP/SSE) to bake.
+</ParamField>
+
+<ParamField type="CMD">
+  MCP stdio server command to bake.
+</ParamField>
+
+**Connection options**
+
+<ParamField type="URL">
+  Override the base URL. Stored in the config and used on every invocation.
+</ParamField>
+
+<ParamField type="K:V">
+  HTTP header to include on every request. Repeatable. Values support `env:` and `file:` prefixes so secrets are never stored in plaintext in `baked.json`.
+</ParamField>
+
+<ParamField type="KEY=VALUE">
+  Environment variable for the MCP stdio server process. Repeatable. Only relevant with `--mcp-stdio`.
+</ParamField>
+
+<ParamField type="string">
+  MCP HTTP transport: `auto` | `sse` | `streamable`.
+</ParamField>
+
+<ParamField type="integer">
+  Cache TTL in seconds for the baked tool.
+</ParamField>
+
+**OAuth options**
+
+<ParamField type="boolean">
+  Enable OAuth (authorization code + PKCE flow).
+</ParamField>
+
+<ParamField type="ID">
+  OAuth client ID. Supports `env:` and `file:` prefixes.
+</ParamField>
+
+<ParamField type="string">
+  OAuth client secret. Supports `env:` and `file:` prefixes.
+</ParamField>
+
+<ParamField type="NAME">
+  Client name sent during Dynamic Client Registration.
+</ParamField>
+
+<ParamField type="SCOPE">
+  OAuth scope(s) to request.
+</ParamField>
+
+<ParamField type="URI">
+  Full redirect URI for the OAuth callback. Must be a loopback `http://` URI.
+</ParamField>
+
+<ParamField type="string">
+  OAuth flow: `auto` | `authorization_code` | `client_credentials`.
+</ParamField>
+
+**Filtering options**
+
+<ParamField type="string">
+  Comma-separated glob patterns to whitelist tools. Only matching tools are exposed when using this baked tool.
+
+  ```bash theme={null}
+  --include "list-*,get-*"
+  ```
+</ParamField>
+
+<ParamField type="string">
+  Comma-separated glob patterns to blacklist tools. Matching tools are hidden.
+
+  ```bash theme={null}
+  --exclude "delete-*,update-*"
+  ```
+</ParamField>
+
+<ParamField type="string">
+  Comma-separated HTTP methods to allow (OpenAPI only). Tools for other methods are hidden.
+
+  ```bash theme={null}
+  --methods "GET,POST"
+  ```
+</ParamField>
+
+**Other**
+
+<ParamField type="string">
+  Human-readable description stored in the config. Displayed in `bake list`.
+</ParamField>
+
+<ParamField type="boolean">
+  Overwrite an existing baked tool with the same name without prompting.
+</ParamField>
+
+**Examples**
+
+```bash theme={null}
+# Bake an OpenAPI spec with auth, filters, and a custom TTL
+mcp2cli bake create petstore \
+  --spec https://petstore3.swagger.io/api/v3/openapi.json \
+  --auth-header "Authorization:env:PETSTORE_TOKEN" \
+  --exclude "delete-*" \
+  --methods GET,POST \
+  --cache-ttl 7200
+
+# Bake an MCP stdio server with tool filtering
+mcp2cli bake create mygit \
+  --mcp-stdio "npx @mcp/github" \
+  --include "search-*,list-*" \
+  --exclude "delete-*"
+
+# Overwrite an existing baked tool
+mcp2cli bake create petstore --spec https://api.example.com/v2/openapi.json --force
+```
+
+***
+
+## bake list
+
+List all baked tools with their type and source.
+
+**Syntax**
+
+```bash theme={null}
+mcp2cli bake list
+```
+
+**Output**
+
+Prints a table with three columns: `Name`, `Type`, and `Source`.
+
+```
+Name                 Type       Source
+--------------------------------------------------------------------------------
+mygit                mcp_stdio  npx @mcp/github
+petstore             spec       https://petstore3.swagger.io/api/v3/openapi.json
+```
+
+Source values longer than 48 characters are truncated with `...`.
+
+***
+
+## bake show
+
+Show the full stored configuration for a baked tool. Auth header values are masked: literal secrets are truncated to their first four characters followed by `****`. Values using `env:` or `file:` prefixes are shown as-is.
+
+**Syntax**
+
+```bash theme={null}
+mcp2cli bake show NAME
+```
+
+**Example**
+
+```bash theme={null}
+mcp2cli bake show petstore
+```
+
+```json theme={null}
+{
+  "source_type": "spec",
+  "source": "https://petstore3.swagger.io/api/v3/openapi.json",
+  "base_url": null,
+  "auth_headers": [["Authorization", "Bear****"]],
+  "env_vars": {},
+  "cache_ttl": 7200,
+  "transport": "auto",
+  "oauth": false,
+  "oauth_client_id": null,
+  "oauth_client_secret": null,
+  "oauth_client_name": "mcp2cli",
+  "oauth_scope": null,
+  "oauth_redirect_uri": null,
+  "oauth_flow": "auto",
+  "include": [],
+  "exclude": ["delete-*"],
+  "methods": ["GET", "POST"],
+  "description": ""
+}
+```
+
+***
+
+## bake update
+
+Update specific settings on an existing baked tool without recreating it. Only the fields you pass are changed.
+
+**Syntax**
+
+```bash theme={null}
+mcp2cli bake update NAME [options]
+```
+
+**Options**
+
+<ParamField type="integer">
+  New cache TTL in seconds.
+</ParamField>
+
+<ParamField type="string">
+  Replace the include glob list (comma-separated).
+</ParamField>
+
+<ParamField type="string">
+  Replace the exclude glob list (comma-separated).
+</ParamField>
+
+<ParamField type="string">
+  Replace the allowed HTTP methods list (comma-separated, OpenAPI only).
+</ParamField>
+
+<ParamField type="string">
+  Update the description.
+</ParamField>
+
+<ParamField type="URL">
+  Update the base URL override.
+</ParamField>
+
+<ParamField type="string">
+  Update the MCP HTTP transport: `auto` | `sse` | `streamable`.
+</ParamField>
+
+**Example**
+
+```bash theme={null}
+# Extend TTL and narrow to GET only
+mcp2cli bake update petstore --cache-ttl 86400 --methods GET
+```
+
+***
+
+## bake remove
+
+Delete a baked tool. If a wrapper script was installed with `bake install`, it is also removed from `~/.local/bin`.
+
+**Syntax**
+
+```bash theme={null}
+mcp2cli bake remove NAME
+```
+
+**Example**
+
+```bash theme={null}
+mcp2cli bake remove petstore
+# Baked tool 'petstore' removed.
+# (also removes ~/.local/bin/petstore if it exists)
+```
+
+***
+
+## bake install
+
+Create a standalone executable wrapper script that calls `mcp2cli @NAME "$@"`. The wrapper is placed in `~/.local/bin` by default, making the baked tool available as a first-class CLI command.
+
+**Syntax**
+
+```bash theme={null}
+mcp2cli bake install NAME [--dir DIR]
+```
+
+**Options**
+
+<ParamField type="DIR">
+  Directory to install the wrapper into. Defaults to `~/.local/bin`. The directory is created if it does not exist.
+</ParamField>
+
+**Example**
+
+```bash theme={null}
+# Install to ~/.local/bin/petstore
+mcp2cli bake install petstore
+
+# Install to a project-local scripts directory
+mcp2cli bake install petstore --dir ./scripts/
+
+# Now call it directly (if ~/.local/bin is on PATH)
+petstore --list
+petstore list-pets --status available
+```
+
+<Tip>
+  If `~/.local/bin` is not in your `PATH`, the install command will print a reminder. Add `export PATH="$HOME/.local/bin:$PATH"` to your shell profile.
+</Tip>
+
+The generated wrapper script contains:
+
+```sh theme={null}
+#!/bin/sh
+exec mcp2cli @petstore "$@"
+```
+
+***
+
+## @NAME
+
+Run a baked tool directly using the `@` prefix. All positional arguments and flags after `@NAME` are forwarded to the underlying source.
+
+**Syntax**
+
+```bash theme={null}
+mcp2cli @NAME [args]
+```
+
+**Examples**
+
+```bash theme={null}
+# List tools
+mcp2cli @petstore --list
+
+# Call a subcommand
+mcp2cli @petstore list-pets --status available
+
+# Combine with output flags
+mcp2cli @petstore --list --top 10 --compact
+mcp2cli @mygit search-repos --query "rust" --jq '.[].full_name'
+```
+
+<Note>
+  `@NAME` is syntactic sugar for re-running `mcp2cli` with all the saved flags from the baked config plus any `--include`/`--exclude`/`--methods` filters applied on top.
+</Note>
+
+
+# Environment variables
+Source: https://www.mintlify.com/knowsuchagency/mcp2cli/reference/environment-variables
+
+Environment variables that control mcp2cli behavior
+
+mcp2cli reads two environment variables at startup to override its default file system locations.
+
+***
+
+## MCP2CLI\_CACHE\_DIR
+
+<ParamField type="string">
+  Override the directory where mcp2cli stores cached data. When unset, defaults to `~/.cache/mcp2cli/`.
+
+  Affects:
+
+  * Remote spec and tool list cache (keyed by URL hash or `--cache-key`)
+  * Usage tracking file (`usage.json`)
+  * Active session socket and metadata files (`sessions/`)
+
+  Does **not** affect the OAuth token cache, which is always stored inside this same directory under `oauth/` — so overriding `MCP2CLI_CACHE_DIR` does relocate OAuth tokens too.
+
+  ```bash theme={null}
+  MCP2CLI_CACHE_DIR=/tmp/my-cache mcp2cli --spec ./spec.json --list
+  ```
+</ParamField>
+
+***
+
+## MCP2CLI\_CONFIG\_DIR
+
+<ParamField type="string">
+  Override the directory where mcp2cli stores configuration. When unset, defaults to `~/.config/mcp2cli/`.
+
+  Affects:
+
+  * Baked tool configurations (`baked.json`)
+
+  ```bash theme={null}
+  MCP2CLI_CONFIG_DIR=/etc/mcp2cli mcp2cli bake list
+  ```
+</ParamField>
+
+***
+
+## File locations
+
+The table below summarises all files mcp2cli reads or writes and which environment variable controls their location.
+
+| File                     | Default location                        | Controlled by        |
+| ------------------------ | --------------------------------------- | -------------------- |
+| Baked tool configs       | `~/.config/mcp2cli/baked.json`          | `MCP2CLI_CONFIG_DIR` |
+| Spec and tool list cache | `~/.cache/mcp2cli/<hash>.json`          | `MCP2CLI_CACHE_DIR`  |
+| Usage tracking           | `~/.cache/mcp2cli/usage.json`           | `MCP2CLI_CACHE_DIR`  |
+| OAuth tokens             | `~/.cache/mcp2cli/oauth/`               | `MCP2CLI_CACHE_DIR`  |
+| Session metadata         | `~/.cache/mcp2cli/sessions/<name>.json` | `MCP2CLI_CACHE_DIR`  |
+
+***
+
+## Examples
+
+**Use a temporary cache directory for CI**
+
+```bash theme={null}
+MCP2CLI_CACHE_DIR=/tmp/mcp2cli-ci mcp2cli --spec https://api.example.com/openapi.json --list
+```
+
+<Tip>
+  In CI pipelines, set `MCP2CLI_CACHE_DIR` to a writable temp directory and `MCP2CLI_CONFIG_DIR` to a pre-populated config directory that contains your `baked.json`. This avoids writing to the home directory and lets you cache specs between runs with full control over the cache path.
+</Tip>
+
+**Relocate config and cache to a shared path**
+
+```bash theme={null}
+export MCP2CLI_CONFIG_DIR=/opt/mcp2cli/config
+export MCP2CLI_CACHE_DIR=/opt/mcp2cli/cache
+mcp2cli bake list
+```
+
+**Override the cache directory for a single invocation**
+
+```bash theme={null}
+MCP2CLI_CACHE_DIR=/tmp/fresh mcp2cli --spec ./spec.json --refresh --list
+```
+
+<Note>
+  Local file specs (passed as a file path rather than a URL to `--spec`) are never cached regardless of `MCP2CLI_CACHE_DIR`.
+</Note>
+
+
+# Global options
+Source: https://www.mintlify.com/knowsuchagency/mcp2cli/reference/global-options
+
+All global flags for mcp2cli — source selection, auth, output, and more
+
+Global options appear before the subcommand name and apply to every invocation.
+
+```bash theme={null}
+mcp2cli [global options] <subcommand> [command options]
+```
+
+***
+
+## Source
+
+Exactly one source flag is required on most invocations. These flags are mutually exclusive. Session management operations (`--session-list`, `--session-stop`) do not require a source flag.
+
+<ParamField type="URL|FILE">
+  OpenAPI spec to introspect. Accepts a remote URL (`https://...`) or a local file path (JSON or YAML). Local files are never cached.
+
+  ```bash theme={null}
+  mcp2cli --spec https://petstore3.swagger.io/api/v3/openapi.json --list
+  mcp2cli --spec ./api.yaml --base-url http://localhost:8000 --list
+  ```
+</ParamField>
+
+<ParamField type="URL">
+  MCP server URL for HTTP or SSE transport.
+
+  ```bash theme={null}
+  mcp2cli --mcp https://mcp.example.com/sse --list
+  ```
+</ParamField>
+
+<ParamField type="CMD">
+  Shell command that launches an MCP server using stdio transport. The command is parsed with `shlex.split`, so quoting rules apply.
+
+  ```bash theme={null}
+  mcp2cli --mcp-stdio "npx @modelcontextprotocol/server-filesystem /tmp" --list
+  ```
+</ParamField>
+
+<ParamField type="URL">
+  GraphQL endpoint URL. mcp2cli introspects the schema and auto-generates subcommands for every query and mutation.
+
+  ```bash theme={null}
+  mcp2cli --graphql https://api.example.com/graphql --list
+  ```
+</ParamField>
+
+***
+
+## Connection options
+
+<ParamField type="K:V">
+  HTTP header to include with every request, formatted as `Name:Value`. Repeatable — pass the flag multiple times to add several headers.
+
+  The value portion supports `env:` and `file:` prefixes to avoid exposing secrets in process listings:
+
+  * `Authorization:env:MY_TOKEN` — read from environment variable `MY_TOKEN`
+  * `x-api-key:file:/run/secrets/key` — read from file
+
+  ```bash theme={null}
+  mcp2cli --mcp https://mcp.example.com/sse \
+    --auth-header "Authorization:Bearer tok_..." \
+    --auth-header "x-tenant-id:acme" \
+    --list
+  ```
+</ParamField>
+
+<ParamField type="URL">
+  Override the base URL derived from the spec's `servers` block. Required when using a local spec file that doesn't embed a base URL, and also needed for OAuth discovery with local spec files.
+
+  ```bash theme={null}
+  mcp2cli --spec ./openapi.json --base-url https://api.example.com --list
+  ```
+</ParamField>
+
+<ParamField type="string">
+  MCP HTTP transport mode. Only applies when `--mcp` is used.
+
+  | Value        | Behavior                                                  |
+  | ------------ | --------------------------------------------------------- |
+  | `auto`       | Tries streamable HTTP first, falls back to SSE on failure |
+  | `sse`        | Forces SSE transport, skips streamable HTTP               |
+  | `streamable` | Forces streamable HTTP, no SSE fallback                   |
+
+  ```bash theme={null}
+  mcp2cli --mcp https://mcp.example.com/sse --transport sse --list
+  ```
+</ParamField>
+
+<ParamField type="KEY=VALUE">
+  Environment variable to pass to the MCP stdio server process. Repeatable. Only applies when `--mcp-stdio` is used.
+
+  ```bash theme={null}
+  mcp2cli --mcp-stdio "node server.js" --env API_KEY=sk-... --env DEBUG=1 search --query "test"
+  ```
+</ParamField>
+
+***
+
+## OAuth options
+
+<Note>
+  OAuth is not supported with `--mcp-stdio`. When using a local spec file, provide `--base-url` so mcp2cli can discover the OAuth server.
+</Note>
+
+<ParamField type="boolean">
+  Enable OAuth authentication using the authorization code + PKCE flow. Opens a browser window for interactive login. Tokens are cached in `~/.cache/mcp2cli/oauth/` and refreshed automatically.
+
+  ```bash theme={null}
+  mcp2cli --mcp https://mcp.example.com/sse --oauth --list
+  ```
+</ParamField>
+
+<ParamField type="ID">
+  OAuth client ID. Supports `env:VAR` and `file:/path` prefixes. When provided alongside `--oauth-client-secret`, mcp2cli defaults to the client credentials flow unless `--oauth-flow` overrides it.
+
+  ```bash theme={null}
+  mcp2cli --spec https://api.example.com/openapi.json \
+    --oauth-client-id "env:OAUTH_CLIENT_ID" \
+    --oauth-client-secret "env:OAUTH_CLIENT_SECRET" \
+    list-pets
+  ```
+</ParamField>
+
+<ParamField type="string">
+  OAuth client secret. Supports `env:VAR` and `file:/path` prefixes. Requires `--oauth-client-id`.
+</ParamField>
+
+<ParamField type="SCOPE">
+  OAuth scope string to request. Pass multiple scopes space-separated within the value.
+
+  ```bash theme={null}
+  mcp2cli --graphql https://api.example.com/graphql --oauth --oauth-scope "read write" users
+  ```
+</ParamField>
+
+<ParamField type="NAME">
+  Client name sent during OAuth Dynamic Client Registration. Some servers require a specific name for DCR to succeed.
+</ParamField>
+
+<ParamField type="URI">
+  Full redirect URI for the OAuth callback (e.g. `http://localhost:3334/oauth/callback`). Overrides the default, which uses a random loopback port (`http://127.0.0.1:<port>/callback`). Must be a loopback `http://` URI.
+</ParamField>
+
+<ParamField type="string">
+  OAuth flow to use.
+
+  | Value                | Behavior                                                                                              |
+  | -------------------- | ----------------------------------------------------------------------------------------------------- |
+  | `auto`               | Uses `client_credentials` when both client ID and secret are provided, otherwise `authorization_code` |
+  | `authorization_code` | Forces auth code + PKCE flow (required for confidential-client servers like Slack)                    |
+  | `client_credentials` | Machine-to-machine, no browser. Requires both `--oauth-client-id` and `--oauth-client-secret`         |
+</ParamField>
+
+***
+
+## Caching
+
+Specs and MCP tool lists are cached in `~/.cache/mcp2cli/` (override with `MCP2CLI_CACHE_DIR`). Local file specs are never cached.
+
+<ParamField type="KEY">
+  Custom string to use as the cache key instead of the URL hash. Useful when you want to pin a cache entry across URL changes.
+
+  ```bash theme={null}
+  mcp2cli --spec https://api.example.com/spec.json --cache-key my-api --list
+  ```
+</ParamField>
+
+<ParamField type="integer">
+  Cache time-to-live in seconds. Set to `0` to disable caching.
+
+  ```bash theme={null}
+  mcp2cli --spec https://api.example.com/spec.json --cache-ttl 86400 --list
+  ```
+</ParamField>
+
+<ParamField type="boolean">
+  Bypass the cache and re-fetch the spec or tool list even if a valid cached copy exists.
+
+  ```bash theme={null}
+  mcp2cli --spec https://api.example.com/spec.json --refresh --list
+  ```
+</ParamField>
+
+***
+
+## Listing and discovery
+
+<ParamField type="boolean">
+  Print all available subcommands for the given source and exit. Output format depends on source type: OpenAPI groups commands by HTTP method prefix; MCP shows tool names with descriptions.
+</ParamField>
+
+<ParamField type="PATTERN">
+  Filter the `--list` output to tools whose name or description contains the pattern (case-insensitive substring match). Implies `--list`.
+
+  ```bash theme={null}
+  mcp2cli --mcp https://mcp.example.com/sse --search "task"
+  ```
+</ParamField>
+
+<ParamField type="string">
+  Sort order for `--list` output.
+
+  | Value     | Behavior                                         |
+  | --------- | ------------------------------------------------ |
+  | `usage`   | Sort by call frequency (most-used first)         |
+  | `recent`  | Sort by last-used time                           |
+  | `alpha`   | Alphabetical order                               |
+  | `default` | Preserve insertion order from the spec or server |
+
+  When omitted, `--list` defaults to `usage` if usage data exists for the source, otherwise `default`.
+</ParamField>
+
+<ParamField type="integer">
+  Limit `--list` output to the top N tools. Useful for LLM agents that only need the most relevant tools.
+
+  ```bash theme={null}
+  mcp2cli @myapi --list --top 10 --compact
+  ```
+</ParamField>
+
+<ParamField type="boolean">
+  Print tool names only, space-separated, with no descriptions. Approximately 2 tokens per tool — optimal for LLM agents doing discovery.
+
+  ```bash theme={null}
+  mcp2cli @myapi --list --top 10 --compact
+  # → list-pets get-pet create-pet delete-pet ...
+  ```
+</ParamField>
+
+<ParamField type="boolean">
+  Show full, unwrapped tool descriptions in `--list` output. By default, descriptions are truncated with `...` to fit on one line.
+</ParamField>
+
+***
+
+## Output
+
+<ParamField type="FIELDS">
+  Override the auto-generated GraphQL selection set with a space-separated list of field names. Only applies when `--graphql` is used.
+
+  ```bash theme={null}
+  mcp2cli --graphql https://api.example.com/graphql users --fields "id name email"
+  ```
+</ParamField>
+
+<ParamField type="boolean">
+  Pretty-print JSON output with indentation. Automatically enabled when stdout is a terminal (TTY).
+</ParamField>
+
+<ParamField type="boolean">
+  Print the raw response body without JSON parsing. Useful for binary responses or when you want to pipe raw bytes.
+</ParamField>
+
+<ParamField type="boolean">
+  Encode output as TOON (Token-Oriented Object Notation) instead of JSON. TOON is 40–60% more token-efficient for large uniform arrays (e.g. list results) and 15–20% for semi-uniform data. Optimised for LLM consumption.
+
+  Requires [`@toon-format/cli`](https://www.npmjs.com/package/@toon-format/cli):
+
+  ```bash theme={null}
+  npm install -g @toon-format/cli
+  ```
+
+  <Warning>
+    `--toon` and `--jq` are mutually exclusive.
+  </Warning>
+</ParamField>
+
+<ParamField type="EXPR">
+  Filter JSON output through a [jq](https://jqlang.org) expression before printing. Requires `jq` to be installed and on `PATH`.
+
+  ```bash theme={null}
+  mcp2cli --spec ./spec.json list-pets --jq '.[].name'
+  mcp2cli --spec ./spec.json list-pets --jq '[.[] | select(.status == "available")] | length'
+  ```
+</ParamField>
+
+<ParamField type="integer">
+  Truncate array output to the first N elements before any further processing. Non-array values (strings, objects) are passed through unchanged.
+
+  ```bash theme={null}
+  mcp2cli --spec ./spec.json list-records --head 5
+  ```
+</ParamField>
+
+***
+
+## MCP resources
+
+These flags access MCP [Resources](https://modelcontextprotocol.io/docs/concepts/resources) — server-side data objects exposed alongside tools. Only available with `--mcp` and `--mcp-stdio`.
+
+<ParamField type="boolean">
+  List all resources the MCP server exposes.
+
+  ```bash theme={null}
+  mcp2cli --mcp https://mcp.example.com/sse --list-resources
+  ```
+</ParamField>
+
+<ParamField type="boolean">
+  List all resource templates (URI templates) the MCP server exposes.
+
+  ```bash theme={null}
+  mcp2cli --mcp https://mcp.example.com/sse --list-resource-templates
+  ```
+</ParamField>
+
+<ParamField type="URI">
+  Read the content of a specific resource by its URI.
+
+  ```bash theme={null}
+  mcp2cli --mcp https://mcp.example.com/sse --read-resource "file:///data/report.txt"
+  ```
+</ParamField>
+
+***
+
+## MCP prompts
+
+These flags access MCP [Prompts](https://modelcontextprotocol.io/docs/concepts/prompts) — server-defined prompt templates. Only available with `--mcp` and `--mcp-stdio`.
+
+<ParamField type="boolean">
+  List all prompt templates the MCP server exposes.
+
+  ```bash theme={null}
+  mcp2cli --mcp https://mcp.example.com/sse --list-prompts
+  ```
+</ParamField>
+
+<ParamField type="NAME">
+  Retrieve a prompt template by name, optionally passing arguments with `--prompt-arg`.
+
+  ```bash theme={null}
+  mcp2cli --mcp https://mcp.example.com/sse --get-prompt summarize --prompt-arg "topic=AI"
+  ```
+</ParamField>
+
+<ParamField type="KEY=VALUE">
+  Argument for `--get-prompt`. Repeatable.
+
+  ```bash theme={null}
+  mcp2cli --mcp https://mcp.example.com/sse \
+    --get-prompt summarize \
+    --prompt-arg "topic=AI" \
+    --prompt-arg "length=short"
+  ```
+</ParamField>
+
+***
+
+## Sessions
+
+Sessions let you keep a persistent MCP server process alive between calls, avoiding the startup cost of re-spawning the server on every invocation. Only available with `--mcp` and `--mcp-stdio`.
+
+<ParamField type="NAME">
+  Start a named persistent session daemon for an MCP server. Requires `--mcp` or `--mcp-stdio`.
+
+  ```bash theme={null}
+  mcp2cli --mcp https://mcp.example.com/sse --session-start myserver
+  # Session 'myserver' started (PID 12345)
+  ```
+</ParamField>
+
+<ParamField type="NAME">
+  Stop a named session daemon by name.
+
+  ```bash theme={null}
+  mcp2cli --session-stop myserver
+  ```
+</ParamField>
+
+<ParamField type="boolean">
+  List all active session daemons with their name, transport, status, and PID. Does not require a source flag.
+
+  ```bash theme={null}
+  mcp2cli --session-list
+  ```
+</ParamField>
+
+<ParamField type="NAME">
+  Route a tool call or listing operation through an existing session daemon instead of connecting directly.
+
+  ```bash theme={null}
+  # List tools via a running session
+  mcp2cli --session myserver --list
+
+  # Call a tool via a running session
+  mcp2cli --session myserver search --query "test"
+
+  # List resources via a running session
+  mcp2cli --session myserver --list-resources
+  ```
+</ParamField>
+
+***
+
+## Other
+
+<ParamField type="boolean">
+  Print the installed version of mcp2cli and exit.
+
+  ```bash theme={null}
+  mcp2cli --version
+  # → mcp2cli 2.7.0
+  ```
+</ParamField>
+
+

--- a/docs/research/mintlify-cache/knowsuchagency/mcp2cli/llms.txt
+++ b/docs/research/mintlify-cache/knowsuchagency/mcp2cli/llms.txt
@@ -1,0 +1,29 @@
+# mcp2cli
+
+## Docs
+
+- [Authentication](https://www.mintlify.com/knowsuchagency/mcp2cli/features/authentication.md): Static headers, OAuth PKCE, and client credentials — all modes supported
+- [Bake mode](https://www.mintlify.com/knowsuchagency/mcp2cli/features/bake-mode.md): Save connection settings as named tools — no more repeated flags
+- [Caching](https://www.mintlify.com/knowsuchagency/mcp2cli/features/caching.md): Specs and tool lists are cached locally to speed up repeated calls
+- [Output control](https://www.mintlify.com/knowsuchagency/mcp2cli/features/output-control.md): Filter, format, and truncate output for humans and LLM agents
+- [Usage tracking](https://www.mintlify.com/knowsuchagency/mcp2cli/features/usage-tracking.md): mcp2cli tracks tool invocations to rank --list output and reduce tokens
+- [AI agent skill](https://www.mintlify.com/knowsuchagency/mcp2cli/guides/ai-agent-skill.md): Teach Claude Code, Cursor, and Codex to use mcp2cli with a single install command
+- [Secrets management](https://www.mintlify.com/knowsuchagency/mcp2cli/guides/secrets-management.md): Pass credentials securely using env: and file: prefixes
+- [Token efficiency](https://www.mintlify.com/knowsuchagency/mcp2cli/guides/token-efficiency.md): How mcp2cli saves 96–99% of tokens wasted on tool schemas
+- [Installation](https://www.mintlify.com/knowsuchagency/mcp2cli/installation.md): Install mcp2cli using uv or run it directly with uvx
+- [Introduction](https://www.mintlify.com/knowsuchagency/mcp2cli/introduction.md): What mcp2cli is and why it exists
+- [GraphQL](https://www.mintlify.com/knowsuchagency/mcp2cli/modes/graphql.md): Introspect and call any GraphQL endpoint — queries and mutations
+- [MCP HTTP/SSE](https://www.mintlify.com/knowsuchagency/mcp2cli/modes/mcp-http.md): Connect to MCP servers over HTTP or Server-Sent Events
+- [MCP stdio](https://www.mintlify.com/knowsuchagency/mcp2cli/modes/mcp-stdio.md): Spawn and talk to local MCP servers over stdin/stdout
+- [OpenAPI](https://www.mintlify.com/knowsuchagency/mcp2cli/modes/openapi.md): Turn any OpenAPI 3.x spec into a CLI — local or remote, JSON or YAML
+- [Quickstart](https://www.mintlify.com/knowsuchagency/mcp2cli/quickstart.md): Call your first API in under 60 seconds
+- [Bake commands](https://www.mintlify.com/knowsuchagency/mcp2cli/reference/bake-commands.md): Save and manage named connection configurations
+- [Environment variables](https://www.mintlify.com/knowsuchagency/mcp2cli/reference/environment-variables.md): Environment variables that control mcp2cli behavior
+- [Global options](https://www.mintlify.com/knowsuchagency/mcp2cli/reference/global-options.md): All global flags for mcp2cli — source selection, auth, output, and more
+
+## OpenAPI Specs
+
+- [openapi](https://www.mintlify.com/knowsuchagency/mcp2cli/api-reference/openapi.json)
+
+
+Built with [Mintlify](https://mintlify.com).

--- a/docs/research/mintlify-cache/starship/starship/llms-full.txt
+++ b/docs/research/mintlify-cache/starship/starship/llms-full.txt
@@ -1,0 +1,3848 @@
+# Custom commands and hooks
+Source: https://www.mintlify.com/starship/starship/advanced/custom-commands
+
+Run code before the prompt renders, configure continuation prompts, add a right-side prompt, and switch between prompt profiles.
+
+Starship exposes several hooks and configuration options that let you extend the prompt beyond what modules provide: run arbitrary code before the prompt is drawn, customise the continuation prompt, display content on the right side of the terminal, and switch between named prompt profiles.
+
+<Warning>
+  The configurations in this section are subject to change in future releases of Starship.
+</Warning>
+
+## Pre-prompt commands
+
+You can run a custom function immediately before Starship renders the prompt. This is useful for tasks like updating the terminal window title, printing separators, or logging session activity.
+
+<Tabs>
+  <Tab title="PowerShell">
+    Define a function named `Invoke-Starship-PreCommand`:
+
+    ```powershell theme={null}
+    function Invoke-Starship-PreCommand {
+        $host.ui.Write("🚀")
+    }
+    ```
+
+    For example, to update the window title before each prompt:
+
+    ```powershell theme={null}
+    # edit $PROFILE
+    function Invoke-Starship-PreCommand {
+      $host.ui.RawUI.WindowTitle = "$env:USERNAME@$env:COMPUTERNAME`: $pwd `a"
+    }
+
+    Invoke-Expression (&starship init powershell)
+    ```
+  </Tab>
+
+  <Tab title="Bash">
+    Bash does not have a formal `precmd` framework. Starship lets you assign a function name to `starship_precmd_user_func`, which Starship calls before drawing the prompt:
+
+    ```bash theme={null}
+    function blastoff(){
+        echo "🚀"
+    }
+    starship_precmd_user_func="blastoff"
+    ```
+
+    To run code before each command executes (pre-execution hook), use the `DEBUG` trap. You **must** set the trap before initializing Starship:
+
+    ```bash theme={null}
+    function blastoff(){
+        echo "🚀"
+    }
+    trap blastoff DEBUG     # Trap DEBUG *before* running starship
+    set -o functrace
+    eval $(starship init bash)
+    set +o functrace
+    ```
+
+    For example, to update the window title:
+
+    ```bash theme={null}
+    function set_win_title(){
+        echo -ne "\033]0; $(basename "$PWD") \007"
+    }
+    starship_precmd_user_func="set_win_title"
+    ```
+  </Tab>
+
+  <Tab title="Fish">
+    In Fish you can add functions to the standard `fish_prompt` event or define `starship_precmd_user_func` equivalently. The recommended approach is to use Fish's built-in `fish_preexec` and `fish_prompt` events in your `~/.config/fish/config.fish`.
+
+    To set the window title before each prompt, for example:
+
+    ```fish theme={null}
+    function set_win_title
+        echo -ne "\033]0; $(basename $PWD) \007"
+    end
+    starship init fish | source
+    ```
+  </Tab>
+
+  <Tab title="Zsh">
+    Add functions to the `precmd_functions` array in `~/.zshrc`:
+
+    ```bash theme={null}
+    precmd_functions+=(set_win_title)
+    ```
+
+    For example, to update the window title:
+
+    ```bash theme={null}
+    function set_win_title(){
+        echo -ne "\033]0; $(basename "$PWD") \007"
+    }
+    precmd_functions+=(set_win_title)
+    ```
+  </Tab>
+
+  <Tab title="Cmd (Clink)">
+    Clink provides `starship_preprompt_user_func` (runs before the prompt is drawn) and `starship_precmd_user_func` (runs before a command is executed). Define them in your `starship.lua`:
+
+    ```lua theme={null}
+    -- Runs before the prompt is drawn
+    function starship_preprompt_user_func(prompt)
+      print("🚀")
+    end
+
+    load(io.popen('starship init cmd'):read("*a"))()
+    ```
+
+    ```lua theme={null}
+    -- Runs before a command is executed; receives the command line as a string
+    function starship_precmd_user_func(line)
+      print("Executing: "..line)
+    end
+
+    load(io.popen('starship init cmd'):read("*a"))()
+    ```
+
+    To update the window title:
+
+    ```lua theme={null}
+    function starship_preprompt_user_func(prompt)
+      console.settitle(os.getenv('USERNAME').."@"..os.getenv('COMPUTERNAME')..": "..os.getcwd())
+    end
+
+    load(io.popen('starship init cmd'):read("*a"))()
+    ```
+  </Tab>
+</Tabs>
+
+## Continuation prompt
+
+A continuation prompt appears instead of the normal prompt when you have entered an incomplete statement — for example, an unclosed parenthesis or quote. Starship exposes this as the `continuation_prompt` option in `starship.toml`.
+
+**Supported shells:** `bash`, `zsh`, `PowerShell`
+
+<Note>
+  `continuation_prompt` must be a literal string. Variables are not expanded inside it.
+</Note>
+
+The default continuation prompt is `'[∙](bright-black) '`. To customize it, set `continuation_prompt` at the top level of your config:
+
+```toml theme={null}
+# ~/.config/starship.toml
+
+# A continuation prompt that displays two filled-in arrows
+continuation_prompt = '▶▶ '
+```
+
+## Right prompt
+
+Some shells support a right-aligned prompt that renders on the same line as the input cursor. Set the `right_format` option in `starship.toml` to populate it:
+
+```toml theme={null}
+# ~/.config/starship.toml
+
+# A minimal left prompt
+format = """$character"""
+
+# Move the rest of the prompt to the right
+right_format = """$all"""
+```
+
+This produces output like:
+
+```
+▶                                   starship on  rprompt [!] is 📦 v0.57.0 via 🦀 v1.54.0 took 17s
+```
+
+**Supported shells:** elvish, fish, zsh, xonsh, cmd, nushell, bash (requires Ble.sh v0.4+)
+
+<Note>
+  The right prompt is a single line following the input cursor. To right-align content above the input line in a multi-line prompt, use the `fill` module instead.
+</Note>
+
+Any module that can appear in `format` can also appear in `right_format`. The `$all` variable only includes modules not already used in either `format` or `right_format`.
+
+## Prompt profiles
+
+Starship supports named prompt profiles. A profile is a named format string defined under `[profiles]` in your `starship.toml`. You activate it by passing `--profile <name>` to `starship prompt`.
+
+### Defining a profile
+
+Add a `[profiles]` table to your `starship.toml`:
+
+```toml theme={null}
+# ~/.config/starship.toml
+
+[profiles]
+myprofile = "$character$directory$git_branch"
+```
+
+The profile value is a format string — the same syntax used for the top-level `format` option.
+
+### Activating a profile from your shell
+
+Pass `--profile` when initializing or invoking the prompt. For example, to activate `myprofile` in Bash, override the `PS1` assignment in your shell init after Starship is loaded:
+
+```bash theme={null}
+PS1='$(starship prompt --profile myprofile)'
+```
+
+In Fish:
+
+```fish theme={null}
+function fish_prompt
+    starship prompt --profile myprofile
+end
+```
+
+<Tip>
+  Profiles are useful for context-specific prompts — for example, a minimal prompt inside editor terminals or a verbose prompt in your main shell.
+</Tip>
+
+### The `claude-code` profile
+
+Starship ships with a built-in `claude-code` profile for use as a Claude Code statusline. It provides three dedicated modules: `claude_model`, `claude_context`, and `claude_cost`. This profile is activated automatically when running `starship statusline claude-code`.
+
+
+# Performance tuning
+Source: https://www.mintlify.com/starship/starship/advanced/performance
+
+Diagnose slow prompts and configure timeouts, disabled modules, and logging to keep Starship fast.
+
+Starship is designed to be fast, but some modules involve filesystem scans, git operations, or external commands that can add latency — especially in large repositories or on slow network filesystems. This page covers how to measure, diagnose, and improve prompt rendering speed.
+
+## Diagnosing slow prompts
+
+### `starship timings`
+
+Run `starship timings` to see how long each active module takes to render:
+
+```bash theme={null}
+starship timings
+```
+
+The output lists every module that contributed to the last prompt, along with the time each one took in milliseconds. Modules that took the longest appear at the top. Use this to identify which modules are worth tuning or disabling.
+
+### `starship explain`
+
+Run `starship explain` to see which modules are active in the current directory and why:
+
+```bash theme={null}
+starship explain
+```
+
+The output describes each active module and the condition that triggered it — for example, the presence of a `package.json` file activating the `nodejs` module. Use this to confirm that only the modules you want are running.
+
+## Common slow modules
+
+<AccordionGroup>
+  <Accordion title="git_status and git_metrics">
+    Git status checks can be slow in repositories with many files or submodules. The `git_status` module runs git operations on every prompt render.
+
+    To disable submodule scanning, which is often the main source of slowness in monorepos:
+
+    ```toml theme={null}
+    # ~/.config/starship.toml
+
+    [git_status]
+    ignore_submodules = true
+    ```
+
+    To disable `git_metrics` entirely (it is disabled by default, but if you have enabled it):
+
+    ```toml theme={null}
+    [git_metrics]
+    disabled = true
+    ```
+
+    To disable `git_status` entirely:
+
+    ```toml theme={null}
+    [git_status]
+    disabled = true
+    ```
+  </Accordion>
+
+  <Accordion title="package">
+    The `package` module reads files like `package.json`, `Cargo.toml`, `pyproject.toml`, and others to display the current project version. If you don't need the version in your prompt, disabling it saves a filesystem read on every render:
+
+    ```toml theme={null}
+    # ~/.config/starship.toml
+
+    [package]
+    disabled = true
+    ```
+  </Accordion>
+
+  <Accordion title="Custom modules with slow commands">
+    Custom modules that run shell commands via the `command` option are subject to `command_timeout`. If your custom module's command is slow, either optimize the command or increase the timeout:
+
+    ```toml theme={null}
+    # ~/.config/starship.toml
+
+    [custom.my_module]
+    command = "my-slow-tool --query"
+    when = "test -f .my-config"
+    ```
+
+    Speed up the `when` condition first — if the condition exits early, the `command` never runs. If the command itself is unavoidably slow, consider disabling the module in contexts where you don't need it.
+
+    <Note>
+      Custom modules also support `ignore_timeout = true` to bypass `command_timeout` entirely for a specific module. Use this only when you know the command will eventually complete.
+    </Note>
+  </Accordion>
+</AccordionGroup>
+
+## Timeout configuration
+
+Starship provides two global timeout options in `starship.toml`:
+
+| Option            | Default | Description                                                         |
+| ----------------- | ------- | ------------------------------------------------------------------- |
+| `scan_timeout`    | `30`    | Timeout for file scanning operations, in milliseconds.              |
+| `command_timeout` | `500`   | Timeout for external commands executed by modules, in milliseconds. |
+
+```toml theme={null}
+# ~/.config/starship.toml
+
+# Reduce file scan timeout for faster prompts on large directories
+scan_timeout = 10
+
+# Allow slower commands more time before they are killed
+command_timeout = 1000
+```
+
+<Tip>
+  Lowering `scan_timeout` is usually safe and can noticeably reduce prompt latency on directories with many files.
+</Tip>
+
+## Disabling modules
+
+Any module can be disabled with `disabled = true`. Disabled modules are skipped entirely and add no latency:
+
+```toml theme={null}
+# ~/.config/starship.toml
+
+[package]
+disabled = true
+
+[git_metrics]
+disabled = true
+```
+
+Only enable the modules you actively use. You can see all currently active modules with `starship explain`.
+
+## Debug logging
+
+To get detailed logs of what Starship is doing during a prompt render, set the `STARSHIP_LOG` environment variable to `debug` and redirect stderr to a file:
+
+```bash theme={null}
+STARSHIP_LOG=debug starship prompt 2>~/starship.log
+```
+
+The log file will contain timing information, module execution details, and any warnings or errors. This is useful for diagnosing unexpected slowness or modules that are not rendering as expected.
+
+By default, Starship logs warnings and errors to `~/.cache/starship/session_${STARSHIP_SESSION_KEY}.log`. You can change the log directory with the `STARSHIP_CACHE` environment variable:
+
+```bash theme={null}
+export STARSHIP_CACHE=~/.starship/cache
+```
+
+## Summary: tips for a fast prompt
+
+* Run `starship timings` to identify slow modules.
+* Disable modules you don't use with `disabled = true`.
+* Lower `scan_timeout` if you don't need deep file scanning.
+* Set `ignore_submodules = true` in `git_status` for large repositories.
+* Optimize `when` conditions in custom modules so they exit fast.
+* Use `STARSHIP_LOG=debug` to investigate unexpected slowness.
+
+
+# Transient prompt
+Source: https://www.mintlify.com/starship/starship/advanced/transient-prompt
+
+Replace previous prompts with a simpler version after each command, keeping your scrollback clean.
+
+The transient prompt feature replaces already-executed prompts in your terminal scrollback with a simpler, shorter version. Only the current prompt is rendered in full — all previous prompts are replaced with a minimal substitute. This makes it easier to scan your command history and reduces visual clutter.
+
+<Warning>
+  The configurations in this section are subject to change in future releases of Starship.
+</Warning>
+
+## How it works
+
+When you run a command, Starship replaces the full prompt above with a compact version (typically just the `character` module, showing `❯` or `>`). Your scrollback shows only the condensed prompt alongside each command's output, while the live prompt at the bottom remains complete.
+
+## Setup by shell
+
+<Tabs>
+  <Tab title="PowerShell">
+    Run `Enable-TransientPrompt` in your shell session to activate transience. To make it permanent, add it to your `$PROFILE`. You can disable it at any time with `Disable-TransientPrompt`.
+
+    By default, the left side of the input is replaced with `>`. To customize it, define `Invoke-Starship-TransientFunction`. For example, to display the `character` module:
+
+    ```powershell theme={null}
+    function Invoke-Starship-TransientFunction {
+      &starship module character
+    }
+
+    Invoke-Expression (&starship init powershell)
+
+    Enable-TransientPrompt
+    ```
+  </Tab>
+
+  <Tab title="Fish">
+    Run `enable_transience` in your shell session to activate transience. To make it permanent, add it to `~/.config/fish/config.fish`. You can disable it with `disable_transience`.
+
+    <Note>
+      In Fish, the transient prompt is only printed if the command line is non-empty and syntactically correct.
+    </Note>
+
+    By default, the left side is replaced with a bold-green `❯`. To customize it, define `starship_transient_prompt_func`. For example, to display the `character` module:
+
+    ```fish theme={null}
+    function starship_transient_prompt_func
+      starship module character
+    end
+    starship init fish | source
+    enable_transience
+    ```
+
+    To also customize the right-side transient prompt, define `starship_transient_rprompt_func`. For example, to display the time the last command was started:
+
+    ```fish theme={null}
+    function starship_transient_rprompt_func
+      starship module time
+    end
+    starship init fish | source
+    enable_transience
+    ```
+  </Tab>
+
+  <Tab title="Bash">
+    Transient prompt in Bash requires the [Ble.sh](https://github.com/akinomyoga/ble.sh) framework at v0.4 or higher.
+
+    In `~/.bashrc`, set the `prompt_ps1_transient` option:
+
+    ```bash theme={null}
+    bleopt prompt_ps1_transient=always
+    ```
+
+    The value is a colon-separated list of fields:
+
+    | Field      | Behavior                                                            |
+    | ---------- | ------------------------------------------------------------------- |
+    | `always`   | Always replace the previous prompt on leaving the command line.     |
+    | `same-dir` | Only replace the prompt if the working directory has not changed.   |
+    | `trim`     | Preserve only the last line of a multi-line prompt; erase the rest. |
+
+    To customize what the left side is replaced with, set `prompt_ps1_final` in `~/.blerc` (or `~/.config/blesh/init.sh`). For example, to display the `character` module:
+
+    ```bash theme={null}
+    bleopt prompt_ps1_final='$(starship module character)'
+    ```
+
+    To customize the right-side transient prompt, set `prompt_rps1_final`:
+
+    ```bash theme={null}
+    bleopt prompt_rps1_final='$(starship module time)'
+    ```
+  </Tab>
+
+  <Tab title="Cmd (Clink)">
+    Transient prompt in Cmd requires [Clink](https://chrisant996.github.io/clink/). Enable it by running the following command once:
+
+    ```batch theme={null}
+    clink set prompt.transient always
+    ```
+
+    The `prompt.transient` value can be one of:
+
+    | Value      | Behavior                                                        |
+    | ---------- | --------------------------------------------------------------- |
+    | `always`   | Always replace the previous prompt.                             |
+    | `same_dir` | Replace only if the working directory is the same as last time. |
+    | `off`      | Disable transience.                                             |
+
+    To customize the left-side transient prompt, define `starship_transient_prompt_func` in your `starship.lua`. For example, to display the `character` module:
+
+    ```lua theme={null}
+    function starship_transient_prompt_func(prompt)
+      return io.popen("starship module character"
+        .." --keymap="..rl.getvariable('keymap')
+      ):read("*a")
+    end
+    load(io.popen('starship init cmd'):read("*a"))()
+    ```
+
+    To customize the right-side transient prompt, define `starship_transient_rprompt_func`. For example, to display the time the last command was started:
+
+    ```lua theme={null}
+    function starship_transient_rprompt_func(prompt)
+      return io.popen("starship module time"):read("*a")
+    end
+    load(io.popen('starship init cmd'):read("*a"))()
+    ```
+  </Tab>
+
+  <Tab title="Zsh">
+    Zsh does not have native transient prompt support built into Starship. You can approximate the behavior using the `zle-line-finish` hook to redraw the prompt when a command is accepted.
+
+    Add the following to your `~/.zshrc`:
+
+    ```zsh theme={null}
+    zle-line-finish() {
+      PROMPT="%F{green}❯%f "
+      zle reset-prompt
+    }
+    zle -N zle-line-finish
+    ```
+
+    <Tip>
+      Replace the `PROMPT` value with whatever minimal format you prefer for historical prompts.
+    </Tip>
+  </Tab>
+</Tabs>
+
+
+# Custom modules
+Source: https://www.mintlify.com/starship/starship/config/custom-modules
+
+Create your own prompt modules that run shell commands, detect files, and display any information you want.
+
+Custom modules let you add any information to your prompt by running a shell command and displaying its output. They live in `[custom.<name>]` sections of your config.
+
+## Basic example
+
+```toml theme={null}
+# ~/.config/starship.toml
+
+[custom.my_project]
+description = "Shows project name from a .project file"
+command = "cat .project"
+when = "test -f .project"
+format = "[$symbol($output )]($style)"
+symbol = "📁 "
+style = "bold yellow"
+```
+
+This module:
+
+* Runs `cat .project` and captures its output
+* Only shows if the `when` command exits with code 0 (`test -f .project` succeeds when `.project` exists)
+* Renders the output styled in bold yellow with a folder symbol
+
+<Tip>
+  Multiple custom modules can be defined in the same config. They appear in the order they are defined unless you explicitly place `${custom.name}` in the top-level `format`.
+</Tip>
+
+## When a module is shown
+
+A custom module is shown when **any** of the following conditions are met:
+
+* A file matching `detect_files` exists in the current directory
+* A directory matching `detect_folders` exists in the current directory
+* A file matching `detect_extensions` exists in the current directory
+* The `when` command exits with code `0`
+* The current OS matches the `os` field (if defined)
+
+## All options
+
+<ParamField type="string">
+  The shell command to run. Its stdout is captured as `$output`. The command is passed to the shell via stdin.
+</ParamField>
+
+<ParamField type="string | boolean">
+  A condition for showing the module. Either a boolean (`true`/`false`) or a shell command string. If a string, the module shows when the command exits with code `0`.
+</ParamField>
+
+<ParamField type="string[]">
+  The shell to use when running `command` and `when`. First element is the shell path; remaining elements are arguments. Defaults to `STARSHIP_SHELL`, then `sh` on Linux/macOS, or `cmd /C` on Windows.
+
+  ```toml theme={null}
+  shell = ['pwsh', '-NoProfile', '-Command', '-']
+  ```
+</ParamField>
+
+<ParamField type="string">
+  A human-readable description shown in `starship explain` output.
+</ParamField>
+
+<ParamField type="string">
+  The format string for the module. Available variables: `$output`, `$symbol`, `$style`.
+</ParamField>
+
+<ParamField type="string">
+  A symbol displayed before the command output.
+</ParamField>
+
+<ParamField type="string">
+  The style for the module output. See [Format strings](/config/format-strings) for style syntax.
+</ParamField>
+
+<ParamField type="boolean">
+  Set to `true` to hide this custom module.
+</ParamField>
+
+<ParamField type="string">
+  Restrict the module to a specific operating system. Accepted values match Rust's `std::env::consts::OS` (e.g. `linux`, `macos`, `windows`).
+</ParamField>
+
+<ParamField type="boolean">
+  If `true`, only show the module in directories that contain a git repository. This option alone is not a sufficient display condition; combine it with `when` or detection options.
+</ParamField>
+
+<ParamField type="string[]">
+  File names to look for in the current directory. The module shows if any are found.
+</ParamField>
+
+<ParamField type="string[]">
+  Directory names to look for in the current directory. The module shows if any are found.
+</ParamField>
+
+<ParamField type="string[]">
+  File extensions to look for in the current directory. The module shows if any files match.
+</ParamField>
+
+<ParamField type="boolean">
+  Override whether the command is passed via stdin (default) or as a shell argument. Only needed for shells that don't support stdin input.
+</ParamField>
+
+<ParamField type="boolean">
+  If `true`, ignore the global `command_timeout` and let the command run as long as needed.
+</ParamField>
+
+<ParamField type="boolean">
+  If `true`, command output is printed unescaped. Only enable this if you fully trust the command's output.
+</ParamField>
+
+## The `when` condition
+
+`when` accepts either a boolean or a shell command string:
+
+```toml theme={null}
+# Always show
+when = true
+
+# Never show (default)
+when = false
+
+# Show when a file exists
+when = "test -f .project"
+
+# Show when an environment variable is set
+when = 'test -n "$MY_ENV_VAR"'
+
+# Show when inside a specific directory
+when = ''' test "$PWD" = "$HOME/work" '''
+```
+
+The module is shown when the `when` command exits with code `0`.
+
+## Specifying a shell
+
+If your `when` or `command` uses shell-specific syntax, set `shell` explicitly:
+
+<Tabs>
+  <Tab title="PowerShell">
+    ```toml theme={null}
+    [custom.time]
+    command = 'time /T'
+    detect_extensions = ['pst']
+    shell = ['pwsh', '-NoProfile', '-Command', '-']
+    ```
+  </Tab>
+
+  <Tab title="bash">
+    ```toml theme={null}
+    [custom.git_email]
+    command = 'git config user.email'
+    when = 'git rev-parse --is-inside-work-tree'
+    shell = ['bash', '--noprofile', '--norc', '-c']
+    use_stdin = false
+    ```
+  </Tab>
+
+  <Tab title="Nushell">
+    ```toml theme={null}
+    [custom.nu_version]
+    command = 'version | get version'
+    shell = ['nu', '-c']
+    use_stdin = false
+    ```
+  </Tab>
+</Tabs>
+
+<Warning>
+  Make sure your custom shell configuration exits gracefully. For PowerShell, always include `-NoProfile` and `-Command` to prevent Starship from entering a recursive loop where the shell tries to load a full profile (which includes Starship, which runs the custom command again).
+</Warning>
+
+## Controlling module order
+
+By default, custom modules appear in the order they were defined. To place a custom module at a specific position in the prompt, reference it explicitly in the top-level `format`:
+
+```toml theme={null}
+# ~/.config/starship.toml
+
+# ${custom.foo} uses ${...} syntax because the name contains a dot
+format = '$directory${custom.my_project}$git_branch$character'
+
+[custom.my_project]
+command = "cat .project"
+when = "test -f .project"
+```
+
+## Practical examples
+
+### Show content of a project file
+
+```toml theme={null}
+[custom.foo]
+command = 'echo foo'
+detect_files = ['foo']
+when = ''' test "$HOME" = "$PWD" '''
+format = ' transcending [$output]($style)'
+```
+
+### Show a custom environment badge
+
+```toml theme={null}
+[custom.env_badge]
+description = "Shows the current ENVIRONMENT variable"
+command = 'echo $ENVIRONMENT'
+when = 'test -n "$ENVIRONMENT"'
+symbol = '🌍 '
+style = 'bold blue'
+format = '[$symbol$output ]($style)'
+```
+
+### Detect a monorepo workspace
+
+```toml theme={null}
+[custom.workspace]
+description = "Shows the current yarn/npm workspace name"
+command = "cat package.json | python3 -c \"import sys,json; d=json.load(sys.stdin); print(d.get('name',''))\" 2>/dev/null"
+detect_files = ['package.json']
+require_repo = true
+symbol = '📦 '
+style = 'bold cyan'
+```
+
+## Custom modules vs `env_var`
+
+Starship has a dedicated `env_var` module for displaying environment variable values without running a command. Use it when you only need to show an existing variable.
+
+```toml theme={null}
+# Show the value of $ENVIRONMENT directly
+[env_var.ENVIRONMENT]
+default = 'development'
+format = 'env: [$env_value]($style) '
+style = 'bold dimmed green'
+```
+
+| Feature                   | `[custom.*]` | `[env_var.*]` |
+| ------------------------- | :----------: | :-----------: |
+| Runs a shell command      |      Yes     |       No      |
+| Reads an env var directly |  Indirectly  |      Yes      |
+| Supports `when` condition |      Yes     |       No      |
+| Supports file detection   |      Yes     |       No      |
+| Overhead                  |    Higher    |    Minimal    |
+
+Use `[env_var.*]` when you just need a variable's value. Use `[custom.*]` when you need to run a command or apply conditional logic.
+
+### `env_var` options
+
+| Option        | Default                               | Description                                                    |
+| ------------- | ------------------------------------- | -------------------------------------------------------------- |
+| `variable`    |                                       | The environment variable to display. Defaults to the key name. |
+| `default`     |                                       | Value shown when the variable is not set.                      |
+| `format`      | `"with [$symbol$env_value]($style) "` | The format for the module.                                     |
+| `symbol`      | `""`                                  | Symbol before the variable value.                              |
+| `style`       | `"black bold dimmed"`                 | Style for the module.                                          |
+| `description` | `"<env_var module>"`                  | Description shown by `starship explain`.                       |
+| `disabled`    | `false`                               | Disables this module.                                          |
+
+Example showing multiple variables:
+
+```toml theme={null}
+[env_var.SHELL]
+variable = 'SHELL'
+default = 'unknown shell'
+
+[env_var.USER]
+default = 'unknown user'
+```
+
+
+# Format strings
+Source: https://www.mintlify.com/starship/starship/config/format-strings
+
+Understand how Starship's format string syntax works—variables, text groups, style strings, conditional rendering, and TOML string types.
+
+Every Starship module exposes a `format` option that controls what the module prints and how it looks. Format strings combine plain text, variables, and styled text groups.
+
+## Variables
+
+A variable starts with `$` followed by the variable name. Variable names can only contain letters, numbers, and `_`.
+
+```
+$version          → the value of the "version" variable
+$git_branch       → the value of the "git_branch" variable
+$git_branch $git_commit  → two variables separated by a space
+```
+
+If a variable is unset or empty, it renders as an empty string.
+
+## Text groups
+
+A text group applies a style to a piece of text (which may itself contain variables):
+
+```
+[text content](<style string>)
+```
+
+Examples from real modules:
+
+```
+[on](red bold)                      → prints "on" in bold red
+[⌘ $version](bold green)            → prints ⌘ followed by $version, in bold green
+[a [b](red) c](green)               → prints "a b c" where "b" is red, "a" and "c" green
+```
+
+### Conditional text groups
+
+A text group wrapped in `(` and `)` is **conditional**: it renders nothing if all variables inside are empty.
+
+```
+(@$region)        → renders nothing if $region is empty, otherwise "@<region>"
+(some text)       → always renders nothing—no variables inside
+```
+
+This is how modules hide optional segments when data is unavailable.
+
+## Style strings
+
+The second part of a text group is a style string. Combine tokens with spaces.
+
+### Color names
+
+| Token           | Effect                              |
+| --------------- | ----------------------------------- |
+| `black`         | Black foreground                    |
+| `red`           | Red foreground                      |
+| `green`         | Green foreground                    |
+| `yellow`        | Yellow foreground                   |
+| `blue`          | Blue foreground                     |
+| `purple`        | Purple foreground                   |
+| `cyan`          | Cyan foreground                     |
+| `white`         | White foreground                    |
+| `bright-black`  | Bright black (dark gray) foreground |
+| `bright-red`    | Bright red foreground               |
+| `bright-green`  | Bright green foreground             |
+| `bright-yellow` | Bright yellow foreground            |
+| `bright-blue`   | Bright blue foreground              |
+| `bright-purple` | Bright purple foreground            |
+| `bright-cyan`   | Bright cyan foreground              |
+| `bright-white`  | Bright white foreground             |
+
+### Text attributes
+
+| Token           | Effect                                 |
+| --------------- | -------------------------------------- |
+| `bold`          | Bold text                              |
+| `italic`        | Italic text (terminal must support it) |
+| `underline`     | Underlined text                        |
+| `dimmed`        | Dimmed/faint text                      |
+| `blink`         | Blinking text                          |
+| `hidden`        | Invisible text (still occupies space)  |
+| `strikethrough` | Strikethrough text                     |
+| `inverted`      | Swap foreground and background colors  |
+
+### Background colors
+
+Prefix any color with `bg:` to set the background:
+
+```
+bg:blue           → blue background
+bg:#bf5700        → hex color background
+```
+
+### ANSI 256 colors and hex values
+
+```
+fg:27             → ANSI color 27 (foreground)
+bg:255            → ANSI color 255 (background)
+fg:#ff8800        → hex color foreground
+bg:#bf5700        → hex color background (burnt orange)
+```
+
+### Combining tokens
+
+```
+'fg:green bg:blue'          → green text on blue background
+'bg:blue fg:bright-green'   → bright green text on blue background
+'bold fg:27'                → bold text with ANSI color 27
+'underline bg:#bf5700'      → underlined text on burnt orange background
+'bold italic fg:purple'     → bold italic purple text
+''                          → explicitly disables all styling
+```
+
+<Note>
+  Rendering depends on your terminal emulator. Some terminals brighten colors instead of bolding, and some color themes map normal and bright values to the same color.
+</Note>
+
+## Special characters that need escaping
+
+The following characters have special meaning in Starship format strings and must be escaped with `\` to appear literally:
+
+| Character | Escaped form |
+| --------- | ------------ |
+| `$`       | `\$`         |
+| `[`       | `\[`         |
+| `]`       | `\]`         |
+| `(`       | `\(`         |
+| `)`       | `\)`         |
+
+Example:
+
+```toml theme={null}
+format = '\[\$\] '    # renders: [$] 
+```
+
+## TOML string types
+
+TOML offers four string types. Choosing the right one avoids double-escaping.
+
+| Syntax      | Type               | Notes                                                       |
+| ----------- | ------------------ | ----------------------------------------------------------- |
+| `'...'`     | Literal string     | No escape sequences—backslashes are literal                 |
+| `"..."`     | Basic string       | Supports `\\`, `\n`, `\t`, etc.                             |
+| `'''...'''` | Multi-line literal | Same as literal, spans multiple lines                       |
+| `"""..."""` | Multi-line basic   | Supports escape sequences; newlines can be ignored with `\` |
+
+**Prefer literal strings** (`'...'`) for format strings—you can write Starship escape sequences without double-escaping:
+
+```toml theme={null}
+# literal string — backslash is literal, no extra escaping needed
+format = '☺\☻ '
+
+# basic string — backslash must be doubled
+format = "☺\\☻ "
+
+# escaping Starship special characters in a literal string
+format = '\[\$\] '
+```
+
+### Multi-line format strings
+
+Use multi-line strings when your format spans multiple lines:
+
+```toml theme={null}
+# literal multi-line string
+format = '''
+[┌─>](bold green)
+[└─>](bold green) '''
+
+# basic multi-line with escaped newline (no newline in output)
+format = """
+line1\
+line1
+line2\
+line2
+"""
+```
+
+## Real module format string examples
+
+### `git_branch` default format
+
+```toml theme={null}
+format = 'on [$symbol$branch(:$remote_branch)]($style) '
+```
+
+* `$symbol` — the branch icon (default: ` `)
+* `$branch` — the current branch name
+* `(:$remote_branch)` — conditional: only shows if `$remote_branch` is set
+* The whole group is styled with `$style`
+
+### `nodejs` default format
+
+```toml theme={null}
+format = 'via [$symbol($version )]($style)'
+```
+
+* `($version )` — conditional: the space only appears if `$version` is non-empty
+
+### `git_status` example
+
+```toml theme={null}
+format = '([\[$all_status$ahead_behind\]]($style) )'
+```
+
+* `\[` and `\]` are escaped brackets (rendered literally)
+* The outer `(...)` makes the whole segment conditional
+
+### Custom styled format
+
+```toml theme={null}
+[character]
+success_symbol = '[➜](bold green)'
+error_symbol = '[✗](bold red)'
+```
+
+
+# Built-in modules
+Source: https://www.mintlify.com/starship/starship/config/modules
+
+Browse Starship's 100+ built-in modules organized by category, with configuration examples and common options.
+
+Starship ships with over 100 built-in modules that display information about your environment—language versions, cloud context, git state, system status, and more. Each module is auto-detected based on files in the current directory and only appears when relevant.
+
+Every module supports these common options:
+
+| Option     | Default | Description                                                                              |
+| ---------- | ------- | ---------------------------------------------------------------------------------------- |
+| `format`   | varies  | Template string controlling module output. See [Format strings](/config/format-strings). |
+| `style`    | varies  | Style string for colors and text attributes.                                             |
+| `symbol`   | varies  | Symbol displayed before the module output.                                               |
+| `disabled` | `false` | Set to `true` to hide the module completely.                                             |
+
+<Tip>
+  Run `starship explain` to see which modules are active in your current directory and why.
+  Run `starship module <name>` to preview a single module's output in isolation.
+</Tip>
+
+## Version control
+
+<AccordionGroup>
+  <Accordion title="git_branch">
+    Shows the active branch (or commit hash in detached HEAD state).
+
+    ```toml theme={null}
+    [git_branch]
+    symbol = '🌱 '
+    truncation_length = 20
+    truncation_symbol = '…'
+    ignore_branches = ['master', 'main']
+    style = 'bold purple'
+    ```
+
+    | Option              | Default                                           | Description                                       |
+    | ------------------- | ------------------------------------------------- | ------------------------------------------------- |
+    | `format`            | `'on [$symbol$branch(:$remote_branch)]($style) '` | The format for the module.                        |
+    | `symbol`            | `' '`                                             | Symbol before the branch name.                    |
+    | `truncation_length` | `2^63 - 1`                                        | Truncate branch name to N graphemes.              |
+    | `truncation_symbol` | `'…'`                                             | Symbol appended when truncated.                   |
+    | `ignore_branches`   | `[]`                                              | Branch names to hide (e.g. `['master', 'main']`). |
+    | `only_attached`     | `false`                                           | Only show when not in detached HEAD state.        |
+    | `disabled`          | `false`                                           | Disables this module.                             |
+  </Accordion>
+
+  <Accordion title="git_commit">
+    Shows the current commit hash, and optionally the tag.
+
+    ```toml theme={null}
+    [git_commit]
+    commit_hash_length = 4
+    tag_symbol = '🔖 '
+    tag_disabled = false
+    ```
+
+    | Option               | Default   | Description                                           |
+    | -------------------- | --------- | ----------------------------------------------------- |
+    | `commit_hash_length` | `7`       | Number of characters to display from the commit hash. |
+    | `only_detached`      | `true`    | Only show hash in detached HEAD state.                |
+    | `tag_disabled`       | `true`    | Disable tag display.                                  |
+    | `tag_symbol`         | `' 🏷  '` | Symbol prefixing the tag name.                        |
+    | `disabled`           | `false`   | Disables this module.                                 |
+  </Accordion>
+
+  <Accordion title="git_status">
+    Shows symbols representing staged, unstaged, and untracked changes.
+
+    ```toml theme={null}
+    [git_status]
+    conflicted = '🏳'
+    ahead = '🏎💨'
+    behind = '😰'
+    diverged = '😵'
+    untracked = '🤷'
+    modified = '📝'
+    staged = '[++\($count\)](green)'
+    deleted = '🗑'
+    ```
+
+    | Option       | Default | Description                      |
+    | ------------ | ------- | -------------------------------- |
+    | `conflicted` | `'='`   | Branch has merge conflicts.      |
+    | `ahead`      | `'⇡'`   | Branch is ahead of remote.       |
+    | `behind`     | `'⇣'`   | Branch is behind remote.         |
+    | `diverged`   | `'⇕'`   | Branch has diverged from remote. |
+    | `untracked`  | `'?'`   | Untracked files present.         |
+    | `modified`   | `'!'`   | Modified files present.          |
+    | `staged`     | `'+'`   | Staged files present.            |
+    | `deleted`    | `'✘'`   | Deleted files staged.            |
+    | `disabled`   | `false` | Disables this module.            |
+  </Accordion>
+
+  <Accordion title="git_metrics">
+    Shows the number of added/deleted lines since the last commit.
+
+    ```toml theme={null}
+    [git_metrics]
+    added_style = 'bold blue'
+    deleted_style = 'bold red'
+    disabled = false
+    ```
+
+    <Note>This module is disabled by default. Set `disabled = false` to enable it.</Note>
+  </Accordion>
+
+  <Accordion title="git_state">
+    Shows the current operation in progress (REBASING, MERGING, BISECTING, etc.) with optional progress counters.
+
+    ```toml theme={null}
+    [git_state]
+    rebase = 'REBASING'
+    merge = 'MERGING'
+    style = 'bold yellow'
+    ```
+  </Accordion>
+
+  <Accordion title="hg_branch, fossil_branch, pijul_channel">
+    Similar to `git_branch` but for Mercurial, Fossil, and Pijul repositories respectively.
+
+    ```toml theme={null}
+    [hg_branch]
+    symbol = '🍀 '
+    style = 'bold green'
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Languages
+
+<AccordionGroup>
+  <Accordion title="nodejs">
+    Shows the current Node.js version. Auto-detected from `package.json`, `.nvmrc`, `.node-version`, `node_modules/`, and `.js`/`.ts` files.
+
+    ```toml theme={null}
+    [nodejs]
+    format = 'via [🤖 $version](bold green) '
+    detect_files = ['package.json', '.node-version', '.nvmrc']
+    detect_folders = ['node_modules']
+    disabled = false
+    ```
+
+    | Option     | Default                              | Description                       |
+    | ---------- | ------------------------------------ | --------------------------------- |
+    | `format`   | `'via [$symbol($version )]($style)'` | The format for the module.        |
+    | `symbol`   | `' '`                                | Symbol before the version number. |
+    | `style`    | `'bold green'`                       | Style for the module.             |
+    | `disabled` | `false`                              | Disables this module.             |
+  </Accordion>
+
+  <Accordion title="python">
+    Shows the Python version and active virtual environment. Auto-detected from `.py` files, `pyproject.toml`, `requirements.txt`, and others.
+
+    ```toml theme={null}
+    [python]
+    symbol = '👾 '
+    pyenv_version_name = true
+    ```
+
+    ```toml theme={null}
+    [python]
+    # Only use python3 binary
+    python_binary = 'python3'
+    ```
+
+    | Option               | Default                                                                   | Description                                |
+    | -------------------- | ------------------------------------------------------------------------- | ------------------------------------------ |
+    | `format`             | `'via [${symbol}${pyenv_prefix}(${version} )(\($virtualenv\) )]($style)'` | The format for the module.                 |
+    | `symbol`             | `'🐍 '`                                                                   | Symbol before the version.                 |
+    | `pyenv_version_name` | `false`                                                                   | Use pyenv to get the version name.         |
+    | `python_binary`      | `['python', 'python3', 'python2']`                                        | Which binary to run for version detection. |
+    | `disabled`           | `false`                                                                   | Disables this module.                      |
+  </Accordion>
+
+  <Accordion title="rust">
+    Shows the Rust version. Auto-detected from `Cargo.toml` and `.rs` files.
+
+    ```toml theme={null}
+    [rust]
+    format = 'via [⚙️ $version](red bold)'
+    symbol = '🦀 '
+    ```
+
+    | Option     | Default                              | Description                |
+    | ---------- | ------------------------------------ | -------------------------- |
+    | `format`   | `'via [$symbol($version )]($style)'` | The format for the module. |
+    | `symbol`   | `'🦀 '`                              | Symbol before the version. |
+    | `style`    | `'bold red'`                         | Style for the module.      |
+    | `disabled` | `false`                              | Disables this module.      |
+  </Accordion>
+
+  <Accordion title="go">
+    Shows the Go version. Auto-detected from `go.mod`, `go.sum`, `go.work`, and `.go` files.
+
+    ```toml theme={null}
+    [golang]
+    format = 'via [🏎💨 $version](bold cyan) '
+    ```
+  </Accordion>
+
+  <Accordion title="java">
+    Shows the Java version. Auto-detected from `pom.xml`, `build.gradle`, `.java`, `.class`, `.jar`, and similar files.
+
+    ```toml theme={null}
+    [java]
+    symbol = '☕ '
+    style = 'red dimmed'
+    ```
+  </Accordion>
+
+  <Accordion title="Other language modules">
+    Starship includes modules for all of the following languages. Each follows the same pattern: auto-detected from relevant files, configurable via `format`, `symbol`, `style`, and `disabled`.
+
+    | Module       | Language   | Default symbol |
+    | ------------ | ---------- | -------------- |
+    | `c`          | C          | `C `           |
+    | `crystal`    | Crystal    | `🔮 `          |
+    | `dart`       | Dart       | `🎯 `          |
+    | `deno`       | Deno       | `🦕 `          |
+    | `dotnet`     | .NET       | `🎃 `          |
+    | `elixir`     | Elixir     | `💧 `          |
+    | `elm`        | Elm        | `🌳 `          |
+    | `erlang`     | Erlang/OTP | ` `            |
+    | `fennel`     | Fennel     | `🧅 `          |
+    | `gleam`      | Gleam      | `⭐ `           |
+    | `haskell`    | Haskell    | `λ `           |
+    | `julia`      | Julia      | `ஃ `           |
+    | `kotlin`     | Kotlin     | `🅺 `          |
+    | `lua`        | Lua        | `🌙 `          |
+    | `nim`        | Nim        | `👑 `          |
+    | `nodejs`     | Node.js    | ` `            |
+    | `ocaml`      | OCaml      | `🐫 `          |
+    | `perl`       | Perl       | `🐪 `          |
+    | `php`        | PHP        | `🐘 `          |
+    | `purescript` | PureScript | `<= `          |
+    | `python`     | Python     | `🐍 `          |
+    | `raku`       | Raku       | `🦋 `          |
+    | `red`        | Red        | `🔴 `          |
+    | `rlang`      | R          | `📐 `          |
+    | `ruby`       | Ruby       | `💎 `          |
+    | `rust`       | Rust       | `🦀 `          |
+    | `scala`      | Scala      | `🆂 `          |
+    | `swift`      | Swift      | `🐦 `          |
+    | `typst`      | Typst      | `t `           |
+    | `vlang`      | V          | `V `           |
+    | `zig`        | Zig        | `⚡ `           |
+  </Accordion>
+</AccordionGroup>
+
+## Cloud and DevOps
+
+<AccordionGroup>
+  <Accordion title="aws">
+    Shows the current AWS region, profile, and credential expiration timer.
+
+    ```toml theme={null}
+    [aws]
+    format = 'on [$symbol($profile )(\($region\) )]($style)'
+    style = 'bold blue'
+    symbol = '🅰 '
+
+    [aws.region_aliases]
+    ap-southeast-2 = 'au'
+    us-east-1 = 'va'
+    ```
+
+    | Option           | Default                                                           | Description                                   |
+    | ---------------- | ----------------------------------------------------------------- | --------------------------------------------- |
+    | `format`         | `'on [$symbol($profile )(\($region\) )(\[$duration\] )]($style)'` | The format for the module.                    |
+    | `symbol`         | `'☁️ '`                                                           | Symbol before the profile name.               |
+    | `region_aliases` | `{}`                                                              | Map of region name aliases.                   |
+    | `force_display`  | `false`                                                           | Show even when no credentials are configured. |
+    | `disabled`       | `false`                                                           | Disables this module.                         |
+  </Accordion>
+
+  <Accordion title="gcloud">
+    Shows the current Google Cloud active configuration, project, and region.
+
+    ```toml theme={null}
+    [gcloud]
+    format = 'on [$symbol$account(@$domain)(\($region\))]($style) '
+    style = 'bold blue'
+    symbol = '☁️ '
+    ```
+  </Accordion>
+
+  <Accordion title="kubernetes">
+    Shows the current Kubernetes context and namespace.
+
+    <Note>This module is disabled by default. Set `disabled = false` to enable it.</Note>
+
+    ```toml theme={null}
+    [kubernetes]
+    format = 'on [⛵ ($user on )($cluster in )$context \($namespace\)](dimmed green) '
+    disabled = false
+    contexts = [
+      { context_pattern = "dev.local.cluster.k8s", style = "green", symbol = "💔 " },
+    ]
+    ```
+
+    | Option     | Default                                            | Description                             |
+    | ---------- | -------------------------------------------------- | --------------------------------------- |
+    | `format`   | `'[$symbol$context( \($namespace\))]($style) in '` | The format for the module.              |
+    | `symbol`   | `'☸ '`                                             | Symbol before the context name.         |
+    | `contexts` | `[]`                                               | Per-context style and symbol overrides. |
+    | `disabled` | `true`                                             | Disables this module.                   |
+  </Accordion>
+
+  <Accordion title="azure">
+    Shows the current Azure subscription name.
+
+    <Note>This module is disabled by default. Set `disabled = false` to enable it.</Note>
+
+    ```toml theme={null}
+    [azure]
+    disabled = false
+    format = 'on [$symbol($subscription)]($style) '
+    symbol = '󰠅 '
+    style = 'blue bold'
+    ```
+  </Accordion>
+
+  <Accordion title="terraform, helm, openstack, pulumi">
+    These modules display information about Terraform workspaces, Helm chart versions, OpenStack clouds, and Pulumi stacks respectively.
+
+    ```toml theme={null}
+    [terraform]
+    format = 'via [🏎💨 $workspace]($style) '
+
+    [helm]
+    format = 'via [⎈ $version](bold white) '
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## System
+
+<AccordionGroup>
+  <Accordion title="directory">
+    Shows the current working directory. This module is always shown and cannot be disabled in the same way as other modules.
+
+    ```toml theme={null}
+    [directory]
+    truncation_length = 3
+    truncate_to_repo = false
+    style = 'bold cyan'
+    read_only = '🔒'
+    ```
+
+    | Option              | Default       | Description                                   |
+    | ------------------- | ------------- | --------------------------------------------- |
+    | `truncation_length` | `3`           | Number of parent directories to show.         |
+    | `truncate_to_repo`  | `true`        | Truncate to the root of the current git repo. |
+    | `read_only`         | `'🔒'`        | Symbol shown when directory is read-only.     |
+    | `style`             | `'bold cyan'` | Style for the directory path.                 |
+  </Accordion>
+
+  <Accordion title="username">
+    Shows the active user's username. Only shown when root, on SSH, or when `show_always = true`.
+
+    ```toml theme={null}
+    [username]
+    style_user = 'white bold'
+    style_root = 'black bold'
+    format = 'user: [$user]($style) '
+    disabled = false
+    show_always = true
+    ```
+  </Accordion>
+
+  <Accordion title="hostname">
+    Shows the system hostname. Only shown on SSH sessions by default.
+
+    ```toml theme={null}
+    [hostname]
+    ssh_only = false
+    format = '[$ssh_symbol](bold blue) on [$hostname](bold red) '
+    ```
+  </Accordion>
+
+  <Accordion title="battery">
+    Shows the battery charge percentage. Only visible when battery is below 10% by default.
+
+    ```toml theme={null}
+    [battery]
+    full_symbol = '🔋 '
+    charging_symbol = '⚡️ '
+    discharging_symbol = '💀 '
+
+    [[battery.display]]
+    threshold = 30
+    style = 'bold yellow'
+    ```
+  </Accordion>
+
+  <Accordion title="cmd_duration">
+    Shows how long the last command took. Only shown when the command exceeds the threshold.
+
+    ```toml theme={null}
+    [cmd_duration]
+    min_time = 500
+    format = 'underwent [$duration](bold yellow)'
+    ```
+  </Accordion>
+
+  <Accordion title="time">
+    Shows the current time.
+
+    <Note>This module is disabled by default. Set `disabled = false` to enable it.</Note>
+
+    ```toml theme={null}
+    [time]
+    disabled = false
+    format = '🕙[\[ $time \]]($style) '
+    time_format = '%T'
+    ```
+  </Accordion>
+
+  <Accordion title="memory_usage">
+    Shows current RAM and swap usage.
+
+    <Note>This module is disabled by default. Set `disabled = false` to enable it.</Note>
+
+    ```toml theme={null}
+    [memory_usage]
+    disabled = false
+    threshold = -1
+    symbol = ' '
+    style = 'bold dimmed green'
+    ```
+  </Accordion>
+
+  <Accordion title="status">
+    Shows the exit code of the last command.
+
+    <Note>This module is disabled by default. Set `disabled = false` to enable it.</Note>
+
+    ```toml theme={null}
+    [status]
+    style = 'bg:blue'
+    symbol = '🔴 '
+    success_symbol = '🟢 SUCCESS'
+    format = '[\[$symbol$common_meaning$signal_name$maybe_int\]]($style) '
+    disabled = false
+    ```
+  </Accordion>
+
+  <Accordion title="os, shell, jobs, shlvl, localip">
+    Additional system modules:
+
+    * **`os`** — shows the current operating system name/icon (disabled by default)
+    * **`shell`** — shows which shell is running (disabled by default)
+    * **`jobs`** — shows the number of background jobs
+    * **`shlvl`** — shows the shell nesting level
+    * **`localip`** — shows the local IP address (disabled by default)
+  </Accordion>
+</AccordionGroup>
+
+## Package managers and tools
+
+<AccordionGroup>
+  <Accordion title="package">
+    Shows the version from the current project's package manifest (`package.json`, `Cargo.toml`, `pyproject.toml`, etc.).
+
+    ```toml theme={null}
+    [package]
+    format = 'via [🎁 $version](208 bold) '
+    ```
+  </Accordion>
+
+  <Accordion title="docker_context">
+    Shows the current Docker context when not set to `default`.
+
+    ```toml theme={null}
+    [docker_context]
+    format = 'via [🐋 $context](blue bold)'
+    ```
+  </Accordion>
+
+  <Accordion title="conda">
+    Shows the current conda environment when `$CONDA_DEFAULT_ENV` is set.
+
+    ```toml theme={null}
+    [conda]
+    format = '[$symbol$environment](dimmed green) '
+    ```
+  </Accordion>
+
+  <Accordion title="nix_shell">
+    Shows the nix-shell environment name.
+
+    ```toml theme={null}
+    [nix_shell]
+    impure_msg = '[impure shell](bold red)'
+    pure_msg = '[pure shell](bold green)'
+    unknown_msg = '[unknown shell](bold yellow)'
+    format = 'via [☃️ $state( \($name\))](bold blue) '
+    ```
+  </Accordion>
+
+  <Accordion title="buf, bun, cmake, daml, direnv, gradle, guix_shell, meson, mise, mojo, nats, pixi, spack, vagrant, xmake">
+    Starship also includes modules for these tools and package managers. Each follows the same auto-detection pattern.
+
+    ```toml theme={null}
+    [buf]
+    symbol = '🦬 '
+
+    [bun]
+    format = 'via [🍔 $version](bold green) '
+
+    [direnv]
+    disabled = false
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Debugging a single module
+
+To preview what a specific module outputs in the current directory:
+
+```sh theme={null}
+starship module git_branch
+starship module nodejs
+starship module python
+```
+
+To see all active modules and why they are shown:
+
+```sh theme={null}
+starship explain
+```
+
+
+# Configuration overview
+Source: https://www.mintlify.com/starship/starship/config/overview
+
+Learn where Starship stores its config file, how to create it, and the top-level options that control global prompt behavior.
+
+Starship is configured via a single [TOML](https://toml.io) file at `~/.config/starship.toml`. Every setting—from module visibility to prompt layout—lives in that file.
+
+## Creating the config file
+
+```sh theme={null}
+mkdir -p ~/.config && touch ~/.config/starship.toml
+```
+
+A minimal starting point:
+
+```toml theme={null}
+# Get editor completions based on the config schema
+"$schema" = 'https://starship.rs/config-schema.json'
+
+# Insert a blank line between shell prompts
+add_newline = true
+
+# Replace the '❯' symbol with '➜'
+[character]
+success_symbol = '[➜](bold green)'
+
+# Disable the package module entirely
+[package]
+disabled = true
+```
+
+<Tip>
+  Adding `"$schema" = 'https://starship.rs/config-schema.json'` at the top of your config enables auto-completion and validation in editors that support JSON Schema (VS Code, Neovim with LSP, etc.).
+</Tip>
+
+## Overriding the config file location
+
+Set `STARSHIP_CONFIG` to use a file at a different path.
+
+<Tabs>
+  <Tab title="bash / zsh / fish">
+    ```sh theme={null}
+    export STARSHIP_CONFIG=~/example/non/default/path/starship.toml
+    ```
+  </Tab>
+
+  <Tab title="PowerShell">
+    ```powershell theme={null}
+    $ENV:STARSHIP_CONFIG = "$HOME\example\non\default\path\starship.toml"
+    ```
+  </Tab>
+
+  <Tab title="Cmd (starship.lua)">
+    ```lua theme={null}
+    os.setenv('STARSHIP_CONFIG', 'C:\\Users\\user\\example\\non\\default\\path\\starship.toml')
+    ```
+  </Tab>
+</Tabs>
+
+## Overriding the cache location
+
+Starship logs warnings and errors to `~/.cache/starship/session_${STARSHIP_SESSION_KEY}.log` by default. Set `STARSHIP_CACHE` to change this.
+
+<Tabs>
+  <Tab title="bash / zsh / fish">
+    ```sh theme={null}
+    export STARSHIP_CACHE=~/.starship/cache
+    ```
+  </Tab>
+
+  <Tab title="PowerShell">
+    ```powershell theme={null}
+    $ENV:STARSHIP_CACHE = "$HOME\AppData\Local\Temp"
+    ```
+  </Tab>
+
+  <Tab title="Cmd (starship.lua)">
+    ```lua theme={null}
+    os.setenv('STARSHIP_CACHE', 'C:\\Users\\user\\AppData\\Local\\Temp')
+    ```
+  </Tab>
+</Tabs>
+
+## Top-level prompt options
+
+These options go at the root of your `starship.toml` (not inside any `[module]` section).
+
+| Option                | Default                | Description                                                       |
+| --------------------- | ---------------------- | ----------------------------------------------------------------- |
+| `format`              | `'$all'`               | The overall prompt format. References modules by `$module_name`.  |
+| `right_format`        | `''`                   | Content rendered on the right side of the prompt (right-prompt).  |
+| `continuation_prompt` | `'[∙](bright-black) '` | Prompt shown for continuation lines (e.g. multi-line commands).   |
+| `scan_timeout`        | `30`                   | Timeout (ms) for Starship to scan files in the current directory. |
+| `command_timeout`     | `500`                  | Timeout (ms) for commands executed by modules.                    |
+| `add_newline`         | `true`                 | Insert a blank line between shell prompts.                        |
+| `follow_symlinks`     | `true`                 | Follow symlinks when checking if a path is a git repository.      |
+| `palette`             | `''`                   | Name of a color palette defined in `[palettes.*]` to activate.    |
+| `palettes`            | `{}`                   | Map of named color palettes. Use to assign aliases to colors.     |
+
+### Example: custom format and timeouts
+
+```toml theme={null}
+# ~/.config/starship.toml
+
+format = '''
+[┌───────────────────>](bold green)
+[│](bold green)$directory$rust$package
+[└─>](bold green) '''
+
+scan_timeout = 10
+add_newline = false
+```
+
+<Note>
+  `follow_symlinks = false` is recommended if you have symlinks pointing to networked or slow filesystems, as directory detection can block the prompt.
+</Note>
+
+## Disabling a module
+
+Every module supports a `disabled` option. Set it to `true` to hide that module from the prompt entirely.
+
+```toml theme={null}
+[package]
+disabled = true
+```
+
+## Setting values from the command line
+
+Use `starship config` to set a single key without editing the file directly:
+
+```sh theme={null}
+starship config add_newline false
+starship config character.success_symbol '[➜](bold green)'
+```
+
+## Viewing the computed config
+
+`starship print-config` prints the full resolved configuration (including all defaults):
+
+```sh theme={null}
+starship print-config
+```
+
+To print only a specific module's config:
+
+```sh theme={null}
+starship print-config --default character
+```
+
+## Key terminology
+
+* **Module**: A component in the prompt that displays information based on context—for example, `nodejs` shows the current Node.js version when you're in a Node.js project.
+* **Variable**: A sub-component of a module, such as `$version` inside the `nodejs` module.
+* **Format string**: A template string used to compose module output from variables and styled text groups. See [Format strings](/config/format-strings) for full syntax.
+
+
+# FAQ
+Source: https://www.mintlify.com/starship/starship/faq
+
+Answers to common questions about Starship configuration, debugging, and compatibility.
+
+<AccordionGroup>
+  <Accordion title="What is the configuration used in the demo GIF?">
+    The demo uses the following setup:
+
+    * **Terminal emulator**: [iTerm2](https://iterm2.com/) with the Minimal theme and the [Snazzy](https://github.com/sindresorhus/iterm2-snazzy) color scheme
+    * **Font**: [FiraCode Nerd Font](https://www.nerdfonts.com/font-downloads)
+    * **Shell**: [Fish Shell](https://fishshell.com/)
+    * **Prompt**: Starship with [matchai's dotfiles](https://github.com/matchai/dotfiles/blob/b6c6a701d0af8d145a8370288c00bb9f0648b5c2/.config/fish/config.fish)
+  </Accordion>
+
+  <Accordion title="How do I get command completion as shown in the demo GIF?">
+    Completion (autosuggestions) is a feature of your shell, not Starship. The demo uses [Fish Shell](https://fishshell.com/), which provides autosuggestions by default.
+
+    If you use Zsh, [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions) provides the same behavior.
+  </Accordion>
+
+  <Accordion title="Do top-level format and module.disabled do the same thing?">
+    Yes — both can disable a module. However, `<module>.disabled` is the preferred approach for these reasons:
+
+    * It is more explicit about intent than omitting the module from `format`.
+    * Newly released modules are added to the default `format` automatically, so you won't miss them if you use `disabled` instead of a manually curated format string.
+  </Accordion>
+
+  <Accordion title="The docs say Starship is cross-shell. Why isn't my preferred shell supported?">
+    The Starship binary is stateless and shell-agnostic. As long as your shell supports prompt customization and command substitution, you can integrate Starship manually. Here is a minimal Bash example:
+
+    ```bash theme={null}
+    # Get the status code from the last command executed
+    STATUS=$?
+
+    # Get the number of jobs running
+    NUM_JOBS=$(jobs -p | wc -l)
+
+    # Set the prompt to the output of `starship prompt`
+    PS1="$(starship prompt --status=$STATUS --jobs=$NUM_JOBS)"
+    ```
+
+    The built-in Bash integration is more complex to support features like the Command Duration module and compatibility with existing Bash configurations, but the above shows the core idea.
+
+    To see all flags accepted by `starship prompt`:
+
+    ```bash theme={null}
+    starship prompt --help
+    ```
+
+    All flags are optional — Starship uses whatever context is provided.
+  </Accordion>
+
+  <Accordion title="How do I run Starship on Linux distributions with older versions of glibc?">
+    If you see an error like `version 'GLIBC_2.18' not found (required by starship)` when using the prebuilt binary (for example on CentOS 6 or 7), use the `musl`-compiled binary instead:
+
+    ```bash theme={null}
+    curl -sS https://starship.rs/install.sh | sh -s -- --platform unknown-linux-musl
+    ```
+  </Accordion>
+
+  <Accordion title="Why do I see 'Executing command timed out' warnings?">
+    Starship runs external commands to gather prompt data — for example, checking the git status or reading a language version. To prevent the prompt from hanging, Starship enforces a time limit on each command. When a command exceeds that limit, Starship stops it and emits this warning.
+
+    You have a few options:
+
+    * **Increase the timeout**: Set the [`command_timeout`](/config/overview#prompt) key in your config to a higher value (in milliseconds).
+    * **Investigate the slow command**: Run `starship timings` to identify which module is slow, then check whether you can optimize it.
+    * **Suppress the warnings**: Set `STARSHIP_LOG=error` to hide warnings without changing the timeout.
+  </Accordion>
+
+  <Accordion title="I see symbols I don't understand or expect. What do they mean?">
+    Run `starship explain` to get a description of every module currently shown in your prompt, including what each symbol represents and why the module is active:
+
+    ```bash theme={null}
+    starship explain
+    ```
+  </Accordion>
+
+  <Accordion title="Starship is doing something unexpected. How can I debug it?">
+    Enable debug logging with `STARSHIP_LOG`:
+
+    ```bash theme={null}
+    # Debug a specific module
+    STARSHIP_LOG=trace starship module rust
+
+    # Debug overall prompt performance
+    STARSHIP_LOG=trace starship timings
+    ```
+
+    The `timings` command shows a breakdown of all modules that took more than 1 ms to execute or produced output.
+
+    If you find a bug, use `starship bug-report` to create a pre-populated GitHub issue:
+
+    ```bash theme={null}
+    starship bug-report
+    ```
+  </Accordion>
+
+  <Accordion title="Why don't I see a glyph or symbol in my prompt?">
+    The most common cause is a misconfigured system font or locale. Check the following:
+
+    1. **Locale**: Your locale must be a UTF-8 value (e.g., `en_US.UTF-8`). If `LC_ALL` is not a UTF-8 value, [update it](https://www.tecmint.com/set-system-locales-in-linux/).
+    2. **Emoji font**: Most systems include one by default, but some (notably Arch Linux) do not. Install a font like [Noto Emoji](https://www.google.com/get/noto/help/emoji/) through your package manager.
+    3. **Nerd Font**: Starship uses [Nerd Font](https://www.nerdfonts.com/) glyphs for many symbols. Make sure your terminal is configured to use a Nerd Font.
+
+    To test your setup, run these commands in your terminal:
+
+    ```bash theme={null}
+    echo -e "\xf0\x9f\x90\x8d"   # Should display a snake emoji 🐍
+    echo -e "\xee\x82\xa0"        # Should display a Powerline branch symbol 
+    ```
+
+    If either fails to display, your system font configuration needs adjustment. If both display correctly but you still don't see the symbols in Starship, file a bug report.
+  </Accordion>
+
+  <Accordion title="How do I uninstall Starship?">
+    1. Remove the Starship initialization line from your shell config (e.g., `~/.bashrc`, `~/.zshrc`, or `~/.config/fish/config.fish`).
+    2. Delete the Starship binary.
+
+    If you installed via a package manager, follow its uninstall instructions. If you used the install script:
+
+    ```bash theme={null}
+    sh -c 'rm "$(command -v starship)"'
+    ```
+  </Accordion>
+
+  <Accordion title="How do I install Starship without sudo?">
+    The install script only uses `sudo` when the target directory is not writable by the current user. Set the installation directory to one you own using the `-b` flag:
+
+    ```bash theme={null}
+    curl -sS https://starship.rs/install.sh | sh -s -- -b ~/.local/bin
+    ```
+
+    For a non-interactive installation, add `-y` to skip the confirmation prompt.
+  </Accordion>
+</AccordionGroup>
+
+***
+
+## Submit a bug report
+
+If you encounter unexpected behavior not covered here, use `starship bug-report` to create a pre-populated GitHub issue with your configuration, shell, OS, and Starship version:
+
+```bash theme={null}
+starship bug-report
+```
+
+
+# Installation
+Source: https://www.mintlify.com/starship/starship/installation
+
+Install Starship on Linux, macOS, Windows, Android, or BSD, then configure your shell.
+
+<Steps>
+  <Step title="Install the Starship binary">
+    Select your operating system to see available installation methods.
+
+    <Tabs>
+      <Tab title="Linux">
+        Install the latest version using the install script:
+
+        ```sh theme={null}
+        curl -sS https://starship.rs/install.sh | sh
+        ```
+
+        Or install using a package manager:
+
+        | Distribution       | Repository            | Command                                                     |
+        | ------------------ | --------------------- | ----------------------------------------------------------- |
+        | Any                | crates.io             | `cargo install starship --locked`                           |
+        | Any                | conda-forge           | `conda install -c conda-forge starship`                     |
+        | Any                | Linuxbrew             | `brew install starship`                                     |
+        | Alpine Linux 3.13+ | Alpine Linux Packages | `apk add starship`                                          |
+        | Arch Linux         | Arch Linux Extra      | `pacman -S starship`                                        |
+        | CentOS 7+          | Copr                  | `dnf copr enable atim/starship` then `dnf install starship` |
+        | Debian 13+         | Debian Main           | `apt install starship`                                      |
+        | Fedora 40+         | Copr                  | `dnf copr enable atim/starship` then `dnf install starship` |
+        | Gentoo             | Gentoo Packages       | `emerge app-shells/starship`                                |
+        | Manjaro            | —                     | `pacman -S starship`                                        |
+        | NixOS              | nixpkgs               | `nix-env -iA nixpkgs.starship`                              |
+        | openSUSE           | OSS                   | `zypper in starship`                                        |
+        | Ubuntu 25.04+      | Ubuntu Universe       | `apt install starship`                                      |
+        | Void Linux         | Void Linux Packages   | `xbps-install -S starship`                                  |
+      </Tab>
+
+      <Tab title="macOS">
+        Install the latest version using the install script:
+
+        ```sh theme={null}
+        curl -sS https://starship.rs/install.sh | sh
+        ```
+
+        Or install using a package manager:
+
+        | Repository  | Command                                 |
+        | ----------- | --------------------------------------- |
+        | crates.io   | `cargo install starship --locked`       |
+        | conda-forge | `conda install -c conda-forge starship` |
+        | Homebrew    | `brew install starship`                 |
+        | MacPorts    | `port install starship`                 |
+      </Tab>
+
+      <Tab title="Windows">
+        Install the latest version using the MSI installer from the [releases page](https://github.com/starship/starship/releases/latest).
+
+        Or install using a package manager:
+
+        | Repository  | Command                                 |
+        | ----------- | --------------------------------------- |
+        | crates.io   | `cargo install starship --locked`       |
+        | Chocolatey  | `choco install starship`                |
+        | conda-forge | `conda install -c conda-forge starship` |
+        | Scoop       | `scoop install starship`                |
+        | winget      | `winget install --id Starship.Starship` |
+      </Tab>
+
+      <Tab title="Android">
+        Install Starship using Termux:
+
+        | Repository | Command                |
+        | ---------- | ---------------------- |
+        | Termux     | `pkg install starship` |
+      </Tab>
+
+      <Tab title="BSD">
+        | Distribution | Repository | Command                           |
+        | ------------ | ---------- | --------------------------------- |
+        | Any          | crates.io  | `cargo install starship --locked` |
+        | FreeBSD      | FreshPorts | `pkg install starship`            |
+        | NetBSD       | pkgsrc     | `pkgin install starship`          |
+      </Tab>
+    </Tabs>
+  </Step>
+
+  <Step title="Set up your shell">
+    Add the Starship init line to your shell configuration file. Select your shell:
+
+    <Tabs>
+      <Tab title="Bash">
+        Add the following to the end of `~/.bashrc`:
+
+        ```sh theme={null}
+        eval "$(starship init bash)"
+        ```
+      </Tab>
+
+      <Tab title="Zsh">
+        Add the following to the end of `~/.zshrc`:
+
+        ```sh theme={null}
+        eval "$(starship init zsh)"
+        ```
+      </Tab>
+
+      <Tab title="Fish">
+        Add the following to the end of `~/.config/fish/config.fish`:
+
+        ```fish theme={null}
+        starship init fish | source
+        ```
+      </Tab>
+
+      <Tab title="PowerShell">
+        Add the following to the end of your PowerShell configuration (find it by running `$PROFILE`):
+
+        ```powershell theme={null}
+        Invoke-Expression (&starship init powershell)
+        ```
+      </Tab>
+
+      <Tab title="Nushell">
+        Add the following to the end of your Nushell configuration (find it by running `$nu.config-path`):
+
+        ```sh theme={null}
+        mkdir ($nu.data-dir | path join "vendor/autoload")
+        starship init nu | save -f ($nu.data-dir | path join "vendor/autoload/starship.nu")
+        ```
+
+        <Note>Only Nushell v0.96+ is supported.</Note>
+      </Tab>
+
+      <Tab title="Elvish">
+        Add the following to the end of `~/.config/elvish/rc.elv` (or `%AppData%\elvish\rc.elv` on Windows):
+
+        ```sh theme={null}
+        eval (starship init elvish)
+        ```
+
+        <Note>Only Elvish v0.18+ is supported. For versions prior to v0.21.0, the config file may be `~/.elvish/rc.elv` instead.</Note>
+      </Tab>
+
+      <Tab title="Ion">
+        Add the following to the end of `~/.config/ion/initrc`:
+
+        ```sh theme={null}
+        eval $(starship init ion)
+        ```
+      </Tab>
+
+      <Tab title="Cmd">
+        You need to use [Clink](https://chrisant996.github.io/clink/clink.html) (v1.2.30+) with Cmd. Create a file at `%LocalAppData%\clink\starship.lua` with the following contents:
+
+        ```lua theme={null}
+        load(io.popen('starship init cmd'):read("*a"))()
+        ```
+      </Tab>
+
+      <Tab title="Tcsh">
+        Add the following to the end of `~/.tcshrc`:
+
+        ```sh theme={null}
+        eval `starship init tcsh`
+        ```
+      </Tab>
+
+      <Tab title="Xonsh">
+        Add the following to the end of `~/.xonshrc`:
+
+        ```python theme={null}
+        execx($(starship init xonsh))
+        ```
+      </Tab>
+    </Tabs>
+  </Step>
+
+  <Step title="Configure Starship (optional)">
+    Start a new shell session and your Starship prompt will appear. If you want to customize it, create `~/.config/starship.toml`:
+
+    ```toml theme={null}
+    "$schema" = 'https://starship.rs/config-schema.json'
+    add_newline = true
+
+    [character]
+    success_symbol = '[➜](bold green)'
+
+    [package]
+    disabled = true
+    ```
+
+    <Tip>See the [configuration docs](/config/overview) for a full reference of all modules and options.</Tip>
+  </Step>
+</Steps>
+
+## Prerequisites
+
+<Note>
+  A [Nerd Font](https://www.nerdfonts.com/) installed and enabled in your terminal is recommended for the best experience with icons and symbols. The [FiraCode Nerd Font](https://www.nerdfonts.com/font-downloads) is a popular choice.
+</Note>
+
+
+# Introduction
+Source: https://www.mintlify.com/starship/starship/introduction
+
+Starship is the minimal, blazing-fast, and infinitely customizable prompt for any shell.
+
+Starship is a cross-shell prompt written in Rust. It shows only the information you need, exactly when you need it — current directory, git status, language versions, cloud context, and much more — all with millisecond-level performance.
+
+## Key features
+
+* **Cross-shell support** — works with Bash, Zsh, Fish, PowerShell, Nushell, Elvish, Ion, Cmd, Tcsh, Xonsh, and more
+* **100+ modules** — built-in support for Git, Node.js, Python, Rust, Go, Kubernetes, AWS, GCloud, and many other tools
+* **Rust performance** — written in Rust for speed; your prompt renders in milliseconds even with many modules active
+* **TOML configuration** — configure every module using a single `~/.config/starship.toml` file
+* **Intelligent context-aware display** — modules appear only when they are relevant to your current directory or environment
+* **Nerd Font support** — rich icons and symbols when used with a Nerd Font-compatible terminal
+
+## Where to go next
+
+<CardGroup>
+  <Card title="Installation" icon="download" href="/installation">
+    Install Starship on Linux, macOS, Windows, Android, or BSD using the install script or your preferred package manager.
+  </Card>
+
+  <Card title="Quickstart" icon="rocket" href="/quickstart">
+    Get a working Starship prompt running in minutes with step-by-step instructions.
+  </Card>
+
+  <Card title="Configuration" icon="sliders" href="/config/overview">
+    Learn how to customize modules, format strings, colors, and symbols with a simple TOML file.
+  </Card>
+
+  <Card title="Presets" icon="paintbrush" href="/presets/overview">
+    Jump-start your setup with community-crafted prompt themes ready to apply in one command.
+  </Card>
+</CardGroup>
+
+
+# Minimal presets
+Source: https://www.mintlify.com/starship/starship/presets/minimal
+
+Starship presets that reduce visual clutter: plain text, no runtime versions, no empty icons, and Pure-style prompts.
+
+These presets focus on reducing visual noise. Rather than changing colors or adding icons, they strip away information you may not need — replacing symbols with plain text, hiding runtime version numbers, or suppressing icons when a tool is not active.
+
+## Plain text symbols
+
+**Preset name:** `plain-text-symbols`
+
+Replaces every symbol in every module with a plain ASCII string. This is useful when you have no access to Unicode, are using a minimal terminal, or prefer a fully text-based prompt.
+
+**When to use it:** Terminals without Unicode support, SSH sessions with restricted fonts, or any environment where special characters appear as boxes.
+
+```bash theme={null}
+starship preset plain-text-symbols -o ~/.config/starship.toml
+```
+
+<Accordion title="Full configuration">
+  ```toml theme={null}
+  "$schema" = 'https://starship.rs/config-schema.json'
+
+  continuation_prompt = "[.](bright-black) "
+
+  [character]
+  success_symbol = "[>](bold green)"
+  error_symbol = "[x](bold red)"
+  vimcmd_symbol = "[<](bold green)"
+  vimcmd_visual_symbol = "[<](bold yellow)"
+  vimcmd_replace_symbol = "[<](bold purple)"
+  vimcmd_replace_one_symbol = "[<](bold purple)"
+
+  [git_commit]
+  tag_symbol = " tag "
+
+  [git_status]
+  ahead = ">"
+  behind = "<"
+  diverged = "<>"
+  renamed = "r"
+  deleted = "x"
+
+  [aws]
+  symbol = "aws "
+
+  [azure]
+  symbol = "az "
+
+  [battery]
+  full_symbol = "full "
+  charging_symbol = "charging "
+  discharging_symbol = "discharging "
+  unknown_symbol = "unknown "
+  empty_symbol = "empty "
+
+  [buf]
+  symbol = "buf "
+
+  [bun]
+  symbol = "bun "
+
+  [c]
+  symbol = "C "
+
+  [cpp]
+  symbol = "C++ "
+
+  [cobol]
+  symbol = "cobol "
+
+  [conda]
+  symbol = "conda "
+
+  [container]
+  symbol = "container "
+
+  [crystal]
+  symbol = "cr "
+
+  [cmake]
+  symbol = "cmake "
+
+  [daml]
+  symbol = "daml "
+
+  [dart]
+  symbol = "dart "
+
+  [deno]
+  symbol = "deno "
+
+  [dotnet]
+  format = "via [$symbol($version )(target $tfm )]($style)"
+  symbol = ".NET "
+
+  [directory]
+  read_only = " ro"
+
+  [docker_context]
+  symbol = "docker "
+
+  [elixir]
+  symbol = "exs "
+
+  [elm]
+  symbol = "elm "
+
+  [erlang]
+  symbol = "erl "
+
+  [fennel]
+  symbol = "fnl "
+
+  [fortran]
+  symbol = "fortran "
+
+  [fossil_branch]
+  symbol = "fossil "
+  truncation_symbol = "..."
+
+  [gcloud]
+  symbol = "gcp "
+
+  [git_branch]
+  symbol = "git "
+  truncation_symbol = "..."
+
+  [gleam]
+  symbol = "gleam "
+
+  [golang]
+  symbol = "go "
+
+  [gradle]
+  symbol = "gradle "
+
+  [guix_shell]
+  symbol = "guix "
+
+  [haskell]
+  symbol = "haskell "
+
+  [haxe]
+  symbol = "hx "
+
+  [helm]
+  symbol = "helm "
+
+  [hg_branch]
+  symbol = "hg "
+  truncation_symbol = "..."
+
+  [hostname]
+  ssh_symbol = "ssh "
+
+  [java]
+  symbol = "java "
+
+  [jobs]
+  symbol = "*"
+
+  [julia]
+  symbol = "jl "
+
+  [kotlin]
+  symbol = "kt "
+
+  [kubernetes]
+  symbol = "kubernetes "
+
+  [lua]
+  symbol = "lua "
+
+  [maven]
+  symbol = "maven "
+
+  [nodejs]
+  symbol = "nodejs "
+
+  [memory_usage]
+  symbol = "memory "
+
+  [meson]
+  symbol = "meson "
+  truncation_symbol = "..."
+
+  [mojo]
+  symbol = "mojo "
+
+  [nats]
+  symbol = "nats "
+
+  [netns]
+  symbol = "netns "
+
+  [nim]
+  symbol = "nim "
+
+  [nix_shell]
+  symbol = "nix "
+
+  [ocaml]
+  symbol = "ml "
+
+  [odin]
+  symbol = "odin "
+
+  [opa]
+  symbol = "opa "
+
+  [openstack]
+  symbol = "openstack "
+
+  [os.symbols]
+  AIX = "aix "
+  Alpaquita = "alq "
+  AlmaLinux = "alma "
+  Alpine = "alp "
+  ALTLinux = "alt "
+  Amazon = "amz "
+  Android = "andr "
+  AOSC = "aosc "
+  Arch = "rch "
+  Artix = "atx "
+  Bluefin = "blfn "
+  CachyOS = "cach "
+  CentOS = "cent "
+  Debian = "deb "
+  DragonFly = "dfbsd "
+  Elementary = "elem "
+  Emscripten = "emsc "
+  EndeavourOS = "ndev "
+  Fedora = "fed "
+  FreeBSD = "fbsd "
+  Garuda = "garu "
+  Gentoo = "gent "
+  HardenedBSD = "hbsd "
+  Illumos = "lum "
+  Ios = "ios "
+  InstantOS = "inst "
+  Kali = "kali "
+  Linux = "lnx "
+  Mabox = "mbox "
+  Macos = "mac "
+  Manjaro = "mjo "
+  Mariner = "mrn "
+  MidnightBSD = "mid "
+  Mint = "mint "
+  NetBSD = "nbsd "
+  NixOS = "nix "
+  Nobara = "nbra "
+  OpenBSD = "obsd "
+  OpenCloudOS = "ocos "
+  openEuler = "oeul "
+  openSUSE = "osuse "
+  OracleLinux = "orac "
+  PikaOS = "pika "
+  Pop = "pop "
+  Raspbian = "rasp "
+  Redhat = "rhl "
+  RedHatEnterprise = "rhel "
+  RockyLinux = "rky "
+  Redox = "redox "
+  Solus = "sol "
+  SUSE = "suse "
+  Ubuntu = "ubnt "
+  Ultramarine = "ultm "
+  Unknown = "unk "
+  Uos = "uos "
+  Void = "void "
+  Windows = "win "
+  Zorin = "zorn "
+
+  [package]
+  symbol = "pkg "
+
+  [perl]
+  symbol = "pl "
+
+  [php]
+  symbol = "php "
+
+  [pijul_channel]
+  symbol = "pijul "
+  truncation_symbol = "..."
+
+  [pixi]
+  symbol = "pixi "
+
+  [pulumi]
+  symbol = "pulumi "
+
+  [purescript]
+  symbol = "purs "
+
+  [python]
+  symbol = "py "
+
+  [quarto]
+  symbol = "quarto "
+
+  [raku]
+  symbol = "raku "
+
+  [red]
+  symbol = "red "
+
+  [rlang]
+  symbol = "r "
+
+  [ruby]
+  symbol = "rb "
+
+  [rust]
+  symbol = "rs "
+
+  [scala]
+  symbol = "scala "
+
+  [shlvl]
+  symbol = "shlvl "
+
+  [spack]
+  symbol = "spack "
+
+  [solidity]
+  symbol = "solidity "
+
+  [status]
+  symbol = "[x](bold red) "
+  not_executable_symbol = "noexec"
+  not_found_symbol = "notfound"
+  sigint_symbol = "sigint"
+  signal_symbol = "sig"
+
+  [sudo]
+  symbol = "sudo "
+
+  [swift]
+  symbol = "swift "
+
+  [typst]
+  symbol = "typst "
+
+  [vagrant]
+  symbol = "vagrant "
+
+  [terraform]
+  symbol = "terraform "
+
+  [xmake]
+  symbol = "xmake "
+
+  [zig]
+  symbol = "zig "
+  ```
+</Accordion>
+
+***
+
+## No runtime versions
+
+**Preset name:** `no-runtime-versions`
+
+Hides version numbers for all language runtimes while still showing their icons. The module for each language still appears when you are in a relevant project directory — you just won't see the version string.
+
+**When to use it:** Containers and virtualized environments where the version is managed externally, or any setup where version numbers add noise without adding value.
+
+```bash theme={null}
+starship preset no-runtime-versions -o ~/.config/starship.toml
+```
+
+<Accordion title="Full configuration">
+  ```toml theme={null}
+  "$schema" = 'https://starship.rs/config-schema.json'
+
+  [bun]
+  format = "via [$symbol]($style)"
+
+  [buf]
+  format = "with [$symbol]($style)"
+
+  [c]
+  format = "via [$symbol($name)]($style)"
+
+  [cmake]
+  format = "via [$symbol]($style)"
+
+  [cobol]
+  format = "via [$symbol]($style)"
+
+  [cpp]
+  format = "via [$symbol($name)]($style)"
+
+  [crystal]
+  format = "via [$symbol]($style)"
+
+  [daml]
+  format = "via [$symbol]($style)"
+
+  [dart]
+  format = "via [$symbol]($style)"
+
+  [deno]
+  format = "via [$symbol]($style)"
+
+  [dotnet]
+  format = "[$symbol(🎯 $tfm )]($style)"
+
+  [elixir]
+  format = 'via [$symbol]($style)'
+
+  [elm]
+  format = 'via [$symbol]($style)'
+
+  [erlang]
+  format = 'via [$symbol]($style)'
+
+  [fennel]
+  format = 'via [$symbol]($style)'
+
+  [fortran]
+  format = 'via [$symbol]($style)'
+
+  [gleam]
+  format = 'via [$symbol]($style)'
+
+  [golang]
+  format = 'via [$symbol]($style)'
+
+  [gradle]
+  format = 'via [$symbol]($style)'
+
+  [haskell]
+  format = 'via [$symbol]($style)'
+
+  [haxe]
+  format = 'via [$symbol]($style)'
+
+  [helm]
+  format = 'via [$symbol]($style)'
+
+  [java]
+  format = 'via [$symbol]($style)'
+
+  [julia]
+  format = 'via [$symbol]($style)'
+
+  [kotlin]
+  format = 'via [$symbol]($style)'
+
+  [lua]
+  format = 'via [$symbol]($style)'
+
+  [maven]
+  format = 'via [$symbol]($style)'
+
+  [meson]
+  format = 'via [$symbol]($style)'
+
+  [mojo]
+  format = 'with [$symbol]($style)'
+
+  [nim]
+  format = 'via [$symbol]($style)'
+
+  [nodejs]
+  format = 'via [$symbol]($style)'
+
+  [ocaml]
+  format = 'via [$symbol(\($switch_indicator$switch_name\) )]($style)'
+
+  [odin]
+  format = 'via [$symbol]($style)'
+
+  [opa]
+  format = 'via [$symbol]($style)'
+
+  [perl]
+  format = 'via [$symbol]($style)'
+
+  [php]
+  format = 'via [$symbol]($style)'
+
+  [pixi]
+  format = 'via [$symbol($environment )]($style)'
+
+  [pulumi]
+  format = 'via [$symbol$stack]($style)'
+
+  [purescript]
+  format = 'via [$symbol]($style)'
+
+  [python]
+  format = 'via [$symbol]($style)'
+
+  [quarto]
+  format = 'via [$symbol]($style)'
+
+  [raku]
+  format = 'via [$symbol]($style)'
+
+  [red]
+  format = 'via [$symbol]($style)'
+
+  [rlang]
+  format = 'via [$symbol]($style)'
+
+  [ruby]
+  format = 'via [$symbol]($style)'
+
+  [rust]
+  format = 'via [$symbol]($style)'
+
+  [scala]
+  format = 'via [$symbol]($style)'
+
+  [solidity]
+  format = 'via [$symbol]($style)'
+
+  [swift]
+  format = 'via [$symbol]($style)'
+
+  [typst]
+  format = 'via [$symbol]($style)'
+
+  [vagrant]
+  format = 'via [$symbol]($style)'
+
+  [vlang]
+  format = 'via [$symbol]($style)'
+
+  [xmake]
+  format = "via [$symbol]($style)"
+
+  [zig]
+  format = 'via [$symbol]($style)'
+  ```
+</Accordion>
+
+***
+
+## No empty icons
+
+**Preset name:** `no-empty-icons`
+
+By default, Starship shows a module's icon even when it cannot determine the tool's version (for example, if the tool is not installed but a relevant file is present). This preset wraps every module's format string in an optional group so the icon is only shown when the version is actually available.
+
+**When to use it:** Keeping your prompt tidy when you work across projects that reference tools you don't have installed locally.
+
+```bash theme={null}
+starship preset no-empty-icons -o ~/.config/starship.toml
+```
+
+<Accordion title="Full configuration">
+  ```toml theme={null}
+  "$schema" = 'https://starship.rs/config-schema.json'
+
+  [buf]
+  format = '(with [$symbol($version )]($style))'
+
+  [bun]
+  format = '(via [$symbol($version )]($style))'
+
+  [c]
+  format = '(via [$symbol($version(-$name) )]($style))'
+
+  [cpp]
+  format = '(via [$symbol($version(-$name) )]($style))'
+
+  [cmake]
+  format = '(via [$symbol($version )]($style))'
+
+  [cobol]
+  format = '(via [$symbol($version )]($style))'
+
+  [crystal]
+  format = '(via [$symbol($version )]($style))'
+
+  [daml]
+  format = '(via [$symbol($version )]($style))'
+
+  [dart]
+  format = '(via [$symbol($version )]($style))'
+
+  [deno]
+  format = '(via [$symbol($version )]($style))'
+
+  [dotnet]
+  format = '(via [$symbol($version )(🎯 $tfm )]($style))'
+
+  [elixir]
+  format = '(via [$symbol($version \(OTP $otp_version\) )]($style))'
+
+  [elm]
+  format = '(via [$symbol($version )]($style))'
+
+  [erlang]
+  format = '(via [$symbol($version )]($style))'
+
+  [fennel]
+  format = '(via [$symbol($version )]($style))'
+
+  [fortran]
+  format = "(via [$symbol($version )]($style))"
+
+  [gleam]
+  format = '(via [$symbol($version )]($style))'
+
+  [golang]
+  format = '(via [$symbol($version )]($style))'
+
+  [haskell]
+  format = '(via [$symbol($version )]($style))'
+
+  [helm]
+  format = '(via [$symbol($version )]($style))'
+
+  [java]
+  format = '(via [$symbol($version )]($style))'
+
+  [julia]
+  format = '(via [$symbol($version )]($style))'
+
+  [kotlin]
+  format = '(via [$symbol($version )]($style))'
+
+  [lua]
+  format = '(via [$symbol($version )]($style))'
+
+  [nim]
+  format = '(via [$symbol($version )]($style))'
+
+  [nodejs]
+  format = '(via [$symbol($version )]($style))'
+
+  [ocaml]
+  format = '(via [$symbol($version )(\($switch_indicator$switch_name\) )]($style))'
+
+  [opa]
+  format = '(via [$symbol($version )]($style))'
+
+  [package]
+  format = '(is [$symbol$version]($style) )'
+
+  [perl]
+  format = '(via [$symbol($version )]($style))'
+
+  [php]
+  format = '(via [$symbol($version )]($style))'
+
+  [purescript]
+  format = '(via [$symbol($version )]($style))'
+
+  [python]
+  format = '(via [${symbol}${pyenv_prefix}(${version} )(\($virtualenv\) )]($style))'
+
+  [quarto]
+  format = '(via [$symbol($version )]($style))'
+
+  [raku]
+  format = '(via [$symbol($version-$vm_version )]($style))'
+
+  [red]
+  format = '(via [$symbol($version )]($style))'
+
+  [rlang]
+  format = '(via [$symbol($version )]($style))'
+
+  [ruby]
+  format = '(via [$symbol($version )]($style))'
+
+  [rust]
+  format = '(via [$symbol($version )]($style))'
+
+  [scala]
+  format = '(via [$symbol($version )]($style))'
+
+  [swift]
+  format = '(via [$symbol($version )]($style))'
+
+  [typst]
+  format = '(via [$symbol($version )]($style))'
+
+  [vagrant]
+  format = '(via [$symbol($version )]($style))'
+
+  [vlang]
+  format = '(via [$symbol($version )]($style))'
+
+  [xmake]
+  format = '(via [$symbol($version )]($style))'
+
+  [zig]
+  format = '(via [$symbol($version )]($style))'
+  ```
+</Accordion>
+
+***
+
+## Pure preset
+
+**Preset name:** `pure-preset`
+
+Emulates the look and behavior of [Pure](https://github.com/sindresorhus/pure), the minimalist zsh theme. It shows only the directory, git branch, git status, command duration, and a prompt character — nothing else unless you are in a Python virtual environment.
+
+**When to use it:** If you want a clean, distraction-free prompt that stays out of the way and only surfaces essential information.
+
+```bash theme={null}
+starship preset pure-preset -o ~/.config/starship.toml
+```
+
+<Accordion title="Full configuration">
+  ```toml theme={null}
+  "$schema" = 'https://starship.rs/config-schema.json'
+
+  format = """
+  $username\
+  $hostname\
+  $directory\
+  $git_branch\
+  $git_state\
+  $git_status\
+  $cmd_duration\
+  $line_break\
+  $python\
+  $character"""
+
+  [directory]
+  style = "blue"
+
+  [character]
+  success_symbol = "[❯](purple)"
+  error_symbol = "[❯](red)"
+  vimcmd_symbol = "[❮](green)"
+
+  [git_branch]
+  format = "[$branch]($style)"
+  style = "bright-black"
+
+  [git_status]
+  format = "[[(*$conflicted$untracked$modified$staged$renamed$deleted)](218) ($ahead_behind$stashed)]($style)"
+  style = "cyan"
+  conflicted = "​"
+  untracked = "​"
+  modified = "​"
+  staged = "​"
+  renamed = "​"
+  deleted = "​"
+  stashed = "≡"
+
+  [git_state]
+  format = '\([$state( $progress_current/$progress_total)]($style)\) '
+  style = "bright-black"
+
+  [cmd_duration]
+  format = "[$duration]($style) "
+  style = "yellow"
+
+  [python]
+  format = "[$virtualenv]($style) "
+  style = "bright-black"
+  detect_extensions = []
+  detect_files = []
+  ```
+</Accordion>
+
+
+# Nerd Font Symbols preset
+Source: https://www.mintlify.com/starship/starship/presets/nerd-font
+
+Apply rich Nerd Font icons to every Starship module in one command.
+
+The Nerd Font Symbols preset replaces the default symbols for every Starship module with [Nerd Font](https://www.nerdfonts.com/) icons. The result is a visually dense prompt where each tool, language, and context is represented by a distinctive glyph.
+
+## Requirement
+
+<Warning>
+  You must have a [Nerd Font](https://www.nerdfonts.com/) installed and selected in your terminal emulator before applying this preset. The screenshot in the Starship docs uses **Fira Code Nerd Font**. Without a Nerd Font, the symbols will appear as boxes or question marks.
+</Warning>
+
+## Apply the preset
+
+```bash theme={null}
+starship preset nerd-font-symbols -o ~/.config/starship.toml
+```
+
+## What it changes
+
+The preset sets a `symbol` value for every supported module so that Starship displays the appropriate Nerd Font glyph instead of plain text or emoji. Modules covered include all major language runtimes, version control systems, cloud providers, operating systems, and status indicators.
+
+A few representative changes:
+
+| Module                  | Default      | Nerd Font symbol |
+| ----------------------- | ------------ | ---------------- |
+| `git_branch`            | `on ` (text) | ` `              |
+| `nodejs`                | `⬢ `         | ` `              |
+| `python`                | `🐍 `        | ` `              |
+| `rust`                  | `⚙️ `        | `󱘗 `            |
+| `directory` (read-only) | `🔒`         | ` 󰌾`            |
+| `hostname` (SSH)        | `🌐 `        | ` `              |
+
+## Full configuration
+
+This is the complete TOML configuration applied by the preset:
+
+```toml theme={null}
+"$schema" = 'https://starship.rs/config-schema.json'
+
+[aws]
+symbol = " "
+
+[buf]
+symbol = " "
+
+[bun]
+symbol = " "
+
+[c]
+symbol = " "
+
+[cpp]
+symbol = " "
+
+[cmake]
+symbol = " "
+
+[conda]
+symbol = " "
+
+[crystal]
+symbol = " "
+
+[dart]
+symbol = " "
+
+[deno]
+symbol = " "
+
+[directory]
+read_only = " 󰌾"
+
+[docker_context]
+symbol = " "
+
+[elixir]
+symbol = " "
+
+[elm]
+symbol = " "
+
+[fennel]
+symbol = " "
+
+[fortran]
+symbol = " "
+
+[fossil_branch]
+symbol = " "
+
+[gcloud]
+symbol = " "
+
+[git_branch]
+symbol = " "
+
+[git_commit]
+tag_symbol = '  '
+
+[golang]
+symbol = " "
+
+[gradle]
+symbol = " "
+
+[guix_shell]
+symbol = " "
+
+[haskell]
+symbol = " "
+
+[haxe]
+symbol = " "
+
+[hg_branch]
+symbol = " "
+
+[hostname]
+ssh_symbol = " "
+
+[java]
+symbol = " "
+
+[julia]
+symbol = " "
+
+[kotlin]
+symbol = " "
+
+[lua]
+symbol = " "
+
+[maven]
+symbol = " "
+
+[memory_usage]
+symbol = "󰍛 "
+
+[meson]
+symbol = "󰔷 "
+
+[nim]
+symbol = "󰆥 "
+
+[nix_shell]
+symbol = " "
+
+[nodejs]
+symbol = " "
+
+[ocaml]
+symbol = " "
+
+[os.symbols]
+Alpaquita = " "
+Alpine = " "
+AlmaLinux = " "
+Amazon = " "
+Android = " "
+AOSC = " "
+Arch = " "
+Artix = " "
+CachyOS = " "
+CentOS = " "
+Debian = " "
+DragonFly = " "
+Elementary = " "
+Emscripten = " "
+EndeavourOS = " "
+Fedora = " "
+FreeBSD = " "
+Garuda = "󰛓 "
+Gentoo = " "
+HardenedBSD = "󰞌 "
+Illumos = "󰈸 "
+Ios = "󰀷 "
+Kali = " "
+Linux = " "
+Mabox = " "
+Macos = " "
+Manjaro = " "
+Mariner = " "
+MidnightBSD = " "
+Mint = " "
+NetBSD = " "
+NixOS = " "
+Nobara = " "
+OpenBSD = "󰈺 "
+openSUSE = " "
+OracleLinux = "󰌷 "
+Pop = " "
+Raspbian = " "
+Redhat = " "
+RedHatEnterprise = " "
+RockyLinux = " "
+Redox = "󰀘 "
+Solus = "󰠳 "
+SUSE = " "
+Ubuntu = " "
+Unknown = " "
+Void = " "
+Windows = "󰍲 "
+Zorin = " "
+
+[package]
+symbol = "󰏗 "
+
+[perl]
+symbol = " "
+
+[php]
+symbol = " "
+
+[pijul_channel]
+symbol = " "
+
+[pixi]
+symbol = "󰏗 "
+
+[python]
+symbol = " "
+
+[rlang]
+symbol = "󰟔 "
+
+[ruby]
+symbol = " "
+
+[rust]
+symbol = "󱘗 "
+
+[scala]
+symbol = " "
+
+[status]
+symbol = " "
+
+[swift]
+symbol = " "
+
+[xmake]
+symbol = " "
+
+[zig]
+symbol = " "
+```
+
+<Tip>
+  You can combine this preset with other configuration. After applying it, open `~/.config/starship.toml` and add or override any settings you want to customize further.
+</Tip>
+
+
+# No Nerd Font preset
+Source: https://www.mintlify.com/starship/starship/presets/no-nerd-font
+
+A Starship preset that uses only emoji and powerline symbols — no Nerd Font required.
+
+The No Nerd Font preset restricts module symbols to emoji and powerline character sets. Every symbol it uses is available in a standard terminal font, so you get a clean, readable prompt without installing any special font.
+
+<Tip>
+  This preset is planned to become the default Starship configuration in a future release.
+</Tip>
+
+## Apply the preset
+
+```bash theme={null}
+starship preset no-nerd-font -o ~/.config/starship.toml
+```
+
+## What it changes
+
+The preset replaces a small number of symbols that would otherwise require a Nerd Font. Most modules are unaffected — only the ones that ship with Nerd Font glyphs by default are updated.
+
+| Module                  | Symbol applied     |
+| ----------------------- | ------------------ |
+| `battery` (full)        | `• `               |
+| `battery` (charging)    | `⇡ `               |
+| `battery` (discharging) | `⇣ `               |
+| `battery` (unknown)     | `❓ `               |
+| `battery` (empty)       | `❗ `               |
+| `erlang`                | `ⓔ `               |
+| `fortran`               | `F `               |
+| `nodejs`                | `[⬢](bold green) ` |
+| `pulumi`                | `🧊 `              |
+| `typst`                 | `t `               |
+
+## Full configuration
+
+```toml theme={null}
+"$schema" = 'https://starship.rs/config-schema.json'
+
+[battery]
+full_symbol = "• "
+charging_symbol = "⇡ "
+discharging_symbol = "⇣ "
+unknown_symbol = "❓ "
+empty_symbol = "❗ "
+
+[erlang]
+symbol = "ⓔ "
+
+[fortran]
+symbol = "F "
+
+[nodejs]
+symbol = "[⬢](bold green) "
+
+[pulumi]
+symbol = "🧊 "
+
+[typst]
+symbol = "t "
+```
+
+<Note>
+  This preset only overrides the symbols that would be problematic without a Nerd Font. All other modules continue to use their default configuration. If you want to replace every symbol with plain ASCII text, see the [Minimal presets](/presets/minimal) page for the plain-text-symbols preset instead.
+</Note>
+
+
+# Presets
+Source: https://www.mintlify.com/starship/starship/presets/overview
+
+Pre-built Starship configurations you can apply in one command.
+
+Presets are community-crafted Starship configurations that change how your prompt looks and behaves. Each preset is a complete `starship.toml` file you can apply instantly without writing any configuration by hand.
+
+## How to use a preset
+
+<Steps>
+  <Step title="List available presets">
+    See all preset names built into your installed version of Starship:
+
+    ```bash theme={null}
+    starship preset --list
+    ```
+  </Step>
+
+  <Step title="Preview a preset">
+    Print a preset's TOML config to stdout without changing anything:
+
+    ```bash theme={null}
+    starship preset <preset-name>
+    ```
+  </Step>
+
+  <Step title="Apply a preset">
+    Write the preset directly to your Starship config file:
+
+    ```bash theme={null}
+    starship preset <preset-name> -o ~/.config/starship.toml
+    ```
+
+    <Warning>
+      This overwrites your existing `~/.config/starship.toml`. Back it up first if you have customizations you want to keep.
+    </Warning>
+  </Step>
+</Steps>
+
+## Available presets
+
+<CardGroup>
+  <Card title="Nerd Font Symbols" icon="font" href="/presets/nerd-font">
+    Replaces all module symbols with Nerd Font icons for a visually rich prompt. Requires a Nerd Font installed in your terminal.
+  </Card>
+
+  <Card title="No Nerd Font" icon="text-size" href="/presets/no-nerd-font">
+    Uses only emoji and powerline symbols — no Nerd Font required. Works in any standard terminal.
+  </Card>
+
+  <Card title="Minimal presets" icon="minus" href="/presets/minimal">
+    A set of presets that reduce visual clutter: plain text symbols, no runtime versions, and no empty icons.
+  </Card>
+
+  <Card title="Pure Prompt" icon="terminal" href="/presets/minimal#pure-preset">
+    Emulates the look and behavior of the Pure zsh theme — minimal, single-line, and focused.
+  </Card>
+</CardGroup>
+
+## Other presets
+
+These presets ship with Starship and can be applied with the commands shown below.
+
+### Bracketed Segments
+
+Changes the format of all built-in modules to show their segment in brackets instead of using the default Starship wording ("via", "on", etc.).
+
+```bash theme={null}
+starship preset bracketed-segments -o ~/.config/starship.toml
+```
+
+### Pastel Powerline
+
+A powerline-style prompt with pastel colors, inspired by [M365Princess](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/themes/M365Princess.omp.json). Also demonstrates path substitution.
+
+<Note>Requires a Nerd Font — the example uses Caskaydia Cove Nerd Font.</Note>
+
+```bash theme={null}
+starship preset pastel-powerline -o ~/.config/starship.toml
+```
+
+### Tokyo Night
+
+A dark, atmospheric prompt inspired by the [tokyo-night-vscode-theme](https://github.com/enkia/tokyo-night-vscode-theme).
+
+<Note>Requires a Nerd Font installed in your terminal.</Note>
+
+```bash theme={null}
+starship preset tokyo-night -o ~/.config/starship.toml
+```
+
+### Gruvbox Rainbow
+
+A colorful powerline-style preset using the Gruvbox dark palette. Heavily inspired by Pastel Powerline and Tokyo Night.
+
+<Note>Requires a Nerd Font installed in your terminal.</Note>
+
+```bash theme={null}
+starship preset gruvbox-rainbow -o ~/.config/starship.toml
+```
+
+### Jetpack
+
+A pseudo-minimalist preset inspired by the [geometry](https://github.com/geometry-zsh/geometry) and [spaceship](https://github.com/spaceship-prompt/spaceship-prompt) prompts. Uses the terminal's own color theme and places language/tool info in the right prompt.
+
+<Note>Requires a shell with right-prompt support. JetBrains Mono is recommended.</Note>
+
+```bash theme={null}
+starship preset jetpack -o ~/.config/starship.toml
+```
+
+### Catppuccin Powerline
+
+A powerline-style preset using the [Catppuccin](https://github.com/catppuccin/catppuccin) theme palette. A minimally modified version of Gruvbox Rainbow. Uses Mocha by default, but you can switch to `catppuccin_frappe`, `catppuccin_macchiato`, or `catppuccin_latte` by editing the `palette` option.
+
+<Note>Requires a Nerd Font installed in your terminal.</Note>
+
+```bash theme={null}
+starship preset catppuccin-powerline -o ~/.config/starship.toml
+```
+
+
+# Quickstart
+Source: https://www.mintlify.com/starship/starship/quickstart
+
+Get a working Starship prompt running in minutes.
+
+This guide takes you from zero to a working Starship prompt as quickly as possible.
+
+<Steps>
+  <Step title="Install the Starship binary">
+    Run the install script to download and install the latest Starship binary:
+
+    ```sh theme={null}
+    curl -sS https://starship.rs/install.sh | sh
+    ```
+
+    <Note>
+      On Windows, download the MSI installer from the [releases page](https://github.com/starship/starship/releases/latest), or use a package manager such as `winget install --id Starship.Starship`. For all installation options, see the [installation guide](/installation).
+    </Note>
+
+    Verify the installation:
+
+    ```sh theme={null}
+    starship --version
+    ```
+  </Step>
+
+  <Step title="Initialize Starship in your shell">
+    Add the init line to your shell configuration file, then open a new terminal session.
+
+    <Tabs>
+      <Tab title="Bash">
+        Add to the end of `~/.bashrc`:
+
+        ```sh theme={null}
+        eval "$(starship init bash)"
+        ```
+      </Tab>
+
+      <Tab title="Zsh">
+        Add to the end of `~/.zshrc`:
+
+        ```sh theme={null}
+        eval "$(starship init zsh)"
+        ```
+      </Tab>
+
+      <Tab title="Fish">
+        Add to the end of `~/.config/fish/config.fish`:
+
+        ```fish theme={null}
+        starship init fish | source
+        ```
+      </Tab>
+    </Tabs>
+
+    For PowerShell, Nushell, Elvish, Ion, Cmd, Tcsh, Xonsh, and other shells, see the [installation guide](/installation).
+  </Step>
+
+  <Step title="Open a new shell session">
+    Close your current terminal and open a new one, or source your config file:
+
+    <Tabs>
+      <Tab title="Bash">
+        ```sh theme={null}
+        source ~/.bashrc
+        ```
+      </Tab>
+
+      <Tab title="Zsh">
+        ```sh theme={null}
+        source ~/.zshrc
+        ```
+      </Tab>
+
+      <Tab title="Fish">
+        ```fish theme={null}
+        source ~/.config/fish/config.fish
+        ```
+      </Tab>
+    </Tabs>
+
+    You should now see the Starship prompt. It will automatically display contextual information — git branch, language versions, and more — as you navigate your filesystem.
+  </Step>
+
+  <Step title="Create a starter config (optional)">
+    Create `~/.config/starship.toml` to start customizing your prompt:
+
+    ```toml theme={null}
+    "$schema" = 'https://starship.rs/config-schema.json'
+    add_newline = true
+
+    [character]
+    success_symbol = '[➜](bold green)'
+
+    [package]
+    disabled = true
+    ```
+
+    Starship picks up changes to `starship.toml` immediately — no restart needed.
+
+    <Tip>
+      For a full list of modules and configuration options, see the [configuration docs](/config/overview). To apply a ready-made theme, browse the [presets](/presets/overview).
+    </Tip>
+  </Step>
+</Steps>
+
+
+# CLI reference
+Source: https://www.mintlify.com/starship/starship/reference/commands
+
+Complete reference for all Starship commands and flags.
+
+Starship is invoked as `starship <command> [options]`. All commands print to stdout unless otherwise noted. No flags are globally required — Starship uses as much context as is provided.
+
+***
+
+## `starship init <shell>`
+
+Prints the shell function used to initialize Starship. Your shell's config file sources this output to hook Starship into the prompt.
+
+```bash theme={null}
+eval "$(starship init bash)"
+```
+
+**Supported shells:** `bash`, `zsh`, `fish`, `powershell`, `elvish`, `ion`, `nu`, `cmd`, `tcsh`, `xonsh`
+
+| Flag                | Description                                                           |
+| ------------------- | --------------------------------------------------------------------- |
+| `--print-full-init` | Print the full initialization script instead of the lightweight stub. |
+
+The default behavior prints a minimal stub that sources the full init on first use. Pass `--print-full-init` to embed the complete script directly.
+
+***
+
+## `starship prompt`
+
+Renders and prints the full Starship prompt. Your shell calls this on every prompt draw, passing context flags so Starship can display accurate information.
+
+```bash theme={null}
+starship prompt --status=$? --jobs=$(jobs -p | wc -l)
+```
+
+### Prompt type flags
+
+| Flag               | Description                                                                                          |
+| ------------------ | ---------------------------------------------------------------------------------------------------- |
+| `--right`          | Print the right-side prompt instead of the standard left prompt.                                     |
+| `--profile <name>` | Print the prompt using a named profile. Conflicts with `--right`.                                    |
+| `--continuation`   | Print the continuation prompt (shown on multi-line input). Conflicts with `--right` and `--profile`. |
+
+### Context flags
+
+These flags provide shell context to Starship modules. All are optional.
+
+| Flag                    | Short | Description                                                                  |
+| ----------------------- | ----- | ---------------------------------------------------------------------------- |
+| `--status <code>`       | `-s`  | Exit status code of the previously run command.                              |
+| `--pipestatus <codes>`  |       | Space-separated exit codes for each process in a pipeline (Bash, Fish, Zsh). |
+| `--jobs <n>`            | `-j`  | Number of currently running background jobs.                                 |
+| `--cmd-duration <ms>`   | `-d`  | Execution duration of the last command, in milliseconds.                     |
+| `--keymap <name>`       | `-k`  | Current keymap of the shell (e.g., `viins`, `vicmd`). Default: `viins`.      |
+| `--terminal-width <n>`  | `-w`  | Width of the current interactive terminal in columns.                        |
+| `--path <path>`         | `-p`  | The filesystem path the prompt should render for.                            |
+| `--logical-path <path>` | `-P`  | Logical/virtual path representation (used when the physical path differs).   |
+| `--shlvl <n>`           |       | Current value of `SHLVL`, for shells that mis-handle it inside `$()`.        |
+
+***
+
+## `starship module <name>`
+
+Prints a single Starship module. Useful for debugging a specific module or embedding it in a custom prompt.
+
+```bash theme={null}
+starship module git_branch
+```
+
+```bash theme={null}
+# List all available modules
+starship module --list
+```
+
+| Flag     | Short | Description                               |
+| -------- | ----- | ----------------------------------------- |
+| `--list` | `-l`  | List all available module names and exit. |
+
+This command also accepts all [context flags](#context-flags) from `starship prompt`.
+
+***
+
+## `starship config [key] [value]`
+
+Edits your Starship configuration.
+
+```bash theme={null}
+# Open config file in $EDITOR
+starship config
+
+# Set a specific configuration key
+starship config add_newline false
+```
+
+| Usage                           | Description                                                           |
+| ------------------------------- | --------------------------------------------------------------------- |
+| `starship config`               | Opens `~/.config/starship.toml` (or `$STARSHIP_CONFIG`) in `$EDITOR`. |
+| `starship config <key> <value>` | Sets `key` to `value` in the config file directly.                    |
+
+<Note>
+  Both `key` and `value` must be provided together — supplying only a key is not valid.
+</Note>
+
+***
+
+## `starship print-config`
+
+Prints the fully computed Starship configuration as TOML, merging your config file with all defaults.
+
+```bash theme={null}
+starship print-config
+```
+
+```bash theme={null}
+# Print the built-in default config instead
+starship print-config --default
+```
+
+```bash theme={null}
+# Print specific keys only
+starship print-config git_branch format
+```
+
+| Flag        | Short | Description                                                               |
+| ----------- | ----- | ------------------------------------------------------------------------- |
+| `--default` | `-d`  | Print the built-in default configuration instead of your computed config. |
+| `[name...]` |       | One or more configuration key names to print (prints all if omitted).     |
+
+***
+
+## `starship toggle <name> [value]`
+
+Toggles a configuration key on a named module. By default, toggles the `disabled` key.
+
+```bash theme={null}
+# Disable the git_branch module
+starship toggle git_branch
+
+# Toggle a different key
+starship toggle git_branch show_remote_url
+```
+
+| Argument  | Description                                       |
+| --------- | ------------------------------------------------- |
+| `<name>`  | The name of the module to toggle.                 |
+| `[value]` | The config key to toggle. Defaults to `disabled`. |
+
+***
+
+## `starship preset <name>`
+
+Prints or applies a named community preset configuration.
+
+```bash theme={null}
+# Print a preset to stdout
+starship preset nerd-font-symbols
+
+# Write a preset to a file
+starship preset nerd-font-symbols --output ~/.config/starship.toml
+
+# List all available presets
+starship preset --list
+```
+
+| Flag              | Short | Description                                                                               |
+| ----------------- | ----- | ----------------------------------------------------------------------------------------- |
+| `--output <file>` | `-o`  | Write the preset config to a file instead of printing to stdout. Conflicts with `--list`. |
+| `--list`          | `-l`  | List all available preset names.                                                          |
+
+***
+
+## `starship explain`
+
+Prints a description of each module currently shown in the prompt, along with the value it is displaying and why it is active.
+
+```bash theme={null}
+starship explain
+```
+
+This command accepts all [context flags](#context-flags) from `starship prompt`.
+
+***
+
+## `starship timings`
+
+Prints the render time of every active module. Use this to identify slow modules.
+
+```bash theme={null}
+starship timings
+```
+
+Modules that took more than 1 ms to execute or that produced output are shown with their timing breakdown. This command accepts all [context flags](#context-flags) from `starship prompt`.
+
+<Tip>
+  Combine with `STARSHIP_LOG=trace` for the most detailed performance output:
+
+  ```bash theme={null}
+  STARSHIP_LOG=trace starship timings
+  ```
+</Tip>
+
+***
+
+## `starship completions <shell>`
+
+Generates shell completion scripts and prints them to stdout.
+
+```bash theme={null}
+starship completions bash > ~/.local/share/bash-completion/completions/starship
+```
+
+**Supported shells:** `bash`, `elvish`, `fish`, `nushell`, `powershell` (aliases: `pwsh`, `power-shell`), `zsh`
+
+<Tabs>
+  <Tab title="Bash">
+    ```bash theme={null}
+    starship completions bash > ~/.local/share/bash-completion/completions/starship
+    ```
+  </Tab>
+
+  <Tab title="Zsh">
+    ```zsh theme={null}
+    starship completions zsh > ~/.zfunc/_starship
+    # Ensure ~/.zfunc is in your $fpath before calling compinit
+    ```
+  </Tab>
+
+  <Tab title="Fish">
+    ```fish theme={null}
+    starship completions fish > ~/.config/fish/completions/starship.fish
+    ```
+  </Tab>
+
+  <Tab title="PowerShell">
+    ```powershell theme={null}
+    starship completions powershell | Out-String | Invoke-Expression
+    ```
+  </Tab>
+
+  <Tab title="Nushell">
+    ```nu theme={null}
+    starship completions nushell | save -f ~/.cache/starship/completions.nu
+    # Then source the file in your config.nu
+    ```
+  </Tab>
+
+  <Tab title="Elvish">
+    ```elvish theme={null}
+    starship completions elvish >> ~/.elvish/rc.elv
+    ```
+  </Tab>
+</Tabs>
+
+***
+
+## `starship bug-report`
+
+Opens a pre-populated GitHub issue in your browser with details about your Starship version, shell, operating system, and configuration. Use this when filing a bug.
+
+```bash theme={null}
+starship bug-report
+```
+
+***
+
+## `starship statusline <provider>`
+
+Prints a statusline prompt for a specific external tool integration. Currently supports the `claude-code` provider (also aliased as `claude`).
+
+```bash theme={null}
+starship statusline claude-code
+```
+
+| Argument           | Description                                                                           |
+| ------------------ | ------------------------------------------------------------------------------------- |
+| `<provider>`       | The statusline provider. Accepted value: `claude-code` (alias: `claude`).             |
+| `--profile <name>` | Use a named prompt profile. Defaults to `claude-code` for the `claude-code` provider. |
+
+This command also accepts all [context flags](#context-flags) from `starship prompt`.
+
+<Note>
+  `starship statusline` is used internally by Claude Code to render a statusline prompt. It is not needed for normal shell prompt usage.
+</Note>
+
+***
+
+## `starship session`
+
+Generates a random 16-character alphanumeric session key and prints it to stdout. This is used internally by shell init scripts to name per-session log files.
+
+```bash theme={null}
+starship session
+```
+
+<Note>
+  You do not normally need to call this directly. Shell init scripts call it automatically to set `STARSHIP_SESSION_KEY`.
+</Note>
+
+
+# Environment variables
+Source: https://www.mintlify.com/starship/starship/reference/environment-variables
+
+Environment variables that control Starship's behavior, config location, cache, and logging.
+
+Starship reads several environment variables at startup to determine where to find its configuration, where to write logs, and how verbose those logs should be.
+
+## Variable reference
+
+| Variable               | Description                                                      | Default                           |
+| ---------------------- | ---------------------------------------------------------------- | --------------------------------- |
+| `STARSHIP_CONFIG`      | Path to the Starship configuration file.                         | `~/.config/starship.toml`         |
+| `STARSHIP_CACHE`       | Path to the cache and log directory.                             | `~/.cache/starship`               |
+| `STARSHIP_LOG`         | Minimum log level: `trace`, `debug`, `info`, `warn`, or `error`. | `warn` (written to log file only) |
+| `STARSHIP_SESSION_KEY` | Session key used to name the per-session log file.               | Auto-generated by shell init      |
+
+***
+
+## `STARSHIP_CONFIG`
+
+Override the default location of `starship.toml`. Set this if you keep your dotfiles in a non-standard location or want to switch between multiple configurations.
+
+<Tabs>
+  <Tab title="Bash / Zsh">
+    ```bash theme={null}
+    export STARSHIP_CONFIG=~/dotfiles/starship.toml
+    ```
+
+    Add this line to `~/.bashrc` or `~/.zshrc`.
+  </Tab>
+
+  <Tab title="Fish">
+    ```fish theme={null}
+    set -gx STARSHIP_CONFIG ~/dotfiles/starship.toml
+    ```
+
+    Add this to `~/.config/fish/config.fish`.
+  </Tab>
+
+  <Tab title="PowerShell">
+    ```powershell theme={null}
+    $ENV:STARSHIP_CONFIG = "$HOME\dotfiles\starship.toml"
+    ```
+
+    Add this line to your `$PROFILE`.
+  </Tab>
+</Tabs>
+
+***
+
+## `STARSHIP_CACHE`
+
+Override the directory Starship uses for its cache and log files. By default, Starship writes session logs to `~/.cache/starship/session_${STARSHIP_SESSION_KEY}.log`.
+
+<Tabs>
+  <Tab title="Bash / Zsh">
+    ```bash theme={null}
+    export STARSHIP_CACHE=~/.starship/cache
+    ```
+  </Tab>
+
+  <Tab title="Fish">
+    ```fish theme={null}
+    set -gx STARSHIP_CACHE ~/.starship/cache
+    ```
+  </Tab>
+
+  <Tab title="PowerShell">
+    ```powershell theme={null}
+    $ENV:STARSHIP_CACHE = "$HOME\AppData\Local\Temp"
+    ```
+  </Tab>
+</Tabs>
+
+***
+
+## `STARSHIP_LOG`
+
+Controls the minimum severity of messages written to Starship's log file. Accepted values (from most to least verbose):
+
+| Value   | Description                                                    |
+| ------- | -------------------------------------------------------------- |
+| `trace` | All internal trace events. Very verbose.                       |
+| `debug` | Debug-level messages useful for investigating module behavior. |
+| `info`  | General informational messages.                                |
+| `warn`  | Warnings only (the default).                                   |
+| `error` | Errors only. Use this to suppress timeout warnings.            |
+
+<Note>
+  Log output goes to the session log file, not to your terminal. To see it, either redirect stderr or read the log file directly.
+</Note>
+
+### Debugging a specific module
+
+```bash theme={null}
+STARSHIP_LOG=trace starship module rust
+```
+
+### Debugging prompt performance
+
+```bash theme={null}
+STARSHIP_LOG=trace starship timings
+```
+
+### Capturing debug output to a file
+
+```bash theme={null}
+STARSHIP_LOG=debug starship prompt 2>starship.log
+```
+
+### Suppressing timeout warnings
+
+If you see `Executing command "..." timed out.` warnings and want to silence them:
+
+```bash theme={null}
+export STARSHIP_LOG=error
+```
+
+***
+
+## `STARSHIP_SESSION_KEY`
+
+A 16-character alphanumeric key that uniquely identifies the current terminal session. Starship's shell init scripts generate this automatically using `starship session` (or an equivalent random source).
+
+The session key determines the name of the per-session log file:
+
+```
+~/.cache/starship/session_<STARSHIP_SESSION_KEY>.log
+```
+
+<Warning>
+  Setting `STARSHIP_SESSION_KEY` manually will cause all terminal sessions that share the same key to write to the same log file, which may produce confusing output. Let the shell init script manage this value.
+</Warning>
+
+To inspect the current session's log file:
+
+```bash theme={null}
+cat ~/.cache/starship/session_${STARSHIP_SESSION_KEY}.log
+```
+
+Starship automatically removes old session log files on startup to keep the cache directory tidy.
+
+

--- a/docs/research/mintlify-cache/starship/starship/llms.txt
+++ b/docs/research/mintlify-cache/starship/starship/llms.txt
@@ -1,0 +1,28 @@
+# Starship
+
+## Docs
+
+- [Custom commands and hooks](https://www.mintlify.com/starship/starship/advanced/custom-commands.md): Run code before the prompt renders, configure continuation prompts, add a right-side prompt, and switch between prompt profiles.
+- [Performance tuning](https://www.mintlify.com/starship/starship/advanced/performance.md): Diagnose slow prompts and configure timeouts, disabled modules, and logging to keep Starship fast.
+- [Transient prompt](https://www.mintlify.com/starship/starship/advanced/transient-prompt.md): Replace previous prompts with a simpler version after each command, keeping your scrollback clean.
+- [Custom modules](https://www.mintlify.com/starship/starship/config/custom-modules.md): Create your own prompt modules that run shell commands, detect files, and display any information you want.
+- [Format strings](https://www.mintlify.com/starship/starship/config/format-strings.md): Understand how Starship's format string syntax works—variables, text groups, style strings, conditional rendering, and TOML string types.
+- [Built-in modules](https://www.mintlify.com/starship/starship/config/modules.md): Browse Starship's 100+ built-in modules organized by category, with configuration examples and common options.
+- [Configuration overview](https://www.mintlify.com/starship/starship/config/overview.md): Learn where Starship stores its config file, how to create it, and the top-level options that control global prompt behavior.
+- [FAQ](https://www.mintlify.com/starship/starship/faq.md): Answers to common questions about Starship configuration, debugging, and compatibility.
+- [Installation](https://www.mintlify.com/starship/starship/installation.md): Install Starship on Linux, macOS, Windows, Android, or BSD, then configure your shell.
+- [Introduction](https://www.mintlify.com/starship/starship/introduction.md): Starship is the minimal, blazing-fast, and infinitely customizable prompt for any shell.
+- [Minimal presets](https://www.mintlify.com/starship/starship/presets/minimal.md): Starship presets that reduce visual clutter: plain text, no runtime versions, no empty icons, and Pure-style prompts.
+- [Nerd Font Symbols preset](https://www.mintlify.com/starship/starship/presets/nerd-font.md): Apply rich Nerd Font icons to every Starship module in one command.
+- [No Nerd Font preset](https://www.mintlify.com/starship/starship/presets/no-nerd-font.md): A Starship preset that uses only emoji and powerline symbols — no Nerd Font required.
+- [Presets](https://www.mintlify.com/starship/starship/presets/overview.md): Pre-built Starship configurations you can apply in one command.
+- [Quickstart](https://www.mintlify.com/starship/starship/quickstart.md): Get a working Starship prompt running in minutes.
+- [CLI reference](https://www.mintlify.com/starship/starship/reference/commands.md): Complete reference for all Starship commands and flags.
+- [Environment variables](https://www.mintlify.com/starship/starship/reference/environment-variables.md): Environment variables that control Starship's behavior, config location, cache, and logging.
+
+## OpenAPI Specs
+
+- [openapi](https://www.mintlify.com/starship/starship/api-reference/openapi.json)
+
+
+Built with [Mintlify](https://mintlify.com).

--- a/docs/research/mintlify-cache/twpayne/chezmoi/llms-full.txt
+++ b/docs/research/mintlify-cache/twpayne/chezmoi/llms-full.txt
@@ -1,0 +1,22330 @@
+# Customize chezmoi
+Source: https://twpayne-chezmoi.mintlify.app/advanced/customize-chezmoi
+
+Advanced customization options for chezmoi's behavior and structure
+
+This guide covers advanced customization options for chezmoi, including customizing the source directory structure, using alternative version control systems, and configuring various behaviors.
+
+## Customize Source Directory Structure
+
+### Use a Subdirectory as Source Root
+
+By default, chezmoi uses the root of your dotfiles repository as the source state root. If your repository root contains many files (like README, LICENSE, scripts, etc.), you can keep your home directory cleaner by using a subdirectory.
+
+Create a `.chezmoiroot` file in your source directory:
+
+```text title="~/.local/share/chezmoi/.chezmoiroot" theme={null}
+home
+```
+
+This tells chezmoi to read the source state from the `home/` subdirectory. Your directory structure becomes:
+
+```
+~/.local/share/chezmoi/
+├── .chezmoiroot          # Contains "home"
+├── README.md             # Not managed by chezmoi
+├── LICENSE               # Not managed by chezmoi
+├── scripts/              # Not managed by chezmoi
+└── home/                 # This is the source state root
+    ├── .chezmoi.toml.tmpl
+    ├── dot_bashrc
+    ├── dot_gitconfig
+    └── dot_config/
+        └── ...
+```
+
+With this setup:
+
+* `~/.gitconfig` is sourced from `home/dot_gitconfig` (not `dot_gitconfig`)
+* Files in the repository root (like README.md) don't clutter your home directory
+* You don't need to maintain `.chezmoiignore` for repository metadata files
+
+### Migration Steps
+
+When migrating an existing chezmoi setup to use `.chezmoiroot`:
+
+1. **Create the subdirectory**:
+   ```bash theme={null}
+   cd ~/.local/share/chezmoi
+   mkdir home
+   ```
+
+2. **Create `.chezmoiroot`**:
+   ```bash theme={null}
+   echo "home" > .chezmoiroot
+   ```
+
+3. **Move managed files**:
+   ```bash theme={null}
+   # Move dotfiles
+   mv dot_* home/
+
+   # Move special files
+   mv .chezmoi.* home/
+
+   # Move directories
+   mv private_* exact_* home/
+   ```
+
+4. **Update `.chezmoiignore`** (if you have one):
+   ```bash theme={null}
+   mv .chezmoiignore home/
+   # Edit home/.chezmoiignore to remove entries for repo files
+   ```
+
+5. **Test the changes**:
+   ```bash theme={null}
+   chezmoi diff
+   ```
+
+6. **Commit**:
+   ```bash theme={null}
+   git add .
+   git commit -m "Reorganize using .chezmoiroot"
+   ```
+
+## Use Alternative Version Control Systems
+
+While chezmoi is designed to work with git, you can use other version control systems like Fossil, Pijul, or Mercurial.
+
+### Where chezmoi Uses Git
+
+chezmoi uses git in only three places:
+
+1. **`chezmoi init`** - Uses `git clone` to clone your dotfiles repo
+2. **`chezmoi update`** - Uses `git pull` to fetch changes
+3. **Auto-commit/push** - Uses `git status`, `git add`, `git commit`, and `git push`
+
+### Git-Compatible VCS
+
+If your VCS is git-compatible (same CLI), configure it:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[git]
+    command = "gitoxide"  # or your git-compatible command
+
+useBuiltinGit = false
+```
+
+### Non-Git VCS Setup
+
+For VCS systems that aren't git-compatible:
+
+#### 1. Manual Clone
+
+Create the source directory manually:
+
+```bash theme={null}
+# Example with Fossil
+fossil clone https://dotfiles.example.com/repo dotfiles.fossil
+mkdir -p ~/.local/share/chezmoi/.git
+cd ~/.local/share/chezmoi
+fossil open ~/dotfiles.fossil
+chezmoi init --apply
+```
+
+**Note:** The empty `.git` directory is required for chezmoi to identify the working tree.
+
+#### 2. Configure Updates
+
+Tell chezmoi how to update:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[update]
+    command = "fossil"
+    args = ["update"]
+```
+
+Now `chezmoi update` will use `fossil update` instead of `git pull`.
+
+#### 3. Manual Commits
+
+Auto-commit/push features won't work with non-git VCS. Commit manually:
+
+```bash theme={null}
+chezmoi cd
+fossil add .
+fossil commit -m "Update dotfiles"
+fossil push
+```
+
+### Example: Using Fossil
+
+Complete setup for Fossil:
+
+```bash theme={null}
+# Initial setup
+fossil clone https://example.com/dotfiles.fossil ~/dotfiles.fossil
+mkdir -p ~/.local/share/chezmoi/.git
+cd ~/.local/share/chezmoi
+fossil open ~/dotfiles.fossil
+```
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[update]
+    command = "fossil"
+    args = ["update"]
+```
+
+```bash theme={null}
+# Update workflow
+chezmoi update  # Runs 'fossil update'
+
+# Commit workflow
+chezmoi cd
+fossil add .
+fossil commit
+```
+
+### Example: Using Pijul
+
+```bash theme={null}
+# Initial setup
+cd ~/.local/share/chezmoi
+pijul clone https://nest.pijul.com/user/dotfiles .
+mkdir .git  # Required for chezmoi
+```
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[update]
+    command = "pijul"
+    args = ["pull"]
+```
+
+## Customize Git Behavior
+
+### Auto-Commit and Auto-Push
+
+Automatically commit and push changes:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[git]
+    autoCommit = true
+    autoPush = true
+```
+
+Now when you run `chezmoi add`, `chezmoi edit`, etc., changes are automatically committed and pushed.
+
+### Custom Commit Messages
+
+Template your commit messages:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[git]
+    autoCommit = true
+    commitMessageTemplate = "{{ .commitMessage }} on {{ .chezmoi.hostname }}"
+```
+
+### Use External Git
+
+Force chezmoi to use external git (not built-in):
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+useBuiltinGit = false
+
+[git]
+    command = "git"
+```
+
+Useful if you need git hooks or specific git configurations.
+
+## Directory and File Locations
+
+### Custom Source Directory
+
+Change where chezmoi stores the source state:
+
+```bash theme={null}
+chezmoi init --source=/custom/path
+```
+
+Or set permanently:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+sourceDir = "/custom/path"
+```
+
+### Custom Destination Directory
+
+Manage files outside your home directory (discouraged for dotfiles):
+
+```bash theme={null}
+chezmoi apply --destination=/opt/myapp
+```
+
+Or:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+destDir = "/opt/myapp"
+```
+
+### Custom Config File Location
+
+```bash theme={null}
+chezmoi apply --config=/custom/config.toml
+```
+
+### Custom Cache Directory
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+cacheDir = "/custom/cache/dir"
+```
+
+## Script Behavior
+
+### Script Environment Variables
+
+Inject data into scripts via environment variables:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[scriptEnv]
+    MY_VAR = "value"
+    ANOTHER_VAR = "{{ .chezmoi.hostname }}"
+```
+
+Access in scripts:
+
+```bash title="run_onchange_setup.sh" theme={null}
+#!/bin/bash
+echo "Running on $MY_VAR"
+echo "Hostname: $ANOTHER_VAR"
+```
+
+### Custom Script Interpreter
+
+Override interpreters for script extensions:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[interpreters.py]
+    command = "python3.11"
+    args = ["-u"]
+
+[interpreters.sh]
+    command = "bash"
+    args = ["-euo", "pipefail"]
+```
+
+### Script Temporary Directory
+
+Change where chezmoi writes temporary script files:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+scriptTempDir = "~/tmp"
+```
+
+Useful if `/tmp` is mounted with `noexec`.
+
+## Template Customization
+
+### Custom Template Delimiters
+
+Avoid conflicts with other templating systems:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[template]
+    leftDelimiter = "[["
+    rightDelimiter = "]]"
+```
+
+Now use `[[ .chezmoi.os ]]` instead of `{{ .chezmoi.os }}`.
+
+### Template Functions
+
+Define custom template functions:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[template]
+    options = ["missingkey=error"]
+```
+
+Options:
+
+* `missingkey=error` - Error on undefined variables (default: zero value)
+* `missingkey=zero` - Use zero value for undefined variables
+* `missingkey=invalid` - Template execution stops immediately
+
+## File Permissions
+
+### Custom Umask
+
+Set a global umask for all managed files:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+umask = 0o022
+```
+
+This prevents group-writeable files (e.g., for SSH config).
+
+### Per-File Permissions
+
+Use filename attributes:
+
+```bash theme={null}
+# Read-only file
+chezmoi add --template readonly_dot_file
+
+# Private file (0600)
+chezmoi add --template private_dot_ssh_config
+
+# Executable file (0755)
+chezmoi add --template executable_dot_local_bin_script
+```
+
+## Encryption
+
+### Configure Age Encryption
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[age]
+    identity = "~/.config/chezmoi/key.txt"
+    recipient = "age1xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```
+
+### Configure GPG Encryption
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[gpg]
+    recipient = "your@email.com"
+    symmetric = false
+```
+
+### Transparent Encryption
+
+Keep encrypted files in the source but edit them transparently:
+
+```bash theme={null}
+# Add encrypted file
+chezmoi add --encrypt ~/.ssh/config
+
+# Edit (automatically decrypts/re-encrypts)
+chezmoi edit ~/.ssh/config
+```
+
+## Hooks
+
+Run commands before or after chezmoi operations:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[hooks.read-source-state.pre]
+    command = "./scripts/pre-hook.sh"
+
+[hooks.read-source-state.post]
+    command = "./scripts/post-hook.sh"
+```
+
+Available hooks:
+
+* `read-source-state.pre` / `read-source-state.post`
+
+## Warnings
+
+Disable specific warnings:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[warnings]
+    configFileTemplateHasChangedExternally = false
+```
+
+## Working with Multiple Machines
+
+### Machine-Specific Source Directories
+
+You can use different source directories on different machines by passing `--source` or `--config`:
+
+```bash theme={null}
+# On work machine
+chezmoi apply --config ~/.config/chezmoi-work/chezmoi.toml
+
+# On personal machine
+chezmoi apply --config ~/.config/chezmoi-personal/chezmoi.toml
+```
+
+Wrap in a shell function:
+
+```bash theme={null}
+function cm-all() {
+    chezmoi apply --config ~/.config/chezmoi-work/chezmoi.toml \
+                  --source ~/.local/share/chezmoi-work && \
+    chezmoi apply --config ~/.config/chezmoi-personal/chezmoi.toml \
+                  --source ~/.local/share/chezmoi-personal
+}
+```
+
+### Nested chezmoi
+
+Run a second instance of chezmoi from within a script:
+
+```bash title="run_after_rootmoi.sh" theme={null}
+#!/bin/bash
+# Manage system files with a separate chezmoi instance
+sudo -u root chezmoi apply --source /root/.local/share/chezmoi
+```
+
+See [felipecrs/dotfiles rootmoi example](https://github.com/felipecrs/dotfiles/blob/master/home/.chezmoiscripts/run_after_20-run-rootmoi.sh.tmpl).
+
+## Symlink Mode
+
+Make chezmoi use symlinks where possible:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+mode = "symlink"
+```
+
+**Limitations:**
+
+* Symlinks cannot be used for encrypted files
+* Symlinks cannot be used for executable files
+* Symlinks cannot be used for private files
+* Symlinks cannot be used for templates
+* Symlinks cannot be used for entire directories
+
+## Advanced Configuration Examples
+
+### Minimal Container Configuration
+
+```toml title="~/.config/chezmoi/chezmoi.toml.tmpl" theme={null}
+{{- $isContainer := or (stat "/run/.containerenv") (stat "/.dockerenv") -}}
+
+{{- if $isContainer }}
+# Minimal config for containers
+pager = ""
+verbose = false
+{{- end }}
+```
+
+### Multi-Environment Setup
+
+```toml title="~/.config/chezmoi/chezmoi.toml.tmpl" theme={null}
+{{- $workMachine := promptBool "work machine" -}}
+
+{{- if $workMachine }}
+[git]
+    autoCommit = false  # Don't auto-commit on work machine
+[http]
+    proxy = "http://proxy.work.com:8080"
+{{- else }}
+[git]
+    autoCommit = true
+    autoPush = true
+{{- end }}
+```
+
+### Debug Mode Configuration
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+# Uncomment for debugging
+# verbose = true
+# [template]
+#     options = ["missingkey=error"]
+```
+
+## Best Practices
+
+1. **Use `.chezmoiroot`** for cleaner repositories
+2. **Commit your config file template** (`.chezmoi.toml.tmpl`) not the generated config
+3. **Document your customizations** with comments in your config
+4. **Test on all machines** before committing major changes
+5. **Use templates for machine-specific paths** instead of hardcoding
+6. **Keep auto-commit off** until you're confident in your setup
+
+## Troubleshooting
+
+### Config File Not Found
+
+Check the config search path:
+
+```bash theme={null}
+chezmoi doctor
+```
+
+### Source Directory Issues
+
+Verify your source directory:
+
+```bash theme={null}
+chezmoi source-path
+```
+
+### Git Integration Problems
+
+Test git commands:
+
+```bash theme={null}
+chezmoi cd
+git status
+```
+
+### VCS Integration
+
+For non-git VCS, ensure:
+
+1. Empty `.git` directory exists in source directory
+2. `update.command` is configured correctly
+3. You commit changes manually
+
+
+# Machine-Specific Configurations
+Source: https://twpayne-chezmoi.mintlify.app/advanced/machines
+
+Manage dotfiles across different machines with templates and conditionals
+
+chezmoi excels at managing dotfiles across multiple machines with different operating systems, hardware configurations, and purposes (work vs. personal, laptop vs. desktop, etc.). This guide covers techniques for handling machine-to-machine differences.
+
+## Detecting Machine Characteristics
+
+### Determine Laptop vs. Desktop
+
+You can automatically detect whether a machine is a laptop or desktop and adjust configurations accordingly.
+
+```go title=".chezmoi.toml.tmpl" theme={null}
+{{- $chassisType := "desktop" }}
+{{- if eq .chezmoi.os "darwin" }}
+{{-   if contains "MacBook" (output "system_profiler" "SPHardwareDataType") }}
+{{-     $chassisType = "laptop" }}
+{{-   else }}
+{{-     $chassisType = "desktop" }}
+{{-   end }}
+{{- else if eq .chezmoi.os "linux" }}
+{{-   $chassisType = (output "hostnamectl" "--json=short" | mustFromJson).Chassis }}
+{{- else if eq .chezmoi.os "windows" }}
+{{-   $chassisType = (output "pwsh.exe" "-NoProfile" "-NonInteractive" "-Command" "if ((Get-CimInstance -Class Win32_Battery | Measure-Object).Count -gt 0) { Write-Output 'laptop' } else { Write-Output 'desktop' }") | trim }}
+{{- end }}
+
+[data]
+    chassisType = {{ $chassisType | quote }}
+```
+
+Use in templates:
+
+```bash title="dot_bashrc.tmpl" theme={null}
+{{- if eq .chassisType "laptop" }}
+# Laptop-specific settings
+export POWERSAVE=1
+{{- else }}
+# Desktop-specific settings
+export POWERSAVE=0
+{{- end }}
+```
+
+### Detect CPU Cores and Threads
+
+Optimize configurations based on available CPU resources:
+
+```go title=".chezmoi.toml.tmpl" theme={null}
+{{- $cpuCores := 1 }}
+{{- $cpuThreads := 1 }}
+{{- if eq .chezmoi.os "darwin" }}
+{{-   $cpuCores = (output "sysctl" "-n" "hw.physicalcpu_max") | trim | atoi }}
+{{-   $cpuThreads = (output "sysctl" "-n" "hw.logicalcpu_max") | trim | atoi }}
+{{- else if eq .chezmoi.os "linux" }}
+{{-   $cpuCores = (output "sh" "-c" "lscpu --online --parse | grep --invert-match '^#' | sort --field-separator=',' --key='2,4' --unique | wc --lines") | trim | atoi }}
+{{-   $cpuThreads = (output "sh" "-c" "lscpu --online --parse | grep --invert-match '^#' | wc --lines") | trim | atoi }}
+{{- else if eq .chezmoi.os "windows" }}
+{{-   $cpuCores = (output "pwsh.exe" "-NoProfile" "-NonInteractive" "-Command" "(Get-CimInstance -ClassName 'Win32_Processor').NumberOfCores") | trim | atoi }}
+{{-   $cpuThreads = (output "pwsh.exe" "-NoProfile" "-NonInteractive" "-Command" "(Get-CimInstance -ClassName 'Win32_Processor').NumberOfLogicalProcessors") | trim | atoi }}
+{{- end }}
+
+[data.cpu]
+    cores = {{ $cpuCores }}
+    threads = {{ $cpuThreads }}
+```
+
+Use in build configurations:
+
+```make title="dot_config/make/settings.mk.tmpl" theme={null}
+# Makefile settings
+MAKEFLAGS += -j{{ .cpu.threads }}
+```
+
+## Operating System Conditionals
+
+### Basic OS Detection
+
+Use the `.chezmoi.os` variable to handle different operating systems:
+
+```bash title="dot_bashrc.tmpl" theme={null}
+{{- if eq .chezmoi.os "darwin" }}
+# macOS-specific settings
+export HOMEBREW_PREFIX="/opt/homebrew"
+alias ls='ls -G'
+{{- else if eq .chezmoi.os "linux" }}
+# Linux-specific settings
+alias ls='ls --color=auto'
+{{- else if eq .chezmoi.os "windows" }}
+# Windows-specific settings
+alias ls='ls --color=auto'
+{{- end }}
+```
+
+### Linux Distribution Detection
+
+Handle differences between Linux distributions:
+
+```go title=".chezmoi.toml.tmpl" theme={null}
+{{- $osid := .chezmoi.os -}}
+{{- if hasKey .chezmoi.osRelease "id" -}}
+{{-   $osid = printf "%s-%s" .chezmoi.os .chezmoi.osRelease.id -}}
+{{- end -}}
+
+[data]
+    osid = {{ $osid | quote }}
+```
+
+Use in scripts:
+
+```bash title="run_once_install_packages.sh.tmpl" theme={null}
+#!/bin/bash
+
+{{- if eq .osid "darwin" }}
+brew install git vim curl
+{{- else if eq .osid "linux-ubuntu" }}
+sudo apt update
+sudo apt install -y git vim curl
+{{- else if eq .osid "linux-fedora" }}
+sudo dnf install -y git vim curl
+{{- else if eq .osid "linux-arch" }}
+sudo pacman -S --noconfirm git vim curl
+{{- end }}
+```
+
+## Platform-Specific Guides
+
+### macOS
+
+#### Use Homebrew Bundle
+
+Manage packages declaratively with a `run_onchange_` script:
+
+```bash title="run_onchange_before_install-packages-darwin.sh.tmpl" theme={null}
+{{- if eq .chezmoi.os "darwin" -}}
+#!/bin/bash
+
+brew bundle --file=/dev/stdin <<EOF
+brew "git"
+brew "vim"
+brew "tmux"
+cask "visual-studio-code"
+cask "iterm2"
+EOF
+{{ end -}}
+```
+
+#### Get Stable Hostname
+
+The `hostname` command can change based on network. Use `scutil` instead:
+
+```go theme={null}
+{{- $computerName := output "scutil" "--get" "ComputerName" | trim }}
+```
+
+#### Run Scripts After macOS Updates
+
+Automate tasks after system updates:
+
+```bash title="run_onchange_after_macos_update.sh.tmpl" theme={null}
+{{- if eq .chezmoi.os "darwin" -}}
+#!/bin/bash
+
+# This will run whenever macOS is updated
+# {{ output "sw_vers" "--buildVersion" }}
+
+echo "macOS updated, running post-update tasks..."
+# Your post-update commands here
+{{ end -}}
+```
+
+### Linux
+
+#### Combine OS and Distribution Checks
+
+Simplify nested conditionals:
+
+```bash title="dot_bashrc.tmpl" theme={null}
+{{- if eq .osid "darwin" }}
+# macOS-specific code
+export BROWSER="open"
+{{- else if eq .osid "linux-debian" }}
+# Debian-specific code
+export BROWSER="xdg-open"
+{{- else if eq .osid "linux-fedora" }}
+# Fedora-specific code
+export BROWSER="xdg-open"
+{{- end }}
+```
+
+#### Handle Package Managers
+
+Different distributions use different package managers:
+
+```bash title="run_once_install_tools.sh.tmpl" theme={null}
+#!/bin/bash
+
+set -e
+
+{{- if eq .osid "linux-ubuntu" }}
+sudo apt update && sudo apt install -y build-essential
+{{- else if eq .osid "linux-fedora" }}
+sudo dnf groupinstall -y "Development Tools"
+{{- else if eq .osid "linux-arch" }}
+sudo pacman -S --noconfirm base-devel
+{{- end }}
+```
+
+### Windows
+
+#### Detect Windows Subsystem for Linux (WSL)
+
+Detect if running in WSL:
+
+```bash title="dot_bashrc.tmpl" theme={null}
+{{- if eq .chezmoi.os "linux" }}
+{{-   if (.chezmoi.kernel.osrelease | lower | contains "microsoft") }}
+# WSL-specific configuration
+export DISPLAY=$(cat /etc/resolv.conf | grep nameserver | awk '{print $2}'):0
+export BROWSER="wslview"
+{{-   end }}
+{{- end }}
+```
+
+#### Run PowerShell Scripts as Admin
+
+Self-elevate PowerShell scripts:
+
+```powershell title="run_once_install_tools.ps1.tmpl" theme={null}
+{{- if eq .chezmoi.os "windows" -}}
+# Self-elevate the script if required
+if (-Not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] 'Administrator')) {
+  if ([int](Get-CimInstance -Class Win32_OperatingSystem | Select-Object -ExpandProperty BuildNumber) -ge 6000) {
+    $CommandLine = "-NoExit -File `"" + $MyInvocation.MyCommand.Path + "`" " + $MyInvocation.UnboundArguments
+    Start-Process -Wait -FilePath pwsh.exe -Verb Runas -ArgumentList $CommandLine
+    Exit
+  }
+}
+
+# Your elevated commands here
+winget install Microsoft.VisualStudioCode
+{{ end -}}
+```
+
+#### Create Symlinks on Windows
+
+Enable symlink creation by turning on Developer Mode or setting the appropriate permission.
+
+### Containers and VMs
+
+#### Detect Container Environments
+
+```bash title="dot_bashrc.tmpl" theme={null}
+{{- if stat "/run/.containerenv" }}
+# Running in Podman
+export IN_CONTAINER=1
+{{- else if stat "/.dockerenv" }}
+# Running in Docker
+export IN_CONTAINER=1
+{{- end }}
+```
+
+#### Minimal Configurations for Containers
+
+Use `.chezmoiignore` to skip unnecessary files in containers:
+
+```text title="dot_chezmoiignore" theme={null}
+{{- if or (stat "/run/.containerenv") (stat "/.dockerenv") }}
+.config/autostart/
+.local/share/applications/
+{{- end }}
+```
+
+## Hostname-Based Configuration
+
+### Simple Hostname Check
+
+```bash title="dot_gitconfig.tmpl" theme={null}
+[user]
+    name = Your Name
+{{- if eq .chezmoi.hostname "work-laptop" }}
+    email = you@work.com
+{{- else if eq .chezmoi.hostname "personal-desktop" }}
+    email = you@personal.com
+{{- else }}
+    email = you@default.com
+{{- end }}
+```
+
+### Hostname Patterns
+
+Match multiple machines with similar names:
+
+```bash title="dot_bashrc.tmpl" theme={null}
+{{- if hasPrefix "work-" .chezmoi.hostname }}
+# Work machine settings
+export WORK_ENV=1
+export http_proxy="http://proxy.work.com:8080"
+{{- end }}
+```
+
+## Interactive Configuration
+
+Prompt for machine-specific data during `chezmoi init`:
+
+```go title=".chezmoi.toml.tmpl" theme={null}
+{{- $email := promptString "email" -}}
+{{- $work := promptBool "work machine" -}}
+
+[data]
+    email = {{ $email | quote }}
+    work = {{ $work }}
+```
+
+Use the values in your dotfiles:
+
+```gitconfig title="dot_gitconfig.tmpl" theme={null}
+[user]
+    name = Your Name
+    email = {{ .email }}
+
+{{- if .work }}
+[http]
+    proxy = http://proxy.work.com:8080
+{{- end }}
+```
+
+## Architecture-Specific Configuration
+
+Handle different CPU architectures:
+
+```bash title="dot_bashrc.tmpl" theme={null}
+{{- if eq .chezmoi.arch "amd64" }}
+export ARCH="x86_64"
+{{- else if eq .chezmoi.arch "arm64" }}
+export ARCH="aarch64"
+{{- end }}
+```
+
+## Best Practices
+
+### Use Data Variables
+
+Store complex logic in your config file template and expose simple variables:
+
+```go title=".chezmoi.toml.tmpl" theme={null}
+{{- $isWork := or (eq .chezmoi.hostname "work-laptop") (hasPrefix "work-" .chezmoi.hostname) -}}
+{{- $isPersonal := not $isWork -}}
+
+[data]
+    isWork = {{ $isWork }}
+    isPersonal = {{ $isPersonal }}
+```
+
+Use in templates:
+
+```bash title="dot_bashrc.tmpl" theme={null}
+{{- if .isWork }}
+export http_proxy="http://proxy.work.com:8080"
+{{- end }}
+```
+
+### Keep Templates Simple
+
+Avoid complex logic in individual file templates. Put it in `.chezmoi.toml.tmpl` instead.
+
+### Test on All Machines
+
+Before committing changes, test on all your machines:
+
+```bash theme={null}
+# See what would change
+chezmoi diff
+
+# Apply changes
+chezmoi apply
+```
+
+### Document Your Variables
+
+Add comments to your config template:
+
+```go title=".chezmoi.toml.tmpl" theme={null}
+# Detect chassis type (laptop vs desktop)
+{{- $chassisType := "desktop" }}
+# ... detection logic ...
+
+# Prompt for email if not set
+{{- $email := promptString "email" -}}
+
+[data]
+    # Used in .gitconfig and .bashrc
+    email = {{ $email | quote }}
+    # Used for power management settings
+    chassisType = {{ $chassisType | quote }}
+```
+
+## Troubleshooting
+
+### Debug Template Variables
+
+Create a debug file to inspect available variables:
+
+```bash theme={null}
+chezmoi execute-template '{{ . | toJson }}' | jq .
+```
+
+### Test Templates
+
+Test template rendering without applying:
+
+```bash theme={null}
+chezmoi execute-template < ~/.local/share/chezmoi/dot_bashrc.tmpl
+```
+
+### Check OS Release Info
+
+On Linux, inspect `/etc/os-release`:
+
+```bash theme={null}
+chezmoi execute-template '{{ .chezmoi.osRelease | toJson }}' | jq .
+```
+
+
+# Migrating from Another Dotfile Manager
+Source: https://twpayne-chezmoi.mintlify.app/advanced/migrating-from-another-dotfile-manager
+
+Guide to migrating your dotfiles from other tools to chezmoi
+
+If you're currently using another dotfile manager, chezmoi makes it easy to migrate your existing setup. This guide covers common migration scenarios and compares chezmoi with other popular tools.
+
+## Migrate from Symlink-Based Managers
+
+Many dotfile managers (like GNU Stow, rcm, and bare git setups) use symbolic links to connect your dotfiles to a centralized directory. chezmoi takes a different approach by copying files directly to their target locations, which enables advanced features like templates, encryption, and per-machine customization.
+
+### Using the `--follow` Flag
+
+When migrating from a symlink-based system, use the `--follow` option with `chezmoi add`. This tells chezmoi to add the file that the symlink points to, rather than the symlink itself.
+
+```bash theme={null}
+# Add a single dotfile
+chezmoi add --follow ~/.bashrc
+
+# Add multiple dotfiles
+chezmoi add --follow ~/.bashrc ~/.zshrc ~/.vimrc
+
+# Add an entire directory
+chezmoi add --follow ~/.config/nvim
+```
+
+### Migration Process
+
+When you run `chezmoi apply`, chezmoi will replace the symlinks with actual files containing the correct content. Here's a typical migration workflow:
+
+1. **Initialize chezmoi** (if not already done):
+   ```bash theme={null}
+   chezmoi init
+   ```
+
+2. **Add your dotfiles with `--follow`**:
+   ```bash theme={null}
+   chezmoi add --follow ~/.bashrc ~/.zshrc ~/.vimrc
+   ```
+
+3. **Review the changes**:
+   ```bash theme={null}
+   chezmoi diff
+   ```
+
+4. **Apply the changes** (this replaces symlinks with files):
+   ```bash theme={null}
+   chezmoi apply
+   ```
+
+5. **Clean up your old dotfile manager** (optional):
+   * Remove the old centralized dotfiles directory
+   * Uninstall the old dotfile manager
+   * Update any scripts that referenced the old setup
+
+## Comparing Dotfile Managers
+
+### chezmoi vs. GNU Stow
+
+**GNU Stow** uses symlinks to create a layer of indirection between your dotfiles' locations and their contents.
+
+**Key differences:**
+
+* **chezmoi**: Files are regular files in their final location
+* **GNU Stow**: Files are symlinks pointing to a central directory
+
+**Advantages of chezmoi:**
+
+* Support for templates (machine-specific configurations)
+* Built-in encryption for sensitive files
+* Executable and private file permissions
+* Works better on Windows (no symlink permission issues)
+* No "special" files that reveal your dotfile management setup
+
+### chezmoi vs. yadm
+
+**yadm** (Yet Another Dotfiles Manager) uses a bare git repository in your home directory.
+
+**Key differences:**
+
+* **chezmoi**: Uses a separate source directory (`~/.local/share/chezmoi`)
+* **yadm**: Stores dotfiles directly in your home directory
+
+**Advantages of chezmoi:**
+
+* Password manager integration (1Password, Bitwarden, etc.)
+* More powerful templating with custom variables
+* Easier to manage files outside your home directory
+* Better handling of machine-to-machine differences
+
+### chezmoi vs. dotbot
+
+**dotbot** is a Python-based tool that uses a configuration file to set up symlinks.
+
+**Key differences:**
+
+* **chezmoi**: Single binary, no dependencies
+* **dotbot**: Requires Python and git
+
+**Advantages of chezmoi:**
+
+* No runtime dependencies
+* Cross-platform (Linux, macOS, Windows, BSD)
+* Built-in diff viewing before applying changes
+* Encryption support
+* More flexible templating
+
+### Feature Comparison Table
+
+| Feature                    | chezmoi       | GNU Stow | yadm          | dotbot         | bare git      |
+| -------------------------- | ------------- | -------- | ------------- | -------------- | ------------- |
+| **Distribution**           | Single binary | Package  | Single script | Python package | Manual        |
+| **Bootstrap requirements** | None          | Perl     | git           | Python, git    | git           |
+| **Windows support**        | ✅             | ❌        | ✅             | ✅              | ✅             |
+| **Files are...**           | Regular files | Symlinks | Regular files | Symlinks       | Regular files |
+| **Templates**              | ✅             | ❌        | ✅ (limited)   | ❌              | ❌             |
+| **Encryption**             | ✅             | ❌        | ✅             | ❌              | ❌             |
+| **Password managers**      | ✅             | ❌        | ❌             | ❌              | ❌             |
+| **Diff before apply**      | ✅             | ❌        | ✅             | ❌              | ✅             |
+| **Run scripts**            | ✅             | ❌        | ✅             | ✅              | ❌             |
+| **Private files**          | ✅             | ❌        | ✅             | ❌              | ❌             |
+
+## Migration Examples
+
+### From GNU Stow
+
+If you have a typical GNU Stow setup with structure like:
+
+```
+~/dotfiles/
+  bash/.bashrc
+  vim/.vimrc
+  git/.gitconfig
+```
+
+Migrate to chezmoi:
+
+```bash theme={null}
+# Initialize chezmoi
+chezmoi init
+
+# Add dotfiles (they're currently symlinks)
+chezmoi add --follow ~/.bashrc ~/.vimrc ~/.gitconfig
+
+# Review changes
+chezmoi diff
+
+# Apply (replaces symlinks with regular files)
+chezmoi apply
+
+# Commit to version control
+chezmoi cd
+git add .
+git commit -m "Migrate from GNU Stow to chezmoi"
+```
+
+### From yadm
+
+If you're using yadm, your dotfiles are already in your home directory:
+
+```bash theme={null}
+# List yadm-managed files
+yadm list
+
+# Initialize chezmoi
+chezmoi init
+
+# Add each file to chezmoi
+yadm list | xargs -I {} chezmoi add ~/{}
+
+# Or add common dotfiles
+chezmoi add ~/.bashrc ~/.zshrc ~/.gitconfig ~/.config
+
+# Review and apply
+chezmoi diff
+chezmoi apply
+
+# Archive yadm repo (optional)
+yadm clone --backup
+```
+
+### From bare git
+
+If you're using the bare git approach:
+
+```bash theme={null}
+# Your alias might be something like:
+# alias config='/usr/bin/git --git-dir=$HOME/.cfg/ --work-tree=$HOME'
+
+# List tracked files
+config ls-tree --full-tree -r --name-only HEAD
+
+# Initialize chezmoi
+chezmoi init
+
+# Add each tracked file
+config ls-tree --full-tree -r --name-only HEAD | xargs -I {} chezmoi add ~/{}
+
+# Review and apply
+chezmoi diff
+chezmoi apply
+```
+
+## Post-Migration Tips
+
+### Take Advantage of Templates
+
+Now that you're using chezmoi, you can add machine-specific logic:
+
+```bash theme={null}
+# Make .gitconfig a template
+chezmoi add --template ~/.gitconfig
+
+# Edit it to add conditionals
+chezmoi edit ~/.gitconfig
+```
+
+Example template:
+
+```gitconfig theme={null}
+[user]
+    name = Your Name
+{{- if eq .chezmoi.hostname "work-laptop" }}
+    email = you@work.com
+{{- else }}
+    email = you@personal.com
+{{- end }}
+```
+
+### Add Encryption for Secrets
+
+Protect sensitive files with age or gpg encryption:
+
+```bash theme={null}
+# Initialize encryption
+chezmoi age init
+
+# Add encrypted file
+chezmoi add --encrypt ~/.ssh/config
+```
+
+### Set Up Automatic Updates
+
+Configure git auto-commit and auto-push:
+
+```toml theme={null}
+# ~/.config/chezmoi/chezmoi.toml
+[git]
+    autoCommit = true
+    autoPush = true
+```
+
+### Create Run Scripts
+
+Automate setup tasks with scripts:
+
+```bash theme={null}
+# Create a script to install packages
+chezmoi cd
+cat > run_once_install_packages.sh <<EOF
+#!/bin/bash
+sudo apt update
+sudo apt install -y vim git curl
+EOF
+chmod +x run_once_install_packages.sh
+```
+
+## Troubleshooting Migration
+
+### Symlinks Still Exist After Apply
+
+If symlinks persist after running `chezmoi apply`, ensure you used `--follow` when adding:
+
+```bash theme={null}
+chezmoi forget ~/.bashrc
+chezmoi add --follow ~/.bashrc
+chezmoi apply
+```
+
+### File Permissions Changed
+
+Check your umask configuration:
+
+```toml theme={null}
+# ~/.config/chezmoi/chezmoi.toml
+umask = 0o022
+```
+
+### Lost Custom Scripts
+
+If your old dotfile manager ran custom scripts, convert them to chezmoi scripts:
+
+```bash theme={null}
+# Old: install.sh in your dotfiles
+# New: run_once_install.sh in chezmoi source directory
+chezmoi cd
+mv ~/old-dotfiles/install.sh run_once_install.sh
+```
+
+## Next Steps
+
+After migrating, explore chezmoi's advanced features:
+
+* [Machine-specific configurations](/advanced/machines)
+* [Configuring tools](/advanced/tools)
+* [Customizing chezmoi](/advanced/customize-chezmoi)
+* [Using templates](/user-guide/templating)
+* [Encryption setup](/encryption/overview)
+
+
+# Configuring External Tools
+Source: https://twpayne-chezmoi.mintlify.app/advanced/tools
+
+Customize diff, merge, and editor tools used by chezmoi
+
+chezmoi integrates with external tools to provide a better user experience. This guide covers how to configure your preferred diff tool, merge tool, editor, and other utilities.
+
+## Editor Configuration
+
+### Setting Your Editor
+
+By default, chezmoi uses the editor specified by the `$VISUAL` or `$EDITOR` environment variables, falling back to:
+
+* `vi` on Unix-like systems
+* `notepad.exe` on Windows
+
+You can override this in your config file:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[edit]
+    command = "vim"
+```
+
+Or set it with command-line arguments:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[edit]
+    command = "code"
+    args = ["--wait"]
+```
+
+### VSCode / VSCodium
+
+VSCode requires the `--wait` flag to keep chezmoi from continuing before you finish editing:
+
+```bash theme={null}
+# Set via environment variable
+export EDITOR="code --wait"
+```
+
+Or in your config:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[edit]
+    command = "code"
+    args = ["--wait"]
+```
+
+For VSCodium:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[edit]
+    command = "codium"
+    args = ["--wait"]
+```
+
+### Vim
+
+Vim requires the `-f` (foreground) flag:
+
+```bash theme={null}
+export EDITOR="vim -f"
+```
+
+Or:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[edit]
+    command = "vim"
+    args = ["-f"]
+```
+
+#### Vim Plugins
+
+Enhance your chezmoi workflow with these Vim plugins:
+
+**[chezmoi.vim](https://github.com/alker0/chezmoi.vim)** - Syntax highlighting for chezmoi files including templates:
+
+```vim theme={null}
+Plug 'alker0/chezmoi.vim'
+```
+
+**[vim-chezmoi](https://github.com/Lilja/vim-chezmoi)** - Automatically apply changes when saving with `chezmoi edit`:
+
+```vim theme={null}
+Plug 'Lilja/vim-chezmoi'
+```
+
+**[chezmoi.nvim](https://github.com/xvzc/chezmoi.nvim)** - Edit and auto-apply chezmoi-managed files:
+
+```lua theme={null}
+use 'xvzc/chezmoi.nvim'
+```
+
+#### Auto-Apply on Save
+
+You can also configure Vim to run `chezmoi apply` automatically. First, disable hardlinking:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[edit]
+    hardlink = false
+```
+
+Then add an autocmd:
+
+```vim title="~/.vimrc" theme={null}
+autocmd BufWritePost ~/.local/share/chezmoi/* ! chezmoi apply --source-path "%"
+```
+
+### Neovim
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[edit]
+    command = "nvim"
+```
+
+### Emacs
+
+**[chezmoi.el](https://github.com/tuh8888/chezmoi.el)** provides convenience functions for Emacs (available on MELPA):
+
+```elisp theme={null}
+(use-package chezmoi)
+```
+
+### Helix
+
+Helix 25.01+ works out of the box:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[edit]
+    command = "hx"
+```
+
+## Diff Tool Configuration
+
+### Built-in Diff
+
+By default, chezmoi uses a built-in diff with color output piped through your pager (usually `less`).
+
+If colors aren't displaying correctly, set:
+
+```bash theme={null}
+export LESS=-R
+```
+
+Or in your config:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+pager = "less -R"
+```
+
+### Custom Diff Tool
+
+Use any diff tool by setting `diff.command` and `diff.args`. The templates variables `.Destination` and `.Target` contain the file paths:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[diff]
+    command = "meld"
+    args = ["--diff", "{{ .Destination }}", "{{ .Target }}"]
+```
+
+**Note:** If you generate your config from a template, escape the braces:
+
+```toml title="~/.local/share/chezmoi/.chezmoi.toml.tmpl" theme={null}
+[diff]
+    command = "meld"
+    args = ["--diff", {{ printf "%q" "{{ .Destination }}" }}, {{ printf "%q" "{{ .Target }}" }}]
+```
+
+### VSCode as Diff Tool
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[diff]
+    command = "code"
+    args = ["--wait", "--diff", "{{ .Destination }}", "{{ .Target }}"]
+```
+
+For VSCodium:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[diff]
+    command = "codium"
+    args = ["--wait", "--diff", "{{ .Destination }}", "{{ .Target }}"]
+```
+
+### Delta
+
+[Delta](https://dandavison.github.io/delta/) is a syntax-highlighting pager for git, diff, and grep output:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[diff]
+    pager = "delta"
+```
+
+### diff-so-fancy
+
+[diff-so-fancy](https://github.com/so-fancy/diff-so-fancy) makes diffs more readable:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[diff]
+    pager = "diff-so-fancy"
+```
+
+### Meld
+
+[Meld](https://meldmerge.org/) is a visual diff and merge tool:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[diff]
+    command = "meld"
+    args = ["--diff", "{{ .Destination }}", "{{ .Target }}"]
+```
+
+### Disable Pager
+
+Disable the pager with a flag:
+
+```bash theme={null}
+chezmoi diff --no-pager
+```
+
+Or in config:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[diff]
+    pager = ""
+```
+
+### Exclude Scripts from Diff
+
+By default, `chezmoi diff` shows script contents. To exclude them:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[diff]
+    exclude = ["scripts"]
+```
+
+### Exclude Externals from Diff
+
+```bash theme={null}
+chezmoi diff --exclude=externals
+```
+
+Or:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[diff]
+    exclude = ["externals"]
+```
+
+### Human-Friendly Binary Diffs
+
+chezmoi supports "textconv" to transform binary files before diffing. This is useful for viewing diffs of binary formats.
+
+#### macOS .plist Files
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[[textconv]]
+    pattern = "**/*.plist"
+    command = "plutil"
+    args = ["-convert", "xml1", "-o", "-", "-"]
+```
+
+#### PDF Files
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[[textconv]]
+    pattern = "**/*.pdf"
+    command = "pdftotext"
+    args = ["-", "-"]
+```
+
+#### Images (with exiftool)
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[[textconv]]
+    pattern = "**/*.{jpg,png}"
+    command = "exiftool"
+    args = ["-"]
+```
+
+## Merge Tool Configuration
+
+### Default Merge Tool
+
+By default, chezmoi uses `vimdiff`. Configure a custom merge tool with `merge.command` and `merge.args`:
+
+Templates variables available:
+
+* `.Destination` - file in destination state
+* `.Source` - file in source state
+* `.Target` - file in target state
+
+### Neovim
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[merge]
+    command = "nvim"
+    args = ["-d", "{{ .Destination }}", "{{ .Source }}", "{{ .Target }}"]
+```
+
+### VSCode
+
+VSCode requires a wrapper script to provide all four files for 3-way merge:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[merge]
+    command = "bash"
+    args = [
+        "-c",
+        "cp {{ .Target | quote }} {{ printf \"%s.base\" .Target | quote }} && code --new-window --wait --merge {{ .Destination | quote }} {{ .Target | quote }} {{ printf \"%s.base\" .Target | quote }} {{ .Source | quote }}",
+    ]
+```
+
+### Beyond Compare
+
+[Beyond Compare](https://www.scootersoftware.com/) is a commercial diff and merge tool:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[merge]
+    command = "bcomp"
+    args = ["{{ .Destination }}", "{{ .Source }}", "{{ .Target }}", "{{ .Source }}"]
+```
+
+### Meld
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[merge]
+    command = "meld"
+    args = ["{{ .Destination }}", "{{ .Source }}", "{{ .Target }}"]
+```
+
+### KDiff3
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[merge]
+    command = "kdiff3"
+    args = ["{{ .Destination }}", "{{ .Source }}", "{{ .Target }}", "-o", "{{ .Source }}"]
+```
+
+## HTTP/SOCKS5 Proxy
+
+Configure chezmoi to use a proxy for external sources and updates:
+
+### HTTP Proxy
+
+Set environment variables:
+
+```bash theme={null}
+export HTTP_PROXY=http://proxy.example.com:8080
+export HTTPS_PROXY=http://proxy.example.com:8080
+```
+
+Or in config:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[http]
+    proxy = "http://proxy.example.com:8080"
+```
+
+### SOCKS5 Proxy
+
+```bash theme={null}
+export ALL_PROXY=socks5://proxy.example.com:1080
+```
+
+## Flatpak Integration
+
+Tools installed via Flatpak require special invocation.
+
+### Wrapper Script Approach (Recommended)
+
+Create a wrapper script with the same name as the command:
+
+```bash title="~/bin/keepassxc-cli" theme={null}
+#!/bin/bash
+flatpak run --command=keepassxc-cli org.keepassxc.KeePassXC -- "$@"
+```
+
+Make it executable:
+
+```bash theme={null}
+chmod +x ~/bin/keepassxc-cli
+```
+
+Ensure `~/bin` is in your `$PATH`.
+
+### Direct Configuration
+
+For tools with `.command` and `.args` config options:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[diff]
+    command = "flatpak"
+    args = ["run", "com.vscodium.codium", "--wait", "--diff"]
+```
+
+## Password Manager Integration
+
+chezmoi integrates with many password managers. Each requires configuration:
+
+### 1Password
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[onepassword]
+    command = "op"
+```
+
+### Bitwarden
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[bitwarden]
+    command = "bw"
+```
+
+### KeePassXC
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[keepassxc]
+    command = "keepassxc-cli"
+    database = "/path/to/database.kdbx"
+```
+
+### LastPass
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[lastpass]
+    command = "lpass"
+```
+
+### Pass
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[pass]
+    command = "pass"
+```
+
+## Shell Completion
+
+chezmoi provides shell completion for bash, zsh, fish, and PowerShell.
+
+### Bash
+
+```bash theme={null}
+# Add to ~/.bashrc
+eval "$(chezmoi completion bash)"
+```
+
+Or install system-wide:
+
+```bash theme={null}
+chezmoi completion bash | sudo tee /usr/share/bash-completion/completions/chezmoi
+```
+
+### Zsh
+
+```bash theme={null}
+# Add to ~/.zshrc
+eval "$(chezmoi completion zsh)"
+```
+
+Or add to fpath:
+
+```bash theme={null}
+chezmoi completion zsh > ~/.zsh/completions/_chezmoi
+```
+
+### Fish
+
+```bash theme={null}
+chezmoi completion fish | source
+```
+
+Or:
+
+```bash theme={null}
+chezmoi completion fish > ~/.config/fish/completions/chezmoi.fish
+```
+
+### PowerShell
+
+Add to your PowerShell profile:
+
+```powershell theme={null}
+chezmoi completion powershell | Out-String | Invoke-Expression
+```
+
+## Script Interpreters
+
+Override the interpreter for run scripts:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[interpreters.ps1]
+    command = "pwsh"
+    args = ["-NoLogo"]
+
+[interpreters.py]
+    command = "python3"
+```
+
+## Custom Umask
+
+Control file permissions:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+umask = 0o022
+```
+
+This prevents group-writeable files (useful for `~/.ssh/config`).
+
+## Pinentry for GPG
+
+Configure pinentry for GPG encryption:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[pinentry]
+    command = "pinentry-mac"
+    args = []
+```
+
+## Warnings Configuration
+
+Disable specific warnings:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[warnings]
+    # Don't warn about config file template generating different output
+    configFileTemplateHasChangedExternally = false
+```
+
+## Git Configuration
+
+Configure git behavior:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[git]
+    autoCommit = true
+    autoPush = true
+    commitMessageTemplate = "{{ .commitMessage }}"
+```
+
+Use a different VCS:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[git]
+    command = "git"
+
+useBuiltinGit = false
+```
+
+## Troubleshooting
+
+### Editor Returns Too Quickly
+
+If you see:
+
+```
+chezmoi: warning: $EDITOR returned in less than 1s
+```
+
+Your editor is forking a background process. Add the appropriate flag:
+
+* VSCode: `--wait`
+* Vim: `-f`
+* Sublime: `-w`
+
+### Colors Not Showing in Diff
+
+Set the `LESS` environment variable:
+
+```bash theme={null}
+export LESS=-R
+```
+
+### Flatpak Tools Not Found
+
+Ensure your wrapper scripts are:
+
+1. Executable (`chmod +x`)
+2. In your `$PATH`
+3. Named exactly like the command
+
+
+# add
+Source: https://twpayne-chezmoi.mintlify.app/commands/add
+
+Add files, directories, or symlinks to the source state
+
+The `add` command adds existing files, directories, or symlinks from your home directory to chezmoi's source state. If the target is already in the source state, its source state is replaced with its current state in the destination directory.
+
+## Usage
+
+```bash theme={null}
+chezmoi add target...
+```
+
+## Description
+
+When you add a file to chezmoi, it copies the file from your home directory to the source directory, applying any naming conventions (like prefixes for attributes) automatically.
+
+## Flags
+
+<ParamField type="boolean">
+  Automatically generate a template by replacing strings that match variable values from the `data` section of the config file with their respective config names as template strings. Longer substitutions occur before shorter ones. This implies the `--template` option.
+
+  **Warning:** Uses a greedy algorithm which occasionally generates templates with unwanted variable substitutions. Carefully review any templates it generates.
+</ParamField>
+
+<ParamField type="boolean">
+  Add files that should exist, irrespective of their contents. Sets the `create_` attribute on the added file. A file will be created with the given contents if it doesn't exist, but its contents won't be changed if it already exists. Useful for managing files with an initial state that shouldn't be changed by chezmoi afterwards.
+</ParamField>
+
+<ParamField type="boolean">
+  Encrypt files using the defined encryption method. Can be configured via `add.encrypt` in the config file.
+</ParamField>
+
+<ParamField type="boolean">
+  Set the `exact` attribute on added directories. Directories with the `exact` attribute are statefully synced between target and source directories.
+
+  **Warning:** When running `re-add`, any files deleted from the exact target directory will be removed from the source directory. Likewise, any files added to the exact target directory will be added to the source directory.
+</ParamField>
+
+<ParamField type="boolean">
+  If the last part of a target is a symlink, add the target of the symlink instead of the symlink itself.
+</ParamField>
+
+<ParamField type="boolean">
+  Create a new file if the target does not exist.
+</ParamField>
+
+<ParamField type="boolean">
+  Interactively prompt before adding each file.
+</ParamField>
+
+<ParamField type="boolean">
+  Suppress warnings about adding ignored entries.
+</ParamField>
+
+<ParamField type="boolean">
+  Recurse into subdirectories.
+</ParamField>
+
+<ParamField type="string">
+  Action to take when a secret is found when adding a file. Options: `ignore`, `warning`, `error`. Can be configured via `add.secrets` in the config file.
+</ParamField>
+
+<ParamField type="boolean">
+  Set the `template` attribute on added files and symlinks.
+</ParamField>
+
+<ParamField type="boolean">
+  When adding a symlink to an absolute path in the source directory or destination directory, create a symlink template with `.chezmoi.sourceDir` or `.chezmoi.homeDir`. Useful for creating portable absolute symlinks. Can be configured via `add.templateSymlinks` in the config file.
+</ParamField>
+
+<ParamField type="types">
+  Exclude entry types (comma-separated: `dirs`, `files`, `remove`, `scripts`, `symlinks`, `always`, `encrypted`, `externals`, `templates`).
+</ParamField>
+
+<ParamField type="types">
+  Include only specified entry types (comma-separated: `dirs`, `files`, `remove`, `scripts`, `symlinks`, `always`, `encrypted`, `externals`, `templates`).
+</ParamField>
+
+## Examples
+
+### Add a single file
+
+```bash theme={null}
+chezmoi add ~/.bashrc
+```
+
+This creates `~/.local/share/chezmoi/dot_bashrc`.
+
+### Add a file as a template
+
+```bash theme={null}
+chezmoi add ~/.gitconfig --template
+```
+
+This creates `~/.local/share/chezmoi/dot_gitconfig.tmpl`.
+
+### Add and encrypt a private file
+
+```bash theme={null}
+chezmoi add ~/.ssh/id_rsa --encrypt
+```
+
+This creates an encrypted file in the source directory.
+
+### Add a directory recursively
+
+```bash theme={null}
+chezmoi add ~/.vim --recursive
+```
+
+### Add an exact directory
+
+```bash theme={null}
+chezmoi add ~/.oh-my-zsh --exact --recursive
+```
+
+The `exact` attribute ensures the directory in your home directory exactly matches the source state.
+
+### Add with automatic templating
+
+```bash theme={null}
+chezmoi add ~/.bashrc --autotemplate
+```
+
+This will automatically detect values from your config that appear in the file and convert them to template variables.
+
+### Interactively add files
+
+```bash theme={null}
+chezmoi add ~/.config --recursive --prompt
+```
+
+You'll be prompted for each file before it's added.
+
+## Notes
+
+<Warning>
+  `chezmoi add` will fail if the entry being added is in a directory implicitly created by an external. This is a known limitation.
+</Warning>
+
+<Warning>
+  `chezmoi add --exact --recursive DIR` works in predictable but surprising ways for nested directories.
+
+  If you haven't previously added any files from `~/.config` to chezmoi and run `chezmoi add --exact --recursive ~/.config/nvim`, chezmoi will consider all files under `~/.config` to be managed, and any file not in `~/.config/nvim` will be removed on your next `chezmoi apply`.
+
+  To prevent this, add a `.keep` file first:
+
+  ```bash theme={null}
+  touch ~/.config/.keep
+  chezmoi add ~/.config/.keep
+  chezmoi add --recursive --exact ~/.config/nvim
+  ```
+</Warning>
+
+## Related Commands
+
+* [edit](/commands/edit) - Edit files in the source state
+* [apply](/commands/apply) - Apply changes to the destination directory
+
+
+# apply
+Source: https://twpayne-chezmoi.mintlify.app/commands/apply
+
+Update the destination directory to match the target state
+
+The `apply` command ensures that the specified targets are in the target state, updating them if necessary. This is the command that actually modifies files in your home directory to match your source state.
+
+## Usage
+
+```bash theme={null}
+chezmoi apply [target]...
+```
+
+## Description
+
+The `apply` command updates the destination directory to match the target state defined in your source directory. If no targets are specified, chezmoi applies changes to all managed files.
+
+If a target has been modified since chezmoi last wrote it, you will be prompted to confirm whether you want to overwrite the file (unless `--force` is specified).
+
+## Flags
+
+<ParamField type="types">
+  Exclude entry types (comma-separated: `dirs`, `files`, `remove`, `scripts`, `symlinks`, `always`, `encrypted`, `externals`, `templates`).
+</ParamField>
+
+<ParamField type="types">
+  Include only specified entry types (comma-separated: `dirs`, `files`, `remove`, `scripts`, `symlinks`, `always`, `encrypted`, `externals`, `templates`).
+</ParamField>
+
+<ParamField type="boolean">
+  Recreate the config file from the template in the source directory. Useful when template data has changed.
+</ParamField>
+
+<ParamField type="boolean">
+  Apply changes to all parent directories of the specified targets.
+</ParamField>
+
+<ParamField type="boolean">
+  Recurse into subdirectories.
+</ParamField>
+
+## Examples
+
+### Apply all changes
+
+```bash theme={null}
+chezmoi apply
+```
+
+This updates your entire home directory to match the target state.
+
+### Dry run to see what would change
+
+```bash theme={null}
+chezmoi apply --dry-run --verbose
+```
+
+Shows what changes would be made without actually making them.
+
+### Apply changes to a specific file
+
+```bash theme={null}
+chezmoi apply ~/.bashrc
+```
+
+### Apply with verbose output
+
+```bash theme={null}
+chezmoi apply -v
+```
+
+Shows detailed information about what changes are being made.
+
+### Apply and recreate config
+
+```bash theme={null}
+chezmoi apply --init
+```
+
+Useful when you've updated template data and want to regenerate your config file.
+
+## Behavior
+
+### Interactive Prompts
+
+When a file has been modified locally and differs from both the target state and the last known state, chezmoi will prompt you to choose an action:
+
+* **Yes** - Overwrite the local file with the target state
+* **No** - Skip this file
+* **All** - Overwrite this and all subsequent files without prompting
+* **Quit** - Exit chezmoi immediately
+
+Use `--force` to automatically overwrite without prompting.
+
+### Scripts
+
+Scripts in your source state (files starting with `run_`) are executed when you apply changes. Scripts are only run once unless:
+
+* They have the `always` attribute (prefix `run_always_`)
+* You use the `--force` flag
+
+## Terminal Output
+
+```bash theme={null}
+$ chezmoi apply -v
+.bashrc: updating
+.gitconfig: updating
+.tmux.conf: no changes
+run_once_install-packages.sh: running script
+```
+
+## Related Commands
+
+* [diff](/commands/diff) - Preview changes before applying
+* [status](/commands/status) - Check the status of managed files
+* [update](/commands/update) - Pull changes and apply them
+
+
+# cat
+Source: https://twpayne-chezmoi.mintlify.app/commands/cat
+
+Print the target contents of files, scripts, or symlinks
+
+The `cat` command prints the target contents of one or more files, scripts, or symlinks. For templates, it shows the evaluated output.
+
+## Usage
+
+```bash theme={null}
+chezmoi cat target...
+```
+
+## Description
+
+The `cat` command displays what chezmoi would write to your destination directory for the specified targets. This is useful for:
+
+* **Templates**: See the evaluated output without applying
+* **Encrypted files**: View decrypted contents without saving to disk
+* **Scripts**: Preview script contents
+* **Symlinks**: Show symlink targets
+
+Unlike `chezmoi apply`, this command doesn't modify any files.
+
+## Examples
+
+### View a template's output
+
+```bash theme={null}
+chezmoi cat ~/.gitconfig
+```
+
+If `~/.gitconfig` is a template, this shows the evaluated version with all template variables replaced.
+
+### View an encrypted file
+
+```bash theme={null}
+chezmoi cat ~/.ssh/config
+```
+
+If the file is encrypted, chezmoi decrypts it and prints the plaintext.
+
+### View multiple files
+
+```bash theme={null}
+chezmoi cat ~/.bashrc ~/.zshrc
+```
+
+Prints the contents of both files concatenated.
+
+### View a symlink target
+
+```bash theme={null}
+chezmoi cat ~/.config/nvim
+```
+
+For symlinks, prints the link target followed by a newline.
+
+### Pipe to other commands
+
+```bash theme={null}
+chezmoi cat ~/.bashrc | grep alias
+```
+
+Search through the target contents.
+
+### Compare template output with destination
+
+```bash theme={null}
+diff <(chezmoi cat ~/.bashrc) ~/.bashrc
+```
+
+See differences between the target state and current file.
+
+## Terminal Output
+
+```bash theme={null}
+$ chezmoi cat ~/.gitconfig
+[user]
+    name = John Doe
+    email = john@example.com
+[core]
+    editor = nvim
+```
+
+## Use Cases
+
+### Debug templates
+
+When a template isn't evaluating correctly:
+
+```bash theme={null}
+chezmoi cat ~/.bashrc
+```
+
+See the actual output and identify template errors.
+
+### Verify encryption
+
+Check that a file is properly encrypted in the source:
+
+```bash theme={null}
+# This should show plaintext
+chezmoi cat ~/.ssh/id_rsa
+
+# This should show encrypted data
+cat ~/.local/share/chezmoi/private_dot_ssh/encrypted_private_id_rsa.age
+```
+
+### Preview before applying
+
+```bash theme={null}
+# See what will be written
+chezmoi cat ~/.bashrc
+
+# Compare with current file  
+diff <(chezmoi cat ~/.bashrc) ~/.bashrc
+
+# Apply if satisfied
+chezmoi apply ~/.bashrc
+```
+
+### Extract specific content
+
+```bash theme={null}
+# Get all aliases from bashrc
+chezmoi cat ~/.bashrc | grep "^alias"
+
+# Count lines in the target
+chezmoi cat ~/.vimrc | wc -l
+```
+
+## Template Debugging Example
+
+Source template (`dot_bashrc.tmpl`):
+
+```bash theme={null}
+export EDITOR={{ .editor }}
+export PATH=$HOME/bin:$PATH
+{{ if eq .chezmoi.os "darwin" }}
+alias ls="ls -G"
+{{ else }}
+alias ls="ls --color=auto"
+{{ end }}
+```
+
+View the evaluated output:
+
+```bash theme={null}
+$ chezmoi cat ~/.bashrc
+export EDITOR=nvim
+export PATH=$HOME/bin:$PATH
+alias ls="ls --color=auto"
+```
+
+## Error Messages
+
+If a target is not a file, script, or symlink:
+
+```bash theme={null}
+$ chezmoi cat ~/.config
+error: .config: not a file, script, or symlink
+```
+
+If a template has errors:
+
+```bash theme={null}
+$ chezmoi cat ~/.bashrc  
+error: .bashrc: template: dot_bashrc.tmpl:5: undefined variable "editr"
+```
+
+## Related Commands
+
+* [apply](/commands/apply) - Apply the files shown by cat
+* [execute-template](/commands/execute-template) - Execute arbitrary templates
+* [diff](/commands/diff) - Show differences between target and destination
+
+
+# cd
+Source: https://twpayne-chezmoi.mintlify.app/commands/cd
+
+Launch a shell in the source directory
+
+The `cd` command launches a shell in the chezmoi source directory, making it easy to work with your dotfiles using standard shell commands.
+
+## Usage
+
+```bash theme={null}
+chezmoi cd [path]
+```
+
+## Description
+
+The `cd` command starts a new shell session in your chezmoi source directory (typically `~/.local/share/chezmoi`). This is useful for performing version control operations, bulk edits, or other file management tasks.
+
+When you exit the shell, you return to your original directory.
+
+The environment variable `CHEZMOI_SUBSHELL=1` is set in the launched shell, which you can use in your shell prompt or scripts to indicate you're in a chezmoi subshell.
+
+## Arguments
+
+<ParamField type="string">
+  Optional path to open. If provided, chezmoi will:
+
+  * Open the source directory if the path is the destination directory
+  * Open the corresponding source path if the path is a managed file
+  * If not specified, opens the root of the source directory
+</ParamField>
+
+## Configuration
+
+Configure the shell to use in your config file:
+
+```toml theme={null}
+[cd]
+    command = "zsh"
+    args = ["-i"]
+```
+
+If not configured, chezmoi uses your current shell (from the `SHELL` environment variable).
+
+## Examples
+
+### Open the source directory
+
+```bash theme={null}
+chezmoi cd
+```
+
+Opens a shell in `~/.local/share/chezmoi`.
+
+### Navigate to a specific file's location
+
+```bash theme={null}
+chezmoi cd ~/.bashrc
+```
+
+Opens a shell in the directory containing `dot_bashrc` in the source directory.
+
+### Use with git commands
+
+```bash theme={null}
+$ chezmoi cd
+$ git status
+$ git add .
+$ git commit -m "Update dotfiles"
+$ git push
+$ exit
+```
+
+### Make bulk changes
+
+```bash theme={null}
+$ chezmoi cd
+$ find . -name "*.sh" -exec chmod +x {} \;
+$ git add .
+$ git commit -m "Make all scripts executable"
+$ exit
+$ chezmoi apply
+```
+
+## Terminal Output
+
+```bash theme={null}
+$ chezmoi cd
+$ pwd
+/home/username/.local/share/chezmoi
+$ ls
+dot_bashrc  dot_vimrc  dot_gitconfig.tmpl
+$ exit
+$
+```
+
+## Shell Prompt Integration
+
+You can modify your shell prompt to indicate when you're in a chezmoi subshell:
+
+### Bash
+
+```bash theme={null}
+if [ -n "$CHEZMOI_SUBSHELL" ]; then
+    PS1="(chezmoi) $PS1"
+fi
+```
+
+### Zsh
+
+```zsh theme={null}
+if [[ -n "$CHEZMOI_SUBSHELL" ]]; then
+    PROMPT="(chezmoi) $PROMPT"
+fi
+```
+
+### Fish
+
+```fish theme={null}
+if set -q CHEZMOI_SUBSHELL
+    function fish_prompt
+        echo -n "(chezmoi) "
+        # your normal prompt here
+    end
+end
+```
+
+## Common Workflows
+
+### Version control operations
+
+```bash theme={null}
+chezmoi cd
+git status
+git add .
+git commit -m "Update config"
+git push
+exit
+```
+
+### Search and replace across files
+
+```bash theme={null}
+chezmoi cd
+sed -i 's/old-value/new-value/g' dot_*
+git diff
+exit
+chezmoi apply
+```
+
+### Review recent changes
+
+```bash theme={null}
+chezmoi cd
+git log --oneline -10
+git show HEAD
+exit
+```
+
+## Tips
+
+<Tip>
+  The `cd` command is particularly useful when you need to:
+
+  * Perform git operations (commit, push, pull)
+  * Use advanced text processing tools (sed, awk, grep)
+  * Make bulk changes to multiple files
+  * Review file permissions and attributes
+  * Work with files that aren't easily accessible via chezmoi commands
+</Tip>
+
+<Note>
+  Remember to run `chezmoi apply` after making changes in the source directory if you want those changes reflected in your home directory.
+</Note>
+
+## Alternative Approaches
+
+Instead of using `cd`, you can also:
+
+```bash theme={null}
+# Direct git operations
+chezmoi git status
+chezmoi git commit -m "message"
+chezmoi git push
+
+# Edit files directly
+chezmoi edit ~/.bashrc
+
+# Use environment variable
+cd $CHEZMOI_SOURCE_DIR
+```
+
+## Related Commands
+
+* [edit](/commands/edit) - Edit specific files in the source directory
+* [apply](/commands/apply) - Apply changes after modifying source files
+
+
+# completion
+Source: https://twpayne-chezmoi.mintlify.app/commands/completion
+
+Generate shell completion scripts
+
+The `completion` command generates shell completion scripts for bash, fish, PowerShell, and zsh.
+
+## Usage
+
+```bash theme={null}
+chezmoi completion <shell>
+```
+
+## Description
+
+Shell completion provides command-line suggestions and auto-completion for chezmoi commands, flags, and file paths. The `completion` command generates the appropriate completion script for your shell.
+
+## Supported Shells
+
+* `bash` - Bash completion
+* `fish` - Fish completion
+* `powershell` - PowerShell completion
+* `zsh` - Zsh completion
+
+## Examples
+
+### Bash
+
+**One-time setup:**
+
+```bash theme={null}
+# Generate and install completion
+chezmoi completion bash > /etc/bash_completion.d/chezmoi
+
+# Or for user-only installation
+mkdir -p ~/.local/share/bash-completion/completions
+chezmoi completion bash > ~/.local/share/bash-completion/completions/chezmoi
+```
+
+**Add to `.bashrc`:**
+
+```bash theme={null}
+eval "$(chezmoi completion bash)"
+```
+
+**Source immediately:**
+
+```bash theme={null}
+source <(chezmoi completion bash)
+```
+
+### Zsh
+
+**One-time setup:**
+
+```bash theme={null}
+# Add to fpath
+mkdir -p ~/.zsh/completion
+chezmoi completion zsh > ~/.zsh/completion/_chezmoi
+
+# Add to .zshrc (before compinit)
+fpath=(~/.zsh/completion $fpath)
+autoload -Uz compinit && compinit
+```
+
+**Or generate on-the-fly:**
+
+Add to `.zshrc`:
+
+```zsh theme={null}
+eval "$(chezmoi completion zsh)"
+```
+
+**For Oh My Zsh:**
+
+```bash theme={null}
+mkdir -p ~/.oh-my-zsh/custom/plugins/chezmoi
+chezmoi completion zsh > ~/.oh-my-zsh/custom/plugins/chezmoi/_chezmoi
+
+# Add 'chezmoi' to plugins in .zshrc
+plugins=(git ... chezmoi)
+```
+
+### Fish
+
+**One-time setup:**
+
+```fish theme={null}
+chezmoi completion fish > ~/.config/fish/completions/chezmoi.fish
+```
+
+**Source immediately:**
+
+```fish theme={null}
+chezmoi completion fish | source
+```
+
+### PowerShell
+
+**Add to profile:**
+
+```powershell theme={null}
+chdir completion powershell >> $PROFILE
+```
+
+**Or load dynamically:**
+
+```powershell theme={null}
+chezmoi completion powershell | Out-String | Invoke-Expression
+```
+
+## Platform-Specific Instructions
+
+### macOS
+
+**Bash (via Homebrew):**
+
+```bash theme={null}
+# Install bash-completion if not already installed
+brew install bash-completion
+
+# Generate completion
+chezmoi completion bash > $(brew --prefix)/etc/bash_completion.d/chezmoi
+```
+
+**Zsh (default shell on macOS Catalina+):**
+
+```bash theme={null}
+mkdir -p ~/.zsh/completion
+chezmoi completion zsh > ~/.zsh/completion/_chezmoi
+
+# Add to ~/.zshrc
+fpath=(~/.zsh/completion $fpath)
+autoload -Uz compinit && compinit
+```
+
+### Linux
+
+**Debian/Ubuntu (bash):**
+
+```bash theme={null}
+sudo chezmoi completion bash > /etc/bash_completion.d/chezmoi
+```
+
+**Fedora/RHEL/CentOS (bash):**
+
+```bash theme={null}
+sudo chezmoi completion bash > /etc/bash_completion.d/chezmoi
+```
+
+**Arch Linux (zsh):**
+
+```bash theme={null}
+sudo chezmoi completion zsh > /usr/share/zsh/site-functions/_chezmoi
+```
+
+### Windows
+
+**PowerShell:**
+
+```powershell theme={null}
+# Create profile if it doesn't exist
+if (!(Test-Path -Path $PROFILE)) {
+    New-Item -ItemType File -Path $PROFILE -Force
+}
+
+# Add completion
+chezmoi completion powershell >> $PROFILE
+```
+
+## Testing Completion
+
+After installation, test the completion:
+
+```bash theme={null}
+# Type 'chezmoi ' and press Tab
+chezmoi <Tab>
+
+# Should show available commands:
+apply  add  edit  init  update  status  diff  ...
+
+# Test flag completion
+chezmoi apply --<Tab>
+
+# Should show available flags:
+--apply  --dry-run  --exclude  --include  --verbose  ...
+```
+
+## Features
+
+### Command completion
+
+```bash theme={null}
+chezmoi <Tab>
+# Shows: add, apply, cd, diff, edit, init, status, update, ...
+```
+
+### Flag completion
+
+```bash theme={null}
+chezmoi apply --<Tab>  
+# Shows: --dry-run, --exclude, --include, --recursive, --verbose, ...
+```
+
+### File path completion
+
+```bash theme={null}
+chezmoi add ~/<Tab>
+# Shows files in your home directory
+
+chezmoi edit ~/.<Tab>
+# Shows dotfiles in your home directory
+```
+
+### Subcommand completion
+
+```bash theme={null}
+chezmoi git <Tab>
+# Shows: add, commit, push, pull, status, ...
+```
+
+## Troubleshooting
+
+### Completion not working (bash)
+
+Ensure bash-completion is installed:
+
+```bash theme={null}
+# Debian/Ubuntu
+sudo apt install bash-completion
+
+# macOS
+brew install bash-completion
+
+# Fedora
+sudo dnf install bash-completion
+```
+
+Source completion manually:
+
+```bash theme={null}
+source /etc/bash_completion
+```
+
+### Completion not working (zsh)
+
+Ensure compinit is loaded:
+
+```zsh theme={null}
+# Add to .zshrc before loading completion
+autoload -Uz compinit && compinit
+```
+
+Check fpath:
+
+```zsh theme={null}
+echo $fpath
+# Should include the directory containing _chezmoi
+```
+
+### Completion not working (fish)
+
+Check completion file location:
+
+```fish theme={null}
+echo $fish_complete_path
+# Should include ~/.config/fish/completions
+```
+
+Regenerate completions:
+
+```fish theme={null}
+rm ~/.config/fish/completions/chezmoi.fish
+chezmoi completion fish > ~/.config/fish/completions/chezmoi.fish
+```
+
+### Permission denied
+
+If installing system-wide:
+
+```bash theme={null}
+sudo chezmoi completion bash > /etc/bash_completion.d/chezmoi
+```
+
+Or install to user directory instead.
+
+## Updating Completions
+
+After upgrading chezmoi, regenerate completions:
+
+```bash theme={null}
+# Bash
+chezmoi completion bash > ~/.local/share/bash-completion/completions/chezmoi
+
+# Zsh  
+chezmoi completion zsh > ~/.zsh/completion/_chezmoi
+
+# Fish
+chezmoi completion fish > ~/.config/fish/completions/chezmoi.fish
+```
+
+## Related Commands
+
+* [init](/commands/init) - Initialize chezmoi
+
+
+# diff
+Source: https://twpayne-chezmoi.mintlify.app/commands/diff
+
+Show differences between the target state and the destination state
+
+The `diff` command displays the differences between your target state (what chezmoi wants to apply) and the destination state (your current files) for specified targets.
+
+## Usage
+
+```bash theme={null}
+chezmoi diff [target]...
+```
+
+## Description
+
+The `diff` command shows what changes would be made by `chezmoi apply` without actually making those changes. If no targets are specified, it shows differences for all managed files.
+
+If a `diff.pager` command is set in the configuration file, the output will be piped to it (e.g., `less`).
+
+## Custom Diff Commands
+
+If `diff.command` is set, chezmoi will invoke it to show individual file differences. Each element of `diff.args` is interpreted as a template with variables:
+
+* `.Destination` - Path to the file in the destination state
+* `.Target` - Path to the file in the target state
+
+Default value of `diff.args` is `["{{ .Destination }}", "{{ .Target }}"]`. If `diff.args` doesn't contain template arguments, these will be appended automatically.
+
+## Flags
+
+<ParamField type="string">
+  Pager to use for output (e.g., `less`, `more`). Can be configured via `diff.pager` in the config file.
+</ParamField>
+
+<ParamField type="boolean">
+  Reverse the direction of the diff, i.e., show the changes to the target required to match the destination. Can be configured via `diff.reverse` in the config file.
+</ParamField>
+
+<ParamField type="boolean">
+  Show script contents in the diff.
+</ParamField>
+
+<ParamField type="types">
+  Exclude entry types (comma-separated: `dirs`, `files`, `remove`, `scripts`, `symlinks`, `always`, `encrypted`, `externals`, `templates`).
+</ParamField>
+
+<ParamField type="types">
+  Include only specified entry types (comma-separated: `dirs`, `files`, `remove`, `scripts`, `symlinks`, `always`, `encrypted`, `externals`, `templates`).
+</ParamField>
+
+<ParamField type="boolean">
+  Recreate the config file from the template in the source directory.
+</ParamField>
+
+<ParamField type="boolean">
+  Show differences for all parent directories.
+</ParamField>
+
+<ParamField type="boolean">
+  Recurse into subdirectories.
+</ParamField>
+
+## Configuration
+
+Configure diff behavior in your config file:
+
+```toml theme={null}
+[diff]
+    pager = "less"
+    command = "diff"
+    args = ["--color=always", "{{ .Destination }}", "{{ .Target }}"]
+```
+
+Using a custom diff tool:
+
+```toml theme={null}
+[diff]
+    command = "delta"
+    args = ["{{ .Destination }}", "{{ .Target }}"]
+```
+
+## Examples
+
+### Show all differences
+
+```bash theme={null}
+chezmoi diff
+```
+
+### Show differences for a specific file
+
+```bash theme={null}
+chezmoi diff ~/.bashrc
+```
+
+### Use a custom pager
+
+```bash theme={null}
+chezmoi diff --pager "less -R"
+```
+
+### Show reverse diff
+
+```bash theme={null}
+chezmoi diff --reverse
+```
+
+Shows what changes are needed in the source state to match the destination.
+
+### Diff with syntax highlighting
+
+```bash theme={null}
+chezmoi diff | delta
+```
+
+Pipe the output to `delta` or another diff viewer.
+
+## Terminal Output
+
+Standard unified diff format:
+
+```diff theme={null}
+$ chezmoi diff
+diff --git a/home/.bashrc b/home/.bashrc
+index abc1234..def5678 100644
+--- a/home/.bashrc
++++ b/home/.bashrc
+@@ -10,7 +10,7 @@
+ # Environment variables
+-export EDITOR=vim
++export EDITOR=nvim
+ export PATH="$HOME/bin:$PATH"
+```
+
+## Use Cases
+
+### Before applying changes
+
+```bash theme={null}
+chezmoi diff
+chezmoi apply
+```
+
+Review changes before applying them.
+
+### After making local changes
+
+```bash theme={null}
+chezmoi diff
+```
+
+See how your local files differ from the source state.
+
+### After updating from repository
+
+```bash theme={null}
+chezmoi update --apply=false
+chezmoi diff
+chezmoi apply
+```
+
+Pull changes, review them, then apply.
+
+## Related Commands
+
+* [apply](/commands/apply) - Apply the changes shown by diff
+* [status](/commands/status) - Show a concise status of changes
+* [merge](/commands/merge) - Perform three-way merges for conflicts
+
+
+# doctor
+Source: https://twpayne-chezmoi.mintlify.app/commands/doctor
+
+Check your system for potential problems
+
+The `doctor` command checks your system for potential problems and reports the results. It helps diagnose configuration issues and verify that all required tools are properly installed.
+
+## Usage
+
+```bash theme={null}
+chezmoi doctor
+```
+
+## Description
+
+The `doctor` command performs a comprehensive health check of your chezmoi installation and environment. It verifies:
+
+* **Version information**: chezmoi version, Go version, OS/arch
+* **Configuration**: Config file location and validity
+* **Directories**: Source, working tree, and destination directories
+* **VCS**: Git repository status (clean, dirty, or error)
+* **Tools**: Editor, shell, diff, merge, and git commands
+* **Encryption**: age, GPG, and other encryption tools
+* **Secret managers**: 1Password, Bitwarden, LastPass, etc.
+* **System capabilities**: Symlinks, hard links
+
+Each check returns a status:
+
+* `ok` - Check passed
+* `info` - Informational message (not a problem)
+* `warning` - Potential issue (chezmoi will still work)
+* `error` - Problem that needs to be fixed
+* `skipped` - Check was skipped (e.g., no network for version check)
+* `failed` - Check could not be completed
+
+## Flags
+
+<ParamField type="boolean">
+  Do not use network connection. Skips the latest version check.
+</ParamField>
+
+## Examples
+
+### Run a full health check
+
+```bash theme={null}
+chezmoi doctor
+```
+
+### Run without network access
+
+```bash theme={null}
+chezmoi doctor --no-network
+```
+
+Skips checking for the latest chezmoi version.
+
+### Check exit code
+
+```bash theme={null}
+if chezmoi doctor; then
+    echo "All checks passed"
+else
+    echo "Issues detected"
+fi
+```
+
+The command exits with code 1 if any check returns `error`.
+
+## Terminal Output
+
+```bash theme={null}
+$ chezmoi doctor
+RESULT   CHECK                MESSAGE
+ok       version              v2.46.1, commit abc1234, built at 2024-01-15T10:30:00Z
+ok       latest-version       v2.46.1
+ok       os-arch              linux/amd64 (Ubuntu 22.04)
+ok       go-version           go1.21.5 (gc)
+ok       executable           /usr/local/bin/chezmoi
+ok       upgrade-method       snap-refresh
+ok       config-file          found ~/.config/chezmoi/chezmoi.toml, last modified 2024-01-10T14:22:30Z
+ok       source-dir           ~/.local/share/chezmoi is a git working tree (clean)
+ok       working-tree         ~/.local/share/chezmoi is a directory
+ok       dest-dir             ~ is a directory
+ok       cd-command           found /bin/bash
+ok       cd-args              /bin/bash
+info     diff-command         not set
+ok       edit-command         found /usr/bin/vim
+ok       edit-args            /usr/bin/vim
+ok       git-command          found /usr/bin/git, version 2.39.2
+warning  merge-command        not set
+ok       shell-command        found /bin/zsh
+ok       shell-args           /bin/zsh
+warning  age-command          not set
+info     gpg-command          found /usr/bin/gpg, version 2.2.27
+info     1password-command    found /usr/bin/op, version 2.18.0
+info     bitwarden-command    not set
+```
+
+## Check Descriptions
+
+### Version Checks
+
+**version**
+
+* Shows chezmoi version, commit, and build date
+* `warning` if version information is incomplete
+
+**latest-version**
+
+* Compares installed version with latest GitHub release
+* `warning` if a newer version is available
+* `skipped` with `--no-network`
+
+**go-version**
+
+* Shows Go version used to build chezmoi
+
+**os-arch**
+
+* Shows operating system and architecture
+* Includes OS release information if available
+
+### Executable Checks
+
+**executable**
+
+* Shows path to chezmoi binary
+
+**upgrade-method**
+
+* Shows detected upgrade method (e.g., `brew-upgrade`, `snap-refresh`)
+* Helps determine how to upgrade chezmoi
+
+### Configuration Checks
+
+**config-file**
+
+* Validates config file exists and is readable
+* Shows path and last modification time
+* `info` if config file doesn't exist (optional)
+* `error` if config file is invalid
+
+### Directory Checks
+
+**source-dir**
+
+* Verifies source directory exists
+* Shows git status if it's a repository:
+  * `(clean)` - No uncommitted changes
+  * `(dirty)` - Uncommitted changes present
+  * `(error)` - Git error
+
+**working-tree**
+
+* Verifies working tree directory exists
+
+**dest-dir**
+
+* Verifies destination directory exists
+
+### Tool Checks
+
+**cd-command**, **edit-command**, **shell-command**
+
+* `error` if not found and required
+* Shows path and version if available
+
+**diff-command**, **merge-command**
+
+* `info` if not set (optional tools)
+* `warning` if set but not found
+
+**git-command**
+
+* `warning` if not found
+* Shows version if found
+
+### Encryption Tool Checks
+
+**age-command**, **gpg-command**
+
+* `info` if not found (optional)
+* Shows version if found
+
+**pinentry-command**
+
+* Used by GPG for password entry
+* `info` if not set
+* `warning` if set but not found
+
+### Secret Manager Checks
+
+**1password-command**, **bitwarden-command**, etc.
+
+* `info` if not found (optional)
+* Shows version if found
+* `error` if found but version is too old
+
+### System Capability Checks
+
+**symlink**
+
+* Tests if symbolic links can be created
+* `failed` if symlinks not supported
+
+**hardlink**
+
+* Tests if hard links can be created
+
+**umask**
+
+* Shows current umask value
+
+## Common Issues
+
+### Config file not found
+
+```
+info     config-file          ~/.config/chezmoi/chezmoi.toml: not found
+```
+
+This is normal if you haven't created a config file. Create one:
+
+```bash theme={null}
+chezmoi edit-config
+```
+
+### Dirty working tree
+
+```
+warning  source-dir           ~/.local/share/chezmoi is a git working tree (dirty)
+```
+
+You have uncommitted changes:
+
+```bash theme={null}
+chezmoi cd
+git status
+git add .
+git commit -m "Update"
+```
+
+### Outdated version
+
+```
+warning  latest-version       v2.47.0
+```
+
+Your chezmoi is out of date. Upgrade:
+
+```bash theme={null}
+chezmoi upgrade
+```
+
+### Tool not found
+
+```
+warning  git-command          git not found in $PATH
+```
+
+Install the missing tool:
+
+```bash theme={null}
+# Ubuntu/Debian
+sudo apt install git
+
+# macOS
+brew install git
+
+# Fedora
+sudo dnf install git
+```
+
+### Minimum version not met
+
+```
+error    gopass-command       found /usr/bin/gopass, version 1.12.0, need 1.14.0
+```
+
+Upgrade the tool to the minimum required version.
+
+## Troubleshooting Workflow
+
+```bash theme={null}
+# 1. Run doctor
+chezmoi doctor
+
+# 2. Review errors and warnings
+# Fix any issues
+
+# 3. Verify fixes
+chezmoi doctor
+
+# 4. Test chezmoi functionality  
+chezmoi apply --dry-run --verbose
+```
+
+## CI/CD Usage
+
+### Verify environment
+
+```yaml theme={null}
+- name: Verify chezmoi environment
+  run: |
+    chezmoi doctor
+    chezmoi doctor --no-network
+```
+
+### Fail on warnings
+
+```bash theme={null}
+#!/bin/bash
+output=$(chezmoi doctor 2>&1)
+echo "$output"
+
+if echo "$output" | grep -q "error\|warning"; then
+    echo "Doctor found issues"
+    exit 1
+fi
+```
+
+## Saving Output
+
+### Save for bug reports
+
+```bash theme={null}
+chezmoi doctor > chezmoi-doctor.txt 2>&1
+```
+
+### Redact sensitive information
+
+The output includes your home directory path. Redact if needed:
+
+```bash theme={null}
+chezmoi doctor | sed "s|$HOME|~|g"
+```
+
+## Related Commands
+
+* [upgrade](/commands/upgrade) - Upgrade chezmoi to the latest version
+* [init](/commands/init) - Initialize chezmoi
+
+
+# edit
+Source: https://twpayne-chezmoi.mintlify.app/commands/edit
+
+Edit the source state of targets
+
+The `edit` command opens files or symlinks in your source state in your default editor. If no targets are specified, it opens the entire source directory.
+
+## Usage
+
+```bash theme={null}
+chezmoi edit [target]...
+```
+
+## Description
+
+The `edit` command allows you to modify files in the source state using your configured editor. When you edit files:
+
+* **Encrypted files** are automatically decrypted to a temporary directory, and re-encrypted when you save
+* **Hard links** are created (when supported) so the editor sees the target filename, helping with syntax highlighting
+* **Templates** preserve their `.tmpl` extension for proper editor highlighting
+
+## Flags
+
+<ParamField type="boolean">
+  Apply the target immediately after editing. Ignored if there are no targets. Can be configured via `edit.apply` in the config file.
+</ParamField>
+
+<ParamField type="boolean">
+  Invoke the editor with a hard link to the source file with a name matching the target filename. This helps the editor determine the file type correctly. Can be configured via `edit.hardlink` in the config file.
+
+  **Note:** Creating hardlinks is not possible between different filesystems. If your `tempDir` resides on a different filesystem (e.g., a tmpfs), this won't work.
+</ParamField>
+
+<ParamField type="boolean">
+  Automatically apply changes when files are saved. Can be configured via `edit.watch` in the config file.
+
+  **Limitations:**
+
+  * Only available when targets are specified (not for directory-wide editing)
+  * All edited files are applied when any file is saved
+  * Only the edited files are watched, not dependent files like `.chezmoitemplates`
+  * Only works on operating systems supported by fsnotify
+  * Only works if `edit.hardlink` is enabled and functional
+</ParamField>
+
+<ParamField type="types">
+  Exclude entry types (comma-separated: `dirs`, `files`, `remove`, `scripts`, `symlinks`, `always`, `encrypted`, `externals`, `templates`).
+</ParamField>
+
+<ParamField type="types">
+  Include only specified entry types (comma-separated: `dirs`, `files`, `remove`, `scripts`, `symlinks`, `always`, `encrypted`, `externals`, `templates`).
+</ParamField>
+
+<ParamField type="boolean">
+  Recreate the config file from the template after editing.
+</ParamField>
+
+## Examples
+
+### Edit a specific file
+
+```bash theme={null}
+chezmoi edit ~/.bashrc
+```
+
+Opens `~/.local/share/chezmoi/dot_bashrc` in your editor.
+
+### Edit and apply immediately
+
+```bash theme={null}
+chezmoi edit ~/.bashrc --apply
+```
+
+After you save and exit the editor, changes are immediately applied to `~/.bashrc`.
+
+### Edit with auto-apply on save
+
+```bash theme={null}
+chezmoi edit ~/.bashrc --watch
+```
+
+Changes are automatically applied every time you save the file.
+
+### Edit the entire source directory
+
+```bash theme={null}
+chezmoi edit
+```
+
+Opens `~/.local/share/chezmoi` in your editor (useful for IDEs like VS Code).
+
+### Edit multiple files
+
+```bash theme={null}
+chezmoi edit ~/.bashrc ~/.vimrc ~/.tmux.conf
+```
+
+## Editor Configuration
+
+Set your preferred editor using the `VISUAL` or `EDITOR` environment variable, or configure it in your chezmoi config file:
+
+```toml theme={null}
+[edit]
+    command = "code"
+    args = ["--wait"]
+```
+
+Common editor configurations:
+
+```bash theme={null}
+# VS Code
+export EDITOR="code --wait"
+
+# Vim
+export EDITOR=vim
+
+# Neovim
+export EDITOR=nvim
+
+# Nano
+export EDITOR=nano
+
+# Emacs
+export EDITOR=emacs
+```
+
+## Syntax Highlighting for Templates
+
+You can use modelines in your template files to tell your editor how to highlight them:
+
+```bash theme={null}
+# vim: ft=bash
+{{ if eq .chezmoi.os "linux" }}
+alias ll="ls -la"
+{{ end }}
+```
+
+## Terminal Output
+
+```bash theme={null}
+$ chezmoi edit ~/.bashrc --apply
+# Editor opens, you make changes and save...
+.bashrc: updating
+```
+
+## Related Commands
+
+* [add](/commands/add) - Add new files to the source state
+* [apply](/commands/apply) - Apply changes without editing
+* [diff](/commands/diff) - Preview changes before applying
+
+
+# execute-template
+Source: https://twpayne-chezmoi.mintlify.app/commands/execute-template
+
+Execute templates with access to template data
+
+The `execute-template` command executes one or more templates and writes the output to stdout. This is useful for testing templates and template functions.
+
+## Usage
+
+```bash theme={null}
+chezmoi execute-template [template]...
+```
+
+## Description
+
+The `execute-template` command evaluates templates with access to all template data and functions available in chezmoi, including:
+
+* Configuration data (`.` variables)
+* Template functions (`lookupSecret`, `output`, etc.)
+* Chezmoi metadata (`.chezmoi.*` variables)
+
+If no arguments are provided, reads a template from stdin. If arguments are provided, they are treated as template strings (or filenames with `--file`).
+
+## Flags
+
+<ParamField type="boolean">
+  Treat arguments as filenames containing templates rather than template strings.
+</ParamField>
+
+<ParamField type="boolean">
+  Simulate `chezmoi init` mode, which provides access to init-specific template functions like `promptString`, `promptBool`, etc.
+</ParamField>
+
+<ParamField type="string">
+  Set the left template delimiter.
+</ParamField>
+
+<ParamField type="string">
+  Set the right template delimiter.
+</ParamField>
+
+<ParamField type="key=value">
+  Simulate `promptString` responses. Format: `prompt=value`. Can be specified multiple times.
+</ParamField>
+
+<ParamField type="key=value">
+  Simulate `promptBool` responses. Format: `prompt=true|false`. Can be specified multiple times.
+</ParamField>
+
+<ParamField type="key=value">
+  Simulate `promptInt` responses. Format: `prompt=123`. Can be specified multiple times.
+</ParamField>
+
+<ParamField type="key=value">
+  Simulate `promptChoice` responses. Format: `prompt=choice`. Can be specified multiple times.
+</ParamField>
+
+<ParamField type="key=value">
+  Simulate `promptMultichoice` responses. Format: `prompt=choice1/choice2`. Can be specified multiple times.
+</ParamField>
+
+<ParamField type="boolean">
+  Simulate `stdinIsATTY` returning true.
+</ParamField>
+
+<ParamField type="boolean">
+  Set `.chezmoi.stdin` to the contents of stdin.
+</ParamField>
+
+## Examples
+
+### Execute a simple template string
+
+```bash theme={null}
+chezmoi execute-template "{{ .chezmoi.os }}"
+```
+
+Output:
+
+```
+linux
+```
+
+### Access configuration data
+
+```bash theme={null}
+chezmoi execute-template "{{ .email }}"
+```
+
+Output:
+
+```
+john@example.com
+```
+
+### Test template functions
+
+```bash theme={null}
+chezmoi execute-template "{{ output \"uname\" \"-m\" }}"
+```
+
+Output:
+
+```
+x86_64
+```
+
+### Execute a template file
+
+```bash theme={null}
+chezmoi execute-template --file template.tmpl
+```
+
+### Read template from stdin
+
+```bash theme={null}
+echo "{{ .chezmoi.hostname }}" | chezmoi execute-template
+```
+
+Output:
+
+```
+mylaptop
+```
+
+### Test init templates with prompts
+
+```bash theme={null}
+chezmoi execute-template --init \
+  --promptString "email=john@example.com" \
+  --promptBool "useColor=true" \
+  "Email: {{ .email }}, Color: {{ .useColor }}"
+```
+
+Output:
+
+```
+Email: john@example.com, Color: true
+```
+
+### Use custom delimiters
+
+```bash theme={null}
+chezmoi execute-template \
+  --left-delimiter "[[" \
+  --right-delimiter "]]" \
+  "OS: [[ .chezmoi.os ]]"
+```
+
+### Execute multiple templates
+
+```bash theme={null}
+chezmoi execute-template \
+  "OS: {{ .chezmoi.os }}" \
+  "Arch: {{ .chezmoi.arch }}"
+```
+
+Output:
+
+```
+OS: linux
+Arch: amd64
+```
+
+### Access stdin in templates
+
+```bash theme={null}
+echo "Hello World" | chezmoi execute-template --with-stdin \
+  "Input was: {{ .chezmoi.stdin }}"
+```
+
+Output:
+
+```
+Input was: Hello World
+```
+
+## Template Testing
+
+### Test conditionals
+
+```bash theme={null}
+chezmoi execute-template '{{ if eq .chezmoi.os "linux" }}Linux!{{ else }}Not Linux{{ end }}'
+```
+
+### Test loops
+
+```bash theme={null}
+chezmoi execute-template '{{ range list "a" "b" "c" }}{{ . }} {{ end }}'
+```
+
+Output:
+
+```
+a b c
+```
+
+### Test secret managers
+
+```bash theme={null}
+chezmoi execute-template '{{ (onepassword "item").password }}'
+```
+
+### Debug template data
+
+```bash theme={null}
+chezmoi execute-template '{{ . | toPrettyJson }}'
+```
+
+Prints all available template data in JSON format.
+
+## Init Template Testing
+
+Test your `.chezmoi.toml.tmpl` configuration template:
+
+```bash theme={null}
+chezmoi execute-template --init \
+  --promptString "email=john@example.com" \
+  --promptString "name=John Doe" \
+  --promptBool "installDevTools=true" \
+  --file .chezmoi.toml.tmpl
+```
+
+## Terminal Output
+
+```bash theme={null}
+$ chezmoi execute-template "My username is {{ .chezmoi.username }}"
+My username is john
+
+$ chezmoi execute-template '{{ .chezmoi | toPrettyJson }}'
+{
+  "arch": "amd64",
+  "os": "linux",
+  "hostname": "mylaptop",
+  "username": "john"
+}
+```
+
+## Common Use Cases
+
+### Debug why a template isn't working
+
+```bash theme={null}
+# See the actual output
+chezmoi execute-template --file ~/.local/share/chezmoi/dot_bashrc.tmpl
+
+# Test specific expressions
+chezmoi execute-template '{{ .nonexistent }}'
+```
+
+### Test template functions before using them
+
+```bash theme={null}
+# Test onepassword
+chezmoi execute-template '{{ (onepassword "item") | toPrettyJson }}'
+
+# Test bitwarden  
+chezmoi execute-template '{{ (bitwarden "item") | toPrettyJson }}'
+```
+
+### Validate init prompts
+
+```bash theme={null}
+chezmoi execute-template --init \
+  --promptString "email=test@example.com" \
+  "{{ .email }}"
+```
+
+## Related Commands
+
+* [cat](/commands/cat) - View target contents of managed files
+* [init](/commands/init) - Initialize chezmoi with template prompts
+
+
+# init
+Source: https://twpayne-chezmoi.mintlify.app/commands/init
+
+Setup the source directory and update the destination directory to match the target state
+
+The `init` command sets up the source directory, optionally clones a repository, generates the config file, and optionally applies the changes to your system.
+
+## Usage
+
+```bash theme={null}
+chezmoi init [repo]
+```
+
+## Description
+
+The `init` command performs the following steps in order:
+
+1. **Initialize the source directory** - If chezmoi does not detect a Git repository in the source directory, chezmoi will clone the provided `repo` into the source directory. If no `repo` is provided, chezmoi will initialize a new Git repository.
+
+2. **Generate config file** - If the initialized source directory contains a `.chezmoi.$FORMAT.tmpl` file, a new configuration file will be created using that file as a template.
+
+3. **Apply changes** (if `--apply` is set) - Run `chezmoi apply` to update the destination directory.
+
+4. **Purge** (if `--purge` is set) - Remove the source, config, and cache directories.
+
+5. **Purge binary** (if `--purge-binary` is set) - Attempt to remove the chezmoi binary itself.
+
+## Repository URL Guessing
+
+By default, if a repo argument is given, chezmoi will guess the full git repo URL using HTTPS (or SSH with `--ssh`), according to these patterns:
+
+| Pattern            | HTTPS Repo                             | SSH Repo                           |
+| ------------------ | -------------------------------------- | ---------------------------------- |
+| `user`             | `https://github.com/user/dotfiles.git` | `git@github.com:user/dotfiles.git` |
+| `user/repo`        | `https://github.com/user/repo.git`     | `git@github.com:user/repo.git`     |
+| `site/user/repo`   | `https://site/user/repo.git`           | `git@site:user/repo.git`           |
+| `sr.ht/~user`      | `https://git.sr.ht/~user/dotfiles`     | `git@git.sr.ht:~user/dotfiles`     |
+| `sr.ht/~user/repo` | `https://git.sr.ht/~user/repo`         | `git@git.sr.ht:~user/repo`         |
+
+To disable URL guessing, use `--guess-repo-url=false`.
+
+## Flags
+
+<ParamField type="boolean">
+  Run `chezmoi apply` after checking out the repo and creating the config file.
+</ParamField>
+
+<ParamField type="string">
+  Check out the specified branch instead of the default branch.
+</ParamField>
+
+<ParamField type="path">
+  Write the generated config file to the specified path instead of the default location.
+</ParamField>
+
+<ParamField type="boolean">
+  Include existing template data when creating the config file. Set to `false` to simulate creating the config file with no existing template data.
+</ParamField>
+
+<ParamField type="integer">
+  Clone the repo with the specified depth (creates a shallow clone).
+</ParamField>
+
+<ParamField type="boolean">
+  Run `git lfs pull` after cloning the repo.
+</ParamField>
+
+<ParamField type="boolean">
+  Guess the repo URL from the repo argument.
+</ParamField>
+
+<ParamField type="boolean">
+  Equivalent to `--apply --depth=1 --force --purge --purge-binary`. Attempts to install your dotfiles with chezmoi and then remove all traces of chezmoi from the system. Useful for temporary environments like Docker containers.
+</ParamField>
+
+<ParamField type="boolean">
+  Remove the source and config directories after applying.
+</ParamField>
+
+<ParamField type="boolean">
+  Attempt to remove the chezmoi binary after applying.
+</ParamField>
+
+<ParamField type="boolean">
+  Recursively clone submodules.
+</ParamField>
+
+<ParamField type="boolean">
+  Guess an SSH repo URL instead of an HTTPS repo URL.
+</ParamField>
+
+<ParamField type="types">
+  Exclude entry types (comma-separated: `dirs`, `files`, `remove`, `scripts`, `symlinks`, `always`, `encrypted`, `externals`, `templates`).
+</ParamField>
+
+<ParamField type="types">
+  Include only specified entry types (comma-separated: `dirs`, `files`, `remove`, `scripts`, `symlinks`, `always`, `encrypted`, `externals`, `templates`).
+</ParamField>
+
+## Examples
+
+### Initialize from a GitHub user's dotfiles repository
+
+```bash theme={null}
+chezmoi init username
+```
+
+### Initialize and apply immediately
+
+```bash theme={null}
+chezmoi init username --apply
+```
+
+### Initialize and purge afterwards
+
+```bash theme={null}
+chezmoi init username --apply --purge
+```
+
+### Initialize from a specific repository
+
+```bash theme={null}
+chezmoi init user/dots
+```
+
+### Initialize from GitLab or other providers
+
+```bash theme={null}
+chezmoi init gitlab.com/user
+chezmoi init codeberg.org/user
+```
+
+### One-shot mode for Docker containers
+
+```bash theme={null}
+chezmoi init username --one-shot
+```
+
+This will clone your dotfiles, apply them, and remove chezmoi completely.
+
+## Notes
+
+<Warning>
+  If you're using a different version control system (not Git), you'll need to manually create the source directory structure. To prevent chezmoi from trying to clone or create a Git repository, add an empty `.git` directory:
+
+  ```bash theme={null}
+  mkdir -p ~/.local/share/chezmoi/.git
+  ```
+</Warning>
+
+## Related Commands
+
+* [apply](/commands/apply) - Apply changes after initialization
+* [update](/commands/update) - Pull and apply changes from the repository
+
+
+# managed
+Source: https://twpayne-chezmoi.mintlify.app/commands/managed
+
+List the managed entries in the destination directory
+
+The `managed` command (also available as `list`) lists all files, directories, and symlinks managed by chezmoi.
+
+## Usage
+
+```bash theme={null}
+chezmoi managed [path]...
+```
+
+## Description
+
+The `managed` command displays all entries that chezmoi manages in your destination directory. You can optionally specify paths to list only managed entries under those paths.
+
+## Flags
+
+<ParamField type="types">
+  Exclude entry types (comma-separated: `dirs`, `files`, `remove`, `scripts`, `symlinks`, `always`, `encrypted`, `externals`, `templates`).
+</ParamField>
+
+<ParamField type="string">
+  Output format. Options: `text`, `json`, `yaml`.
+</ParamField>
+
+<ParamField type="types">
+  Include only specified entry types (comma-separated: `dirs`, `files`, `remove`, `scripts`, `symlinks`, `always`, `encrypted`, `externals`, `templates`).
+</ParamField>
+
+<ParamField type="boolean">
+  Use NUL character as path separator. Useful for piping to `xargs -0`.
+</ParamField>
+
+<ParamField type="string">
+  Path style to use. Options:
+
+  * `relative` - Paths relative to home directory
+  * `absolute` - Absolute paths
+  * `source-relative` - Paths relative to source directory
+  * `source-absolute` - Absolute paths in source directory
+  * `all` - All path information in structured format
+</ParamField>
+
+<ParamField type="boolean">
+  Print paths as a tree structure.
+</ParamField>
+
+## Examples
+
+### List all managed files
+
+```bash theme={null}
+chezmoi managed
+```
+
+Output:
+
+```
+.bashrc
+.gitconfig
+.ssh/config
+.vim/vimrc
+.zshrc
+```
+
+### List with absolute paths
+
+```bash theme={null}
+chezmoi managed --path-style=absolute
+```
+
+Output:
+
+```
+/home/john/.bashrc
+/home/john/.gitconfig
+/home/john/.ssh/config
+/home/john/.vim/vimrc
+/home/john/.zshrc
+```
+
+### List in tree format
+
+```bash theme={null}
+chezmoi managed --tree
+```
+
+Output:
+
+```
+.
+├── .bashrc
+├── .gitconfig
+├── .ssh
+│   └── config
+├── .vim
+│   └── vimrc
+└── .zshrc
+```
+
+### List only files (exclude directories)
+
+```bash theme={null}
+chezmoi managed --include=files
+```
+
+### List managed files in a specific directory
+
+```bash theme={null}
+chezmoi managed ~/.config
+```
+
+Output:
+
+```
+.config/nvim/init.vim
+.config/tmux/tmux.conf
+```
+
+### List source paths
+
+```bash theme={null}
+chezmoi managed --path-style=source-relative
+```
+
+Output:
+
+```
+dot_bashrc
+dot_gitconfig
+private_dot_ssh/config
+dot_vim/vimrc
+dot_zshrc
+```
+
+### Export to JSON
+
+```bash theme={null}
+chezmoi managed --path-style=all --format=json
+```
+
+Output:
+
+```json theme={null}
+{
+  ".bashrc": {
+    "absolute": "/home/john/.bashrc",
+    "sourceAbsolute": "/home/john/.local/share/chezmoi/dot_bashrc",
+    "sourceRelative": "dot_bashrc"
+  },
+  ".gitconfig": {
+    "absolute": "/home/john/.gitconfig",
+    "sourceAbsolute": "/home/john/.local/share/chezmoi/dot_gitconfig",
+    "sourceRelative": "dot_gitconfig"
+  }
+}
+```
+
+### Use with xargs
+
+```bash theme={null}
+chezmoi managed --nul-path-separator | xargs -0 ls -l
+```
+
+Safely pass managed files to other commands, even if filenames contain spaces.
+
+### Count managed files
+
+```bash theme={null}
+chezmoi managed | wc -l
+```
+
+### Find large managed files
+
+```bash theme={null}
+chezmoi managed --path-style=absolute | xargs ls -lh | sort -k5 -h
+```
+
+## Output Examples
+
+### Default (relative paths)
+
+```bash theme={null}
+$ chezmoi managed
+.bashrc
+.config/nvim/init.vim
+.gitconfig
+.ssh/config
+.vimrc
+```
+
+### Tree view
+
+```bash theme={null}
+$ chezmoi managed --tree
+.
+├── .bashrc
+├── .config
+│   └── nvim
+│       └── init.vim
+├── .gitconfig  
+├── .ssh
+│   └── config
+└── .vimrc
+```
+
+### Source paths
+
+```bash theme={null}
+$ chezmoi managed --path-style=source-relative
+dot_bashrc
+dot_config/nvim/init.vim
+dot_gitconfig.tmpl
+private_dot_ssh/config
+dot_vimrc
+```
+
+## Filtering Examples
+
+### List only template files
+
+```bash theme={null}
+chezmoi managed --include=templates
+```
+
+### List only encrypted files
+
+```bash theme={null}
+chezmoi managed --include=encrypted
+```
+
+### List everything except scripts
+
+```bash theme={null}
+chezmoi managed --exclude=scripts
+```
+
+### List only directories
+
+```bash theme={null}
+chezmoi managed --include=dirs
+```
+
+## Scripting Examples
+
+### Backup all managed files
+
+```bash theme={null}
+tar czf dotfiles-backup.tar.gz -C ~ $(chezmoi managed)
+```
+
+### Check permissions of managed files
+
+```bash theme={null}
+chezmoi managed --path-style=absolute | xargs stat -c '%n %a'
+```
+
+### Search for a pattern in managed files
+
+```bash theme={null}
+chezmoi managed --include=files | \
+  xargs -I {} grep -l "pattern" ~/{}  
+```
+
+## Common Use Cases
+
+### Verify what's managed
+
+Check which files chezmoi is tracking:
+
+```bash theme={null}
+chezmoi managed | grep -E "\.(bash|zsh|vim)rc"
+```
+
+### Compare with actual files
+
+```bash theme={null}
+# List managed files
+chezmoi managed > /tmp/managed.txt
+
+# List actual files
+find ~ -type f > /tmp/actual.txt
+
+# Compare
+comm -3 /tmp/managed.txt /tmp/actual.txt
+```
+
+### Export inventory
+
+Create a manifest of managed files:
+
+```bash theme={null}
+chezmoi managed --path-style=all --format=yaml > inventory.yaml
+```
+
+## Related Commands
+
+* [unmanaged](/commands/unmanaged) - List unmanaged files
+* [status](/commands/status) - Show status of managed files
+* [add](/commands/add) - Add new files to be managed
+
+
+# merge
+Source: https://twpayne-chezmoi.mintlify.app/commands/merge
+
+Perform three-way merges between the destination, source, and target states
+
+The `merge` command performs a three-way merge between the destination state (your current file), the source state (in your chezmoi directory), and the target state (what chezmoi wants to apply).
+
+## Usage
+
+```bash theme={null}
+chezmoi merge target...
+```
+
+## Description
+
+The `merge` command invokes your configured merge tool to help resolve conflicts between three versions of a file:
+
+1. **Destination** - The current state of the file in your home directory
+2. **Source** - The file in chezmoi's source directory
+3. **Target** - The computed target state (templates evaluated, files decrypted, etc.)
+
+The merge tool is defined by the `merge.command` configuration variable and defaults to `vimdiff`. If multiple targets are specified, the merge tool is invoked separately and sequentially for each target.
+
+If the target state cannot be computed (e.g., a template with errors or an encrypted file that cannot be decrypted), a two-way merge is performed instead.
+
+## Merge Command Arguments
+
+The order of arguments to `merge.command` is set by `merge.args`. Each argument is interpreted as a template with these variables:
+
+* `.Destination` - Path to the file in the destination state
+* `.Source` - Path to the file in the source state
+* `.Target` - Path to the file in the target state
+
+Default value: `["{{ .Destination }}", "{{ .Source }}", "{{ .Target }}"]`
+
+If `merge.args` doesn't contain template arguments, the three paths will be appended automatically.
+
+## Configuration
+
+Configure your merge tool in your config file:
+
+```toml theme={null}
+[merge]
+    command = "vimdiff"
+```
+
+Common merge tools:
+
+```toml theme={null}
+# vimdiff (default)
+[merge]
+    command = "vimdiff"
+
+# meld
+[merge]
+    command = "meld"
+    args = ["{{ .Destination }}", "{{ .Source }}", "{{ .Target }}"]
+
+# kdiff3
+[merge]
+    command = "kdiff3"
+    args = ["{{ .Destination }}", "{{ .Source }}", "{{ .Target }}"]
+
+# VS Code
+[merge]
+    command = "code"
+    args = ["--wait", "--diff", "{{ .Destination }}", "{{ .Target }}"]
+```
+
+## Examples
+
+### Merge a single file
+
+```bash theme={null}
+chezmoi merge ~/.bashrc
+```
+
+Opens your merge tool with three versions of `.bashrc`.
+
+### Merge multiple files
+
+```bash theme={null}
+chezmoi merge ~/.bashrc ~/.vimrc
+```
+
+Opens the merge tool separately for each file.
+
+## Workflow
+
+1. **Detect conflict** - Use `chezmoi status` or `chezmoi diff` to identify files with conflicts
+2. **Merge** - Run `chezmoi merge <file>` to resolve conflicts
+3. **Review** - Use your merge tool to choose which changes to keep
+4. **Save** - The source file is automatically updated when you save and exit
+5. **Apply** - Run `chezmoi apply` to apply the merged changes
+
+## Example Workflow
+
+```bash theme={null}
+# Check status
+$ chezmoi status
+MM .bashrc
+
+# See what changed
+$ chezmoi diff ~/.bashrc
+
+# Merge to resolve conflicts  
+$ chezmoi merge ~/.bashrc
+# (merge tool opens, resolve conflicts, save and exit)
+
+# Verify the merge
+$ chezmoi diff ~/.bashrc
+
+# Apply changes
+$ chezmoi apply ~/.bashrc
+```
+
+## Encrypted Files
+
+For encrypted files, chezmoi automatically:
+
+1. Decrypts the source file to a temporary directory
+2. Invokes the merge tool with the decrypted plaintext
+3. Re-encrypts the file after you save and exit
+
+## Template Files
+
+For template files, the merge shows:
+
+* **Destination**: Your current file
+* **Source**: The template source with `{{ }}` syntax
+* **Target**: The evaluated template
+
+This allows you to see both the template logic and the final output.
+
+## Terminal Output
+
+```bash theme={null}
+$ chezmoi merge ~/.bashrc
+# (vimdiff opens with three-way split)
+# After resolving and saving:
+merged ~/.bashrc
+```
+
+## Related Commands
+
+* [diff](/commands/diff) - View differences before merging
+* [edit](/commands/edit) - Edit source files directly
+* [status](/commands/status) - Check for conflicts
+
+
+# Command Reference
+Source: https://twpayne-chezmoi.mintlify.app/commands/overview
+
+Complete reference for all chezmoi commands
+
+chezmoi provides a comprehensive set of commands for managing your dotfiles. Commands are organized into the following categories:
+
+## Daily Commands
+
+These are the commands you'll use most frequently:
+
+* [init](/commands/init) - Setup the source directory and optionally clone a repository
+* [add](/commands/add) - Add files to the source state
+* [edit](/commands/edit) - Edit the source state of files
+* [apply](/commands/apply) - Update the destination directory to match the target state
+* [update](/commands/update) - Pull changes from the source repository and apply them
+* [status](/commands/status) - Show the status of managed files
+* [diff](/commands/diff) - Show differences between target and destination state
+* [merge](/commands/merge) - Perform three-way merges between states
+
+## Inspection Commands
+
+Commands for inspecting the state of your dotfiles:
+
+* [cat](/commands/cat) - Print the target contents of a file
+* [execute-template](/commands/execute-template) - Execute templates
+* [managed](/commands/managed) - List managed files
+* [unmanaged](/commands/unmanaged) - List unmanaged files
+* [verify](/commands/verify) - Verify the destination state matches the target state
+
+## Utility Commands
+
+Utility commands for working with chezmoi:
+
+* [cd](/commands/cd) - Launch a shell in the source directory
+* [doctor](/commands/doctor) - Check your system for potential problems
+* [upgrade](/commands/upgrade) - Upgrade chezmoi to the latest version
+* [completion](/commands/completion) - Generate shell completion scripts
+
+## Global Flags
+
+All commands support these global flags:
+
+* `--color` *value* - Colorize output (default `auto`, options: `on`, `off`, `auto`)
+* `--config` *path* - Set config file path
+* `--config-format` *format* - Set config file format (json, jsonc, toml, yaml)
+* `--debug` - Include debug information in output
+* `--destination` *path* - Set destination directory
+* `--dry-run` / `-n` - Run without making changes
+* `--force` - Make changes without prompting
+* `--source` *path* - Set source directory
+* `--verbose` / `-v` - Make output more verbose
+* `--working-tree` *path* - Set working tree directory
+
+## Exit Codes
+
+chezmoi uses the following exit codes:
+
+* `0` - Success
+* `1` - Generic error
+* `2` - Verification failed (used by `verify` command)
+
+## Command Aliases
+
+Some commands have shorter aliases:
+
+* `manage` → `add`
+* `list` → `managed`
+
+
+# status
+Source: https://twpayne-chezmoi.mintlify.app/commands/status
+
+Show the status of files and scripts managed by chezmoi
+
+The `status` command prints the status of managed files and scripts in a format similar to `git status`.
+
+## Usage
+
+```bash theme={null}
+chezmoi status [target]...
+```
+
+## Description
+
+The `status` command shows a two-character status code for each managed file:
+
+* **First column**: Difference between the last state written by chezmoi and the actual state
+* **Second column**: Difference between the actual state and the target state (what `chezmoi apply` will do)
+
+## Status Codes
+
+| Character | Meaning   | First Column       | Second Column          |
+| --------- | --------- | ------------------ | ---------------------- |
+| Space     | No change | No change          | No change              |
+| `A`       | Added     | Entry was created  | Entry will be created  |
+| `D`       | Deleted   | Entry was deleted  | Entry will be deleted  |
+| `M`       | Modified  | Entry was modified | Entry will be modified |
+| `R`       | Run       | Not applicable     | Script will be run     |
+
+## Flags
+
+<ParamField type="types">
+  Exclude entry types (comma-separated: `dirs`, `files`, `remove`, `scripts`, `symlinks`, `always`, `encrypted`, `externals`, `templates`).
+</ParamField>
+
+<ParamField type="types">
+  Include only specified entry types (comma-separated: `dirs`, `files`, `remove`, `scripts`, `symlinks`, `always`, `encrypted`, `externals`, `templates`).
+</ParamField>
+
+<ParamField type="boolean">
+  Recreate the config file from the template in the source directory.
+</ParamField>
+
+<ParamField type="boolean">
+  Show status of all parent directories.
+</ParamField>
+
+<ParamField type="string">
+  Path style to use in output. Options: `absolute`, `relative`. Can be configured via `status.pathStyle` in the config file.
+</ParamField>
+
+<ParamField type="boolean">
+  Recurse into subdirectories.
+</ParamField>
+
+## Examples
+
+### Show status of all managed files
+
+```bash theme={null}
+chezmoi status
+```
+
+### Show status with absolute paths
+
+```bash theme={null}
+chezmoi status --path-style=absolute
+```
+
+### Show status for specific files
+
+```bash theme={null}
+chezmoi status ~/.bashrc ~/.vimrc
+```
+
+## Terminal Output
+
+```bash theme={null}
+$ chezmoi status
+ M .bashrc
+A  .gitconfig
+ D .vimrc
+MM .tmux.conf
+ R run_once_install-packages.sh
+```
+
+## Interpreting Output
+
+### Clean state (no output)
+
+```bash theme={null}
+$ chezmoi status
+$
+```
+
+All files match the target state. Nothing to do.
+
+### Modified in destination
+
+```bash theme={null}
+ M .bashrc
+```
+
+You modified `.bashrc` locally. `chezmoi apply` will overwrite it with the target state.
+
+### Modified in source
+
+```bash theme={null}
+M  .bashrc
+```
+
+The source state changed (e.g., you edited it or pulled changes). The destination file was not modified locally.
+
+### Modified in both
+
+```bash theme={null}
+MM .bashrc
+```
+
+Both the source and destination were modified. There may be a conflict. Use `chezmoi diff` or `chezmoi merge` to resolve.
+
+### Will be added
+
+```bash theme={null}
+A  .gitconfig
+```
+
+A new file will be created by `chezmoi apply`.
+
+### Will be deleted
+
+```bash theme={null}
+ D .vimrc
+```
+
+You deleted `.vimrc` from the source state. `chezmoi apply` will remove it from your home directory.
+
+### Script will run
+
+```bash theme={null}
+ R run_once_install-packages.sh
+```
+
+A script will be executed by `chezmoi apply`.
+
+## Common Workflows
+
+### Before applying changes
+
+```bash theme={null}
+chezmoi status    # See what will change
+chezmoi diff      # See detailed differences  
+chezmoi apply     # Apply the changes
+```
+
+### After making local changes
+
+```bash theme={null}
+chezmoi status    # Check status
+chezmoi diff      # Review changes
+chezmoi add ~/.bashrc  # Add changes to source state
+```
+
+### After pulling from repository
+
+```bash theme={null}
+chezmoi update --apply=false  # Pull changes
+chezmoi status    # See what changed
+chezmoi diff      # Review differences
+chezmoi apply     # Apply changes
+```
+
+### Checking for conflicts
+
+```bash theme={null}
+$ chezmoi status
+MM .bashrc        # Conflict detected
+MM .vimrc         # Another conflict
+
+$ chezmoi merge ~/.bashrc  # Resolve with merge tool
+$ chezmoi merge ~/.vimrc
+```
+
+## Exit Code
+
+The `status` command exits with code 0 even if there are differences. Use the output to determine if action is needed.
+
+## Related Commands
+
+* [diff](/commands/diff) - Show detailed differences
+* [apply](/commands/apply) - Apply changes shown in status
+* [merge](/commands/merge) - Resolve conflicts
+
+
+# unmanaged
+Source: https://twpayne-chezmoi.mintlify.app/commands/unmanaged
+
+List the unmanaged files in the destination directory
+
+The `unmanaged` command lists all files in your destination directory (typically your home directory) that are not managed by chezmoi.
+
+## Usage
+
+```bash theme={null}
+chezmoi unmanaged [path]...
+```
+
+## Description
+
+The `unmanaged` command shows files that exist in your home directory but are not tracked by chezmoi. This is useful for:
+
+* Finding files you might want to add to chezmoi
+* Identifying files that should be in `.chezmoiignore`
+* Cleaning up temporary or unnecessary files
+* Auditing your dotfile coverage
+
+Files listed in `.chezmoiignore` are not shown as unmanaged.
+
+## Flags
+
+<ParamField type="types">
+  Exclude entry types (comma-separated: `dirs`, `files`, `remove`, `scripts`, `symlinks`, `always`, `encrypted`, `externals`, `templates`).
+</ParamField>
+
+<ParamField type="types">
+  Include only specified entry types (comma-separated: `dirs`, `files`, `remove`, `scripts`, `symlinks`, `always`, `encrypted`, `externals`, `templates`).
+</ParamField>
+
+<ParamField type="boolean">
+  Use NUL character as path separator. Useful for piping to `xargs -0`.
+</ParamField>
+
+<ParamField type="string">
+  Path style to use. Options:
+
+  * `relative` - Paths relative to home directory
+  * `absolute` - Absolute paths
+</ParamField>
+
+<ParamField type="boolean">
+  Print paths as a tree structure.
+</ParamField>
+
+## Examples
+
+### List all unmanaged files
+
+```bash theme={null}
+chezmoi unmanaged
+```
+
+Output:
+
+```
+.bash_history
+.cache
+.local/bin/custom-script
+Downloads
+Documents
+```
+
+### List with absolute paths
+
+```bash theme={null}
+chezmoi unmanaged --path-style=absolute
+```
+
+Output:
+
+```
+/home/john/.bash_history
+/home/john/.cache
+/home/john/.local/bin/custom-script
+/home/john/Downloads
+/home/john/Documents
+```
+
+### List in tree format
+
+```bash theme={null}
+chezmoi unmanaged --tree
+```
+
+Output:
+
+```
+.
+├── .bash_history
+├── .cache
+├── .local
+│   └── bin
+│       └── custom-script
+├── Documents
+└── Downloads
+```
+
+### List unmanaged files in a specific directory
+
+```bash theme={null}
+chezmoi unmanaged ~/.config
+```
+
+Shows unmanaged files only within `~/.config`.
+
+### List only unmanaged regular files
+
+```bash theme={null}
+chezmoi unmanaged --include=files
+```
+
+Excludes directories and symlinks.
+
+### Use with xargs
+
+```bash theme={null}
+chezmoi unmanaged --nul-path-separator | xargs -0 ls -lh
+```
+
+Safely pass unmanaged files to other commands.
+
+## Common Workflows
+
+### Find dotfiles to add
+
+Find configuration files that aren't managed:
+
+```bash theme={null}
+chezmoi unmanaged | grep "^\."
+```
+
+Output:
+
+```
+.bashrc-backup
+.custom-config
+.local-settings
+```
+
+### Add important unmanaged files
+
+```bash theme={null}
+# Find important configs
+chezmoi unmanaged | grep -E "\.(bash|zsh|vim)rc"
+
+# Add them
+chezmoi add ~/.custom-bashrc
+```
+
+### Identify files to ignore
+
+Find files that should be in `.chezmoiignore`:
+
+```bash theme={null}
+# Check for temporary or cache files
+chezmoi unmanaged | grep -E "\.(log|cache|tmp)"
+
+# Add to .chezmoiignore
+echo ".*.log" >> ~/.local/share/chezmoi/.chezmoiignore
+```
+
+### Clean up unmanaged files
+
+```bash theme={null}
+# Review unmanaged files
+chezmoi unmanaged --tree
+
+# Remove temporary files
+chezmoi unmanaged | grep -E "\.(tmp|bak|old)$" | xargs rm
+```
+
+## Output Examples
+
+### Default output
+
+```bash theme={null}
+$ chezmoi unmanaged
+.bash_history
+.cache
+.lesshst
+.viminfo  
+Downloads
+```
+
+### Tree view
+
+```bash theme={null}
+$ chezmoi unmanaged --tree
+.
+├── .bash_history
+├── .cache
+│   ├── mozilla
+│   └── pip
+├── .lesshst
+├── .viminfo
+└── Downloads
+    └── file.zip
+```
+
+### In specific directory
+
+```bash theme={null}
+$ chezmoi unmanaged ~/.config
+.config/Slack
+.config/discord  
+.config/spotify
+```
+
+## Filtering Examples
+
+### Find large unmanaged files
+
+```bash theme={null}
+chezmoi unmanaged --path-style=absolute --include=files | \
+  xargs du -h | \
+  sort -rh | \
+  head -20
+```
+
+### Find unmanaged config files
+
+```bash theme={null}
+chezmoi unmanaged ~/.config --include=files
+```
+
+### Count unmanaged files
+
+```bash theme={null}
+chezmoi unmanaged | wc -l
+```
+
+## Understanding `.chezmoiignore`
+
+Files matching patterns in `.chezmoiignore` won't appear in `unmanaged` output:
+
+```bash theme={null}
+# ~/.local/share/chezmoi/.chezmoiignore
+.bash_history
+.cache/
+*.log
+*.tmp
+Downloads/
+Documents/
+```
+
+After adding this, those files won't show up:
+
+```bash theme={null}
+$ chezmoi unmanaged
+# Only shows files not in .chezmoiignore
+```
+
+## Practical Examples
+
+### Audit dotfile coverage
+
+Check which config files aren't managed:
+
+```bash theme={null}
+#!/bin/bash
+echo "Unmanaged dotfiles:"
+chezmoi unmanaged | grep "^\."
+
+echo "\nManaged dotfiles:"
+chezmoi managed | grep "^\."
+```
+
+### Find unmanaged scripts
+
+```bash theme={null}
+chezmoi unmanaged ~/.local/bin --include=files
+```
+
+### Generate ignore patterns
+
+Create `.chezmoiignore` entries from unmanaged files:
+
+```bash theme={null}
+chezmoi unmanaged | grep -E "\.(cache|log|tmp)" > /tmp/to-ignore.txt
+```
+
+### Interactive file addition
+
+```bash theme={null}
+#!/bin/bash
+for file in $(chezmoi unmanaged | grep "^\."); do
+    echo "Add $file to chezmoi? (y/n)"
+    read -r response
+    if [ "$response" = "y" ]; then
+        chezmoi add ~/$file
+    fi
+done
+```
+
+## Performance Note
+
+The `unmanaged` command may be slow on home directories with many files. To speed it up:
+
+1. Add common directories to `.chezmoiignore` (Downloads, Documents, etc.)
+2. Specify a subdirectory: `chezmoi unmanaged ~/.config`
+3. Exclude file types: `chezmoi unmanaged --exclude=dirs`
+
+## Related Commands
+
+* [managed](/commands/managed) - List managed files
+* [add](/commands/add) - Add unmanaged files to chezmoi
+* [status](/commands/status) - Show status of managed files
+
+
+# update
+Source: https://twpayne-chezmoi.mintlify.app/commands/update
+
+Pull changes from the source repository and apply them
+
+The `update` command pulls the latest changes from your source repository and optionally applies them to your system.
+
+## Usage
+
+```bash theme={null}
+chezmoi update
+```
+
+## Description
+
+The `update` command combines pulling changes from your version control system with applying those changes to your destination directory.
+
+**Default behavior:**
+
+* If `update.command` is set in the config, chezmoi runs that command with `update.args` in the working tree
+* Otherwise, chezmoi runs `git pull --autostash --rebase` (with `--recurse-submodules` if enabled)
+* Uses chezmoi's builtin git if `useBuiltinGit` is `true` or if `git.command` cannot be found in `$PATH`
+
+## Flags
+
+<ParamField type="boolean">
+  Apply changes after pulling. Can be disabled with `--apply=false`.
+</ParamField>
+
+<ParamField type="boolean">
+  Update submodules recursively. Can be disabled with `--recurse-submodules=false`. Can be configured via `update.recurseSubmodules` in the config file.
+</ParamField>
+
+<ParamField type="types">
+  Exclude entry types (comma-separated: `dirs`, `files`, `remove`, `scripts`, `symlinks`, `always`, `encrypted`, `externals`, `templates`).
+</ParamField>
+
+<ParamField type="types">
+  Include only specified entry types (comma-separated: `dirs`, `files`, `remove`, `scripts`, `symlinks`, `always`, `encrypted`, `externals`, `templates`).
+</ParamField>
+
+<ParamField type="boolean">
+  Recreate the config file from the template in the source directory.
+</ParamField>
+
+<ParamField type="boolean">
+  Apply changes to all parent directories.
+</ParamField>
+
+<ParamField type="boolean">
+  Recurse into subdirectories when applying.
+</ParamField>
+
+## Configuration
+
+You can customize the update behavior in your config file:
+
+```toml theme={null}
+[update]
+    command = "git"
+    args = ["pull", "--rebase"]
+    apply = true
+    recurseSubmodules = true
+```
+
+## Examples
+
+### Update and apply changes
+
+```bash theme={null}
+chezmoi update
+```
+
+This is equivalent to:
+
+```bash theme={null}
+cd ~/.local/share/chezmoi
+git pull --autostash --rebase
+chezmoi apply
+```
+
+### Update without applying
+
+```bash theme={null}
+chezmoi update --apply=false
+```
+
+Pulls changes but doesn't apply them. Useful when you want to review changes first.
+
+### Update with dry run
+
+```bash theme={null}
+chezmoi update --dry-run --verbose
+```
+
+Shows what changes would be pulled and applied without making any changes.
+
+### Update and check diff
+
+```bash theme={null}
+chezmoi update --apply=false
+chezmoi diff
+```
+
+Pull changes, review them, then apply manually if desired.
+
+## Terminal Output
+
+```bash theme={null}
+$ chezmoi update
+From github.com:username/dotfiles
+   abc1234..def5678  main -> origin/main
+Updating abc1234..def5678
+Fast-forward
+ .bashrc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+.bashrc: updating
+```
+
+## Related Commands
+
+* [init](/commands/init) - Initialize chezmoi with a repository
+* [apply](/commands/apply) - Apply changes without pulling
+* [diff](/commands/diff) - View differences before applying
+
+
+# upgrade
+Source: https://twpayne-chezmoi.mintlify.app/commands/upgrade
+
+Upgrade chezmoi to the latest released version
+
+The `upgrade` command upgrades chezmoi to the latest released version from GitHub.
+
+## Usage
+
+```bash theme={null}
+chezmoi upgrade
+```
+
+## Description
+
+The `upgrade` command automatically downloads and installs the latest stable version of chezmoi from the official GitHub releases. The upgrade method is automatically detected based on how chezmoi was installed.
+
+After upgrading, the new chezmoi version is executed with the `--version` flag to verify the upgrade was successful.
+
+## Upgrade Methods
+
+chezmoi automatically detects the appropriate upgrade method:
+
+* **replace-executable**: Direct binary replacement (most common)
+* **brew-upgrade**: Homebrew on macOS/Linux
+* **snap-refresh**: Snap on Linux
+* **winget-upgrade**: Windows Package Manager
+* **upgrade-package**: Package manager on Linux (APT, DNF, etc.)
+
+Use `chezmoi doctor` to see which upgrade method will be used.
+
+## Flags
+
+<ParamField type="string">
+  Path to the executable to replace. By default, uses the currently running chezmoi executable.
+</ParamField>
+
+<ParamField type="string">
+  Force a specific upgrade method. Options: `replace-executable`, `brew-upgrade`, `snap-refresh`, `winget-upgrade`, `upgrade-package`. If not specified, the method is automatically detected.
+</ParamField>
+
+## Examples
+
+### Upgrade to latest version
+
+```bash theme={null}
+chezmoi upgrade
+```
+
+### Force upgrade even if already on latest version
+
+```bash theme={null}
+chezmoi upgrade --force
+```
+
+Useful for reinstalling or fixing a broken installation.
+
+### Upgrade with specific method
+
+```bash theme={null}
+chezmoi upgrade --method=replace-executable
+```
+
+### Check what method will be used
+
+```bash theme={null}
+chezmoi doctor | grep upgrade-method
+```
+
+## Terminal Output
+
+### Successful upgrade
+
+```bash theme={null}
+$ chezmoi upgrade
+Downloading chezmoi v2.47.0...
+Installing...
+chezmoi version v2.47.0, commit abc1234def5678, built at 2024-01-20T10:30:00Z
+```
+
+### Already on latest version
+
+```bash theme={null}
+$ chezmoi upgrade  
+chezmoi: already at the latest version (v2.47.0)
+```
+
+### Forced upgrade
+
+```bash theme={null}
+$ chezmoi upgrade --force
+Downloading chezmoi v2.47.0...
+Installing...
+chezmoi version v2.47.0, commit abc1234def5678, built at 2024-01-20T10:30:00Z
+```
+
+## Platform-Specific Behavior
+
+### Linux
+
+On Linux, chezmoi determines whether to use:
+
+* **glibc** or **musl** builds (for x86\_64)
+* Package managers (if installed via APT, DNF, etc.)
+* Snap (if installed via Snap)
+* Direct binary replacement
+
+### macOS
+
+On macOS:
+
+* Uses Homebrew if chezmoi was installed via `brew`
+* Otherwise replaces the binary directly
+
+### Windows
+
+On Windows:
+
+* Uses WinGet if available
+* Otherwise downloads and replaces the `.exe` file
+* The old executable is renamed to `chezmoi.exe.old`
+
+## Automation
+
+### Automatic updates with cron
+
+```bash theme={null}
+# Check for updates daily
+0 0 * * * /usr/local/bin/chezmoi upgrade
+```
+
+### Systemd timer
+
+```ini theme={null}
+# /etc/systemd/system/chezmoi-upgrade.service
+[Unit]
+Description=Upgrade chezmoi
+
+[Service]
+Type=oneshot
+User=username
+ExecStart=/usr/local/bin/chezmoi upgrade
+```
+
+```ini theme={null}
+# /etc/systemd/system/chezmoi-upgrade.timer  
+[Unit]
+Description=Weekly chezmoi upgrade
+
+[Timer]
+OnCalendar=weekly
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable:
+
+```bash theme={null}
+systemctl enable --now chezmoi-upgrade.timer
+```
+
+### Upgrade notification script
+
+```bash theme={null}
+#!/bin/bash
+current_version=$(chezmoi --version | awk '{print $3}' | cut -d'v' -f2)
+latest_version=$(curl -s https://api.github.com/repos/twpayne/chezmoi/releases/latest | \
+                 grep '"tag_name":' | cut -d'"' -f4 | cut -d'v' -f2)
+
+if [ "$current_version" != "$latest_version" ]; then
+    echo "Chezmoi update available: v$current_version -> v$latest_version"
+    echo "Run 'chezmoi upgrade' to update"
+fi
+```
+
+## Troubleshooting
+
+### Permission denied
+
+If you get a permission error:
+
+```bash theme={null}
+# Make sure you have write permission
+ls -l $(which chezmoi)
+
+# If installed system-wide, use sudo
+sudo chezmoi upgrade
+
+# Or install to user directory
+chezmoi upgrade --executable ~/.local/bin/chezmoi
+```
+
+### Cannot determine upgrade method
+
+```bash theme={null}
+$ chezmoi upgrade
+error: linux/amd64: cannot determine upgrade method for /usr/local/bin/chezmoi
+```
+
+Specify the method explicitly:
+
+```bash theme={null}
+chezmoi upgrade --method=replace-executable
+```
+
+### Network errors
+
+If GitHub is unreachable:
+
+```bash theme={null}
+# Check network connectivity
+curl -I https://api.github.com
+
+# Use a proxy if needed
+export HTTPS_PROXY=http://proxy.example.com:8080
+chezmoi upgrade
+```
+
+### Dev version warning
+
+```bash theme={null}
+$ chezmoi upgrade
+error: cannot upgrade dev version to latest released version unless --force is set
+```
+
+If you're running a development build, use `--force`:
+
+```bash theme={null}
+chezmoi upgrade --force
+```
+
+## Manual Upgrade
+
+If automatic upgrade fails, manually download from GitHub:
+
+```bash theme={null}
+# Linux x86_64
+curl -sfL https://github.com/twpayne/chezmoi/releases/latest/download/chezmoi-linux-amd64.tar.gz | \
+  tar -xz -C ~/.local/bin
+
+# macOS ARM64
+curl -sfL https://github.com/twpayne/chezmoi/releases/latest/download/chezmoi-darwin-arm64.tar.gz | \
+  tar -xz -C ~/.local/bin
+
+# Verify
+chezmoi --version
+```
+
+## Upgrade via Package Managers
+
+### Homebrew
+
+```bash theme={null}
+brew update
+brew upgrade chezmoi
+```
+
+### Snap
+
+```bash theme={null}
+sudo snap refresh chezmoi
+```
+
+### APT (Ubuntu/Debian)
+
+If installed from PPA:
+
+```bash theme={null}
+sudo apt update
+sudo apt upgrade chezmoi
+```
+
+### Pacman (Arch Linux)
+
+```bash theme={null}
+sudo pacman -Syu chezmoi
+```
+
+### Scoop (Windows)
+
+```powershell theme={null}
+scoop update chezmoi
+```
+
+## Downgrading
+
+If you need to downgrade:
+
+```bash theme={null}
+# Find the version you want
+chown +x install.sh
+
+# Install specific version
+sh -c "$(curl -fsLS get.chezmoi.io)" -- -b ~/.local/bin v2.46.0
+```
+
+## Checking for Updates
+
+### Check current version
+
+```bash theme={null}
+chezmoi --version
+```
+
+### Check latest version
+
+```bash theme={null}
+curl -s https://api.github.com/repos/twpayne/chezmoi/releases/latest | \
+  grep '"tag_name":' | cut -d'"' -f4
+```
+
+### Compare versions
+
+```bash theme={null}
+chezm doctor | grep -E "(version|latest-version)"
+```
+
+## Related Commands
+
+* [doctor](/commands/doctor) - Check upgrade method and version
+
+
+# verify
+Source: https://twpayne-chezmoi.mintlify.app/commands/verify
+
+Verify that the destination state matches the target state
+
+The `verify` command checks that the destination directory matches the target state. It exits with success if they match, and fails otherwise.
+
+## Usage
+
+```bash theme={null}
+chezmoi verify [target]...
+```
+
+## Description
+
+The `verify` command performs the same operations as `chezmoi apply` but on a read-only file system. If any changes would be made, the command exits with an error code.
+
+This is useful for:
+
+* **CI/CD pipelines**: Verify dotfiles are correctly applied in automated environments
+* **Monitoring**: Check if configuration drift has occurred
+* **Testing**: Validate that `chezmoi apply` was successful
+* **Auditing**: Confirm system state matches expected configuration
+
+## Exit Codes
+
+* `0` - Success: destination state matches target state
+* `1` - Failure: destination state differs from target state
+
+## Flags
+
+<ParamField type="types">
+  Exclude entry types (comma-separated: `dirs`, `files`, `remove`, `scripts`, `symlinks`, `always`, `encrypted`, `externals`, `templates`).
+</ParamField>
+
+<ParamField type="types">
+  Include only specified entry types (comma-separated: `dirs`, `files`, `remove`, `scripts`, `symlinks`, `always`, `encrypted`, `externals`, `templates`).
+</ParamField>
+
+<ParamField type="boolean">
+  Recreate the config file from the template in the source directory.
+</ParamField>
+
+<ParamField type="boolean">
+  Verify all parent directories.
+</ParamField>
+
+<ParamField type="boolean">
+  Recurse into subdirectories.
+</ParamField>
+
+## Examples
+
+### Verify all files
+
+```bash theme={null}
+chezmoi verify
+```
+
+Exits with code 0 if everything matches, code 1 if differences exist.
+
+### Verify specific files
+
+```bash theme={null}
+chezmoi verify ~/.bashrc ~/.vimrc
+```
+
+### Verify with verbose output
+
+```bash theme={null}
+chezmoi verify --verbose
+```
+
+Shows which files are being checked.
+
+### Check exit code
+
+```bash theme={null}
+if chezmoi verify; then
+    echo "All files match!"
+else
+    echo "Configuration drift detected!"
+    exit 1
+fi
+```
+
+## CI/CD Usage
+
+### GitHub Actions
+
+```yaml theme={null}
+name: Verify Dotfiles
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 0 * * *'  # Daily
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Install chezmoi
+        run: |
+          sh -c "$(curl -fsLS get.chezmoi.io)" -- -b ~/.local/bin
+          
+      - name: Initialize chezmoi
+        run: |
+          chezmoi init --source=$GITHUB_WORKSPACE
+          chezmoi apply
+          
+      - name: Verify configuration
+        run: chezmoi verify
+```
+
+### GitLab CI
+
+```yaml theme={null}
+verify-dotfiles:
+  stage: test
+  script:
+    - curl -sfL https://git.io/chezmoi | sh
+    - ./bin/chezmoi init --source=.
+    - ./bin/chezmoi apply
+    - ./bin/chezmoi verify
+  only:
+    - main
+```
+
+### Jenkins
+
+```groovy theme={null}
+stage('Verify Dotfiles') {
+    steps {
+        sh '''
+            curl -sfL https://git.io/chezmoi | sh
+            ./bin/chezmoi init --source=.
+            ./bin/chezmoi apply  
+            ./bin/chezmoi verify
+        '''
+    }
+}
+```
+
+## Monitoring
+
+### Cron job for drift detection
+
+```bash theme={null}
+#!/bin/bash
+# /etc/cron.daily/check-dotfiles
+
+if ! chezmoi verify --quiet; then
+    echo "Configuration drift detected!" | \
+        mail -s "Dotfile Verification Failed" admin@example.com
+fi
+```
+
+### Systemd timer
+
+```ini theme={null}
+# /etc/systemd/system/chezmoi-verify.service
+[Unit]
+Description=Verify dotfiles with chezmoi
+
+[Service]
+Type=oneshot  
+User=username
+ExecStart=/usr/bin/chezmoi verify
+```
+
+```ini theme={null}
+# /etc/systemd/system/chezmoi-verify.timer
+[Unit]
+Description=Daily dotfile verification
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable:
+
+```bash theme={null}
+systemctl enable --now chezmoi-verify.timer
+```
+
+## Terminal Output
+
+### Success
+
+```bash theme={null}
+$ chezmoi verify
+$ echo $?
+0
+```
+
+### Failure
+
+```bash theme={null}
+$ chezmoi verify
+error: .bashrc: contents differ
+error: .vimrc: not in destination state
+$ echo $?
+1
+```
+
+### Verbose mode
+
+```bash theme={null}
+$ chezmoi verify --verbose
+.bashrc: verifying
+.gitconfig: verifying
+.vimrc: verifying  
+error: .bashrc: contents differ
+$ echo $?
+1
+```
+
+## Troubleshooting
+
+### Find which files differ
+
+```bash theme={null}
+chezmoi verify || chezmoi status
+```
+
+If verification fails, check status to see what's different.
+
+### Get detailed differences
+
+```bash theme={null}
+chezmoi verify || chezmoi diff
+```
+
+Show exactly what differs.
+
+### Fix verification failures
+
+```bash theme={null}
+if ! chezmoi verify; then
+    echo "Differences found. Applying..."
+    chezmoi apply
+    chezmoi verify  # Verify again
+fi
+```
+
+## Common Patterns
+
+### Verify before and after apply
+
+```bash theme={null}
+# Should fail if changes needed
+chezmoi verify || echo "Changes needed"
+
+# Apply changes
+chezmoi apply
+
+# Should now succeed
+chezmoi verify && echo "Verified!"
+```
+
+### Verify subset of files
+
+```bash theme={null}
+# Only verify config files
+chezmoi verify --include=files ~/.config
+```
+
+### Verify in Docker
+
+```dockerfile theme={null}
+FROM ubuntu:latest
+
+# Install chezmoi
+RUN sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/local/bin
+
+# Copy dotfiles
+COPY . /root/.local/share/chezmoi
+
+# Apply and verify
+RUN chezmoi init --source /root/.local/share/chezmoi && \
+    chezmoi apply && \
+    chezmoi verify
+```
+
+## Related Commands
+
+* [apply](/commands/apply) - Apply changes to match target state
+* [status](/commands/status) - Show what differs
+* [diff](/commands/diff) - Show detailed differences
+
+
+# Articles and Blog Posts
+Source: https://twpayne-chezmoi.mintlify.app/community/articles
+
+Community articles, tutorials, and blog posts about chezmoi
+
+Discover articles, tutorials, and blog posts written by the chezmoi community.
+
+## Finding Articles
+
+<CardGroup>
+  <Card title="Hacker News" icon="newspaper" href="https://hn.algolia.com/?dateRange=all&page=0&prefix=false&query=chezmoi&sort=byDate&type=comment">
+    Search for chezmoi discussions on Hacker News
+  </Card>
+
+  <Card title="Reddit" icon="reddit" href="https://www.reddit.com/search/?q=chezmoi+dotfiles&sort=new">
+    Find chezmoi posts and discussions on Reddit
+  </Card>
+
+  <Card title="Stack Overflow" icon="stack-overflow" href="https://stackoverflow.com/questions/tagged/chezmoi">
+    Browse chezmoi questions and answers
+  </Card>
+
+  <Card title="LinkedIn" icon="linkedin" href="https://www.linkedin.com/search/results/all/?keywords=chezmoi%20dotfiles&origin=GLOBAL_SEARCH_HEADER">
+    Professional articles and discussions about chezmoi
+  </Card>
+</CardGroup>
+
+## Community Blogs
+
+<CardGroup>
+  <Card title="lobste.rs Stories" icon="link" href="https://lobste.rs/search?q=chezmoi&what=stories&order=newest">
+    Technical articles shared on lobste.rs
+  </Card>
+
+  <Card title="lobste.rs Comments" icon="comments" href="https://lobste.rs/search?q=chezmoi&what=comments&order=newest">
+    Community discussions and insights
+  </Card>
+</CardGroup>
+
+## Writing About chezmoi
+
+We encourage you to share your experiences with chezmoi! Here are some ideas for articles:
+
+### Getting Started Guides
+
+* How I set up chezmoi for the first time
+* Migrating from another dotfile manager to chezmoi
+* Bootstrapping a new machine with chezmoi
+* Setting up chezmoi with your specific tech stack
+
+### Advanced Tutorials
+
+* Using templates to manage different environments
+* Integrating chezmoi with your password manager
+* Encrypting secrets with age or GPG
+* Managing dotfiles across Windows, macOS, and Linux
+* Using chezmoi in CI/CD pipelines
+
+### Use Cases
+
+* How I use chezmoi at work
+* Managing dotfiles for a team
+* Using chezmoi for system configuration
+* Combining chezmoi with other tools
+
+### Tips and Tricks
+
+* My favorite chezmoi features
+* Template functions you should know about
+* Organizing your dotfiles repository
+* Debugging chezmoi issues
+
+## Sharing Your Article
+
+After writing an article about chezmoi, consider sharing it:
+
+1. **Social media**: Post on Reddit, Twitter, LinkedIn
+2. **Communities**: Share on Hacker News, lobste.rs
+3. **GitHub Discussions**: Start a discussion in the [chezmoi repository](https://github.com/twpayne/chezmoi/discussions)
+
+## Featured Topics
+
+### Template System
+
+Articles about chezmoi's powerful template system are particularly valuable:
+
+* Using template functions
+* Conditional configuration
+* Machine-specific settings
+* Data files and templates
+
+### Security and Secrets
+
+Content about managing secrets securely:
+
+* Encryption best practices
+* Password manager integration
+* Handling API keys and tokens
+* Security considerations
+
+### Cross-Platform Management
+
+Guides for managing dotfiles across different operating systems:
+
+* Windows-specific configurations
+* macOS vs Linux differences
+* Platform-specific templates
+* Universal dotfiles
+
+## See Also
+
+* [Videos](/community/videos) - Video tutorials and presentations
+* [Dotfile Repos](/community/dotfile-repos) - Example dotfile repositories
+
+
+# Comparison Table
+Source: https://twpayne-chezmoi.mintlify.app/community/comparison-table
+
+Feature comparison between chezmoi and other dotfile managers
+
+This table compares chezmoi with other popular dotfile management solutions to help you understand the differences and choose the right tool for your needs.
+
+## Feature Comparison
+
+| Feature                                    | chezmoi       | dotbot            | rcm               | vcsh                     | yadm                         | bare git |
+| ------------------------------------------ | ------------- | ----------------- | ----------------- | ------------------------ | ---------------------------- | -------- |
+| **Distribution**                           | Single binary | Python package    | Multiple files    | Single script or package | Single script                | -        |
+| **Install method**                         | Many          | git submodule     | Many              | Many                     | Many                         | Manual   |
+| **Non-root install on bare system**        | ✅             | ⁉️                | ✅                 | ✅                        | ✅                            | ✅        |
+| **Windows support**                        | ✅             | ✅                 | ❌                 | ❌                        | ✅                            | ✅        |
+| **Bootstrap requirements**                 | None          | Python, git       | Bash              | sh, git                  | git                          | git      |
+| **Source repos**                           | Single        | Single            | Multiple          | Multiple                 | Single                       | Single   |
+| **dotfiles are...**                        | Files         | Symlinks          | Symlinks          | Files                    | Files                        | Files    |
+| **Config file**                            | Optional      | Required          | Optional          | None                     | Optional                     | Optional |
+| **Private files**                          | ✅             | ❌                 | ❌                 | ❌                        | ✅                            | ❌        |
+| **Show differences without applying**      | ✅             | ❌                 | ❌                 | ✅                        | ✅                            | ✅        |
+| **Whole file encryption**                  | ✅             | ❌                 | ❌                 | ❌                        | ✅                            | ❌        |
+| **Password manager integration**           | ✅             | ❌                 | ❌                 | ❌                        | ❌                            | ❌        |
+| **Machine-to-machine file differences**    | Templates     | Alternative files | Alternative files | Branches                 | Alternative files, templates | ⁉️       |
+| **Custom variables in templates**          | ✅             | ❌                 | ❌                 | ❌                        | ❌                            | ❌        |
+| **Executable files**                       | ✅             | ✅                 | ✅                 | ✅                        | ✅                            | ✅        |
+| **File creation with initial contents**    | ✅             | ❌                 | ❌                 | ✅                        | ❌                            | ❌        |
+| **Externals**                              | ✅             | ❌                 | ❌                 | ❌                        | ❌                            | ❌        |
+| **Manage partial files**                   | ✅             | ❌                 | ❌                 | ⁉️                       | ✅                            | ⁉️       |
+| **File removal**                           | ✅             | ❌                 | ❌                 | ✅                        | ✅                            | ❌        |
+| **Directory creation**                     | ✅             | ✅                 | ✅                 | ✅                        | ✅                            | ✅        |
+| **Run scripts**                            | ✅             | ✅                 | ✅                 | ✅                        | ✅                            | ❌        |
+| **Run once scripts**                       | ✅             | ❌                 | ❌                 | ✅                        | ✅                            | ❌        |
+| **Machine-to-machine symlink differences** | ✅             | ❌                 | ❌                 | ⁉️                       | ✅                            | ⁉️       |
+| **Shell completion**                       | ✅             | ❌                 | ❌                 | ✅                        | ✅                            | ✅        |
+| **Archive import**                         | ✅             | ❌                 | ❌                 | ✅                        | ❌                            | ✅        |
+| **Archive export**                         | ✅             | ❌                 | ❌                 | ✅                        | ❌                            | ✅        |
+| **Implementation language**                | Go            | Python            | Bash              | POSIX Shell              | Bash                         | C        |
+
+## Legend
+
+* ✅ Supported
+* ⁉️ Possible with significant manual effort
+* ❌ Not supported
+
+## Key Differentiators
+
+### Single Binary Distribution
+
+chezmoi is distributed as a single, statically-linked binary with no runtime dependencies. This makes it:
+
+* Easy to install on any system
+* Perfect for bootstrapping new machines
+* Portable across different environments
+
+### Template System
+
+chezmoi's powerful template system allows you to:
+
+* Use different configurations on different machines
+* Include custom variables and logic
+* Integrate with password managers
+* Generate files dynamically
+
+### Encryption Support
+
+chezmoi provides built-in support for:
+
+* Age encryption
+* GPG encryption
+* Encrypted files in your repository
+* Secure secret management
+
+### Password Manager Integration
+
+Seamless integration with popular password managers:
+
+* 1Password
+* Bitwarden
+* LastPass
+* pass
+* And many others
+
+## Choosing the Right Tool
+
+### Choose chezmoi if you need:
+
+* Cross-platform support (especially Windows)
+* Template-based configuration
+* Encryption and secret management
+* Password manager integration
+* Zero bootstrap dependencies
+
+### Consider alternatives if you:
+
+* Prefer symlink-based management (dotbot, rcm)
+* Want multiple separate repositories (vcsh)
+* Need a simpler, script-based solution (bare git)
+* Are already invested in a specific ecosystem
+
+## Additional Resources
+
+For more comparisons and dotfile management tools, visit [dotfiles.github.io/utilities](https://dotfiles.github.io/utilities/).
+
+## Links
+
+* [chezmoi](https://chezmoi.io/)
+* [dotbot](https://github.com/anishathalye/dotbot)
+* [rcm](https://github.com/thoughtbot/rcm)
+* [vcsh](https://github.com/RichiH/vcsh)
+* [yadm](https://yadm.io/)
+* [bare git](https://www.atlassian.com/git/tutorials/dotfiles)
+
+
+# Dotfile Repositories
+Source: https://twpayne-chezmoi.mintlify.app/community/dotfile-repos
+
+Browse and learn from community dotfile repositories using chezmoi
+
+Explore dotfile repositories from the chezmoi community to learn best practices, discover new techniques, and get inspiration for your own configuration.
+
+## Repository Platforms
+
+<CardGroup>
+  <Card title="GitHub" icon="github" href="https://github.com/topics/chezmoi?o=desc&s=updated">
+    Browse chezmoi repositories on GitHub, sorted by recent activity
+  </Card>
+
+  <Card title="GitLab" icon="gitlab" href="https://gitlab.com/explore/projects/topics/chezmoi">
+    Explore chezmoi projects on GitLab
+  </Card>
+
+  <Card title="Codeberg" icon="code" href="https://codeberg.org/explore/repos?sort=recentupdate&q=chezmoi&tab=">
+    Discover chezmoi repositories on Codeberg
+  </Card>
+</CardGroup>
+
+## Why Browse Dotfile Repos?
+
+### Learn by Example
+
+* See how others structure their dotfiles
+* Discover new chezmoi features in action
+* Find solutions to common problems
+* Get ideas for your own configuration
+
+### Best Practices
+
+* Template organization patterns
+* Secret management approaches
+* Cross-platform configuration strategies
+* Script organization and automation
+
+### Inspiration
+
+* Shell configurations (bash, zsh, fish)
+* Editor setups (Vim, Neovim, Emacs, VS Code)
+* Terminal multiplexer configs (tmux, screen)
+* Window manager configurations
+* Tool configurations (git, ssh, etc.)
+
+## What to Look For
+
+### Repository Structure
+
+Well-organized repositories typically include:
+
+* Clear README with setup instructions
+* Organized directory structure
+* Documented templates and scripts
+* Platform-specific configurations
+
+### Template Usage
+
+Look for examples of:
+
+* Conditional configuration based on OS
+* Machine-specific settings
+* Template functions and variables
+* Data files (`.chezmoidata.yaml`)
+
+### Secret Management
+
+Examples of handling secrets:
+
+* Encrypted files
+* Password manager integration
+* Template-based secret injection
+* External file references
+
+### Scripts and Automation
+
+* `run_once_` scripts for one-time setup
+* `run_onchange_` scripts for configuration updates
+* Package installation automation
+* System configuration scripts
+
+## Common Patterns
+
+### Basic Structure
+
+```
+~/.local/share/chezmoi/
+├── .chezmoi.yaml.tmpl          # Config file template
+├── .chezmoiignore              # Ignored files
+├── .chezmoitemplates/          # Reusable templates
+├── dot_bashrc.tmpl             # Shell configuration
+├── dot_gitconfig.tmpl          # Git configuration
+└── run_once_install-packages.sh # Setup script
+```
+
+### Platform-Specific Files
+
+```
+~/.local/share/chezmoi/
+├── dot_bashrc.tmpl
+├── dot_bashrc.linux.tmpl       # Linux-specific
+├── dot_bashrc.darwin.tmpl      # macOS-specific
+└── dot_bashrc.windows.tmpl     # Windows-specific
+```
+
+### Template Data Files
+
+```yaml theme={null}
+# .chezmoidata.yaml
+email: "user@example.com"
+git:
+  signing_key: "ABC123"
+editor: "nvim"
+```
+
+## Tips for Learning
+
+### Start Small
+
+* Don't try to copy entire configurations
+* Pick specific features you need
+* Understand before implementing
+* Test changes incrementally
+
+### Use as Reference
+
+* Bookmark useful repositories
+* Study different approaches to the same problem
+* Compare implementations
+* Adapt ideas to your needs
+
+### Respect Licenses
+
+* Check repository licenses before using code
+* Give credit where due
+* Follow license terms
+* Consider licensing your own dotfiles
+
+## Sharing Your Dotfiles
+
+Consider making your dotfiles public to help others:
+
+### Benefits
+
+* Contribute to the community
+* Get feedback on your configuration
+* Help others learn
+* Document your setup for yourself
+
+### What to Include
+
+* **README**: Installation instructions, features, requirements
+* **LICENSE**: Choose an open source license
+* **Documentation**: Explain unique configurations
+* **Screenshots**: Show your setup in action
+
+### What to Exclude
+
+* Private API keys or tokens
+* Personal email addresses or phone numbers
+* Company-specific information
+* Sensitive file contents
+
+Use encryption or templates to handle secrets properly.
+
+### Tagging Your Repository
+
+Help others find your dotfiles:
+
+* Add the `chezmoi` topic/tag
+* Include `dotfiles` tag
+* Add platform tags (linux, macos, windows)
+* Include tool tags (vim, zsh, tmux, etc.)
+
+## Popular Configuration Types
+
+### Shell Configurations
+
+* bash
+* zsh (with oh-my-zsh, prezto)
+* fish
+* PowerShell
+
+### Editor Configurations
+
+* Vim/Neovim
+* Emacs
+* VS Code
+* Sublime Text
+
+### Terminal Tools
+
+* tmux
+* screen
+* Alacritty
+* kitty
+* WezTerm
+
+### Window Managers
+
+* i3
+* sway
+* Xmonad
+* awesome
+
+### Development Tools
+
+* Git
+* SSH
+* GPG
+* Docker
+
+## Community Highlights
+
+When you find particularly helpful repositories:
+
+* Star them for future reference
+* Consider contributing improvements
+* Share them with others
+* Learn from their approach
+
+## See Also
+
+* [Articles](/community/articles) - Written guides and tutorials
+* [Videos](/community/videos) - Video tutorials and presentations
+
+
+# Related Software
+Source: https://twpayne-chezmoi.mintlify.app/community/related-software
+
+Tools, plugins, and integrations that work with chezmoi
+
+Discover software that integrates with chezmoi or enhances your dotfile management experience.
+
+## Editor Integration
+
+### NeoVim Plugins
+
+<CardGroup>
+  <Card title="nvim-chezmoi" icon="code" href="https://github.com/andre-kotake/nvim-chezmoi">
+    A NeoVim plugin that integrates with chezmoi
+  </Card>
+
+  <Card title="chezmoi.nvim" icon="code" href="https://github.com/xvzc/chezmoi.nvim">
+    Edit your chezmoi-managed files and automatically apply
+  </Card>
+
+  <Card title="chezmoi-telescope.nvim" icon="search" href="https://github.com/GianniBYoung/chezmoi-telescope.nvim">
+    Custom Telescope picker for chezmoi managed dotfiles
+  </Card>
+</CardGroup>
+
+### Vim Plugins
+
+<CardGroup>
+  <Card title="chezmoi.vim" icon="code" href="https://github.com/alker0/chezmoi.vim">
+    Intelligent VIM syntax highlighting when editing files in your source directory. Works with both `chezmoi edit` and editing files directly.
+  </Card>
+
+  <Card title="vim-chezmoi" icon="code" href="https://github.com/Lilja/vim-chezmoi">
+    A plugin for VIM to apply the dotfile you are editing on `:w`
+  </Card>
+</CardGroup>
+
+### Emacs Packages
+
+<CardGroup>
+  <Card title="chezmoi.el" icon="code" href="https://github.com/tuh8888/chezmoi.el">
+    Convenience functions for interacting with chezmoi in Emacs
+  </Card>
+
+  <Card title="tmpl-mode" icon="code" href="https://github.com/Lindydancer/tmpl-mode">
+    Emacs minor mode for "tmpl" template files
+  </Card>
+</CardGroup>
+
+## Shell Integration
+
+<CardGroup>
+  <Card title="zsh-chezmoi" icon="terminal" href="https://github.com/mass8326/zsh-chezmoi">
+    Add completion and aliases for chezmoi to make managing dotfiles easier in zsh
+  </Card>
+
+  <Card title="fish-chezmoi" icon="terminal" href="https://github.com/halostatue/fish-chezmoi">
+    A plugin for the Fish shell that ensures completions are always loaded and a function that wraps `chezmoi cd`
+  </Card>
+</CardGroup>
+
+## UI Tools
+
+<CardGroup>
+  <Card title="chezmoi-ui" icon="desktop" href="https://github.com/johan-weitner/chezmoi-ui">
+    A web UI for managing a list of apps to seed/feed a chezmoi setup
+  </Card>
+
+  <Card title="chezmoi-mousse" icon="desktop" href="https://github.com/matmaer/chezmoi-mousse">
+    Visual interface in the terminal for the chezmoi dotfile manager, with a wink to the mouse
+  </Card>
+</CardGroup>
+
+## System Integration
+
+### Root File Management
+
+<CardGroup>
+  <Card title="chezroot" icon="lock" href="https://github.com/main-branch/chezroot">
+    A `sudo` wrapper for chezmoi to manage root-owned files across your entire filesystem
+  </Card>
+
+  <Card title="Chezetc" icon="lock" href="https://silverrainz.me/chezetc/">
+    Extending chezmoi to manage files under /etc and other root-owned directories
+  </Card>
+</CardGroup>
+
+### Package Managers
+
+<CardGroup>
+  <Card title="asdf-chezmoi" icon="package" href="https://github.com/joke/asdf-chezmoi">
+    chezmoi plugin for asdf version manager
+  </Card>
+
+  <Card title="ansible-role-chezmoi" icon="package" href="https://github.com/hussainweb/ansible-role-chezmoi">
+    Installs chezmoi on Ubuntu and Debian servers
+  </Card>
+</CardGroup>
+
+## Utilities
+
+### Configuration Management
+
+<CardGroup>
+  <Card title="drapeau" icon="palette" href="https://github.com/tcaxle/drapeau">
+    An add-on to synchronize your color schemes across systems and allow easy colorscheme switching using chezmoi templates
+  </Card>
+
+  <Card title="chezmoi_modify_manager" icon="wrench" href="https://github.com/VorpalBlade/chezmoi_modify_manager">
+    An add-on to deal with config files that contain a mix of settings and transient state, such as GUI program settings
+  </Card>
+</CardGroup>
+
+### System Tools
+
+<CardGroup>
+  <Card title="atuin" icon="clock" href="https://atuin.sh/">
+    Sync, search and backup shell history. Works great with chezmoi for complete dotfile management
+  </Card>
+
+  <Card title="xdg-ninja" icon="broom" href="https://github.com/b3nj5m1n/xdg-ninja">
+    A shell script which checks your \$HOME for unwanted files and directories
+  </Card>
+</CardGroup>
+
+## Complete Solutions
+
+<Card title="install.doctor" icon="stethoscope" href="https://install.doctor">
+  Desktop provisioning system that uses chezmoi as part of a complete system setup solution
+</Card>
+
+## Building Your Own Integration
+
+Interested in building a tool that integrates with chezmoi?
+
+<Card title="Building on Top of chezmoi" icon="hammer" href="/developer/building-on-top-of-chezmoi">
+  Learn how to integrate with chezmoi and use its APIs
+</Card>
+
+## Categories
+
+### By Use Case
+
+* **Editing**: Vim, NeoVim, and Emacs plugins for editing dotfiles
+* **Shell**: Completion and convenience functions for shells
+* **Automation**: Scripts and tools for automated setup
+* **Security**: Tools for managing secrets and root files
+* **UI**: Graphical and TUI interfaces for chezmoi
+
+### By Platform
+
+* **Linux**: Most tools work on Linux
+* **macOS**: Most tools work on macOS
+* **Windows**: Check individual tool compatibility
+* **BSD**: Some tools support BSD systems
+
+## Contributing
+
+If you've built a tool that works with chezmoi:
+
+1. Add the `chezmoi` topic to your repository
+2. Share it in [GitHub Discussions](https://github.com/twpayne/chezmoi/discussions)
+3. Consider submitting a PR to add it to the official documentation
+
+## See Also
+
+* [Dotfile Repos](/community/dotfile-repos) - Example dotfile repositories
+* [Articles](/community/articles) - Articles about chezmoi integrations
+
+
+# Videos and Presentations
+Source: https://twpayne-chezmoi.mintlify.app/community/videos
+
+Video tutorials, talks, and presentations about chezmoi
+
+Watch video tutorials, conference talks, and presentations about chezmoi from the community.
+
+## Finding Videos
+
+<Card title="YouTube" icon="youtube" href="https://www.youtube.com/results?search_query=%22chezmoi%22+dotfiles">
+  Search for chezmoi videos on YouTube
+</Card>
+
+## Types of Videos
+
+### Tutorial Videos
+
+Learn chezmoi through step-by-step video tutorials:
+
+* Getting started with chezmoi
+* Installation and setup
+* Basic commands and workflows
+* Managing your first dotfiles
+
+### Advanced Tutorials
+
+Dive deeper into advanced features:
+
+* Template system deep dives
+* Encryption and secret management
+* Password manager integration
+* Cross-platform configuration
+
+### Live Coding Sessions
+
+Watch developers use chezmoi in real-world scenarios:
+
+* Setting up a development environment
+* Migrating existing dotfiles
+* Troubleshooting common issues
+* Best practices and workflows
+
+### Conference Talks
+
+Presentations from conferences and meetups:
+
+* chezmoi architecture and design
+* Dotfile management strategies
+* Tools and automation
+* Developer productivity
+
+## Creating Videos
+
+We welcome video content about chezmoi! Consider creating:
+
+### Beginner-Friendly Content
+
+* Installation walkthrough
+* Your first dotfile with chezmoi
+* Understanding the basics
+* Common use cases
+
+### Intermediate Tutorials
+
+* Working with templates
+* Managing multiple machines
+* Integrating with other tools
+* Organizing your dotfiles
+
+### Advanced Topics
+
+* Complex template scenarios
+* Custom scripts and automation
+* Security best practices
+* Performance optimization
+
+### Screencast Ideas
+
+* Quick tips and tricks (5-10 minutes)
+* Full setup from scratch (20-30 minutes)
+* Solving specific problems
+* Feature demonstrations
+
+## Video Production Tips
+
+### Content Planning
+
+* Outline your content before recording
+* Focus on one topic per video
+* Include practical examples
+* Show real-world use cases
+
+### Technical Setup
+
+* Use a good screen recording tool (OBS, ScreenFlow, etc.)
+* Ensure clear audio quality
+* Use a readable terminal font and theme
+* Increase terminal font size for visibility
+
+### Presentation Style
+
+* Speak clearly and at a moderate pace
+* Explain what you're doing as you do it
+* Pause between major steps
+* Include error handling and troubleshooting
+
+### Post-Production
+
+* Edit out long pauses and mistakes
+* Add chapters for longer videos
+* Include timestamps in the description
+* Add links to resources in the description
+
+## Sharing Your Videos
+
+After creating a video about chezmoi:
+
+1. **YouTube**: Upload with good metadata
+   * Clear title with "chezmoi" in it
+   * Detailed description
+   * Relevant tags
+   * Custom thumbnail
+
+2. **Social Media**: Share on
+   * Reddit (r/commandline, r/linux, etc.)
+   * Twitter
+   * LinkedIn
+   * Mastodon
+
+3. **Community**: Post in
+   * [GitHub Discussions](https://github.com/twpayne/chezmoi/discussions)
+   * Hacker News
+   * lobste.rs
+
+## Video Topics in Demand
+
+### Platform-Specific
+
+* chezmoi on Windows (WSL and native)
+* macOS setup and configuration
+* Linux distribution guides
+* Cross-platform workflows
+
+### Integration Videos
+
+* Using chezmoi with password managers
+* Integration with text editors (Vim, VS Code, etc.)
+* Combining with other dotfile tools
+* CI/CD integration
+
+### Problem-Solving
+
+* Debugging common issues
+* Migration guides
+* Recovering from mistakes
+* Advanced troubleshooting
+
+## Community Contributions
+
+If you create a video about chezmoi:
+
+* We appreciate you sharing your knowledge
+* Consider adding it to the [GitHub Discussions](https://github.com/twpayne/chezmoi/discussions)
+* Help others by answering questions in the comments
+* Keep your content up to date with new chezmoi versions
+
+## See Also
+
+* [Articles](/community/articles) - Written tutorials and blog posts
+* [Dotfile Repos](/community/dotfile-repos) - Example configurations to learn from
+
+
+# How chezmoi works
+Source: https://twpayne-chezmoi.mintlify.app/concepts/how-chezmoi-works
+
+Understand chezmoi architecture, core concepts, and how it manages dotfiles from source state to destination state.
+
+chezmoi uses a declarative approach to manage your dotfiles. It computes the target state for the current machine and then updates the destination directory to match.
+
+## Core concepts
+
+<AccordionGroup>
+  <Accordion title="Destination directory" icon="house">
+    The directory that chezmoi manages, usually your home directory (`~`).
+  </Accordion>
+
+  <Accordion title="Target" icon="bullseye">
+    A file, directory, or symlink in the destination directory that chezmoi manages.
+  </Accordion>
+
+  <Accordion title="Destination state" icon="folder">
+    The current state of all the targets in the destination directory.
+  </Accordion>
+
+  <Accordion title="Source state" icon="code-branch">
+    Declares the desired state of your home directory, including templates that use machine-specific data. It contains only regular files and directories.
+  </Accordion>
+
+  <Accordion title="Source directory" icon="folder-tree">
+    Where chezmoi stores the source state. By default it is `~/.local/share/chezmoi`.
+  </Accordion>
+
+  <Accordion title="Config file" icon="file-code">
+    Contains machine-specific data. By default it is `~/.config/chezmoi/chezmoi.toml`.
+  </Accordion>
+
+  <Accordion title="Target state" icon="crosshairs">
+    The desired state of the destination directory. It is computed from the source state, the config file, and the destination state. The target state includes regular files and directories, and may also include symbolic links, scripts to be run, and targets to be removed.
+  </Accordion>
+
+  <Accordion title="Working tree" icon="diagram-project">
+    The git working tree. Normally it is the same as the source directory, but can be a parent of the source directory.
+  </Accordion>
+</AccordionGroup>
+
+## State flow diagram
+
+Here's how chezmoi transforms your source state into your destination state:
+
+```mermaid theme={null}
+graph LR
+    A[Source State<br/>~/.local/share/chezmoi] --> B[Template Evaluation]
+    C[Config File<br/>~/.config/chezmoi/chezmoi.toml] --> B
+    D[Destination State<br/>~/ current state] --> E[Difference Detection]
+    B --> F[Target State<br/>desired state]
+    F --> E
+    E --> G[Apply Changes]
+    G --> H[Updated Home Directory]
+    
+    style A fill:#e1f5ff
+    style C fill:#e1f5ff
+    style D fill:#fff4e6
+    style F fill:#e8f5e9
+    style H fill:#e8f5e9
+```
+
+## Understanding entries
+
+chezmoi uses the generic term **entry** to describe something that it manages. Entries can be:
+
+* Files
+* Directories
+* Symlinks
+* Scripts
+* Remove operations
+
+### Entry types in source state
+
+<Columns>
+  <Card title="SourceStateFile" icon="file">
+    Regular files in the source directory. Include attributes parsed from the file name (like `dot_`, `executable_`, `encrypted_`).
+  </Card>
+
+  <Card title="SourceStateDir" icon="folder">
+    Directories in the source directory. Include attributes parsed from the directory name (like `exact_`, `private_`).
+  </Card>
+</Columns>
+
+### Entry types in target state
+
+<Columns>
+  <Card title="TargetStateFile" icon="file-lines">
+    A file with contents and permissions in the destination.
+  </Card>
+
+  <Card title="TargetStateDir" icon="folder-open">
+    A directory in the destination.
+  </Card>
+
+  <Card title="TargetStateSymlink" icon="link">
+    A symbolic link in the destination.
+  </Card>
+
+  <Card title="TargetStateScript" icon="terminal">
+    A script that should be executed.
+  </Card>
+
+  <Card title="TargetStateRemove" icon="trash">
+    An entry that should be removed from the destination.
+  </Card>
+</Columns>
+
+### Actual state entries
+
+<Info>
+  The actual state represents what currently exists in your destination directory.
+</Info>
+
+* `ActualStateAbsent`: Entry does not exist
+* `ActualStateDir`: Entry is a directory
+* `ActualStateFile`: Entry is a file
+* `ActualStateSymlink`: Entry is a symlink
+
+## Source state attributes
+
+chezmoi encodes metadata about files using special prefixes and suffixes in filenames. This is how a regular file becomes a dotfile, executable, or template.
+
+### Common prefixes
+
+| Prefix        | Effect                                           | Example                                  |
+| ------------- | ------------------------------------------------ | ---------------------------------------- |
+| `dot_`        | Rename to use a leading dot                      | `dot_bashrc` → `.bashrc`                 |
+| `executable_` | Add executable permissions                       | `executable_script.sh` → executable file |
+| `private_`    | Remove all group and world permissions           | `private_key` → mode 600                 |
+| `readonly_`   | Remove all write permissions                     | `readonly_config` → read-only file       |
+| `encrypted_`  | File is encrypted in source state                | `encrypted_secrets.txt.age`              |
+| `empty_`      | Ensure file exists even if empty                 | `empty_file`                             |
+| `create_`     | Create if doesn't exist, don't modify if it does | `create_config.json`                     |
+| `modify_`     | Run as script to modify existing file            | `modify_settings.sh`                     |
+| `remove_`     | Remove the entry if it exists                    | `remove_oldfile`                         |
+| `run_`        | Execute as a script                              | `run_setup.sh`                           |
+| `symlink_`    | Create a symbolic link                           | `symlink_config`                         |
+| `exact_`      | Remove anything not managed by chezmoi           | `exact_directory/`                       |
+
+### Script-specific prefixes
+
+<Columns>
+  <Card title="run_once_" icon="1">
+    Only run if contents haven't been run successfully before.
+  </Card>
+
+  <Card title="run_onchange_" icon="arrows-rotate">
+    Run whenever the script contents change.
+  </Card>
+
+  <Card title="before_" icon="backward">
+    Execute before updating files.
+  </Card>
+
+  <Card title="after_" icon="forward">
+    Execute after all files are updated.
+  </Card>
+</Columns>
+
+### Common suffixes
+
+| Suffix     | Effect                               |
+| ---------- | ------------------------------------ |
+| `.tmpl`    | Treat file contents as a Go template |
+| `.literal` | Stop parsing suffix attributes       |
+
+### Prefix order matters
+
+<Warning>
+  Prefixes must be in the correct order. chezmoi will not recognize incorrectly ordered attributes.
+</Warning>
+
+<Tabs>
+  <Tab title="Regular file">
+    ```
+    encrypted_private_readonly_empty_executable_dot_filename.tmpl
+    ```
+
+    Order: `encrypted_` → `private_` → `readonly_` → `empty_` → `executable_` → `dot_`
+  </Tab>
+
+  <Tab title="Create file">
+    ```
+    create_encrypted_private_readonly_empty_executable_dot_config.json.tmpl
+    ```
+
+    Order: `create_` → `encrypted_` → `private_` → `readonly_` → `empty_` → `executable_` → `dot_`
+  </Tab>
+
+  <Tab title="Script">
+    ```
+    run_once_before_install-packages.sh.tmpl
+    ```
+
+    Order: `run_` → `once_` or `onchange_` → `before_` or `after_`
+  </Tab>
+
+  <Tab title="Directory">
+    ```
+    exact_private_readonly_dot_config/
+    ```
+
+    Order: `remove_` → `external_` → `exact_` → `private_` → `readonly_` → `dot_`
+  </Tab>
+</Tabs>
+
+## The apply workflow
+
+When you run `chezmoi apply`, here's what happens:
+
+<Steps>
+  <Step title="Read source state">
+    chezmoi reads all files and directories from the source directory (`~/.local/share/chezmoi`).
+  </Step>
+
+  <Step title="Parse attributes">
+    For each entry, chezmoi parses the filename to extract attributes (prefixes and suffixes).
+  </Step>
+
+  <Step title="Execute templates">
+    Files with `.tmpl` suffix are executed as Go templates using data from the config file and built-in variables.
+  </Step>
+
+  <Step title="Compute target state">
+    Each source state entry computes its corresponding target state entry (what it should be in your home directory).
+  </Step>
+
+  <Step title="Read actual state">
+    chezmoi reads the current state of each target in the destination directory.
+  </Step>
+
+  <Step title="Compare states">
+    chezmoi compares the target state with the actual state to determine what changes are needed.
+  </Step>
+
+  <Step title="Apply changes">
+    chezmoi applies the minimal set of changes to make the actual state match the target state:
+
+    * Create missing files/directories
+    * Update modified files
+    * Remove extra files (in `exact_` directories)
+    * Execute scripts
+    * Update permissions
+  </Step>
+
+  <Step title="Update persistent state">
+    chezmoi stores the SHA256 hash of each entry it writes in persistent state for future change detection.
+  </Step>
+</Steps>
+
+<Tip>
+  All file operations are atomic. You will never be left with incomplete files, even if the process is interrupted.
+</Tip>
+
+## System abstraction
+
+chezmoi abstracts all operating system interactions through a `System` interface. This enables powerful features:
+
+### System implementations
+
+<AccordionGroup>
+  <Accordion title="RealSystem">
+    The actual underlying system that performs real file operations.
+  </Accordion>
+
+  <Accordion title="DryRunSystem">
+    Wraps RealSystem for `--dry-run` mode. Allows reads to pass through but silently discards all writes.
+  </Accordion>
+
+  <Accordion title="DebugSystem">
+    Wraps RealSystem for `--debug` mode. Logs all calls to the underlying system.
+  </Accordion>
+</AccordionGroup>
+
+<Note>
+  This layered architecture is what makes features like `--dry-run` and `--debug` possible without modifying the core logic.
+</Note>
+
+## Persistent state
+
+chezmoi maintains a persistent state to track what it has managed. This is stored as a two-level key-value store:
+
+```
+map[Bucket]map[Key]Value
+```
+
+### Why persistent state?
+
+<Columns>
+  <Card title="Change detection" icon="magnifying-glass">
+    Detect if a third party has modified a file since chezmoi last wrote it.
+  </Card>
+
+  <Card title="Script execution" icon="list-check">
+    Track which `run_once_` and `run_onchange_` scripts have been executed.
+  </Card>
+</Columns>
+
+### EntryState storage
+
+<Info>
+  chezmoi stores the SHA256 hash of each entry's contents in persistent state, rather than the full contents, to avoid storing secrets.
+</Info>
+
+## Path handling
+
+chezmoi uses type-safe path handling to prevent errors:
+
+* `AbsPath`: Absolute paths
+* `RelPath`: Relative paths
+* `SourceRelPath`: Relative path within the source directory with attribute handling
+* `ExtPath`: External paths from user input (may include `~` for home directory)
+
+<Warning>
+  Internally, chezmoi normalizes all paths to use forward slashes and is case-sensitive. It makes no attempt to handle case-insensitive or case-preserving file systems.
+</Warning>
+
+## Execution order
+
+chezmoi performs actions in a deterministic order:
+
+<Steps>
+  <Step title="Before scripts">
+    Execute all `run_before_` scripts in ASCII order of their target names.
+  </Step>
+
+  <Step title="Files, directories, symlinks">
+    Process in ASCII order of target names.
+  </Step>
+
+  <Step title="Regular scripts">
+    Execute `run_` scripts (without `before_` or `after_`) in ASCII order alongside files.
+  </Step>
+
+  <Step title="After scripts">
+    Execute all `run_after_` scripts in ASCII order of their target names.
+  </Step>
+</Steps>
+
+<Tip>
+  **Example**: Given `dot_a` (file), `run_z.sh` (script), and `exact_dot_c/` (directory), chezmoi will:
+
+  1. Create `.a`
+  2. Create `.c/` directory
+  3. Execute `run_z.sh`
+</Tip>
+
+## Encryption support
+
+Encryption tools are abstracted through an `Encryption` interface:
+
+<Columns>
+  <Card title="AGE encryption" icon="lock">
+    Modern, simple file encryption with `age`.
+  </Card>
+
+  <Card title="GPG encryption" icon="key">
+    Traditional encryption with GnuPG.
+  </Card>
+</Columns>
+
+Encrypted files in the source state have their encryption suffix (`.age` or `.asc`) automatically stripped when determining the target name.
+
+## Interactive workflow diagram
+
+```mermaid theme={null}
+sequenceDiagram
+    participant User
+    participant CLI as chezmoi CLI
+    participant Source as Source State
+    participant Target as Target State
+    participant Dest as Destination Dir
+    
+    User->>CLI: chezmoi add ~/.bashrc
+    CLI->>Dest: Read ~/.bashrc
+    CLI->>Source: Write dot_bashrc
+    
+    User->>CLI: chezmoi edit ~/.bashrc
+    CLI->>Source: Open dot_bashrc in $EDITOR
+    User->>Source: Make changes
+    
+    User->>CLI: chezmoi diff
+    CLI->>Source: Read source state
+    CLI->>Target: Compute target state
+    CLI->>Dest: Read actual state
+    CLI->>User: Show differences
+    
+    User->>CLI: chezmoi apply
+    CLI->>Source: Read source state
+    CLI->>Target: Compute target state
+    CLI->>Dest: Read actual state
+    CLI->>Dest: Apply minimal changes
+    CLI->>User: Report changes made
+```
+
+## Key takeaways
+
+<Check>
+  **Declarative**: You specify what you want, chezmoi figures out how to get there.
+</Check>
+
+<Check>
+  **Idempotent**: Running `chezmoi apply` multiple times produces the same result.
+</Check>
+
+<Check>
+  **Safe**: Dry-run mode, atomic operations, and persistent state tracking prevent accidents.
+</Check>
+
+<Check>
+  **Flexible**: Templates, attributes, and scripts provide powerful customization.
+</Check>
+
+<Tip>
+  Ready to dive deeper? Explore the [configuration reference](/reference/configuration-file) for complete details on all attributes, [template functions](/reference/templates/functions), and configuration options.
+</Tip>
+
+
+# What does chezmoi do?
+Source: https://twpayne-chezmoi.mintlify.app/concepts/what-does-chezmoi-do
+
+Learn how chezmoi helps manage personal configuration files across multiple machines and operating systems.
+
+chezmoi helps you manage your personal configuration files (dotfiles, like `~/.gitconfig`) across multiple machines.
+
+<Info>
+  chezmoi is helpful if you have spent time customizing the tools you use (e.g. shells, editors, and version control systems) and want to keep machines running different accounts (e.g. home and work) and/or different operating systems (e.g. Linux, macOS, and Windows) in sync, while still being able to easily cope with differences from machine to machine.
+</Info>
+
+## When should you use chezmoi?
+
+chezmoi scales from the trivial to the complex:
+
+* **Simple use cases**: Copying a few dotfiles onto a Raspberry Pi, development container, or virtual machine
+* **Complex environments**: Keeping any number of home and work, Linux, macOS, and Windows machines in sync
+
+In all cases you only need to maintain a **single source of truth** (a single branch in git) and getting started only requires adding a single binary to your machine (which you can do with `curl`, `wget`, or `scp`).
+
+<Tip>
+  chezmoi has strong support for security, allowing you to manage secrets (e.g. passwords, access tokens, and private keys) securely and seamlessly using a password manager and/or encrypt whole files with your favorite encryption tool.
+</Tip>
+
+<Warning>
+  If you do not personalize your configuration or only ever use a single operating system with a single account and none of your dotfiles contain secrets, then you might not need chezmoi. Otherwise, read on...
+</Warning>
+
+## Key features
+
+### Flexible
+
+You can share as much configuration across machines as you want, while still being able to control machine-specific details.
+
+<Columns>
+  <Card title="Template support" icon="file-code">
+    Your dotfiles can be templates using Go `text/template` syntax. Predefined variables allow you to change behavior depending on operating system, architecture, and hostname.
+  </Card>
+
+  <Card title="Cross-platform" icon="laptop">
+    Runs on all commonly-used platforms like Linux, macOS, and Windows, plus less common ones like FreeBSD, OpenBSD, and Termux.
+  </Card>
+</Columns>
+
+### Personal and secure
+
+Nothing leaves your machine, unless you want it to. Your configuration remains in a git repo under your control.
+
+<AccordionGroup>
+  <Accordion title="Password manager integration">
+    chezmoi can retrieve secrets from:
+
+    * 1Password
+    * AWS Secrets Manager
+    * Azure Key Vault
+    * Bitwarden
+    * Dashlane
+    * Doppler
+    * gopass
+    * KeePassXC
+    * Keeper
+    * LastPass
+    * pass
+    * passage
+    * passhole
+    * Proton Pass
+    * Vault
+    * macOS Keychain
+    * GNOME Keyring
+    * Any command-line utility of your choice
+  </Accordion>
+
+  <Accordion title="File encryption">
+    You can encrypt individual files with GnuPG or age. You can checkout your dotfiles repo on as many machines as you want without revealing any secrets to anyone.
+  </Accordion>
+
+  <Accordion title="Configuration format">
+    You can write the configuration file in the format of your choice (TOML, JSON, YAML, etc.).
+  </Accordion>
+</AccordionGroup>
+
+### Transparent
+
+chezmoi includes verbose and dry run modes so you can review exactly what changes it will make to your home directory before making them.
+
+<Note>
+  chezmoi's source format uses only regular files and directories that map one-to-one with the files, directories, and symlinks in your home directory that you choose to manage. If you decide not to use chezmoi in the future, it is easy to move your data elsewhere.
+</Note>
+
+### Declarative and robust
+
+<Steps>
+  <Step title="Declare desired state">
+    You declare the desired state of files, directories, and symbolic links in your source of truth.
+  </Step>
+
+  <Step title="chezmoi computes changes">
+    chezmoi calculates the minimal changes needed to match that state.
+  </Step>
+
+  <Step title="Atomic updates">
+    chezmoi updates all files and symbolic links atomically. You will never be left with incomplete files that could lock you out, even if the update process is interrupted.
+  </Step>
+</Steps>
+
+### Fast and easy to use
+
+Using chezmoi feels like using git: the commands are similar and chezmoi runs in fractions of a second.
+
+<Tip>
+  chezmoi makes most day-to-day operations one line commands, including installation, initialization, and keeping your machines up-to-date. chezmoi can pull and apply changes from your dotfiles repo in a single command, and automatically commit and push changes.
+</Tip>
+
+#### Common one-line operations
+
+```bash theme={null}
+# Pull and apply changes in one command
+chezmoi update
+
+# Initialize and apply dotfiles on a new machine
+chezmoi init --apply https://github.com/username/dotfiles.git
+
+# Add, edit, and apply a file
+chezmoi edit ~/.bashrc
+chezmoi apply
+```
+
+## What you get is what you want
+
+With chezmoi, you declare the desired state and chezmoi makes it happen. The declarative approach means:
+
+* **Predictable outcomes**: What you specify is what you get
+* **Idempotent operations**: Running commands multiple times produces the same result
+* **Safe experimentation**: Dry run mode (`-n`) and verbose mode (`-v`) let you preview changes
+* **Version control**: All changes are tracked in git, giving you a complete history
+
+<Check>
+  Ready to get started? Check out the [Quick Start](/quick-start) guide to install and configure chezmoi.
+</Check>
+
+
+# Why use chezmoi?
+Source: https://twpayne-chezmoi.mintlify.app/concepts/why-use-chezmoi
+
+Understand the benefits of using chezmoi over other dotfile management approaches and why thousands of developers trust it.
+
+## Why should I use a dotfile manager?
+
+Dotfile managers give you the combined benefit of a consistent environment everywhere with an undo command and a restore from backup.
+
+<Info>
+  As the core of our development environments become increasingly standardized (e.g. using git at both home and work), and we further customize them, at the same time we increasingly work in ephemeral environments like Docker containers, virtual machines, and GitHub Codespaces.
+</Info>
+
+In the same way that nobody would use an editor without an undo command, or develop software without a version control system, chezmoi brings the investment that you have made in mastering your tools to every environment that you work in.
+
+## I already have a dotfile system, why should I use chezmoi?
+
+### What users say
+
+<AccordionGroup>
+  <Accordion title="Fast machine setup with secrets management" icon="rocket">
+    > I've been using Chezmoi for more than a year now, across at least 3 computers simultaneously, and I really love it. Most of all, I love how fast I can configure a new machine when I use it. In just a couple minutes of work, I can kick off a process on a brand-new computer that will set up my dotfiles and install all my usual software so it feels like a computer I've been using for years. I also appreciate features like secrets management, which allow me to share my dotfiles while keeping my secrets safe. Overall, I love the way Chezmoi fits so perfectly into the niche of managing dotfiles.
+    >
+    > — @mike\_kasberg
+  </Accordion>
+
+  <Accordion title="More complex than it first appears" icon="puzzle">
+    > I had initially been turned off when I first encountered \[chezmoi], because \[chezmoi] seemed overkill for (what appeared to me) a simple task.
+    >
+    > But the problem of managing a relatively small number of dotfiles across a relatively small number of machines with small differences between them and keeping them up to date proved to be *MUCH* more complex than I imagined. Copy things around by hand, and then later distributing them via source control got hairy very quickly.
+    >
+    > I finally realized all those features were absolutely necessary to manage things sanely, and once I took some time to learn how to do things with chezmoi, I have never looked back.
+    >
+    > — njt
+  </Accordion>
+
+  <Accordion title="Best dotfile manager" icon="star">
+    > Regular reminder that chezmoi is the best dotfile manager utility I've used and you can too
+    >
+    > — @mbbroberg
+  </Accordion>
+</AccordionGroup>
+
+## Common problems chezmoi solves
+
+If you're using any of the following methods, you've probably encountered these issues:
+
+* A custom shell script
+* An existing dotfile manager like dotbot, rcm, homesick, vcsh, yadm, or GNU Stow
+* A bare git repo approach
+
+### Managing differences between machines requires extra effort
+
+<Columns>
+  <Card title="Without chezmoi" icon="xmark">
+    * Manually perform extra steps for each machine
+    * Run different commands on different machines
+    * Maintain separate per-machine files or branches
+    * Deal with merge conflicts and rebasing
+    * Hope custom logic handles differences correctly
+  </Card>
+
+  <Card title="With chezmoi" icon="check">
+    * Single source of truth (one branch)
+    * Single command works on every machine
+    * Templates handle machine-to-machine differences
+    * Predefined variables for OS, architecture, hostname
+  </Card>
+</Columns>
+
+<Tip>
+  chezmoi uses a single source of truth and a single command that works on every machine. Individual files can be templates to handle differences automatically.
+</Tip>
+
+### Keeping your dotfiles repo private
+
+<Warning>
+  If your system stores secrets in plain text, then you must be very careful about where you clone your dotfiles. If you clone them on your work machine, anyone with access to your work machine (e.g. your IT department) will have access to your home secrets. If you clone it on your home machine, you risk leaking work secrets.
+</Warning>
+
+> And regarding dotfiles, I saw that. It's only public dotfiles repos so I have to evaluate my dotfiles history to be sure. I have secrets scanning and more, but it was easier to keep it private for security, I'm ok mostly though. I'm using chezmoi and it's easier now
+>
+> — @sheldon\_hull
+
+<Check>
+  With chezmoi you can store secrets in your password manager or encrypt them, and even store passwords in different ways on different machines. You can clone your dotfiles repository anywhere, and even make your dotfiles repo public, without leaving personal secrets on your work machine or work secrets on your personal machine.
+</Check>
+
+### Maintaining your own tool
+
+<Columns>
+  <Card title="Custom shell script" icon="code">
+    > I've offloaded my dotfiles deployment from a homespun shell script to chezmoi. I'm quite happy with this decision.
+    >
+    > — @gotgenes
+  </Card>
+
+  <Card title="Migration experience" icon="arrows-rotate">
+    > I discovered chezmoi and it's pretty cool, just migrated my old custom multi-machine sync dotfile setup and it's so much simpler now
+    >
+    > in case you're wondering I have written 0 code
+    >
+    > — @buritica
+  </Card>
+</Columns>
+
+> Chezmoi is like what you might get if you re-wrote my bash script in Go, came up with better solutions than `diff` for managing config on multiple machines, added in secrets management and other useful dotfile tools, and tweaked and perfected it over years.
+>
+> — @mike\_kasberg
+
+<Info>
+  If your system was written by you for your personal use, then it probably has the functionality that you needed when you wrote it. If you need more functionality then you have to implement it yourself.
+</Info>
+
+chezmoi includes a huge range of battle-tested functionality out-of-the-box:
+
+* Dry-run and diff modes
+* Script execution
+* Conflict resolution
+* Windows support
+* Template functions
+* Password manager integration
+* File encryption
+* And much, much more
+
+<Tip>
+  chezmoi is used by thousands of people and has a rich suite of both unit and integration tests. When you hit the limits of your existing dotfile management system, chezmoi already has a tried-and-tested solution ready for you to use.
+</Tip>
+
+### Setting up dotfiles requires more than one command
+
+<Warning>
+  If your system is written in a scripting language like Python, Perl, or Ruby, then you also need to install a compatible version of that language's runtime before you can use your system.
+</Warning>
+
+#### chezmoi's advantage
+
+chezmoi is distributed as a **single stand-alone statically-linked binary** with no dependencies that you can simply copy onto your machine and run.
+
+<Steps>
+  <Step title="No runtime required">
+    You don't need Python, Ruby, Perl, or even git installed.
+  </Step>
+
+  <Step title="One-line install">
+    chezmoi provides one-line installs for all major platforms.
+  </Step>
+
+  <Step title="Multiple distribution methods">
+    Pre-built binaries, packages for Linux and BSD distributions, Homebrew formulae, Scoop and Chocolatey support on Windows.
+  </Step>
+
+  <Step title="Initial config generation">
+    Automated mechanism to make installing your dotfiles on a new machine as painless as possible.
+  </Step>
+</Steps>
+
+#### Installation examples
+
+<CodeGroup>
+  ```bash Linux/macOS (script) theme={null}
+  sh -c "$(curl -fsLS get.chezmoi.io)"
+  ```
+
+  ```bash Homebrew theme={null}
+  brew install chezmoi
+  ```
+
+  ```powershell Windows (Scoop) theme={null}
+  scoop install chezmoi
+  ```
+
+  ```bash Arch Linux theme={null}
+  pacman -S chezmoi
+  ```
+</CodeGroup>
+
+## Key differentiators
+
+<Columns>
+  <Card title="Zero dependencies" icon="feather">
+    Single binary, no runtime required. Works anywhere.
+  </Card>
+
+  <Card title="Battle-tested" icon="shield">
+    Used by thousands of developers with comprehensive test coverage.
+  </Card>
+
+  <Card title="Secure by design" icon="lock">
+    Built-in support for secrets management and encryption.
+  </Card>
+
+  <Card title="Template power" icon="wand-magic-sparkles">
+    Go templates with extensive functions for dynamic configs.
+  </Card>
+
+  <Card title="Git-like workflow" icon="code-branch">
+    Familiar commands and patterns for version control.
+  </Card>
+
+  <Card title="Active development" icon="rocket">
+    Regular updates, active community, and responsive maintainer.
+  </Card>
+</Columns>
+
+## Ready to make the switch?
+
+<Check>
+  Migrating from another dotfile manager? Check out the [migration guide](/advanced/migrating-from-another-dotfile-manager) for step-by-step instructions on moving from popular alternatives like yadm, rcm, GNU Stow, and bare git repos.
+</Check>
+
+<Tip>
+  New to dotfile management? Start with the [Quick Start](/quick-start) guide to set up chezmoi in minutes.
+</Tip>
+
+
+# Architecture
+Source: https://twpayne-chezmoi.mintlify.app/developer/architecture
+
+High-level overview of chezmoi's source code architecture
+
+This document gives a high-level overview of chezmoi's source code for anyone interested in contributing to chezmoi.
+
+## Documentation
+
+You can generate Go documentation for chezmoi's source code with `go doc`, for example:
+
+```sh theme={null}
+go doc -all -u github.com/twpayne/chezmoi/internal/chezmoi
+```
+
+You can also [browse chezmoi's generated documentation online](https://pkg.go.dev/github.com/twpayne/chezmoi).
+
+## Directory Structure
+
+The important directories in chezmoi are:
+
+| Directory                        | Contents                                                                                                                                                       |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `assets/chezmoi.io/docs/`        | The documentation single source of truth. Help text, examples, and the [chezmoi.io](https://chezmoi.io) website are generated from the files in this directory |
+| `internal/chezmoi/`              | chezmoi's core functionality                                                                                                                                   |
+| `internal/cmd/`                  | Code for the `chezmoi` command                                                                                                                                 |
+| `internal/cmd/testdata/scripts/` | High-level tests of chezmoi's commands using [`testscript`](https://pkg.go.dev/github.com/rogpeppe/go-internal/testscript)                                     |
+
+## Key Concepts
+
+As described in the reference manual, chezmoi evaluates the source state to compute a target state for the destination directory (typically your home directory). It then compares the target state to the actual state of the destination directory and performs any changes necessary to update the destination directory to match the target state. These concepts are represented directly in chezmoi's code.
+
+chezmoi uses the generic term **entry** to describe something that it manages. Entries can be files, directories, symlinks, scripts, amongst other things.
+
+## `internal/chezmoi/` Directory
+
+### System Interface
+
+All of chezmoi's interaction with the operating system is abstracted through the `System` interface. A `System` includes functionality to read and write files and directories and execute commands. chezmoi makes a distinction between:
+
+* **Idempotent commands** that can be run multiple times without modifying the underlying system
+* **Arbitrary commands** that may modify the underlying system
+
+The real underlying system is implemented via a `RealSystem` struct. Other `System`s are composed on top of this to provide further functionality:
+
+* The `--debug` flag is implemented by wrapping the `RealSystem` with a `DebugSystem` that logs all calls to the underlying `RealSystem`.
+* `--dry-run` is implemented by wrapping the `RealSystem` with a `DryRunSystem` that allows reads to pass through but silently discards all writes.
+
+### Source State
+
+The `SourceState` struct represents a source state, including:
+
+* Reading a source state from the source directory
+* Executing templates
+* Applying the source state (i.e. updating a `System` to match the desired source state)
+* Adding more entries to the source state
+
+Entries in the source state are abstracted by the `SourceStateEntry` interface implemented by:
+
+* `SourceStateFile` - regular files in the source state
+* `SourceStateDir` - directories in the source state
+
+A `SourceStateFile` includes a `FileAttr` struct describing the attributes parsed from its file name. Similarly, a `SourceStateDir` includes a `DirAttr` struct describing the directory attributes parsed from a directory name.
+
+### Target State
+
+`SourceStateEntry`s can compute their target state entries, i.e. what the equivalent entry should be in the target state, abstracted by the `TargetStateEntry` interface.
+
+Actual target state entries include:
+
+* `TargetStateFile` - a file with contents and permissions
+* `TargetStateDir` - a directory
+* `TargetStateSymlink` - a symlink
+* `TargetStateRemove` - entries that should be removed
+* `TargetStateScript` - scripts that should be run
+
+### Actual State
+
+The actual state of an entry in the target state is abstracted via the `ActualStateEntry` interface, with these structs implementing this interface:
+
+* `ActualStateAbsent`
+* `ActualStateDir`
+* `ActualStateFile`
+* `ActualStateSymlink`
+
+### Entry State
+
+An `EntryState` struct represents a serialization of an `ActualEntryState` for storage in and retrieval from chezmoi's persistent state. It stores a SHA256 of the entry's contents, rather than the full contents, to avoid storing secrets in the persistent state.
+
+### The Apply Command
+
+With these concepts, chezmoi's apply command is effectively:
+
+1. Read the source state from the source directory.
+
+2. For each entry in the source state (`SourceStateEntry`), compute its `TargetStateEntry` and read its actual state in the destination state (`ActualStateEntry`).
+
+3. If the `ActualStateEntry` is not equivalent to the `TargetStateEntry` then apply the minimal set of changes to the `ActualStateEntry` so that they are equivalent.
+
+Furthermore, chezmoi stores the `EntryState` of each entry that it writes in its persistent state. chezmoi can then detect if a third party has updated a target since chezmoi last wrote it by comparing the actual state entry in the target state with the entry state in the persistent state.
+
+## `internal/cmd/` Directory
+
+`internal/cmd/*cmd.go` files contain the code for each individual command. `internal/cmd/*templatefuncs.go` files contain the template functions.
+
+Commands are defined as methods on the `Config` struct. The `Config` struct is large, containing all configuration values read from the config file, command line arguments, and computed and cached values.
+
+The `Config.persistentPreRunRootE` and `Config.persistentPostRunRootE` methods set up and tear down state for individual commands based on the command's `Annotations` field, which defines how the command interacts with the file system and persistent state.
+
+## Path Handling
+
+chezmoi uses separate types for absolute paths (`AbsPath`) and relative paths (`RelPath`) to avoid errors where paths are combined (e.g. joining two absolute paths is an error). The type `SourceRelPath` is a relative path within the source directory and handles file and directory attributes.
+
+Internally, chezmoi normalizes all paths to use forward slashes with an optional upper-cased Windows volume so they can be compared with string comparisons. Paths read from the user may include tilde (`~`) to represent the user's home directory, use forward or backward slashes, and are treated as external paths (`ExtPath`). These are normalized to absolute paths. chezmoi is case-sensitive internally and makes no attempt to handle case-insensitive or case-preserving file systems.
+
+## Persistent State
+
+Persistent state is treated as a two-level key-value store with the pseudo-structure `map[Bucket]map[Key]Value`, where `Bucket`, `Key`, and `Value` are all `[]byte`s. The `PersistentState` interface defines interaction with them.
+
+Sometimes temporary persistent states are used. For example, in dry run mode (`--dry-run`) the actual persistent state is copied into a temporary persistent state in memory which remembers writes but does not persist them to disk.
+
+## Encryption
+
+Encryption tools are abstracted by the `Encryption` interface that contains methods of encrypting and decrypting files and `[]byte`s. Implementations are:
+
+* `AGEEncryption` struct
+* `GPGEncryption` struct
+* `DebugEncryption` struct - wraps an `Encryption` interface and logs the methods called
+
+## `run_once_` and `run_onchange_` Scripts
+
+The execution of a `run_once_` script is recorded by storing the SHA256 of its contents in the `scriptState` bucket in the persistent state. On future invocations the script is only run if no matching contents SHA256 is found in the persistent state.
+
+The execution of a `run_onchange_` script is recorded by storing its target name in the `entryState` bucket along with its contents SHA256 sum. On future invocations the script is only run if its contents SHA256 sum has changed, and its contents SHA256 sum is then updated in the persistent state.
+
+## Testing
+
+chezmoi has a mix of unit, integration, and end-to-end tests:
+
+* **Unit and integration tests** use the [`github.com/alecthomas/assert/v2`](https://pkg.go.dev/github.com/alecthomas/assert) framework.
+* **End-to-end tests** use [`github.com/rogpeppe/go-internal/testscript`](https://pkg.go.dev/github.com/rogpeppe/go-internal/testscript) with the test scripts themselves in `internal/cmd/testdata/scripts/$TEST_NAME.txtar`.
+
+You can run individual end-to-end tests with:
+
+```sh theme={null}
+go test ./internal/cmd -run=TestScript/$TEST_NAME
+```
+
+Tests should, if at all possible, run unmodified on all operating systems tested in CI (Linux, macOS, Windows, and FreeBSD). Windows will sometimes need special handling due to its path separator and lack of POSIX-style file permissions.
+
+
+# Building chezmoi
+Source: https://twpayne-chezmoi.mintlify.app/developer/building
+
+Instructions for building chezmoi from source
+
+chemzoi is written in [Go](https://golang.org) and development happens on [GitHub](https://github.com). chezmoi is a standard Go project, using standard Go tooling. chezmoi requires Go 1.25 or later.
+
+## Quick Start
+
+Checkout chezmoi:
+
+```sh theme={null}
+git clone https://github.com/twpayne/chezmoi.git
+cd chezmoi
+```
+
+Build chezmoi:
+
+```sh theme={null}
+go build
+```
+
+Run chezmoi:
+
+```sh theme={null}
+go tool chezmoi --version
+```
+
+## Building with Make
+
+chezmoi can be built with GNU make, assuming you have the Go toolchain installed.
+
+Running `make` will build a `chezmoi` binary in the current directory for the host OS and architecture. To embed version information in the binary and control installation the following variables are available:
+
+| Variable    | Example                | Purpose                                        |
+| ----------- | ---------------------- | ---------------------------------------------- |
+| `$VERSION`  | `v2.0.0`               | Set version                                    |
+| `$COMMIT`   | `3895680a`...          | Set the git commit at which the code was built |
+| `$DATE`     | `2019-11-23T18:29:25Z` | The time of the build                          |
+| `$BUILT_BY` | `homebrew`             | The packaging system performing the build      |
+| `$PREFIX`   | `/usr`                 | Installation prefix                            |
+| `$DESTDIR`  | `install-root`         | Fake installation root                         |
+
+Running `make install` will install the `chezmoi` binary in `${DESTDIR}${PREFIX}/bin`.
+
+## Build Targets
+
+### Default Build
+
+Build for the current platform:
+
+```sh theme={null}
+make build
+```
+
+### Build from Git Working Copy
+
+Build with embedded version information from git:
+
+```sh theme={null}
+make build-in-git-working-copy
+```
+
+Install with embedded version information from git:
+
+```sh theme={null}
+make install-from-git-working-copy
+```
+
+### Cross-Compilation
+
+Build for all supported platforms:
+
+```sh theme={null}
+make build-all
+```
+
+Or build for specific platforms:
+
+```sh theme={null}
+make build-darwin    # macOS (amd64 and arm64)
+make build-freebsd   # FreeBSD (amd64)
+make build-linux     # Linux (amd64)
+make build-windows   # Windows (amd64)
+```
+
+### Test Builds
+
+Run a set of smoke tests, including cross-compilation, tests, and linting:
+
+```sh theme={null}
+make smoke-test
+```
+
+Test building chezmoi for all architectures:
+
+```sh theme={null}
+make test-release
+```
+
+## Shell Configuration
+
+<Note>
+  If you use `fish` as your primary shell, you may get warnings from Fish during tests:
+
+  ```text theme={null}
+  error: can not save history
+  warning-path: Unable to locate data directory derived from $HOME: '/home/user/.local/share/fish'.
+  warning-path: The error was 'Operation not supported'.
+  warning-path: Please set $HOME to a directory where you have write access.
+  ```
+
+  These can be avoided by running tests with `SHELL=bash` or `SHELL=zsh`:
+
+  ```sh theme={null}
+  SHELL=bash make test
+  SHELL=zsh make smoke-test
+  SHELL=bash go test ./...
+  ```
+</Note>
+
+## Build Dependencies
+
+chezmoi has no build dependencies other than the standard Go toolchain.
+
+## See Also
+
+* [Testing](/developer/testing) - Running the test suite
+* [Packaging](/developer/packaging) - Packaging guidelines for distributions
+
+
+# Building on Top of chezmoi
+Source: https://twpayne-chezmoi.mintlify.app/developer/building-on-top-of-chezmoi
+
+Guidelines for integrating with chezmoi and building tools on top of it
+
+chemzoi is designed with UNIX-style composability in mind, making it an excellent foundation for building additional tools and integrations.
+
+## Design Philosophy
+
+chezmoi follows these principles for composability:
+
+* **Semantic versioning**: The command line tool follows semantic versioning, ensuring stable APIs
+* **Standard I/O**: Commands work with standard input, output, and error streams
+* **Exit codes**: Proper exit codes for success and failure conditions
+* **Scriptability**: All functionality is accessible via the command line
+
+## Integration Approaches
+
+### Command-Line Execution
+
+The recommended approach is to execute the `chezmoi` binary with appropriate arguments:
+
+```bash theme={null}
+# Get version information
+chemzoi --version
+
+# Apply changes
+chemzoi apply
+
+# Check status
+chemzoi status
+```
+
+### Inspecting Internal State
+
+chezmoi provides commands to inspect its internal state:
+
+#### `chezmoi dump`
+
+Dump chezmoi's computed state in JSON format:
+
+```bash theme={null}
+chemzoi dump
+```
+
+This is useful for:
+
+* Understanding what chezmoi will do
+* Debugging template evaluation
+* Building tools that need to understand chezmoi's state
+
+#### `chezmoi state`
+
+Manage and inspect chezmoi's persistent state:
+
+```bash theme={null}
+# Dump the state
+chemzoi state dump
+
+# Get a specific value
+chemzoi state get --bucket=entryState --key=<key>
+```
+
+## Best Practices
+
+### Standard I/O Configuration
+
+When executing chezmoi, configure standard input and output appropriately:
+
+```python theme={null}
+import subprocess
+
+result = subprocess.run(
+    ['chezmoi', 'dump'],
+    capture_output=True,
+    text=True,
+    check=True
+)
+
+state = json.loads(result.stdout)
+```
+
+### Error Handling
+
+Always check exit codes and handle errors appropriately:
+
+```bash theme={null}
+if ! chezmoi apply; then
+    echo "Failed to apply changes" >&2
+    exit 1
+fi
+```
+
+### Version Compatibility
+
+Check the chezmoi version to ensure compatibility:
+
+```bash theme={null}
+chemzoi --version
+```
+
+Parse the version string to verify minimum requirements for your tool.
+
+## Example Integrations
+
+See the [Related Software](/community/related-software) page for examples of tools built on top of chezmoi, including:
+
+* Editor integrations (Vim, NeoVim, Emacs)
+* UI tools
+* Automation scripts
+* Package manager plugins
+
+## See Also
+
+* [Architecture](/developer/architecture) - Understanding chezmoi's internal structure
+* [Related Software](/community/related-software) - Examples of existing integrations
+
+
+# Contributing to chezmoi
+Source: https://twpayne-chezmoi.mintlify.app/developer/contributing
+
+Guidelines for contributing changes to chezmoi
+
+<Warning>
+  If you use an LLM (Large Language Model, like ChatGPT, Claude, Gemini, GitHub Copilot, or Llama) to make any kind of contribution then you will immediately be banned without recourse. See the [Code of Conduct](https://github.com/twpayne/chezmoi/blob/master/.github/CODE_OF_CONDUCT.md) for more information.
+</Warning>
+
+Bug reports, bug fixes, and documentation improvements are always welcome. Please [open an issue](https://github.com/twpayne/chezmoi/issues/new/choose) or [create a pull request](https://help.github.com/en/articles/creating-a-pull-request) with your report, fix, or improvement.
+
+## Before Making Significant Changes
+
+If you want to make a more significant change, please first [open an issue](https://github.com/twpayne/chezmoi/issues/new/choose) to discuss the change that you want to make. Dave Cheney gives a [good rationale](https://dave.cheney.net/2019/02/18/talk-then-code) as to why this is important.
+
+## Pull Request Checklist
+
+All changes are made via pull requests. In your pull request, please make sure that:
+
+### Tests
+
+* All existing tests pass. You can ensure this by running `make test`.
+* There are appropriate additional tests that demonstrate that your PR works as intended.
+
+### Documentation
+
+* The documentation is updated, if necessary. For new features you should add an entry in `assets/chezmoi.io/docs/user-guide/` and a complete description in `assets/chezmoi.io/docs/reference/`.
+* By default, chezmoi will panic if a flag is undocumented or a long help is missing for a command. You can disable this panic during development by setting the environment variable `CHEZMOIDEV` to `ignoreflags=1,ignorehelp=1`.
+* Once you have documented the command and its flags, run `make generate` to generate the embedded documentation.
+
+To build and view the documentation locally, see the [chezmoi.io website repository](https://github.com/twpayne/chezmoi.io).
+
+### Code Quality
+
+* All generated files are up to date. You can ensure this by running `make generate` and including any modified files in your commit.
+* The code is correctly formatted. You can ensure this by running `make format`.
+* The code passes [`golangci-lint`](https://github.com/golangci/golangci-lint). You can ensure this by running `make lint`.
+
+### Commit Messages
+
+* The commit messages adhere to the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/), with the following additional requirements:
+
+  * The first character of the commit message is uppercase, e.g:
+
+    ```text theme={null}
+    chore: Fix typo in test
+    ```
+
+    The purpose of this is to maintain consistency in chezmoi's release notes, which are generated directly from the commit messages.
+
+  * The commits do not have scopes (e.g. `chore(scope): Message` is invalid).
+
+The following criteria can be used to determine the commit type:
+
+* `fix`: bug fixes in chezmoi code
+* `feat`: extending an existing feature or adding a new feature
+* `docs`: adding to or updating the documentation
+* `chore`: small changes, such as fixing a typo, correcting grammar (including in documentation), or anything not covered by the above
+
+Examples can be found in the [commit history](https://github.com/twpayne/chezmoi/commits/master/).
+
+### Branch Quality
+
+* Commits are logically separate, with no merge or "fixup" commits.
+* The branch applies cleanly to `master`.
+
+## Code of Conduct
+
+chezmoi follows the [Contributor Covenant Code Of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) with the following additions for LLM (Large Language Model)-generated contributions:
+
+* Any contribution of any LLM-generated content will be rejected and result in an immediate ban for the contributor, without recourse.
+
+
+# Install Script
+Source: https://twpayne-chezmoi.mintlify.app/developer/install-script
+
+Information about chezmoi's install script generation
+
+chemzoi generates its [install script](https://github.com/twpayne/chezmoi/blob/master/assets/scripts/install.sh) from a single source of truth to ensure consistency and maintainability.
+
+## When to Regenerate
+
+You must run `make generate` if your change includes any of the following:
+
+* Modifications to the install script template
+* Additions or modifications to the list of supported operating systems and architectures
+
+## Regenerating the Install Script
+
+To regenerate all generated files, including the install script:
+
+```sh theme={null}
+make generate
+```
+
+This command will:
+
+1. Process the install script template
+2. Generate platform-specific installation code
+3. Update all derived files
+
+## Continuous Integration
+
+chemzoi's continuous integration verifies that all generated files are up to date. Changes to generated files should be included in the commit that modifies the source of truth.
+
+## Workflow
+
+When making changes to the install script:
+
+1. Edit the template or configuration that defines the install script
+2. Run `make generate` to update the generated files
+3. Review the changes to ensure they match your expectations
+4. Commit both the source changes and the generated files together
+
+## Template Location
+
+The install script template is located in the chezmoi source tree. The exact location and template engine used may vary, so check the repository structure for the current setup.
+
+## Testing Changes
+
+After regenerating the install script, test it on the target platforms:
+
+```sh theme={null}
+# Test on current system
+sh -c "$(curl -fsLS get.chezmoi.io)"
+
+# Or test locally
+sh assets/scripts/install.sh
+```
+
+## Supported Platforms
+
+The install script supports a wide range of operating systems and architectures:
+
+* Linux (amd64, arm, arm64, i386, ppc64, ppc64le, riscv64, s390x)
+* macOS (amd64, arm64)
+* FreeBSD (amd64, arm, arm64, i386)
+* OpenBSD (amd64, arm, arm64, i386)
+* Windows (amd64, arm64, i386)
+
+When adding support for new platforms, update the relevant configuration and regenerate the install script.
+
+## See Also
+
+* [Packaging](/developer/packaging) - Guidelines for packaging chezmoi
+* [Releases](/developer/releases) - Release process and automation
+
+
+# Packaging chezmoi
+Source: https://twpayne-chezmoi.mintlify.app/developer/packaging
+
+Guidelines for packaging chezmoi for operating systems and distributions
+
+If you're packaging chezmoi for an operating system or distribution, this guide provides essential information to ensure a quality package.
+
+## Build Dependencies
+
+chezmoi has no build dependencies other than the standard Go toolchain.
+
+## Runtime Dependencies
+
+chezmoi has no runtime dependencies, but is usually used with `git`, so many packagers choose to make `git` an install dependency or recommended package.
+
+## Version Information
+
+Please set the version number, git commit, and build time in the binary. This greatly assists debugging when end users report problems or ask for help.
+
+You can do this by passing the following flags to `go build`:
+
+```bash theme={null}
+go build -ldflags "-X main.version=$VERSION \
+                   -X main.commit=$COMMIT \
+                   -X main.date=$DATE \
+                   -X main.builtBy=$BUILT_BY"
+```
+
+### `$VERSION`
+
+* Should be the chezmoi version, e.g. `1.7.3`
+* Any `v` prefix is optional and will be stripped
+* You can pass the git tag in directly
+
+<Tip>
+  The command `git describe --abbrev=0 --tags` will return a suitable value for `$VERSION`.
+</Tip>
+
+### `$COMMIT`
+
+Should be the full git commit hash at which chezmoi is built, e.g. `4d678ce6850c9d81c7ab2fe0d8f20c1547688b91`.
+
+<Tip>
+  The `internal/cmds/generate-commit/main.go` script will return a suitable value for `$COMMIT`.
+
+  You can run it with:
+
+  ```bash theme={null}
+  go tool generate-commit
+  ```
+
+  Alternatively, the source archive contains a file called `COMMIT` containing the commit hash.
+</Tip>
+
+### `$DATE`
+
+Should be the date of the build as a UNIX timestamp or in RFC3339 format.
+
+<Tip>
+  The command `git show -s --format=%ct HEAD` returns the UNIX timestamp of the last commit, e.g. `1636668628`.
+
+  The command `date -u +%Y-%m-%dT%H:%M:%SZ` returns the current time in RFC3339 format, e.g. `2019-11-23T18:29:25Z`.
+</Tip>
+
+### `$BUILT_BY`
+
+Should be a string indicating what system was used to build the binary. Typically it should be the name of your packaging system, e.g. `homebrew`.
+
+## CGO Considerations
+
+Please enable cgo, if possible. chezmoi can be built and run without cgo, but the `.chezmoi.username` and `.chezmoi.group` template variables may not be set correctly on some systems.
+
+## Upgrade Command
+
+chezmoi includes an `upgrade` command which attempts to self-upgrade. You can remove this command completely by building chezmoi with the `noupgrade` build tag:
+
+```bash theme={null}
+go build -tags noupgrade
+```
+
+This is recommended for system package managers to prevent users from accidentally upgrading outside of the package management system.
+
+## Shell Completions
+
+chezmoi includes shell completions in the `completions` directory. Please include these in the package and install them in the shell-appropriate directory, if possible.
+
+Typical installation paths:
+
+* **Bash**: `/usr/share/bash-completion/completions/chezmoi`
+* **Zsh**: `/usr/share/zsh/site-functions/_chezmoi`
+* **Fish**: `/usr/share/fish/vendor_completions.d/chezmoi.fish`
+* **PowerShell**: Check your distribution's conventions
+
+## Using Make
+
+You can use the provided Makefile for building and installing:
+
+```bash theme={null}
+make VERSION=v2.0.0 \
+     COMMIT=$(git rev-parse HEAD) \
+     DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ) \
+     BUILT_BY=mypackage \
+     PREFIX=/usr \
+     DESTDIR=$pkgdir \
+     install
+```
+
+This will:
+
+1. Build the binary with embedded version information
+2. Install it to `${DESTDIR}${PREFIX}/bin/chezmoi`
+
+## Installation Guide
+
+If the instructions for installing chezmoi in chezmoi's [install guide](/install) are absent or incorrect, please open an issue or submit a PR to correct them.
+
+## Example Package Configurations
+
+### Homebrew
+
+```ruby theme={null}
+class Chezmoi < Formula
+  desc "Manage your dotfiles across multiple machines"
+  homepage "https://chezmoi.io/"
+  url "https://github.com/twpayne/chezmoi/archive/v2.0.0.tar.gz"
+  
+  depends_on "go" => :build
+  
+  def install
+    system "make",
+           "VERSION=v#{version}",
+           "COMMIT=#{stable.specs[:revision]}",
+           "DATE=#{time.iso8601}",
+           "BUILT_BY=homebrew",
+           "PREFIX=#{prefix}",
+           "install"
+  end
+end
+```
+
+### Arch Linux PKGBUILD
+
+```bash theme={null}
+build() {
+  cd "$srcdir/chezmoi-$pkgver"
+  
+  make VERSION="v$pkgver" \
+       COMMIT="$(cat COMMIT)" \
+       DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+       BUILT_BY="arch" \
+       build
+}
+
+package() {
+  cd "$srcdir/chezmoi-$pkgver"
+  
+  install -Dm755 chezmoi "$pkgdir/usr/bin/chezmoi"
+  
+  # Shell completions
+  install -Dm644 completions/chezmoi-completion.bash \
+    "$pkgdir/usr/share/bash-completion/completions/chezmoi"
+  install -Dm644 completions/chezmoi.fish \
+    "$pkgdir/usr/share/fish/vendor_completions.d/chezmoi.fish"
+  install -Dm644 completions/chezmoi.zsh \
+    "$pkgdir/usr/share/zsh/site-functions/_chezmoi"
+}
+```
+
+## See Also
+
+* [Building](/developer/building) - Build instructions
+* [Releases](/developer/releases) - Release process
+
+
+# Releases
+Source: https://twpayne-chezmoi.mintlify.app/developer/releases
+
+How chezmoi releases are created and published
+
+Releases are managed with [goreleaser](https://goreleaser.com/), providing automated builds, packaging, and distribution across multiple platforms.
+
+## Testing a Release
+
+To build a test release without publishing (Ubuntu Linux only), first ensure that the `musl-tools` and `snapcraft` packages are installed:
+
+```sh theme={null}
+sudo apt-get install musl-tools snapcraft
+```
+
+Then run:
+
+```sh theme={null}
+make test-release
+```
+
+This creates a local build with all distribution formats but skips publishing and code signing.
+
+## Publishing a Release
+
+Publish a new release by creating and pushing a tag:
+
+```sh theme={null}
+git tag v1.2.3
+git push --tags
+```
+
+This triggers a [GitHub Action](https://github.com/twpayne/chezmoi/actions) that:
+
+1. Builds archives, packages, and snaps for all supported platforms
+2. Creates a new [GitHub Release](https://github.com/twpayne/chezmoi/releases)
+3. Publishes to package repositories
+4. Deploys the [website](https://chezmoi.io)
+
+## Distribution Channels
+
+### Snaps
+
+Publishing [Snaps](https://snapcraft.io/) requires a `SNAPCRAFT_STORE_CREDENTIALS` [repository secret](https://github.com/twpayne/chezmoi/settings/secrets/actions).
+
+#### Credential Expiration
+
+Snapcraft store credentials periodically expire. This is visible in the release GitHub Action reporting:
+
+```text theme={null}
+Run snapcraft whoami
+Store operation failed:
+- macaroon-authorization-required: The request is missing an Authorization header field containing a valid macaroon
+```
+
+#### Refreshing Credentials
+
+Create new snapcraft store credentials by running:
+
+```sh theme={null}
+snapcraft export-login --snaps=chezmoi --channels=stable,candidate,beta,edge --acls=package_upload -
+```
+
+<Warning>
+  This command requires a Ubuntu machine with snapcraft installed and a keyring, which is typically not available over SSH connections.
+</Warning>
+
+Login to a GNOME session on a Ubuntu machine and run:
+
+```sh theme={null}
+sudo snap install --classic snapcraft
+snapcraft login
+```
+
+### Homebrew
+
+[Homebrew](https://brew.sh/) automation automatically detects new releases of chezmoi within a few hours and opens a pull request in [github.com/Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core) to bump the version.
+
+If needed, the pull request can be created manually:
+
+```sh theme={null}
+brew bump-formula-pr --tag=v1.2.3 chezmoi
+```
+
+### Scoop
+
+chezmoi is in [Scoop](https://scoop.sh/)'s Main bucket. Scoop's automation automatically detects new releases within a few hours.
+
+## Signing
+
+chezmoi uses [GoReleaser's support for signing](https://goreleaser.com/customization/sign/) to sign the checksums of its release assets with [cosign](https://github.com/sigstore/cosign).
+
+### Security Details
+
+<AccordionGroup>
+  <Accordion title="Key Generation">
+    * The cosign private key was generated with cosign v1.12.1
+    * Generated on a private recently-installed Ubuntu 22.04.1 system
+    * Single user system with all available updates applied
+  </Accordion>
+
+  <Accordion title="Key Protection">
+    * The private key uses a long (more than 32 character) password
+    * Password generated locally by a password manager
+    * The password-protected private key is stored in chezmoi's public GitHub repo
+    * The private key's password is stored as a GitHub Actions secret
+    * Only available to the `release` step of `release` job of the `main` workflow
+  </Accordion>
+
+  <Accordion title="Public Key Distribution">
+    * The cosign public key is included in the release assets
+    * Also uploaded to [https://chezmoi.io/cosign.pub](https://chezmoi.io/cosign.pub)
+    * Served by [GitHub pages](https://pages.github.com/)
+    * Has equivalent security to the [GitHub Releases page](https://github.com/twpayne/chezmoi/releases)
+  </Accordion>
+</AccordionGroup>
+
+### Verifying Releases
+
+Users can verify release checksums using cosign:
+
+```sh theme={null}
+# Download the public key
+curl -O https://chezmoi.io/cosign.pub
+
+# Verify the checksums
+cosign verify-blob \
+  --key cosign.pub \
+  --signature chezmoi_${VERSION}_checksums.txt.sig \
+  chezmoi_${VERSION}_checksums.txt
+```
+
+## Release Checklist
+
+Before creating a release:
+
+* [ ] All tests pass on main branch
+* [ ] Documentation is up to date
+* [ ] CHANGELOG is updated
+* [ ] Version number follows semantic versioning
+* [ ] No open critical issues
+
+After creating a release:
+
+* [ ] GitHub Release is created successfully
+* [ ] All distribution formats are available
+* [ ] Checksums are signed
+* [ ] Website is deployed
+* [ ] Package repositories are updated
+
+## See Also
+
+* [Packaging](/developer/packaging) - Guidelines for packaging chezmoi
+* [Install Script](/developer/install-script) - Install script generation
+
+
+# Security
+Source: https://twpayne-chezmoi.mintlify.app/developer/security
+
+Security policy and vulnerability reporting for chezmoi
+
+## Supported Versions
+
+Only the most recent version of chezmoi is supported with security updates.
+
+<Warning>
+  Always upgrade to the latest version to receive security fixes.
+</Warning>
+
+## Virus Scanner False Positives
+
+Virus scanning software, especially on Windows machines, occasionally report viruses or trojans in the chezmoi binary. This is almost certainly a false positive.
+
+### Why This Happens
+
+Go binaries, especially those that are compressed or use certain compilation techniques, can trigger heuristic virus detection. This is a known issue with Go programs.
+
+For more information see [Why does my virus-scanning software think my Go distribution or compiled binary is infected?](https://go.dev/doc/faq#virus) in the Go FAQ.
+
+### What to Do
+
+If your virus scanner flags chezmoi:
+
+1. Verify you downloaded chezmoi from official sources:
+   * [GitHub Releases](https://github.com/twpayne/chezmoi/releases)
+   * Official package managers (Homebrew, apt, etc.)
+   * The official install script at [get.chezmoi.io](https://get.chezmoi.io)
+
+2. Verify the checksum of the binary against the official checksums
+
+3. Check the [signed checksums](/developer/releases#signing) using cosign
+
+4. If you're still concerned, build from source:
+   ```sh theme={null}
+   git clone https://github.com/twpayne/chezmoi.git
+   cd chezmoi
+   make build
+   ```
+
+5. Add an exception in your virus scanner for the chezmoi binary
+
+## Reporting a Vulnerability
+
+<Warning>
+  Do not report security vulnerabilities through public GitHub issues.
+</Warning>
+
+Please report vulnerabilities through one of these channels:
+
+### GitHub Security Advisories
+
+[Open a security advisory](https://github.com/twpayne/chezmoi/security/advisories/new) on GitHub (preferred method).
+
+### Email
+
+Send an email to [twpayne+chezmoi-security@gmail.com](mailto:twpayne+chezmoi-security@gmail.com).
+
+### GitHub Issue
+
+If the vulnerability is minor or you're unsure, you can [open a GitHub issue](https://github.com/twpayne/chezmoi/issues/new/choose).
+
+## What to Include
+
+When reporting a vulnerability, please include:
+
+* Description of the vulnerability
+* Steps to reproduce the issue
+* Affected versions
+* Potential impact
+* Suggested fix (if any)
+
+## Response Timeline
+
+* **Initial response**: Within 48 hours
+* **Status update**: Within 1 week
+* **Fix timeline**: Depends on severity
+  * Critical: As soon as possible
+  * High: Within 2 weeks
+  * Medium: Within 1 month
+  * Low: Next release cycle
+
+## Disclosure Policy
+
+We follow coordinated disclosure:
+
+1. Vulnerability is reported privately
+2. We confirm and investigate the issue
+3. A fix is developed and tested
+4. A new version is released
+5. Public disclosure after users have had time to upgrade
+
+## Security Best Practices
+
+When using chezmoi:
+
+### Protect Your Source Directory
+
+* Keep your dotfiles repository private if it contains sensitive data
+* Use [encryption](/encryption/overview) for secrets
+* Never commit unencrypted passwords or API keys
+
+### Use Templates for Secrets
+
+* Store secrets in a password manager
+* Use [template functions](/reference/templates/functions) to retrieve secrets
+* Use [age](/encryption/age) or [gpg](/encryption/gpg) encryption
+
+### Regular Updates
+
+* Keep chezmoi updated to the latest version
+* Subscribe to the [GitHub releases](https://github.com/twpayne/chezmoi/releases) for notifications
+
+### Verify Downloads
+
+* Always verify checksums when downloading binaries
+* Use official package managers when possible
+* Check signatures using cosign
+
+## See Also
+
+* [Releases](/developer/releases) - Information about release signing
+* [Code of Conduct](https://github.com/twpayne/chezmoi/blob/master/.github/CODE_OF_CONDUCT.md)
+
+
+# Testing chezmoi
+Source: https://twpayne-chezmoi.mintlify.app/developer/testing
+
+Overview of chezmoi's testing strategy and how to run tests
+
+chemzoi uses multiple levels of testing to ensure code quality and correctness across different platforms and use cases.
+
+## Test Levels
+
+### 1. Unit Testing
+
+Unit tests use the standard [`testing`](https://pkg.go.dev/testing) package and [`github.com/alecthomas/assert/v2`](https://pkg.go.dev/github.com/alecthomas/assert/v2) to test that functions and small components behave as expected for a wide range of inputs, especially edge cases.
+
+* Location: `internal/chezmoi/*_test.go`
+* Purpose: Test individual functions and components in isolation
+
+### 2. File System Integration Tests
+
+Integration tests use `testing` and [`github.com/twpayne/go-vfs/v5`](https://pkg.go.dev/github.com/twpayne/go-vfs/v5) to test chezmoi's effects on the file system.
+
+* Location: `internal/chezmoi/*_test.go` and `internal/cmd/*cmd_test.go`
+* Purpose: Test interactions with the file system in a controlled environment
+
+### 3. High-Level Integration Tests
+
+High-level integration tests use [`github.com/rogpeppe/go-internal/testscript`](https://pkg.go.dev/github.com/rogpeppe/go-internal/testscript) to test complete workflows and command interactions.
+
+* Location: `internal/cmd/testdata/scripts/*.txtar`
+* Test runner: `internal/cmd/main_test.go`
+* Purpose: Test complete user workflows and command-line interactions
+
+### 4. Distribution and OS Tests
+
+Full test suite execution across different environments:
+
+* **Linux distributions**: Run using Docker (in `assets/docker`)
+* **Other OSes**: Run using Vagrant (in `assets/vagrant`)
+* **Windows**: Run in GitHub Actions
+* Purpose: Ensure compatibility across different operating systems and distributions
+
+## Running Tests
+
+### Run All Tests
+
+```sh theme={null}
+go test ./...
+```
+
+Or using make:
+
+```sh theme={null}
+make test
+```
+
+The make target runs tests with different umask values to ensure correct behavior:
+
+```sh theme={null}
+# Tests with umask 022
+go test -ldflags="-X chezmoi.io/chezmoi/internal/chezmoitest.umaskStr=0o022" ./...
+
+# Tests with umask 002
+go test -ldflags="-X chezmoi.io/chezmoi/internal/chezmoitest.umaskStr=0o002" ./...
+```
+
+### Run Individual Tests
+
+Run a specific test:
+
+```sh theme={null}
+go test ./internal/cmd -run=TestScript/$TEST_NAME
+```
+
+For example:
+
+```sh theme={null}
+go test ./internal/cmd -run=TestScript/add
+```
+
+### Run Docker Tests
+
+Test on specific Linux distributions:
+
+```sh theme={null}
+make test-docker
+```
+
+This runs tests on Alpine, Arch Linux, and Fedora.
+
+### Run Vagrant Tests
+
+Test on other operating systems:
+
+```sh theme={null}
+make test-vagrant
+```
+
+This runs tests on FreeBSD 14.
+
+## Code Coverage
+
+Generate a coverage report:
+
+```sh theme={null}
+make coverage
+```
+
+View coverage in your browser:
+
+```sh theme={null}
+make coverage-html
+```
+
+## Test Requirements
+
+chezmoi's tests include integration tests with other software. If the other software is not found in `$PATH`, the tests will be skipped. Running the full set of tests requires:
+
+* `age`
+* `base64`
+* `bash`
+* `bzip2`
+* `git`
+* `gpg`
+* `gzip`
+* `perl`
+* `python3`
+* `rage`
+* `ruby`
+* `sed`
+* `sha256sum`
+* `tr`
+* `true`
+* `unzip`
+* `xz`
+* `zip`
+* `zstd`
+
+## Platform Compatibility
+
+Tests should, if at all possible, run unmodified on all operating systems tested in CI:
+
+* Linux
+* macOS
+* Windows
+* FreeBSD
+
+Windows will sometimes need special handling due to its path separator and lack of POSIX-style file permissions.
+
+## Shell Compatibility
+
+<Note>
+  If you use `fish` as your primary shell, you may get warnings from Fish during tests. These can be avoided by running tests with `SHELL=bash` or `SHELL=zsh`:
+
+  ```sh theme={null}
+  SHELL=bash make test
+  SHELL=zsh make smoke-test
+  SHELL=bash go test ./...
+  ```
+</Note>
+
+## See Also
+
+* [Architecture](/developer/architecture) - Understanding chezmoi's architecture
+* [Contributing](/developer/contributing) - Guidelines for contributing changes
+
+
+# age Encryption
+Source: https://twpayne-chezmoi.mintlify.app/encryption/age
+
+Encrypt your dotfiles with age, a modern encryption tool
+
+chezmoi supports encrypting files with [age](https://age-encryption.org), a simple, modern, and secure file encryption tool.
+
+## Quick Start
+
+Generate a key using `chezmoi age-keygen`:
+
+```bash theme={null}
+chezmoi age-keygen --output=$HOME/key.txt
+```
+
+This will output your public key:
+
+```
+Public key: age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p
+```
+
+## Configuration
+
+Specify age encryption in your configuration file with at least one identity and one recipient:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+encryption = "age"
+
+[age]
+    identity = "/home/user/key.txt"
+    recipient = "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"
+```
+
+<Warning>
+  Make sure `encryption = "age"` is at the top level of your config, before any other sections.
+</Warning>
+
+## Multiple Keys
+
+chezmoi supports multiple identities and recipients for scenarios where you need to decrypt files on multiple machines or share encrypted files with others:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+encryption = "age"
+
+[age]
+    identities = [
+        "/home/user/key1.txt",
+        "/home/user/key2.txt"
+    ]
+    recipients = [
+        "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p",
+        "age1p3ty9zvgd4rztpfm5nm0gy6ckhlvvfz8upvfr4zjp7qmq5dyp8tqm87hjp"
+    ]
+```
+
+## Symmetric Encryption
+
+To use age's symmetric encryption, specify a single identity and enable symmetric mode:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+encryption = "age"
+
+[age]
+    identity = "~/.ssh/id_rsa"
+    symmetric = true
+```
+
+## Passphrase Encryption
+
+To use age's symmetric encryption with a passphrase, set `age.passphrase` to `true`:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+encryption = "age"
+
+[age]
+    passphrase = true
+```
+
+You will be prompted for the passphrase:
+
+* When running `chezmoi add --encrypt`
+* When chezmoi needs to decrypt files (`apply`, `diff`, `status`)
+
+## Usage Examples
+
+### Encrypting Files
+
+Add an encrypted SSH key:
+
+```bash theme={null}
+chezmoi add --encrypt ~/.ssh/id_rsa
+```
+
+### Editing Encrypted Files
+
+Edit an encrypted file (automatically decrypts and re-encrypts):
+
+```bash theme={null}
+chezmoi edit ~/.ssh/id_rsa
+```
+
+### Using Different Keys Per Machine
+
+<CodeGroup>
+  ```toml Personal Machine theme={null}
+  encryption = "age"
+
+  [age]
+      identity = "/home/user/.config/age/personal.key"
+      recipient = "age1personal..."
+  ```
+
+  ```toml Work Machine theme={null}
+  encryption = "age"
+
+  [age]
+      identity = "/home/user/.config/age/work.key"
+      recipient = "age1work..."
+  ```
+</CodeGroup>
+
+### Encrypting Specific File Types
+
+<CodeGroup>
+  ```bash SSH Keys theme={null}
+  chezmoi add --encrypt ~/.ssh/id_rsa
+  chezmoi add --encrypt ~/.ssh/id_ed25519
+  ```
+
+  ```bash API Tokens theme={null}
+  chezmoi add --encrypt ~/.config/github/token
+  chezmoi add --encrypt ~/.aws/credentials
+  ```
+
+  ```bash Certificates theme={null}
+  chezmoi add --encrypt ~/.cert/client-key.pem
+  chezmoi add --encrypt ~/.config/ssl/private.key
+  ```
+</CodeGroup>
+
+## Built-in age Encryption
+
+chezmoi has built-in support for age encryption which is automatically used if the `age` command is not found in `$PATH`.
+
+<Note>
+  The built-in age encryption does not support:
+
+  * Passphrases
+  * Symmetric encryption
+  * SSH keys
+
+  For these features, install the standalone [age tool](https://github.com/FiloSottile/age).
+</Note>
+
+### Why No Passphrase Support?
+
+Passphrases are not supported in built-in mode because chezmoi needs to decrypt files regularly (e.g., during `chezmoi diff` or `chezmoi status`), not just when running `chezmoi apply`. Prompting for a passphrase each time would quickly become tiresome.
+
+### Why No SSH Key Support?
+
+The [age documentation](https://pkg.go.dev/filippo.io/age#hdr-Key_management) explicitly recommends not using SSH keys:
+
+> When integrating age into a new system, it's recommended that you only support X25519 keys, and not SSH keys. The latter are supported for manual encryption operations.
+
+## Sharing Encrypted Files
+
+To share encrypted files with another user:
+
+1. Get their public age key (recipient)
+2. Add their recipient to your config:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+encryption = "age"
+
+[age]
+    identity = "/home/user/key.txt"
+    recipients = [
+        "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p",  # Your key
+        "age1p3ty9zvgd4rztpfm5nm0gy6ckhlvvfz8upvfr4zjp7qmq5dyp8tqm87hjp"   # Their key
+    ]
+```
+
+3. Re-encrypt existing files:
+
+```bash theme={null}
+chezmoi re-add --encrypt
+```
+
+## Troubleshooting
+
+### "failed to decrypt" Error
+
+Ensure your identity file exists and contains the correct private key:
+
+```bash theme={null}
+cat ~/.config/age/key.txt
+```
+
+### Permission Denied
+
+Check that your identity file has restricted permissions:
+
+```bash theme={null}
+chmod 600 ~/.config/age/key.txt
+```
+
+### Multiple Recipients Not Working
+
+Verify your config has `recipients` (plural), not `recipient`:
+
+```toml theme={null}
+[age]
+    recipients = ["age1...", "age2..."]  # ✓ Correct
+    # recipient = "age1..."               # ✗ Wrong for multiple
+```
+
+## Best Practices
+
+1. **Store keys securely**: Keep your identity file outside your chezmoi source directory
+2. **Use different keys per environment**: Personal vs. work machines
+3. **Backup your keys**: Without them, encrypted files cannot be decrypted
+4. **Test decryption**: Verify you can decrypt before removing originals
+5. **Use age over GPG**: age is simpler and more modern for new setups
+
+## See Also
+
+* [age website](https://age-encryption.org/)
+* [age GitHub repository](https://github.com/FiloSottile/age)
+* [Encryption Overview](/encryption/overview)
+* [GPG Encryption](/encryption/gpg)
+
+
+# GPG Encryption
+Source: https://twpayne-chezmoi.mintlify.app/encryption/gpg
+
+Encrypt your dotfiles with GPG/PGP encryption
+
+chezmoi supports encrypting files with [GPG](https://www.gnupg.org/), also known as GnuPG. Encrypted files are stored in the source state and automatically decrypted when generating the target state or editing with `chezmoi edit`.
+
+## Quick Start
+
+Configure GPG encryption in your chezmoi config:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+encryption = "gpg"
+
+[gpg]
+    recipient = "your-email@example.com"
+```
+
+<Warning>
+  Make sure `encryption = "gpg"` is at the top level of your config, before any other sections.
+</Warning>
+
+## Asymmetric (Private/Public Key) Encryption
+
+Asymmetric encryption uses your GPG key pair. Specify the encryption key recipient in your configuration:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+encryption = "gpg"
+
+[gpg]
+    recipient = "your-email@example.com"
+```
+
+Or use the key ID directly:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+encryption = "gpg"
+
+[gpg]
+    recipient = "0x1234567890ABCDEF"
+```
+
+### How It Works
+
+chezmoi will encrypt files using:
+
+```bash theme={null}
+gpg --armor --recipient $RECIPIENT --encrypt
+```
+
+The encrypted file is stored in the source state and automatically decrypted when generating the target state.
+
+## Symmetric Encryption
+
+For symmetric encryption (password-based), configure:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+encryption = "gpg"
+
+[gpg]
+    symmetric = true
+```
+
+chezmoi will encrypt files using:
+
+```bash theme={null}
+gpg --armor --symmetric
+```
+
+## Encrypting with a Passphrase
+
+If you want to encrypt files with a passphrase that's stored in plaintext on your machines:
+
+```toml ~/.local/share/chezmoi/.chezmoi.toml.tmpl theme={null}
+{{ $passphrase := promptStringOnce . "passphrase" "passphrase" -}}
+
+encryption = "gpg"
+
+[data]
+    passphrase = {{ $passphrase | quote }}
+
+[gpg]
+    symmetric = true
+    args = [
+        "--batch",
+        "--passphrase", {{ $passphrase | quote }},
+        "--no-symkey-cache"
+    ]
+```
+
+This will:
+
+1. Prompt for the passphrase on first run of `chezmoi init`
+2. Remember the passphrase in your configuration file
+3. Use it automatically for encryption/decryption
+
+<Warning>
+  The passphrase will be stored in plaintext in your config file. Only use this if you're comfortable with that trade-off.
+</Warning>
+
+## Usage Examples
+
+### Encrypting Files
+
+Add an encrypted SSH key:
+
+```bash theme={null}
+chezmoi add --encrypt ~/.ssh/id_rsa
+```
+
+### Editing Encrypted Files
+
+Edit an encrypted file (automatically decrypts and re-encrypts):
+
+```bash theme={null}
+chezmoi edit ~/.ssh/id_rsa
+```
+
+### Different Recipients Per Machine
+
+<CodeGroup>
+  ```toml Personal Machine theme={null}
+  encryption = "gpg"
+
+  [gpg]
+      recipient = "personal@example.com"
+  ```
+
+  ```toml Work Machine theme={null}
+  encryption = "gpg"
+
+  [gpg]
+      recipient = "work@company.com"
+  ```
+</CodeGroup>
+
+### Encrypting Specific File Types
+
+<CodeGroup>
+  ```bash SSH Keys theme={null}
+  chezmoi add --encrypt ~/.ssh/id_rsa
+  chezmoi add --encrypt ~/.ssh/id_ed25519
+  ```
+
+  ```bash API Tokens theme={null}
+  chezmoi add --encrypt ~/.config/github/token
+  chezmoi add --encrypt ~/.npmrc
+  ```
+
+  ```bash AWS Credentials theme={null}
+  chezmoi add --encrypt ~/.aws/credentials
+  chezmoi add --encrypt ~/.aws/config
+  ```
+</CodeGroup>
+
+## Muting GPG Output
+
+GPG sends some info messages to stderr instead of stdout. To mute this output, add `--quiet` to `gpg.args`:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[gpg]
+    recipient = "your-email@example.com"
+    args = ["--quiet"]
+```
+
+## Custom GPG Arguments
+
+You can pass additional arguments to GPG:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[gpg]
+    recipient = "your-email@example.com"
+    args = [
+        "--quiet",
+        "--trust-model", "always",
+        "--armor"
+    ]
+```
+
+## Using a Specific GPG Key
+
+If you have multiple GPG keys, specify which one to use:
+
+```bash theme={null}
+gpg --list-secret-keys --keyid-format LONG
+```
+
+Then use the key ID in your config:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+encryption = "gpg"
+
+[gpg]
+    recipient = "0x1234567890ABCDEF"
+```
+
+## Multiple Recipients
+
+To encrypt files for multiple recipients:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+encryption = "gpg"
+
+[gpg]
+    recipient = "key1@example.com"
+    args = [
+        "--recipient", "key2@example.com",
+        "--recipient", "key3@example.com"
+    ]
+```
+
+## Setting Up GPG Keys
+
+If you don't have a GPG key yet:
+
+### Generate a New Key
+
+```bash theme={null}
+gpg --full-generate-key
+```
+
+Follow the prompts to create your key.
+
+### List Your Keys
+
+```bash theme={null}
+gpg --list-secret-keys --keyid-format LONG
+```
+
+### Export Your Public Key
+
+```bash theme={null}
+gpg --armor --export your-email@example.com > public-key.asc
+```
+
+### Import a Key on Another Machine
+
+```bash theme={null}
+gpg --import public-key.asc
+gpg --import private-key.asc
+```
+
+## Troubleshooting
+
+### "no public key" Error
+
+Ensure the recipient key is in your GPG keyring:
+
+```bash theme={null}
+gpg --list-keys your-email@example.com
+```
+
+If not found, import it:
+
+```bash theme={null}
+gpg --import public-key.asc
+```
+
+### "decryption failed" Error
+
+Verify you have the private key:
+
+```bash theme={null}
+gpg --list-secret-keys
+```
+
+### Trust Issues
+
+If GPG complains about untrusted keys:
+
+```bash theme={null}
+gpg --edit-key your-email@example.com
+# In the GPG prompt:
+gpg> trust
+gpg> 5  # Ultimate trust
+gpg> quit
+```
+
+Or use `--trust-model always` in your config:
+
+```toml theme={null}
+[gpg]
+    args = ["--trust-model", "always"]
+```
+
+### Permission Denied
+
+Check GPG directory permissions:
+
+```bash theme={null}
+chmod 700 ~/.gnupg
+chmod 600 ~/.gnupg/*
+```
+
+## Best Practices
+
+1. **Backup your keys**: Export and securely store your GPG keys
+2. **Use subkeys**: Create separate subkeys for encryption
+3. **Set expiration**: Use key expiration dates for better security
+4. **Test decryption**: Verify you can decrypt before removing originals
+5. **Consider age**: For new setups, [age](/encryption/age) is simpler and more modern
+
+## GPG vs age
+
+| Feature        | GPG                         | age                        |
+| -------------- | --------------------------- | -------------------------- |
+| Maturity       | Very mature, widely used    | Modern, actively developed |
+| Key Management | Complex, multiple key types | Simple, single key type    |
+| Setup          | Requires GPG installation   | Built-in to chezmoi        |
+| Speed          | Slower                      | Faster                     |
+| Best For       | Existing GPG users          | New users, simple setups   |
+
+## See Also
+
+* [GPG website](https://www.gnupg.org/)
+* [GPG documentation](https://www.gnupg.org/documentation/)
+* [Encryption Overview](/encryption/overview)
+* [age Encryption](/encryption/age)
+
+
+# Encryption Overview
+Source: https://twpayne-chezmoi.mintlify.app/encryption/overview
+
+Keep your secrets secure with chezmoi's encryption support
+
+chezmoi supports encrypting files with [age](https://age-encryption.org), [git-crypt](https://github.com/AGWA/git-crypt), [gpg](https://www.gnupg.com/), and [transcrypt](https://github.com/elasticdog/transcrypt).
+
+Encrypted files are stored in ASCII-armored format in the source directory with the `encrypted_` attribute and are automatically decrypted when needed.
+
+## Adding Encrypted Files
+
+Add files to be encrypted with the `--encrypt` flag:
+
+```bash theme={null}
+chezmoi add --encrypt ~/.ssh/id_rsa
+```
+
+This will encrypt the file and store it in your source directory (typically `~/.local/share/chezmoi`).
+
+## Editing Encrypted Files
+
+`chezmoi edit` will transparently decrypt the file before editing and re-encrypt it afterwards:
+
+```bash theme={null}
+chezmoi edit ~/.ssh/id_rsa
+```
+
+## Template Functions
+
+chezmoi provides template functions for encrypting and decrypting data within templates:
+
+### `encrypt`
+
+Encrypts plaintext data using your configured encryption method:
+
+```text theme={null}
+{{ encrypt "my-secret-value" }}
+```
+
+### `decrypt`
+
+Decrypts ciphertext data:
+
+```text theme={null}
+{{ decrypt "-----BEGIN AGE ENCRYPTED FILE-----..." }}
+```
+
+## Supported Encryption Methods
+
+chezmoi supports several encryption methods:
+
+<CardGroup>
+  <Card title="age" icon="key" href="/encryption/age">
+    Modern encryption tool with simple key management
+  </Card>
+
+  <Card title="gpg" icon="lock" href="/encryption/gpg">
+    Traditional GPG/PGP encryption with asymmetric keys
+  </Card>
+</CardGroup>
+
+## Choosing an Encryption Method
+
+Configure your preferred encryption method in `~/.config/chezmoi/chezmoi.toml`:
+
+```toml theme={null}
+encryption = "age"  # or "gpg"
+```
+
+<Warning>
+  Make sure `encryption` is added to the top level section at the beginning of the config, before any other sections.
+</Warning>
+
+## How It Works
+
+When you add an encrypted file:
+
+1. chezmoi encrypts the file content using your configured encryption method
+2. The encrypted content is stored with the `encrypted_` prefix in the filename
+3. When applying your dotfiles, chezmoi automatically decrypts the file
+4. The decrypted content is written to the target location
+
+## Best Practices
+
+* **Keep your keys secure**: Store encryption keys outside of your chezmoi source directory
+* **Use different keys per machine**: For sensitive environments, use machine-specific encryption keys
+* **Test decryption**: Verify you can decrypt files before removing the originals
+* **Backup your keys**: Without your encryption keys, your encrypted files cannot be recovered
+
+## Common Use Cases
+
+### SSH Keys
+
+```bash theme={null}
+chezmoi add --encrypt ~/.ssh/id_rsa
+chezmoi add --encrypt ~/.ssh/id_ed25519
+```
+
+### API Tokens
+
+Store API tokens in an encrypted file:
+
+```bash theme={null}
+chezmoi add --encrypt ~/.config/api-tokens
+```
+
+### Certificates
+
+```bash theme={null}
+chezmoi add --encrypt ~/.cert/private-key.pem
+```
+
+## Next Steps
+
+<CardGroup>
+  <Card title="Configure age" icon="key" href="/encryption/age">
+    Set up modern encryption with age
+  </Card>
+
+  <Card title="Configure GPG" icon="lock" href="/encryption/gpg">
+    Set up traditional GPG encryption
+  </Card>
+</CardGroup>
+
+
+# Design Decisions FAQ
+Source: https://twpayne-chezmoi.mintlify.app/faq/design
+
+Frequently asked questions about chezmoi's design and architecture
+
+Questions about why chezmoi works the way it does, and the reasoning behind key design decisions.
+
+<AccordionGroup>
+  <Accordion title="Do I have to use `chezmoi edit` to edit my dotfiles?">
+    No, you don't have to! `chezmoi edit` is a convenience command with useful features, but there are multiple ways to edit your dotfiles.
+
+    **Option 1: Use `chezmoi edit`** (recommended for most users)
+
+    ```bash theme={null}
+    chezmoi edit ~/.bashrc
+    chezmoi edit --apply ~/.bashrc  # Apply after editing
+    chezmoi edit --watch ~/.bashrc  # Auto-apply on save
+    ```
+
+    **Benefits:**
+
+    * Automatically handles encryption/decryption
+    * Works with target paths (not source paths)
+    * Syntax highlighting works correctly
+    * Can auto-apply changes with `--apply`
+    * Integrates with git auto-commit/push
+
+    **Option 2: Edit in source directory**
+
+    ```bash theme={null}
+    chezmoi cd  # Open shell in source directory
+    vim dot_bashrc  # Edit directly
+    chezmoi diff  # Preview changes
+    chezmoi apply  # Apply if happy
+    ```
+
+    **Option 3: Edit target, then re-add**
+
+    ```bash theme={null}
+    vim ~/.bashrc  # Edit in place
+    chezmoi re-add  # Update source state
+    ```
+
+    **Option 4: Edit target, then merge**
+
+    ```bash theme={null}
+    vim ~/.bashrc
+    chezmoi merge ~/.bashrc  # Resolve differences
+    ```
+
+    Choose the workflow that fits your style!
+  </Accordion>
+
+  <Accordion title="Why doesn't chezmoi use symlinks like GNU Stow?">
+    chezmoi **does** support symlinks as first-class citizens - you can create, update, and remove symlinks, and even template them to point to different targets on different machines.
+
+    However, unlike GNU Stow, chezmoi doesn't **require** symlinks as a layer of indirection between your dotfiles and their content.
+
+    **GNU Stow approach:**
+
+    * Home directory files are symlinks pointing to a central directory
+    * Your dotfiles are "special" (they're actually symlinks)
+    * Changes to the central directory are immediately visible
+
+    **chezmoi approach:**
+
+    * Home directory files are regular files
+    * Your dotfiles are "normal" (no special symlink behavior)
+    * Provides features impossible with symlinks (encryption, templates, private files)
+
+    **Why regular files are better for dotfiles:**
+
+    1. **Advanced features:**
+       * Encrypted files (can't symlink to ciphertext)
+       * Template files (can't symlink to template source)
+       * Private files (can't control permissions via symlink)
+       * Executable files (git doesn't track executable bit)
+    2. **Cross-platform compatibility:**
+       * Windows has limited symlink support
+       * No permission issues on Windows
+       * Works the same everywhere
+    3. **Security:**
+       * Encrypted secrets stay encrypted
+       * Private files have correct permissions
+       * No accidental exposure via symlink
+
+    **If you really want symlinks:**
+
+    chezmoi provides a symlink mode:
+
+    ```toml theme={null}
+    # ~/.config/chezmoi/chezmoi.toml
+    mode = "symlink"
+    ```
+
+    However, this has limitations (see limitations below).
+  </Accordion>
+
+  <Accordion title="What are the limitations of chezmoi's symlink mode?">
+    When you enable symlink mode, chezmoi creates symlinks back to the source directory where possible. However, many features require regular files:
+
+    **Cannot use symlinks for:**
+
+    1. **Encrypted files** - The source contains ciphertext, not plaintext
+    2. **Executable files** - Source files must be regular files for portability
+    3. **Private files** - Git doesn't persist group/world permission bits
+    4. **Template files** - The source contains the template, not the result
+    5. **Entire directories** - Attributes and exact\_ behavior don't work
+
+    **Other limitations:**
+
+    * Running `chezmoi add` doesn't immediately create symlinks
+    * You must run `chezmoi apply` to create symlinks
+    * Mixed file types in the same directory can be confusing
+
+    **When to use symlink mode:**
+
+    * You have simple dotfiles without templates or encryption
+    * You want immediate visibility of changes
+    * You're transitioning from GNU Stow
+
+    **When NOT to use symlink mode:**
+
+    * You need encryption
+    * You want machine-specific configurations (templates)
+    * You manage dotfiles on Windows
+    * You need executable or private files
+  </Accordion>
+
+  <Accordion title="Why does chezmoi use weird filenames?">
+    chezmoi's filename convention (like `dot_bashrc`, `private_dot_ssh`) is a deliberate design choice with important benefits.
+
+    **The criticism:**
+
+    * Filenames are verbose and unusual
+    * Not all file permissions can be represented
+    * Everything is in a single directory
+
+    **The reasoning:**
+
+    1. **Metadata in filenames is universal**
+       * Almost all programs store metadata in filenames (the extension)
+       * chezmoi extends this to prefixes (attributes)
+    2. **Transparency and clarity**
+       * `dot_` makes it obvious which files are managed
+       * Files starting with `.` are ignored by chezmoi (for version control)
+       * No special whitelists needed for `.git`, `.gitignore`, etc.
+    3. **Simplicity and atomicity**
+       * Each file's metadata is stored with the file
+       * Adding/removing a file touches only that file
+       * Changing attributes is a simple rename
+       * No need to parse/update a central config file
+    4. **Version control friendly**
+       * Changes to metadata are simple git operations
+       * Easy to see what changed in git history
+       * Comments and formatting are never lost
+
+    **Supported permissions:**
+
+    chezmoi's attributes support the most common permission combinations:
+
+    * `0o644`, `0o755`, `0o600`, `0o700`, `0o444`, `0o555`, `0o400`, `0o500`
+    * Directories: `0o755`, `0o700`, `0o500`
+
+    In practice, these cover 99% of dotfile use cases.
+
+    **The directory issue:**
+
+    Yes, all root-level dotfiles appear in the source root. Mitigate this with `.chezmoiroot`:
+
+    ```bash theme={null}
+    echo "home" > ~/.local/share/chezmoi/.chezmoiroot
+    ```
+
+    Now your dotfiles live in the `home/` subdirectory, keeping the repo root clean.
+
+    **Backwards compatibility:**
+
+    chezmoi has many users, so the filename convention must remain stable. Any changes would need to:
+
+    1. Be fully backwards-compatible
+    2. Fix a genuine real-world problem
+    3. Work across all operating systems
+    4. Not add significant complexity
+  </Accordion>
+
+  <Accordion title="Can chezmoi support multiple sources or multiple source states?">
+    chezmoi deliberately uses a **single source of truth** - one branch in one git repo. This is an opinionated design choice to avoid complexity and ambiguity.
+
+    **Why single source?**
+
+    Multiple sources create problems:
+
+    1. **Ambiguous user interface:**
+       * `chezmoi add ~/.bashrc` - which source should this go to?
+       * How does the user specify their preference?
+    2. **Overlapping targets:**
+       * What if two sources both want to set `$EDITOR` in `.bashrc`?
+       * How do you handle mutually exclusive configs (vim vs emacs)?
+    3. **Dependencies between sources:**
+       * Should shell completions be with the app or the shell?
+       * Hard to maintain clean separation
+
+    **How chezmoi handles variation:**
+
+    Instead of multiple sources, use:
+
+    * **Templates** for minor differences
+    * **`.chezmoiignore`** to exclude files on certain machines
+    * **Password managers** for secrets (not stored in repo)
+    * **Externals** to pull in third-party dotfiles
+
+    **If you really need multiple sources:**
+
+    **Option 1: Multiple apply commands**
+
+    ```bash theme={null}
+    chezmoi-apply() {
+        chezmoi apply --config ~/.config/chezmoi-home/chezmoi.toml \
+                      --source ~/.local/share/chezmoi-home && \
+        chezmoi apply --config ~/.config/chezmoi-work/chezmoi.toml \
+                      --source ~/.local/share/chezmoi-work
+    }
+    ```
+
+    **Option 2: Combine sources before applying**
+
+    ```bash theme={null}
+    #!/bin/bash
+    combined_source="$(mktemp -d)"
+    trap 'rm -rf -- "${combined_source}"' INT TERM
+
+    for source in $HOME/.dotfiles/*; do
+        cp -r "${source}"/* "${combined_source}"
+    done
+
+    chezmoi apply --source "${combined_source}"
+    ```
+
+    **Option 3: Nested chezmoi**
+    Use a `run_` script to invoke a second chezmoi instance. See [felipecrs/dotfiles](https://github.com/felipecrs/dotfiles) for an example.
+  </Accordion>
+
+  <Accordion title="Why does `chezmoi cd` spawn a shell instead of just changing directory?">
+    This is a technical limitation, not a design choice.
+
+    **The problem:**
+    A program cannot change the working directory of its parent process. When you run `chezmoi cd`, it's running as a child process of your shell - it can only change its own directory, not your shell's.
+
+    **The workaround:**
+
+    Create a shell function instead:
+
+    ```bash theme={null}
+    # Add to ~/.bashrc or ~/.zshrc
+    chezmoi-cd() {
+        cd $(chezmoi source-path)
+    }
+    ```
+
+    Or as an alias:
+
+    ```bash theme={null}
+    alias ccd='cd $(chezmoi source-path)'
+    ```
+
+    Now typing `chezmoi-cd` or `ccd` changes your current shell's directory.
+  </Accordion>
+
+  <Accordion title="Why are the `prompt*` functions only available in config file templates?">
+    The `promptString`, `promptBool`, and similar functions only work during `chezmoi init` because prompting during normal operations would be disruptive.
+
+    **The problem:**
+
+    chezmoi executes templates for many commands:
+
+    * `chezmoi apply`
+    * `chezmoi diff`
+    * `chezmoi status`
+    * Many others
+
+    If templates could prompt interactively, you'd have to answer questions every time you run any command. This would quickly become tiresome.
+
+    **The solution:**
+
+    Prompt once during initialization:
+
+    ```go title=".chezmoi.toml.tmpl" theme={null}
+    {{- $email := promptString "email" -}}
+    {{- $work := promptBool "work machine" -}}
+
+    [data]
+        email = {{ $email | quote }}
+        work = {{ $work }}
+    ```
+
+    Then use the values in other templates:
+
+    ```gitconfig title="dot_gitconfig.tmpl" theme={null}
+    [user]
+        email = {{ .email }}
+    ```
+
+    **Re-prompting:**
+
+    If you need to change answers:
+
+    ```bash theme={null}
+    chezmoi init  # Prompts again
+    ```
+  </Accordion>
+
+  <Accordion title="Why not use Ansible/Chef/Puppet/Salt to manage dotfiles?">
+    You **can** use full system management tools for dotfiles, but chezmoi is purpose-built for this specific use case.
+
+    **chezmoi advantages:**
+
+    1. **Simplicity:**
+       * Single binary, no dependencies
+       * Small, focused feature set
+       * Easy to learn (not a full configuration management system)
+    2. **Easy installation:**
+       * Copy one binary - done
+       * No scripting runtime required
+       * No packages to install
+       * No system services needed
+       * No root access required
+    3. **Runs everywhere:**
+       * ARM-based Linux systems
+       * Windows desktops
+       * Lightweight containers
+       * FreeBSD VMs
+       * Any platform with a binary available
+    4. **User focus:**
+       * Designed for personal configurations
+       * No need to learn system administration concepts
+       * Quick to get started
+
+    **When to use system management tools:**
+
+    Use Ansible/Chef/Puppet/Salt when:
+
+    * You need to manage system configuration (not just dotfiles)
+    * You're managing multiple users or servers
+    * You need complex orchestration
+    * You already know these tools
+
+    **Hybrid approach:**
+
+    You can use both! Let chezmoi manage dotfiles, and call system management tools from scripts:
+
+    ```bash title="run_once_configure_system.sh" theme={null}
+    #!/bin/bash
+    # Let Ansible handle system configuration
+    ansible-playbook ~/.local/share/chezmoi/ansible/playbook.yml
+    ```
+
+    Keep your Ansible playbooks in `.chezmoiignore` so they don't pollute your home directory.
+  </Accordion>
+
+  <Accordion title="Can I use chezmoi to manage files outside my home directory?">
+    Technically yes, but this is **strongly discouraged** for anything beyond simple cases.
+
+    **chezmoi is designed for:**
+
+    * Managing personal dotfiles in your home directory
+    * Running without root access
+    * User-level configuration
+
+    **chezmoi is NOT designed for:**
+
+    * System-wide configuration files
+    * Managing `/etc/`
+    * Multi-user setups
+
+    **Simple cases that work:**
+
+    Use a `run_` script to handle a few files:
+
+    ```bash title="run_after_copy_system_file.sh" theme={null}
+    #!/bin/bash
+    # Copy a file to /etc (requires sudo)
+    sudo cp ~/.local/etc/hosts /etc/hosts
+    ```
+
+    Or create a symlink:
+
+    ```bash title="run_after_link_system_file.sh" theme={null}
+    #!/bin/bash
+    sudo ln -sf ~/config/app.conf /etc/app/app.conf
+    ```
+
+    **For anything more complex:**
+
+    Use proper system configuration management tools:
+
+    * [Ansible](https://www.ansible.com/)
+    * [Puppet](https://puppet.com/)
+    * [Chef](https://www.chef.io/)
+    * [Salt](https://saltproject.io/)
+
+    These tools are designed for system-wide configuration and handle:
+
+    * Package management
+    * Service configuration
+    * Multi-user setups
+    * Privilege escalation
+    * System state management
+
+    You can call these from chezmoi scripts, keeping your system configs in `.chezmoiignore`.
+  </Accordion>
+
+  <Accordion title="What inspired chezmoi?">
+    chezmoi was inspired by [Puppet](https://puppet.com/), a powerful system configuration management tool.
+
+    **Why not just use Puppet?**
+
+    Puppet is excellent for its intended use case (system administration), but it's overkill for personal dotfiles:
+
+    * Requires Ruby and many dependencies
+    * Needs system services running
+    * Requires root access to install
+    * Has a steep learning curve
+    * Designed for managing servers, not personal configs
+
+    **What chezmoi borrowed from Puppet:**
+
+    * The concept of desired state vs. current state
+    * Idempotent operations
+    * Declarative configuration
+    * Dry-run mode (diff before apply)
+
+    **What chezmoi does differently:**
+
+    * Single binary with no dependencies
+    * User-focused (no root required)
+    * Simplified feature set
+    * Cross-platform support
+    * Designed specifically for dotfiles
+
+    **The future:**
+
+    chezmoi will always focus on personal dotfile management. If your needs grow beyond that (managing multiple machines, system configuration, etc.), switch to a full system configuration management tool like Puppet, Ansible, Chef, or Salt.
+  </Accordion>
+</AccordionGroup>
+
+
+# General FAQ
+Source: https://twpayne-chezmoi.mintlify.app/faq/general
+
+Frequently asked questions about chezmoi
+
+General questions about chezmoi, from getting started to contributing to the project.
+
+<AccordionGroup>
+  <Accordion title="What is chezmoi?">
+    chezmoi is a dotfile manager that helps you manage your personal configuration files (dotfiles) across multiple machines. It stores your dotfiles in a version control repository and provides features like:
+
+    * **Templates** for machine-specific configurations
+    * **Encryption** for sensitive data
+    * **Cross-platform support** (Linux, macOS, Windows, BSD)
+    * **Password manager integration**
+    * **Scripts** to automate setup tasks
+
+    Unlike other dotfile managers that use symlinks, chezmoi generates regular files in their final location, enabling more advanced features.
+  </Accordion>
+
+  <Accordion title="Where do I ask a question that isn't answered here?">
+    If your question isn't answered in the documentation, you have several options:
+
+    * **[Open an issue on GitHub](https://github.com/twpayne/chezmoi/issues/new/choose)** - For bug reports or feature requests
+    * **[Start a discussion](https://github.com/twpayne/chezmoi/discussions/new)** - For general questions and community help
+    * **Browse [existing issues](https://github.com/twpayne/chezmoi/issues?q=is%3Aissue+label%3Asupport)** - Your question may already be answered
+    * **Check [discussions](https://github.com/twpayne/chezmoi/discussions)** - See what others are asking
+
+    The community is friendly and responsive!
+  </Accordion>
+
+  <Accordion title="I like chezmoi. How do I say thanks?">
+    Thank you! chezmoi was created to solve a personal need, and it's wonderful that it's useful to you. Here are ways to show your support:
+
+    **Give chezmoi a star:**
+
+    * Visit the [GitHub repository](https://github.com/twpayne/chezmoi/stargazers) and click the star button
+
+    **Share your dotfiles:**
+
+    * If you have a public dotfiles repository, [tag it with `chezmoi`](https://github.com/topics/chezmoi?o=desc\&s=updated)
+    * This helps others discover chezmoi and see real-world examples
+
+    **Write or present about chezmoi:**
+
+    * Written an article or blog post? [Let us know](https://github.com/twpayne/chezmoi/issues/new/choose)
+    * Given a talk or presentation? We'd love to add it to our [videos page](https://chezmoi.io/links/videos/)
+    * Created a podcast episode? Share it for our [podcasts page](https://chezmoi.io/links/podcasts/)
+
+    **Contribute:**
+
+    * [Contributions are very welcome](https://chezmoi.io/developer-guide/contributing-changes/) - code, docs, bug reports, and feature requests all help make chezmoi better
+    * Every contribution, no matter how small, is appreciated!
+  </Accordion>
+
+  <Accordion title="Who created chezmoi and why?">
+    chezmoi was created by Tom Payne to manage his personal dotfiles across multiple machines. The name "chezmoi" comes from the French "chez moi" (pronounced shay-mwa), meaning "at my house" or "at my place."
+
+    The project was inspired by Puppet but designed specifically for personal dotfile management rather than full system configuration. The goal was to create a tool that:
+
+    * Works without root access
+    * Runs on any platform
+    * Has minimal dependencies (single binary)
+    * Provides advanced features like templates and encryption
+  </Accordion>
+
+  <Accordion title="Is chezmoi free and open source?">
+    Yes! chezmoi is completely free and open source, licensed under the MIT License. You can:
+
+    * Use it for personal or commercial purposes
+    * Modify it to suit your needs
+    * Distribute it freely
+    * View the source code on [GitHub](https://github.com/twpayne/chezmoi)
+
+    The project welcomes contributions from the community.
+  </Accordion>
+
+  <Accordion title="What does the name 'chezmoi' mean?">
+    "chezmoi" comes from the French phrase "chez moi" (pronounced /ʃeˈmwa/ or shay-mwa), which means "at my house" or "at my place."
+
+    **Why this name?**
+
+    * It's fitting for a tool that manages your personal environment
+    * At 7 letters, it's short enough for occasional use but not so short that you need an alias
+
+    **Want a shorter command?**
+    Add an alias to your shell configuration:
+
+    ```bash theme={null}
+    alias cz=chezmoi
+    ```
+
+    Then use `cz apply`, `cz edit`, etc.
+  </Accordion>
+
+  <Accordion title="How is chezmoi different from other dotfile managers?">
+    chezmoi differs from other dotfile managers in several key ways:
+
+    **vs. Symlink-based managers (GNU Stow, rcm):**
+
+    * chezmoi creates regular files, not symlinks
+    * Enables templates, encryption, and per-machine customization
+    * Works better on Windows (no symlink permission issues)
+
+    **vs. Bare git repos:**
+
+    * Separate source directory keeps your home directory clean
+    * Built-in diff and apply workflow
+    * Template and encryption support
+
+    **vs. Configuration management (Ansible, Chef, Puppet):**
+
+    * Single binary with no dependencies
+    * Doesn't require root access
+    * Focused on personal dotfiles, not system configuration
+    * Much simpler to learn and use
+
+    See the [migration guide](/advanced/migrating-from-another-dotfile-manager) for detailed comparisons.
+  </Accordion>
+
+  <Accordion title="Can I use chezmoi with my existing dotfiles?">
+    Yes! You can migrate from any dotfile setup:
+
+    **From symlink-based managers:**
+
+    ```bash theme={null}
+    chezmoi add --follow ~/.bashrc ~/.zshrc
+    ```
+
+    **From existing dotfiles in your home directory:**
+
+    ```bash theme={null}
+    chezmoi add ~/.bashrc ~/.zshrc ~/.gitconfig
+    chezmoi add ~/.config/nvim
+    ```
+
+    **From a bare git repository:**
+
+    ```bash theme={null}
+    # List tracked files and add them
+    config ls-tree --full-tree -r --name-only HEAD | xargs -I {} chezmoi add ~/{}
+    ```
+
+    See the [migration guide](/advanced/migrating-from-another-dotfile-manager) for detailed instructions.
+  </Accordion>
+
+  <Accordion title="Does chezmoi work on Windows?">
+    Yes! chezmoi has full Windows support:
+
+    * Native Windows binary available
+    * Works in PowerShell, Command Prompt, and Windows Terminal
+    * Supports Windows Subsystem for Linux (WSL)
+    * Handles Windows-specific file permissions
+
+    Install on Windows:
+
+    ```powershell theme={null}
+    # Using winget
+    winget install twpayne.chezmoi
+
+    # Using Scoop
+    scoop install chezmoi
+
+    # Using Chocolatey
+    choco install chezmoi
+    ```
+  </Accordion>
+
+  <Accordion title="Can I try chezmoi without committing to it?">
+    Absolutely! chezmoi is designed to be safe and reversible:
+
+    **Preview changes before applying:**
+
+    ```bash theme={null}
+    chezmoi init
+    chezmoi add ~/.bashrc
+    chezmoi diff  # See what would change
+    ```
+
+    **Remove chezmoi completely:**
+
+    ```bash theme={null}
+    # Remove source directory
+    rm -rf ~/.local/share/chezmoi
+
+    # Remove config
+    rm -rf ~/.config/chezmoi
+
+    # Uninstall binary (depends on installation method)
+    ```
+
+    Your actual dotfiles are never modified until you run `chezmoi apply`, and even then you can review changes with `chezmoi diff` first.
+  </Accordion>
+
+  <Accordion title="How do I update chezmoi to the latest version?">
+    The update method depends on how you installed chezmoi:
+
+    **Homebrew (macOS/Linux):**
+
+    ```bash theme={null}
+    brew upgrade chezmoi
+    ```
+
+    **apt (Debian/Ubuntu):**
+
+    ```bash theme={null}
+    sudo apt update && sudo apt upgrade chezmoi
+    ```
+
+    **pacman (Arch Linux):**
+
+    ```bash theme={null}
+    sudo pacman -Syu chezmoi
+    ```
+
+    **winget (Windows):**
+
+    ```powershell theme={null}
+    winget upgrade twpayne.chezmoi
+    ```
+
+    **Script installation:**
+
+    ```bash theme={null}
+    sh -c "$(curl -fsLS get.chezmoi.io)" -- -b ~/.local/bin
+    ```
+  </Accordion>
+
+  <Accordion title="Where can I find examples of chezmoi configurations?">
+    There are many public dotfile repositories using chezmoi:
+
+    **GitHub Topics:**
+
+    * Browse repositories tagged with [`chezmoi`](https://github.com/topics/chezmoi?o=desc\&s=updated)
+    * Sort by recently updated to see active configurations
+
+    **Official Resources:**
+
+    * [Example configurations](https://chezmoi.io/user-guide/setup/)
+    * [Template examples](https://chezmoi.io/user-guide/templating/)
+    * [Real-world use cases](https://chezmoi.io/links/articles/)
+
+    **Learning tips:**
+
+    * Look for repositories with similar setups to yours
+    * Check how others handle machine-specific configurations
+    * See examples of password manager integration
+    * Learn from script usage patterns
+  </Accordion>
+
+  <Accordion title="Is there a chezmoi community?">
+    Yes! The chezmoi community is active and welcoming:
+
+    **GitHub:**
+
+    * [Discussions](https://github.com/twpayne/chezmoi/discussions) - Ask questions and share tips
+    * [Issues](https://github.com/twpayne/chezmoi/issues) - Report bugs and request features
+
+    **Articles and Videos:**
+
+    * [Articles about chezmoi](https://chezmoi.io/links/articles/)
+    * [Video tutorials](https://chezmoi.io/links/videos/)
+    * [Podcast episodes](https://chezmoi.io/links/podcasts/)
+
+    **Contributing:**
+
+    * [Contribution guidelines](https://chezmoi.io/developer-guide/contributing-changes/)
+    * [Developer documentation](https://chezmoi.io/developer-guide/)
+  </Accordion>
+</AccordionGroup>
+
+
+# Troubleshooting FAQ
+Source: https://twpayne-chezmoi.mintlify.app/faq/troubleshooting
+
+Solutions to common problems and errors with chezmoi
+
+Solutions to common problems, errors, and unexpected behavior.
+
+<AccordionGroup>
+  <Accordion title="How can I quickly check for problems with chezmoi on my machine?">
+    Run the built-in diagnostic command:
+
+    ```bash theme={null}
+    chezmoi doctor
+    ```
+
+    **What it checks:**
+
+    * chezmoi version
+    * Configuration file location and validity
+    * Source directory location
+    * Destination directory (usually home)
+    * Editor configuration
+    * Merge tool configuration
+    * Password manager availability
+    * Git configuration
+    * And more...
+
+    **Understanding the output:**
+
+    * `ok` - Everything is fine
+    * `warning` - Only a problem if you use that feature
+    * `error` - Definite problem that needs fixing
+
+    **Example output:**
+
+    ```
+    RESULT CHECK MESSAGE
+    ok     version v2.46.0
+    ok     os linux
+    ok     config-file ~/.config/chezmoi/chezmoi.toml
+    ok     source-dir ~/.local/share/chezmoi
+    ok     working-tree ~/.local/share/chezmoi
+    warning age-command age not found in $PATH
+    ok     git-command git
+    ok     merge-command vimdiff
+    ```
+  </Accordion>
+
+  <Accordion title="How do I debug a command that's not working as expected?">
+    chezmoi provides two levels of debugging output:
+
+    **Verbose mode (recommended first):**
+
+    ```bash theme={null}
+    chezmoi --verbose apply
+    chezmoi --verbose diff
+    chezmoi -v add ~/.bashrc  # Short form
+    ```
+
+    This shows:
+
+    * What chezmoi is doing
+    * Files being read/written
+    * Scripts being executed
+    * External commands being run
+
+    **Debug mode (very detailed):**
+
+    ```bash theme={null}
+    chezmoi --debug apply
+    chezmoi --debug diff
+    ```
+
+    This shows:
+
+    * Step-by-step execution
+    * Template evaluation
+    * File comparisons
+    * Internal state changes
+    * Very detailed information
+
+    **Debug a specific file:**
+
+    ```bash theme={null}
+    chezmoi --verbose apply ~/.bashrc
+    chezmoi --debug execute-template < ~/.local/share/chezmoi/dot_bashrc.tmpl
+    ```
+  </Accordion>
+
+  <Accordion title="The output of `chezmoi diff` is broken with escape sequences. How do I fix it?">
+    This happens when your pager doesn't pass through ANSI color codes. You'll see output like `ESC[37m` instead of colors.
+
+    **Quick fix - Set LESS environment variable:**
+
+    ```bash theme={null}
+    export LESS=-R
+    ```
+
+    Add this to your `~/.bashrc` or `~/.zshrc`.
+
+    **Permanent fix - Configure chezmoi:**
+
+    ```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+    pager = "less -R"
+    ```
+
+    **Alternative solutions:**
+
+    Disable colors:
+
+    ```bash theme={null}
+    chezmoi diff --color=false
+    ```
+
+    Disable pager:
+
+    ```bash theme={null}
+    chezmoi diff --no-pager
+    ```
+
+    Or in config:
+
+    ```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+    [diff]
+        pager = ""
+    ```
+
+    **For other pagers:**
+
+    * `bat`: Use `bat --paging=always`
+    * `most`: Already handles colors correctly
+    * Custom pager: Ensure it supports ANSI codes
+  </Accordion>
+
+  <Accordion title="Why do I get a blank buffer when running `chezmoi edit`?">
+    This happens when your editor command exits immediately (forking to background) instead of waiting for you to finish editing.
+
+    **The warning:**
+
+    ```
+    chezmoi: warning: $EDITOR returned in less than 1s
+    ```
+
+    **What's happening:**
+
+    1. chezmoi creates a temporary file
+    2. Your editor command starts and immediately returns
+    3. chezmoi thinks you're done and deletes the temp file
+    4. Your editor (running in background) opens a now-deleted file
+    5. You see a blank buffer
+
+    **Solutions by editor:**
+
+    **VSCode:**
+
+    ```bash theme={null}
+    export EDITOR="code --wait"
+    ```
+
+    Or in config:
+
+    ```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+    [edit]
+        command = "code"
+        args = ["--wait"]
+    ```
+
+    **Vim:**
+
+    ```bash theme={null}
+    export EDITOR="vim -f"
+    ```
+
+    Or:
+
+    ```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+    [edit]
+        command = "vim"
+        args = ["-f"]
+    ```
+
+    **Sublime Text:**
+
+    ```bash theme={null}
+    export EDITOR="subl -w"
+    ```
+
+    **Neovim:**
+    Usually works by default, but if needed:
+
+    ```bash theme={null}
+    export EDITOR="nvim"
+    ```
+
+    **The key:** Your editor command must block until you close the file.
+  </Accordion>
+
+  <Accordion title="chezmoi makes `~/.ssh/config` group writeable. How do I fix this?">
+    This happens when your system umask is `002` (group-writable by default) instead of the more common `022`.
+
+    **SSH requires strict permissions:**
+
+    * `~/.ssh/config` must not be group or world writable
+    * SSH will refuse to use it if permissions are wrong
+
+    **Solution - Set chezmoi's umask:**
+
+    ```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+    umask = 0o022
+    ```
+
+    This ensures all files created by chezmoi follow this umask.
+
+    **Apply the fix:**
+
+    ```bash theme={null}
+    chezmoi apply
+    ```
+
+    **Check permissions:**
+
+    ```bash theme={null}
+    ls -la ~/.ssh/config
+    # Should show: -rw-r--r-- (644)
+    ```
+
+    **Note:** This umask applies to all files managed by chezmoi, not just SSH config.
+  </Accordion>
+
+  <Accordion title="chezmoi reports `user: lookup userid NNNNN: input/output error`">
+    This error occurs when using a statically-compiled chezmoi binary (built with musl) on a system using LDAP or NIS for user management.
+
+    **Why it happens:**
+
+    * Static binaries with musl can't dynamically load LDAP/NIS libraries
+    * Your system needs these libraries to look up user information
+
+    **Solution:**
+
+    Install a dynamically-linked package for your distribution instead:
+
+    **Debian/Ubuntu:**
+
+    ```bash theme={null}
+    sudo apt install chezmoi
+    ```
+
+    **Fedora:**
+
+    ```bash theme={null}
+    sudo dnf install chezmoi
+    ```
+
+    **Arch Linux:**
+
+    ```bash theme={null}
+    sudo pacman -S chezmoi
+    ```
+
+    These packages are linked against glibc and include LDAP/NIS support.
+
+    **Don't use:** The statically-compiled binary from GitHub releases on LDAP/NIS systems.
+
+    If the problem persists, [open an issue](https://github.com/twpayne/chezmoi/issues/new/choose).
+  </Accordion>
+
+  <Accordion title="chezmoi reports timeout obtaining persistent state lock">
+    This error occurs when another chezmoi instance is running and holding the lock.
+
+    **Full error:**
+
+    ```
+    chezmoi: timeout obtaining persistent state lock
+    ```
+
+    **Common causes:**
+
+    1. **Another chezmoi command is running**
+       * Check for background chezmoi processes
+       * Look in other terminal windows
+    2. **Script calling chezmoi**
+       * A `run_` script is invoking chezmoi
+       * Creates a deadlock (chezmoi waiting for itself)
+    3. **Stale lock from crashed process**
+       * chezmoi crashed without releasing lock
+       * Lock file persists
+
+    **Solutions:**
+
+    **Find running chezmoi processes:**
+
+    ```bash theme={null}
+    ps aux | grep chezmoi
+    ```
+
+    **Kill if necessary:**
+
+    ```bash theme={null}
+    killall chezmoi
+    ```
+
+    **Check for scripts calling chezmoi:**
+
+    ```bash theme={null}
+    chezmoi cd
+    grep -r "chezmoi" run_*
+    ```
+
+    **Understanding locks:**
+
+    * Write lock: `add`, `apply`, `edit`, `forget`, `import`, `init`, `state`, `unmanage`, `update`
+    * Read lock: `diff`, `status`, `verify`
+    * Multiple readers OK, but only one writer
+
+    The lock file is at `~/.config/chezmoi/chezmoistate.boltdb`.
+  </Accordion>
+
+  <Accordion title="chezmoi reports `fork/exec: exec format error` for a script">
+    This error means your script has a newline before the shebang (`#!`).
+
+    **Problem script:**
+
+    ```bash title="run_once_setup.sh.tmpl" theme={null}
+    {{ if eq .chezmoi.os "linux" }}
+    #!/bin/bash
+    echo "Setting up Linux"
+    {{ end }}
+    ```
+
+    This creates:
+
+    ```bash theme={null}
+
+    #!/bin/bash
+    ```
+
+    The blank line breaks the shebang.
+
+    **Solution - Add dash to trim whitespace:**
+
+    ```bash title="run_once_setup.sh.tmpl" theme={null}
+    {{ if eq .chezmoi.os "linux" -}}
+    #!/bin/bash
+    echo "Setting up Linux"
+    {{ end }}
+    ```
+
+    The `-` before `}}` suppresses the trailing newline.
+
+    Now creates:
+
+    ```bash theme={null}
+    #!/bin/bash
+    echo "Setting up Linux"
+    ```
+
+    **General rule:** Use `-` to trim whitespace in templates:
+
+    * `{{-` trims whitespace before
+    * `-}}` trims whitespace after
+  </Accordion>
+
+  <Accordion title="chezmoi reports `permission denied` when executing a script">
+    This occurs when your `/tmp` directory is mounted with the `noexec` option, preventing script execution.
+
+    **Full error:**
+
+    ```
+    chezmoi: fork/exec /tmp/XXXXXXXXXX.XX: permission denied
+    ```
+
+    **Check if /tmp is noexec:**
+
+    ```bash theme={null}
+    mount | grep /tmp
+    # Look for "noexec" in the output
+    ```
+
+    **Solution - Use a different temp directory:**
+
+    ```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+    scriptTempDir = "~/tmp"
+    ```
+
+    **Create the directory:**
+
+    ```bash theme={null}
+    mkdir -p ~/tmp
+    ```
+
+    Now chezmoi will write scripts to `~/tmp` instead of `/tmp`.
+
+    **Why this happens:**
+
+    * chezmoi needs to write scripts to a temp location
+    * Scripts might be templates or encrypted
+    * Must be executable to run
+    * `/tmp` with `noexec` prevents this
+  </Accordion>
+
+  <Accordion title="chezmoi reports `no such file or directory` when adding a file">
+    This error occurs when you try to add a file to a directory that only exists in `.chezmoiexternal.*` but not in your source directory.
+
+    **Example scenario:**
+
+    `.chezmoiexternal.toml` has:
+
+    ```toml theme={null}
+    [".config/nvim"]
+        type = "git-repo"
+        url = "https://github.com/NvChad/NvChad.git"
+    ```
+
+    Then you try:
+
+    ```bash theme={null}
+    chezmoi add ~/.config/direnv/direnvrc
+    ```
+
+    **Error:**
+
+    ```
+    chezmoi: mkdir /home/user/.local/share/chezmoi/dot_config/direnv: no such file or directory
+    ```
+
+    **Why:** The `dot_config` directory doesn't exist in source because it's external-only.
+
+    **Solution - Create placeholder directory:**
+
+    ```bash theme={null}
+    chezmoi cd
+    mkdir -p dot_config
+    touch dot_config/.keep
+    ```
+
+    Now the add command works:
+
+    ```bash theme={null}
+    chezmoi add ~/.config/direnv/direnvrc
+    ```
+
+    See [issue #2006](https://github.com/twpayne/chezmoi/issues/2006) for details.
+  </Accordion>
+
+  <Accordion title="chezmoi reports `permission denied` for stdin/stdout with snap">
+    This is a [long-standing bug in snap](https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/1849753), not chezmoi.
+
+    **Error when using redirection:**
+
+    ```bash theme={null}
+    chezmoi apply <file.txt  # Fails
+    chezmoi diff >output.txt  # Fails
+    ```
+
+    **Workarounds:**
+
+    **For stdin:**
+
+    ```bash theme={null}
+    # Instead of:
+    chezmoi apply <file.txt
+
+    # Use:
+    cat file.txt | chezmoi apply
+    ```
+
+    **For stdout:**
+
+    ```bash theme={null}
+    # Instead of:
+    chezmoi diff >output.txt
+
+    # Use one of:
+    chezmoi diff -o output.txt
+    chezmoi diff --output=output.txt
+    chezmoi diff | tee output.txt >/dev/null
+    ```
+
+    **Better solution - Don't use snap:**
+
+    Install chezmoi via another method:
+
+    ```bash theme={null}
+    # Script install
+    sh -c "$(curl -fsLS get.chezmoi.io)"
+
+    # APT (if available)
+    sudo apt install chezmoi
+
+    # Homebrew
+    brew install chezmoi
+    ```
+
+    See the [install page](https://chezmoi.io/install/) for all options.
+  </Accordion>
+
+  <Accordion title="chezmoi reports `no such file or directory` for scripts on Nix/Termux">
+    This occurs when using hardcoded interpreter paths that don't exist on Nix or Termux.
+
+    **Problem script:**
+
+    ```bash title="run_once_setup.sh" theme={null}
+    #!/bin/bash
+    echo "Setting up"
+    ```
+
+    On Nix/Termux, `/bin/bash` doesn't exist.
+
+    **Solution 1 - Use lookPath (recommended):**
+
+    Make the script a template:
+
+    ```bash title="run_once_setup.sh.tmpl" theme={null}
+    #!{{ lookPath "bash" }}
+    echo "Setting up"
+    ```
+
+    This finds bash wherever it is on the system.
+
+    **Solution 2 - Use env (Nix):**
+
+    ```bash title="run_once_setup.sh" theme={null}
+    #!/usr/bin/env bash
+    echo "Setting up"
+    ```
+
+    **Solution 3 - Hardcode Termux path:**
+
+    ```bash title="run_once_setup.sh" theme={null}
+    #!/data/data/com.termux/files/usr/bin/bash
+    echo "Setting up"
+    ```
+
+    **For Python scripts:**
+
+    ```python title="run_once_setup.py.tmpl" theme={null}
+    #!{{ lookPath "python3" }}
+    print("Setting up")
+    ```
+
+    **Best practice:** Always use `lookPath` in templates for maximum portability.
+  </Accordion>
+</AccordionGroup>
+
+
+# Usage FAQ
+Source: https://twpayne-chezmoi.mintlify.app/faq/usage
+
+Frequently asked questions about using chezmoi day-to-day
+
+Common questions about using chezmoi for everyday dotfile management.
+
+<AccordionGroup>
+  <Accordion title="How do I edit my dotfiles with chezmoi?">
+    There are five popular approaches for editing dotfiles. Choose the one that fits your workflow:
+
+    **1. Use `chezmoi edit` (recommended):**
+
+    ```bash theme={null}
+    chezmoi edit ~/.bashrc
+    ```
+
+    With auto-apply:
+
+    ```bash theme={null}
+    chezmoi edit --apply ~/.bashrc
+    ```
+
+    With watch mode (auto-apply on save):
+
+    ```bash theme={null}
+    chezmoi edit --watch ~/.bashrc
+    ```
+
+    **Benefits:** Handles encryption transparently, uses target paths, enables git auto-commit.
+
+    **2. Edit in source directory:**
+
+    ```bash theme={null}
+    chezmoi cd
+    vim dot_bashrc
+    chezmoi diff  # Preview changes
+    chezmoi apply  # Apply changes
+    ```
+
+    **Benefits:** Direct file editing, works with any editor, can edit multiple files.
+
+    **3. Open source directory in editor:**
+
+    ```bash theme={null}
+    chezmoi edit  # Opens source directory
+    ```
+
+    **Benefits:** Works with IDEs, edit multiple files at once.
+
+    **4. Edit target, then re-add:**
+
+    ```bash theme={null}
+    vim ~/.bashrc
+    chezmoi add ~/.bashrc  # or: chezmoi re-add
+    ```
+
+    **Benefits:** Familiar workflow, edit in place.
+
+    **Note:** `re-add` doesn't work with templates.
+
+    **5. Edit target, then merge:**
+
+    ```bash theme={null}
+    vim ~/.bashrc
+    chezmoi merge ~/.bashrc
+    ```
+
+    **Benefits:** Resolve conflicts with a merge tool.
+  </Accordion>
+
+  <Accordion title="What happens if I edit a dotfile without using `chezmoi edit`?">
+    If you edit `~/.zshrc` directly (without using chezmoi), nothing breaks immediately:
+
+    **Before running `chezmoi apply`:**
+
+    * Your modified `~/.zshrc` remains in place
+    * Changes persist until you run `chezmoi apply`
+
+    **When you run `chezmoi apply`:**
+
+    * chezmoi detects that `~/.zshrc` has changed
+    * You'll be prompted what to do
+    * Options: overwrite, keep current, or merge
+
+    **To resolve differences:**
+
+    ```bash theme={null}
+    # Option 1: Update source state with current file
+    chezmoi add ~/.zshrc
+
+    # Option 2: Use merge tool to resolve
+    chezmoi merge ~/.zshrc
+
+    # Option 3: See differences
+    chezmoi diff
+    ```
+
+    **Best practice:** Use `chezmoi edit` to avoid conflicts, or configure auto-apply to see changes immediately.
+  </Accordion>
+
+  <Accordion title="How can I tell what dotfiles aren't managed by chezmoi?">
+    Use `chezmoi unmanaged` to see all files that exist in your home directory but aren't managed by chezmoi:
+
+    ```bash theme={null}
+    # List all unmanaged files
+    chezmoi unmanaged
+
+    # List only unmanaged dotfiles (starting with .)
+    chezmoi unmanaged | grep '^\.'
+
+    # Search for specific patterns
+    chezmoi unmanaged | grep config
+    ```
+
+    **Add multiple files at once:**
+
+    ```bash theme={null}
+    # Add specific files
+    chezmoi add ~/.vimrc ~/.tmux.conf
+
+    # Add an entire directory
+    chezmoi add ~/.config/nvim
+
+    # Add multiple directories
+    chezmoi add ~/.config/kitty ~/.config/alacritty
+    ```
+  </Accordion>
+
+  <Accordion title="How can I tell what dotfiles are currently managed by chezmoi?">
+    Use `chezmoi managed` to list all files managed by chezmoi:
+
+    ```bash theme={null}
+    # List all managed files
+    chezmoi managed
+
+    # List managed files in a specific directory
+    chezmoi managed | grep .config/nvim
+
+    # Count managed files
+    chezmoi managed | wc -l
+    ```
+
+    **See the source path for a file:**
+
+    ```bash theme={null}
+    chezmoi source-path ~/.bashrc
+    # Output: /home/user/.local/share/chezmoi/dot_bashrc
+    ```
+  </Accordion>
+
+  <Accordion title="How do I tell chezmoi to ignore specific files?">
+    By default, chezmoi only manages files you explicitly add. To ignore files in your source directory, use `.chezmoiignore`.
+
+    **Create `.chezmoiignore` in your source directory:**
+
+    ```bash theme={null}
+    chezmoi cd
+    cat > .chezmoiignore << 'EOF'
+    README.md
+    LICENSE
+    *.swp
+    **/*.backup
+    EOF
+    ```
+
+    **Pattern examples:**
+
+    ```text theme={null}
+    # Ignore specific file
+    .config/specific_file
+
+    # Ignore all .txt files
+    *.txt
+
+    # Ignore directory
+    .config/cache/
+
+    # Ignore pattern recursively
+    **/*.log
+    ```
+
+    **Machine-specific ignores:**
+
+    ```text title=".chezmoiignore" theme={null}
+    {{- if ne .chezmoi.os "darwin" }}
+    .config/karabiner
+    .config/hammerspoon
+    {{- end }}
+
+    {{- if ne .chezmoi.os "linux" }}
+    .config/i3
+    .config/sway
+    {{- end }}
+    ```
+
+    See the [reference documentation](/reference/special-files-and-directories#chezmoiignore) for full syntax.
+  </Accordion>
+
+  <Accordion title="How do I commit changes to my dotfiles?">
+    You have several options for committing changes:
+
+    **Option 1: Use `chezmoi cd` (manual):**
+
+    ```bash theme={null}
+    chezmoi cd
+    git add .
+    git commit -m "Update dotfiles"
+    git push
+    exit  # Return to previous directory
+    ```
+
+    **Option 2: Use `chezmoi git` (shortcut):**
+
+    ```bash theme={null}
+    chezmoi git add .
+    chezmoi git commit -m "Update dotfiles"
+    chezmoi git push
+    ```
+
+    **Note:** Use `--` before flags:
+
+    ```bash theme={null}
+    chezmoi git -- commit -m "Update dotfiles"
+    chezmoi git -- push --force
+    ```
+
+    **Option 3: Auto-commit (automatic):**
+
+    ```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+    [git]
+        autoCommit = true
+        autoPush = true
+    ```
+
+    Now chezmoi automatically commits and pushes after:
+
+    * `chezmoi add`
+    * `chezmoi edit`
+    * `chezmoi apply` (with changes)
+
+    See the [daily operations guide](/user-guide/daily-operations#automatically-commit-and-push-changes-to-your-repo) for details.
+  </Accordion>
+
+  <Accordion title="I've made changes to both the destination and source state. How do I keep both?">
+    Use `chezmoi merge` to resolve differences with a merge tool:
+
+    ```bash theme={null}
+    chezmoi merge ~/.bashrc
+    ```
+
+    This opens your configured merge tool with:
+
+    * **Destination:** Current file in your home directory (your local changes)
+    * **Source:** File in source state (what chezmoi would apply)
+    * **Target:** What the file would become
+
+    Copy the changes you want to keep into the source state, save, and exit.
+
+    **Configure your merge tool:**
+
+    ```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+    [merge]
+        command = "vimdiff"  # or: meld, kdiff3, code, etc.
+    ```
+
+    See the [tools guide](/advanced/tools#merge-tool-configuration) for merge tool configuration.
+  </Accordion>
+
+  <Accordion title="Can I use chezmoi to manage my shell history?">
+    No, and you shouldn't. Here's why:
+
+    **Why chezmoi is unsuitable for shell history:**
+
+    * Every command creates a change
+    * Would require a commit for each command
+    * Would create thousands of commits per day
+    * Shell history changes too rapidly
+    * Not practical to sync via git
+
+    **Use a dedicated tool instead:**
+
+    [Atuin](https://atuin.sh/) is designed specifically for shell history sync:
+
+    * End-to-end encrypted
+    * Real-time sync across machines
+    * Enhanced search and statistics
+    * Works with bash, zsh, fish
+
+    **Install Atuin with chezmoi:**
+
+    ```bash title="run_once_install_atuin.sh" theme={null}
+    #!/bin/bash
+    curl --proto '=https' --tlsv1.2 -sSf https://setup.atuin.sh | bash
+    ```
+
+    Then use chezmoi to manage Atuin's configuration file.
+  </Accordion>
+
+  <Accordion title="How do I install prerequisites for templates?">
+    If your templates depend on external tools (like `curl`, `jq`, etc.), install them with a `run_before` script:
+
+    ```bash title="run_before_00-install-prerequisites.sh" theme={null}
+    #!/bin/bash
+    set -eu
+
+    # Install curl if not present
+    if ! command -v curl >/dev/null; then
+        sudo apt update
+        sudo apt install -y curl
+    fi
+
+    # Install jq if not present
+    if ! command -v jq >/dev/null; then
+        sudo apt install -y jq
+    fi
+    ```
+
+    **Important:** Don't make this script a template (no `.tmpl` extension), or it will be evaluated before the prerequisites are installed.
+
+    **Inject data via environment variables:**
+
+    If you need to pass data to non-template scripts:
+
+    ```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+    [scriptEnv]
+        OS = "{{ .chezmoi.os }}"
+        ARCH = "{{ .chezmoi.arch }}"
+    ```
+
+    See the [scripts guide](/user-guide/use-scripts-to-perform-actions#set-environment-variables) for details.
+  </Accordion>
+
+  <Accordion title="How do I write a literal `{{` or `}}` in a template?">
+    Use Go template syntax to escape the delimiters:
+
+    **For single braces:**
+
+    ```go theme={null}
+    {{ "{{" }}
+    {{ "}}" }}
+    ```
+
+    **Result:**
+
+    ```
+    {{
+    }}
+    ```
+
+    **For complete template expressions:**
+
+    ```go theme={null}
+    {{ "{{ .Target }}" }}
+    ```
+
+    **Result:**
+
+    ```
+    {{ .Target }}
+    ```
+
+    **Example use case - documenting templates:**
+
+    ```markdown title="README.md.tmpl" theme={null}
+    # My Dotfiles
+
+    This repository uses chezmoi templates.
+
+    Example template syntax: {{ "{{ .chezmoi.hostname }}" }}
+    ```
+  </Accordion>
+
+  <Accordion title="How do I run a script when an external repo changes?">
+    Use a `run_onchange_after_*.tmpl` script that includes the HEAD commit:
+
+    ```bash title="run_onchange_after_emacs_d.tmpl" theme={null}
+    #!/bin/bash
+
+    # This comment includes the current HEAD, so the script runs when it changes
+    # {{ output "git" "-C" (joinPath .chezmoi.homeDir ".emacs.d") "rev-parse" "HEAD" }}
+
+    echo "~/.emacs.d updated, running setup..."
+    ~/.emacs.d/bin/doom sync
+    ```
+
+    **How it works:**
+
+    * The template output includes the git HEAD commit hash
+    * When the external repo updates, HEAD changes
+    * chezmoi detects the script content changed
+    * The script runs automatically
+  </Accordion>
+
+  <Accordion title="How do I run a script periodically (daily, weekly)?">
+    Use a `run_onchange_*.tmpl` script with the current date/time truncated to your desired period.
+
+    **Run daily:**
+
+    ```bash title="run_onchange_daily.tmpl" theme={null}
+    #!/bin/bash
+
+    # This comment changes daily, triggering the script
+    # {{ now | date "2006-01-02" }}
+
+    echo "Running daily tasks"
+    # Your daily tasks here
+    ```
+
+    **Run weekly:**
+
+    ```bash title="run_onchange_weekly.tmpl" theme={null}
+    #!/bin/bash
+
+    # Week number (changes weekly)
+    # {{ output "date" "+%V" | trim }}
+
+    echo "Running weekly tasks"
+    # Your weekly tasks here
+    ```
+
+    **Alternative weekly (template functions):**
+
+    ```bash title="run_onchange_weekly_alt.tmpl" theme={null}
+    #!/bin/bash
+
+    # Approximate week number
+    # {{ div now.YearDay 7 }}
+
+    echo "Running weekly tasks"
+    ```
+
+    **How it works:**
+
+    * The comment contains a date that changes daily/weekly
+    * chezmoi detects the script content changed
+    * The script runs automatically
+  </Accordion>
+
+  <Accordion title="How do I enable shell completions?">
+    chezmoi provides completions for bash, zsh, fish, and PowerShell.
+
+    **Bash:**
+
+    ```bash theme={null}
+    # Add to ~/.bashrc
+    eval "$(chezmoi completion bash)"
+    ```
+
+    Or install system-wide:
+
+    ```bash theme={null}
+    chezmoi completion bash | sudo tee /usr/share/bash-completion/completions/chezmoi
+    ```
+
+    **Zsh:**
+
+    ```bash theme={null}
+    # Add to ~/.zshrc
+    eval "$(chezmoi completion zsh)"
+    ```
+
+    Or add to fpath:
+
+    ```bash theme={null}
+    chezmoi completion zsh > ~/.zsh/completions/_chezmoi
+    ```
+
+    **Fish:**
+
+    ```bash theme={null}
+    chezmoi completion fish | source
+    ```
+
+    Or save permanently:
+
+    ```bash theme={null}
+    chezmoi completion fish > ~/.config/fish/completions/chezmoi.fish
+    ```
+
+    **PowerShell:**
+    Add to your profile:
+
+    ```powershell theme={null}
+    chezmoi completion powershell | Out-String | Invoke-Expression
+    ```
+
+    **Package managers:** If you installed via a package manager (brew, apt, etc.), completions may already be installed.
+  </Accordion>
+
+  <Accordion title="How do I use tools installed with Flatpak?">
+    Command-line tools installed with Flatpak must be run with `flatpak run`. There are two approaches:
+
+    **Approach 1: Wrapper script (recommended):**
+
+    Create a wrapper with the same name as the command:
+
+    ```bash title="~/bin/keepassxc-cli" theme={null}
+    #!/bin/bash
+    flatpak run --command=keepassxc-cli org.keepassxc.KeePassXC -- "$@"
+    ```
+
+    Make it executable:
+
+    ```bash theme={null}
+    chmod +x ~/bin/keepassxc-cli
+    ```
+
+    Ensure `~/bin` is in your `$PATH`. Now chezmoi can find and run `keepassxc-cli` normally.
+
+    **Approach 2: Direct configuration:**
+
+    For tools with `.command` and `.args` config options:
+
+    ```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+    [diff]
+        command = "flatpak"
+        args = ["run", "com.vscodium.codium", "--wait", "--diff"]
+    ```
+
+    The wrapper script approach is recommended because it works with `chezmoi doctor` and feels more natural.
+
+    See the [tools guide](/advanced/tools#flatpak-integration) for more details.
+  </Accordion>
+</AccordionGroup>
+
+
+# Install chezmoi
+Source: https://twpayne-chezmoi.mintlify.app/install
+
+Install chezmoi on Linux, macOS, Windows, FreeBSD, and more with your preferred package manager or direct download
+
+# Install chezmoi
+
+chezmoi is distributed as a single stand-alone statically-linked binary with no dependencies. You can install it using your package manager, download a pre-built binary, or build from source.
+
+## One-Line Package Install
+
+Install chezmoi with your package manager with a single command:
+
+<Tabs>
+  <Tab title="Linux">
+    <CodeGroup>
+      ```bash Alpine theme={null}
+      apk add chezmoi
+      ```
+
+      ```bash Arch theme={null}
+      pacman -S chezmoi
+      ```
+
+      ```bash Fedora theme={null}
+      dnf install chezmoi
+      ```
+
+      ```bash NixOS theme={null}
+      nix-env -i chezmoi
+      ```
+
+      ```bash openSUSE theme={null}
+      zypper install chezmoi
+      ```
+
+      ```bash RHEL/CentOS (EPEL) theme={null}
+      dnf install epel-release && dnf install chezmoi
+      ```
+
+      ```bash Termux theme={null}
+      pkg install chezmoi
+      ```
+
+      ```bash Void Linux theme={null}
+      xbps-install -S chezmoi
+      ```
+    </CodeGroup>
+  </Tab>
+
+  <Tab title="macOS">
+    <CodeGroup>
+      ```bash Homebrew theme={null}
+      brew install chezmoi
+      ```
+
+      ```bash MacPorts theme={null}
+      port install chezmoi
+      ```
+
+      ```bash Nix theme={null}
+      nix-env -i chezmoi
+      ```
+    </CodeGroup>
+  </Tab>
+
+  <Tab title="Windows">
+    <CodeGroup>
+      ```powershell Chocolatey theme={null}
+      choco install chezmoi
+      ```
+
+      ```powershell Scoop theme={null}
+      scoop install chezmoi
+      ```
+
+      ```powershell Winget theme={null}
+      winget install twpayne.chezmoi
+      ```
+    </CodeGroup>
+  </Tab>
+
+  <Tab title="FreeBSD">
+    ```bash theme={null}
+    pkg install chezmoi
+    ```
+  </Tab>
+
+  <Tab title="OpenIndiana">
+    ```bash theme={null}
+    pkg install application/chezmoi
+    ```
+  </Tab>
+</Tabs>
+
+### Cross-Platform Package Managers
+
+chezmoi is also available in several cross-platform package managers:
+
+<CodeGroup>
+  ```bash asdf theme={null}
+  asdf plugin add chezmoi && asdf install chezmoi latest
+  ```
+
+  ```bash mise theme={null}
+  mise use --global chezmoi@latest
+  ```
+
+  ```bash Homebrew theme={null}
+  brew install chezmoi
+  ```
+
+  ```bash snap theme={null}
+  snap install chezmoi --classic
+  ```
+</CodeGroup>
+
+<Tip>
+  For more packages, see [chezmoi on repology.org](https://repology.org/project/chezmoi/versions).
+</Tip>
+
+## One-Line Binary Install
+
+Install the correct binary for your operating system and architecture in `./bin` with a single command:
+
+<CodeGroup>
+  ```bash curl theme={null}
+  sh -c "$(curl -fsLS get.chezmoi.io)"
+  ```
+
+  ```bash wget theme={null}
+  sh -c "$(wget -qO- get.chezmoi.io)"
+  ```
+
+  ```powershell PowerShell theme={null}
+  iex "&{$(irm 'https://get.chezmoi.io/ps1')}"
+  ```
+</CodeGroup>
+
+<Tip>
+  If you already have a dotfiles repo on GitHub at `https://github.com/$GITHUB_USERNAME/dotfiles`, you can install chezmoi and your dotfiles with a single command:
+
+  ```bash theme={null}
+  sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply $GITHUB_USERNAME
+  ```
+
+  For private repos, use SSH authentication:
+
+  ```bash theme={null}
+  sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply git@github.com:$GITHUB_USERNAME/dotfiles.git
+  ```
+</Tip>
+
+### Customize Installation Directory
+
+By default, the install script places the binary in `./bin`. You can customize this:
+
+<CodeGroup>
+  ```bash Install to ~/.local/bin theme={null}
+  sh -c "$(curl -fsLS get.chezmoi.io)" -- -b $HOME/.local/bin
+  ```
+
+  ```bash Alternative URL for ~/.local/bin theme={null}
+  sh -c "$(curl -fsLS get.chezmoi.io/lb)"
+  ```
+</CodeGroup>
+
+## Download Pre-Built Packages
+
+Download a package for your distribution and architecture from the [latest release](https://github.com/twpayne/chezmoi/releases/latest):
+
+<Tabs>
+  <Tab title="Debian/Ubuntu (.deb)">
+    Available architectures:
+
+    * amd64 (x86\_64)
+    * arm64 (aarch64)
+    * armel, armhf
+    * i386
+    * ppc64, ppc64le
+    * riscv64
+    * s390x
+    * loong64
+
+    Download from: `https://github.com/twpayne/chezmoi/releases/latest`
+  </Tab>
+
+  <Tab title="RHEL/Fedora (.rpm)">
+    Available architectures:
+
+    * x86\_64 (amd64)
+    * aarch64 (arm64)
+    * armhfp
+    * i686
+    * ppc64, ppc64le
+    * riscv64
+    * s390x
+    * loong64
+
+    Download from: `https://github.com/twpayne/chezmoi/releases/latest`
+  </Tab>
+
+  <Tab title="Alpine (.apk)">
+    Available architectures:
+
+    * 386, amd64
+    * arm, arm64
+    * ppc64, ppc64le
+    * riscv64
+    * s390x
+    * loong64
+
+    Download from: `https://github.com/twpayne/chezmoi/releases/latest`
+  </Tab>
+
+  <Tab title="Arch Linux">
+    Available as `.pkg.tar.zst` for multiple architectures.
+
+    Download from: `https://github.com/twpayne/chezmoi/releases/latest`
+  </Tab>
+</Tabs>
+
+## Download Pre-Built Binaries
+
+Download an archive for your operating system and architecture containing a pre-built binary and shell completions:
+
+<Tabs>
+  <Tab title="Linux">
+    Download `.tar.gz` archives for:
+
+    * amd64, i386
+    * arm, arm64
+    * ppc64, ppc64le
+    * riscv64
+    * s390x
+    * loong64, mips64, mips64le
+
+    Special builds:
+
+    * `linux-glibc_amd64` - glibc version
+    * `linux-musl_amd64` - musl version
+    * `android_arm64` - Termux
+  </Tab>
+
+  <Tab title="macOS">
+    Download `.tar.gz` archives for:
+
+    * amd64 (Intel)
+    * arm64 (Apple Silicon)
+  </Tab>
+
+  <Tab title="Windows">
+    Download `.zip` archives for:
+
+    * amd64 (x86\_64)
+    * arm64
+    * i386 (32-bit)
+  </Tab>
+
+  <Tab title="FreeBSD">
+    Download `.tar.gz` archives for:
+
+    * amd64, i386
+    * arm, arm64
+    * riscv64
+  </Tab>
+
+  <Tab title="OpenBSD">
+    Download `.tar.gz` archives for:
+
+    * amd64, i386
+    * arm, arm64
+    * ppc64
+    * riscv64
+  </Tab>
+</Tabs>
+
+[Download from GitHub Releases →](https://github.com/twpayne/chezmoi/releases/latest)
+
+## Build from Source
+
+Build and install chezmoi with Go 1.25 or later:
+
+<Steps>
+  <Step title="Clone the repository">
+    ```bash theme={null}
+    git clone https://github.com/twpayne/chezmoi.git
+    cd chezmoi
+    ```
+  </Step>
+
+  <Step title="Build and install">
+    ```bash theme={null}
+    make install-from-git-working-copy
+    ```
+  </Step>
+</Steps>
+
+## Verify Your Download
+
+chezmoi's release process signs the SHA256 checksums of all released assets with [cosign](https://github.com/SigStore/cosign).
+
+<Steps>
+  <Step title="Download verification files">
+    Download the checksum file, signature, and public key:
+
+    ```bash theme={null}
+    VERSION=$(curl -s https://api.github.com/repos/twpayne/chezmoi/releases/latest | grep tag_name | cut -d'"' -f4 | sed 's/v//')
+    curl --location --remote-name-all \
+      https://github.com/twpayne/chezmoi/releases/download/v${VERSION}/chezmoi_${VERSION}_checksums.txt \
+      https://github.com/twpayne/chezmoi/releases/download/v${VERSION}/chezmoi_${VERSION}_checksums.txt.sig \
+      https://github.com/twpayne/chezmoi/releases/download/v${VERSION}/chezmoi_cosign.pub
+    ```
+  </Step>
+
+  <Step title="Verify the signature">
+    Verify the signature with cosign:
+
+    ```bash theme={null}
+    cosign verify-blob --key=chezmoi_cosign.pub \
+      --signature=chezmoi_${VERSION}_checksums.txt.sig \
+      chezmoi_${VERSION}_checksums.txt
+    ```
+
+    <Warning>
+      cosign should print `Verified OK`. Do not proceed if verification fails.
+    </Warning>
+  </Step>
+
+  <Step title="Verify checksums">
+    Verify the SHA256 sum of your download matches the verified checksum file:
+
+    <CodeGroup>
+      ```bash Linux theme={null}
+      sha256sum --check chezmoi_${VERSION}_checksums.txt --ignore-missing
+      ```
+
+      ```bash macOS theme={null}
+      shasum --algorithm 256 --check chezmoi_${VERSION}_checksums.txt --ignore-missing
+      ```
+    </CodeGroup>
+  </Step>
+</Steps>
+
+## Next Steps
+
+<CardGroup>
+  <Card title="Quick Start" icon="rocket" href="/quick-start">
+    Learn how to start using chezmoi
+  </Card>
+
+  <Card title="User Guide" icon="book" href="https://chezmoi.io/user-guide/setup/">
+    Understand chezmoi's concepts and workflow
+  </Card>
+</CardGroup>
+
+
+# chezmoi - Manage Your Dotfiles Across Multiple Machines
+Source: https://twpayne-chezmoi.mintlify.app/introduction
+
+Securely manage your personal configuration files (dotfiles) across multiple diverse machines, from your laptop to cloud servers
+
+# Manage Your Dotfiles Across Multiple Machines
+
+chezmoi helps you manage your personal configuration files (dotfiles, like `~/.gitconfig`) across multiple machines.
+
+If you have spent time customizing the tools you use (e.g. shells, editors, and version control systems) and want to keep machines running different accounts (e.g. home and work) and/or different operating systems (e.g. Linux, macOS, and Windows) in sync, while still being able to easily cope with differences from machine to machine, then chezmoi is for you.
+
+<CardGroup>
+  <Card title="Quick Start" icon="rocket" href="/quick-start">
+    Get up and running with chezmoi in minutes
+  </Card>
+
+  <Card title="Installation" icon="download" href="/install">
+    Install chezmoi on your platform
+  </Card>
+
+  <Card title="User Guide" icon="book" href="/user-guide/setup">
+    Learn how to use chezmoi effectively
+  </Card>
+
+  <Card title="Reference" icon="code" href="/reference/configuration-file">
+    Complete command and template reference
+  </Card>
+</CardGroup>
+
+## What Does chezmoi Do?
+
+chezmoi scales from the trivial (e.g. copying a few dotfiles onto a Raspberry Pi, development container, or virtual machine) to complex long-lived multi-machine development environments (e.g. keeping any number of home and work, Linux, macOS, and Windows machines in sync).
+
+In all cases you only need to maintain a **single source of truth** (a single branch in git) and getting started only requires adding a single binary to your machine (which you can do with `curl`, `wget`, or `scp`).
+
+chezmoi has strong support for security, allowing you to manage secrets (e.g. passwords, access tokens, and private keys) securely and seamlessly using a password manager and/or encrypt whole files with your favorite encryption tool.
+
+## Key Features
+
+<AccordionGroup>
+  <Accordion title="Flexible" icon="sliders">
+    Share as much configuration across machines as you want, while still being able to control machine-specific details. Your dotfiles can be **templates** using Go `text/template` syntax. Predefined variables allow you to change behavior depending on operating system, architecture, and hostname.
+
+    chezmoi runs on all commonly-used platforms, like **Linux, macOS, and Windows**. It also runs on less commonly-used platforms, like FreeBSD, OpenBSD, and Termux.
+  </Accordion>
+
+  <Accordion title="Personal and Secure" icon="lock">
+    Nothing leaves your machine, unless you want it to. Your configuration remains in a git repo under your control. chezmoi can retrieve secrets from:
+
+    * 1Password, Bitwarden, Dashlane, Keeper, KeePassXC, LastPass
+    * AWS Secrets Manager, Azure Key Vault, Vault
+    * Doppler, pass, gopass, Proton Pass
+    * macOS Keychain, GNOME Keyring
+    * Any command-line utility of your choice
+
+    You can encrypt individual files with **GnuPG** or **age**. You can checkout your dotfiles repo on as many machines as you want without revealing any secrets to anyone.
+  </Accordion>
+
+  <Accordion title="Transparent" icon="eye">
+    chezmoi includes **verbose and dry run modes** so you can review exactly what changes it will make to your home directory before making them.
+
+    chezmoi's source format uses only regular files and directories that map one-to-one with the files, directories, and symlinks in your home directory that you choose to manage. If you decide not to use chezmoi in the future, it is easy to move your data elsewhere.
+  </Accordion>
+
+  <Accordion title="Declarative and Robust" icon="shield">
+    You declare the desired state of files, directories, and symbolic links in your source of truth and chezmoi updates your home directory to match that state. **What you want is what you get.**
+
+    chezmoi updates all files and symbolic links **atomically**. You will never be left with incomplete files that could lock you out, even if the update process is interrupted.
+  </Accordion>
+
+  <Accordion title="Fast and Easy to Use" icon="bolt">
+    Using chezmoi feels like using git: the commands are similar and chezmoi runs in **fractions of a second**. chezmoi makes most day-to-day operations one line commands, including installation, initialization, and keeping your machines up-to-date.
+
+    chezmoi can pull and apply changes from your dotfiles repo in a single command, and automatically commit and push changes.
+  </Accordion>
+</AccordionGroup>
+
+## Why Use a Dotfile Manager?
+
+Dotfile managers give you the combined benefit of a **consistent environment everywhere** with an **undo command** and a **restore from backup**.
+
+As the core of our development environments become increasingly standardized (e.g. using git at both home and work), and we further customize them, at the same time we increasingly work in ephemeral environments like Docker containers, virtual machines, and GitHub Codespaces.
+
+In the same way that nobody would use an editor without an undo command, or develop software without a version control system, chezmoi brings the investment that you have made in mastering your tools to every environment that you work in.
+
+## What Users Say
+
+<Note>
+  "I've been using Chezmoi for more than a year now, across at least 3 computers simultaneously, and I really love it. Most of all, I love how fast I can configure a new machine when I use it. In just a couple minutes of work, I can kick off a process on a brand-new computer that will set up my dotfiles and install all my usual software so it feels like a computer I've been using for years."
+
+  — @mike\_kasberg
+</Note>
+
+<Note>
+  "Regular reminder that chezmoi is the best dotfile manager utility I've used and you can too"
+
+  — @mbbroberg
+</Note>
+
+## Next Steps
+
+<CardGroup>
+  <Card title="Install chezmoi" icon="download" href="/install">
+    Choose your preferred installation method
+  </Card>
+
+  <Card title="Quick Start Guide" icon="rocket" href="/quick-start">
+    Start managing your dotfiles in minutes
+  </Card>
+</CardGroup>
+
+
+# 1Password
+Source: https://twpayne-chezmoi.mintlify.app/password-managers/1password
+
+Integrate 1Password with chezmoi to manage secrets in your dotfiles
+
+chezmoi includes support for [1Password](https://1password.com/) using the [1Password CLI](https://support.1password.com/command-line-getting-started/) to expose data as template functions.
+
+## Setup
+
+### Install 1Password CLI
+
+Install the 1Password CLI from [1Password's website](https://1password.com/downloads/command-line/).
+
+### Sign In
+
+Log in and get a session:
+
+```bash theme={null}
+op account add --address $SUBDOMAIN.1password.com --email $EMAIL
+eval $(op signin --account $SUBDOMAIN)
+```
+
+<Info>
+  This is not necessary if you are using biometric authentication.
+</Info>
+
+## Template Functions
+
+### `onepasswordRead`
+
+Read a secret using the secret reference URI:
+
+```text theme={null}
+{{ onepasswordRead "op://app-prod/db/password" }}
+```
+
+This runs:
+
+```bash theme={null}
+op read op://app-prod/db/password
+```
+
+### `onepassword`
+
+Get structured data for an item:
+
+```text theme={null}
+{{ (onepassword "$UUID").fields }}
+```
+
+This runs `op item get $UUID --format json` and returns the parsed JSON.
+
+### `onepasswordDetailsFields`
+
+Get a simplified field structure:
+
+```text theme={null}
+{{ (onepasswordDetailsFields "$UUID").password.value }}
+```
+
+This returns fields indexed by their ID or label for easier access.
+
+### `onepasswordItemFields`
+
+Get item-specific fields (fields with sections):
+
+```text theme={null}
+{{ (onepasswordItemFields "$UUID").apikey.value }}
+```
+
+### `onepasswordDocument`
+
+Retrieve a document:
+
+```text theme={null}
+{{ onepasswordDocument "$UUID" }}
+```
+
+<Warning>
+  `onepasswordDocument` is not available in Connect mode.
+</Warning>
+
+## Usage Examples
+
+### Reading Secrets by Reference
+
+The simplest approach using secret references:
+
+<CodeGroup>
+  ```text SSH Config theme={null}
+  # ~/.ssh/config.tmpl
+  Host github.com
+      IdentityFile ~/.ssh/id_ed25519
+      User git
+
+  Host work-github
+      HostName github.com
+      IdentityFile ~/.ssh/work_id_rsa
+      User {{ onepasswordRead "op://Work/GitHub/username" }}
+  ```
+
+  ```text Git Config theme={null}
+  # ~/.gitconfig.tmpl
+  [user]
+      name = {{ onepasswordRead "op://Personal/Git/name" }}
+      email = {{ onepasswordRead "op://Personal/Git/email" }}
+      signingkey = {{ onepasswordRead "op://Personal/Git/gpg-key" }}
+  ```
+
+  ```text AWS Credentials theme={null}
+  # ~/.aws/credentials.tmpl
+  [default]
+  aws_access_key_id = {{ onepasswordRead "op://Personal/AWS/access-key-id" }}
+  aws_secret_access_key = {{ onepasswordRead "op://Personal/AWS/secret-access-key" }}
+
+  [work]
+  aws_access_key_id = {{ onepasswordRead "op://Work/AWS/access-key-id" }}
+  aws_secret_access_key = {{ onepasswordRead "op://Work/AWS/secret-access-key" }}
+  ```
+</CodeGroup>
+
+### Using Structured Data
+
+Access specific fields from the JSON response:
+
+<CodeGroup>
+  ```text By Index theme={null}
+  # Access fields by array index
+  username = {{ (index (onepassword "$UUID").fields 0).value }}
+  password = {{ (index (onepassword "$UUID").fields 1).value }}
+  ```
+
+  ```text By Iteration theme={null}
+  # Find fields by label
+  {{ range (onepassword "$UUID").fields -}}
+  {{   if and (eq .label "password") (eq .purpose "PASSWORD") -}}
+  {{     .value -}}
+  {{   end -}}
+  {{ end }}
+  ```
+
+  ```text Using onepasswordDetailsFields theme={null}
+  # Simplified access
+  username = {{ (onepasswordDetailsFields "$UUID").username.value }}
+  password = {{ (onepasswordDetailsFields "$UUID").password.value }}
+  ```
+</CodeGroup>
+
+### Retrieving Documents
+
+<CodeGroup>
+  ```text SSH Private Key theme={null}
+  # ~/.ssh/work_id_rsa
+  {{ onepasswordDocument "jn5odbpyctjbhk5gqa7xs5cjom" }}
+  ```
+
+  ```text Certificate theme={null}
+  # ~/.config/ssl/client-cert.pem
+  {{ onepasswordDocument "certificate-uuid" }}
+  ```
+</CodeGroup>
+
+### Working with Item Fields
+
+Access additional fields (those in sections):
+
+```text ~/.config/service/config.tmpl theme={null}
+[api]
+key = {{ (onepasswordItemFields "$UUID").api_key.value }}
+endpoint = {{ (onepasswordItemFields "$UUID").endpoint.value }}
+
+[database]
+host = {{ (onepasswordItemFields "$UUID").db_host.value }}
+port = {{ (onepasswordItemFields "$UUID").db_port.value }}
+```
+
+## Configuration
+
+### Sign-In Prompt
+
+By default, chezmoi will verify the session token and prompt for sign-in if needed.
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[onepassword]
+    prompt = true  # Default behavior
+```
+
+To disable automatic prompting:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[onepassword]
+    prompt = false
+```
+
+<Warning>
+  Do not use `prompt = true` on shared machines. Session tokens are passed via command-line parameters, which are visible to other users.
+</Warning>
+
+### Custom Command
+
+If `op` is not in your PATH:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[onepassword]
+    command = "/custom/path/to/op"
+```
+
+## Secrets Automation
+
+chezmoi supports 1Password Connect and Service Accounts for restricted environments where the full desktop app isn't available.
+
+### Account Mode (Default)
+
+For regular 1Password accounts:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[onepassword]
+    mode = "account"  # Default
+```
+
+In account mode, chezmoi will error if:
+
+* `OP_SERVICE_ACCOUNT_TOKEN` is set, or
+* Both `OP_CONNECT_HOST` and `OP_CONNECT_TOKEN` are set
+
+### 1Password Connect
+
+Once [1Password Connect is configured](https://developer.1password.com/docs/connect/connect-cli#requirements):
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[onepassword]
+    mode = "connect"
+```
+
+Set the required environment variables:
+
+```bash theme={null}
+export OP_CONNECT_HOST="http://localhost:8080"
+export OP_CONNECT_TOKEN="your-connect-token"
+```
+
+**Limitations in Connect mode:**
+
+* `onepasswordDocument` is not available
+* Account parameters are not allowed
+* Both `OP_CONNECT_HOST` and `OP_CONNECT_TOKEN` must be set
+
+### 1Password Service Accounts
+
+Once a [service account is created](https://developer.1password.com/docs/service-accounts/use-with-1password-cli/#requirements):
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[onepassword]
+    mode = "service"
+```
+
+Set the required environment variable:
+
+```bash theme={null}
+export OP_SERVICE_ACCOUNT_TOKEN="your-service-account-token"
+```
+
+**Limitations in Service mode:**
+
+* Account parameters are not allowed
+* `OP_SERVICE_ACCOUNT_TOKEN` must be set
+
+<Warning>
+  Both 1Password Connect and Service Accounts prevent the CLI from working with multiple accounts. If you need access to secrets from more than one 1Password account, do not use these features.
+</Warning>
+
+## Multiple Accounts
+
+In account mode, you can specify which account to use:
+
+```text theme={null}
+{{ onepasswordRead "op://app-prod/db/password" "work-account" }}
+```
+
+The account parameter can be:
+
+* Account URL: `example.1password.com`
+* Email: `user@example.com`
+* Account UUID
+* User UUID
+* Shorthand
+
+## Complete Examples
+
+### NPM Configuration
+
+```text ~/.npmrc.tmpl theme={null}
+//registry.npmjs.org/:_authToken={{ onepasswordRead "op://Personal/NPM/token" }}
+email={{ onepasswordRead "op://Personal/NPM/email" }}
+```
+
+### Database Configuration
+
+```text ~/.config/db/config.yml.tmpl theme={null}
+production:
+  host: {{ onepasswordRead "op://Production/Database/host" }}
+  port: {{ onepasswordRead "op://Production/Database/port" }}
+  username: {{ onepasswordRead "op://Production/Database/username" }}
+  password: {{ onepasswordRead "op://Production/Database/password" }}
+  database: {{ onepasswordRead "op://Production/Database/database" }}
+
+development:
+  host: localhost
+  port: 5432
+  username: dev
+  password: {{ onepasswordRead "op://Development/Database/password" }}
+  database: app_dev
+```
+
+### Multi-Service API Keys
+
+```text ~/.config/api-keys.env.tmpl theme={null}
+# GitHub
+GITHUB_TOKEN={{ onepasswordRead "op://Personal/GitHub/token" }}
+GH_TOKEN={{ onepasswordRead "op://Personal/GitHub/token" }}
+
+# OpenAI
+OPENAI_API_KEY={{ onepasswordRead "op://Personal/OpenAI/api-key" }}
+
+# Stripe
+STRIPE_SECRET_KEY={{ onepasswordRead "op://Work/Stripe/secret-key" }}
+STRIPE_PUBLISHABLE_KEY={{ onepasswordRead "op://Work/Stripe/publishable-key" }}
+
+# Slack
+SLACK_WEBHOOK_URL={{ onepasswordRead "op://Work/Slack/webhook-url" }}
+```
+
+## Troubleshooting
+
+### Session Token Expired
+
+```bash theme={null}
+eval $(op signin --account $SUBDOMAIN)
+```
+
+### Command Not Found
+
+Ensure the 1Password CLI is installed and in your PATH:
+
+```bash theme={null}
+which op
+op --version
+```
+
+### Invalid Item Reference
+
+Verify the item exists:
+
+```bash theme={null}
+op item get "$UUID" --format json
+```
+
+### Testing Template Functions
+
+Test your template functions:
+
+```bash theme={null}
+chezmoi execute-template '{{ onepasswordRead "op://Personal/test/value" }}'
+```
+
+## Best Practices
+
+1. **Use secret references**: Prefer `onepasswordRead` with `op://` URIs for simplicity
+2. **Organize vaults**: Use separate vaults for Personal, Work, etc.
+3. **Use descriptive names**: Name items clearly for easy reference
+4. **Test before committing**: Verify templates work before adding to source control
+5. **Document UUIDs**: Keep a reference of UUIDs used in templates
+
+## See Also
+
+* [1Password CLI Documentation](https://developer.1password.com/docs/cli/)
+* [Secret Reference Syntax](https://developer.1password.com/docs/cli/secret-reference-syntax/)
+* [1Password Connect](https://developer.1password.com/docs/connect/)
+* [Service Accounts](https://developer.1password.com/docs/service-accounts/)
+
+
+# AWS Secrets Manager
+Source: https://twpayne-chezmoi.mintlify.app/password-managers/aws-secrets-manager
+
+Integrate AWS Secrets Manager with chezmoi to manage secrets in your dotfiles
+
+chezmoi includes support for [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/) to retrieve secrets stored in AWS.
+
+## Setup
+
+### Install AWS CLI
+
+Ensure you have AWS credentials configured:
+
+<CodeGroup>
+  ```bash AWS CLI v2 theme={null}
+  # Install AWS CLI
+  curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+  unzip awscliv2.zip
+  sudo ./aws/install
+  ```
+
+  ```bash macOS theme={null}
+  brew install awscli
+  ```
+</CodeGroup>
+
+### Configure AWS Credentials
+
+<CodeGroup>
+  ```bash Default Profile theme={null}
+  aws configure
+  # Enter your AWS Access Key ID
+  # Enter your AWS Secret Access Key
+  # Enter your default region
+  ```
+
+  ```bash Named Profile theme={null}
+  aws configure --profile work
+  ```
+</CodeGroup>
+
+Or use environment variables:
+
+```bash theme={null}
+export AWS_ACCESS_KEY_ID="[REDACTED-AWSKEY-DOCS-EXAMPLE]"
+export AWS_SECRET_ACCESS_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+export AWS_DEFAULT_REGION="us-east-1"
+```
+
+## Template Functions
+
+### `awsSecretsManager`
+
+Retrieve structured JSON secrets:
+
+```text theme={null}
+{{ (awsSecretsManager "my-secret-name").username }}
+{{ (awsSecretsManager "my-secret-name").password }}
+```
+
+This retrieves the secret and parses it as JSON.
+
+### `awsSecretsManagerRaw`
+
+Retrieve raw secret strings:
+
+```text theme={null}
+{{ awsSecretsManagerRaw "my-secret-string" }}
+```
+
+Useful for non-JSON secrets like API tokens or passwords.
+
+## Configuration
+
+Configure AWS Secrets Manager in chezmoi:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[awsSecretsManager]
+    profile = "myWorkProfile"
+    region = "us-east-2"
+```
+
+By default, chezmoi uses:
+
+* Standard AWS environment variables (`AWS_PROFILE`, `AWS_REGION`)
+* AWS config files (`~/.aws/config`, `~/.aws/credentials`)
+
+## Usage Examples
+
+### Database Credentials (JSON)
+
+Store a JSON secret in AWS:
+
+```bash theme={null}
+aws secretsmanager create-secret \
+    --name prod-database \
+    --secret-string '{
+        "host": "db.example.com",
+        "port": "5432",
+        "username": "app_user",
+        "password": "super_secret_password",
+        "database": "production_db"
+    }'
+```
+
+Use in templates:
+
+```text ~/.config/db/config.yml.tmpl theme={null}
+production:
+  host: {{ (awsSecretsManager "prod-database").host }}
+  port: {{ (awsSecretsManager "prod-database").port }}
+  username: {{ (awsSecretsManager "prod-database").username }}
+  password: {{ (awsSecretsManager "prod-database").password }}
+  database: {{ (awsSecretsManager "prod-database").database }}
+```
+
+### API Tokens (Raw)
+
+<CodeGroup>
+  ```bash Store Secret theme={null}
+  aws secretsmanager create-secret \
+      --name github-token \
+      --secret-string "[REDACTED-GHTOKEN-DOCS-EXAMPLE]"
+  ```
+
+  ```text Use in Template theme={null}
+  # ~/.config/gh/config.yml.tmpl
+  github_token: {{ awsSecretsManagerRaw "github-token" }}
+  ```
+</CodeGroup>
+
+### Multiple API Keys
+
+```bash theme={null}
+# Store multiple secrets
+aws secretsmanager create-secret --name github-api-token --secret-string "[REDACTED-GHTOKEN-DOCS-EXAMPLE]"
+aws secretsmanager create-secret --name gitlab-api-token --secret-string "[REDACTED-GLPAT-DOCS-EXAMPLE]"
+aws secretsmanager create-secret --name openai-api-key --secret-string "sk-xxx"
+```
+
+```text ~/.config/api-keys.env.tmpl theme={null}
+GITHUB_TOKEN={{ awsSecretsManagerRaw "github-api-token" }}
+GITLAB_TOKEN={{ awsSecretsManagerRaw "gitlab-api-token" }}
+OPENAI_API_KEY={{ awsSecretsManagerRaw "openai-api-key" }}
+```
+
+### AWS Credentials for Different Accounts
+
+Store credentials for other AWS accounts:
+
+```bash theme={null}
+aws secretsmanager create-secret \
+    --name dev-aws-credentials \
+    --secret-string '{
+        "access_key_id": "[REDACTED-AWSKEY-DOCS-EXAMPLE]",
+        "secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        "region": "us-west-2"
+    }'
+```
+
+```text ~/.aws/credentials.tmpl theme={null}
+[development]
+aws_access_key_id = {{ (awsSecretsManager "dev-aws-credentials").access_key_id }}
+aws_secret_access_key = {{ (awsSecretsManager "dev-aws-credentials").secret_access_key }}
+region = {{ (awsSecretsManager "dev-aws-credentials").region }}
+```
+
+### SSH Private Keys
+
+<CodeGroup>
+  ```bash Store Key theme={null}
+  aws secretsmanager create-secret \
+      --name ssh-private-key \
+      --secret-string file://~/.ssh/id_rsa
+  ```
+
+  ```text Use in Template theme={null}
+  # ~/.ssh/work_id_rsa.tmpl
+  {{ awsSecretsManagerRaw "ssh-private-key" }}
+  ```
+</CodeGroup>
+
+### Application Configuration
+
+```bash theme={null}
+aws secretsmanager create-secret \
+    --name app-config \
+    --secret-string '{
+        "api_endpoint": "https://api.example.com",
+        "api_key": "secret_key_here",
+        "db_connection": "postgresql://user:pass@host:5432/db",
+        "redis_url": "redis://localhost:6379",
+        "jwt_secret": "jwt_signing_secret"
+    }'
+```
+
+```text ~/.config/app/config.yml.tmpl theme={null}
+api:
+  endpoint: {{ (awsSecretsManager "app-config").api_endpoint }}
+  key: {{ (awsSecretsManager "app-config").api_key }}
+
+database:
+  connection: {{ (awsSecretsManager "app-config").db_connection }}
+
+redis:
+  url: {{ (awsSecretsManager "app-config").redis_url }}
+
+auth:
+  jwt_secret: {{ (awsSecretsManager "app-config").jwt_secret }}
+```
+
+## Using Different Regions and Profiles
+
+### Per-Profile Configuration
+
+<CodeGroup>
+  ```toml Personal Profile theme={null}
+  # ~/.config/chezmoi/chezmoi.toml
+  [awsSecretsManager]
+      profile = "personal"
+      region = "us-east-1"
+  ```
+
+  ```toml Work Profile theme={null}
+  # ~/.config/chezmoi/chezmoi.toml
+  [awsSecretsManager]
+      profile = "work"
+      region = "eu-west-1"
+  ```
+</CodeGroup>
+
+### Using ARNs
+
+You can use full ARNs for cross-region or cross-account access:
+
+```text theme={null}
+{{ awsSecretsManagerRaw "arn:aws:secretsmanager:us-west-2:123456789012:secret:my-secret-ABC123" }}
+```
+
+## Advanced Usage
+
+### Versioned Secrets
+
+AWS Secrets Manager supports versioning. By default, chezmoi retrieves the current version (AWSCURRENT).
+
+### Binary Secrets
+
+For binary secrets, `awsSecretsManagerRaw` automatically decodes base64 data.
+
+### Nested JSON
+
+Access nested JSON structures:
+
+```bash theme={null}
+aws secretsmanager create-secret \
+    --name complex-config \
+    --secret-string '{
+        "database": {
+            "primary": {"host": "db1.example.com", "port": 5432},
+            "replica": {"host": "db2.example.com", "port": 5432}
+        },
+        "cache": {"redis": {"host": "cache.example.com", "port": 6379}}
+    }'
+```
+
+```text theme={null}
+{{ (awsSecretsManager "complex-config").database.primary.host }}
+{{ (awsSecretsManager "complex-config").cache.redis.host }}
+```
+
+### Conditional Secrets by Environment
+
+```text ~/.config/app/config.yml.tmpl theme={null}
+{{ if eq .chezmoi.hostname "prod-server" -}}
+# Production
+api_key: {{ awsSecretsManagerRaw "prod-api-key" }}
+db_password: {{ (awsSecretsManager "prod-database").password }}
+{{ else -}}
+# Development
+api_key: {{ awsSecretsManagerRaw "dev-api-key" }}
+db_password: {{ (awsSecretsManager "dev-database").password }}
+{{ end }}
+```
+
+## Complete Examples
+
+### Multi-Service Configuration
+
+```text ~/.config/services.yml.tmpl theme={null}
+services:
+  database:
+    host: {{ (awsSecretsManager "database").host }}
+    port: {{ (awsSecretsManager "database").port }}
+    username: {{ (awsSecretsManager "database").username }}
+    password: {{ (awsSecretsManager "database").password }}
+  
+  redis:
+    host: {{ (awsSecretsManager "redis").host }}
+    port: {{ (awsSecretsManager "redis").port }}
+    password: {{ awsSecretsManagerRaw "redis-password" }}
+  
+  api:
+    github: {{ awsSecretsManagerRaw "github-token" }}
+    gitlab: {{ awsSecretsManagerRaw "gitlab-token" }}
+    openai: {{ awsSecretsManagerRaw "openai-key" }}
+```
+
+### Kubernetes Secrets
+
+```text ~/.kube/config.tmpl theme={null}
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: {{ (awsSecretsManager "k8s-cluster").server }}
+    certificate-authority-data: {{ (awsSecretsManager "k8s-cluster").ca_cert }}
+  name: production
+users:
+- name: admin
+  user:
+    token: {{ awsSecretsManagerRaw "k8s-admin-token" }}
+contexts:
+- context:
+    cluster: production
+    user: admin
+  name: prod-context
+current-context: prod-context
+```
+
+## IAM Permissions
+
+Your AWS user/role needs these permissions:
+
+```json theme={null}
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret"
+            ],
+            "Resource": "arn:aws:secretsmanager:*:*:secret:*"
+        }
+    ]
+}
+```
+
+For specific secrets:
+
+```json theme={null}
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "secretsmanager:GetSecretValue",
+            "Resource": [
+                "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret-*",
+                "arn:aws:secretsmanager:us-east-1:123456789012:secret:other-secret-*"
+            ]
+        }
+    ]
+}
+```
+
+## Troubleshooting
+
+### AccessDeniedException
+
+Ensure your IAM user/role has `secretsmanager:GetSecretValue` permission:
+
+```bash theme={null}
+aws secretsmanager get-secret-value --secret-id my-secret
+```
+
+### ResourceNotFoundException
+
+Verify the secret exists in the correct region:
+
+```bash theme={null}
+aws secretsmanager list-secrets --region us-east-1
+```
+
+### Invalid JSON
+
+If using `awsSecretsManager` (not `awsSecretsManagerRaw`), ensure your secret is valid JSON:
+
+```bash theme={null}
+aws secretsmanager get-secret-value --secret-id my-secret | jq .SecretString
+```
+
+### Credentials Not Found
+
+Verify AWS credentials are configured:
+
+```bash theme={null}
+aws configure list
+aws sts get-caller-identity
+```
+
+### Testing Templates
+
+Test template functions:
+
+```bash theme={null}
+chezmoi execute-template '{{ awsSecretsManagerRaw "test-secret" }}'
+```
+
+## Best Practices
+
+1. **Use IAM roles**: On EC2/ECS, use IAM roles instead of access keys
+2. **Least privilege**: Grant only necessary permissions to specific secrets
+3. **Use encryption**: Enable encryption at rest for secrets
+4. **Rotate secrets**: Enable automatic rotation for database credentials
+5. **Use resource policies**: Control access with resource-based policies
+6. **Tag secrets**: Use tags for organization and cost allocation
+7. **Monitor access**: Enable CloudTrail logging for secret access
+8. **Use VPC endpoints**: Access Secrets Manager privately from VPC
+
+## Cost Considerations
+
+AWS Secrets Manager pricing:
+
+* **\$0.40 per secret per month**
+* **\$0.05 per 10,000 API calls**
+
+Consider:
+
+* Caching reduces API calls
+* Use AWS Systems Manager Parameter Store for simpler secrets (cheaper)
+* Delete unused secrets
+
+## See Also
+
+* [AWS Secrets Manager Documentation](https://docs.aws.amazon.com/secretsmanager/)
+* [AWS CLI Secrets Manager Commands](https://docs.aws.amazon.com/cli/latest/reference/secretsmanager/)
+* [IAM Permissions for Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access.html)
+* [Azure Key Vault](/password-managers/azure-key-vault) - Azure equivalent
+
+
+# Azure Key Vault
+Source: https://twpayne-chezmoi.mintlify.app/password-managers/azure-key-vault
+
+Integrate Azure Key Vault with chezmoi to manage secrets in your dotfiles
+
+chezmoi includes support for [Azure Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/secrets/about-secrets) to retrieve secrets stored in Azure.
+
+## Setup
+
+### Install Azure CLI
+
+<CodeGroup>
+  ```bash macOS theme={null}
+  brew install azure-cli
+  ```
+
+  ```bash Ubuntu/Debian theme={null}
+  curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+  ```
+
+  ```bash Windows theme={null}
+  winget install -e --id Microsoft.AzureCLI
+  ```
+</CodeGroup>
+
+### Log In
+
+Authenticate with Azure:
+
+```bash theme={null}
+az login
+```
+
+Or use [alternative authentication methods](https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication?tabs=bash):
+
+<CodeGroup>
+  ```bash Service Principal theme={null}
+  az login --service-principal \
+      --username $APP_ID \
+      --password $PASSWORD \
+      --tenant $TENANT_ID
+  ```
+
+  ```bash Managed Identity theme={null}
+  # Automatically used on Azure VMs with managed identity enabled
+  az login --identity
+  ```
+</CodeGroup>
+
+### Set Permissions
+
+Your user or service principal needs the **Key Vault Secrets User** RBAC role:
+
+```bash theme={null}
+az role assignment create \
+    --role "Key Vault Secrets User" \
+    --assignee user@example.com \
+    --scope /subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.KeyVault/vaults/{vault-name}
+```
+
+## Configuration
+
+Set a default vault in your chezmoi config:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[azureKeyVault]
+    defaultVault = "contoso-vault2"
+```
+
+## Template Function
+
+### `azureKeyVault`
+
+Retrieve a secret from Azure Key Vault:
+
+```text theme={null}
+{{ azureKeyVault "secret-name" }}
+```
+
+With explicit vault name:
+
+```text theme={null}
+{{ azureKeyVault "secret-name" "vault-name" }}
+```
+
+Using vault alias from config:
+
+```text theme={null}
+{{ azureKeyVault "secret-name" .vaultAlias }}
+```
+
+## Usage Examples
+
+### Using Default Vault
+
+<CodeGroup>
+  ```toml Configuration theme={null}
+  # ~/.config/chezmoi/chezmoi.toml
+  [azureKeyVault]
+      defaultVault = "my-vault"
+  ```
+
+  ```text Template theme={null}
+  # ~/.config/app/config.yml.tmpl
+  api_key: {{ azureKeyVault "api-key" }}
+  db_password: {{ azureKeyVault "db-password" }}
+  ```
+</CodeGroup>
+
+### Using Explicit Vault Names
+
+```text ~/.config/app/config.yml.tmpl theme={null}
+# Production secrets from prod vault
+prod_api_key: {{ azureKeyVault "api-key" "production-vault" }}
+prod_db_password: {{ azureKeyVault "db-password" "production-vault" }}
+
+# Development secrets from dev vault
+dev_api_key: {{ azureKeyVault "api-key" "development-vault" }}
+dev_db_password: {{ azureKeyVault "db-password" "development-vault" }}
+```
+
+### Using Vault Aliases
+
+Define vault aliases in your config:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[azureKeyVault]
+    defaultVault = "personal-vault"
+
+[data]
+    prodVault = "production-vault"
+    devVault = "development-vault"
+    sharedVault = "team-shared-vault"
+```
+
+Use in templates:
+
+```text ~/.config/app/config.yml.tmpl theme={null}
+production:
+  api_key: {{ azureKeyVault "api-key" .prodVault }}
+  db_password: {{ azureKeyVault "db-password" .prodVault }}
+
+development:
+  api_key: {{ azureKeyVault "api-key" .devVault }}
+  db_password: {{ azureKeyVault "db-password" .devVault }}
+
+shared:
+  license_key: {{ azureKeyVault "license-key" .sharedVault }}
+```
+
+### Database Credentials
+
+```text ~/.config/db/config.yml.tmpl theme={null}
+production:
+  host: {{ azureKeyVault "prod-db-host" }}
+  port: 5432
+  username: {{ azureKeyVault "prod-db-username" }}
+  password: {{ azureKeyVault "prod-db-password" }}
+  database: {{ azureKeyVault "prod-db-name" }}
+
+development:
+  host: localhost
+  port: 5432
+  username: devuser
+  password: {{ azureKeyVault "dev-db-password" }}
+  database: myapp_dev
+```
+
+### API Keys
+
+```text ~/.config/api-keys.env.tmpl theme={null}
+# Cloud providers
+AZURE_SUBSCRIPTION_ID={{ azureKeyVault "azure-subscription-id" }}
+AZURE_CLIENT_ID={{ azureKeyVault "azure-client-id" }}
+AZURE_CLIENT_SECRET={{ azureKeyVault "azure-client-secret" }}
+
+# Third-party APIs
+GITHUB_TOKEN={{ azureKeyVault "github-token" }}
+OPENAI_API_KEY={{ azureKeyVault "openai-api-key" }}
+STRIPE_SECRET_KEY={{ azureKeyVault "stripe-secret-key" }}
+```
+
+### SSH Keys
+
+<CodeGroup>
+  ```bash Store in Key Vault theme={null}
+  # Store SSH private key
+  az keyvault secret set \
+      --vault-name my-vault \
+      --name ssh-private-key \
+      --file ~/.ssh/id_rsa
+  ```
+
+  ```text Use in Template theme={null}
+  # ~/.ssh/work_id_rsa.tmpl
+  {{ azureKeyVault "ssh-private-key" }}
+  ```
+</CodeGroup>
+
+### Git Configuration
+
+```text ~/.gitconfig.tmpl theme={null}
+[user]
+    name = {{ azureKeyVault "git-name" }}
+    email = {{ azureKeyVault "git-email" }}
+    signingkey = {{ azureKeyVault "git-signing-key" }}
+
+[github]
+    user = {{ azureKeyVault "github-username" }}
+
+[credential]
+    helper = store
+```
+
+### NPM Configuration
+
+```text ~/.npmrc.tmpl theme={null}
+//registry.npmjs.org/:_authToken={{ azureKeyVault "npm-token" }}
+email={{ azureKeyVault "npm-email" }}
+```
+
+### Kubernetes Config
+
+```text ~/.kube/config.tmpl theme={null}
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: {{ azureKeyVault "k8s-server-url" }}
+    certificate-authority-data: {{ azureKeyVault "k8s-ca-cert" }}
+  name: production
+users:
+- name: admin
+  user:
+    token: {{ azureKeyVault "k8s-admin-token" }}
+contexts:
+- context:
+    cluster: production
+    user: admin
+  name: prod-context
+current-context: prod-context
+```
+
+## Managing Secrets in Azure Key Vault
+
+### Create Secrets
+
+<CodeGroup>
+  ```bash Simple Secret theme={null}
+  az keyvault secret set \
+      --vault-name my-vault \
+      --name api-key \
+      --value "secret-value-here"
+  ```
+
+  ```bash From File theme={null}
+  az keyvault secret set \
+      --vault-name my-vault \
+      --name ssh-key \
+      --file ~/.ssh/id_rsa
+  ```
+
+  ```bash From Stdin theme={null}
+  echo "secret-value" | az keyvault secret set \
+      --vault-name my-vault \
+      --name password \
+      --file /dev/stdin
+  ```
+</CodeGroup>
+
+### List Secrets
+
+```bash theme={null}
+az keyvault secret list --vault-name my-vault --output table
+```
+
+### Show Secret Value
+
+```bash theme={null}
+az keyvault secret show \
+    --vault-name my-vault \
+    --name api-key \
+    --query value \
+    --output tsv
+```
+
+### Delete Secrets
+
+```bash theme={null}
+az keyvault secret delete \
+    --vault-name my-vault \
+    --name old-secret
+```
+
+## Advanced Usage
+
+### Environment-Specific Vaults
+
+```text ~/.config/app/config.yml.tmpl theme={null}
+{{ if eq .chezmoi.hostname "prod-server" -}}
+# Production
+api_key: {{ azureKeyVault "api-key" "production-vault" }}
+{{ else if eq .chezmoi.hostname "staging-server" -}}
+# Staging
+api_key: {{ azureKeyVault "api-key" "staging-vault" }}
+{{ else -}}
+# Development
+api_key: {{ azureKeyVault "api-key" "development-vault" }}
+{{ end }}
+```
+
+### Secret Versioning
+
+By default, chezmoi retrieves the latest version. Azure Key Vault maintains version history automatically.
+
+### Multi-Vault Configuration
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[azureKeyVault]
+    defaultVault = "personal-vault"
+
+[data]
+    # Different vaults for different purposes
+    personalVault = "personal-vault"
+    workVault = "work-vault"
+    sharedVault = "team-vault"
+    prodVault = "production-vault"
+    stagingVault = "staging-vault"
+    devVault = "development-vault"
+```
+
+## Complete Examples
+
+### Multi-Service Application Config
+
+```text ~/.config/services.yml.tmpl theme={null}
+services:
+  database:
+    host: {{ azureKeyVault "db-host" }}
+    username: {{ azureKeyVault "db-username" }}
+    password: {{ azureKeyVault "db-password" }}
+  
+  redis:
+    host: {{ azureKeyVault "redis-host" }}
+    password: {{ azureKeyVault "redis-password" }}
+  
+  storage:
+    account_name: {{ azureKeyVault "storage-account" }}
+    account_key: {{ azureKeyVault "storage-key" }}
+  
+  api:
+    github: {{ azureKeyVault "github-token" }}
+    openai: {{ azureKeyVault "openai-key" }}
+    stripe: {{ azureKeyVault "stripe-secret" }}
+```
+
+### Azure Service Connection
+
+```text ~/.azure/credentials.tmpl theme={null}
+[default]
+subscription_id = {{ azureKeyVault "azure-subscription-id" }}
+client_id = {{ azureKeyVault "azure-client-id" }}
+client_secret = {{ azureKeyVault "azure-client-secret" }}
+tenant_id = {{ azureKeyVault "azure-tenant-id" }}
+```
+
+## RBAC Permissions
+
+Required Azure RBAC role:
+
+* **Key Vault Secrets User**: Read secret contents
+
+Assign via Azure Portal, CLI, or ARM template:
+
+```bash theme={null}
+az role assignment create \
+    --role "Key Vault Secrets User" \
+    --assignee-object-id $OBJECT_ID \
+    --scope /subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RG/providers/Microsoft.KeyVault/vaults/$VAULT_NAME
+```
+
+For service principals:
+
+```bash theme={null}
+az role assignment create \
+    --role "Key Vault Secrets User" \
+    --assignee $APP_ID \
+    --scope /subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RG/providers/Microsoft.KeyVault/vaults/$VAULT_NAME
+```
+
+## Troubleshooting
+
+### Access Denied
+
+Ensure you have the correct RBAC role:
+
+```bash theme={null}
+az role assignment list \
+    --scope /subscriptions/$SUB_ID/resourceGroups/$RG/providers/Microsoft.KeyVault/vaults/$VAULT \
+    --assignee user@example.com
+```
+
+### Vault Not Found
+
+Verify the vault exists and you have access:
+
+```bash theme={null}
+az keyvault list --output table
+```
+
+### Secret Not Found
+
+List secrets in the vault:
+
+```bash theme={null}
+az keyvault secret list --vault-name my-vault
+```
+
+### Authentication Failed
+
+Re-authenticate:
+
+```bash theme={null}
+az logout
+az login
+```
+
+### Testing Templates
+
+Test template functions:
+
+```bash theme={null}
+chezmoi execute-template '{{ azureKeyVault "test-secret" }}'
+```
+
+## Best Practices
+
+1. **Use RBAC**: Prefer RBAC over access policies for granular control
+2. **Separate vaults**: Use different vaults for different environments
+3. **Least privilege**: Grant minimum required permissions
+4. **Enable soft delete**: Protect against accidental deletion
+5. **Enable purge protection**: Prevent permanent deletion during retention period
+6. **Use managed identities**: On Azure VMs, use managed identities instead of service principals
+7. **Monitor access**: Enable diagnostic logs and alerts
+8. **Use private endpoints**: Access Key Vault privately from VNet
+9. **Rotate secrets**: Implement secret rotation policies
+10. **Tag secrets**: Use tags for organization and cost tracking
+
+## Cost Considerations
+
+Azure Key Vault pricing:
+
+* **Standard tier**: \$0.03 per 10,000 operations
+* **Premium tier**: \$0.03 per 10,000 operations + HSM operations
+
+Chezmoi caches secrets to minimize operations.
+
+## See Also
+
+* [Azure Key Vault Documentation](https://learn.microsoft.com/en-us/azure/key-vault/)
+* [Azure CLI Key Vault Commands](https://learn.microsoft.com/en-us/cli/azure/keyvault)
+* [Azure Authentication](https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication)
+* [AWS Secrets Manager](/password-managers/aws-secrets-manager) - AWS equivalent
+
+
+# Bitwarden
+Source: https://twpayne-chezmoi.mintlify.app/password-managers/bitwarden
+
+Integrate Bitwarden with chezmoi to manage secrets in your dotfiles
+
+chezmoi includes support for [Bitwarden](https://bitwarden.com/) using the [Bitwarden CLI](https://bitwarden.com/help/cli/) (`bw`), [Bitwarden Secrets CLI](https://bitwarden.com/help/secrets-manager-cli/) (`bws`), and [`rbw`](https://github.com/doy/rbw) to expose data as template functions.
+
+## Bitwarden CLI Setup
+
+### Install
+
+Install the Bitwarden CLI:
+
+```bash theme={null}
+# macOS
+brew install bitwarden-cli
+
+# Linux/Windows - download from
+# https://bitwarden.com/help/cli/
+```
+
+### Log In
+
+Log in using one of these methods:
+
+<CodeGroup>
+  ```bash Email theme={null}
+  bw login $BITWARDEN_EMAIL
+  ```
+
+  ```bash API Key theme={null}
+  bw login --apikey
+  ```
+
+  ```bash SSO theme={null}
+  bw login --sso
+  ```
+</CodeGroup>
+
+### Unlock
+
+If required, unlock your vault (API key and SSO logins always require an explicit unlock):
+
+```bash theme={null}
+bw unlock
+```
+
+Set the `BW_SESSION` environment variable as instructed.
+
+### Quick Session Setup
+
+<CodeGroup>
+  ```bash Already Logged In theme={null}
+  export BW_SESSION=$(bw unlock --raw)
+  ```
+
+  ```bash Email Login theme={null}
+  export BW_SESSION=$(bw login $BITWARDEN_EMAIL --raw)
+  ```
+
+  ```bash SSO/API Login theme={null}
+  export BW_SESSION=$(bw login --sso && bw unlock --raw)
+  ```
+</CodeGroup>
+
+## Template Functions
+
+### `bitwarden`
+
+Get structured data from an item:
+
+```text theme={null}
+username = {{ (bitwarden "item" "example.com").login.username }}
+password = {{ (bitwarden "item" "example.com").login.password }}
+```
+
+This runs `bw get item example.com` and returns parsed JSON.
+
+### `bitwardenFields`
+
+Access custom fields:
+
+```text theme={null}
+{{ (bitwardenFields "item" "example.com").token.value }}
+```
+
+### `bitwardenAttachment`
+
+Retrieve attachments by item ID:
+
+```text theme={null}
+{{ bitwardenAttachment "id_rsa" "bf22e4b4-ae4a-4d1c-8c98-ac620004b628" }}
+```
+
+### `bitwardenAttachmentByRef`
+
+Retrieve attachments by item reference:
+
+```text theme={null}
+{{ bitwardenAttachmentByRef "id_rsa" "item" "example.com" }}
+```
+
+## Usage Examples
+
+### Login Credentials
+
+<CodeGroup>
+  ```text Git Config theme={null}
+  # ~/.gitconfig.tmpl
+  [user]
+      name = {{ (bitwarden "item" "git-config").login.username }}
+      email = {{ (bitwarden "item" "git-config").notes }}
+
+  [github]
+      user = {{ (bitwarden "item" "github").login.username }}
+  ```
+
+  ```text SSH Config theme={null}
+  # ~/.ssh/config.tmpl
+  Host github.com
+      User {{ (bitwarden "item" "github").login.username }}
+      IdentityFile ~/.ssh/id_ed25519
+
+  Host gitlab.com
+      User {{ (bitwarden "item" "gitlab").login.username }}
+      IdentityFile ~/.ssh/id_rsa
+  ```
+</CodeGroup>
+
+### Custom Fields
+
+<CodeGroup>
+  ```text API Tokens theme={null}
+  # ~/.config/tokens.env.tmpl
+  GITHUB_TOKEN={{ (bitwardenFields "item" "github-api").token.value }}
+  GITLAB_TOKEN={{ (bitwardenFields "item" "gitlab-api").api_token.value }}
+  OPENAI_API_KEY={{ (bitwardenFields "item" "openai").api_key.value }}
+  ```
+
+  ```text Database Config theme={null}
+  # ~/.config/db.yml.tmpl
+  production:
+    host: {{ (bitwardenFields "item" "prod-db").host.value }}
+    port: {{ (bitwardenFields "item" "prod-db").port.value }}
+    username: {{ (bitwarden "item" "prod-db").login.username }}
+    password: {{ (bitwarden "item" "prod-db").login.password }}
+    database: {{ (bitwardenFields "item" "prod-db").database.value }}
+  ```
+</CodeGroup>
+
+### Attachments
+
+<CodeGroup>
+  ```text SSH Key by ID theme={null}
+  # ~/.ssh/work_id_rsa
+  {{ bitwardenAttachment "id_rsa" "bf22e4b4-ae4a-4d1c-8c98-ac620004b628" }}
+  ```
+
+  ```text SSH Key by Reference theme={null}
+  # ~/.ssh/work_id_rsa
+  {{ bitwardenAttachmentByRef "id_rsa" "item" "work-ssh-key" }}
+  ```
+
+  ```text Certificate theme={null}
+  # ~/.config/ssl/client.crt
+  {{ bitwardenAttachmentByRef "client.crt" "item" "ssl-certificates" }}
+  ```
+</CodeGroup>
+
+## Configuration
+
+### Automatic Unlock
+
+Enable automatic unlocking if `BW_SESSION` is not set:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[bitwarden]
+    unlock = "auto"
+```
+
+### Custom Command
+
+If `bw` is not in your PATH:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[bitwarden]
+    command = "/custom/path/to/bw"
+```
+
+## Bitwarden Secrets CLI
+
+The Secrets CLI (`bws`) is for [Bitwarden Secrets Manager](https://bitwarden.com/help/secrets-manager-cli/).
+
+### Setup
+
+1. Generate an [access token](https://bitwarden.com/help/access-tokens/) for a [service account](https://bitwarden.com/help/service-accounts/)
+2. Either set the environment variable or store in config:
+
+<CodeGroup>
+  ```bash Environment Variable theme={null}
+  export BWS_ACCESS_TOKEN="0.48c78342-1635-48a6-accd-afbe01336365.C0tMmQqHnAp1h0gL8bngprlPOYutt0:B3h5D+YgLvFiQhWkIq6Bow=="
+  ```
+
+  ```toml Config File theme={null}
+  # ~/.config/chezmoi/chezmoi.toml
+  [data]
+      accessToken = "0.48c78342-1635-48a6-accd-afbe01336365.C0tMmQqHnAp1h0gL8bngprlPOYutt0:B3h5D+YgLvFiQhWkIq6Bow=="
+  ```
+</CodeGroup>
+
+### `bitwardenSecrets`
+
+Retrieve secrets:
+
+```text theme={null}
+{{ (bitwardenSecrets "be8e0ad8-d545-4017-a55a-b02f014d4158").value }}
+```
+
+With token from config:
+
+```text theme={null}
+{{ (bitwardenSecrets "be8e0ad8-d545-4017-a55a-b02f014d4158" .accessToken).value }}
+```
+
+### Usage Examples
+
+<CodeGroup>
+  ```text Environment Variables theme={null}
+  # ~/.config/secrets.env.tmpl
+  API_KEY={{ (bitwardenSecrets "api-key-uuid").value }}
+  DB_PASSWORD={{ (bitwardenSecrets "db-password-uuid").value }}
+  JWT_SECRET={{ (bitwardenSecrets "jwt-secret-uuid").value }}
+  ```
+
+  ```text Application Config theme={null}
+  # ~/.config/app/config.yml.tmpl
+  api:
+    key: {{ (bitwardenSecrets "api-key-uuid" .accessToken).value }}
+    endpoint: https://api.example.com
+
+  database:
+    password: {{ (bitwardenSecrets "db-password-uuid" .accessToken).value }}
+  ```
+</CodeGroup>
+
+## Unofficial Alternative: rbw
+
+[rbw](https://github.com/doy/rbw) is an unofficial Bitwarden CLI with better daemon support.
+
+See the [rbw template functions reference](/reference/templates/password-manager-functions#bitwarden) for usage.
+
+## Complete Examples
+
+### AWS Credentials
+
+```text ~/.aws/credentials.tmpl theme={null}
+[default]
+aws_access_key_id = {{ (bitwardenFields "item" "aws-personal").access_key_id.value }}
+aws_secret_access_key = {{ (bitwardenFields "item" "aws-personal").secret_access_key.value }}
+region = {{ (bitwardenFields "item" "aws-personal").region.value }}
+
+[work]
+aws_access_key_id = {{ (bitwardenFields "item" "aws-work").access_key_id.value }}
+aws_secret_access_key = {{ (bitwardenFields "item" "aws-work").secret_access_key.value }}
+region = us-east-1
+```
+
+### NPM Configuration
+
+```text ~/.npmrc.tmpl theme={null}
+//registry.npmjs.org/:_authToken={{ (bitwardenFields "item" "npm").token.value }}
+email={{ (bitwarden "item" "npm").login.username }}
+```
+
+### Multiple API Keys
+
+```text ~/.config/api-keys.sh.tmpl theme={null}
+#!/bin/bash
+
+# Cloud providers
+export AWS_ACCESS_KEY_ID="{{ (bitwardenFields "item" "aws").access_key_id.value }}"
+export AWS_SECRET_ACCESS_KEY="{{ (bitwardenFields "item" "aws").secret_access_key.value }}"
+export DIGITALOCEAN_TOKEN="{{ (bitwardenFields "item" "digitalocean").token.value }}"
+
+# APIs
+export GITHUB_TOKEN="{{ (bitwardenFields "item" "github").token.value }}"
+export GITLAB_TOKEN="{{ (bitwardenFields "item" "gitlab").token.value }}"
+export OPENAI_API_KEY="{{ (bitwardenFields "item" "openai").api_key.value }}"
+
+# Databases
+export POSTGRES_PASSWORD="{{ (bitwarden "item" "postgres").login.password }}"
+export REDIS_PASSWORD="{{ (bitwarden "item" "redis").login.password }}"
+```
+
+## Troubleshooting
+
+### Session Not Set
+
+If you get "Session key is invalid":
+
+```bash theme={null}
+export BW_SESSION=$(bw unlock --raw)
+```
+
+### Vault Locked
+
+```bash theme={null}
+bw unlock
+export BW_SESSION=$(bw unlock --raw)
+```
+
+### Command Not Found
+
+Ensure Bitwarden CLI is installed:
+
+```bash theme={null}
+which bw
+bw --version
+```
+
+### Item Not Found
+
+Verify the item exists:
+
+```bash theme={null}
+bw list items --search "example.com"
+```
+
+### Testing Templates
+
+Test your template functions:
+
+```bash theme={null}
+chezmoi execute-template '{{ (bitwarden "item" "test").login.username }}'
+```
+
+### Enable Auto-Unlock
+
+To avoid manually unlocking:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[bitwarden]
+    unlock = "auto"
+```
+
+## Best Practices
+
+1. **Use auto-unlock**: Set `bitwarden.unlock = "auto"` for convenience
+2. **Organize items**: Use clear naming conventions for items
+3. **Use custom fields**: Store structured data in custom fields
+4. **Session management**: Set `BW_SESSION` in your shell profile
+5. **Test incrementally**: Test templates before adding more complexity
+6. **Use Secrets Manager**: For production/CI/CD, use Bitwarden Secrets Manager
+
+## See Also
+
+* [Bitwarden CLI Documentation](https://bitwarden.com/help/cli/)
+* [Bitwarden Secrets Manager](https://bitwarden.com/help/secrets-manager-cli/)
+* [rbw GitHub](https://github.com/doy/rbw)
+* [Template Functions Reference](/reference/templates/password-manager-functions#bitwarden)
+
+
+# Dashlane
+Source: https://twpayne-chezmoi.mintlify.app/password-managers/dashlane
+
+Integrate Dashlane with chezmoi to manage secrets in your dotfiles
+
+chezmoi includes support for [Dashlane](https://dashlane.com), a password manager, using the Dashlane CLI to expose data as template functions.
+
+## Setup
+
+### Install Dashlane CLI
+
+Install the Dashlane CLI from the [Dashlane website](https://www.dashlane.com/cli).
+
+<CodeGroup>
+  ```bash macOS theme={null}
+  brew install dashlane/tap/dashlane-cli
+  ```
+
+  ```bash Linux theme={null}
+  npm install -g @dashlane/cli
+  ```
+
+  ```bash Windows theme={null}
+  npm install -g @dashlane/cli
+  ```
+</CodeGroup>
+
+### Log In
+
+Authenticate with Dashlane:
+
+```bash theme={null}
+dcli sync
+```
+
+Follow the prompts to complete authentication.
+
+## Template Functions
+
+### `dashlanePassword`
+
+Retrieve password entries matching a filter:
+
+```text theme={null}
+{{ (index (dashlanePassword "filter") 0).password }}
+```
+
+Returns an array of matching password entries.
+
+### `dashlaneNote`
+
+Retrieve secure notes matching a filter:
+
+```text theme={null}
+{{ dashlaneNote "filter" }}
+```
+
+Returns the note content as a string.
+
+## Usage Examples
+
+### Basic Password Retrieval
+
+<CodeGroup>
+  ```text By Title theme={null}
+  # Get password from entry titled "GitHub"
+  {{ (index (dashlanePassword "GitHub") 0).password }}
+  ```
+
+  ```text By Domain theme={null}
+  # Get password from entry with domain "github.com"
+  {{ (index (dashlanePassword "github.com") 0).password }}
+  ```
+</CodeGroup>
+
+### Git Configuration
+
+```bash theme={null}
+# Store in Dashlane with title "Git Config"
+# Fields: username, email, signing_key
+```
+
+```text ~/.gitconfig.tmpl theme={null}
+{{ $git := index (dashlanePassword "Git Config") 0 -}}
+
+[user]
+    name = {{ $git.username }}
+    email = {{ $git.email }}
+    signingkey = {{ $git.note }}
+```
+
+### AWS Credentials
+
+```text ~/.aws/credentials.tmpl theme={null}
+{{ $aws := index (dashlanePassword "AWS") 0 -}}
+
+[default]
+aws_access_key_id = {{ $aws.username }}
+aws_secret_access_key = {{ $aws.password }}
+```
+
+### NPM Configuration
+
+```text ~/.npmrc.tmpl theme={null}
+{{ $npm := index (dashlanePassword "NPM") 0 -}}
+
+//registry.npmjs.org/:_authToken={{ $npm.password }}
+email={{ $npm.email }}
+```
+
+### Database Credentials
+
+```text ~/.config/db/config.yml.tmpl theme={null}
+{{ $db := index (dashlanePassword "Production Database") 0 -}}
+
+production:
+  host: {{ $db.url }}
+  username: {{ $db.username }}
+  password: {{ $db.password }}
+  port: 5432
+  database: production_db
+```
+
+### Multiple Services
+
+```text ~/.config/api-keys.env.tmpl theme={null}
+# GitHub
+{{ $github := index (dashlanePassword "GitHub API") 0 -}}
+GITHUB_TOKEN={{ $github.password }}
+
+# GitLab
+{{ $gitlab := index (dashlanePassword "GitLab API") 0 -}}
+GITLAB_TOKEN={{ $gitlab.password }}
+
+# OpenAI
+{{ $openai := index (dashlanePassword "OpenAI") 0 -}}
+OPENAI_API_KEY={{ $openai.password }}
+```
+
+### SSH Configuration
+
+```text ~/.ssh/config.tmpl theme={null}
+{{ $github := index (dashlanePassword "GitHub SSH") 0 -}}
+{{ $gitlab := index (dashlanePassword "GitLab SSH") 0 -}}
+
+Host github.com
+    User {{ $github.username }}
+    IdentityFile ~/.ssh/id_ed25519
+
+Host gitlab.com
+    User {{ $gitlab.username }}
+    IdentityFile ~/.ssh/id_rsa
+```
+
+### Secure Notes
+
+Store multiline data like SSH keys or certificates in secure notes:
+
+```text ~/.ssh/id_rsa.tmpl theme={null}
+{{ dashlaneNote "SSH Private Key" }}
+```
+
+```text ~/.config/ssl/certificate.pem.tmpl theme={null}
+{{ dashlaneNote "SSL Certificate" }}
+```
+
+### Kubernetes Config
+
+```text ~/.kube/config.tmpl theme={null}
+{{ $k8s := index (dashlanePassword "Kubernetes") 0 -}}
+
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: {{ $k8s.url }}
+    certificate-authority-data: {{ dashlaneNote "K8s CA Cert" | b64enc }}
+  name: production
+users:
+- name: admin
+  user:
+    token: {{ $k8s.password }}
+contexts:
+- context:
+    cluster: production
+    user: admin
+  name: prod-context
+current-context: prod-context
+```
+
+## Password Entry Structure
+
+Dashlane password entries typically have these fields:
+
+* `title`: Entry title
+* `username`: Username or login
+* `password`: Password value
+* `email`: Email address
+* `url`: Website URL
+* `note`: Additional notes
+
+```text theme={null}
+{{ $entry := index (dashlanePassword "Service") 0 -}}
+
+Title: {{ $entry.title }}
+Username: {{ $entry.username }}
+Password: {{ $entry.password }}
+Email: {{ $entry.email }}
+URL: {{ $entry.url }}
+Note: {{ $entry.note }}
+```
+
+## Filtering
+
+The filter argument matches against:
+
+* Entry title
+* Domain/URL
+* Username
+* Email
+
+```text theme={null}
+# Matches title, domain, or any field
+{{ dashlanePassword "github" }}
+
+# More specific filter
+{{ dashlanePassword "github.com" }}
+{{ dashlanePassword "GitHub API" }}
+```
+
+## Configuration
+
+### Custom Command
+
+If `dcli` is not in your PATH:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[dashlane]
+    command = "/custom/path/to/dcli"
+```
+
+## Complete Examples
+
+### Multi-Service Configuration
+
+```text ~/.config/services.yml.tmpl theme={null}
+{{ $github := index (dashlanePassword "GitHub") 0 -}}
+{{ $aws := index (dashlanePassword "AWS") 0 -}}
+{{ $db := index (dashlanePassword "Database") 0 -}}
+
+github:
+  username: {{ $github.username }}
+  token: {{ $github.password }}
+  email: {{ $github.email }}
+
+aws:
+  access_key_id: {{ $aws.username }}
+  secret_access_key: {{ $aws.password }}
+  region: us-east-1
+
+database:
+  host: {{ $db.url }}
+  username: {{ $db.username }}
+  password: {{ $db.password }}
+  database: production_db
+```
+
+### Docker Registry
+
+```text ~/.docker/config.json.tmpl theme={null}
+{{ $docker := index (dashlanePassword "Docker Hub") 0 -}}
+
+{
+  "auths": {
+    "https://index.docker.io/v1/": {
+      "auth": "{{ printf "%s:%s" $docker.username $docker.password | b64enc }}"
+    }
+  }
+}
+```
+
+### Environment Variables
+
+```text ~/.config/env.sh.tmpl theme={null}
+#!/bin/bash
+
+{{ $github := index (dashlanePassword "GitHub") 0 -}}
+{{ $aws := index (dashlanePassword "AWS") 0 -}}
+{{ $openai := index (dashlanePassword "OpenAI") 0 -}}
+
+# GitHub
+export GITHUB_TOKEN="{{ $github.password }}"
+export GH_TOKEN="{{ $github.password }}"
+
+# AWS
+export AWS_ACCESS_KEY_ID="{{ $aws.username }}"
+export AWS_SECRET_ACCESS_KEY="{{ $aws.password }}"
+
+# OpenAI
+export OPENAI_API_KEY="{{ $openai.password }}"
+```
+
+## Troubleshooting
+
+### Not Logged In
+
+Sync and authenticate:
+
+```bash theme={null}
+dcli sync
+```
+
+### Entry Not Found
+
+List all password entries:
+
+```bash theme={null}
+dcli password
+```
+
+List all notes:
+
+```bash theme={null}
+dcli note
+```
+
+### Command Not Found
+
+Ensure Dashlane CLI is installed:
+
+```bash theme={null}
+which dcli
+dcli --version
+```
+
+### Testing Templates
+
+Test template functions:
+
+```bash theme={null}
+chezmoi execute-template '{{ index (dashlanePassword "test") 0 | toJson }}'
+chezmoi execute-template '{{ dashlaneNote "test-note" }}'
+```
+
+### Multiple Matches
+
+If a filter returns multiple results, access by index:
+
+```text theme={null}
+# First match
+{{ (index (dashlanePassword "github") 0).password }}
+
+# Second match
+{{ (index (dashlanePassword "github") 1).password }}
+```
+
+Use more specific filters to avoid multiple matches.
+
+## Best Practices
+
+1. **Use descriptive titles**: Make entries easy to filter
+2. **Consistent naming**: Use a naming convention for entries
+3. **Use notes field**: Store additional structured data in notes
+4. **Specific filters**: Use precise filters to avoid multiple matches
+5. **Secure notes**: Use secure notes for large/multiline data
+6. **Test filters**: Verify filters match the right entries
+7. **Stay synced**: Run `dcli sync` regularly
+8. **Organize**: Use Dashlane's folders/categories for organization
+
+## See Also
+
+* [Dashlane CLI Documentation](https://www.dashlane.com/cli)
+* [Dashlane Website](https://dashlane.com)
+* [Template Functions Reference](/reference/templates/password-manager-functions#dashlane)
+
+
+# Doppler
+Source: https://twpayne-chezmoi.mintlify.app/password-managers/doppler
+
+Integrate Doppler with chezmoi to manage secrets in your dotfiles
+
+chezmoi includes support for [Doppler](https://www.doppler.com), a secrets management platform, using the `doppler` CLI to expose data through template functions.
+
+## Setup
+
+### Install Doppler CLI
+
+<CodeGroup>
+  ```bash macOS theme={null}
+  brew install dopplerhq/cli/doppler
+  ```
+
+  ```bash Linux theme={null}
+  (curl -Ls --tlsv1.2 --proto "=https" --retry 3 https://cli.doppler.com/install.sh || wget -t 3 -qO- https://cli.doppler.com/install.sh) | sudo sh
+  ```
+
+  ```bash Windows theme={null}
+  scoop install doppler
+  ```
+</CodeGroup>
+
+### Log In
+
+Authenticate with Doppler:
+
+```bash theme={null}
+doppler login
+```
+
+This opens your browser to complete authentication.
+
+### Setup Project
+
+Configure Doppler for your project:
+
+```bash theme={null}
+# In your project directory
+doppler setup
+```
+
+Or specify project and config:
+
+```bash theme={null}
+doppler configure set project my-project
+doppler configure set config dev
+```
+
+## Template Functions
+
+### `doppler`
+
+Retrieve a specific secret by key:
+
+```text theme={null}
+{{ doppler "SECRET_NAME" "project-name" "config" }}
+```
+
+All three arguments:
+
+* `SECRET_NAME`: Required, the secret key
+* `project-name`: Optional, defaults to configured project
+* `config`: Optional, defaults to configured config (environment)
+
+### `dopplerProjectJson`
+
+Get all secrets as structured JSON:
+
+```text theme={null}
+{{ (dopplerProjectJson "project" "config").PASSWORD }}
+{{ (dopplerProjectJson "project" "config").API_KEY }}
+```
+
+Both arguments optional if defaults are configured.
+
+## Configuration
+
+Set default project and config in chezmoi:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[doppler]
+    project = "my-project"
+    config = "dev"
+```
+
+With defaults configured, you can omit project/config in template functions:
+
+```text theme={null}
+{{ doppler "SECRET_NAME" }}
+{{ dopplerProjectJson.SECRET_NAME }}
+```
+
+## Usage Examples
+
+### Simple Secrets
+
+<CodeGroup>
+  ```text With Defaults theme={null}
+  # ~/.config/chezmoi/chezmoi.toml
+  [doppler]
+      project = "my-app"
+      config = "dev"
+
+  # Template
+  {{ doppler "API_KEY" }}
+  {{ doppler "DB_PASSWORD" }}
+  ```
+
+  ```text Explicit Project/Config theme={null}
+  {{ doppler "API_KEY" "my-app" "prod" }}
+  {{ doppler "DB_PASSWORD" "my-app" "staging" }}
+  ```
+</CodeGroup>
+
+### Database Configuration
+
+<CodeGroup>
+  ```bash Store in Doppler theme={null}
+  # Set secrets in Doppler
+  doppler secrets set DB_HOST=db.example.com
+  doppler secrets set DB_PORT=5432
+  doppler secrets set DB_USERNAME=app_user
+  doppler secrets set DB_PASSWORD=super_secret_password
+  doppler secrets set DB_NAME=production_db
+  ```
+
+  ```text Use in Template theme={null}
+  # ~/.config/db/config.yml.tmpl
+  production:
+    host: {{ doppler "DB_HOST" }}
+    port: {{ doppler "DB_PORT" }}
+    username: {{ doppler "DB_USERNAME" }}
+    password: {{ doppler "DB_PASSWORD" }}
+    database: {{ doppler "DB_NAME" }}
+  ```
+</CodeGroup>
+
+### Using dopplerProjectJson
+
+```text ~/.config/app/config.yml.tmpl theme={null}
+{{ $secrets := dopplerProjectJson -}}
+
+api:
+  key: {{ $secrets.API_KEY }}
+  endpoint: {{ $secrets.API_ENDPOINT }}
+
+database:
+  host: {{ $secrets.DB_HOST }}
+  username: {{ $secrets.DB_USERNAME }}
+  password: {{ $secrets.DB_PASSWORD }}
+
+redis:
+  url: {{ $secrets.REDIS_URL }}
+```
+
+### Git Configuration
+
+```bash theme={null}
+doppler secrets set GIT_NAME="John Doe"
+doppler secrets set GIT_EMAIL="john@example.com"
+doppler secrets set GIT_SIGNING_KEY="0x1234567890ABCDEF"
+```
+
+```text ~/.gitconfig.tmpl theme={null}
+[user]
+    name = {{ doppler "GIT_NAME" }}
+    email = {{ doppler "GIT_EMAIL" }}
+    signingkey = {{ doppler "GIT_SIGNING_KEY" }}
+```
+
+### AWS Credentials
+
+```bash theme={null}
+doppler secrets set AWS_ACCESS_KEY_ID=[REDACTED-AWSKEY-DOCS-EXAMPLE]
+doppler secrets set AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG
+doppler secrets set AWS_REGION=us-east-1
+```
+
+```text ~/.aws/credentials.tmpl theme={null}
+[default]
+aws_access_key_id = {{ doppler "AWS_ACCESS_KEY_ID" }}
+aws_secret_access_key = {{ doppler "AWS_SECRET_ACCESS_KEY" }}
+region = {{ doppler "AWS_REGION" }}
+```
+
+### Multiple API Keys
+
+```text ~/.config/api-keys.env.tmpl theme={null}
+{{ $secrets := dopplerProjectJson -}}
+
+# Version Control
+GITHUB_TOKEN={{ $secrets.GITHUB_TOKEN }}
+GITLAB_TOKEN={{ $secrets.GITLAB_TOKEN }}
+
+# Cloud Providers
+AWS_ACCESS_KEY_ID={{ $secrets.AWS_ACCESS_KEY_ID }}
+AWS_SECRET_ACCESS_KEY={{ $secrets.AWS_SECRET_ACCESS_KEY }}
+DIGITALOCEAN_TOKEN={{ $secrets.DIGITALOCEAN_TOKEN }}
+
+# AI Services
+OPENAI_API_KEY={{ $secrets.OPENAI_API_KEY }}
+ANTHROPIC_API_KEY={{ $secrets.ANTHROPIC_API_KEY }}
+
+# Payment Processing
+STRIPE_SECRET_KEY={{ $secrets.STRIPE_SECRET_KEY }}
+STRIPE_PUBLISHABLE_KEY={{ $secrets.STRIPE_PUBLISHABLE_KEY }}
+```
+
+### NPM Configuration
+
+```bash theme={null}
+doppler secrets set NPM_TOKEN=npm_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+doppler secrets set NPM_EMAIL=user@example.com
+```
+
+```text ~/.npmrc.tmpl theme={null}
+//registry.npmjs.org/:_authToken={{ doppler "NPM_TOKEN" }}
+email={{ doppler "NPM_EMAIL" }}
+```
+
+### JSON Secrets
+
+Doppler can store JSON data:
+
+```bash theme={null}
+doppler secrets set SERVICE_CONFIG='{"api_key": "secret", "endpoint": "https://api.example.com"}'
+```
+
+```text ~/.config/app/config.yml.tmpl theme={null}
+{{ $config := doppler "SERVICE_CONFIG" | fromJson -}}
+
+service:
+  api_key: {{ $config.api_key }}
+  endpoint: {{ $config.endpoint }}
+```
+
+## Environment-Specific Secrets
+
+Doppler excels at managing secrets across environments:
+
+### Setup Multiple Configs
+
+```bash theme={null}
+# Development
+doppler configure set config dev
+doppler secrets set API_KEY=dev_key_here
+doppler secrets set DB_PASSWORD=dev_password
+
+# Staging  
+doppler configure set config stg
+doppler secrets set API_KEY=staging_key_here
+doppler secrets set DB_PASSWORD=staging_password
+
+# Production
+doppler configure set config prd
+doppler secrets set API_KEY=production_key_here
+doppler secrets set DB_PASSWORD=production_password
+```
+
+### Use in Templates
+
+```text ~/.config/app/config.yml.tmpl theme={null}
+{{ if eq .chezmoi.hostname "prod-server" -}}
+# Production
+api_key: {{ doppler "API_KEY" "my-app" "prd" }}
+db_password: {{ doppler "DB_PASSWORD" "my-app" "prd" }}
+{{ else if eq .chezmoi.hostname "staging-server" -}}
+# Staging
+api_key: {{ doppler "API_KEY" "my-app" "stg" }}
+db_password: {{ doppler "DB_PASSWORD" "my-app" "stg" }}
+{{ else -}}
+# Development
+api_key: {{ doppler "API_KEY" "my-app" "dev" }}
+db_password: {{ doppler "DB_PASSWORD" "my-app" "dev" }}
+{{ end }}
+```
+
+## Performance: Caching
+
+chezmoi caches all secrets from a project/config combination:
+
+* First call to `doppler` or `dopplerProjectJson` fetches all secrets
+* Subsequent calls for the same project/config use the cache
+* No additional API calls for multiple secrets from the same config
+
+```text theme={null}
+# Single API call fetches all secrets
+{{ doppler "SECRET_1" }}
+{{ doppler "SECRET_2" }}  // Uses cache
+{{ doppler "SECRET_3" }}  // Uses cache
+```
+
+## Complete Examples
+
+### Full Application Configuration
+
+```text ~/.config/app/config.yml.tmpl theme={null}
+{{ $secrets := dopplerProjectJson -}}
+
+application:
+  name: {{ $secrets.APP_NAME }}
+  environment: {{ $secrets.ENVIRONMENT }}
+  debug: {{ $secrets.DEBUG }}
+
+server:
+  host: {{ $secrets.SERVER_HOST }}
+  port: {{ $secrets.SERVER_PORT }}
+
+database:
+  host: {{ $secrets.DB_HOST }}
+  port: {{ $secrets.DB_PORT }}
+  username: {{ $secrets.DB_USERNAME }}
+  password: {{ $secrets.DB_PASSWORD }}
+  database: {{ $secrets.DB_NAME }}
+  ssl_mode: {{ $secrets.DB_SSL_MODE }}
+
+redis:
+  host: {{ $secrets.REDIS_HOST }}
+  port: {{ $secrets.REDIS_PORT }}
+  password: {{ $secrets.REDIS_PASSWORD }}
+
+aws:
+  region: {{ $secrets.AWS_REGION }}
+  access_key_id: {{ $secrets.AWS_ACCESS_KEY_ID }}
+  secret_access_key: {{ $secrets.AWS_SECRET_ACCESS_KEY }}
+
+auth:
+  jwt_secret: {{ $secrets.JWT_SECRET }}
+  session_secret: {{ $secrets.SESSION_SECRET }}
+
+api_keys:
+  github: {{ $secrets.GITHUB_TOKEN }}
+  stripe: {{ $secrets.STRIPE_SECRET_KEY }}
+  sendgrid: {{ $secrets.SENDGRID_API_KEY }}
+```
+
+### Kubernetes ConfigMap
+
+```text ~/k8s/configmap.yaml.tmpl theme={null}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-config
+data:
+  DATABASE_URL: {{ doppler "DATABASE_URL" }}
+  REDIS_URL: {{ doppler "REDIS_URL" }}
+  API_KEY: {{ doppler "API_KEY" }}
+```
+
+## Managing Secrets in Doppler
+
+### Set Secrets
+
+```bash theme={null}
+# Single secret
+doppler secrets set API_KEY=secret_value
+
+# Multiple secrets
+doppler secrets set KEY1=value1 KEY2=value2 KEY3=value3
+
+# From file
+doppler secrets set MY_SECRET="$(cat secret.txt)"
+
+# From stdin
+echo "secret_value" | doppler secrets set API_KEY
+```
+
+### List Secrets
+
+```bash theme={null}
+doppler secrets
+```
+
+### Download Secrets
+
+```bash theme={null}
+# As JSON
+doppler secrets download --no-file --format json
+
+# As environment variables
+doppler secrets download --no-file --format env
+```
+
+### Delete Secrets
+
+```bash theme={null}
+doppler secrets delete API_KEY
+```
+
+## Service Tokens
+
+For CI/CD or production servers, use service tokens:
+
+```bash theme={null}
+# Create a service token
+doppler configs tokens create production-server --config prd
+
+# Use the token
+export DOPPLER_TOKEN=dp.st.xxx
+```
+
+With a service token set, chezmoi will automatically use it.
+
+## Troubleshooting
+
+### Not Logged In
+
+Log in to Doppler:
+
+```bash theme={null}
+doppler login
+```
+
+### Project/Config Not Set
+
+Configure project and config:
+
+```bash theme={null}
+doppler setup
+# or
+doppler configure set project my-project
+doppler configure set config dev
+```
+
+### Secret Not Found
+
+List all secrets:
+
+```bash theme={null}
+doppler secrets
+```
+
+### Command Not Found
+
+Ensure Doppler CLI is installed:
+
+```bash theme={null}
+which doppler
+doppler --version
+```
+
+### Testing Templates
+
+Test template functions:
+
+```bash theme={null}
+chezmoi execute-template '{{ doppler "API_KEY" }}'
+chezmoi execute-template '{{ dopplerProjectJson.API_KEY }}'
+```
+
+### Verify Doppler Access
+
+```bash theme={null}
+doppler secrets download --no-file --format json | jq .
+```
+
+## Best Practices
+
+1. **Use environments**: Leverage Doppler's config system (dev, staging, prod)
+2. **Set defaults**: Configure project/config in chezmoi.toml
+3. **Use dopplerProjectJson**: More efficient than multiple doppler calls
+4. **Service tokens**: Use service tokens for automated deployments
+5. **Name consistently**: Use UPPER\_SNAKE\_CASE for secret names
+6. **Organize projects**: Separate projects for different applications
+7. **Access control**: Use Doppler's RBAC for team access
+8. **Secret rotation**: Regularly rotate sensitive credentials
+9. **Audit logs**: Monitor secret access in Doppler dashboard
+10. **Local development**: Use personal config for local dev secrets
+
+## See Also
+
+* [Doppler Documentation](https://docs.doppler.com/)
+* [Doppler CLI Reference](https://docs.doppler.com/docs/cli)
+* [Service Tokens](https://docs.doppler.com/docs/service-tokens)
+* [Template Functions Reference](/reference/templates/password-manager-functions#doppler)
+
+
+# gopass
+Source: https://twpayne-chezmoi.mintlify.app/password-managers/gopass
+
+Integrate gopass with chezmoi to manage secrets in your dotfiles
+
+chezmoi includes support for [gopass](https://www.gopass.pw/), a password manager for teams built on top of `pass`.
+
+## Setup
+
+### Install gopass
+
+<CodeGroup>
+  ```bash macOS theme={null}
+  brew install gopass
+  ```
+
+  ```bash Ubuntu/Debian theme={null}
+  sudo apt install gopass
+  ```
+
+  ```bash Fedora theme={null}
+  sudo dnf install gopass
+  ```
+
+  ```bash From Source theme={null}
+  go install github.com/gopasspw/gopass@latest
+  ```
+</CodeGroup>
+
+### Initialize gopass
+
+If you haven't set up gopass yet:
+
+```bash theme={null}
+# Initialize with your GPG key
+gopass init your-gpg-id@example.com
+
+# Or create a new team
+gopass init --store=work work-team@company.com
+```
+
+### Add Secrets
+
+```bash theme={null}
+# Add a secret
+gopass insert github/token
+
+# Generate a random password
+gopass generate aws/secret-key 32
+
+# Add multiline data
+gopass insert -m ssh/private-key
+```
+
+## Template Function
+
+### `gopass`
+
+Get the first line from a gopass entry:
+
+```text theme={null}
+{{ gopass "github/token" }}
+```
+
+This runs `gopass show -o github/token` and returns the first line.
+
+## Usage Examples
+
+### Simple Passwords
+
+<CodeGroup>
+  ```text GitHub Token theme={null}
+  # ~/.config/gh/config.yml.tmpl
+  github_token: {{ gopass "github/token" }}
+  ```
+
+  ```text NPM Token theme={null}
+  # ~/.npmrc.tmpl
+  //registry.npmjs.org/:_authToken={{ gopass "npm/token" }}
+  ```
+
+  ```text API Key theme={null}
+  # ~/.config/app/config.yml.tmpl
+  api_key: {{ gopass "service/api-key" }}
+  ```
+</CodeGroup>
+
+### Git Configuration
+
+```text ~/.gitconfig.tmpl theme={null}
+[user]
+    name = John Doe
+    email = {{ gopass "git/email" }}
+    signingkey = {{ gopass "git/signing-key" }}
+
+[github]
+    user = {{ gopass "github/username" }}
+
+[gitlab]
+    user = {{ gopass "gitlab/username" }}
+```
+
+### AWS Credentials
+
+```bash theme={null}
+# Store AWS credentials in gopass
+gopass insert aws/personal/access-key-id
+gopass insert aws/personal/secret-access-key
+gopass insert aws/work/access-key-id
+gopass insert aws/work/secret-access-key
+```
+
+```text ~/.aws/credentials.tmpl theme={null}
+[personal]
+aws_access_key_id = {{ gopass "aws/personal/access-key-id" }}
+aws_secret_access_key = {{ gopass "aws/personal/secret-access-key" }}
+
+[work]
+aws_access_key_id = {{ gopass "aws/work/access-key-id" }}
+aws_secret_access_key = {{ gopass "aws/work/secret-access-key" }}
+```
+
+### Database Credentials
+
+```bash theme={null}
+# Store database credentials
+gopass insert db/production/host
+gopass insert db/production/username
+gopass insert db/production/password
+```
+
+```text ~/.config/db/config.yml.tmpl theme={null}
+production:
+  host: {{ gopass "db/production/host" }}
+  port: 5432
+  username: {{ gopass "db/production/username" }}
+  password: {{ gopass "db/production/password" }}
+  database: production_db
+
+development:
+  host: localhost
+  port: 5432
+  username: dev
+  password: {{ gopass "db/development/password" }}
+  database: app_dev
+```
+
+### Multiple API Keys
+
+```text ~/.config/api-keys.env.tmpl theme={null}
+# Version Control
+GITHUB_TOKEN={{ gopass "github/token" }}
+GITLAB_TOKEN={{ gopass "gitlab/token" }}
+
+# Cloud Providers
+AWS_ACCESS_KEY_ID={{ gopass "aws/access-key-id" }}
+AWS_SECRET_ACCESS_KEY={{ gopass "aws/secret-access-key" }}
+DIGITALOCEAN_TOKEN={{ gopass "digitalocean/token" }}
+
+# Development APIs
+OPENAI_API_KEY={{ gopass "openai/api-key" }}
+ANTHROPIC_API_KEY={{ gopass "anthropic/api-key" }}
+
+# Payment Services
+STRIPE_SECRET_KEY={{ gopass "stripe/secret-key" }}
+STRIPE_PUBLISHABLE_KEY={{ gopass "stripe/publishable-key" }}
+```
+
+### SSH Configuration
+
+```bash theme={null}
+# Store SSH usernames
+gopass insert ssh/github/username
+gopass insert ssh/gitlab/username
+gopass insert ssh/work-server/username
+```
+
+```text ~/.ssh/config.tmpl theme={null}
+Host github.com
+    User {{ gopass "ssh/github/username" }}
+    IdentityFile ~/.ssh/id_ed25519
+
+Host gitlab.com
+    User {{ gopass "ssh/gitlab/username" }}
+    IdentityFile ~/.ssh/id_rsa
+
+Host work-server
+    HostName server.company.com
+    User {{ gopass "ssh/work-server/username" }}
+    IdentityFile ~/.ssh/work_id_rsa
+```
+
+### Docker Registry Credentials
+
+```bash theme={null}
+# Store Docker credentials
+gopass insert docker/username
+gopass insert docker/password
+```
+
+```text ~/.docker/config.json.tmpl theme={null}
+{
+  "auths": {
+    "https://index.docker.io/v1/": {
+      "auth": "{{ printf "%s:%s" (gopass "docker/username") (gopass "docker/password") | b64enc }}"
+    }
+  }
+}
+```
+
+## Configuration
+
+### Custom Command
+
+If `gopass` is not in your PATH:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[gopass]
+    command = "/custom/path/to/gopass"
+```
+
+## gopass Features
+
+### Multiple Stores (Mounts)
+
+gopass supports multiple password stores:
+
+```bash theme={null}
+# Initialize stores
+gopass init --store=personal personal@example.com
+gopass init --store=work work@company.com
+
+# Use different stores
+gopass insert personal/github/token
+gopass insert work/gitlab/token
+```
+
+Access in templates:
+
+```text theme={null}
+{{ gopass "personal/github/token" }}
+{{ gopass "work/gitlab/token" }}
+```
+
+### Team Collaboration
+
+gopass makes it easy to share passwords with a team:
+
+```bash theme={null}
+# Initialize for multiple recipients
+gopass init --store=team user1@company.com user2@company.com
+
+# Clone a team store
+gopass clone git@github.com:company/passwords.git team
+```
+
+### Sync with Git
+
+gopass automatically commits changes to git:
+
+```bash theme={null}
+# Setup git remote
+gopass git remote add origin git@github.com:username/passwords.git
+
+# Push changes
+gopass git push
+
+# Pull changes
+gopass git pull
+
+# Sync (pull then push)
+gopass sync
+```
+
+### Generate Passwords
+
+```bash theme={null}
+# Generate a 32-character password
+gopass generate github/token 32
+
+# Generate without symbols
+gopass generate -n aws/secret-key 40
+
+# Generate and copy to clipboard
+gopass generate -c service/api-key 24
+```
+
+## Organizing Your Password Store
+
+Use a hierarchical structure:
+
+```
+~/.local/share/gopass/stores/root/
+├── personal/
+│   ├── email/
+│   │   └── gmail.gpg
+│   ├── github/
+│   │   ├── token.gpg
+│   │   └── username.gpg
+│   └── ssh/
+│       └── passphrase.gpg
+├── work/
+│   ├── aws/
+│   │   ├── access-key-id.gpg
+│   │   └── secret-access-key.gpg
+│   ├── github/
+│   │   └── token.gpg
+│   └── vpn/
+│       └── password.gpg
+└── shared/
+    └── wifi/
+        └── home.gpg
+```
+
+## Advanced Usage
+
+### Environment-Specific Secrets
+
+```text ~/.config/app/config.yml.tmpl theme={null}
+{{ if eq .chezmoi.hostname "work-laptop" -}}
+# Work environment
+api_key: {{ gopass "work/api-key" }}
+db_password: {{ gopass "work/db-password" }}
+{{ else -}}
+# Personal environment
+api_key: {{ gopass "personal/api-key" }}
+db_password: {{ gopass "personal/db-password" }}
+{{ end }}
+```
+
+### Copy Secrets to Clipboard
+
+```bash theme={null}
+# Copy to clipboard
+gopass show -c github/token
+
+# Copy for 10 seconds
+gopass show -C 10 github/token
+```
+
+### Search Secrets
+
+```bash theme={null}
+# Search for secrets
+gopass search github
+
+# Grep for content
+gopass grep "api-key"
+```
+
+### Audit and Security
+
+```bash theme={null}
+# Check recipients
+gopass recipients
+
+# Audit store
+gopass audit
+
+# Fix permissions
+gopass fsck
+```
+
+## Complete Examples
+
+### Multi-Service Configuration
+
+```text ~/.config/services.yml.tmpl theme={null}
+github:
+  username: {{ gopass "github/username" }}
+  token: {{ gopass "github/token" }}
+  email: {{ gopass "github/email" }}
+
+aws:
+  access_key_id: {{ gopass "aws/access-key-id" }}
+  secret_access_key: {{ gopass "aws/secret-access-key" }}
+  region: us-east-1
+
+database:
+  host: {{ gopass "database/host" }}
+  port: {{ gopass "database/port" }}
+  username: {{ gopass "database/username" }}
+  password: {{ gopass "database/password" }}
+
+smtp:
+  host: {{ gopass "email/smtp-host" }}
+  port: {{ gopass "email/smtp-port" }}
+  username: {{ gopass "email/username" }}
+  password: {{ gopass "email/password" }}
+```
+
+## Troubleshooting
+
+### GPG Key Not Found
+
+Ensure your GPG key is available:
+
+```bash theme={null}
+gpg --list-secret-keys
+```
+
+### Secret Not Found
+
+List all secrets:
+
+```bash theme={null}
+gopass ls
+```
+
+Or search:
+
+```bash theme={null}
+gopass search github
+```
+
+### Command Not Found
+
+Ensure gopass is installed:
+
+```bash theme={null}
+which gopass
+gopass --version
+```
+
+### Testing Templates
+
+Test template functions:
+
+```bash theme={null}
+chezmoi execute-template '{{ gopass "test/password" }}'
+```
+
+### Sync Issues
+
+Force sync with git:
+
+```bash theme={null}
+gopass sync
+```
+
+Or manually:
+
+```bash theme={null}
+gopass git pull
+gopass git push
+```
+
+## gopass vs pass
+
+| Feature            | pass       | gopass    |
+| ------------------ | ---------- | --------- |
+| Backend            | GPG + Git  | GPG + Git |
+| Team Support       | Manual     | Built-in  |
+| Multiple Stores    | Manual     | Native    |
+| Auto-sync          | No         | Yes       |
+| Binary Attachments | Extensions | Native    |
+| YAML/JSON Support  | No         | Yes       |
+| UI                 | CLI only   | CLI + GUI |
+| OTP Support        | Extension  | Native    |
+
+## Best Practices
+
+1. **Use stores**: Separate personal, work, and shared passwords
+2. **Sync regularly**: Enable automatic git sync
+3. **Use hierarchy**: Organize secrets in logical folders
+4. **Generate passwords**: Use gopass generate for strong passwords
+5. **Audit regularly**: Run `gopass audit` to check for issues
+6. **Backup**: Keep encrypted backups of your password store
+7. **Team sharing**: Use proper recipient management for teams
+8. **Use descriptive names**: Make entry names clear and searchable
+
+## See Also
+
+* [gopass Website](https://www.gopass.pw/)
+* [gopass GitHub](https://github.com/gopasspw/gopass)
+* [gopass Documentation](https://github.com/gopasspw/gopass/tree/master/docs)
+* [pass](/password-managers/pass) - Standard Unix password manager
+* [Template Functions Reference](/reference/templates/password-manager-functions#gopass)
+
+
+# KeePassXC
+Source: https://twpayne-chezmoi.mintlify.app/password-managers/keepassxc
+
+Integrate KeePassXC with chezmoi to manage secrets in your dotfiles
+
+chezmoi includes support for [KeePassXC](https://keepassxc.org) using the KeePassXC CLI (`keepassxc-cli`) to expose data as template functions.
+
+## Setup
+
+### Install KeePassXC CLI
+
+<CodeGroup>
+  ```bash macOS theme={null}
+  brew install keepassxc
+  ```
+
+  ```bash Ubuntu/Debian theme={null}
+  sudo apt install keepassxc
+  ```
+
+  ```bash Fedora theme={null}
+  sudo dnf install keepassxc
+  ```
+</CodeGroup>
+
+### Configuration
+
+Provide the path to your KeePassXC database:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[keepassxc]
+    database = "/home/user/Passwords.kdbx"
+```
+
+## Template Functions
+
+### `keepassxc`
+
+Get structured data from an entry:
+
+```text theme={null}
+username = {{ (keepassxc "example.com").UserName }}
+password = {{ (keepassxc "example.com").Password }}
+```
+
+This runs `keepassxc-cli show $database example.com` and returns parsed data.
+
+### `keepassxcAttribute`
+
+Get additional attributes from an entry:
+
+```text theme={null}
+{{ keepassxcAttribute "SSH Key" "private-key" }}
+```
+
+## Usage Examples
+
+### Basic Credentials
+
+<CodeGroup>
+  ```text Git Config theme={null}
+  # ~/.gitconfig.tmpl
+  [user]
+      name = {{ (keepassxc "git-config").UserName }}
+      email = {{ (keepassxc "git-config").URL }}
+
+  [github]
+      user = {{ (keepassxc "github").UserName }}
+  ```
+
+  ```text NPM Config theme={null}
+  # ~/.npmrc.tmpl
+  //registry.npmjs.org/:_authToken={{ (keepassxc "npm").Password }}
+  email={{ (keepassxc "npm").UserName }}
+  ```
+</CodeGroup>
+
+### Database Credentials
+
+```text ~/.config/db/config.yml.tmpl theme={null}
+production:
+  host: {{ (keepassxc "prod-database").URL }}
+  username: {{ (keepassxc "prod-database").UserName }}
+  password: {{ (keepassxc "prod-database").Password }}
+  database: {{ keepassxcAttribute "prod-database" "database" }}
+  port: {{ keepassxcAttribute "prod-database" "port" }}
+
+development:
+  host: localhost
+  username: {{ (keepassxc "dev-database").UserName }}
+  password: {{ (keepassxc "dev-database").Password }}
+  database: myapp_dev
+```
+
+### SSH Private Keys
+
+Store SSH keys as additional attributes:
+
+```text ~/.ssh/id_rsa.tmpl theme={null}
+{{ keepassxcAttribute "SSH Key" "private-key" }}
+```
+
+### AWS Credentials
+
+```text ~/.aws/credentials.tmpl theme={null}
+[default]
+aws_access_key_id = {{ keepassxcAttribute "AWS Personal" "access-key-id" }}
+aws_secret_access_key = {{ (keepassxc "AWS Personal").Password }}
+region = {{ keepassxcAttribute "AWS Personal" "region" }}
+
+[work]
+aws_access_key_id = {{ keepassxcAttribute "AWS Work" "access-key-id" }}
+aws_secret_access_key = {{ (keepassxc "AWS Work").Password }}
+region = us-east-1
+```
+
+### API Tokens
+
+```text ~/.config/tokens.env.tmpl theme={null}
+# GitHub
+GITHUB_TOKEN={{ (keepassxc "GitHub API").Password }}
+GH_TOKEN={{ (keepassxc "GitHub API").Password }}
+
+# GitLab
+GITLAB_TOKEN={{ (keepassxc "GitLab API").Password }}
+
+# OpenAI
+OPENAI_API_KEY={{ (keepassxc "OpenAI").Password }}
+
+# Additional fields
+STRIPE_SECRET_KEY={{ keepassxcAttribute "Stripe" "secret-key" }}
+STRIPE_PUBLISHABLE_KEY={{ keepassxcAttribute "Stripe" "publishable-key" }}
+```
+
+### Multiple Service Credentials
+
+```text ~/.netrc.tmpl theme={null}
+machine github.com
+login {{ (keepassxc "github").UserName }}
+password {{ (keepassxc "github").Password }}
+
+machine gitlab.com
+login {{ (keepassxc "gitlab").UserName }}
+password {{ (keepassxc "gitlab").Password }}
+
+machine bitbucket.org
+login {{ (keepassxc "bitbucket").UserName }}
+password {{ (keepassxc "bitbucket").Password }}
+```
+
+## Configuration Options
+
+### Non-Password-Protected Databases
+
+If your database is not password protected:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[keepassxc]
+    database = "/home/user/Passwords.kdbx"
+    args = ["--no-password"]
+    prompt = false
+```
+
+### YubiKey Support
+
+chezmoi includes experimental YubiKey support. Set `keepassxc.mode` to `open`:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[keepassxc]
+    database = "/home/user/Passwords.kdbx"
+    mode = "open"
+    args = ["--no-password", "--yubikey", "2:7370001"]
+```
+
+The YubiKey slot format is `slot:serial`, where:
+
+* `slot`: YubiKey configuration slot (usually 1 or 2)
+* `serial`: YubiKey serial number
+
+Find your YubiKey serial:
+
+```bash theme={null}
+ykman info
+```
+
+### Custom Command
+
+If `keepassxc-cli` is not in your PATH:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[keepassxc]
+    command = "/custom/path/to/keepassxc-cli"
+    database = "/home/user/Passwords.kdbx"
+```
+
+### Additional Arguments
+
+Pass additional arguments to `keepassxc-cli`:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[keepassxc]
+    database = "/home/user/Passwords.kdbx"
+    args = ["--quiet", "--key-file", "/path/to/keyfile"]
+```
+
+## Advanced Usage
+
+### Using Key Files
+
+If your database uses a key file:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[keepassxc]
+    database = "/home/user/Passwords.kdbx"
+    args = ["--key-file", "/home/user/.keepass/keyfile.key"]
+```
+
+### Accessing Standard Fields
+
+KeePassXC entries have standard fields:
+
+```text theme={null}
+Title: {{ (keepassxc "entry-name").Title }}
+UserName: {{ (keepassxc "entry-name").UserName }}
+Password: {{ (keepassxc "entry-name").Password }}
+URL: {{ (keepassxc "entry-name").URL }}
+Notes: {{ (keepassxc "entry-name").Notes }}
+```
+
+### Organizing Entries in Groups
+
+Reference entries by their full path:
+
+```text theme={null}
+{{ (keepassxc "Work/GitHub").Password }}
+{{ (keepassxc "Personal/Email").Password }}
+{{ (keepassxc "Servers/Production/Database").Password }}
+```
+
+### Conditional Template Logic
+
+```text ~/.gitconfig.tmpl theme={null}
+[user]
+    name = {{ (keepassxc "git").UserName }}
+{{- if (keepassxc "git").URL }}
+    email = {{ (keepassxc "git").URL }}
+{{- end }}
+{{- $signingKey := keepassxcAttribute "git" "signing-key" }}
+{{- if $signingKey }}
+    signingkey = {{ $signingKey }}
+{{- end }}
+```
+
+## Complete Examples
+
+### Multi-Environment Setup
+
+```text ~/.config/app/config.yml.tmpl theme={null}
+{{ if eq .chezmoi.hostname "work-laptop" -}}
+# Work environment
+api:
+  endpoint: {{ (keepassxc "Work/API").URL }}
+  key: {{ (keepassxc "Work/API").Password }}
+
+database:
+  host: {{ keepassxcAttribute "Work/Database" "host" }}
+  username: {{ (keepassxc "Work/Database").UserName }}
+  password: {{ (keepassxc "Work/Database").Password }}
+{{ else -}}
+# Personal environment
+api:
+  endpoint: {{ (keepassxc "Personal/API").URL }}
+  key: {{ (keepassxc "Personal/API").Password }}
+
+database:
+  host: localhost
+  username: {{ (keepassxc "Personal/Database").UserName }}
+  password: {{ (keepassxc "Personal/Database").Password }}
+{{ end }}
+```
+
+### SSH Configuration
+
+```text ~/.ssh/config.tmpl theme={null}
+{{ range $entry := list "github" "gitlab" "work-gitlab" -}}
+Host {{ $entry }}
+    HostName {{ (keepassxc $entry).URL }}
+    User {{ (keepassxc $entry).UserName }}
+    IdentityFile ~/.ssh/{{ $entry }}_id_rsa
+    IdentitiesOnly yes
+
+{{ end }}
+```
+
+## Troubleshooting
+
+### Database Locked
+
+You'll be prompted for the password when chezmoi accesses the database. Enter your master password.
+
+### Entry Not Found
+
+List all entries to find the correct path:
+
+```bash theme={null}
+keepassxc-cli ls /path/to/database.kdbx
+```
+
+### Command Not Found
+
+Ensure KeePassXC CLI is installed:
+
+```bash theme={null}
+which keepassxc-cli
+keepassxc-cli --version
+```
+
+### Testing Templates
+
+Test template functions:
+
+```bash theme={null}
+chezmoi execute-template '{{ (keepassxc "test").UserName }}'
+```
+
+### Verify Entry Structure
+
+Show entry details:
+
+```bash theme={null}
+keepassxc-cli show /path/to/database.kdbx "Entry Name"
+```
+
+### Permission Denied
+
+Ensure your database file has proper permissions:
+
+```bash theme={null}
+chmod 600 /path/to/database.kdbx
+```
+
+## Best Practices
+
+1. **Use groups**: Organize entries in folders (Work, Personal, Servers)
+2. **Use attributes**: Store additional data as custom attributes
+3. **Secure your database**: Use a strong master password
+4. **Backup regularly**: Keep encrypted backups of your database
+5. **Test access**: Verify entries are accessible before using in templates
+6. **Use key files**: Add a key file for additional security
+7. **YubiKey**: Consider using a YubiKey for hardware-based security
+
+## See Also
+
+* [KeePassXC Website](https://keepassxc.org)
+* [KeePassXC CLI Documentation](https://keepassxc.org/docs/KeePassXC_UserGuide.html#_command_line_interface)
+* [Template Functions Reference](/reference/templates/password-manager-functions#keepassxc)
+
+
+# Keeper
+Source: https://twpayne-chezmoi.mintlify.app/password-managers/keeper
+
+Integrate Keeper Security with chezmoi to manage secrets in your dotfiles
+
+chezmoi includes support for [Keeper Security](https://www.keepersecurity.com/) using the [Commander CLI](https://docs.keeper.io/secrets-manager/commander-cli) to expose data as template functions.
+
+## Setup
+
+### Install Keeper Commander
+
+<CodeGroup>
+  ```bash Python (pip) theme={null}
+  pip3 install keepercommander
+  ```
+
+  ```bash macOS (Homebrew) theme={null}
+  brew install keeper-commander
+  ```
+</CodeGroup>
+
+### Create Persistent Login Session
+
+Follow the [Keeper CLI documentation](https://docs.keeper.io/secrets-manager/commander-cli/using-commander/logging-in#persistent-login-sessions) to create a persistent login:
+
+```bash theme={null}
+keeper login
+```
+
+This creates a session that doesn't require re-authentication.
+
+## Template Functions
+
+### `keeperFindPassword`
+
+Find and retrieve a password by path or UID:
+
+```text theme={null}
+{{ keeperFindPassword "$PATH" }}
+{{ keeperFindPassword "$UID" }}
+```
+
+### `keeper`
+
+Get structured data for a record by UID:
+
+```text theme={null}
+{{ (keeper "$UID").data.title }}
+{{ (keeper "$UID").data.fields }}
+```
+
+Returns the full JSON output from `keeper get`.
+
+### `keeperDataFields`
+
+Get a simplified field structure indexed by field type:
+
+```text theme={null}
+{{ index (keeperDataFields "$UID").password 0 }}
+{{ index (keeperDataFields "$UID").url 0 }}
+```
+
+## Usage Examples
+
+### Simple Password Retrieval
+
+<CodeGroup>
+  ```text By Path theme={null}
+  {{ keeperFindPassword "Personal/GitHub" }}
+  ```
+
+  ```text By UID theme={null}
+  {{ keeperFindPassword "jKHj3k4h5j6k7l8m9n0" }}
+  ```
+</CodeGroup>
+
+### Using Structured Data
+
+```text ~/.gitconfig.tmpl theme={null}
+{{ $git := keeper "git-config-uid" -}}
+
+[user]
+    name = {{ $git.data.title }}
+    email = {{ index (keeperDataFields "git-config-uid").email 0 }}
+```
+
+### Database Credentials
+
+```text ~/.config/db/config.yml.tmpl theme={null}
+{{ $db := keeper "prod-db-uid" -}}
+{{ $fields := keeperDataFields "prod-db-uid" -}}
+
+production:
+  host: {{ index $fields.url 0 }}
+  port: 5432
+  username: {{ index $fields.login 0 }}
+  password: {{ index $fields.password 0 }}
+  database: production_db
+```
+
+### AWS Credentials
+
+```text ~/.aws/credentials.tmpl theme={null}
+{{ $aws := keeperDataFields "aws-credentials-uid" -}}
+
+[default]
+aws_access_key_id = {{ index $aws.login 0 }}
+aws_secret_access_key = {{ index $aws.password 0 }}
+region = us-east-1
+```
+
+### Multiple API Keys
+
+```text ~/.config/api-keys.env.tmpl theme={null}
+# GitHub
+GITHUB_TOKEN={{ keeperFindPassword "API Keys/GitHub" }}
+
+# GitLab
+GITLAB_TOKEN={{ keeperFindPassword "API Keys/GitLab" }}
+
+# OpenAI
+OPENAI_API_KEY={{ keeperFindPassword "API Keys/OpenAI" }}
+
+# Stripe
+STRIPE_SECRET_KEY={{ keeperFindPassword "API Keys/Stripe" }}
+```
+
+### NPM Configuration
+
+```text ~/.npmrc.tmpl theme={null}
+{{ $npm := keeperDataFields "npm-token-uid" -}}
+
+//registry.npmjs.org/:_authToken={{ index $npm.password 0 }}
+email={{ index $npm.email 0 }}
+```
+
+### SSH Configuration
+
+```text ~/.ssh/config.tmpl theme={null}
+{{ $github := keeperDataFields "github-ssh-uid" -}}
+{{ $gitlab := keeperDataFields "gitlab-ssh-uid" -}}
+
+Host github.com
+    User {{ index $github.login 0 }}
+    IdentityFile ~/.ssh/id_ed25519
+
+Host gitlab.com
+    User {{ index $gitlab.login 0 }}
+    IdentityFile ~/.ssh/id_rsa
+```
+
+### Kubernetes Config
+
+```text ~/.kube/config.tmpl theme={null}
+{{ $k8s := keeper "k8s-cluster-uid" -}}
+{{ $fields := keeperDataFields "k8s-cluster-uid" -}}
+
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: {{ index $fields.url 0 }}
+    certificate-authority-data: {{ index $fields.text 0 }}
+  name: production
+users:
+- name: admin
+  user:
+    token: {{ index $fields.password 0 }}
+contexts:
+- context:
+    cluster: production
+    user: admin
+  name: prod-context
+current-context: prod-context
+```
+
+## Configuration
+
+### Custom Command
+
+If `keeper` is not in your PATH:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[keeper]
+    command = "/custom/path/to/keeper"
+```
+
+### Custom Config File
+
+Pass additional arguments to Keeper CLI:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[keeper]
+    args = ["--config", "/path/to/config.json"]
+```
+
+## Finding Record UIDs
+
+To find a record's UID:
+
+```bash theme={null}
+# List all records
+keeper list
+
+# Search for a record
+keeper search github
+
+# Get full details
+keeper get "Record Title"
+```
+
+The UID is shown in the output.
+
+## Record Structure
+
+Keeper records have this structure:
+
+```json theme={null}
+{
+  "data": {
+    "title": "GitHub",
+    "type": "login",
+    "fields": [
+      {
+        "type": "login",
+        "value": "username"
+      },
+      {
+        "type": "password",
+        "value": "secret_password"
+      },
+      {
+        "type": "url",
+        "value": "https://github.com"
+      }
+    ],
+    "custom_fields": []
+  }
+}
+```
+
+## Advanced Usage
+
+### Custom Fields
+
+Access custom fields:
+
+```text theme={null}
+{{ $record := keeper "record-uid" -}}
+{{ range $record.data.custom_fields -}}
+  {{ if eq .label "API Key" -}}
+    {{ .value }}
+  {{ end -}}
+{{ end }}
+```
+
+### Accessing All Fields
+
+```text theme={null}
+{{ $record := keeper "record-uid" -}}
+
+Title: {{ $record.data.title }}
+Type: {{ $record.data.type }}
+
+Fields:
+{{ range $record.data.fields -}}
+  Type: {{ .type }}
+  Value: {{ .value }}
+{{ end }}
+```
+
+### Using Variables for Cleaner Templates
+
+```text ~/.config/services.yml.tmpl theme={null}
+{{- $github := keeperDataFields "github-uid" -}}
+{{- $aws := keeperDataFields "aws-uid" -}}
+{{- $db := keeperDataFields "db-uid" -}}
+
+github:
+  token: {{ index $github.password 0 }}
+  username: {{ index $github.login 0 }}
+
+aws:
+  access_key_id: {{ index $aws.login 0 }}
+  secret_access_key: {{ index $aws.password 0 }}
+
+database:
+  host: {{ index $db.url 0 }}
+  username: {{ index $db.login 0 }}
+  password: {{ index $db.password 0 }}
+```
+
+## Complete Examples
+
+### Multi-Service Configuration
+
+```text ~/.config/app/config.yml.tmpl theme={null}
+{{- $github := keeper "github-uid" -}}
+{{- $aws := keeper "aws-uid" -}}
+{{- $db := keeper "db-uid" -}}
+{{- $redis := keeper "redis-uid" -}}
+
+application:
+  name: myapp
+  environment: production
+
+github:
+  token: {{ keeperFindPassword "API Keys/GitHub" }}
+
+aws:
+  region: us-east-1
+  access_key_id: {{ index (keeperDataFields "aws-uid").login 0 }}
+  secret_access_key: {{ index (keeperDataFields "aws-uid").password 0 }}
+
+database:
+  host: {{ index (keeperDataFields "db-uid").url 0 }}
+  port: 5432
+  username: {{ index (keeperDataFields "db-uid").login 0 }}
+  password: {{ index (keeperDataFields "db-uid").password 0 }}
+
+redis:
+  url: {{ index (keeperDataFields "redis-uid").url 0 }}
+  password: {{ index (keeperDataFields "redis-uid").password 0 }}
+```
+
+### Environment Variables File
+
+```text ~/.config/env.sh.tmpl theme={null}
+#!/bin/bash
+
+# GitHub
+export GITHUB_TOKEN="{{ keeperFindPassword "API Keys/GitHub" }}"
+
+# AWS
+export AWS_ACCESS_KEY_ID="{{ index (keeperDataFields "aws-uid").login 0 }}"
+export AWS_SECRET_ACCESS_KEY="{{ index (keeperDataFields "aws-uid").password 0 }}"
+export AWS_DEFAULT_REGION="us-east-1"
+
+# Database
+export DATABASE_URL="postgresql://{{ index (keeperDataFields "db-uid").login 0 }}:{{ index (keeperDataFields "db-uid").password 0 }}@{{ index (keeperDataFields "db-uid").url 0 }}/production"
+
+# API Keys
+export OPENAI_API_KEY="{{ keeperFindPassword "API Keys/OpenAI" }}"
+export STRIPE_SECRET_KEY="{{ keeperFindPassword "API Keys/Stripe" }}"
+```
+
+## Troubleshooting
+
+### Not Logged In
+
+Create a persistent session:
+
+```bash theme={null}
+keeper login
+```
+
+### Record Not Found
+
+Search for the record:
+
+```bash theme={null}
+keeper search "record name"
+keeper list
+```
+
+### Command Not Found
+
+Ensure Keeper Commander is installed:
+
+```bash theme={null}
+which keeper
+keeper version
+```
+
+### Testing Templates
+
+Test template functions:
+
+```bash theme={null}
+chezmoi execute-template '{{ keeperFindPassword "test" }}'
+chezmoi execute-template '{{ keeper "uid" | toJson }}'
+```
+
+### Viewing Record Structure
+
+Inspect a record's full structure:
+
+```bash theme={null}
+keeper get "Record Title" --format=json | jq .
+```
+
+## Best Practices
+
+1. **Use UIDs**: UIDs are more stable than paths/titles
+2. **Organize records**: Use folders to organize secrets
+3. **Persistent sessions**: Set up persistent login for convenience
+4. **Custom fields**: Use custom fields for structured data
+5. **Test access**: Verify records are accessible before templating
+6. **Document UIDs**: Keep a reference of UIDs used in templates
+7. **Use keeperFindPassword**: Simplest for just retrieving passwords
+8. **Use keeperDataFields**: Better for accessing multiple fields
+9. **Cache awareness**: chezmoi caches results per UID/path
+
+## See Also
+
+* [Keeper Commander Documentation](https://docs.keeper.io/secrets-manager/commander-cli)
+* [Keeper Security Website](https://www.keepersecurity.com/)
+* [Getting Started with Commander](https://docs.keeper.io/secrets-manager/commander-cli/using-commander/getting-started)
+* [Template Functions Reference](/reference/templates/password-manager-functions#keeper)
+
+
+# LastPass
+Source: https://twpayne-chezmoi.mintlify.app/password-managers/lastpass
+
+Integrate LastPass with chezmoi to manage secrets in your dotfiles
+
+chezmoi includes support for [LastPass](https://lastpass.com/) using the [LastPass CLI](https://lastpass.github.io/lastpass-cli/lpass.1.html) to expose data as template functions.
+
+## Setup
+
+### Install LastPass CLI
+
+<CodeGroup>
+  ```bash macOS theme={null}
+  brew install lastpass-cli
+  ```
+
+  ```bash Ubuntu/Debian theme={null}
+  sudo apt install lastpass-cli
+  ```
+
+  ```bash Fedora theme={null}
+  sudo dnf install lastpass-cli
+  ```
+</CodeGroup>
+
+### Log In
+
+```bash theme={null}
+lpass login $LASTPASS_USERNAME
+```
+
+Enter your master password when prompted.
+
+### Verify Setup
+
+Check that `lpass` is working:
+
+```bash theme={null}
+lpass show --json $LASTPASS_ENTRY_ID
+```
+
+## Template Functions
+
+### `lastpass`
+
+Get structured data from a LastPass entry:
+
+```text theme={null}
+{{ (index (lastpass "GitHub") 0).password }}
+```
+
+Returns an array of objects from `lpass show --json id`.
+
+### `lastpassRaw`
+
+Get raw note data without parsing:
+
+```text theme={null}
+{{ (index (lastpassRaw "SSH Private Key") 0).note }}
+```
+
+## Entry Specification
+
+LastPass entries can be specified by:
+
+* **Name**: `"GitHub"`
+* **ID**: `"1234567890"`
+* **URL**: `"github.com"`
+* **Group**: `"Work/GitHub"`
+
+See [LastPass Entry Specification](https://lastpass.github.io/lastpass-cli/lpass.1.html#_entry_specification) for details.
+
+## Usage Examples
+
+### Basic Credentials
+
+<CodeGroup>
+  ```text Password theme={null}
+  # Access password from GitHub entry
+  githubPassword = {{ (index (lastpass "GitHub") 0).password | quote }}
+  ```
+
+  ```text Username and Password theme={null}
+  # ~/.netrc.tmpl
+  machine github.com
+  login {{ (index (lastpass "GitHub") 0).username }}
+  password {{ (index (lastpass "GitHub") 0).password }}
+  ```
+</CodeGroup>
+
+### Git Configuration
+
+```text ~/.gitconfig.tmpl theme={null}
+[user]
+    name = {{ (index (lastpass "Git Config") 0).username }}
+    email = {{ (index (lastpass "Git Config") 0).note.email }}
+    signingkey = {{ (index (lastpass "Git Config") 0).note.gpgKey }}
+
+[github]
+    user = {{ (index (lastpass "GitHub") 0).username }}
+```
+
+### SSH Private Key from Notes
+
+LastPass automatically parses notes as colon-separated key-value pairs:
+
+```text ~/.ssh/id_rsa.tmpl theme={null}
+{{ (index (lastpass "SSH") 0).note.privateKey }}
+```
+
+If your LastPass note looks like:
+
+```
+Private Key: -----BEGIN RSA PRIVATE KEY-----
+MIIE...
+Public Key: ssh-rsa AAAA...
+```
+
+Keys in notes written as `CamelCase Words` are converted to `camelCaseWords`.
+
+### Raw Note Data
+
+If the note doesn't contain key-value pairs:
+
+```text ~/.ssh/id_rsa.tmpl theme={null}
+{{ (index (lastpassRaw "SSH Private Key") 0).note }}
+```
+
+### AWS Credentials
+
+<CodeGroup>
+  ```text From Fields theme={null}
+  # ~/.aws/credentials.tmpl
+  [default]
+  aws_access_key_id = {{ (index (lastpass "AWS Personal") 0).username }}
+  aws_secret_access_key = {{ (index (lastpass "AWS Personal") 0).password }}
+
+  [work]
+  aws_access_key_id = {{ (index (lastpass "AWS Work") 0).username }}
+  aws_secret_access_key = {{ (index (lastpass "AWS Work") 0).password }}
+  ```
+
+  ```text From Notes theme={null}
+  # ~/.aws/credentials.tmpl
+  [default]
+  aws_access_key_id = {{ (index (lastpass "AWS") 0).note.accessKeyId }}
+  aws_secret_access_key = {{ (index (lastpass "AWS") 0).note.secretAccessKey }}
+  region = {{ (index (lastpass "AWS") 0).note.region }}
+  ```
+</CodeGroup>
+
+### API Tokens
+
+```text ~/.config/tokens.env.tmpl theme={null}
+# GitHub
+GITHUB_TOKEN={{ (index (lastpass "GitHub API") 0).password }}
+GH_TOKEN={{ (index (lastpass "GitHub API") 0).password }}
+
+# GitLab
+GITLAB_TOKEN={{ (index (lastpass "GitLab API") 0).password }}
+
+# OpenAI
+OPENAI_API_KEY={{ (index (lastpass "OpenAI") 0).password }}
+
+# Stripe
+STRIPE_SECRET_KEY={{ (index (lastpass "Stripe") 0).note.secretKey }}
+STRIPE_PUBLISHABLE_KEY={{ (index (lastpass "Stripe") 0).note.publishableKey }}
+```
+
+### Database Configuration
+
+```text ~/.config/db/config.yml.tmpl theme={null}
+production:
+  host: {{ (index (lastpass "Production DB") 0).note.host }}
+  port: {{ (index (lastpass "Production DB") 0).note.port }}
+  username: {{ (index (lastpass "Production DB") 0).username }}
+  password: {{ (index (lastpass "Production DB") 0).password }}
+  database: {{ (index (lastpass "Production DB") 0).note.database }}
+
+development:
+  host: localhost
+  port: 5432
+  username: {{ (index (lastpass "Dev DB") 0).username }}
+  password: {{ (index (lastpass "Dev DB") 0).password }}
+  database: app_dev
+```
+
+### NPM Configuration
+
+```text ~/.npmrc.tmpl theme={null}
+//registry.npmjs.org/:_authToken={{ (index (lastpass "NPM") 0).password }}
+email={{ (index (lastpass "NPM") 0).username }}
+```
+
+## Advanced Usage
+
+### Multiple Entries
+
+If a search returns multiple entries:
+
+```text theme={null}
+{{ range (lastpass "github") -}}
+Entry: {{ .name }}
+Username: {{ .username }}
+Password: {{ .password }}
+{{ end }}
+```
+
+### Accessing Nested Fields
+
+```text theme={null}
+# All note fields for an entry
+{{ range $key, $value := (index (lastpass "Entry") 0).note -}}
+{{ $key }}: {{ $value }}
+{{ end }}
+```
+
+### Using Entry IDs
+
+Find the entry ID:
+
+```bash theme={null}
+lpass ls
+```
+
+Then reference by ID:
+
+```text theme={null}
+{{ (index (lastpass "1234567890") 0).password }}
+```
+
+### Conditional Access
+
+```text ~/.gitconfig.tmpl theme={null}
+[user]
+    name = {{ (index (lastpass "Git") 0).username }}
+{{- if (index (lastpass "Git") 0).note.email }}
+    email = {{ (index (lastpass "Git") 0).note.email }}
+{{- end }}
+{{- if (index (lastpass "Git") 0).note.signingkey }}
+    signingkey = {{ (index (lastpass "Git") 0).note.signingkey }}
+{{- end }}
+```
+
+## Structuring Notes in LastPass
+
+For best results, structure your notes as key-value pairs:
+
+```
+API Key: sk-abc123...
+Endpoint: https://api.example.com
+Region: us-east-1
+Environment: production
+```
+
+These will be accessible as:
+
+```text theme={null}
+{{ (index (lastpass "Service") 0).note.apiKey }}
+{{ (index (lastpass "Service") 0).note.endpoint }}
+{{ (index (lastpass "Service") 0).note.region }}
+{{ (index (lastpass "Service") 0).note.environment }}
+```
+
+## Configuration
+
+### Custom Command
+
+If `lpass` is not in your PATH:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[lastpass]
+    command = "/custom/path/to/lpass"
+```
+
+## Troubleshooting
+
+### Not Logged In
+
+If you get "Error: Could not find decryption key":
+
+```bash theme={null}
+lpass login $LASTPASS_USERNAME
+```
+
+### Session Expired
+
+Log in again:
+
+```bash theme={null}
+lpass logout
+lpass login $LASTPASS_USERNAME
+```
+
+### Entry Not Found
+
+List all entries to find the correct name:
+
+```bash theme={null}
+lpass ls
+```
+
+Or search for entries:
+
+```bash theme={null}
+lpass ls | grep -i github
+```
+
+### Command Not Found
+
+Ensure LastPass CLI is installed:
+
+```bash theme={null}
+which lpass
+lpass --version
+```
+
+### Testing Templates
+
+Test template functions:
+
+```bash theme={null}
+chezmoi execute-template '{{ (index (lastpass "test") 0).password }}'
+```
+
+### Verify Entry Data
+
+Check what data is available:
+
+```bash theme={null}
+lpass show --json "Entry Name" | jq .
+```
+
+## Best Practices
+
+1. **Use descriptive names**: Name entries clearly for easy reference
+2. **Structure notes**: Use key-value format in notes for easy parsing
+3. **Use folders**: Organize entries in folders (`Work/GitHub`, `Personal/AWS`)
+4. **Test entries**: Verify entries are accessible before using in templates
+5. **Stay logged in**: Keep your LastPass session active on trusted machines
+6. **Use entry IDs**: For stability, consider using entry IDs instead of names
+
+## See Also
+
+* [LastPass CLI Documentation](https://lastpass.github.io/lastpass-cli/lpass.1.html)
+* [Entry Specification](https://lastpass.github.io/lastpass-cli/lpass.1.html#_entry_specification)
+* [Template Functions Reference](/reference/templates/password-manager-functions#lastpass)
+
+
+# pass (Password Store)
+Source: https://twpayne-chezmoi.mintlify.app/password-managers/pass
+
+Integrate pass with chezmoi to manage secrets in your dotfiles
+
+chezmoi includes support for [pass](https://www.passwordstore.org/), the standard Unix password manager, using the pass CLI.
+
+## Setup
+
+### Install pass
+
+<CodeGroup>
+  ```bash macOS theme={null}
+  brew install pass
+  ```
+
+  ```bash Ubuntu/Debian theme={null}
+  sudo apt install pass
+  ```
+
+  ```bash Fedora theme={null}
+  sudo dnf install pass
+  ```
+
+  ```bash Arch theme={null}
+  sudo pacman -S pass
+  ```
+</CodeGroup>
+
+### Initialize pass
+
+If you haven't set up pass yet:
+
+```bash theme={null}
+# Initialize with your GPG key
+pass init your-gpg-id@example.com
+
+# Or initialize with a specific GPG key ID
+pass init 0x1234567890ABCDEF
+```
+
+### Add Passwords
+
+```bash theme={null}
+# Add a password
+pass insert github/token
+
+# Generate a random password
+pass generate aws/secret-key 32
+
+# Add multiline data
+pass insert -m ssh/private-key
+```
+
+## Template Functions
+
+### `pass`
+
+Get the first line from a password entry:
+
+```text theme={null}
+{{ pass "github/token" }}
+```
+
+This runs `pass show github/token` and returns the first line.
+
+### `passFields`
+
+Get structured data from a password entry with key-value pairs:
+
+```text theme={null}
+{{ (passFields "aws/credentials").access_key_id }}
+```
+
+This parses the entry as colon-separated key-value pairs.
+
+### `passRaw`
+
+Get the complete raw output from a password entry:
+
+```text theme={null}
+{{ passRaw "ssh/private-key" }}
+```
+
+Useful for multiline data like SSH keys or certificates.
+
+## Usage Examples
+
+### Simple Passwords
+
+<CodeGroup>
+  ```text GitHub Token theme={null}
+  # ~/.config/gh/config.yml.tmpl
+  github_token: {{ pass "github/token" }}
+  ```
+
+  ```text NPM Token theme={null}
+  # ~/.npmrc.tmpl
+  //registry.npmjs.org/:_authToken={{ pass "npm/token" }}
+  ```
+
+  ```text API Key theme={null}
+  # ~/.config/app/config.yml.tmpl
+  api_key: {{ pass "service/api-key" }}
+  ```
+</CodeGroup>
+
+### Git Configuration
+
+```text ~/.gitconfig.tmpl theme={null}
+[user]
+    name = John Doe
+    email = {{ pass "git/email" }}
+    signingkey = {{ pass "git/signing-key" }}
+
+[github]
+    user = {{ pass "github/username" }}
+
+[credential]
+    helper = store
+```
+
+### SSH Private Keys
+
+Store SSH keys in pass:
+
+```bash theme={null}
+# Add SSH key to pass
+pass insert -m ssh/id_rsa < ~/.ssh/id_rsa
+```
+
+Use in templates:
+
+```text ~/.ssh/id_rsa.tmpl theme={null}
+{{ passRaw "ssh/id_rsa" }}
+```
+
+### Structured Data with passFields
+
+Store data as key-value pairs in pass:
+
+```bash theme={null}
+pass insert -m aws/credentials
+# Then enter:
+access_key_id: [REDACTED-AWSKEY-DOCS-EXAMPLE]
+secret_access_key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+region: us-east-1
+```
+
+Access in templates:
+
+```text ~/.aws/credentials.tmpl theme={null}
+[default]
+aws_access_key_id = {{ (passFields "aws/credentials").access_key_id }}
+aws_secret_access_key = {{ (passFields "aws/credentials").secret_access_key }}
+region = {{ (passFields "aws/credentials").region }}
+```
+
+### Database Credentials
+
+<CodeGroup>
+  ```bash Store in pass theme={null}
+  # Production database
+  pass insert -m db/production
+  # Enter:
+  host: db.example.com
+  port: 5432
+  username: app_user
+  password: super_secret_password
+  database: production_db
+  ```
+
+  ```text Use in template theme={null}
+  # ~/.config/db/config.yml.tmpl
+  production:
+    host: {{ (passFields "db/production").host }}
+    port: {{ (passFields "db/production").port }}
+    username: {{ (passFields "db/production").username }}
+    password: {{ (passFields "db/production").password }}
+    database: {{ (passFields "db/production").database }}
+  ```
+</CodeGroup>
+
+### Multiple API Keys
+
+```text ~/.config/api-keys.env.tmpl theme={null}
+# Cloud Services
+AWS_ACCESS_KEY_ID={{ pass "aws/access-key-id" }}
+AWS_SECRET_ACCESS_KEY={{ pass "aws/secret-access-key" }}
+DIGITALOCEAN_TOKEN={{ pass "digitalocean/token" }}
+
+# Development Tools
+GITHUB_TOKEN={{ pass "github/token" }}
+GITLAB_TOKEN={{ pass "gitlab/token" }}
+OPENAI_API_KEY={{ pass "openai/api-key" }}
+
+# Payment Services
+STRIPE_SECRET_KEY={{ pass "stripe/secret-key" }}
+STRIPE_PUBLISHABLE_KEY={{ pass "stripe/publishable-key" }}
+```
+
+### Docker Registry Credentials
+
+```bash theme={null}
+# Store Docker Hub credentials
+pass insert docker/username
+pass insert docker/password
+```
+
+```text ~/.docker/config.json.tmpl theme={null}
+{
+  "auths": {
+    "https://index.docker.io/v1/": {
+      "auth": "{{ printf "%s:%s" (pass "docker/username") (pass "docker/password") | b64enc }}"
+    }
+  }
+}
+```
+
+### Kubernetes Config
+
+```text ~/.kube/config.tmpl theme={null}
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: {{ pass "kubernetes/server" }}
+    certificate-authority-data: {{ passRaw "kubernetes/ca-cert" | b64enc }}
+  name: production
+contexts:
+- context:
+    cluster: production
+    user: admin
+  name: production
+current-context: production
+users:
+- name: admin
+  user:
+    client-certificate-data: {{ passRaw "kubernetes/client-cert" | b64enc }}
+    client-key-data: {{ passRaw "kubernetes/client-key" | b64enc }}
+```
+
+## Configuration
+
+### Custom Command
+
+If `pass` is not in your PATH:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[pass]
+    command = "/custom/path/to/pass"
+```
+
+### Custom Password Store Location
+
+By default, pass uses `~/.password-store`. To use a different location:
+
+```bash theme={null}
+export PASSWORD_STORE_DIR="$HOME/.my-passwords"
+```
+
+Or add to your shell profile:
+
+```bash ~/.bashrc theme={null}
+export PASSWORD_STORE_DIR="$HOME/.my-passwords"
+```
+
+## Organizing Your Password Store
+
+Use a hierarchical structure:
+
+```
+~/.password-store/
+├── personal/
+│   ├── email/
+│   │   └── gmail
+│   ├── github/
+│   │   ├── token
+│   │   └── username
+│   └── ssh/
+│       └── id_rsa
+├── work/
+│   ├── aws/
+│   │   └── credentials
+│   ├── github/
+│   │   └── token
+│   └── vpn/
+│       └── password
+└── shared/
+    └── wifi/
+        └── home
+```
+
+Access with:
+
+```text theme={null}
+{{ pass "personal/github/token" }}
+{{ pass "work/aws/credentials" }}
+```
+
+## Advanced Usage
+
+### Using pass with Git
+
+pass can sync with git:
+
+```bash theme={null}
+# Initialize git in password store
+pass git init
+
+# Add a remote
+pass git remote add origin git@github.com:username/passwords.git
+
+# Push passwords
+pass git push -u origin master
+```
+
+### Team Password Sharing
+
+Initialize pass for multiple GPG keys:
+
+```bash theme={null}
+pass init key1@example.com key2@example.com
+```
+
+Everyone with these keys can decrypt the passwords.
+
+### Generating Passwords
+
+```bash theme={null}
+# Generate a 32-character password
+pass generate github/token 32
+
+# Generate without symbols
+pass generate -n aws/secret-key 40
+```
+
+### Editing Passwords
+
+```bash theme={null}
+# Edit a password entry
+pass edit github/token
+
+# View a password
+pass show github/token
+```
+
+## Complete Examples
+
+### Multi-Service Configuration
+
+```text ~/.config/services.yml.tmpl theme={null}
+github:
+  username: {{ pass "github/username" }}
+  token: {{ pass "github/token" }}
+  email: {{ pass "github/email" }}
+
+aws:
+  access_key_id: {{ (passFields "aws/credentials").access_key_id }}
+  secret_access_key: {{ (passFields "aws/credentials").secret_access_key }}
+  region: {{ (passFields "aws/credentials").region }}
+
+database:
+  host: {{ (passFields "database/production").host }}
+  port: {{ (passFields "database/production").port }}
+  username: {{ (passFields "database/production").username }}
+  password: {{ (passFields "database/production").password }}
+
+smtp:
+  host: {{ (passFields "email/smtp").host }}
+  port: {{ (passFields "email/smtp").port }}
+  username: {{ (passFields "email/smtp").username }}
+  password: {{ (passFields "email/smtp").password }}
+```
+
+## Troubleshooting
+
+### GPG Key Not Found
+
+Ensure your GPG key is available:
+
+```bash theme={null}
+gpg --list-secret-keys
+```
+
+If not, import it:
+
+```bash theme={null}
+gpg --import private-key.asc
+```
+
+### Password Not Found
+
+List all passwords:
+
+```bash theme={null}
+pass ls
+```
+
+Or search:
+
+```bash theme={null}
+pass find github
+```
+
+### Command Not Found
+
+Ensure pass is installed:
+
+```bash theme={null}
+which pass
+pass --version
+```
+
+### Testing Templates
+
+Test template functions:
+
+```bash theme={null}
+chezmoi execute-template '{{ pass "test/password" }}'
+```
+
+### GPG Agent Issues
+
+If GPG prompts repeatedly for your password:
+
+```bash theme={null}
+# Check GPG agent
+gpg-connect-agent /bye
+
+# Restart GPG agent
+gpgconf --kill gpg-agent
+gpgconf --launch gpg-agent
+```
+
+## Best Practices
+
+1. **Use hierarchy**: Organize passwords in logical folders
+2. **Use descriptive names**: Make entry names clear and searchable
+3. **Backup regularly**: Keep encrypted backups of your password store
+4. **Use git**: Sync your password store across machines with git
+5. **Set GPG key expiry**: Use expiring GPG keys for better security
+6. **Use passFields**: Structure complex data as key-value pairs
+7. **Test access**: Verify passwords are accessible before using in templates
+
+## See Also
+
+* [pass Website](https://www.passwordstore.org/)
+* [pass Git Repository](https://git.zx2c4.com/password-store/)
+* [Template Functions Reference](/reference/templates/password-manager-functions#pass)
+* [gopass](/password-managers/gopass) - Extended version of pass
+
+
+# Passhole
+Source: https://twpayne-chezmoi.mintlify.app/password-managers/passhole
+
+Integrate KeePass with chezmoi using the Passhole CLI
+
+chezmoi includes support for [KeePass](https://keepass.info/) using the [Passhole CLI](https://github.com/Evidlo/passhole) (`ph`) to expose data as template functions.
+
+## Overview
+
+Passhole (`ph`) is a command-line interface for KeePass databases. Unlike KeePassXC CLI, Passhole provides a more streamlined interface for accessing KeePass databases from the terminal.
+
+## Setup
+
+### Install Passhole
+
+<CodeGroup>
+  ```bash pip theme={null}
+  pip install passhole
+  ```
+
+  ```bash pipx theme={null}
+  pipx install passhole
+  ```
+</CodeGroup>
+
+### Initialize Database
+
+If you don't have a KeePass database:
+
+```bash theme={null}
+ph init /path/to/database.kdbx
+```
+
+Or use an existing KeePass database:
+
+```bash theme={null}
+ph set-database /path/to/database.kdbx
+```
+
+## Template Function
+
+### `passhole`
+
+Retrieve a specific field from a KeePass entry:
+
+```text theme={null}
+{{ passhole "path/to/entry" "field" }}
+```
+
+Common field names:
+
+* `password`
+* `username`
+* `url`
+* `notes`
+* Custom field names
+
+## Configuration
+
+### Basic Configuration
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[passhole]
+    command = "ph"
+```
+
+### With Password Prompt
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[passhole]
+    prompt = true
+```
+
+When `prompt = true`, chezmoi will prompt for your database password once and cache it for the session.
+
+### Custom Arguments
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[passhole]
+    args = ["--database", "/path/to/database.kdbx"]
+```
+
+## Usage Examples
+
+### Basic Password Retrieval
+
+```text ~/.config/api-keys.env.tmpl theme={null}
+GITHUB_TOKEN={{ passhole "Personal/GitHub" "password" }}
+```
+
+### Git Configuration
+
+```text ~/.gitconfig.tmpl theme={null}
+[user]
+    name = {{ passhole "Personal/Git" "username" }}
+    email = {{ passhole "Personal/Git" "email" }}
+    signingkey = {{ passhole "Personal/Git" "gpg_key" }}
+```
+
+### Database Credentials
+
+```text ~/.config/db/config.yml.tmpl theme={null}
+production:
+  host: {{ passhole "Work/Database/Production" "url" }}
+  port: 5432
+  username: {{ passhole "Work/Database/Production" "username" }}
+  password: {{ passhole "Work/Database/Production" "password" }}
+  database: {{ passhole "Work/Database/Production" "database_name" }}
+```
+
+### AWS Credentials
+
+```text ~/.aws/credentials.tmpl theme={null}
+[default]
+aws_access_key_id = {{ passhole "Cloud/AWS" "access_key_id" }}
+aws_secret_access_key = {{ passhole "Cloud/AWS" "secret_access_key" }}
+region = {{ passhole "Cloud/AWS" "region" }}
+```
+
+### Multiple API Keys
+
+```text ~/.config/api-keys.env.tmpl theme={null}
+# GitHub
+GITHUB_TOKEN={{ passhole "API/GitHub" "password" }}
+
+# GitLab
+GITLAB_TOKEN={{ passhole "API/GitLab" "password" }}
+
+# OpenAI
+OPENAI_API_KEY={{ passhole "API/OpenAI" "api_key" }}
+
+# Stripe
+STRIPE_SECRET_KEY={{ passhole "API/Stripe" "secret_key" }}
+STRIPE_PUBLISHABLE_KEY={{ passhole "API/Stripe" "publishable_key" }}
+```
+
+### NPM Configuration
+
+```text ~/.npmrc.tmpl theme={null}
+//registry.npmjs.org/:_authToken={{ passhole "Development/NPM" "password" }}
+email={{ passhole "Development/NPM" "email" }}
+```
+
+### SSH Configuration
+
+```text ~/.ssh/config.tmpl theme={null}
+Host github.com
+    User {{ passhole "SSH/GitHub" "username" }}
+    IdentityFile ~/.ssh/id_ed25519
+
+Host gitlab.com
+    User {{ passhole "SSH/GitLab" "username" }}
+    IdentityFile ~/.ssh/id_rsa
+
+Host work-server
+    HostName {{ passhole "SSH/WorkServer" "url" }}
+    User {{ passhole "SSH/WorkServer" "username" }}
+    IdentityFile ~/.ssh/work_id_rsa
+```
+
+### Docker Registry
+
+```text ~/.docker/config.json.tmpl theme={null}
+{
+  "auths": {
+    "https://index.docker.io/v1/": {
+      "auth": "{{ printf "%s:%s" (passhole "Docker/Hub" "username") (passhole "Docker/Hub" "password") | b64enc }}"
+    }
+  }
+}
+```
+
+## Managing KeePass Database with Passhole
+
+### Adding Entries
+
+```bash theme={null}
+# Add a new entry
+ph add "Personal/GitHub"
+# Enter username, password, url, etc.
+
+# Add entry with specific fields
+ph add "API/Service" --username user --password pass --url https://example.com
+```
+
+### Listing Entries
+
+```bash theme={null}
+# List all entries
+ph list
+
+# List entries in a group
+ph list "Personal"
+```
+
+### Viewing Entries
+
+```bash theme={null}
+# Show entry details
+ph show "Personal/GitHub"
+
+# Show specific field
+ph show "Personal/GitHub" --field password
+```
+
+### Editing Entries
+
+```bash theme={null}
+ph edit "Personal/GitHub"
+```
+
+### Deleting Entries
+
+```bash theme={null}
+ph delete "Personal/GitHub"
+```
+
+## Entry Organization
+
+Organize entries in groups (folders):
+
+```
+Root/
+├── Personal/
+│   ├── Email/
+│   │   └── Gmail
+│   ├── GitHub
+│   └── Social/
+│       ├── Twitter
+│       └── LinkedIn
+├── Work/
+│   ├── AWS
+│   ├── GitHub
+│   └── Database/
+│       ├── Production
+│       └── Staging
+└── API/
+    ├── GitHub
+    ├── OpenAI
+    └── Stripe
+```
+
+Access with:
+
+```text theme={null}
+{{ passhole "Personal/GitHub" "password" }}
+{{ passhole "Work/Database/Production" "password" }}
+{{ passhole "API/OpenAI" "api_key" }}
+```
+
+## Custom Fields
+
+Passhole supports custom fields beyond the standard username/password:
+
+```bash theme={null}
+# Add entry with custom fields
+ph add "API/Service"
+# When prompted, add custom fields like:
+# - api_key
+# - endpoint
+# - region
+```
+
+Access custom fields:
+
+```text theme={null}
+api_key: {{ passhole "API/Service" "api_key" }}
+endpoint: {{ passhole "API/Service" "endpoint" }}
+region: {{ passhole "API/Service" "region" }}
+```
+
+## Complete Examples
+
+### Multi-Service Configuration
+
+```text ~/.config/services.yml.tmpl theme={null}
+github:
+  username: {{ passhole "Personal/GitHub" "username" }}
+  token: {{ passhole "Personal/GitHub" "password" }}
+  email: {{ passhole "Personal/GitHub" "email" }}
+
+aws:
+  access_key_id: {{ passhole "Cloud/AWS" "access_key_id" }}
+  secret_access_key: {{ passhole "Cloud/AWS" "secret_access_key" }}
+  region: {{ passhole "Cloud/AWS" "region" }}
+
+database:
+  host: {{ passhole "Work/Database" "url" }}
+  port: 5432
+  username: {{ passhole "Work/Database" "username" }}
+  password: {{ passhole "Work/Database" "password" }}
+  database: production
+
+redis:
+  host: localhost
+  port: 6379
+  password: {{ passhole "Work/Redis" "password" }}
+```
+
+### Application Environment
+
+```text ~/.config/app/.env.tmpl theme={null}
+# Application
+APP_NAME=myapp
+APP_ENV=production
+APP_KEY={{ passhole "App/Laravel" "app_key" }}
+
+# Database
+DB_HOST={{ passhole "App/Database" "url" }}
+DB_PORT=5432
+DB_DATABASE={{ passhole "App/Database" "database" }}
+DB_USERNAME={{ passhole "App/Database" "username" }}
+DB_PASSWORD={{ passhole "App/Database" "password" }}
+
+# Cache
+REDIS_HOST=localhost
+REDIS_PASSWORD={{ passhole "App/Redis" "password" }}
+REDIS_PORT=6379
+
+# Mail
+MAIL_HOST={{ passhole "App/Mail" "host" }}
+MAIL_PORT={{ passhole "App/Mail" "port" }}
+MAIL_USERNAME={{ passhole "App/Mail" "username" }}
+MAIL_PASSWORD={{ passhole "App/Mail" "password" }}
+
+# AWS
+AWS_ACCESS_KEY_ID={{ passhole "App/AWS" "access_key_id" }}
+AWS_SECRET_ACCESS_KEY={{ passhole "App/AWS" "secret_access_key" }}
+AWS_REGION={{ passhole "App/AWS" "region" }}
+```
+
+## Troubleshooting
+
+### Database Locked
+
+If using `prompt = true`, chezmoi will prompt for your password once per session.
+
+If `prompt = false`, ensure your database is unlocked or use a key file.
+
+### Entry Not Found
+
+List all entries to find the correct path:
+
+```bash theme={null}
+ph list
+ph show "path/to/entry"
+```
+
+### Command Not Found
+
+Ensure Passhole is installed:
+
+```bash theme={null}
+which ph
+ph --version
+```
+
+### Testing Templates
+
+Test template functions:
+
+```bash theme={null}
+chezmoi execute-template '{{ passhole "Personal/GitHub" "password" }}'
+```
+
+### Field Not Found
+
+View all fields for an entry:
+
+```bash theme={null}
+ph show "path/to/entry"
+```
+
+## Best Practices
+
+1. **Use groups**: Organize entries in logical groups (Personal, Work, API)
+2. **Consistent paths**: Use a clear naming convention for entry paths
+3. **Custom fields**: Use custom fields for structured data
+4. **Backup database**: Keep encrypted backups of your KeePass database
+5. **Strong master password**: Use a strong password for your database
+6. **Use prompt mode**: Enable `prompt = true` for better security
+7. **Test access**: Verify entries are accessible before templating
+8. **Sync carefully**: If syncing database, ensure it's encrypted
+
+## See Also
+
+* [Passhole GitHub](https://github.com/Evidlo/passhole)
+* [KeePass Website](https://keepass.info/)
+* [KeePassXC](/password-managers/keepassxc) - Alternative KeePass CLI
+* [Template Functions Reference](/reference/templates/password-manager-functions#passhole)
+
+
+# Proton Pass
+Source: https://twpayne-chezmoi.mintlify.app/password-managers/proton-pass
+
+Integrate Proton Pass with chezmoi to manage secrets in your dotfiles
+
+chezmoi includes support for [Proton Pass](https://proton.me/pass), a password manager from Proton, using the [Proton Pass CLI](https://protonpass.github.io/pass-cli/) to expose data as template functions.
+
+## Setup
+
+### Install Proton Pass CLI
+
+Install the Proton Pass CLI:
+
+```bash theme={null}
+npm install -g @protontech/pass-cli
+```
+
+Or download from the [official repository](https://github.com/protonpass/pass-cli).
+
+### Log In
+
+Authenticate with Proton Pass:
+
+```bash theme={null}
+proton-pass-cli login
+```
+
+Follow the authentication prompts.
+
+## Template Functions
+
+### `protonPass`
+
+Retrieve an item using a secret reference URI:
+
+```text theme={null}
+{{ protonPass "pass://$SHARE_ID/$ITEM_ID/$FIELD" }}
+```
+
+The URI format is `pass://share-id/item-id/field-name`.
+
+### `protonPassJSON`
+
+Get structured JSON data for an item:
+
+```text theme={null}
+{{ (protonPassJSON "item-identifier").password }}
+{{ (protonPassJSON "item-identifier").username }}
+```
+
+## Usage Examples
+
+### Simple Secret Retrieval
+
+```text theme={null}
+# Using secret reference
+{{ protonPass "pass://share-123/item-456/password" }}
+```
+
+### Git Configuration
+
+```text ~/.gitconfig.tmpl theme={null}
+[user]
+    name = {{ protonPass "pass://personal/git-config/name" }}
+    email = {{ protonPass "pass://personal/git-config/email" }}
+    signingkey = {{ protonPass "pass://personal/git-config/gpg-key" }}
+```
+
+### Using JSON Structure
+
+```text ~/.config/app/config.yml.tmpl theme={null}
+{{ $github := protonPassJSON "github" -}}
+
+github:
+  username: {{ $github.username }}
+  token: {{ $github.password }}
+  email: {{ $github.email }}
+```
+
+### Database Credentials
+
+```text ~/.config/db/config.yml.tmpl theme={null}
+{{ $db := protonPassJSON "production-database" -}}
+
+production:
+  host: {{ $db.url }}
+  port: 5432
+  username: {{ $db.username }}
+  password: {{ $db.password }}
+  database: production_db
+```
+
+### AWS Credentials
+
+```text ~/.aws/credentials.tmpl theme={null}
+[default]
+aws_access_key_id = {{ protonPass "pass://personal/aws/access-key-id" }}
+aws_secret_access_key = {{ protonPass "pass://personal/aws/secret-access-key" }}
+region = {{ protonPass "pass://personal/aws/region" }}
+```
+
+### Multiple API Keys
+
+```text ~/.config/api-keys.env.tmpl theme={null}
+# GitHub
+GITHUB_TOKEN={{ protonPass "pass://work/github/token" }}
+
+# GitLab
+GITLAB_TOKEN={{ protonPass "pass://work/gitlab/token" }}
+
+# OpenAI
+OPENAI_API_KEY={{ protonPass "pass://personal/openai/api-key" }}
+
+# Stripe
+STRIPE_SECRET_KEY={{ protonPass "pass://work/stripe/secret-key" }}
+```
+
+### NPM Configuration
+
+```text ~/.npmrc.tmpl theme={null}
+//registry.npmjs.org/:_authToken={{ protonPass "pass://personal/npm/token" }}
+email={{ protonPass "pass://personal/npm/email" }}
+```
+
+### SSH Configuration
+
+```text ~/.ssh/config.tmpl theme={null}
+Host github.com
+    User {{ protonPass "pass://personal/github-ssh/username" }}
+    IdentityFile ~/.ssh/id_ed25519
+
+Host gitlab.com
+    User {{ protonPass "pass://work/gitlab-ssh/username" }}
+    IdentityFile ~/.ssh/id_rsa
+```
+
+### Docker Registry
+
+```text ~/.docker/config.json.tmpl theme={null}
+{{ $docker := protonPassJSON "docker-hub" -}}
+
+{
+  "auths": {
+    "https://index.docker.io/v1/": {
+      "auth": "{{ printf "%s:%s" $docker.username $docker.password | b64enc }}"
+    }
+  }
+}
+```
+
+## Secret Reference URI Format
+
+Proton Pass uses URIs in the format:
+
+```
+pass://SHARE_ID/ITEM_ID/FIELD
+```
+
+Where:
+
+* `SHARE_ID`: The vault/share identifier
+* `ITEM_ID`: The item identifier
+* `FIELD`: The field name (e.g., `password`, `username`, `email`)
+
+## Finding Item References
+
+To find item identifiers:
+
+```bash theme={null}
+# List all items
+proton-pass-cli list
+
+# View item details
+proton-pass-cli show "item-name"
+```
+
+## Configuration
+
+### Custom Command
+
+If the Proton Pass CLI is not in your PATH:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[protonPass]
+    command = "/custom/path/to/proton-pass-cli"
+```
+
+## Complete Examples
+
+### Multi-Service Configuration
+
+```text ~/.config/services.yml.tmpl theme={null}
+{{ $github := protonPassJSON "github" -}}
+{{ $aws := protonPassJSON "aws" -}}
+{{ $db := protonPassJSON "database" -}}
+
+github:
+  username: {{ $github.username }}
+  token: {{ $github.password }}
+
+aws:
+  access_key_id: {{ $aws.username }}
+  secret_access_key: {{ $aws.password }}
+  region: us-east-1
+
+database:
+  host: {{ $db.url }}
+  username: {{ $db.username }}
+  password: {{ $db.password }}
+  database: production
+```
+
+### Application Configuration
+
+```text ~/.config/app/config.yml.tmpl theme={null}
+application:
+  name: myapp
+  environment: production
+
+api_keys:
+  github: {{ protonPass "pass://work/github/token" }}
+  openai: {{ protonPass "pass://work/openai/api-key" }}
+  stripe: {{ protonPass "pass://work/stripe/secret-key" }}
+
+database:
+  url: postgresql://{{ protonPass "pass://work/db/username" }}:{{ protonPass "pass://work/db/password" }}@{{ protonPass "pass://work/db/host" }}/production
+
+redis:
+  url: redis://:{{ protonPass "pass://work/redis/password" }}@localhost:6379
+```
+
+### Kubernetes Secrets
+
+```text ~/k8s/secrets.yaml.tmpl theme={null}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: app-secrets
+type: Opaque
+data:
+  database-password: {{ protonPass "pass://work/db/password" | b64enc }}
+  api-key: {{ protonPass "pass://work/api/key" | b64enc }}
+  jwt-secret: {{ protonPass "pass://work/jwt/secret" | b64enc }}
+```
+
+## Troubleshooting
+
+### Not Logged In
+
+Log in to Proton Pass:
+
+```bash theme={null}
+proton-pass-cli login
+```
+
+### Item Not Found
+
+List all items:
+
+```bash theme={null}
+proton-pass-cli list
+```
+
+Verify the item exists and get its reference:
+
+```bash theme={null}
+proton-pass-cli show "item-name"
+```
+
+### Command Not Found
+
+Ensure Proton Pass CLI is installed:
+
+```bash theme={null}
+which proton-pass-cli
+npm list -g @protontech/pass-cli
+```
+
+### Testing Templates
+
+Test template functions:
+
+```bash theme={null}
+chezmoi execute-template '{{ protonPass "pass://share/item/field" }}'
+chezmoi execute-template '{{ protonPassJSON "item" | toJson }}'
+```
+
+### Invalid Reference
+
+Ensure your reference URI is in the correct format:
+
+```
+pass://SHARE_ID/ITEM_ID/FIELD
+```
+
+## Best Practices
+
+1. **Use secret references**: Prefer the `pass://` URI format for clarity
+2. **Organize vaults**: Use separate vaults for work, personal, shared
+3. **Document references**: Keep a list of reference URIs used
+4. **Test access**: Verify items are accessible before templating
+5. **Use descriptive names**: Name items clearly for easy reference
+6. **Leverage JSON**: Use `protonPassJSON` for multiple fields
+7. **Stay synced**: Ensure Proton Pass is synced across devices
+
+## See Also
+
+* [Proton Pass Website](https://proton.me/pass)
+* [Proton Pass CLI Documentation](https://protonpass.github.io/pass-cli/)
+* [Proton Pass CLI GitHub](https://github.com/protonpass/pass-cli)
+* [Template Functions Reference](/reference/templates/password-manager-functions#proton-pass)
+
+
+# HashiCorp Vault
+Source: https://twpayne-chezmoi.mintlify.app/password-managers/vault
+
+Integrate HashiCorp Vault with chezmoi to manage secrets in your dotfiles
+
+chezmoi includes support for [HashiCorp Vault](https://www.vaultproject.io/) using the [Vault CLI](https://www.vaultproject.io/docs/commands/) to expose data as template functions.
+
+## Setup
+
+### Install Vault CLI
+
+<CodeGroup>
+  ```bash macOS theme={null}
+  brew install vault
+  ```
+
+  ```bash Ubuntu/Debian theme={null}
+  wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+  echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+  sudo apt update && sudo apt install vault
+  ```
+
+  ```bash Fedora theme={null}
+  sudo dnf install -y dnf-plugins-core
+  sudo dnf config-manager --add-repo https://rpm.releases.hashicorp.com/fedora/hashicorp.repo
+  sudo dnf install vault
+  ```
+</CodeGroup>
+
+### Configure Vault
+
+Set the required environment variables:
+
+```bash theme={null}
+export VAULT_ADDR='https://vault.example.com:8200'
+export VAULT_TOKEN='your-vault-token'
+```
+
+Or add to your shell profile:
+
+```bash ~/.bashrc theme={null}
+export VAULT_ADDR='https://vault.example.com:8200'
+export VAULT_TOKEN='your-vault-token'
+```
+
+### Verify Setup
+
+Test that Vault is configured correctly:
+
+```bash theme={null}
+vault kv get -format=json secret/test
+```
+
+## Template Function
+
+### `vault`
+
+Get structured data from Vault:
+
+```text theme={null}
+{{ (vault "secret/data/myapp").data.data.password }}
+```
+
+This runs `vault kv get -format=json secret/data/myapp` and returns parsed JSON.
+
+<Note>
+  For KV v2 (default), secrets are stored under `secret/data/path`. The response structure is `{"data": {"data": {"key": "value"}}}`.
+</Note>
+
+## Usage Examples
+
+### Simple Secrets (KV v2)
+
+<CodeGroup>
+  ```bash Store in Vault theme={null}
+  vault kv put secret/github token=[REDACTED-GHTOKEN-DOCS-EXAMPLE]
+  vault kv put secret/aws access_key_id=[REDACTED-AWSKEY-DOCS-EXAMPLE] secret_access_key=wJalrXUtnFEMI/K7MDENG
+  ```
+
+  ```text Use in Templates theme={null}
+  # GitHub token
+  {{ (vault "secret/data/github").data.data.token }}
+
+  # AWS credentials
+  {{ (vault "secret/data/aws").data.data.access_key_id }}
+  {{ (vault "secret/data/aws").data.data.secret_access_key }}
+  ```
+</CodeGroup>
+
+### Database Credentials
+
+<CodeGroup>
+  ```bash Store in Vault theme={null}
+  vault kv put secret/database/production \
+      host=db.example.com \
+      port=5432 \
+      username=app_user \
+      password=super_secret_password \
+      database=production_db
+  ```
+
+  ```text Use in Template theme={null}
+  # ~/.config/db/config.yml.tmpl
+  production:
+    host: {{ (vault "secret/data/database/production").data.data.host }}
+    port: {{ (vault "secret/data/database/production").data.data.port }}
+    username: {{ (vault "secret/data/database/production").data.data.username }}
+    password: {{ (vault "secret/data/database/production").data.data.password }}
+    database: {{ (vault "secret/data/database/production").data.data.database }}
+  ```
+</CodeGroup>
+
+### Git Configuration
+
+```bash theme={null}
+vault kv put secret/git \
+    name="John Doe" \
+    email="john@example.com" \
+    signing_key="0x1234567890ABCDEF"
+```
+
+```text ~/.gitconfig.tmpl theme={null}
+[user]
+    name = {{ (vault "secret/data/git").data.data.name }}
+    email = {{ (vault "secret/data/git").data.data.email }}
+    signingkey = {{ (vault "secret/data/git").data.data.signing_key }}
+```
+
+### AWS Credentials
+
+```bash theme={null}
+vault kv put secret/aws/personal \
+    access_key_id=[REDACTED-AWSKEY-DOCS-EXAMPLE] \
+    secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
+    region=us-east-1
+
+vault kv put secret/aws/work \
+    access_key_id=[REDACTED-AWSKEY-DOCS-EXAMPLE] \
+    secret_access_key=je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY \
+    region=us-west-2
+```
+
+```text ~/.aws/credentials.tmpl theme={null}
+[personal]
+aws_access_key_id = {{ (vault "secret/data/aws/personal").data.data.access_key_id }}
+aws_secret_access_key = {{ (vault "secret/data/aws/personal").data.data.secret_access_key }}
+region = {{ (vault "secret/data/aws/personal").data.data.region }}
+
+[work]
+aws_access_key_id = {{ (vault "secret/data/aws/work").data.data.access_key_id }}
+aws_secret_access_key = {{ (vault "secret/data/aws/work").data.data.secret_access_key }}
+region = {{ (vault "secret/data/aws/work").data.data.region }}
+```
+
+### Multiple API Keys
+
+```bash theme={null}
+vault kv put secret/api-keys \
+    github=[REDACTED-GHTOKEN-DOCS-EXAMPLE] \
+    gitlab=[REDACTED-GLPAT-DOCS-EXAMPLE] \
+    openai=sk-EXAMPLE-REDACTED \
+    stripe=[REDACTED-STRIPE-DOCS-EXAMPLE]
+```
+
+```text ~/.config/api-keys.env.tmpl theme={null}
+GITHUB_TOKEN={{ (vault "secret/data/api-keys").data.data.github }}
+GITLAB_TOKEN={{ (vault "secret/data/api-keys").data.data.gitlab }}
+OPENAI_API_KEY={{ (vault "secret/data/api-keys").data.data.openai }}
+STRIPE_SECRET_KEY={{ (vault "secret/data/api-keys").data.data.stripe }}
+```
+
+### SSH Configuration
+
+```bash theme={null}
+vault kv put secret/ssh/github user=git
+vault kv put secret/ssh/gitlab user=git  
+vault kv put secret/ssh/work-server user=john.doe host=server.company.com
+```
+
+```text ~/.ssh/config.tmpl theme={null}
+Host github.com
+    User {{ (vault "secret/data/ssh/github").data.data.user }}
+    IdentityFile ~/.ssh/id_ed25519
+
+Host gitlab.com
+    User {{ (vault "secret/data/ssh/gitlab").data.data.user }}
+    IdentityFile ~/.ssh/id_rsa
+
+Host work-server
+    HostName {{ (vault "secret/data/ssh/work-server").data.data.host }}
+    User {{ (vault "secret/data/ssh/work-server").data.data.user }}
+    IdentityFile ~/.ssh/work_id_rsa
+```
+
+### NPM Configuration
+
+```bash theme={null}
+vault kv put secret/npm token=npm_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx email=user@example.com
+```
+
+```text ~/.npmrc.tmpl theme={null}
+//registry.npmjs.org/:_authToken={{ (vault "secret/data/npm").data.data.token }}
+email={{ (vault "secret/data/npm").data.data.email }}
+```
+
+## Vault KV Versions
+
+### KV v2 (Default)
+
+KV v2 includes versioning and metadata:
+
+```bash theme={null}
+# Write
+vault kv put secret/myapp password=secret123
+
+# Read in template
+{{ (vault "secret/data/myapp").data.data.password }}
+```
+
+Note the `data` in the path and nested structure.
+
+### KV v1
+
+KV v1 is simpler without versioning:
+
+```bash theme={null}
+# Write
+vault kv put secret/myapp password=secret123
+
+# Read in template (if using KV v1)
+{{ (vault "secret/myapp").data.password }}
+```
+
+## Configuration
+
+### Custom Command
+
+If `vault` is not in your PATH:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[vault]
+    command = "/custom/path/to/vault"
+```
+
+### Environment Variables
+
+Vault CLI respects these environment variables:
+
+```bash theme={null}
+export VAULT_ADDR='https://vault.example.com:8200'
+export VAULT_TOKEN='your-vault-token'
+export VAULT_NAMESPACE='my-namespace'  # For Vault Enterprise
+export VAULT_SKIP_VERIFY='true'        # Skip TLS verification (not recommended)
+```
+
+## Advanced Usage
+
+### Using Vault Namespaces (Enterprise)
+
+```bash theme={null}
+export VAULT_NAMESPACE='my-namespace'
+```
+
+```text theme={null}
+{{ (vault "secret/data/myapp").data.data.password }}
+```
+
+### Dynamic Database Credentials
+
+Vault can generate dynamic database credentials:
+
+```bash theme={null}
+# Enable database secrets engine
+vault secrets enable database
+
+# Configure
+vault write database/config/postgresql \
+    plugin_name=postgresql-database-plugin \
+    connection_url="postgresql://{{username}}:{{password}}@localhost:5432/postgres"
+
+# Create role
+vault write database/roles/readonly \
+    db_name=postgresql \
+    creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}';" \
+    default_ttl="1h" \
+    max_ttl="24h"
+```
+
+```text theme={null}
+# Read dynamic credentials
+{{ $dbCreds := vault "database/creds/readonly" }}
+username: {{ $dbCreds.data.username }}
+password: {{ $dbCreds.data.password }}
+```
+
+### Vault Auth Methods
+
+<CodeGroup>
+  ```bash Token Auth theme={null}
+  export VAULT_TOKEN='your-vault-token'
+  ```
+
+  ```bash AppRole Auth theme={null}
+  vault write auth/approle/login \
+      role_id="$ROLE_ID" \
+      secret_id="$SECRET_ID"
+  ```
+
+  ```bash Kubernetes Auth theme={null}
+  vault write auth/kubernetes/login \
+      role="my-role" \
+      jwt="$SA_TOKEN"
+  ```
+</CodeGroup>
+
+### Simplified Access with Variables
+
+```text ~/.config/app/config.yml.tmpl theme={null}
+{{- $db := (vault "secret/data/database").data.data -}}
+{{- $api := (vault "secret/data/api-keys").data.data -}}
+
+database:
+  host: {{ $db.host }}
+  port: {{ $db.port }}
+  username: {{ $db.username }}
+  password: {{ $db.password }}
+
+api_keys:
+  github: {{ $api.github }}
+  gitlab: {{ $api.gitlab }}
+  openai: {{ $api.openai }}
+```
+
+## Complete Examples
+
+### Multi-Service Configuration
+
+```text ~/.config/services.yml.tmpl theme={null}
+{{- $github := (vault "secret/data/github").data.data -}}
+{{- $aws := (vault "secret/data/aws").data.data -}}
+{{- $db := (vault "secret/data/database/production").data.data -}}
+
+github:
+  token: {{ $github.token }}
+  username: {{ $github.username }}
+
+aws:
+  access_key_id: {{ $aws.access_key_id }}
+  secret_access_key: {{ $aws.secret_access_key }}
+  region: {{ $aws.region }}
+
+database:
+  host: {{ $db.host }}
+  port: {{ $db.port }}
+  username: {{ $db.username }}
+  password: {{ $db.password }}
+  database: {{ $db.database }}
+```
+
+## Troubleshooting
+
+### Connection Refused
+
+Ensure `VAULT_ADDR` is set correctly:
+
+```bash theme={null}
+echo $VAULT_ADDR
+vault status
+```
+
+### Permission Denied
+
+Verify your token has the required policies:
+
+```bash theme={null}
+vault token lookup
+vault policy read my-policy
+```
+
+### Secret Not Found
+
+List secrets to verify the path:
+
+```bash theme={null}
+vault kv list secret/
+vault kv get secret/data/myapp
+```
+
+### TLS Certificate Errors
+
+For development, you can skip TLS verification (not recommended for production):
+
+```bash theme={null}
+export VAULT_SKIP_VERIFY=true
+```
+
+### Testing Templates
+
+Test template functions:
+
+```bash theme={null}
+chezmoi execute-template '{{ (vault "secret/data/test").data.data.value }}'
+```
+
+### Verify Vault CLI
+
+```bash theme={null}
+which vault
+vault --version
+vault status
+```
+
+## Best Practices
+
+1. **Use least privilege**: Grant minimal required permissions via policies
+2. **Rotate tokens**: Use short-lived tokens and rotate regularly
+3. **Use namespaces**: Organize secrets with namespaces (Enterprise)
+4. **Enable audit logging**: Track all secret access
+5. **Use dynamic secrets**: Leverage Vault's dynamic secret generation
+6. **Secure communication**: Always use TLS in production
+7. **Use auth methods**: Prefer AppRole or Kubernetes auth over tokens
+8. **Organize paths**: Use a clear hierarchy for secret paths
+9. **Version secrets**: Use KV v2 for secret versioning
+10. **Monitor access**: Set up alerts for suspicious access patterns
+
+## See Also
+
+* [HashiCorp Vault Documentation](https://www.vaultproject.io/docs)
+* [Vault CLI Commands](https://www.vaultproject.io/docs/commands)
+* [Vault KV Secrets Engine](https://www.vaultproject.io/docs/secrets/kv)
+* [Template Functions Reference](/reference/templates/password-manager-functions#vault)
+
+
+# Quick Start Guide
+Source: https://twpayne-chezmoi.mintlify.app/quick-start
+
+Get started with chezmoi and learn how to manage your dotfiles across multiple machines
+
+# Quick Start Guide
+
+This guide will help you start using chezmoi to manage your dotfiles on your current machine and then sync them across multiple machines.
+
+## Concepts
+
+Roughly speaking, chezmoi stores the desired state of your dotfiles in the directory `~/.local/share/chezmoi`. When you run `chezmoi apply`, chezmoi calculates the desired contents for each of your dotfiles and then makes the minimum changes required to make your dotfiles match your desired state.
+
+<Note>
+  For a more detailed explanation, see the [concepts reference](https://chezmoi.io/reference/concepts/).
+</Note>
+
+## Start Using chezmoi on Your Current Machine
+
+Assuming you have already [installed chezmoi](/install), follow these steps to start managing your dotfiles:
+
+<Steps>
+  <Step title="Initialize chezmoi">
+    Create a new git repository where chezmoi will store its source state:
+
+    ```bash theme={null}
+    chezmoi init
+    ```
+
+    This creates a new git local repository in `~/.local/share/chezmoi`. By default, chezmoi only modifies files in the working copy.
+  </Step>
+
+  <Step title="Manage your first file">
+    Add your first dotfile to chezmoi:
+
+    ```bash theme={null}
+    chezmoi add ~/.bashrc
+    ```
+
+    This will copy `~/.bashrc` to `~/.local/share/chezmoi/dot_bashrc`.
+  </Step>
+
+  <Step title="Edit the source state">
+    Edit the file in chezmoi's source directory:
+
+    ```bash theme={null}
+    chezmoi edit ~/.bashrc
+    ```
+
+    This will open `~/.local/share/chezmoi/dot_bashrc` in your `$EDITOR`. Make some changes and save the file.
+
+    <Tip>
+      You don't have to use `chezmoi edit` to edit your dotfiles. You can edit them directly in the source directory or use your preferred editor workflow.
+    </Tip>
+  </Step>
+
+  <Step title="Preview changes">
+    See what changes chezmoi would make:
+
+    ```bash theme={null}
+    chezmoi diff
+    ```
+
+    This shows you exactly what will change before you apply it.
+  </Step>
+
+  <Step title="Apply the changes">
+    Apply your changes to your home directory:
+
+    ```bash theme={null}
+    chezmoi -v apply
+    ```
+
+    The `-v` (verbose) flag prints out exactly what changes are being made. You can also use `-n` (dry run) to see what would happen without making actual changes.
+
+    <Info>
+      The combination `-n -v` is very useful to see exactly what changes would be made without making them.
+    </Info>
+  </Step>
+
+  <Step title="Commit your changes">
+    Open a shell in the source directory to commit your changes:
+
+    ```bash theme={null}
+    chezmoi cd
+    git add .
+    git commit -m "Initial commit"
+    ```
+  </Step>
+
+  <Step title="Create a GitHub repository">
+    [Create a new repository on GitHub](https://github.com/new) called `dotfiles` and push your repo:
+
+    ```bash theme={null}
+    git remote add origin git@github.com:$GITHUB_USERNAME/dotfiles.git
+    git branch -M main
+    git push -u origin main
+    ```
+
+    <Tip>
+      chezmoi can be configured to automatically [add, commit, and push](https://chezmoi.io/user-guide/daily-operations/#automatically-commit-and-push-changes-to-your-repo) changes to your repo.
+    </Tip>
+  </Step>
+
+  <Step title="Exit the source directory">
+    Return to where you were:
+
+    ```bash theme={null}
+    exit
+    ```
+  </Step>
+</Steps>
+
+### Workflow Diagram
+
+This diagram summarizes the workflow:
+
+```mermaid theme={null}
+sequenceDiagram
+    participant H as home directory
+    participant W as working copy
+    participant L as local repo
+    participant R as remote repo
+    H->>L: chezmoi init
+    H->>W: chezmoi add $FILE
+    W->>W: chezmoi edit $FILE
+    W-->>H: chezmoi diff
+    W->>H: chezmoi apply
+    H-->>W: chezmoi cd
+    W->>L: git add
+    W->>L: git commit
+    L->>R: git push
+    W-->>H: exit
+```
+
+## Using chezmoi Across Multiple Machines
+
+Once you've set up chezmoi on your first machine, you can easily sync your dotfiles to other machines.
+
+<Steps>
+  <Step title="Initialize with your dotfiles repo">
+    On a second machine, initialize chezmoi with your dotfiles repo:
+
+    ```bash theme={null}
+    chezmoi init https://github.com/$GITHUB_USERNAME/dotfiles.git
+    ```
+
+    <Warning>
+      Private GitHub repos require authentication. Use SSH:
+
+      ```bash theme={null}
+      chezmoi init git@github.com:$GITHUB_USERNAME/dotfiles.git
+      ```
+    </Warning>
+
+    This will check out the repo and any submodules and optionally create a chezmoi config file for you.
+  </Step>
+
+  <Step title="Review changes">
+    Check what changes chezmoi will make to your home directory:
+
+    ```bash theme={null}
+    chezmoi diff
+    ```
+  </Step>
+
+  <Step title="Apply changes">
+    If you're happy with the changes, apply them:
+
+    ```bash theme={null}
+    chezmoi apply -v
+    ```
+  </Step>
+
+  <Step title="Edit files if needed">
+    If you're not happy with changes to a specific file, you can:
+
+    **Edit the file:**
+
+    ```bash theme={null}
+    chezmoi edit $FILE
+    ```
+
+    **Or merge changes:**
+
+    ```bash theme={null}
+    chezmoi merge $FILE
+    ```
+
+    This invokes a merge tool (by default `vimdiff`) to merge changes between the current contents of the file, the file in your working copy, and the computed contents.
+  </Step>
+
+  <Step title="Keep machines in sync">
+    Pull and apply the latest changes from your repo:
+
+    ```bash theme={null}
+    chezmoi update -v
+    ```
+  </Step>
+</Steps>
+
+### Multi-Machine Workflow Diagram
+
+```mermaid theme={null}
+sequenceDiagram
+    participant H as home directory
+    participant W as working copy
+    participant L as local repo
+    participant R as remote repo
+    R->>W: chezmoi init $REPO
+    W-->>H: chezmoi diff
+    W->>H: chezmoi apply
+    W->>W: chezmoi edit $FILE
+    W->>W: chezmoi merge $FILE
+    R->>H: chezmoi update
+```
+
+## Set Up a New Machine with a Single Command
+
+You can install your dotfiles on a new machine with a single command:
+
+<CodeGroup>
+  ```bash Full GitHub URL theme={null}
+  chezmoi init --apply https://github.com/$GITHUB_USERNAME/dotfiles.git
+  ```
+
+  ```bash GitHub Shorthand theme={null}
+  chezmoi init --apply $GITHUB_USERNAME
+  ```
+
+  ```bash Private Repo (SSH) theme={null}
+  chezmoi init --apply git@github.com:$GITHUB_USERNAME/dotfiles.git
+  ```
+</CodeGroup>
+
+<Note>
+  If you use GitHub and your dotfiles repo is called `dotfiles`, you can use the shorthand `$GITHUB_USERNAME` instead of the full URL.
+</Note>
+
+### Single-Command Setup Diagram
+
+```mermaid theme={null}
+sequenceDiagram
+    participant H as home directory
+    participant W as working copy
+    participant L as local repo
+    participant R as remote repo
+    R->>H: chezmoi init --apply $REPO
+```
+
+## Common Commands Reference
+
+<AccordionGroup>
+  <Accordion title="Verbose and Dry Run Flags" icon="flag">
+    All chezmoi commands accept these useful flags:
+
+    * `-v` or `--verbose`: Print out exactly what changes will be made
+    * `-n` or `--dry-run`: Don't make any actual changes
+    * `-n -v`: Combination to see exactly what would change without making changes
+
+    Example:
+
+    ```bash theme={null}
+    chezmoi -n -v apply
+    ```
+  </Accordion>
+
+  <Accordion title="Essential Commands" icon="terminal">
+    * `chezmoi init`: Initialize chezmoi
+    * `chezmoi add <file>`: Add a file to chezmoi
+    * `chezmoi edit <file>`: Edit a file in the source state
+    * `chezmoi diff`: Show what would change
+    * `chezmoi apply`: Apply changes to your home directory
+    * `chezmoi update`: Pull and apply latest changes from repo
+    * `chezmoi cd`: Open a shell in the source directory
+  </Accordion>
+
+  <Accordion title="Working with Git" icon="git">
+    chezmoi works seamlessly with Git. You can use chezmoi to manage your dotfiles repo:
+
+    ```bash theme={null}
+    # Enter the source directory
+    chezmoi cd
+
+    # Use git commands as normal
+    git status
+    git add .
+    git commit -m "Update dotfiles"
+    git push
+
+    # Exit back to where you were
+    exit
+    ```
+
+    <Tip>
+      chezmoi can be configured to [automatically commit and push](https://chezmoi.io/user-guide/daily-operations/#automatically-commit-and-push-changes-to-your-repo) changes.
+    </Tip>
+  </Accordion>
+
+  <Accordion title="Git Hosting Services" icon="server">
+    chezmoi works with any git hosting service:
+
+    * [GitHub](https://github.com)
+    * [GitLab](https://gitlab.com)
+    * [Bitbucket](https://bitbucket.org)
+    * [Source Hut](https://sr.ht/)
+    * Any self-hosted git server
+  </Accordion>
+</AccordionGroup>
+
+## Next Steps
+
+For a full list of commands, run:
+
+```bash theme={null}
+chezmoi help
+```
+
+chezmoi has much more functionality to explore:
+
+<CardGroup>
+  <Card title="User Guide" icon="book" href="https://chezmoi.io/user-guide/setup/">
+    Learn about templates, secrets management, and advanced features
+  </Card>
+
+  <Card title="Command Overview" icon="terminal" href="https://chezmoi.io/user-guide/command-overview/">
+    Complete reference of all chezmoi commands
+  </Card>
+
+  <Card title="Daily Operations" icon="calendar" href="https://chezmoi.io/user-guide/daily-operations/">
+    Day-to-day workflows and best practices
+  </Card>
+
+  <Card title="Example Repos" icon="github" href="https://chezmoi.io/links/dotfile-repos/">
+    See how other people use chezmoi
+  </Card>
+</CardGroup>
+
+<Tip>
+  Good next steps include adding more dotfiles, using templates to manage files that vary from machine to machine, and learning how to retrieve secrets from your password manager.
+</Tip>
+
+
+# Application Order
+Source: https://twpayne-chezmoi.mintlify.app/reference/application-order
+
+The deterministic order in which chezmoi applies changes
+
+# Application Order
+
+chezmoi is deterministic in its order of application. Understanding this order is important when writing scripts that depend on other resources or when debugging issues.
+
+## Application Phases
+
+The order of application is:
+
+1. **Read the source state** - chezmoi reads all files in the source directory
+2. **Read the destination state** - chezmoi reads the current state of the destination directory
+3. **Compute the target state** - chezmoi determines what changes need to be made
+4. **Run `run_before_` scripts** - Scripts are executed in alphabetical order
+5. **Update entries** - Files, directories, externals, scripts, symlinks are updated in alphabetical order of their target name
+6. **Run `run_after_` scripts** - Scripts are executed in alphabetical order
+
+## Target Name Ordering
+
+Target names are considered **after all attributes are stripped**.
+
+<Note>
+  Given `create_alpha` and `modify_dot_beta` in the source state, `.beta` will be updated before `alpha` because `.beta` sorts before `alpha`.
+</Note>
+
+### Ordering Examples
+
+```bash theme={null}
+# Source state files:
+create_dot_zshrc          # Target: .zshrc
+modify_dot_bashrc         # Target: .bashrc  
+executable_dot_bin_script # Target: .bin/script
+run_after_update.sh       # Runs after all updates
+run_before_backup.sh      # Runs before all updates
+
+# Execution order:
+# 1. run_before_backup.sh
+# 2. .bashrc (modify)
+# 3. .bin/script (directory created, then file)
+# 4. .zshrc (create)
+# 5. run_after_update.sh
+```
+
+## Directory Handling
+
+Directories (including those created by externals) are updated **before** the files they contain.
+
+### Example
+
+```bash theme={null}
+# Source state:
+exact_dot_config/          # Directory
+exact_dot_config/app/      # Subdirectory
+dot_config_app_config.json # File in subdirectory
+
+# Update order:
+# 1. .config/ directory
+# 2. .config/app/ directory
+# 3. .config/app/config.json file
+```
+
+## Script Execution Order
+
+### Before Scripts
+
+All `run_before_` scripts are executed in alphabetical order **before** any files, directories, or symlinks are updated.
+
+```bash theme={null}
+run_before_01_validate.sh
+run_before_02_backup.sh
+run_before_03_prepare.sh
+```
+
+### During Updates
+
+Scripts without `before_` or `after_` attributes are executed in alphabetical order along with other entry types.
+
+```bash theme={null}
+# Executed in ASCII order with files:
+dot_bashrc
+run_install.sh  # Executed between .bashrc and .zshrc
+dot_zshrc
+```
+
+### After Scripts
+
+All `run_after_` scripts are executed in alphabetical order **after** all files, directories, and symlinks have been updated.
+
+```bash theme={null}
+run_after_01_reload.sh
+run_after_02_cleanup.sh
+run_after_03_notify.sh
+```
+
+## External Resources
+
+External sources (defined in `.chezmoiexternal.$FORMAT` or `.chezmoiexternals/` directories) are updated during the update phase.
+
+<Warning>
+  It is inadvisable for a `run_before_` script to depend on an external applied **during** the update phase. `run_after_` scripts may freely depend on externals.
+</Warning>
+
+### Example
+
+```toml title=".chezmoiexternal.toml" theme={null}
+# This external is applied during the update phase
+[".oh-my-zsh"]
+    type = "archive"
+    url = "https://github.com/ohmyzsh/ohmyzsh/archive/master.tar.gz"
+```
+
+```bash theme={null}
+# run_before_setup.sh
+# BAD: This may fail because .oh-my-zsh doesn't exist yet
+cd ~/.oh-my-zsh
+
+# run_after_setup.sh
+# GOOD: .oh-my-zsh is guaranteed to exist
+cd ~/.oh-my-zsh
+```
+
+## Important Assumptions
+
+chezmoi assumes that the source or destination states are **not modified** while chezmoi is being executed. This assumption permits significant performance improvements, including allowing chezmoi to only read files from the source and destination states if they are needed to compute the target state.
+
+<Warning>
+  chezmoi's behavior when the above assumptions are violated is undefined.
+</Warning>
+
+### Violation Examples
+
+```bash theme={null}
+# BAD: Modifying source state during execution
+# run_before_update_source.sh
+echo "new content" > "$CHEZMOI_SOURCE_DIR/dot_newfile"
+
+# BAD: Modifying destination state during before script
+# run_before_modify_dest.sh  
+echo "content" > ~/.important_file
+```
+
+## Practical Examples
+
+### Database Migration Pattern
+
+```bash theme={null}
+# run_before_01_backup_db.sh
+mysqldump mydb > /tmp/backup.sql
+
+# dot_config_myapp_schema.sql (applied during update phase)
+# run_after_01_migrate_db.sh  
+mysql mydb < ~/.config/myapp/schema.sql
+```
+
+### Service Restart Pattern
+
+```bash theme={null}
+# run_before_stop_service.sh
+sudo systemctl stop myservice
+
+# dot_config_myservice_config.toml (applied during update)
+# run_after_start_service.sh
+sudo systemctl start myservice
+```
+
+### Package Installation Pattern
+
+```bash theme={null}
+# run_once_before_install_deps.sh
+apt-get update
+
+# Various config files applied during update
+# run_onchange_after_configure.sh.tmpl
+# chezmoi:template:left-delimiter=#{{ right-delimiter=}}#
+#{{ range .packages }}#
+apt-get install -y #{{ . }}#
+#{{ end }}#
+```
+
+### Numbered Script Pattern
+
+Use numeric prefixes to control exact execution order:
+
+```bash theme={null}
+run_before_00_validate_system.sh
+run_before_10_backup.sh
+run_before_20_prepare.sh
+
+# ... files updated ...
+
+run_after_10_reload_configs.sh
+run_after_20_restart_services.sh
+run_after_30_verify.sh
+run_after_99_cleanup.sh
+```
+
+## Performance Implications
+
+The deterministic ordering allows chezmoi to:
+
+* **Lazy read files**: Only read files when needed to compute target state
+* **Optimize I/O**: Batch operations where possible
+* **Cache computations**: Reuse computed values across phases
+* **Parallelize safely**: Know which operations can run concurrently
+
+## Debugging Order Issues
+
+Use these commands to understand execution order:
+
+```bash theme={null}
+# Show all changes in order
+chezmoi apply --dry-run --verbose
+
+# Show target state
+chezmoi target-state
+
+# Show scripts that would run
+chezmoi execute-template '{{ range $key, $value := .chezmoi }}{{ $key }}: {{ $value }}\n{{ end }}'
+```
+
+## Related Pages
+
+* [Target Types](/reference/target-types) - Different types of managed resources
+* [Source State Attributes](/reference/source-state-attributes) - File naming conventions
+* [Templates](/reference/templates/overview) - Template syntax for dynamic content
+* [`chezmoi apply`](/commands/apply) - Apply changes to destination
+
+
+# Configuration File
+Source: https://twpayne-chezmoi.mintlify.app/reference/configuration-file
+
+Complete reference for chezmoi's configuration file options
+
+# Configuration File
+
+chezmoi searches for its configuration file according to the [XDG Base Directory Specification](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html). The base name of the config file is `chezmoi`. If multiple configuration file formats are present, chezmoi will report an error.
+
+In most installations, the config file will be read from `$HOME/.config/chezmoi/chezmoi.$FORMAT` (`%USERPROFILE%/.config/chezmoi/chezmoi.$FORMAT` on Windows), where `$FORMAT` is one of `json`, `jsonc`, `toml`, or `yaml`. The config file can be set explicitly with the `--config` command line option. By default, the format is detected based on the extension of the config file name, but can be overridden with the `--config-format` command line option.
+
+## Configuration File Formats
+
+chezmoi supports the following configuration file formats:
+
+* **JSON** (`.json`): Standard JSON format
+* **JSONC** (`.jsonc`): JSON with comments
+* **TOML** (`.toml`): Tom's Obvious, Minimal Language
+* **YAML** (`.yaml` or `.yml`): YAML Ain't Markup Language
+
+## Global Configuration Options
+
+### Directory Paths
+
+| Option            | Type   | Default                  | Description                                |
+| ----------------- | ------ | ------------------------ | ------------------------------------------ |
+| `sourceDir`       | string | `~/.local/share/chezmoi` | The source directory                       |
+| `destDir`         | string | `~`                      | The destination directory                  |
+| `cacheDir`        | string | OS-specific              | The cache directory                        |
+| `persistentState` | string | OS-specific              | Path to persistent state file              |
+| `workingTree`     | string | Same as `sourceDir`      | The git working tree                       |
+| `tempDir`         | string | OS temp dir              | Temporary directory for chezmoi operations |
+| `scriptTempDir`   | string | OS temp dir              | Temporary directory for scripts            |
+
+### Display Options
+
+| Option      | Type        | Default            | Description                                  |
+| ----------- | ----------- | ------------------ | -------------------------------------------- |
+| `color`     | string/bool | `auto`             | Colorize output (`true`, `false`, or `auto`) |
+| `format`    | string      | -                  | Output format (`json`, `yaml`, etc.)         |
+| `pager`     | string      | `$PAGER` or `less` | Pager command                                |
+| `pagerArgs` | \[]string   | -                  | Arguments to pass to pager                   |
+| `progress`  | bool        | `auto`             | Show progress bars                           |
+| `verbose`   | bool        | `false`            | Enable verbose output                        |
+
+### Behavior Options
+
+| Option            | Type   | Default    | Description                                                 |
+| ----------------- | ------ | ---------- | ----------------------------------------------------------- |
+| `mode`            | string | `file`     | Mode (`file` or `symlink`)                                  |
+| `umask`           | int    | OS default | File mode creation mask                                     |
+| `safe`            | bool   | `false`    | Safe mode - require confirmation for destructive operations |
+| `interactive`     | bool   | `false`    | Prompt for confirmation                                     |
+| `lessInteractive` | bool   | `false`    | Reduce interactive prompts                                  |
+
+### Encryption Options
+
+| Option        | Type   | Default | Description                      |
+| ------------- | ------ | ------- | -------------------------------- |
+| `encryption`  | string | -       | Encryption tool (`age` or `gpg`) |
+| `age.command` | string | `age`   | Age command                      |
+| `age.suffix`  | string | `.age`  | Suffix for age-encrypted files   |
+| `gpg.command` | string | `gpg`   | GPG command                      |
+| `gpg.suffix`  | string | `.asc`  | Suffix for GPG-encrypted files   |
+
+### Git Configuration
+
+| Option           | Type   | Default | Description                          |
+| ---------------- | ------ | ------- | ------------------------------------ |
+| `git.autoAdd`    | bool   | `false` | Automatically add changes to git     |
+| `git.autoCommit` | bool   | `false` | Automatically commit changes         |
+| `git.autoPush`   | bool   | `false` | Automatically push changes to remote |
+| `git.command`    | string | `git`   | Git command to use                   |
+
+### Template Configuration
+
+| Option             | Type      | Default                | Description                |
+| ------------------ | --------- | ---------------------- | -------------------------- |
+| `template.options` | \[]string | `["missingkey=error"]` | Template execution options |
+
+### Environment Variables
+
+| Option      | Type               | Description                                       |
+| ----------- | ------------------ | ------------------------------------------------- |
+| `env`       | map\[string]string | Additional environment variables for all commands |
+| `scriptEnv` | map\[string]string | Additional environment variables for scripts only |
+
+### Custom Data
+
+| Option | Type            | Description                                          |
+| ------ | --------------- | ---------------------------------------------------- |
+| `data` | map\[string]any | Custom template variables accessible via `.variable` |
+
+## Password Manager Configurations
+
+Each password manager can be configured with specific options:
+
+### 1Password
+
+| Option                | Type   | Default | Description               |
+| --------------------- | ------ | ------- | ------------------------- |
+| `onepassword.command` | string | `op`    | 1Password CLI command     |
+| `onepassword.cache`   | bool   | `true`  | Enable caching            |
+| `onepassword.prompt`  | bool   | `true`  | Prompt for authentication |
+
+### Bitwarden
+
+| Option              | Type   | Default | Description           |
+| ------------------- | ------ | ------- | --------------------- |
+| `bitwarden.command` | string | `bw`    | Bitwarden CLI command |
+
+### LastPass
+
+| Option             | Type   | Default | Description          |
+| ------------------ | ------ | ------- | -------------------- |
+| `lastpass.command` | string | `lpass` | LastPass CLI command |
+
+### Pass
+
+| Option         | Type   | Default | Description  |
+| -------------- | ------ | ------- | ------------ |
+| `pass.command` | string | `pass`  | Pass command |
+
+### Vault
+
+| Option          | Type   | Default | Description       |
+| --------------- | ------ | ------- | ----------------- |
+| `vault.command` | string | `vault` | Vault CLI command |
+
+See [Password Manager Functions](/reference/templates/password-manager-functions) for usage details.
+
+## Hooks
+
+Hooks allow you to run commands before or after specific chezmoi operations:
+
+```toml theme={null}
+[hooks.read-source-state.pre]
+command = ".local/share/chezmoi/.validate.sh"
+
+[hooks.apply.post]
+command = "notify-send"
+args = ["chezmoi", "Applied successfully"]
+```
+
+Available hook points:
+
+* `read-source-state`
+* `apply`
+
+## Interpreters
+
+Configure interpreters for scripts:
+
+```toml theme={null}
+[interpreters.ps1]
+command = "pwsh"
+args = ["-NoLogo"]
+```
+
+## Examples
+
+### TOML Configuration
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+sourceDir = "~/.dotfiles"
+
+[data]
+email = "user@example.com"
+
+[git]
+autoCommit = true
+autoPush = true
+
+[encryption]
+age.identity = "~/.config/sops/age/keys.txt"
+```
+
+### YAML Configuration
+
+```yaml title="~/.config/chezmoi/chezmoi.yaml" theme={null}
+sourceDir: ~/.dotfiles
+data:
+  email: user@example.com
+git:
+  autoCommit: true
+  autoPush: true
+```
+
+### JSON Configuration
+
+```json title="~/.config/chezmoi/chezmoi.json" theme={null}
+{
+  "sourceDir": "~/.dotfiles",
+  "data": {
+    "email": "user@example.com"
+  },
+  "git": {
+    "autoCommit": true,
+    "autoPush": true
+  }
+}
+```
+
+## Related Commands
+
+* [`chezmoi init`](/commands/init) - Initialize chezmoi configuration
+* `chezmoi cat-config` - Print the configuration file
+* `chezmoi data` - Print template data
+
+
+# Source State Attributes
+Source: https://twpayne-chezmoi.mintlify.app/reference/source-state-attributes
+
+File naming conventions and attributes in chezmoi's source directory
+
+# Source State Attributes
+
+chezmoi stores the source state of files, symbolic links, and directories in regular files and directories in the source directory (`~/.local/share/chezmoi` by default). This location can be overridden with the `-S` flag or by setting `sourceDir` in the configuration file.
+
+Directory targets are represented as directories in the source state. All other target types are represented as files in the source state. Some state is encoded in the source file names using prefixes and suffixes.
+
+Attributes can be changed by renaming the file in the source state or with the `chattr` command.
+
+## Attribute Prefixes
+
+The following prefixes are special and control how chezmoi processes files:
+
+| Prefix        | Effect                                                                           |
+| ------------- | -------------------------------------------------------------------------------- |
+| `after_`      | Run script after updating the destination                                        |
+| `before_`     | Run script before updating the destination                                       |
+| `create_`     | Ensure that the file exists, and create it with contents if it does not          |
+| `dot_`        | Rename to use a leading dot, e.g. `dot_foo` becomes `.foo`                       |
+| `empty_`      | Ensure the file exists, even if it is empty. By default, empty files are removed |
+| `encrypted_`  | Encrypt the file in the source state                                             |
+| `external_`   | Ignore attributes in child entries                                               |
+| `exact_`      | Remove anything not managed by chezmoi                                           |
+| `executable_` | Add executable permissions to the target file                                    |
+| `literal_`    | Stop parsing prefix attributes                                                   |
+| `modify_`     | Treat the contents as a script that modifies an existing file                    |
+| `once_`       | Only run the script if its contents have not been run successfully before        |
+| `onchange_`   | Only run the script if its contents have changed                                 |
+| `private_`    | Remove all group and world permissions from the target file or directory         |
+| `readonly_`   | Remove all write permissions from the target file or directory                   |
+| `remove_`     | Remove the file or symlink if it exists or the directory if it is empty          |
+| `run_`        | Treat the contents as a script to run                                            |
+| `symlink_`    | Create a symlink instead of a regular file                                       |
+
+## Attribute Suffixes
+
+| Suffix     | Effect                                              |
+| ---------- | --------------------------------------------------- |
+| `.literal` | Stop parsing suffix attributes                      |
+| `.tmpl`    | Treat the contents of the source file as a template |
+
+## Allowed Attributes by Target Type
+
+Different target types allow different prefixes and suffixes. The order of prefixes is important.
+
+### Directory
+
+* **Source type**: Directory
+* **Allowed prefixes** (in order): `remove_`, `external_`, `exact_`, `private_`, `readonly_`, `dot_`
+* **Allowed suffixes**: *none*
+
+### Regular File
+
+* **Source type**: File
+* **Allowed prefixes** (in order): `encrypted_`, `private_`, `readonly_`, `empty_`, `executable_`, `dot_`
+* **Allowed suffixes**: `.tmpl`
+
+### Create File
+
+* **Source type**: File
+* **Allowed prefixes** (in order): `create_`, `encrypted_`, `private_`, `readonly_`, `empty_`, `executable_`, `dot_`
+* **Allowed suffixes**: `.tmpl`
+
+### Modify File
+
+* **Source type**: File
+* **Allowed prefixes** (in order): `modify_`, `encrypted_`, `private_`, `readonly_`, `executable_`, `dot_`
+* **Allowed suffixes**: `.tmpl`
+
+### Remove Entry
+
+* **Source type**: File
+* **Allowed prefixes** (in order): `remove_`, `dot_`
+* **Allowed suffixes**: *none*
+
+### Script
+
+* **Source type**: File
+* **Allowed prefixes** (in order): `run_`, `once_` or `onchange_`, `before_` or `after_`
+* **Allowed suffixes**: `.tmpl`
+
+### Symbolic Link
+
+* **Source type**: File
+* **Allowed prefixes** (in order): `symlink_`, `dot_`
+* **Allowed suffixes**: `.tmpl`
+
+## Special Attribute Handling
+
+The `literal_` prefix and `.literal` suffix can appear anywhere and stop attribute parsing. This permits filenames that would otherwise conflict with chezmoi's attributes to be represented.
+
+In addition, if the source file is encrypted, the suffix `.age` (when age encryption is used) or `.asc` (when gpg encryption is used) is stripped. These suffixes can be overridden with the `age.suffix` and `gpg.suffix` configuration variables.
+
+chezmoi ignores all files and directories in the source directory that begin with a `.` with the exception of files and directories that begin with `.chezmoi`.
+
+## Examples
+
+### Basic File Attributes
+
+```bash theme={null}
+# Regular file with dot prefix
+dot_bashrc          # Target: ~/.bashrc
+
+# Executable file
+executable_dot_bin  # Target: ~/.bin (with +x permission)
+
+# Private file (no group/world permissions)
+private_dot_ssh_config  # Target: ~/.ssh/config (mode 0600)
+
+# Template file
+dot_gitconfig.tmpl  # Target: ~/.gitconfig (processed as template)
+```
+
+### Script Attributes
+
+```bash theme={null}
+# Run once script
+run_once_install-packages.sh
+
+# Run on change script
+run_onchange_update-brew.sh
+
+# Run before applying
+run_before_backup.sh
+
+# Run after applying
+run_after_restart-services.sh
+```
+
+### Directory Attributes
+
+```bash theme={null}
+# Exact directory (remove unmanaged files)
+exact_dot_config
+
+# Private directory
+private_dot_ssh
+
+# Combination
+exact_private_dot_gnupg
+```
+
+### Advanced Attributes
+
+```bash theme={null}
+# Create file (don't overwrite if exists)
+create_dot_local_share_file
+
+# Modify file (script that modifies existing file)
+modify_dot_bashrc.tmpl
+
+# Encrypted file
+encrypted_private_dot_ssh_id_rsa.age
+
+# Symlink
+symlink_dot_vimrc
+
+# Remove entry
+remove_dot_oldconfig
+```
+
+### Literal Attributes
+
+```bash theme={null}
+# File literally named "executable_script" (not executable)
+literal_executable_script
+
+# File named ".tmpl" (not a template)
+dot_tmpl.literal
+```
+
+## Order of Operations
+
+Attributes are processed in a specific order:
+
+1. `literal_` prefix or `.literal` suffix stops all attribute parsing
+2. Encryption suffixes (`.age`, `.asc`) are removed
+3. Prefixes are processed left to right in the allowed order for that target type
+4. The `.tmpl` suffix is processed last
+
+## Related Pages
+
+* [Target Types](/reference/target-types) - How different target types work
+* [Special Files and Directories](/reference/special-files-and-directories) - Special files in source directory
+* `chattr` command - Change attributes of files
+
+
+# Special Files and Directories
+Source: https://twpayne-chezmoi.mintlify.app/reference/special-files-and-directories
+
+Special files and directories in chezmoi's source directory
+
+# Special Files and Directories
+
+All files and directories in the source directory whose name begins with `.` are ignored by default, unless they are one of the special files or directories listed here. All of these files and directories are optional and are evaluated in a specific order.
+
+## Special Files
+
+### Processing Order
+
+Special files are processed in the following order:
+
+1. **`.chezmoiroot`** - Sets the source state path
+2. **`.chezmoi.$FORMAT.tmpl`** - Prepares or updates the chezmoi config file
+3. **`.chezmoidata.$FORMAT`** - Provides data for templates
+4. **`.chezmoitemplates/`** - Makes templates available for use
+5. **`.chezmoiignore`** - Determines files to ignore
+6. **`.chezmoiremove`** - Determines files to remove
+7. **`.chezmoiexternal.$FORMAT`** - Includes external files and archives
+8. **`.chezmoiversion`** - Ensures minimum chezmoi version
+
+## `.chezmoiroot`
+
+The `.chezmoiroot` file is read from the root of the source directory before any other file. It sets the source state path, which affects the location of all other files except `.chezmoiversion`.
+
+### Example
+
+```text title="~/.local/share/chezmoi/.chezmoiroot" theme={null}
+home
+```
+
+This makes chezmoi read the source state from `~/.local/share/chezmoi/home` instead of `~/.local/share/chezmoi`.
+
+## `.chezmoi.$FORMAT.tmpl`
+
+This file is used by [`chezmoi init`](/commands/init) to prepare or update the chezmoi config file. It is also used when a command supports the `--init` flag, such as `chezmoi apply --init`.
+
+The file is processed as a template and the result is written to the config file.
+
+### Example
+
+```toml title="~/.local/share/chezmoi/.chezmoi.toml.tmpl" theme={null}
+{{- $email := promptStringOnce . "email" "Email address" -}}
+{{- $name := promptStringOnce . "name" "Full name" -}}
+
+[data]
+    email = {{ $email | quote }}
+    name = {{ $name | quote }}
+```
+
+## `.chezmoidata.$FORMAT`
+
+Data files are read before any templates are processed, making their contents available to templates via the `.` variable.
+
+Supported formats: `.json`, `.jsonc`, `.toml`, `.yaml`
+
+### Example
+
+```yaml title="~/.local/share/chezmoi/.chezmoidata.yaml" theme={null}
+packages:
+  - vim
+  - git
+  - tmux
+email: user@example.com
+```
+
+Access in templates:
+
+```bash title="dot_gitconfig.tmpl" theme={null}
+[user]
+    email = {{ .email }}
+
+# Install packages: {{ range .packages }}{{ . }} {{ end }}
+```
+
+## `.chezmoidata/`
+
+Directory containing multiple data files. Files are read in lexical order along with any `.chezmoidata.$FORMAT` files in the source state.
+
+All files in this directory are merged into the template data.
+
+### Example
+
+```text theme={null}
+~/.local/share/chezmoi/.chezmoidata/
+├── email.yaml
+├── packages.yaml
+└── secrets.yaml
+```
+
+## `.chezmoiignore`
+
+A template file that lists patterns of files to ignore. Each line of the file is a pattern. Blank lines and lines beginning with `#` are ignored.
+
+Patterns are matched using Go's [`filepath.Match`](https://pkg.go.dev/path/filepath#Match) and support `**` for recursive directory matching.
+
+### Example
+
+```text title="~/.local/share/chezmoi/.chezmoiignore" theme={null}
+# Ignore editor backup files
+*~
+*.swp
+
+# Ignore OS-specific files
+{{ if ne .chezmoi.os "darwin" }}
+.config/darwin/**
+{{ end }}
+
+{{ if ne .chezmoi.os "linux" }}
+.config/linux/**
+{{ end }}
+
+# Ignore work-related files on personal machines
+{{ if not .work }}
+.config/work/**
+{{ end }}
+```
+
+## `.chezmoiremove`
+
+A template file that lists patterns of files to remove from the destination directory. The syntax is the same as `.chezmoiignore`.
+
+### Example
+
+```text title="~/.local/share/chezmoi/.chezmoiremove" theme={null}
+# Remove old config files
+.oldconfig
+.legacy/**
+
+# Remove work files on personal machine
+{{ if not .work }}
+.ssh/work_*
+{{ end }}
+```
+
+## `.chezmoiexternal.$FORMAT`
+
+Defines external files and archives to include as if they were in the source state. This is useful for including large files or entire directories from external sources.
+
+Supported formats: `.json`, `.jsonc`, `.toml`, `.yaml`
+
+### Example
+
+```toml title="~/.local/share/chezmoi/.chezmoiexternal.toml" theme={null}
+[".oh-my-zsh"]
+    type = "archive"
+    url = "https://github.com/ohmyzsh/ohmyzsh/archive/master.tar.gz"
+    stripComponents = 1
+    refreshPeriod = "168h"
+
+[".local/share/nvim/site/autoload/plug.vim"]
+    type = "file"
+    url = "https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim"
+    refreshPeriod = "168h"
+```
+
+### External Entry Types
+
+* **`file`**: Single file download
+* **`archive`**: Archive (tar, tar.gz, tar.bz2, zip) extraction
+* **`git-repo`**: Git repository clone
+
+## `.chezmoiexternals/`
+
+Directory containing multiple external definition files. Files are read in lexical order with any `.chezmoiexternal.$FORMAT` files.
+
+## `.chezmoiscripts/`
+
+Directory containing scripts that are read, templated, and executed according to their phase attributes (`run_after_`, `run_before_`, etc.) and lexical ordering.
+
+This allows you to organize scripts in subdirectories while maintaining control over execution order.
+
+### Example
+
+```text theme={null}
+~/.local/share/chezmoi/.chezmoiscripts/
+├── run_once_install/
+│   ├── 01_packages.sh
+│   └── 02_tools.sh
+└── run_after_configure/
+    └── services.sh
+```
+
+## `.chezmoitemplates/`
+
+Directory containing template files that can be included in other templates using the [`includeTemplate` function](/reference/templates/functions#includetemplate).
+
+### Example
+
+```bash title="~/.local/share/chezmoi/.chezmoitemplates/header" theme={null}
+# Managed by chezmoi
+# DO NOT EDIT MANUALLY
+```
+
+Use in templates:
+
+```bash title="dot_bashrc.tmpl" theme={null}
+{{ template "header" }}
+
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+## `.chezmoiversion`
+
+Specifies the minimum version of chezmoi required for the source state. This file is processed before any operation is applied.
+
+### Example
+
+```text title="~/.local/share/chezmoi/.chezmoiversion" theme={null}
+2.40.0
+```
+
+If the running version of chezmoi is older than the specified version, chezmoi will exit with an error.
+
+## Processing Order Summary
+
+| Order | File/Directory                                   | Purpose                    |
+| ----- | ------------------------------------------------ | -------------------------- |
+| 1     | `.chezmoiroot`                                   | Set source state path      |
+| 2     | `.chezmoi.$FORMAT.tmpl`                          | Initialize/update config   |
+| 3     | `.chezmoidata.$FORMAT`, `.chezmoidata/`          | Load template data         |
+| 4     | `.chezmoitemplates/`                             | Make templates available   |
+| 5     | `.chezmoiignore`                                 | Determine ignored files    |
+| 6     | `.chezmoiremove`                                 | Determine files to remove  |
+| 7     | `.chezmoiexternal.$FORMAT`, `.chezmoiexternals/` | Include external resources |
+| 8     | `.chezmoiversion`                                | Verify chezmoi version     |
+
+## Related Pages
+
+* [Source State Attributes](/reference/source-state-attributes) - File naming conventions
+* [Templates](/reference/templates/overview) - Template syntax
+* [`chezmoi init`](/commands/init) - Initialize chezmoi
+
+
+# Target Types
+Source: https://twpayne-chezmoi.mintlify.app/reference/target-types
+
+Different types of targets chezmoi can manage
+
+# Target Types
+
+chezmoi will create, update, and delete files, directories, and symbolic links in the destination directory, and run scripts. chezmoi deterministically performs actions in ASCII order of their target name.
+
+<Note>
+  Given a file `dot_a`, a script `run_z`, and a directory `exact_dot_c`, chezmoi will first create `.a`, create `.c`, and then execute `run_z`.
+</Note>
+
+## Files
+
+Files are represented by regular files in the source state. The file's attributes control how it is processed and applied to the destination.
+
+### Attributes
+
+* **`encrypted_`**: The file in the source state is encrypted
+* **`executable_`**: Sets the executable bits in the target state
+* **`private_`**: Clears all group and world permissions
+* **`readonly_`**: Clears all write permission bits in the target state
+* **`.tmpl`**: The file is interpreted as a template
+* **`empty_`**: Ensures the file is not removed even if empty
+
+By default, if the target contents are empty, the file will be removed unless it has an `empty_` prefix.
+
+### Example
+
+```bash theme={null}
+# Source: ~/.local/share/chezmoi/dot_bashrc
+# Target: ~/.bashrc
+
+# Source: ~/.local/share/chezmoi/executable_dot_local_bin_myscript
+# Target: ~/.local/bin/myscript (with +x permission)
+
+# Source: ~/.local/share/chezmoi/private_dot_ssh_config
+# Target: ~/.ssh/config (mode 0600)
+```
+
+## Create Files
+
+Files with the `create_` prefix will be created in the target state with the contents of the file in the source state if they do not already exist.
+
+If the file in the destination state already exists, then its contents will be left unchanged. This is useful for files that the user is expected to modify.
+
+### Example
+
+```bash theme={null}
+# Source: ~/.local/share/chezmoi/create_dot_config_app_settings.json
+# Target: ~/.config/app/settings.json
+# Behavior: Created only if it doesn't exist, never overwritten
+```
+
+## Modify Files
+
+Files with the `modify_` prefix are treated as scripts that modify an existing file.
+
+### Template Modification
+
+If the file contains the string `chezmoi:modify-template`, then all lines containing that string will be removed, and the rest of the file will be interpreted as a template. The template is executed with the existing file's contents passed as a string in `.chezmoi.stdin`. The result of the template execution becomes the new contents of the file.
+
+```go title="modify_dot_bashrc.tmpl" theme={null}
+# chezmoi:modify-template
+{{ .chezmoi.stdin }}
+
+# Added by chezmoi
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+### Script Modification
+
+Otherwise, the script receives the current contents of the target file on standard input and must write the new contents to standard output.
+
+If the target file does not exist, the script's standard input will be empty, and the script is responsible for generating the complete file contents.
+
+```bash title="modify_dot_profile" theme={null}
+#!/bin/bash
+# Read existing content
+cat
+
+# Append new content
+echo 'export EDITOR=vim'
+```
+
+## Remove Entries
+
+Files with the `remove_` prefix will cause the corresponding entry (file, directory, or symlink) to be removed in the target state.
+
+### Example
+
+```bash theme={null}
+# Source: ~/.local/share/chezmoi/remove_dot_oldconfig
+# Effect: Removes ~/.oldconfig if it exists
+```
+
+## Directories
+
+Directories are represented by regular directories in the source state.
+
+### Attributes
+
+* **`exact_`**: Causes chezmoi to remove any entries in the target state that are not explicitly specified in the source state
+* **`private_`**: Causes chezmoi to clear all group and world permissions
+* **`readonly_`**: Clears all write permission bits
+* **`external_`**: Ignores attributes in child entries
+
+### Example
+
+```bash theme={null}
+# Normal directory
+~/.local/share/chezmoi/dot_config
+
+# Exact directory (removes unmanaged files)
+~/.local/share/chezmoi/exact_dot_config_app
+
+# Private directory
+~/.local/share/chezmoi/private_dot_ssh
+```
+
+## Symbolic Links
+
+Symbolic links are represented by regular files in the source state with the prefix `symlink_`.
+
+The contents of the file will have a trailing newline stripped, and the result will be interpreted as the target of the symbolic link.
+
+Symbolic links with the `.tmpl` suffix in the source state are interpreted as templates. If the target of the symbolic link is empty or consists only of whitespace, then the target is removed.
+
+### Example
+
+```bash title="~/.local/share/chezmoi/symlink_dot_vimrc" theme={null}
+.config/nvim/init.vim
+```
+
+```bash title="~/.local/share/chezmoi/symlink_dot_config_nvim.tmpl" theme={null}
+{{ if eq .chezmoi.os "darwin" }}
+/Applications/Neovim.app/Contents/Resources/nvim
+{{ else }}
+/usr/share/nvim
+{{ end }}
+```
+
+## Scripts
+
+Scripts are represented as regular files in the source state with prefix `run_`. The file's contents (after being interpreted as a template if it has a `.tmpl` suffix) are executed.
+
+### Execution Timing
+
+* **No timing attribute**: Executed in ASCII order with respect to files, directories, and symlinks
+* **`before_`**: Executed before any files, directories, or symlinks are updated
+* **`after_`**: Executed after all files, directories, and symlinks have been updated
+
+### Execution Frequency
+
+* **No frequency attribute**: Executed on every `chezmoi apply`
+* **`once_`**: Executed only if a script with the same contents has not been run successfully before
+* **`onchange_`**: Executed whenever the script contents change
+
+### Examples
+
+```bash title="run_once_install-packages.sh" theme={null}
+#!/bin/bash
+# This runs only once
+apt-get update
+apt-get install -y vim git
+```
+
+```bash title="run_onchange_update-brewfile.sh.tmpl" theme={null}
+#!/bin/bash
+# chezmoi:template:left-delimiter="#{{" right-delimiter="}}#"
+# This runs whenever the Brewfile hash changes
+#{{ range .packages }}#
+brew install #{{ . }}#
+#{{ end }}#
+```
+
+```bash title="run_before_backup.sh" theme={null}
+#!/bin/bash
+# Runs before any changes are applied
+cp -r ~/.config ~/.config.backup
+```
+
+```bash title="run_after_update-completion.sh" theme={null}
+#!/bin/bash  
+# Runs after all changes are applied
+source ~/.bashrc
+```
+
+### Working Directory
+
+Scripts will normally run with their working directory set to their equivalent location in the destination directory. If the equivalent location in the destination directory either does not exist or is not a directory, then chezmoi will walk up the script's directory hierarchy and run the script in the first directory that exists and is a directory.
+
+<Note>
+  A script in `~/.local/share/chezmoi/dir/run_script` will be run with a working directory of `~/dir`.
+</Note>
+
+### Environment Variables
+
+chezmoi sets a number of `CHEZMOI*` environment variables when running scripts, corresponding to commonly-used template data variables. Extra environment variables can be set in the `env` or `scriptEnv` configuration variables.
+
+### Interpreters
+
+Scripts are executed using an interpreter, if configured. See the [interpreters documentation](/reference/configuration-file#interpreters) for more details.
+
+## Symlink Mode
+
+By default, chezmoi will create regular files and directories. Setting `mode = "symlink"` in the configuration file will make chezmoi behave more like a dotfile manager that uses symlinks by default.
+
+In symlink mode, `chezmoi apply` will make dotfiles symlinks to files in the source directory if the target is a regular file and is not encrypted, executable, private, or a template.
+
+### Example Configuration
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+mode = "symlink"
+```
+
+## Application Order
+
+chezmoi applies changes in a deterministic order:
+
+1. Read source state
+2. Read destination state
+3. Compute target state
+4. Run `run_before_` scripts in alphabetical order
+5. Update entries in alphabetical order of their target name (directories before their contents)
+6. Run `run_after_` scripts in alphabetical order
+
+See [Application Order](/reference/application-order) for more details.
+
+## Related Pages
+
+* [Source State Attributes](/reference/source-state-attributes) - File naming conventions
+* [Application Order](/reference/application-order) - Order of operations
+* [Templates](/reference/templates/overview) - Template syntax and features
+
+
+# Template Directives
+Source: https://twpayne-chezmoi.mintlify.app/reference/templates/directives
+
+File-specific template options using directives
+
+# Template Directives
+
+File-specific template options can be set using template directives. Directives are special comments in templates that configure how the template is processed.
+
+## Directive Syntax
+
+Directives use the format:
+
+```text theme={null}
+chezmoi:template:$KEY=$VALUE
+```
+
+Where `$KEY` is the option name and `$VALUE` is its value. `$VALUE` must be quoted if it contains spaces or double quotes.
+
+### Multiple Directives
+
+Multiple key/value pairs may be specified on a single line:
+
+```text theme={null}
+chezmoi:template:left-delimiter="[[" right-delimiter="]]"
+```
+
+If multiple directives are present in a file, later directives override earlier ones.
+
+### Removing Directives
+
+Lines containing template directives are **automatically removed** to avoid parse errors from any delimiters. This means directives don't appear in the final output.
+
+## Delimiters
+
+By default, chezmoi uses the standard `text/template` delimiters `{{` and `}}`. These can be changed per-file using the delimiter directive.
+
+### Syntax
+
+```text theme={null}
+chezmoi:template:left-delimiter=$LEFT right-delimiter=$RIGHT
+```
+
+Either or both of `left-delimiter=$LEFT` and `right-delimiter=$RIGHT` may be omitted. If either `$LEFT` or `$RIGHT` is empty, the default delimiter (`{{` and `}}` respectively) is used instead.
+
+<Note>
+  Delimiters are specific to the file in which they appear and are not inherited by templates called from the file.
+</Note>
+
+### Examples
+
+#### Shell Script with Custom Delimiters
+
+```bash title="script.sh.tmpl" theme={null}
+#!/bin/bash
+# chezmoi:template:left-delimiter="# [[" right-delimiter="]]"
+
+echo "Hello, # [[ .chezmoi.username ]]!"
+
+# [[ if eq .chezmoi.os "darwin" ]]
+echo "Running on macOS"
+# [[ else ]]
+echo "Running on # [[ .chezmoi.os ]]"
+# [[ end ]]
+```
+
+#### Docker Compose with Alternative Delimiters
+
+```yaml title="docker-compose.yml.tmpl" theme={null}
+# chezmoi:template:left-delimiter="<%" right-delimiter="%>"
+version: '3'
+services:
+  app:
+    image: myapp:<% .version %>
+    environment:
+      - USER=<% .chezmoi.username %>
+```
+
+#### Only Change Left Delimiter
+
+```text theme={null}
+chezmoi:template:left-delimiter="<<<"
+# Uses <<< and }}
+<<< .variable }}}
+```
+
+## Encoding
+
+Templates are always written in UTF-8 with no byte order mark. The output encoding can be transformed using the encoding directive.
+
+### Syntax
+
+```text theme={null}
+chezmoi:template:encoding=$ENCODING
+```
+
+### Supported Encodings
+
+| Encoding        | Description                                  |
+| --------------- | -------------------------------------------- |
+| `utf-8`         | UTF-8 with no byte order mark (default)      |
+| `utf-8-bom`     | UTF-8 with a byte order mark                 |
+| `utf-16-be`     | Big-endian UTF-16 with no byte order mark    |
+| `utf-16-be-bom` | Big-endian UTF-16 with a byte order mark     |
+| `utf-16-le`     | Little-endian UTF-16 with no byte order mark |
+| `utf-16-le-bom` | Little-endian UTF-16 with a byte order mark  |
+
+### Examples
+
+#### UTF-16 Little-Endian Output
+
+```text title="config.ini.tmpl" theme={null}
+{{/* chezmoi:template:encoding=utf-16-le */}}
+[settings]
+value={{ .setting }}
+```
+
+#### UTF-8 with BOM
+
+```text title="file.txt.tmpl" theme={null}
+{{/* chezmoi:template:encoding=utf-8-bom */}}
+Content goes here
+```
+
+## Format Indent
+
+By default, chezmoi's `toJson`, `toToml`, and `toYaml` template functions use an indent of two spaces. This can be overridden per-file.
+
+### Syntax
+
+#### Literal String Indent
+
+```text theme={null}
+chezmoi:template:format-indent=$STRING
+```
+
+Sets the indent to the literal `$STRING`.
+
+#### Width-Based Indent
+
+```text theme={null}
+chezmoi:template:format-indent-width=$WIDTH
+```
+
+Sets the indent to `$WIDTH` spaces.
+
+### Examples
+
+#### Tab Indentation
+
+```text title="config.json.tmpl" theme={null}
+{{/* chezmoi:template:format-indent="\t" */}}
+{{ dict "key" "value" "nested" (dict "a" "b") | toJson }}
+```
+
+Output:
+
+```json theme={null}
+{
+	"key": "value",
+	"nested": {
+		"a": "b"
+	}
+}
+```
+
+#### Four-Space Indentation
+
+```text title="config.yaml.tmpl" theme={null}
+{{/* chezmoi:template:format-indent-width=4 */}}
+{{ dict "key" "value" "list" (list 1 2 3) | toYaml }}
+```
+
+Output:
+
+```yaml theme={null}
+key: value
+list:
+    - 1
+    - 2
+    - 3
+```
+
+## Line Endings
+
+Many template functions use UNIX-style line endings (`lf`/`\n`), which may cause unexpected output on Windows or when running `chezmoi diff` on `modify_` templates. Line endings can be overridden with a directive.
+
+### Syntax
+
+```text theme={null}
+chezmoi:template:line-endings=$VALUE
+```
+
+### Values
+
+| Value         | Effect                                                               |
+| ------------- | -------------------------------------------------------------------- |
+| `lf`          | Use UNIX-style line endings (`\n`)                                   |
+| `crlf`        | Use Windows line endings (`\r\n`)                                    |
+| `native`      | Use platform-native line endings (`crlf` on Windows, `lf` elsewhere) |
+| Custom string | Use the literal string as line ending                                |
+
+### Examples
+
+#### Windows Line Endings
+
+```bash title="script.bat.tmpl" theme={null}
+REM chezmoi:template:line-endings=crlf
+@echo off
+echo {{ .message }}
+```
+
+#### Platform-Native Line Endings
+
+```text title="file.txt.tmpl" theme={null}
+{{/* chezmoi:template:line-endings=native */}}
+Line 1
+Line 2
+```
+
+#### Force LF on Windows
+
+```bash title="script.sh.tmpl" theme={null}
+# chezmoi:template:line-endings=lf
+#!/bin/bash
+echo "{{ .message }}"
+```
+
+## Missing Keys
+
+By default, chezmoi returns an error if a template indexes a map with a key that is not present. This behavior can be changed globally with the `template.options` configuration variable or per-file with a directive.
+
+### Syntax
+
+```text theme={null}
+chezmoi:template:missing-key=$VALUE
+```
+
+### Values
+
+| Value     | Effect                                                        |
+| --------- | ------------------------------------------------------------- |
+| `error`   | Return an error on any missing key (default)                  |
+| `invalid` | Ignore missing keys. If printed, the result is `<no value>`   |
+| `zero`    | Ignore missing keys. If printed, the result is the zero value |
+
+### Examples
+
+#### Ignore Missing Keys with Zero Values
+
+```text title="config.tmpl" theme={null}
+{{/* chezmoi:template:missing-key=zero */}}
+username={{ .username }}
+email={{ .email }}
+optional={{ .optional_field }}
+```
+
+If `.optional_field` doesn't exist, it outputs an empty string instead of erroring.
+
+#### Show "no value" for Missing Keys
+
+```text title="debug.tmpl" theme={null}
+{{/* chezmoi:template:missing-key=invalid */}}
+Debug info:
+- required: {{ .required }}
+- optional: {{ .optional }}
+```
+
+Output if `.optional` is missing:
+
+```text theme={null}
+Debug info:
+- required: value
+- optional: <no value>
+```
+
+## Combining Directives
+
+Multiple directives can be used in the same file:
+
+```powershell title="script.ps1.tmpl" theme={null}
+# chezmoi:template:left-delimiter="<%" right-delimiter="%>" line-endings=crlf encoding=utf-8-bom
+
+Write-Host "Hello, <% .chezmoi.username %>!"
+
+<% if eq .chezmoi.os "windows" %>
+Write-Host "Running on Windows"
+<% end %>
+```
+
+## Directive Placement
+
+Directives can appear anywhere in the file but should typically be placed:
+
+1. **At the top** of the file for visibility
+2. **Inside comments** appropriate for the file type
+3. **Before** the content they affect
+
+### Examples
+
+```bash title="Shell Script" theme={null}
+#!/bin/bash
+# chezmoi:template:left-delimiter="[[" right-delimiter="]]"
+```
+
+```go title="Go Template Comment" theme={null}
+{{/* chezmoi:template:missing-key=zero */}}
+```
+
+```yaml title="YAML Comment" theme={null}
+# chezmoi:template:format-indent-width=4
+```
+
+```html title="HTML Comment" theme={null}
+<!-- chezmoi:template:encoding=utf-8-bom -->
+```
+
+## Practical Examples
+
+### PowerShell Script
+
+```powershell title="dot_profile.ps1.tmpl" theme={null}
+# chezmoi:template:line-endings=crlf
+# chezmoi:template:left-delimiter="<%" right-delimiter="%>"
+
+$env:PATH += ";$HOME\\bin"
+
+<% if .work %>
+# Work configuration
+$env:COMPANY_HOME = "<% .company_path %>"
+<% end %>
+
+Write-Host "Welcome, <% .chezmoi.username %>!"
+```
+
+### JSON Configuration with Tabs
+
+```json title="dot_config_app_settings.json.tmpl" theme={null}
+{{/* chezmoi:template:format-indent="\t" */}}
+{{
+	dict 
+		"theme" .theme
+		"fontSize" .font_size
+		"plugins" .plugins
+	| toJson
+}}
+```
+
+### Windows Batch File
+
+```bat title="setup.bat.tmpl" theme={null}
+REM chezmoi:template:line-endings=crlf encoding=utf-8-bom
+@echo off
+set USERNAME={{ .chezmoi.username }}
+set INSTALL_DIR={{ .install_dir }}
+echo Installing for %USERNAME%...
+```
+
+### Modify Template with Matching Line Endings
+
+```bash title="modify_dot_bashrc.tmpl" theme={null}
+# chezmoi:template:line-endings=native
+# chezmoi:modify-template
+{{ .chezmoi.stdin }}
+
+# Added by chezmoi
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+## Global vs. File-Specific Options
+
+### Global Configuration
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[template]
+    options = ["missingkey=zero"]
+```
+
+Applies to all templates.
+
+### File-Specific Override
+
+```text title="specific-file.tmpl" theme={null}
+{{/* chezmoi:template:missing-key=error */}}
+```
+
+Overrides the global setting for this file only.
+
+## Debugging Directives
+
+Test directive behavior:
+
+```bash theme={null}
+# Execute template with directives
+chezmoi cat ~/.bashrc
+
+# View the rendered template
+chezmoi execute-template < template.tmpl
+
+# Compare source and target
+chezmoi diff
+```
+
+## Related Pages
+
+* [Template Overview](/reference/templates/overview) - Template system basics
+* [Template Functions](/reference/templates/functions) - Available functions
+* [Template Variables](/reference/templates/variables) - Built-in variables
+* [Configuration File](/reference/configuration-file) - Global template options
+
+
+# Template Functions
+Source: https://twpayne-chezmoi.mintlify.app/reference/templates/functions
+
+Complete reference of all template functions available in chezmoi
+
+# Template Functions
+
+All standard [`text/template`](https://pkg.go.dev/text/template) and [text template functions from Sprig](http://masterminds.github.io/sprig/) are included. chezmoi provides many additional functions.
+
+## General Functions
+
+### `abortEmpty`
+
+Returns empty, causing the target file to be removed. Useful for conditionally creating files.
+
+```go theme={null}
+{{ if .condition }}
+file content
+{{ else }}
+{{ abortEmpty }}
+{{ end }}
+```
+
+### `comment` *prefix* *string*
+
+Adds *prefix* to the beginning of each line in *string*.
+
+```go theme={null}
+{{ "Line 1\nLine 2" | comment "# " }}
+# Line 1
+# Line 2
+```
+
+### `completion` *shell*
+
+Returns shell completion script for the specified shell (`bash`, `fish`, `powershell`, `zsh`).
+
+```bash theme={null}
+{{ completion "bash" }}
+```
+
+### `decrypt` *ciphertext*
+
+Decrypts *ciphertext* using the configured encryption method.
+
+```go theme={null}
+{{ decrypt "encrypted-data" }}
+```
+
+### `encrypt` *plaintext*
+
+Encrypts *plaintext* using the configured encryption method.
+
+```go theme={null}
+{{ "secret" | encrypt }}
+```
+
+### `ensureLinePrefix` *prefix* \[*addPrefix*] *string*
+
+Ensures each line in *string* has *prefix*. If *addPrefix* is specified, it's added to lines missing *prefix*.
+
+```go theme={null}
+{{ "line1\n# line2" | ensureLinePrefix "# " }}
+# line1
+# line2
+```
+
+### `eqFold` *first* *second* \[*more*...]
+
+Case-insensitive equality comparison.
+
+```go theme={null}
+{{ if eqFold .chezmoi.os "LINUX" }}Linux detected{{ end }}
+```
+
+### `exec` *command* \[*args*...]
+
+Executes *command* with *args* and returns true if successful, false otherwise.
+
+```go theme={null}
+{{ if exec "which" "docker" }}
+Docker is installed
+{{ end }}
+```
+
+## File Functions
+
+### `include` *filename*
+
+Returns the literal contents of *filename*. Relative paths are interpreted relative to the source directory.
+
+```go theme={null}
+{{ include "scripts/setup.sh" }}
+```
+
+### `includeTemplate` *filename* \[*data*]
+
+Executes the template in *filename* with optional *data* and returns the result.
+
+```go theme={null}
+{{ includeTemplate "config.tmpl" . }}
+{{ includeTemplate "header.tmpl" }}
+```
+
+### `stat` *name*
+
+Returns file information for *name* (name, size, mode, perm, modTime, isDir, type). Returns false if file doesn't exist.
+
+```go theme={null}
+{{ if stat "/path/to/file" }}
+File exists
+{{ end }}
+
+{{ $info := stat "/path/to/file" }}
+{{ $info.size }}
+```
+
+### `lstat` *name*
+
+Like `stat`, but doesn't follow symbolic links.
+
+```go theme={null}
+{{ $info := lstat "/path/to/symlink" }}
+{{ $info.type }}
+```
+
+### `glob` *pattern*
+
+Returns list of files matching *pattern* in the destination directory.
+
+```go theme={null}
+{{ range glob "*.conf" }}
+Found: {{ . }}
+{{ end }}
+```
+
+## Execution Functions
+
+### `output` *command* \[*args*...]
+
+Returns the output of executing *command* with *args*. Exits with error if command fails.
+
+```go theme={null}
+current-context: {{ output "kubectl" "config" "current-context" | trim }}
+```
+
+### `outputList` *command* *argsList*
+
+Like `output`, but takes arguments as a list.
+
+```go theme={null}
+{{ $args := list "config" "current-context" }}
+{{ outputList "kubectl" $args }}
+```
+
+### `lookPath` *file*
+
+Returns the full path to *file* if found in PATH, empty string otherwise.
+
+```go theme={null}
+{{ if lookPath "docker" }}
+Docker path: {{ lookPath "docker" }}
+{{ end }}
+```
+
+### `findExecutable` *file* *pathList*
+
+Finds *file* in *pathList* and returns the full path.
+
+```go theme={null}
+{{ findExecutable "python" (list "/usr/bin" "/usr/local/bin") }}
+```
+
+### `findOneExecutable` *fileList* *pathList*
+
+Finds the first executable from *fileList* in *pathList*.
+
+```go theme={null}
+{{ findOneExecutable (list "python3" "python") (splitList ":" (env "PATH")) }}
+```
+
+### `isExecutable` *file*
+
+Returns true if *file* has executable permissions.
+
+```go theme={null}
+{{ if isExecutable "/usr/bin/bash" }}Executable{{ end }}
+```
+
+## Path Functions
+
+### `joinPath` *elements*...
+
+Joins path elements using the OS-specific path separator.
+
+```go theme={null}
+{{ joinPath .chezmoi.homeDir ".config" "app" }}
+```
+
+## Data Conversion Functions
+
+### `fromJson` *string*
+
+Parses *string* as JSON and returns the result.
+
+```go theme={null}
+{{ $data := fromJson .jsonString }}
+{{ $data.key }}
+```
+
+### `fromJsonc` *string*
+
+Parses *string* as JSONC (JSON with comments).
+
+```go theme={null}
+{{ $data := fromJsonc .jsoncString }}
+```
+
+### `fromToml` *string*
+
+Parses *string* as TOML.
+
+```go theme={null}
+{{ $data := fromToml .tomlString }}
+```
+
+### `fromYaml` *string*
+
+Parses *string* as YAML.
+
+```go theme={null}
+{{ $data := fromYaml .yamlString }}
+```
+
+### `fromIni` *string*
+
+Parses *string* as INI format.
+
+```go theme={null}
+{{ $data := fromIni .iniString }}
+```
+
+### `toJson` *data*
+
+Converts *data* to JSON format.
+
+```go theme={null}
+{{ dict "key" "value" | toJson }}
+```
+
+### `toPrettyJson` \[*indent*] *data*
+
+Converts *data* to pretty-printed JSON.
+
+```go theme={null}
+{{ dict "key" "value" | toPrettyJson }}
+{{ dict "key" "value" | toPrettyJson "    " }}
+```
+
+### `toToml` *data*
+
+Converts *data* to TOML format.
+
+```go theme={null}
+{{ dict "key" "value" | toToml }}
+```
+
+### `toYaml` *data*
+
+Converts *data* to YAML format.
+
+```go theme={null}
+{{ dict "key" "value" | toYaml }}
+```
+
+### `toIni` *data*
+
+Converts *data* to INI format.
+
+```go theme={null}
+{{ dict "section" (dict "key" "value") | toIni }}
+```
+
+## String Functions
+
+### `hexDecode` *string*
+
+Decodes hexadecimal *string* to bytes.
+
+```go theme={null}
+{{ hexDecode "48656c6c6f" }}
+```
+
+### `hexEncode` *string*
+
+Encodes *string* to hexadecimal.
+
+```go theme={null}
+{{ "Hello" | hexEncode }}
+```
+
+### `quote` *values*...
+
+Double-quotes each value and joins with spaces.
+
+```go theme={null}
+{{ quote "arg1" "arg2" }}
+# "arg1" "arg2"
+```
+
+### `squote` *values*...
+
+Single-quotes each value and joins with spaces.
+
+```go theme={null}
+{{ squote "arg1" "arg2" }}
+# 'arg1' 'arg2'
+```
+
+### `quoteList` *list*
+
+Double-quotes each element in *list*.
+
+```go theme={null}
+{{ list "a" "b" | quoteList }}
+```
+
+### `replaceAllRegex` *pattern* *replacement* *string*
+
+Replaces all matches of regex *pattern* with *replacement* in *string*.
+
+```go theme={null}
+{{ replaceAllRegex "[0-9]+" "X" "abc123def456" }}
+# abcXdefX
+```
+
+### `splitList` *separator* *string*
+
+Splits *string* by *separator* and returns a list.
+
+```go theme={null}
+{{ splitList "," "a,b,c" }}
+```
+
+### `toString` *value*
+
+Converts *value* to a string.
+
+```go theme={null}
+{{ 123 | toString }}
+```
+
+### `toStrings` *values*...
+
+Converts multiple values to strings.
+
+```go theme={null}
+{{ toStrings 1 2 3 }}
+```
+
+## Data Manipulation Functions
+
+### `deleteValueAtPath` *path* *dict*
+
+Deletes the value at *path* in *dict*.
+
+```go theme={null}
+{{ $data := dict "a" (dict "b" "c") }}
+{{ deleteValueAtPath "a.b" $data }}
+```
+
+### `setValueAtPath` *path* *value* *dict*
+
+Sets *value* at *path* in *dict*.
+
+```go theme={null}
+{{ $data := dict }}
+{{ setValueAtPath "a.b.c" "value" $data }}
+```
+
+### `pruneEmptyDicts` *dict*
+
+Removes all empty dictionaries from *dict*.
+
+```go theme={null}
+{{ dict "empty" (dict) "full" (dict "key" "value") | pruneEmptyDicts }}
+```
+
+### `jq` *query* *input*
+
+Executes jq *query* on *input* and returns results.
+
+```go theme={null}
+{{ $data := dict "items" (list 1 2 3) }}
+{{ jq ".items[] | . * 2" $data }}
+```
+
+## Special Functions
+
+### `mozillaInstallHash` *path*
+
+Returns Mozilla installation hash for *path*.
+
+```go theme={null}
+{{ mozillaInstallHash "/usr/lib/firefox" }}
+```
+
+### `ioreg`
+
+Returns macOS IORegistry information (macOS only).
+
+```go theme={null}
+{{ if eq .chezmoi.os "darwin" }}
+{{ $ioreg := ioreg }}
+{{ end }}
+```
+
+### `warnf` *format* *args*...
+
+Prints a warning message. Returns empty string.
+
+```go theme={null}
+{{ if not (stat "/path/to/file") }}
+{{ warnf "File %s does not exist" "/path/to/file" }}
+{{ end }}
+```
+
+### `getRedirectedURL` *url*
+
+Follows redirects and returns the final URL.
+
+```go theme={null}
+{{ getRedirectedURL "https://short.url" }}
+```
+
+## GitHub Functions
+
+These functions integrate with GitHub's API:
+
+* `gitHubKeys` *user* - Returns user's public SSH keys
+* `gitHubLatestRelease` *repo* - Returns latest release info
+* `gitHubLatestReleaseAssetURL` *repo* *pattern* - Returns asset download URL
+* `gitHubLatestTag` *repo* - Returns latest tag name
+* `gitHubRelease` *repo* *tag* - Returns release info for tag
+* `gitHubReleaseAssetURL` *repo* *tag* *pattern* - Returns asset URL for release
+* `gitHubReleases` *repo* - Returns all releases
+* `gitHubTags` *repo* - Returns all tags
+
+### Example
+
+```go theme={null}
+{{ $release := gitHubLatestRelease "twpayne/chezmoi" }}
+Version: {{ $release.tag_name }}
+
+{{ range gitHubKeys "username" }}
+ssh-key: {{ . }}
+{{ end }}
+```
+
+## Password Manager Functions
+
+See [Password Manager Functions](/reference/templates/password-manager-functions) for:
+
+* 1Password (`onepassword`, `onepasswordDocument`, etc.)
+* Bitwarden (`bitwarden`, `bitwardenFields`, etc.)
+* LastPass (`lastpass`, `lastpassRaw`)
+* Pass (`pass`, `passFields`, `passRaw`)
+* Keeper (`keeper`, `keeperDataFields`)
+* KeePassXC (`keepassxc`, `keepassxcAttribute`)
+* And many more
+
+## Related Pages
+
+* [Template Variables](/reference/templates/variables) - Built-in template variables
+* [Template Directives](/reference/templates/directives) - File-specific template options
+* [Password Manager Functions](/reference/templates/password-manager-functions) - Secret management functions
+* [Sprig Functions](http://masterminds.github.io/sprig/) - Additional functions from Sprig
+
+
+# Templates Overview
+Source: https://twpayne-chezmoi.mintlify.app/reference/templates/overview
+
+Overview of chezmoi's template system
+
+# Templates Overview
+
+chezmoi executes templates using Go's [`text/template`](https://pkg.go.dev/text/template) package. Templates allow you to create dynamic configuration files that adapt to different machines, operating systems, and environments.
+
+## Basic Concepts
+
+Templates are files with a `.tmpl` suffix in the source state. chezmoi processes these files and outputs the result to the destination.
+
+### Example
+
+```bash title="~/.local/share/chezmoi/dot_gitconfig.tmpl" theme={null}
+[user]
+    name = {{ .name }}
+    email = {{ .email }}
+{{ if eq .chezmoi.os "darwin" }}
+[credential]
+    helper = osxkeychain
+{{ end }}
+```
+
+## Template Execution
+
+The result of template execution is treated differently depending on the target type:
+
+### For Files
+
+* If the result is an **empty string**, the file is removed
+* Otherwise, the target file contents are the result
+
+### For Symlinks
+
+* Leading and trailing whitespace are stripped from the result
+* If the result is an **empty string**, the symlink is removed
+* Otherwise, the target symlink target is the result
+
+## Template Options
+
+chezmoi executes templates using `text/template`'s `missingkey=error` option by default, which means that misspelled or missing keys will raise an error.
+
+This can be overridden by setting options in the configuration file:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[template]
+    options = ["missingkey=zero"]
+```
+
+Available options:
+
+* `missingkey=default` - Use the default behavior
+* `missingkey=error` - Return an error on missing keys (default)
+* `missingkey=zero` - Use the zero value for missing keys
+* `missingkey=invalid` - Print `<no value>` for missing keys
+
+For a full list of template options, see [`Template.Option`](https://pkg.go.dev/text/template#Template.Option).
+
+## Template Syntax
+
+### Basic Substitution
+
+```go theme={null}
+{{ .variable }}          # Output a variable
+{{ .chezmoi.os }}        # Access nested values
+{{ .email | quote }}     # Use functions
+```
+
+### Comments
+
+```go theme={null}
+{{/* This is a comment */}}
+{{- /* Comments can trim whitespace */ -}}
+```
+
+### Whitespace Control
+
+```go theme={null}
+{{- .value }}    # Trim whitespace before
+{{ .value -}}    # Trim whitespace after
+{{- .value -}}   # Trim both sides
+```
+
+### Conditionals
+
+```go theme={null}
+{{ if .condition }}
+    # Rendered if condition is true
+{{ end }}
+
+{{ if .condition }}
+    # True branch
+{{ else }}
+    # False branch
+{{ end }}
+
+{{ if .condition1 }}
+    # Branch 1
+{{ else if .condition2 }}
+    # Branch 2
+{{ else }}
+    # Default branch
+{{ end }}
+```
+
+### Loops
+
+```go theme={null}
+{{ range .items }}
+    Item: {{ . }}
+{{ end }}
+
+{{ range $index, $value := .items }}
+    {{ $index }}: {{ $value }}
+{{ end }}
+
+{{ range $key, $value := .dict }}
+    {{ $key }} = {{ $value }}
+{{ end }}
+```
+
+### Variables
+
+```go theme={null}
+{{ $var := .value }}
+{{ $var }}
+
+{{ $name := "John" }}
+{{ $email := .email }}
+```
+
+### Comparison Operators
+
+```go theme={null}
+{{ if eq .chezmoi.os "darwin" }}Mac{{ end }}
+{{ if ne .value "test" }}Not test{{ end }}
+{{ if lt .count 10 }}Less than 10{{ end }}
+{{ if le .count 10 }}10 or less{{ end }}
+{{ if gt .count 5 }}Greater than 5{{ end }}
+{{ if ge .count 5 }}5 or more{{ end }}
+```
+
+### Boolean Operators
+
+```go theme={null}
+{{ if and .condition1 .condition2 }}Both true{{ end }}
+{{ if or .condition1 .condition2 }}At least one true{{ end }}
+{{ if not .condition }}Negated{{ end }}
+```
+
+## Template Functions
+
+chezmoi provides all standard `text/template` functions, all [Sprig functions](http://masterminds.github.io/sprig/), and many additional functions.
+
+See [Template Functions](/reference/templates/functions) for a complete list.
+
+### Common Functions
+
+```go theme={null}
+{{ .value | quote }}                    # Quote a string
+{{ .value | upper }}                    # Convert to uppercase
+{{ .value | lower }}                    # Convert to lowercase
+{{ .dict | toYaml }}                    # Convert to YAML
+{{ .dict | toJson }}                    # Convert to JSON
+{{ include "file.txt" }}                # Include file contents
+{{ includeTemplate "template.tmpl" . }} # Include and execute template
+```
+
+## Template Variables
+
+chezmoi provides automatically-populated variables accessible via `.chezmoi`:
+
+```go theme={null}
+{{ .chezmoi.os }}           # Operating system (linux, darwin, etc.)
+{{ .chezmoi.arch }}         # Architecture (amd64, arm64, etc.)
+{{ .chezmoi.hostname }}     # Hostname
+{{ .chezmoi.username }}     # Username
+{{ .chezmoi.homeDir }}      # Home directory
+{{ .chezmoi.sourceDir }}    # Source directory
+{{ .chezmoi.config }}       # Configuration data
+```
+
+See [Template Variables](/reference/templates/variables) for a complete list.
+
+## Template Directives
+
+File-specific template options can be set using directives:
+
+```go theme={null}
+chezmoi:template:$KEY=$VALUE
+```
+
+### Custom Delimiters
+
+```bash title="script.sh.tmpl" theme={null}
+#!/bin/bash
+# chezmoi:template:left-delimiter="# [[" right-delimiter="]]"
+
+# [[ .variable ]]
+```
+
+### Line Endings
+
+```go theme={null}
+{{/* chezmoi:template:line-endings=crlf */}}
+```
+
+### Encoding
+
+```go theme={null}
+{{/* chezmoi:template:encoding=utf-16-le */}}
+```
+
+See [Template Directives](/reference/templates/directives) for all available directives.
+
+## Practical Examples
+
+### OS-Specific Configuration
+
+```bash title="dot_bashrc.tmpl" theme={null}
+# Common configuration
+export EDITOR=vim
+
+{{ if eq .chezmoi.os "darwin" }}
+# macOS-specific
+export PATH="/usr/local/bin:$PATH"
+alias ls="ls -G"
+{{ else if eq .chezmoi.os "linux" }}
+# Linux-specific
+export PATH="/usr/bin:$PATH"
+alias ls="ls --color=auto"
+{{ end }}
+```
+
+### Machine-Specific Configuration
+
+```toml title="dot_config_app_config.toml.tmpl" theme={null}
+{{ if eq .chezmoi.hostname "workstation" }}
+theme = "dark"
+font_size = 14
+{{ else }}
+theme = "light" 
+font_size = 12
+{{ end }}
+```
+
+### Using Custom Data
+
+```yaml title=".chezmoidata.yaml" theme={null}
+packages:
+  - vim
+  - git
+  - tmux
+```
+
+```bash title="run_once_install-packages.sh.tmpl" theme={null}
+#!/bin/bash
+{{ range .packages }}
+apt-get install -y {{ . }}
+{{ end }}
+```
+
+### Using Secrets
+
+```ini title="dot_config_app_credentials.ini.tmpl" theme={null}
+[api]
+key = {{ onepassword "API Key" }}
+secret = {{ onepassword "API Secret" }}
+
+[database]
+password = {{ bitwarden "item-id" }}
+```
+
+## Error Handling
+
+Templates will stop execution if an error occurs:
+
+```go theme={null}
+# This will error if .missing doesn't exist (with default missingkey=error)
+{{ .missing }}
+
+# Use default to provide a fallback
+{{ .missing | default "default-value" }}
+
+# Check if a key exists
+{{ if hasKey . "missing" }}
+    {{ .missing }}
+{{ else }}
+    default-value
+{{ end }}
+```
+
+## Testing Templates
+
+Use `chezmoi execute-template` to test template expressions:
+
+```bash theme={null}
+# Test a simple expression
+chezmoi execute-template '{{ .chezmoi.os }}'
+
+# Test with file
+echo '{{ .chezmoi.hostname }}' | chezmoi execute-template
+
+# Test complex template
+chezmoi execute-template < template.tmpl
+```
+
+## Performance Tips
+
+1. **Cache expensive operations**: Store results in variables
+2. **Avoid repeated function calls**: Call once and store
+3. **Use includes wisely**: Don't include large files multiple times
+4. **Minimize external calls**: Group `output` calls when possible
+
+```go theme={null}
+{{/* GOOD: Call once */}}
+{{ $os := .chezmoi.os }}
+{{ if eq $os "darwin" }}...{{ end }}
+{{ if eq $os "linux" }}...{{ end }}
+
+{{/* BAD: Multiple calls */}}
+{{ if eq .chezmoi.os "darwin" }}...{{ end }}
+{{ if eq .chezmoi.os "linux" }}...{{ end }}
+```
+
+## Related Pages
+
+* [Template Functions](/reference/templates/functions) - All available functions
+* [Template Variables](/reference/templates/variables) - Built-in variables
+* [Template Directives](/reference/templates/directives) - File-specific options
+* [Password Manager Functions](/reference/templates/password-manager-functions) - Secret management
+
+
+# Password Manager Functions
+Source: https://twpayne-chezmoi.mintlify.app/reference/templates/password-manager-functions
+
+Template functions for integrating with password managers
+
+# Password Manager Functions
+
+chezmoi provides template functions to securely integrate with popular password managers. These functions allow you to retrieve secrets, credentials, and other sensitive data from your password manager without storing them in your dotfiles.
+
+## General Concepts
+
+### Caching
+
+Most password manager functions cache their results during template execution, so calling the same function multiple times with the same arguments will only invoke the password manager CLI once.
+
+### Authentication
+
+Password managers typically require authentication before accessing secrets. chezmoi will:
+
+1. Use existing authenticated sessions when available
+2. Prompt for authentication interactively when needed
+3. Pass through environment variables for non-interactive authentication
+
+### Configuration
+
+Each password manager can be configured in the chezmoi config file:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[onepassword]
+    command = "op"
+    prompt = true
+
+[bitwarden]
+    command = "bw"
+
+[lastpass]
+    command = "lpass"
+```
+
+## 1Password
+
+Integrate with [1Password](https://1password.com/) using the [1Password CLI](https://developer.1password.com/docs/cli/).
+
+### `onepassword` *uuid* \[*vault*] \[*account*]
+
+Returns structured data from 1Password.
+
+```go theme={null}
+{{ $item := onepassword "item-uuid" }}
+password: {{ $item.fields.password.value }}
+
+{{ $item := onepassword "item-uuid" "vault-name" }}
+{{ $item := onepassword "item-uuid" "vault-name" "account-name" }}
+{{ $item := onepassword "item-uuid" "" "account-name" }}
+```
+
+#### Accessing Fields
+
+```go theme={null}
+{{ $item := onepassword "GitHub" }}
+{{ range $item.fields }}
+{{   if eq .label "password" }}
+Password: {{ .value }}
+{{   end }}
+{{ end }}
+```
+
+### `onepasswordDocument` *uuid* \[*vault*] \[*account*]
+
+Returns a document from 1Password.
+
+```go theme={null}
+{{ onepasswordDocument "ssh-key-uuid" }}
+```
+
+### `onepasswordDetailsFields` *uuid* \[*vault*] \[*account*]
+
+Returns details fields from 1Password.
+
+```go theme={null}
+{{ $fields := onepasswordDetailsFields "item-uuid" }}
+{{ $fields.api_key.value }}
+```
+
+### `onepasswordItemFields` *uuid* \[*vault*] \[*account*]
+
+Returns item fields from 1Password.
+
+```go theme={null}
+{{ $fields := onepasswordItemFields "item-uuid" }}
+{{ range $fields }}
+{{ .label }}: {{ .value }}
+{{ end }}
+```
+
+### `onepasswordRead` *url*
+
+Reads a secret using 1Password secret reference URL.
+
+```go theme={null}
+api_key = {{ onepasswordRead "op://vault/item/field" }}
+```
+
+## Bitwarden
+
+Integrate with [Bitwarden](https://bitwarden.com/) using the [Bitwarden CLI](https://bitwarden.com/help/cli/).
+
+### `bitwarden` *id*
+
+Returns structured data from Bitwarden.
+
+```go theme={null}
+{{ $item := bitwarden "item-id" }}
+username: {{ $item.login.username }}
+password: {{ $item.login.password }}
+```
+
+### `bitwardenFields` *id*
+
+Returns custom fields from a Bitwarden item.
+
+```go theme={null}
+{{ $fields := bitwardenFields "item-id" }}
+api_key: {{ $fields.api_key.value }}
+```
+
+### `bitwardenAttachment` *id* *name*
+
+Returns an attachment from a Bitwarden item.
+
+```go theme={null}
+{{ bitwardenAttachment "item-id" "ssh-key.pub" }}
+```
+
+### `bitwardenAttachmentByRef` *reference* *name*
+
+Returns an attachment using a Bitwarden reference.
+
+```go theme={null}
+{{ bitwardenAttachmentByRef "item-name" "attachment.txt" }}
+```
+
+### `bitwardenSecrets` *key*
+
+Returns a secret from Bitwarden Secrets Manager.
+
+```go theme={null}
+token: {{ bitwardenSecrets "secret-key" }}
+```
+
+## LastPass
+
+Integrate with [LastPass](https://www.lastpass.com/) using the [LastPass CLI](https://github.com/lastpass/lastpass-cli).
+
+### `lastpass` *id*
+
+Returns the password for a LastPass entry.
+
+```go theme={null}
+password: {{ lastpass "GitHub" }}
+```
+
+### `lastpassRaw` *id*
+
+Returns structured data from LastPass.
+
+```go theme={null}
+{{ $item := lastpassRaw "GitHub" }}
+username: {{ $item.username }}
+password: {{ $item.password }}
+url: {{ $item.url }}
+```
+
+## Pass (Password Store)
+
+Integrate with [pass](https://www.passwordstore.org/), the standard Unix password manager.
+
+### `pass` *path*
+
+Returns the first line (password) from a pass entry.
+
+```go theme={null}
+password: {{ pass "github/token" }}
+```
+
+### `passRaw` *path*
+
+Returns the entire contents of a pass entry.
+
+```go theme={null}
+{{ passRaw "ssh/config" }}
+```
+
+### `passFields` *path*
+
+Returns structured data from a pass entry.
+
+```go theme={null}
+{{ $item := passFields "github/account" }}
+username: {{ $item.username }}
+token: {{ $item.token }}
+```
+
+Expected format:
+
+```text theme={null}
+password-here
+username: myuser
+token: abc123
+```
+
+### Configuration
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[pass]
+    command = "passage"  # Use pass-compatible manager
+```
+
+## Gopass
+
+Integrate with [gopass](https://www.gopass.pw/), a pass-compatible password manager.
+
+### `gopass` *path*
+
+Returns the first line from a gopass entry.
+
+```go theme={null}
+password: {{ gopass "work/api-key" }}
+```
+
+### `gopassRaw` *path*
+
+Returns the entire contents of a gopass entry.
+
+```go theme={null}
+{{ gopassRaw "ssh/config" }}
+```
+
+## KeePassXC
+
+Integrate with [KeePassXC](https://keepassxc.org/) using the CLI.
+
+### `keepassxc` *entry*
+
+Returns the password for a KeePassXC entry.
+
+```go theme={null}
+password: {{ keepassxc "GitHub" }}
+```
+
+### `keepassxcAttribute` *entry* *attribute*
+
+Returns a specific attribute from a KeePassXC entry.
+
+```go theme={null}
+username: {{ keepassxcAttribute "GitHub" "UserName" }}
+password: {{ keepassxcAttribute "GitHub" "Password" }}
+url: {{ keepassxcAttribute "GitHub" "URL" }}
+```
+
+### `keepassxcAttachment` *entry* *attachment*
+
+Returns an attachment from a KeePassXC entry.
+
+```go theme={null}
+{{ keepassxcAttachment "SSH" "id_rsa.pub" }}
+```
+
+## Keeper
+
+Integrate with [Keeper Security](https://www.keepersecurity.com/) using the CLI.
+
+### `keeper` *path*
+
+Returns the password from a Keeper record.
+
+```go theme={null}
+password: {{ keeper "GitHub/personal" }}
+```
+
+### `keeperDataFields` *path*
+
+Returns structured data fields from a Keeper record.
+
+```go theme={null}
+{{ $fields := keeperDataFields "GitHub/personal" }}
+api_key: {{ $fields.api_key }}
+```
+
+### `keeperFindPassword` *path*
+
+Finds and returns a password from Keeper.
+
+```go theme={null}
+password: {{ keeperFindPassword "GitHub" }}
+```
+
+## Dashlane
+
+Integrate with [Dashlane](https://www.dashlane.com/) using the CLI.
+
+### `dashlanePassword` *title*
+
+Returns the password for a Dashlane entry.
+
+```go theme={null}
+password: {{ dashlanePassword "GitHub" }}
+```
+
+### `dashlaneNote` *title*
+
+Returns the contents of a Dashlane secure note.
+
+```go theme={null}
+{{ dashlaneNote "SSH Config" }}
+```
+
+## AWS Secrets Manager
+
+Integrate with [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/).
+
+### `awsSecretsManager` *secret-id*
+
+Returns and parses a secret from AWS Secrets Manager as JSON.
+
+```go theme={null}
+{{ $secret := awsSecretsManager "prod/api/key" }}
+api_key: {{ $secret.api_key }}
+```
+
+### `awsSecretsManagerRaw` *secret-id*
+
+Returns the raw secret string from AWS Secrets Manager.
+
+```go theme={null}
+token: {{ awsSecretsManagerRaw "prod/token" }}
+```
+
+## Azure Key Vault
+
+Integrate with [Azure Key Vault](https://azure.microsoft.com/en-us/services/key-vault/).
+
+### `azureKeyVault` *secret-name*
+
+Returns a secret from Azure Key Vault.
+
+```go theme={null}
+api_key: {{ azureKeyVault "api-key" }}
+```
+
+## Doppler
+
+Integrate with [Doppler](https://www.doppler.com/) secrets management.
+
+### `doppler` *project* *config* *secret*
+
+Returns a secret from Doppler.
+
+```go theme={null}
+token: {{ doppler "my-project" "dev" "API_TOKEN" }}
+```
+
+### `dopplerProjectJson` *project* *config*
+
+Returns all secrets from a Doppler project as JSON.
+
+```go theme={null}
+{{ $secrets := dopplerProjectJson "my-project" "dev" }}
+api_key: {{ $secrets.API_KEY }}
+```
+
+## Hashicorp Vault
+
+Integrate with [Hashicorp Vault](https://www.vaultproject.io/).
+
+### `vault` *path*
+
+Returns structured data from Vault.
+
+```go theme={null}
+{{ $secret := vault "secret/data/github" }}
+token: {{ $secret.data.token }}
+```
+
+## Keyring
+
+Integrate with system keyrings (macOS Keychain, Windows Credential Manager, Linux Secret Service).
+
+### `keyring` *service* *account*
+
+Returns a password from the system keyring.
+
+```go theme={null}
+password: {{ keyring "github" "myusername" }}
+```
+
+## Generic Secret
+
+Integrate with generic external secret commands.
+
+### `secret` *args*...
+
+Executes a configured secret command and returns the output.
+
+```go theme={null}
+token: {{ secret "get" "api-token" }}
+```
+
+### `secretJSON` *args*...
+
+Executes a configured secret command and parses the output as JSON.
+
+```go theme={null}
+{{ $secret := secretJSON "get" "credentials" }}
+username: {{ $secret.username }}
+password: {{ $secret.password }}
+```
+
+### Configuration
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[secret]
+    command = "my-secret-tool"
+    args = ["--format", "json"]
+```
+
+## Practical Examples
+
+### Git Configuration with 1Password
+
+```ini title="dot_gitconfig.tmpl" theme={null}
+[user]
+    name = {{ .name }}
+    email = {{ .email }}
+
+[github]
+    user = {{ (onepassword "GitHub").fields.username.value }}
+
+[credential "https://github.com"]
+    helper = !echo "password={{ (onepassword "GitHub").fields.password.value }}"
+```
+
+### SSH Configuration with Bitwarden
+
+```text title="private_dot_ssh_config.tmpl" theme={null}
+Host github.com
+    User git
+    IdentityFile ~/.ssh/github
+
+Host work-server
+    HostName {{ (bitwarden "work-server").login.uris.0.uri }}
+    User {{ (bitwarden "work-server").login.username }}
+```
+
+### API Keys from Pass
+
+```bash title="dot_env.tmpl" theme={null}
+export GITHUB_TOKEN="{{ pass "github/token" }}"
+export NPM_TOKEN="{{ pass "npm/token" }}"
+export AWS_ACCESS_KEY_ID="{{ (passFields "aws/credentials").access_key_id }}"
+export AWS_SECRET_ACCESS_KEY="{{ (passFields "aws/credentials").secret_access_key }}"
+```
+
+### Multi-Provider Strategy
+
+```toml title="dot_config_app_credentials.toml.tmpl" theme={null}
+{{ if lookPath "op" }}
+token = {{ onepasswordRead "op://vault/item/token" | quote }}
+{{ else if lookPath "bw" }}
+token = {{ (bitwarden "item-id").login.password | quote }}
+{{ else if lookPath "pass" }}
+token = {{ pass "app/token" | quote }}
+{{ else }}
+{{ warnf "No password manager found" }}
+token = ""
+{{ end }}
+```
+
+### Conditional Secret Retrieval
+
+```bash title="run_once_install-creds.sh.tmpl" theme={null}
+#!/bin/bash
+
+{{ if stat (joinPath .chezmoi.homeDir ".ssh" "id_rsa") }}
+echo "SSH key already exists"
+{{ else }}
+{{ if lookPath "op" }}
+echo "Installing SSH key from 1Password"
+cat > ~/.ssh/id_rsa << 'EOF'
+{{ onepasswordDocument "SSH Key" }}
+EOF
+chmod 600 ~/.ssh/id_rsa
+{{ end }}
+{{ end }}
+```
+
+## Security Best Practices
+
+1. **Never commit secrets**: Template files should only contain function calls, not actual secrets
+2. **Use encryption**: Enable encryption for the chezmoi source directory if needed
+3. **Audit access**: Regularly review which secrets are being accessed
+4. **Rotate credentials**: Use password manager features to rotate credentials regularly
+5. **Limit scope**: Only retrieve secrets that are actually needed
+6. **Use secret references**: Prefer secret references (like 1Password's `op://`) when supported
+
+## Troubleshooting
+
+### Authentication Issues
+
+```bash theme={null}
+# Check password manager CLI is authenticated
+op account list
+bw login --check
+lpass status
+
+# Re-authenticate if needed
+op signin
+bw login
+lpass login
+```
+
+### Testing Secret Retrieval
+
+```bash theme={null}
+# Test a template with secrets
+chezmoi execute-template '{{ onepassword "item-id" }}'
+
+# Dry run to see what would be applied
+chezmoi apply --dry-run --verbose
+```
+
+### Debugging
+
+```bash theme={null}
+# Enable verbose output
+chezmoi apply --verbose
+
+# Check configuration
+chezmoi cat-config
+
+# Test specific secret
+op item get "item-name" --format json
+```
+
+## Related Pages
+
+* [Template Functions](/reference/templates/functions) - All template functions
+* [Template Variables](/reference/templates/variables) - Built-in variables
+* [Configuration File](/reference/configuration-file) - Password manager configuration
+* [Encryption](/encryption/overview) - Encrypting secrets in the source directory
+
+
+# Template Variables
+Source: https://twpayne-chezmoi.mintlify.app/reference/templates/variables
+
+Automatically-populated variables available in chezmoi templates
+
+# Template Variables
+
+chezmoi provides the following automatically-populated variables accessible in templates via the `.chezmoi` namespace.
+
+## System Information
+
+| Variable                  | Type   | Description                                                                              | Example                      |
+| ------------------------- | ------ | ---------------------------------------------------------------------------------------- | ---------------------------- |
+| `.chezmoi.arch`           | string | Architecture as returned by [runtime.GOARCH](https://pkg.go.dev/runtime#pkg-constants)   | `amd64`, `arm64`, `arm`      |
+| `.chezmoi.os`             | string | Operating system as returned by [runtime.GOOS](https://pkg.go.dev/runtime#pkg-constants) | `darwin`, `linux`, `windows` |
+| `.chezmoi.osRelease`      | object | Contents of `/etc/os-release` (Linux only)                                               | See below                    |
+| `.chezmoi.kernel`         | object | Information from `/proc/sys/kernel` (Linux only)                                         | See below                    |
+| `.chezmoi.windowsVersion` | object | Windows version information (Windows only)                                               | See below                    |
+
+### Examples
+
+```go theme={null}
+{{ if eq .chezmoi.os "darwin" }}
+# macOS-specific configuration
+{{ else if eq .chezmoi.os "linux" }}
+# Linux-specific configuration
+{{ end }}
+
+{{ if eq .chezmoi.arch "amd64" }}
+# 64-bit configuration
+{{ end }}
+```
+
+## Host Information
+
+| Variable                | Type   | Description                          | Example                   |
+| ----------------------- | ------ | ------------------------------------ | ------------------------- |
+| `.chezmoi.hostname`     | string | Hostname up to the first `.`         | `workstation`             |
+| `.chezmoi.fqdnHostname` | string | Fully-qualified domain name hostname | `workstation.example.com` |
+
+### Examples
+
+```go theme={null}
+{{ if eq .chezmoi.hostname "workstation" }}
+# Work machine configuration
+{{ else if eq .chezmoi.hostname "laptop" }}
+# Personal laptop configuration
+{{ end }}
+```
+
+## User Information
+
+| Variable            | Type   | Description                          | Example |
+| ------------------- | ------ | ------------------------------------ | ------- |
+| `.chezmoi.username` | string | Username of the user running chezmoi | `john`  |
+| `.chezmoi.uid`      | string | User ID                              | `1000`  |
+| `.chezmoi.gid`      | string | Primary group ID                     | `1000`  |
+| `.chezmoi.group`    | string | Group name of the user               | `users` |
+
+### Examples
+
+```go theme={null}
+[user]
+    name = {{ .chezmoi.username }}
+    uid = {{ .chezmoi.uid }}
+```
+
+## Directory Paths
+
+| Variable               | Type   | Description           | Example                           |
+| ---------------------- | ------ | --------------------- | --------------------------------- |
+| `.chezmoi.homeDir`     | string | Home directory        | `/home/john`                      |
+| `.chezmoi.sourceDir`   | string | Source directory      | `/home/john/.local/share/chezmoi` |
+| `.chezmoi.destDir`     | string | Destination directory | `/home/john`                      |
+| `.chezmoi.cacheDir`    | string | Cache directory       | `/home/john/.cache/chezmoi`       |
+| `.chezmoi.workingTree` | string | Git working tree      | `/home/john/.local/share/chezmoi` |
+
+### Examples
+
+```bash theme={null}
+# Include a file from source directory
+{{ include (joinPath .chezmoi.sourceDir "scripts" "common.sh") }}
+
+# Check if file exists in home directory
+{{ if stat (joinPath .chezmoi.homeDir ".ssh" "id_rsa") }}
+SSH key exists
+{{ end }}
+```
+
+## Template File Information
+
+| Variable              | Type   | Description                                   | Example              |
+| --------------------- | ------ | --------------------------------------------- | -------------------- |
+| `.chezmoi.sourceFile` | string | Path of template relative to source directory | `dot_bashrc.tmpl`    |
+| `.chezmoi.targetFile` | string | Absolute path of the target file              | `/home/john/.bashrc` |
+
+### Examples
+
+```bash theme={null}
+# Managed by chezmoi
+# Source: {{ .chezmoi.sourceFile }}
+# Target: {{ .chezmoi.targetFile }}
+```
+
+## chezmoi Information
+
+| Variable                   | Type      | Description                 | Example                  |
+| -------------------------- | --------- | --------------------------- | ------------------------ |
+| `.chezmoi.executable`      | string    | Path to chezmoi executable  | `/usr/local/bin/chezmoi` |
+| `.chezmoi.args`            | \[]string | Arguments passed to chezmoi | `["chezmoi", "apply"]`   |
+| `.chezmoi.version.version` | string    | chezmoi version             | `2.40.0`                 |
+| `.chezmoi.version.commit`  | string    | Git commit of build         | `abc123...`              |
+| `.chezmoi.version.date`    | string    | Build timestamp             | `2024-01-15T10:30:00Z`   |
+| `.chezmoi.version.builtBy` | string    | Builder name                | `goreleaser`             |
+
+### Examples
+
+```bash theme={null}
+# Generated by chezmoi {{ .chezmoi.version.version }}
+
+{{ if .chezmoi.executable }}
+# To update: {{ .chezmoi.executable }} update
+{{ end }}
+```
+
+## Configuration
+
+| Variable              | Type   | Description                 |
+| --------------------- | ------ | --------------------------- |
+| `.chezmoi.config`     | object | Configuration file contents |
+| `.chezmoi.configFile` | string | Path to configuration file  |
+
+### Examples
+
+```go theme={null}
+{{ if .chezmoi.config.data.email }}
+email = {{ .chezmoi.config.data.email }}
+{{ end }}
+```
+
+## Path Separators
+
+| Variable                     | Type   | Description            | Example                   |
+| ---------------------------- | ------ | ---------------------- | ------------------------- |
+| `.chezmoi.pathSeparator`     | string | OS path separator      | `/` (Unix), `\` (Windows) |
+| `.chezmoi.pathListSeparator` | string | OS path list separator | `:` (Unix), `;` (Windows) |
+
+### Examples
+
+```bash theme={null}
+export PATH="$HOME{{ .chezmoi.pathSeparator }}bin{{ .chezmoi.pathListSeparator }}$PATH"
+```
+
+## OS-Specific Variables
+
+### `.chezmoi.osRelease` (Linux)
+
+Contains information from `/etc/os-release`:
+
+```go theme={null}
+{{ .chezmoi.osRelease.id }}          # "ubuntu", "arch", etc.
+{{ .chezmoi.osRelease.versionID }}   # "22.04", etc.
+{{ .chezmoi.osRelease.name }}        # "Ubuntu"
+{{ .chezmoi.osRelease.prettyName }}  # "Ubuntu 22.04 LTS"
+```
+
+### Example
+
+```go theme={null}
+{{ if eq .chezmoi.osRelease.id "ubuntu" }}
+# Ubuntu-specific configuration
+{{ else if eq .chezmoi.osRelease.id "arch" }}
+# Arch-specific configuration
+{{ end }}
+```
+
+### `.chezmoi.kernel` (Linux)
+
+Contains information from `/proc/sys/kernel`:
+
+```go theme={null}
+{{ .chezmoi.kernel.osrelease }}  # Kernel version
+{{ .chezmoi.kernel.ostype }}     # "Linux"
+```
+
+Useful for detecting WSL:
+
+```go theme={null}
+{{ if .chezmoi.kernel.osrelease | lower | contains "microsoft" }}
+# Running in WSL
+{{ end }}
+```
+
+### `.chezmoi.windowsVersion` (Windows)
+
+Contains Windows version information from the registry:
+
+| Key                         | Type    | Description                    |
+| --------------------------- | ------- | ------------------------------ |
+| `currentBuild`              | string  | Build number                   |
+| `currentMajorVersionNumber` | integer | Major version                  |
+| `currentMinorVersionNumber` | integer | Minor version                  |
+| `currentVersion`            | string  | Version string                 |
+| `displayVersion`            | string  | Display version                |
+| `editionID`                 | string  | Edition (e.g., "Professional") |
+| `productName`               | string  | Product name                   |
+
+### Example
+
+```go theme={null}
+{{ if ge .chezmoi.windowsVersion.currentBuild "22000" }}
+# Windows 11 or later
+{{ end }}
+```
+
+## Custom Data Variables
+
+Additional variables can be defined in the config file's `data` section or in `.chezmoidata.$FORMAT` files:
+
+```toml title="~/.config/chezmoi/chezmoi.toml" theme={null}
+[data]
+    email = "user@example.com"
+    name = "John Doe"
+    work = true
+```
+
+```yaml title="~/.local/share/chezmoi/.chezmoidata.yaml" theme={null}
+packages:
+  - vim
+  - git
+editor: nvim
+```
+
+Access in templates:
+
+```go theme={null}
+{{ .email }}
+{{ .name }}
+{{ if .work }}
+# Work configuration
+{{ end }}
+
+{{ range .packages }}
+install {{ . }}
+{{ end }}
+```
+
+## Testing Variables
+
+To see all available template data:
+
+```bash theme={null}
+# View all chezmoi variables
+chezmoi data
+
+# View specific value
+chezmoi execute-template '{{ .chezmoi.os }}'
+
+# View custom data
+chezmoi execute-template '{{ .email }}'
+```
+
+## Practical Examples
+
+### Multi-OS Configuration
+
+```bash title="dot_bashrc.tmpl" theme={null}
+# Common configuration
+export EDITOR=vim
+
+{{ if eq .chezmoi.os "darwin" }}
+# macOS
+export PATH="/usr/local/bin:$PATH"
+alias ls="ls -G"
+{{ else if eq .chezmoi.os "linux" }}
+# Linux
+export PATH="/usr/bin:$PATH"
+alias ls="ls --color=auto"
+{{ end }}
+```
+
+### Machine-Specific Configuration
+
+```toml title="dot_gitconfig.tmpl" theme={null}
+[user]
+    name = {{ .name }}
+    email = {{ if eq .chezmoi.hostname "work-laptop" }}{{ .work_email }}{{ else }}{{ .personal_email }}{{ end }}
+
+{{ if .work }}
+[url "git@github.com:company/"]
+    insteadOf = https://github.com/company/
+{{ end }}
+```
+
+### Distribution-Specific Configuration
+
+```bash title="run_once_install-packages.sh.tmpl" theme={null}
+#!/bin/bash
+
+{{ if eq .chezmoi.osRelease.id "ubuntu" }}
+apt-get update
+apt-get install -y {{ range .packages }}{{ . }} {{ end }}
+{{ else if eq .chezmoi.osRelease.id "arch" }}
+pacman -Syu --noconfirm {{ range .packages }}{{ . }} {{ end }}
+{{ else if eq .chezmoi.osRelease.id "fedora" }}
+dnf install -y {{ range .packages }}{{ . }} {{ end }}
+{{ end }}
+```
+
+## Related Pages
+
+* [Template Overview](/reference/templates/overview) - Template system overview
+* [Template Functions](/reference/templates/functions) - Available functions
+* [Configuration File](/reference/configuration-file) - Configuration options
+* `chezmoi data` - View template data
+
+
+# Daily Operations
+Source: https://twpayne-chezmoi.mintlify.app/user-guide/daily-operations
+
+Common workflows for managing your dotfiles with chezmoi
+
+## Edit your dotfiles
+
+Edit managed files using the `chezmoi edit` command:
+
+<Tabs>
+  <Tab title="Basic edit">
+    ```bash theme={null}
+    chezmoi edit $FILENAME
+    ```
+
+    This opens the source file in your editor. Changes aren't applied until you run `chezmoi apply`.
+  </Tab>
+
+  <Tab title="Edit and apply">
+    ```bash theme={null}
+    chezmoi edit --apply $FILENAME
+    ```
+
+    Automatically applies changes when you quit the editor.
+  </Tab>
+
+  <Tab title="Edit with watch">
+    ```bash theme={null}
+    chezmoi edit --watch $FILENAME
+    ```
+
+    Automatically applies changes every time you save in the editor.
+  </Tab>
+</Tabs>
+
+<Note>
+  You don't have to use `chezmoi edit`. You can edit files directly in the source directory (`~/.local/share/chezmoi`) and apply changes later.
+</Note>
+
+```mermaid theme={null}
+sequenceDiagram
+    participant H as home directory
+    participant W as working copy
+    participant R as remote repo
+    W->>W: chezmoi edit
+    W->>H: chezmoi apply
+    W->>H: chezmoi edit --apply
+    W->>H: chezmoi edit --watch
+```
+
+## Pull the latest changes from your repo and apply them
+
+<CodeGroup>
+  ```bash Update in one command theme={null}
+  chezmoi update
+  ```
+
+  ```bash What it does theme={null}
+  # Equivalent to:
+  git pull --autostash --rebase  # in source directory
+  chezmoi apply                  # apply changes
+  ```
+</CodeGroup>
+
+```mermaid theme={null}
+sequenceDiagram
+    participant H as home directory
+    participant W as working copy
+    participant R as remote repo
+    R->>H: chezmoi update
+```
+
+## Pull and preview changes without applying
+
+<Steps>
+  <Step title="Pull changes and preview">
+    ```bash theme={null}
+    chezmoi git pull -- --autostash --rebase && chezmoi diff
+    ```
+
+    This shows what would change without modifying your files.
+  </Step>
+
+  <Step title="Apply if satisfied">
+    ```bash theme={null}
+    chezmoi apply
+    ```
+  </Step>
+</Steps>
+
+```mermaid theme={null}
+sequenceDiagram
+    participant H as home directory
+    participant W as working copy
+    participant R as remote repo
+    R->>W: chezmoi git pull
+    W-->>H: chezmoi diff
+    W->>H: chezmoi apply
+```
+
+## Automatically commit and push changes to your repo
+
+Enable auto-commit and auto-push in your config file:
+
+<CodeGroup>
+  ```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+  [git]
+      autoCommit = true
+      autoPush = true
+  ```
+
+  ```toml Custom commit messages theme={null}
+  [git]
+      autoCommit = true
+      commitMessageTemplate = "{{ promptString \"Commit message\" }}"
+  ```
+
+  ```toml Commit message from file theme={null}
+  [git]
+      autoCommit = true
+      commitMessageTemplateFile = ".commit_message.tmpl"
+  ```
+</CodeGroup>
+
+Behavior:
+
+* `autoCommit = true`: Commits changes with auto-generated messages
+* `autoPush = true`: Commits and pushes (implies `autoCommit`)
+* Custom templates: Prompt for messages or use template files
+
+<Warning>
+  Be careful with `autoPush` on public repos. Accidentally committing secrets in plain text will push them immediately.
+</Warning>
+
+```mermaid theme={null}
+sequenceDiagram
+    participant H as home directory
+    participant W as working copy
+    participant L as local repo
+    participant R as remote repo
+    W->>L: autoCommit
+    W->>R: autoPush
+```
+
+## Install chezmoi and your dotfiles on a new machine with a single command
+
+<Tabs>
+  <Tab title="Install and apply">
+    For a repo named `dotfiles` on GitHub:
+
+    ```bash theme={null}
+    sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply $GITHUB_USERNAME
+    ```
+
+    This installs chezmoi, runs `chezmoi init`, and applies your dotfiles in one command.
+  </Tab>
+
+  <Tab title="One-shot mode">
+    For transitory environments (containers, temporary VMs):
+
+    ```bash theme={null}
+    sh -c "$(curl -fsLS get.chezmoi.io)" -- init --one-shot $GITHUB_USERNAME
+    ```
+
+    This installs dotfiles then removes all traces of chezmoi, including the source directory.
+  </Tab>
+
+  <Tab title="Custom repo">
+    For non-GitHub repos or different repo names:
+
+    ```bash theme={null}
+    sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply https://gitlab.com/username/my-dotfiles.git
+    ```
+  </Tab>
+</Tabs>
+
+```mermaid theme={null}
+sequenceDiagram
+    participant H as home directory
+    participant W as working copy
+    participant R as remote repo
+    R->>W: chezmoi init $GITHUB_USERNAME
+    R->>H: chezmoi init --apply $GITHUB_USERNAME
+    R->>H: chezmoi init --one-shot $GITHUB_USERNAME
+```
+
+<Tip>
+  The one-shot mode is perfect for Docker containers or cloud shells where you need your config temporarily.
+</Tip>
+
+
+# Include Files from Elsewhere
+Source: https://twpayne-chezmoi.mintlify.app/user-guide/include-files-from-elsewhere
+
+Import external files and repositories into your dotfiles
+
+Use `.chezmoiexternal.toml` to include files from external sources. chezmoi downloads and manages them as part of your source state.
+
+## Include a subdirectory from a URL
+
+Import entire repositories like Oh My Zsh without using git submodules:
+
+```toml ~/.local/share/chezmoi/.chezmoiexternal.toml theme={null}
+[".oh-my-zsh"]
+    type = "archive"
+    url = "https://github.com/ohmyzsh/ohmyzsh/archive/master.tar.gz"
+    exact = true
+    stripComponents = 1
+    refreshPeriod = "168h"
+[".oh-my-zsh/custom/plugins/zsh-syntax-highlighting"]
+    type = "archive"
+    url = "https://github.com/zsh-users/zsh-syntax-highlighting/archive/master.tar.gz"
+    exact = true
+    stripComponents = 1
+    refreshPeriod = "168h"
+[".oh-my-zsh/custom/themes/powerlevel10k"]
+    type = "archive"
+    url = "https://github.com/romkatv/powerlevel10k/archive/v1.15.0.tar.gz"
+    exact = true
+    stripComponents = 1
+```
+
+<Steps>
+  <Step title="Apply changes">
+    ```bash theme={null}
+    chezmoi apply
+    ```
+
+    chezmoi downloads and unpacks archives automatically.
+  </Step>
+
+  <Step title="Force refresh">
+    <CodeGroup>
+      ```bash Long form theme={null}
+      chezmoi --refresh-externals apply
+      ```
+
+      ```bash Short form theme={null}
+      chezmoi -R apply
+      ```
+    </CodeGroup>
+
+    Forces re-download even within `refreshPeriod`.
+  </Step>
+</Steps>
+
+### Understanding refresh periods
+
+<CardGroup>
+  <Card title="With refreshPeriod" icon="clock">
+    ```toml theme={null}
+    refreshPeriod = "168h"  # 1 week
+    ```
+
+    For URLs pointing to moving targets (e.g., `master` branch)
+  </Card>
+
+  <Card title="Without refreshPeriod" icon="lock">
+    ```toml theme={null}
+    # No refreshPeriod set
+    ```
+
+    For URLs pointing to tagged versions (e.g., `v1.15.0`)
+  </Card>
+</CardGroup>
+
+<Warning>
+  When using Oh My Zsh, disable auto-updates by setting `DISABLE_AUTO_UPDATE="true"` in `~/.zshrc`. Auto-updates will cause the directory to drift from chezmoi's source state.
+</Warning>
+
+<Note>
+  If externals have cache files that change during use, add the cache directory to `.chezmoiignore`. For example, Oh My Zsh caches completions in `.oh-my-zsh/cache/completions/`.
+</Note>
+
+<Warning>
+  Don't use externals for large files or archives. chezmoi validates exact contents every time you run `diff`, `apply`, or `verify`. For large externals, use a `run_onchange_` script instead.
+</Warning>
+
+## Include a subdirectory with selected files from a URL
+
+Use `include` filters to import only specific files:
+
+```toml ~/.local/share/chezmoi/.chezmoiexternal.toml theme={null}
+[".oh-my-zsh/custom/plugins/zsh-syntax-highlighting"]
+    type = "archive"
+    url = "https://github.com/zsh-users/zsh-syntax-highlighting/archive/master.tar.gz"
+    exact = true
+    stripComponents = 1
+    refreshPeriod = "168h"
+    include = ["*/*.zsh", "*/.version", "*/.revision-hash", "*/highlighters/**"]
+```
+
+This imports only the required source files, reducing the size of your dotfiles repo.
+
+## Include a single file from a URL
+
+Use `type = "file"` for single files:
+
+```toml ~/.local/share/chezmoi/.chezmoiexternal.toml theme={null}
+[".vim/autoload/plug.vim"]
+    type = "file"
+    url = "https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim"
+    refreshPeriod = "168h"
+```
+
+<Tabs>
+  <Tab title="Static version">
+    ```toml theme={null}
+    [".vim/autoload/plug.vim"]
+        type = "file"
+        url = "https://raw.githubusercontent.com/junegunn/vim-plug/0.12.0/plug.vim"
+    ```
+
+    No `refreshPeriod` needed for tagged versions.
+  </Tab>
+
+  <Tab title="Latest version">
+    ```toml theme={null}
+    [".vim/autoload/plug.vim"]
+        type = "file"
+        url = "https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim"
+        refreshPeriod = "168h"
+    ```
+
+    Use `refreshPeriod` to check for updates.
+  </Tab>
+</Tabs>
+
+## Extract a single file from an archive
+
+Extract specific files from archives:
+
+```toml ~/.local/share/chezmoi/.chezmoiexternal.toml theme={null}
+{{ $ageVersion := "1.1.1" -}}
+[".local/bin/age"]
+    type = "archive-file"
+    url = "https://github.com/FiloSottile/age/releases/download/v{{ $ageVersion }}/age-v{{ $ageVersion }}-{{ .chezmoi.os }}-{{ .chezmoi.arch }}.tar.gz"
+    path = "age/age"
+```
+
+This:
+
+1. Downloads the archive for your OS and architecture
+2. Extracts only the `age/age` member
+3. Places it at `~/.local/bin/age`
+
+<Tip>
+  Templates in `.chezmoiexternal.toml` allow platform-specific URLs.
+</Tip>
+
+## Import archives
+
+For one-time imports, use the `import` command:
+
+<Steps>
+  <Step title="Download archive">
+    ```bash theme={null}
+    curl -s -L -o ${TMPDIR}/oh-my-zsh-master.tar.gz https://github.com/ohmyzsh/ohmyzsh/archive/master.tar.gz
+    ```
+  </Step>
+
+  <Step title="Create destination directory">
+    ```bash theme={null}
+    mkdir -p $(chezmoi source-path)/dot_oh-my-zsh
+    ```
+  </Step>
+
+  <Step title="Import archive">
+    ```bash theme={null}
+    chezmoi import --strip-components 1 --destination ~/.oh-my-zsh ${TMPDIR}/oh-my-zsh-master.tar.gz
+    ```
+  </Step>
+
+  <Step title="Apply changes">
+    ```bash theme={null}
+    chezmoi apply
+    ```
+  </Step>
+</Steps>
+
+<Note>
+  `import` updates the source state but doesn't apply changes. Run `chezmoi apply` to update your home directory.
+</Note>
+
+## Handle tar archives in unsupported compression formats
+
+chezmoi natively supports: bzip2, gzip, xz, and zstd. For other formats, use filters:
+
+```toml ~/.local/share/chezmoi/.chezmoiexternal.toml theme={null}
+[".Software/anki/2.1.54-qt6"]
+    type = "archive"
+    url = "https://github.com/ankitects/anki/releases/download/2.1.54/anki-2.1.54-linux-qt6.tar.zst"
+    filter.command = "zstd"
+    filter.args = ["-d"]
+    format = "tar"
+```
+
+How it works:
+
+1. `filter.command` and `filter.args` pipe downloaded data through `zstd -d`
+2. `format = "tar"` tells chezmoi the filter outputs uncompressed tar
+
+## Include a subdirectory from a git repository
+
+Manage git repositories directly:
+
+```toml ~/.local/share/chezmoi/.chezmoiexternal.toml theme={null}
+[".vim/pack/alker0/chezmoi.vim"]
+    type = "git-repo"
+    url = "https://github.com/alker0/chezmoi.vim.git"
+    refreshPeriod = "168h"
+```
+
+Behavior:
+
+* First run: `git clone`
+* Subsequent runs: `git pull` (respects `refreshPeriod`)
+* Force refresh: `chezmoi -R apply`
+
+<Warning>
+  chezmoi only runs `git clone`/`git pull`. You must have `git` in your `$PATH`. chezmoi cannot manage other files in the directory, and contents won't appear in `chezmoi diff` or `chezmoi dump`.
+</Warning>
+
+### Customize git commands
+
+```toml ~/.local/share/chezmoi/.chezmoiexternal.toml theme={null}
+[".vim/pack/alker0/chezmoi.vim"]
+    type = "git-repo"
+    url = "https://github.com/alker0/chezmoi.vim.git"
+    refreshPeriod = "168h"
+    [".vim/pack/alker0/chezmoi.vim".pull]
+        args = ["--ff-only"]
+```
+
+<Tip>
+  If you need to manage extra files in a git repository, use `type = "archive"` with a URL pointing to the `master`/`main` branch archive instead.
+</Tip>
+
+## Use git submodules in your source directory
+
+<Warning>
+  If using git submodules, set the `external_` attribute on directories containing submodules.
+</Warning>
+
+chezmoi supports git submodules with `--recurse-submodules` by default:
+
+<Steps>
+  <Step title="Add submodule">
+    ```bash theme={null}
+    chezmoi cd
+    git submodule add https://github.com/user/repo.git external_repo
+    ```
+  </Step>
+
+  <Step title="Set external_ attribute">
+    ```bash theme={null}
+    # Name the directory with external_ prefix
+    mv repo external_repo
+    ```
+
+    This prevents chezmoi from interpreting filenames like `run_test.sh` as scripts.
+  </Step>
+
+  <Step title="Initialize and update">
+    <CodeGroup>
+      ```bash chezmoi init theme={null}
+      chezmoi init --recurse-submodules https://github.com/user/dotfiles.git
+      ```
+
+      ```bash chezmoi update theme={null}
+      chezmoi update  # automatically uses --recurse-submodules
+      ```
+    </CodeGroup>
+  </Step>
+</Steps>
+
+<Note>
+  Disable submodule handling with `--recurse-submodules=false` or set `update.recurseSubmodules = false` in your config.
+</Note>
+
+## Comparison: External types
+
+| Type           | Use case                  | Refresh | Managed by chezmoi |
+| -------------- | ------------------------- | ------- | ------------------ |
+| `archive`      | Full repository/directory | Yes     | Yes                |
+| `file`         | Single file               | Yes     | Yes                |
+| `archive-file` | Single file from archive  | Yes     | Yes                |
+| `git-repo`     | Git repository            | Yes     | No (git manages)   |
+| git submodule  | Git repository            | Yes     | No (git manages)   |
+
+
+# Manage Different Types of File
+Source: https://twpayne-chezmoi.mintlify.app/user-guide/manage-different-types-of-file
+
+Handle special file types and scenarios with chezmoi
+
+## Have chezmoi create a directory, but ignore its contents
+
+For directories like `~/src` where you want the directory created but not its contents managed:
+
+<Steps>
+  <Step title="Create the directory in source state">
+    ```bash theme={null}
+    mkdir -p $(chezmoi source-path)/src
+    ```
+
+    chezmoi will create this directory when you run `chezmoi apply`.
+  </Step>
+
+  <Step title="Add a .keep file">
+    ```bash theme={null}
+    touch $(chezmoi source-path)/src/.keep
+    ```
+
+    This ensures git tracks the directory while chezmoi ignores the `.keep` file.
+  </Step>
+</Steps>
+
+<Note>
+  chezmoi automatically creates `.keep` files when you add an empty directory with `chezmoi add`.
+</Note>
+
+## Ensure that a target is removed
+
+Create a `.chezmoiremove` file in the source directory with patterns of files to remove:
+
+<CodeGroup>
+  ```text ~/.local/share/chezmoi/.chezmoiremove theme={null}
+  # Remove old config files
+  .oldconfig
+  *.backup
+
+  # Machine-specific removals
+  {{- if eq .chezmoi.hostname "work-laptop" }}
+  .personal-scripts
+  {{- end }}
+  ```
+
+  ```bash Preview before removing theme={null}
+  chezmoi apply --dry-run --verbose
+  ```
+</CodeGroup>
+
+<Warning>
+  Always preview with `--dry-run` first. `.chezmoiremove` is a template, so you can remove different files on different machines. Negative matches (prefixed with `!`) and targets in `.chezmoiignore` will never be removed.
+</Warning>
+
+## Manage part, but not all, of a file
+
+chezmoi provides two approaches for managing partial file contents:
+
+<Tabs>
+  <Tab title="modify_ scripts">
+    A `modify_` script receives the current file content on stdin and outputs the modified content:
+
+    <CodeGroup>
+      ```sh modify_dot_config.sh theme={null}
+      #!/bin/sh
+      # Replace 'old' with 'new' in the file
+      sed 's/old/new/g'
+      ```
+
+      ```sh With temporary file theme={null}
+      #!/bin/sh
+      tempfile="$(mktemp)"
+      trap 'rm -rf "${tempfile}"' EXIT
+      cat > "${tempfile}"
+      # modify ${tempfile}
+      cat "${tempfile}"
+      ```
+    </CodeGroup>
+
+    <Note>
+      If the file doesn't exist, stdin will be empty and the script must write a complete file to stdout.
+    </Note>
+  </Tab>
+
+  <Tab title="Modify templates">
+    Scripts containing `chezmoi:modify-template` are interpreted as templates:
+
+    <CodeGroup>
+      ```text modify_dot_config theme={null}
+      {{- /* chezmoi:modify-template */ -}}
+      {{- .chezmoi.stdin | replaceAllRegex "old" "new" }}
+      ```
+
+      ```text Modify JSON/YAML theme={null}
+      {{- /* chezmoi:modify-template */ -}}
+      {{ fromJson .chezmoi.stdin | setValueAtPath "key.nestedKey" "value" | toPrettyJson }}
+      ```
+    </CodeGroup>
+
+    <Warning>
+      Modify templates must NOT have a `.tmpl` extension.
+    </Warning>
+  </Tab>
+
+  <Tab title="Template re-generation">
+    For small changes, use templates to regenerate the full file:
+
+    ```text ~/.local/share/chezmoi/dot_kube/config.tmpl theme={null}
+    current-context: {{ output "kubectl" "config" "current-context" | trim }}
+    ```
+  </Tab>
+</Tabs>
+
+## Manage a file's permissions, but not its contents
+
+Use the `create_` attribute to manage permissions without changing file contents:
+
+<Tabs>
+  <Tab title="Using create_ attribute">
+    Create an empty file with the desired attributes:
+
+    ```bash theme={null}
+    # Ensures ~/.kube/config has 0600 permissions
+    touch $(chezmoi source-path)/dot_kube/private_config
+    ```
+
+    chezmoi will apply permission changes from `private_`, `executable_`, and `readonly_` attributes without modifying contents.
+
+    <Note>
+      This approach creates the file if it doesn't exist.
+    </Note>
+  </Tab>
+
+  <Tab title="Using run_ script">
+    To only set permissions if the file already exists:
+
+    ```bash run_set_kube_config_permissions.sh theme={null}
+    #!/bin/sh
+
+    FILE="$HOME/.kube/config"
+    if [ -f "$FILE" ]; then
+        if [ "$(stat -c %a "$FILE")" != "600" ] ; then
+            chmod 600 "$FILE"
+        fi
+    fi
+    ```
+  </Tab>
+</Tabs>
+
+## Handle configuration files which are externally modified
+
+Some programs modify their own config files. To track these changes, use symlinks:
+
+<Steps>
+  <Step title="Copy config to source directory">
+    ```bash theme={null}
+    cp ~/.config/Code/User/settings.json $(chezmoi source-path)
+    ```
+  </Step>
+
+  <Step title="Tell chezmoi to ignore this file">
+    ```bash theme={null}
+    echo settings.json >> $(chezmoi source-path)/.chezmoiignore
+    ```
+  </Step>
+
+  <Step title="Create a symlink to the source file">
+    ```bash theme={null}
+    mkdir -p $(chezmoi source-path)/private_dot_config/private_Code/User
+    echo -n "{{ .chezmoi.sourceDir }}/settings.json" > $(chezmoi source-path)/private_dot_config/private_Code/User/symlink_settings.json.tmpl
+    ```
+
+    The `private_` prefix is used because `~/.config` and `~/.config/Code` are private by default.
+  </Step>
+
+  <Step title="Apply the changes">
+    ```bash theme={null}
+    chezmoi apply -v
+    ```
+
+    Now when the program modifies its config, it modifies the file in your source state.
+  </Step>
+</Steps>
+
+## Populate `~/.ssh/authorized_keys` with your public SSH keys from GitHub
+
+chezmoi can retrieve public SSH keys from GitHub:
+
+```text ~/.local/share/chezmoi/dot_ssh/authorized_keys.tmpl theme={null}
+{{ range gitHubKeys "$GITHUB_USERNAME" -}}
+{{   .Key }}
+{{ end -}}
+```
+
+This will populate `~/.ssh/authorized_keys` with all public keys from your GitHub account.
+
+<Tip>
+  You can use similar template functions for other services like `gitLabKeys` and `gitHubLatestRelease`.
+</Tip>
+
+
+# Manage Machine-to-Machine Differences
+Source: https://twpayne-chezmoi.mintlify.app/user-guide/manage-machine-to-machine-differences
+
+Use templates to customize dotfiles for different machines
+
+## Use templates
+
+The primary goal of chezmoi is to manage configuration files across multiple machines with different requirements. chezmoi uses Go's [`text/template`](https://pkg.go.dev/text/template) syntax for customization.
+
+<Steps>
+  <Step title="Create a machine-specific config file">
+    Define variables that vary between machines:
+
+    <CodeGroup>
+      ```toml ~/.config/chezmoi/chezmoi.toml (Home) theme={null}
+      [data]
+          email = "me@home.org"
+      ```
+
+      ```toml ~/.config/chezmoi/chezmoi.toml (Work) theme={null}
+      [data]
+          email = "firstname.lastname@company.com"
+      ```
+    </CodeGroup>
+
+    <Warning>
+      If storing private data (access tokens), ensure permissions are `0600`.
+    </Warning>
+  </Step>
+
+  <Step title="Add the file as a template">
+    ```bash theme={null}
+    chezmoi add --template ~/.gitconfig
+    ```
+
+    This creates `~/.local/share/chezmoi/dot_gitconfig.tmpl`.
+  </Step>
+
+  <Step title="Edit the template">
+    ```bash theme={null}
+    chezmoi edit ~/.gitconfig
+    ```
+
+    Update the file to use template variables:
+
+    ```toml ~/.local/share/chezmoi/dot_gitconfig.tmpl theme={null}
+    [user]
+        email = {{ .email | quote }}
+    ```
+  </Step>
+</Steps>
+
+<Tabs>
+  <Tab title="View available data">
+    ```bash theme={null}
+    chezmoi data
+    ```
+
+    Shows all template variables available on your system.
+  </Tab>
+
+  <Tab title="Test templates">
+    ```bash theme={null}
+    chezmoi execute-template "{{ .chezmoi.os }}/{{ .chezmoi.arch }}"
+    ```
+
+    Executes templates directly without creating files.
+  </Tab>
+</Tabs>
+
+## Common template patterns
+
+<CodeGroup>
+  ```bash Machine-specific sections theme={null}
+  # ~/.local/share/chezmoi/dot_bashrc.tmpl
+  # common config
+  export EDITOR=vi
+
+  # machine-specific configuration
+  {{- if eq .chezmoi.hostname "work-laptop" }}
+  # this will only be included in ~/.bashrc on work-laptop
+  export WORK_ENV=production
+  {{- end }}
+  ```
+
+  ```bash OS-specific configuration theme={null}
+  {{- if eq .chezmoi.os "darwin" }}
+  # macOS specific
+  export HOMEBREW_PREFIX="/opt/homebrew"
+  {{- else if eq .chezmoi.os "linux" }}
+  # Linux specific
+  export PATH="$PATH:/usr/local/bin"
+  {{- end }}
+  ```
+
+  ```bash Password manager integration theme={null}
+  # Retrieve a file from 1Password
+  {{- onepasswordDocument "uuid" -}}
+  ```
+</CodeGroup>
+
+<Note>
+  The `-` inside template brackets removes surrounding whitespace. This prevents extra newlines in your output.
+</Note>
+
+## Ignore files or directories on different machines
+
+Use `.chezmoiignore` templates for coarse-grained control:
+
+<CodeGroup>
+  ```text ~/.local/share/chezmoi/.chezmoiignore theme={null}
+  README.md
+  {{- if ne .chezmoi.hostname "work-laptop" }}
+  .work # only manage .work on work-laptop
+  {{- end }}
+  ```
+
+  ```text Exclusion patterns theme={null}
+  dir/f*
+  !dir/foo  # ignore all f* except foo
+  ```
+
+  ```bash Check ignored files theme={null}
+  chezmoi ignored
+  ```
+</CodeGroup>
+
+<Tip>
+  Use `ne` (not equal) to express "only install if". We say "ignore unless work-laptop" instead of "install if work-laptop" because chezmoi installs everything by default.
+</Tip>
+
+## Handle different file locations on different systems with the same contents
+
+Use shared templates in `.chezmoitemplates`:
+
+<Steps>
+  <Step title="Create shared template">
+    ```text ~/.local/share/chezmoi/.chezmoitemplates/file.conf theme={null}
+    # Common configuration
+    setting1 = value1
+    setting2 = value2
+    ```
+  </Step>
+
+  <Step title="Create platform-specific files">
+    <CodeGroup>
+      ```text Library/Application Support/App/file.conf.tmpl (macOS) theme={null}
+      {{- template "file.conf" . -}}
+      ```
+
+      ```text dot_config/app/file.conf.tmpl (Linux) theme={null}
+      {{- template "file.conf" . -}}
+      ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Ignore files on wrong platforms">
+    ```text ~/.local/share/chezmoi/.chezmoiignore theme={null}
+    {{ if ne .chezmoi.os "darwin" }}
+    Library/Application Support/App/file.conf
+    {{ end }}
+    {{ if ne .chezmoi.os "linux" }}
+    .config/app/file.conf
+    {{ end }}
+    ```
+  </Step>
+</Steps>
+
+## Use completely different dotfiles on different machines
+
+<Tabs>
+  <Tab title="Inline approach">
+    ```text ~/.local/share/chezmoi/dot_bashrc.tmpl theme={null}
+    {{ if eq .chezmoi.os "darwin" -}}
+    # macOS .bashrc contents
+    export HOMEBREW_PREFIX="/opt/homebrew"
+    {{ else if eq .chezmoi.os "linux" -}}
+    # Linux .bashrc contents
+    export PATH="$PATH:/usr/local/bin"
+    {{ end -}}
+    ```
+  </Tab>
+
+  <Tab title="Separate files with include">
+    Create separate files for each platform:
+
+    <CodeGroup>
+      ```bash ~/.local/share/chezmoi/.bashrc_darwin theme={null}
+      # macOS .bashrc contents
+      export HOMEBREW_PREFIX="/opt/homebrew"
+      ```
+
+      ```bash ~/.local/share/chezmoi/.bashrc_linux theme={null}
+      # Linux .bashrc contents
+      export PATH="$PATH:/usr/local/bin"
+      ```
+
+      ```text ~/.local/share/chezmoi/dot_bashrc.tmpl theme={null}
+      {{- if eq .chezmoi.os "darwin" -}}
+      {{-   include ".bashrc_darwin" -}}
+      {{- else if eq .chezmoi.os "linux" -}}
+      {{-   include ".bashrc_linux" -}}
+      {{- end -}}
+      ```
+    </CodeGroup>
+  </Tab>
+
+  <Tab title="Templates within templates">
+    For templated content in separate files:
+
+    <CodeGroup>
+      ```text ~/.local/share/chezmoi/.chezmoitemplates/bashrc_darwin.tmpl theme={null}
+      # macOS .bashrc with template variables
+      export EMAIL={{ .email | quote }}
+      ```
+
+      ```text ~/.local/share/chezmoi/.chezmoitemplates/bashrc_linux.tmpl theme={null}
+      # Linux .bashrc with template variables
+      export EMAIL={{ .email | quote }}
+      ```
+
+      ```text ~/.local/share/chezmoi/dot_bashrc.tmpl theme={null}
+      {{- if eq .chezmoi.os "darwin" -}}
+      {{-   template "bashrc_darwin.tmpl" . -}}
+      {{- else if eq .chezmoi.os "linux" -}}
+      {{-   template "bashrc_linux.tmpl" . -}}
+      {{- end -}}
+      ```
+    </CodeGroup>
+
+    <Note>
+      Pass `.` to the template function to make variables available in the included template.
+    </Note>
+  </Tab>
+</Tabs>
+
+
+# Setup
+Source: https://twpayne-chezmoi.mintlify.app/user-guide/setup
+
+Set up chezmoi to manage your dotfiles across multiple machines
+
+## Understand chezmoi's files and directories
+
+chezmoi generates your dotfiles for your local machine by combining two main sources of data:
+
+**Source directory** (`~/.local/share/chezmoi`)
+
+* Common to all your machines
+* A clone of your dotfiles repo
+* Each managed file has a corresponding source file here
+
+**Config file** (`~/.config/chezmoi/chezmoi.toml`)
+
+* Specific to the local machine
+* Can also use JSON or YAML format
+* Contains machine-specific variables
+
+Files with identical contents across machines are copied verbatim. Files that vary are executed as templates, using data from the config file to customize content for each machine.
+
+## Use a hosted repo to manage your dotfiles across multiple machines
+
+chezmoi uses version control to share changes across machines. You should create a repo on your preferred platform (GitHub, GitLab, Bitbucket) to store your dotfiles.
+
+<Steps>
+  <Step title="Push your dotfiles to a remote repo">
+    Navigate to your source directory and add a remote:
+
+    ```bash theme={null}
+    chezmoi cd
+    git remote add origin https://github.com/$GITHUB_USERNAME/dotfiles.git
+    git push -u origin main
+    exit
+    ```
+  </Step>
+
+  <Step title="Initialize chezmoi on another machine">
+    Clone your dotfiles repo:
+
+    ```bash theme={null}
+    chezmoi init https://github.com/$GITHUB_USERNAME/dotfiles.git
+    ```
+  </Step>
+
+  <Step title="Preview and apply changes">
+    <Tabs>
+      <Tab title="Preview changes">
+        See what would be changed:
+
+        ```bash theme={null}
+        chezmoi diff
+        ```
+      </Tab>
+
+      <Tab title="Apply changes">
+        If you're happy with the changes:
+
+        ```bash theme={null}
+        chezmoi apply
+        ```
+      </Tab>
+
+      <Tab title="All in one">
+        Initialize, checkout, and apply in a single command:
+
+        ```bash theme={null}
+        chezmoi init --apply --verbose https://github.com/$GITHUB_USERNAME/dotfiles.git
+        ```
+      </Tab>
+    </Tabs>
+  </Step>
+</Steps>
+
+```mermaid theme={null}
+sequenceDiagram
+    participant H as home directory
+    participant W as working copy
+    participant L as local repo
+    participant R as remote repo
+    R->>W: chezmoi init $REPO
+    W-->>H: chezmoi diff
+    W->>H: chezmoi apply
+    R->>H: chezmoi init --apply $REPO
+```
+
+## Use a private repo to store your dotfiles
+
+chezmoi supports both public and private repos. For security:
+
+* Store secrets in password managers or encrypted files
+* Keep private data in machine-specific config files
+* Your dotfiles repo can remain public
+
+<Note>
+  When using a private GitHub repo without SSH, you'll need to use a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) instead of your password.
+</Note>
+
+## Create a config file on a new machine automatically
+
+Automate config file creation by adding a `.chezmoi.toml.tmpl` template to your repo:
+
+<CodeGroup>
+  ```toml ~/.local/share/chezmoi/.chezmoi.toml.tmpl theme={null}
+  {{- $email := promptStringOnce . "email" "Email address" -}}
+
+  [data]
+      email = {{ $email | quote }}
+  ```
+
+  ```toml Generated output theme={null}
+  [data]
+      email = "user@example.com"
+  ```
+</CodeGroup>
+
+When you run `chezmoi init`, this template will generate your `chezmoi.toml` config file. The `promptStringOnce` function prompts for values not already set.
+
+<Steps>
+  <Step title="Test the template">
+    Use `execute-template` to test without creating files:
+
+    ```bash theme={null}
+    chezmoi execute-template --init --promptString "Email address=me@home.org" < ~/.local/share/chezmoi/.chezmoi.toml.tmpl
+    ```
+  </Step>
+
+  <Step title="Re-create your config file">
+    If you update the template, regenerate your config:
+
+    ```bash theme={null}
+    chezmoi init
+    ```
+
+    Using `promptStringOnce` prevents re-prompting for existing values.
+  </Step>
+</Steps>
+
+<Tip>
+  Supported config formats: `json`, `jsonc`, `toml`, and `yaml`. Name your template `.chezmoi.$FORMAT.tmpl`.
+</Tip>
+
+
+# Templating
+Source: https://twpayne-chezmoi.mintlify.app/user-guide/templating
+
+Master chezmoi's template system for dynamic configuration
+
+## Introduction
+
+Templates allow you to change file contents based on the environment. For example, use different email addresses or API keys on different machines.
+
+chezmoi uses Go's [`text/template`](https://pkg.go.dev/text/template) syntax extended with [Sprig functions](http://masterminds.github.io/sprig/).
+
+A file is interpreted as a template if:
+
+* The filename has a `.tmpl` suffix
+* The file is in `.chezmoitemplates` directory or its subdirectories
+
+## Template data
+
+<CodeGroup>
+  ```bash View all available data theme={null}
+  chezmoi data
+  ```
+
+  ```json Example output theme={null}
+  {
+    "chezmoi": {
+      "arch": "amd64",
+      "os": "linux",
+      "hostname": "myhost",
+      "username": "user"
+    },
+    "email": "user@example.com"
+  }
+  ```
+</CodeGroup>
+
+Data sources (later sources override earlier ones):
+
+1. **Built-in variables** in `.chezmoi` (e.g., `.chezmoi.os`, `.chezmoi.hostname`)
+2. **`.chezmoidata.$FORMAT` files** (read in alphabetical order)
+3. **`data` section** in your config file
+
+chezmoi also provides functions to retrieve runtime data from password managers, environment variables, and the file system.
+
+## Creating a template file
+
+<Tabs>
+  <Tab title="Add with --template">
+    ```bash theme={null}
+    chezmoi add --template ~/.zshrc
+    ```
+
+    Creates `~/.local/share/chezmoi/dot_zshrc.tmpl`.
+  </Tab>
+
+  <Tab title="Convert existing file">
+    ```bash theme={null}
+    chezmoi chattr +template ~/.zshrc
+    ```
+
+    Converts an already-managed file to a template.
+  </Tab>
+
+  <Tab title="Create manually">
+    ```bash theme={null}
+    chezmoi cd
+    $EDITOR dot_zshrc.tmpl
+    ```
+
+    Create the template file directly in the source directory.
+  </Tab>
+
+  <Tab title="Shared templates">
+    ```bash theme={null}
+    chezmoi cd
+    mkdir -p .chezmoitemplates
+    cd .chezmoitemplates
+    $EDITOR mytemplate
+    ```
+
+    Templates in `.chezmoitemplates` must be created manually.
+  </Tab>
+</Tabs>
+
+## Editing a template file
+
+<CodeGroup>
+  ```bash Edit template theme={null}
+  chezmoi edit ~/.zshrc
+  ```
+
+  ```bash Edit and apply theme={null}
+  chezmoi edit --apply ~/.zshrc
+  ```
+</CodeGroup>
+
+The `edit` command opens the source file and checks template syntax when you quit the editor.
+
+## Testing templates
+
+<Tabs>
+  <Tab title="Simple expression">
+    ```bash theme={null}
+    chezmoi execute-template '{{ .chezmoi.hostname }}'
+    ```
+
+    Output: `myhost`
+  </Tab>
+
+  <Tab title="Test file">
+    ```bash theme={null}
+    chezmoi cd
+    chezmoi execute-template < dot_zshrc.tmpl
+    ```
+
+    Shows what the template will generate.
+  </Tab>
+
+  <Tab title="PowerShell">
+    ```powershell theme={null}
+    cat foo.txt | chezmoi execute-template
+    ```
+
+    Use piping if file redirection doesn't work.
+  </Tab>
+</Tabs>
+
+## Template syntax
+
+Template actions are written inside `{{ }}`. Text outside is copied literally.
+
+<Tabs>
+  <Tab title="Variables">
+    ```text theme={null}
+    {{ .chezmoi.hostname }}
+    {{ .email }}
+    ```
+  </Tab>
+
+  <Tab title="Conditionals">
+    ```text theme={null}
+    {{ if eq .chezmoi.os "darwin" }}
+    # darwin
+    {{ else if eq .chezmoi.os "linux" }}
+    # linux
+    {{ else }}
+    # other operating system
+    {{ end }}
+    ```
+  </Tab>
+
+  <Tab title="Removing whitespace">
+    ```text theme={null}
+    HOSTNAME={{- .chezmoi.hostname }}
+    ```
+
+    Output: `HOSTNAME=myhostname`
+
+    The `-` removes all surrounding whitespace (tabs, spaces, newlines).
+  </Tab>
+</Tabs>
+
+## Simple logic
+
+<CodeGroup>
+  ```bash Conditional sections theme={null}
+  # common config
+  export EDITOR=vi
+
+  # machine-specific configuration
+  {{- if eq .chezmoi.hostname "work-laptop" }}
+  # this will only be included in ~/.bashrc on work-laptop
+  export WORK_VAR=value
+  {{- end }}
+  ```
+
+  ```bash Multiple conditions theme={null}
+  {{ if eq "foo" "foo" "bar" }}hello{{end}}
+  {{ if eq "foo" "bar" "foo" }}hello{{end}}
+  {{ if eq "foo" "bar" "bar" }}hello{{end}}
+  ```
+</CodeGroup>
+
+### Boolean functions
+
+| Function | Description                                                  |
+| -------- | ------------------------------------------------------------ |
+| `eq`     | Returns true if first argument equals any other argument     |
+| `not`    | Returns boolean negation                                     |
+| `and`    | Returns boolean AND (returns first empty arg or last arg)    |
+| `or`     | Returns boolean OR (returns first non-empty arg or last arg) |
+
+### Integer comparison functions
+
+| Function | Description            |
+| -------- | ---------------------- |
+| `len`    | Returns integer length |
+| `eq`     | arg1 == arg2           |
+| `ne`     | arg1 != arg2           |
+| `lt`     | arg1 \< arg2           |
+| `le`     | arg1 \<= arg2          |
+| `gt`     | arg1 > arg2            |
+| `ge`     | arg1 >= arg2           |
+
+## More complicated logic
+
+<Tabs>
+  <Tab title="Multiple eq arguments">
+    ```text theme={null}
+    {{ if eq "foo" "foo" "bar" }}hello{{end}}
+    ```
+
+    Checks if first arg equals any of the other args.
+  </Tab>
+
+  <Tab title="Chaining operators">
+    ```text theme={null}
+    {{ if (and (eq .chezmoi.os "linux") (ne .email "me@home.org")) }}
+    # Linux and not home email
+    {{ end }}
+    ```
+
+    Parentheses are required to chain operators.
+  </Tab>
+</Tabs>
+
+## Helper functions
+
+chezmoi includes:
+
+* All [Sprig functions](http://masterminds.github.io/sprig/)
+* Custom chezmoi functions (see [reference](/reference/templates/functions))
+
+<CodeGroup>
+  ```bash Access template variables theme={null}
+  chezmoi data
+  ```
+
+  ```text Use in templates theme={null}
+  {{ .chezmoi.kernel.osrelease }}
+  ```
+</CodeGroup>
+
+## Using `.chezmoitemplates`
+
+Files in `.chezmoitemplates` can be included in other templates using the `template` action:
+
+<Steps>
+  <Step title="Create shared template">
+    ```text .chezmoitemplates/part.tmpl theme={null}
+    {{ if eq .chezmoi.os "linux" }}
+    # linux config
+    {{ else }}
+    # non-linux config
+    {{ end }}
+    ```
+  </Step>
+
+  <Step title="Use in another template">
+    ```text dot_file.tmpl theme={null}
+    {{ template "part.tmpl" . }}
+    ```
+
+    <Warning>
+      Pass `.` to make template variables available. Without it, the template receives `nil` data.
+    </Warning>
+  </Step>
+</Steps>
+
+## Creating similar files with shared templates
+
+<Steps>
+  <Step title="Create shared template">
+    ```text .chezmoitemplates/alacritty theme={null}
+    some: config
+    fontsize: {{ . }}
+    more: config
+    ```
+
+    Files in `.chezmoitemplates` don't need `.tmpl` extension.
+  </Step>
+
+  <Step title="Create files using the template">
+    <CodeGroup>
+      ```text small-font.yml.tmpl theme={null}
+      {{- template "alacritty" 12 -}}
+      ```
+
+      ```text big-font.yml.tmpl theme={null}
+      {{- template "alacritty" 18 -}}
+      ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Test the output">
+    ```bash theme={null}
+    chezmoi cat ~/small-font.yml
+    ```
+
+    Output:
+
+    ```yaml theme={null}
+    some: config
+    fontsize: 12
+    more: config
+    ```
+  </Step>
+</Steps>
+
+### Passing multiple arguments
+
+<Tabs>
+  <Tab title="Via config file">
+    ```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+    [data.alacritty.big]
+        fontsize = 18
+        font = "DejaVu Serif"
+    [data.alacritty.small]
+        fontsize = 12
+        font = "DejaVu Sans Mono"
+    ```
+
+    Template:
+
+    ```text .chezmoitemplates/alacritty theme={null}
+    some: config
+    fontsize: {{ .fontsize }}
+    font: {{ .font }}
+    more: config
+    ```
+
+    Usage:
+
+    ```text small-font.yml.tmpl theme={null}
+    {{- template "alacritty" .alacritty.small -}}
+    ```
+  </Tab>
+
+  <Tab title="Via dictionary">
+    ```text small-font.yml.tmpl theme={null}
+    {{- template "alacritty" dict "fontsize" 12 "font" "DejaVu Sans Mono" -}}
+    ```
+
+    Use this approach to pass arguments inline without config file duplication.
+  </Tab>
+</Tabs>
+
+
+# Use Scripts to Perform Actions
+Source: https://twpayne-chezmoi.mintlify.app/user-guide/use-scripts-to-perform-actions
+
+Automate tasks with chezmoi's script system
+
+## Understand how scripts work
+
+chezmoi supports scripts that execute when you run `chezmoi apply`. Scripts are files in the source directory with the `run_` prefix, executed in alphabetical order.
+
+### Script types
+
+<CardGroup>
+  <Card title="run_" icon="repeat">
+    Execute every time you run `chezmoi apply`
+  </Card>
+
+  <Card title="run_onchange_" icon="arrows-rotate">
+    Execute only when script contents have changed
+  </Card>
+
+  <Card title="run_once_" icon="check">
+    Execute once per unique content version
+  </Card>
+</CardGroup>
+
+<Note>
+  All scripts should be **idempotent** (safe to run multiple times). Scripts break chezmoi's declarative approach and should be used sparingly.
+</Note>
+
+### Script timing
+
+Scripts normally run while chezmoi updates your dotfiles:
+
+```
+a.txt → run_b.sh → c.txt
+```
+
+Use `before_` or `after_` attributes to control timing:
+
+<CodeGroup>
+  ```bash Before updates theme={null}
+  run_once_before_install-password-manager.sh
+  ```
+
+  ```bash After updates theme={null}
+  run_once_after_install-fonts.sh
+  ```
+</CodeGroup>
+
+### Script requirements
+
+<Steps>
+  <Step title="Create manually">
+    ```bash theme={null}
+    chezmoi cd
+    touch run_install-packages.sh
+    chmod +x run_install-packages.sh
+    ```
+
+    No need to set executable bit - chezmoi handles it.
+  </Step>
+
+  <Step title="Include shebang or use binary">
+    ```bash theme={null}
+    #!/bin/bash
+    echo "Installing packages..."
+    ```
+
+    Scripts must include a `#!` line or be an executable binary.
+  </Step>
+
+  <Step title="Template support">
+    ```bash run_install.sh.tmpl theme={null}
+    {{ if eq .chezmoi.os "linux" -}}
+    #!/bin/sh
+    sudo apt install ripgrep
+    {{ else if eq .chezmoi.os "darwin" -}}
+    #!/bin/sh
+    brew install ripgrep
+    {{ end -}}
+    ```
+
+    Scripts with `.tmpl` suffix are templated. If template resolves to whitespace, script won't execute.
+  </Step>
+</Steps>
+
+<Tip>
+  Scripts in `.chezmoiscripts/` directory are executed without creating a corresponding directory in the target state.
+</Tip>
+
+## Set environment variables
+
+Configure extra environment variables for scripts in your config:
+
+```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+[scriptEnv]
+    MY_VAR = "my_value"
+    API_KEY = "{{ onepassword "api-key" }}"
+```
+
+chezmoi automatically sets:
+
+* `CHEZMOI=1`
+* `CHEZMOI_OS` (e.g., `linux`, `darwin`)
+* `CHEZMOI_ARCH` (e.g., `amd64`, `arm64`)
+* Other template data as `CHEZMOI_*` variables
+
+## Don't show scripts in `chezmoi diff`/`chezmoi status`
+
+<Tabs>
+  <Tab title="Exclude from diff">
+    ```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+    [diff]
+        exclude = ["scripts"]
+    ```
+
+    Scripts won't appear in `chezmoi diff` output.
+  </Tab>
+
+  <Tab title="Exclude from status">
+    ```toml ~/.config/chezmoi/chezmoi.toml theme={null}
+    [status]
+        exclude = ["scripts"]
+    ```
+
+    Scripts won't show `R` status in `chezmoi status`.
+  </Tab>
+</Tabs>
+
+## Install packages with scripts
+
+<Steps>
+  <Step title="Create installation script">
+    ```bash theme={null}
+    chezmoi cd
+    touch run_onchange_install-packages.sh
+    ```
+  </Step>
+
+  <Step title="Add package installation commands">
+    <CodeGroup>
+      ```bash Simple version theme={null}
+      #!/bin/sh
+      sudo apt install ripgrep
+      ```
+
+      ```bash Template version theme={null}
+      {{ if eq .chezmoi.os "linux" -}}
+      #!/bin/sh
+      sudo apt install ripgrep
+      {{ else if eq .chezmoi.os "darwin" -}}
+      #!/bin/sh
+      brew install ripgrep
+      {{ end -}}
+      ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Apply changes">
+    ```bash theme={null}
+    chezmoi apply
+    ```
+
+    Script runs on first apply. With `run_onchange_`, it won't run again unless contents change.
+  </Step>
+</Steps>
+
+<Tip>
+  Name your template `run_onchange_install-packages.sh.tmpl` to install platform-specific packages automatically.
+</Tip>
+
+## Run a script when another file changes
+
+Use content checksums to trigger scripts when other files change:
+
+<CodeGroup>
+  ```bash run_onchange_dconf-load.sh.tmpl theme={null}
+  #!/bin/bash
+
+  # dconf.ini hash: {{ include "dconf.ini" | sha256sum }}
+  dconf load / < {{ joinPath .chezmoi.sourceDir "dconf.ini" | quote }}
+  ```
+
+  ```ini dconf.ini theme={null}
+  [org/gnome/desktop/interface]
+  clock-show-seconds=true
+  enable-hot-corners=false
+  ```
+</CodeGroup>
+
+How it works:
+
+1. Template includes SHA256 hash of `dconf.ini` in a comment
+2. When `dconf.ini` changes, the hash changes
+3. Changed hash means changed script content
+4. chezmoi reruns the `run_onchange_` script
+
+<Note>
+  Add `dconf.ini` to `.chezmoiignore` so chezmoi doesn't create it in your home directory.
+</Note>
+
+## Clear the state of all `run_onchange_` and `run_once_` scripts
+
+chezmoi tracks script execution in persistent state.
+
+<Tabs>
+  <Tab title="Clear run_onchange_ state">
+    ```bash theme={null}
+    chezmoi state delete-bucket --bucket=entryState
+    ```
+
+    All `run_onchange_` scripts will run again on next `chezmoi apply`.
+  </Tab>
+
+  <Tab title="Clear run_once_ state">
+    ```bash theme={null}
+    chezmoi state delete-bucket --bucket=scriptState
+    ```
+
+    All `run_once_` scripts will run again on next `chezmoi apply`.
+  </Tab>
+</Tabs>
+
+<Warning>
+  Clearing state causes scripts to run again. Ensure your scripts are idempotent before doing this.
+</Warning>
+
+## Real-world examples
+
+<CodeGroup>
+  ```bash run_onchange_before_install-homebrew.sh.tmpl theme={null}
+  {{ if eq .chezmoi.os "darwin" -}}
+  #!/bin/bash
+
+  if ! command -v brew &> /dev/null; then
+      echo "Installing Homebrew..."
+      /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  fi
+  {{- end }}
+  ```
+
+  ```bash run_once_after_install-oh-my-zsh.sh theme={null}
+  #!/bin/sh
+
+  if [ ! -d "$HOME/.oh-my-zsh" ]; then
+      sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+  fi
+  ```
+
+  ```bash run_onchange_update-packages.sh.tmpl theme={null}
+  #!/bin/bash
+
+  # Package list hash: {{ include "packages.txt" | sha256sum }}
+
+  {{ if eq .chezmoi.os "linux" -}}
+  xargs sudo apt install -y < {{ joinPath .chezmoi.sourceDir "packages.txt" | quote }}
+  {{ else if eq .chezmoi.os "darwin" -}}
+  xargs brew install < {{ joinPath .chezmoi.sourceDir "packages.txt" | quote }}
+  {{ end -}}
+  ```
+</CodeGroup>
+
+

--- a/docs/research/mintlify-cache/twpayne/chezmoi/llms.txt
+++ b/docs/research/mintlify-cache/twpayne/chezmoi/llms.txt
@@ -1,0 +1,87 @@
+# chezmoi
+
+## Docs
+
+- [Customize chezmoi](https://www.mintlify.com/twpayne/chezmoi/advanced/customize-chezmoi.md): Advanced customization options for chezmoi's behavior and structure
+- [Machine-Specific Configurations](https://www.mintlify.com/twpayne/chezmoi/advanced/machines.md): Manage dotfiles across different machines with templates and conditionals
+- [Migrating from Another Dotfile Manager](https://www.mintlify.com/twpayne/chezmoi/advanced/migrating-from-another-dotfile-manager.md): Guide to migrating your dotfiles from other tools to chezmoi
+- [Configuring External Tools](https://www.mintlify.com/twpayne/chezmoi/advanced/tools.md): Customize diff, merge, and editor tools used by chezmoi
+- [add](https://www.mintlify.com/twpayne/chezmoi/commands/add.md): Add files, directories, or symlinks to the source state
+- [apply](https://www.mintlify.com/twpayne/chezmoi/commands/apply.md): Update the destination directory to match the target state
+- [cat](https://www.mintlify.com/twpayne/chezmoi/commands/cat.md): Print the target contents of files, scripts, or symlinks
+- [cd](https://www.mintlify.com/twpayne/chezmoi/commands/cd.md): Launch a shell in the source directory
+- [completion](https://www.mintlify.com/twpayne/chezmoi/commands/completion.md): Generate shell completion scripts
+- [diff](https://www.mintlify.com/twpayne/chezmoi/commands/diff.md): Show differences between the target state and the destination state
+- [doctor](https://www.mintlify.com/twpayne/chezmoi/commands/doctor.md): Check your system for potential problems
+- [edit](https://www.mintlify.com/twpayne/chezmoi/commands/edit.md): Edit the source state of targets
+- [execute-template](https://www.mintlify.com/twpayne/chezmoi/commands/execute-template.md): Execute templates with access to template data
+- [init](https://www.mintlify.com/twpayne/chezmoi/commands/init.md): Setup the source directory and update the destination directory to match the target state
+- [managed](https://www.mintlify.com/twpayne/chezmoi/commands/managed.md): List the managed entries in the destination directory
+- [merge](https://www.mintlify.com/twpayne/chezmoi/commands/merge.md): Perform three-way merges between the destination, source, and target states
+- [Command Reference](https://www.mintlify.com/twpayne/chezmoi/commands/overview.md): Complete reference for all chezmoi commands
+- [status](https://www.mintlify.com/twpayne/chezmoi/commands/status.md): Show the status of files and scripts managed by chezmoi
+- [unmanaged](https://www.mintlify.com/twpayne/chezmoi/commands/unmanaged.md): List the unmanaged files in the destination directory
+- [update](https://www.mintlify.com/twpayne/chezmoi/commands/update.md): Pull changes from the source repository and apply them
+- [upgrade](https://www.mintlify.com/twpayne/chezmoi/commands/upgrade.md): Upgrade chezmoi to the latest released version
+- [verify](https://www.mintlify.com/twpayne/chezmoi/commands/verify.md): Verify that the destination state matches the target state
+- [Articles and Blog Posts](https://www.mintlify.com/twpayne/chezmoi/community/articles.md): Community articles, tutorials, and blog posts about chezmoi
+- [Comparison Table](https://www.mintlify.com/twpayne/chezmoi/community/comparison-table.md): Feature comparison between chezmoi and other dotfile managers
+- [Dotfile Repositories](https://www.mintlify.com/twpayne/chezmoi/community/dotfile-repos.md): Browse and learn from community dotfile repositories using chezmoi
+- [Related Software](https://www.mintlify.com/twpayne/chezmoi/community/related-software.md): Tools, plugins, and integrations that work with chezmoi
+- [Videos and Presentations](https://www.mintlify.com/twpayne/chezmoi/community/videos.md): Video tutorials, talks, and presentations about chezmoi
+- [How chezmoi works](https://www.mintlify.com/twpayne/chezmoi/concepts/how-chezmoi-works.md): Understand chezmoi architecture, core concepts, and how it manages dotfiles from source state to destination state.
+- [What does chezmoi do?](https://www.mintlify.com/twpayne/chezmoi/concepts/what-does-chezmoi-do.md): Learn how chezmoi helps manage personal configuration files across multiple machines and operating systems.
+- [Why use chezmoi?](https://www.mintlify.com/twpayne/chezmoi/concepts/why-use-chezmoi.md): Understand the benefits of using chezmoi over other dotfile management approaches and why thousands of developers trust it.
+- [Architecture](https://www.mintlify.com/twpayne/chezmoi/developer/architecture.md): High-level overview of chezmoi's source code architecture
+- [Building chezmoi](https://www.mintlify.com/twpayne/chezmoi/developer/building.md): Instructions for building chezmoi from source
+- [Building on Top of chezmoi](https://www.mintlify.com/twpayne/chezmoi/developer/building-on-top-of-chezmoi.md): Guidelines for integrating with chezmoi and building tools on top of it
+- [Contributing to chezmoi](https://www.mintlify.com/twpayne/chezmoi/developer/contributing.md): Guidelines for contributing changes to chezmoi
+- [Install Script](https://www.mintlify.com/twpayne/chezmoi/developer/install-script.md): Information about chezmoi's install script generation
+- [Packaging chezmoi](https://www.mintlify.com/twpayne/chezmoi/developer/packaging.md): Guidelines for packaging chezmoi for operating systems and distributions
+- [Releases](https://www.mintlify.com/twpayne/chezmoi/developer/releases.md): How chezmoi releases are created and published
+- [Security](https://www.mintlify.com/twpayne/chezmoi/developer/security.md): Security policy and vulnerability reporting for chezmoi
+- [Testing chezmoi](https://www.mintlify.com/twpayne/chezmoi/developer/testing.md): Overview of chezmoi's testing strategy and how to run tests
+- [age Encryption](https://www.mintlify.com/twpayne/chezmoi/encryption/age.md): Encrypt your dotfiles with age, a modern encryption tool
+- [GPG Encryption](https://www.mintlify.com/twpayne/chezmoi/encryption/gpg.md): Encrypt your dotfiles with GPG/PGP encryption
+- [Encryption Overview](https://www.mintlify.com/twpayne/chezmoi/encryption/overview.md): Keep your secrets secure with chezmoi's encryption support
+- [Design Decisions FAQ](https://www.mintlify.com/twpayne/chezmoi/faq/design.md): Frequently asked questions about chezmoi's design and architecture
+- [General FAQ](https://www.mintlify.com/twpayne/chezmoi/faq/general.md): Frequently asked questions about chezmoi
+- [Troubleshooting FAQ](https://www.mintlify.com/twpayne/chezmoi/faq/troubleshooting.md): Solutions to common problems and errors with chezmoi
+- [Usage FAQ](https://www.mintlify.com/twpayne/chezmoi/faq/usage.md): Frequently asked questions about using chezmoi day-to-day
+- [Install chezmoi](https://www.mintlify.com/twpayne/chezmoi/install.md): Install chezmoi on Linux, macOS, Windows, FreeBSD, and more with your preferred package manager or direct download
+- [chezmoi - Manage Your Dotfiles Across Multiple Machines](https://www.mintlify.com/twpayne/chezmoi/introduction.md): Securely manage your personal configuration files (dotfiles) across multiple diverse machines, from your laptop to cloud servers
+- [1Password](https://www.mintlify.com/twpayne/chezmoi/password-managers/1password.md): Integrate 1Password with chezmoi to manage secrets in your dotfiles
+- [AWS Secrets Manager](https://www.mintlify.com/twpayne/chezmoi/password-managers/aws-secrets-manager.md): Integrate AWS Secrets Manager with chezmoi to manage secrets in your dotfiles
+- [Azure Key Vault](https://www.mintlify.com/twpayne/chezmoi/password-managers/azure-key-vault.md): Integrate Azure Key Vault with chezmoi to manage secrets in your dotfiles
+- [Bitwarden](https://www.mintlify.com/twpayne/chezmoi/password-managers/bitwarden.md): Integrate Bitwarden with chezmoi to manage secrets in your dotfiles
+- [Dashlane](https://www.mintlify.com/twpayne/chezmoi/password-managers/dashlane.md): Integrate Dashlane with chezmoi to manage secrets in your dotfiles
+- [Doppler](https://www.mintlify.com/twpayne/chezmoi/password-managers/doppler.md): Integrate Doppler with chezmoi to manage secrets in your dotfiles
+- [gopass](https://www.mintlify.com/twpayne/chezmoi/password-managers/gopass.md): Integrate gopass with chezmoi to manage secrets in your dotfiles
+- [KeePassXC](https://www.mintlify.com/twpayne/chezmoi/password-managers/keepassxc.md): Integrate KeePassXC with chezmoi to manage secrets in your dotfiles
+- [Keeper](https://www.mintlify.com/twpayne/chezmoi/password-managers/keeper.md): Integrate Keeper Security with chezmoi to manage secrets in your dotfiles
+- [LastPass](https://www.mintlify.com/twpayne/chezmoi/password-managers/lastpass.md): Integrate LastPass with chezmoi to manage secrets in your dotfiles
+- [pass (Password Store)](https://www.mintlify.com/twpayne/chezmoi/password-managers/pass.md): Integrate pass with chezmoi to manage secrets in your dotfiles
+- [Passhole](https://www.mintlify.com/twpayne/chezmoi/password-managers/passhole.md): Integrate KeePass with chezmoi using the Passhole CLI
+- [Proton Pass](https://www.mintlify.com/twpayne/chezmoi/password-managers/proton-pass.md): Integrate Proton Pass with chezmoi to manage secrets in your dotfiles
+- [HashiCorp Vault](https://www.mintlify.com/twpayne/chezmoi/password-managers/vault.md): Integrate HashiCorp Vault with chezmoi to manage secrets in your dotfiles
+- [Quick Start Guide](https://www.mintlify.com/twpayne/chezmoi/quick-start.md): Get started with chezmoi and learn how to manage your dotfiles across multiple machines
+- [Application Order](https://www.mintlify.com/twpayne/chezmoi/reference/application-order.md): The deterministic order in which chezmoi applies changes
+- [Configuration File](https://www.mintlify.com/twpayne/chezmoi/reference/configuration-file.md): Complete reference for chezmoi's configuration file options
+- [Source State Attributes](https://www.mintlify.com/twpayne/chezmoi/reference/source-state-attributes.md): File naming conventions and attributes in chezmoi's source directory
+- [Special Files and Directories](https://www.mintlify.com/twpayne/chezmoi/reference/special-files-and-directories.md): Special files and directories in chezmoi's source directory
+- [Target Types](https://www.mintlify.com/twpayne/chezmoi/reference/target-types.md): Different types of targets chezmoi can manage
+- [Template Directives](https://www.mintlify.com/twpayne/chezmoi/reference/templates/directives.md): File-specific template options using directives
+- [Template Functions](https://www.mintlify.com/twpayne/chezmoi/reference/templates/functions.md): Complete reference of all template functions available in chezmoi
+- [Templates Overview](https://www.mintlify.com/twpayne/chezmoi/reference/templates/overview.md): Overview of chezmoi's template system
+- [Password Manager Functions](https://www.mintlify.com/twpayne/chezmoi/reference/templates/password-manager-functions.md): Template functions for integrating with password managers
+- [Template Variables](https://www.mintlify.com/twpayne/chezmoi/reference/templates/variables.md): Automatically-populated variables available in chezmoi templates
+- [Daily Operations](https://www.mintlify.com/twpayne/chezmoi/user-guide/daily-operations.md): Common workflows for managing your dotfiles with chezmoi
+- [Include Files from Elsewhere](https://www.mintlify.com/twpayne/chezmoi/user-guide/include-files-from-elsewhere.md): Import external files and repositories into your dotfiles
+- [Manage Different Types of File](https://www.mintlify.com/twpayne/chezmoi/user-guide/manage-different-types-of-file.md): Handle special file types and scenarios with chezmoi
+- [Manage Machine-to-Machine Differences](https://www.mintlify.com/twpayne/chezmoi/user-guide/manage-machine-to-machine-differences.md): Use templates to customize dotfiles for different machines
+- [Setup](https://www.mintlify.com/twpayne/chezmoi/user-guide/setup.md): Set up chezmoi to manage your dotfiles across multiple machines
+- [Templating](https://www.mintlify.com/twpayne/chezmoi/user-guide/templating.md): Master chezmoi's template system for dynamic configuration
+- [Use Scripts to Perform Actions](https://www.mintlify.com/twpayne/chezmoi/user-guide/use-scripts-to-perform-actions.md): Automate tasks with chezmoi's script system
+
+
+Built with [Mintlify](https://mintlify.com).

--- a/docs/research/mintlify-cache/wagoodman/dive/llms-full.txt
+++ b/docs/research/mintlify-cache/wagoodman/dive/llms-full.txt
@@ -1,0 +1,1790 @@
+# CI integration
+Source: https://wagoodman-dive.atlas.mintlify.me/configuration/ci-integration
+
+Run dive in CI pipelines to enforce image efficiency rules with pass/fail output.
+
+dive includes a CI mode that skips the interactive TUI and instead analyzes your image against a set of configurable rules, exiting with a non-zero code if any rule fails. Use this to gate deployments on image quality.
+
+## Basic usage
+
+Set the `CI` environment variable to `true` when running any valid dive command:
+
+```bash theme={null}
+CI=true dive <your-image>
+```
+
+You can also pass the `--ci` flag directly:
+
+```bash theme={null}
+dive --ci <your-image>
+```
+
+dive will print a summary of the analysis and exit with code `0` if all rules pass, or a non-zero code if any rule fails.
+
+## CI rules
+
+Pass/fail is determined by three configurable rules. Create a `.dive-ci` file at the root of your repository to set thresholds:
+
+```yaml theme={null}
+rules:
+  # If the efficiency is measured below X%, mark as failed.
+  # Expressed as a ratio between 0-1.
+  lowestEfficiency: 0.95
+
+  # If the amount of wasted space is at least X or larger than X, mark as failed.
+  # Expressed in B, KB, MB, and GB.
+  highestWastedBytes: 20MB
+
+  # If the amount of wasted space makes up for X% or more of the image, mark as failed.
+  # Note: the base image layer is NOT included in the total image size.
+  # Expressed as a ratio between 0-1; fails if the threshold is met or crossed.
+  highestUserWastedPercent: 0.20
+```
+
+<Note>
+  The `.dive-ci` file uses camelCase keys (`lowestEfficiency`, `highestWastedBytes`, `highestUserWastedPercent`). These are different from the snake-case keys used in the main dive config file.
+</Note>
+
+### Rule reference
+
+<ParamField type="number">
+  The lowest allowable image efficiency score. Expressed as a ratio between `0` and `1`. dive fails if the measured efficiency falls below this threshold.
+</ParamField>
+
+<ParamField type="string">
+  The maximum allowable wasted bytes. Expressed as a value with a unit suffix: `B`, `KB`, `MB`, or `GB`. dive fails if wasted space meets or exceeds this threshold. Set to `disabled` to skip this rule.
+</ParamField>
+
+<ParamField type="number">
+  The maximum allowable percentage of the image that is wasted space. Expressed as a ratio between `0` and `1`. The base image layer is excluded from the total image size. dive fails if the wasted percentage meets or exceeds this threshold.
+</ParamField>
+
+<Note>
+  Set any rule value to `disabled` to skip that rule entirely.
+</Note>
+
+## Exit codes
+
+| Code     | Meaning                  |
+| -------- | ------------------------ |
+| `0`      | All rules passed         |
+| non-zero | One or more rules failed |
+
+## Config file path
+
+By default, dive looks for `.dive-ci` at the current working directory. Override this with the `--ci-config` flag:
+
+```bash theme={null}
+CI=true dive --ci-config /path/to/my-ci-rules.yaml <your-image>
+```
+
+## CLI flag overrides
+
+You can set rule thresholds directly on the command line without a config file. These flags are only evaluated when CI mode is active.
+
+```bash theme={null}
+CI=true dive \
+  --lowestEfficiency 0.95 \
+  --highestWastedBytes 20MB \
+  --highestUserWastedPercent 0.20 \
+  <your-image>
+```
+
+## GitHub Actions example
+
+<Steps>
+  <Step title="Build your image">
+    Build the image in an earlier step and tag it for reference.
+
+    ```yaml theme={null}
+    - name: Build Docker image
+      run: docker build -t ${{ env.IMAGE_TAG }} .
+    ```
+  </Step>
+
+  <Step title="Analyze with dive">
+    Run dive in CI mode against the built image.
+
+    ```yaml theme={null}
+    - name: Analyze Docker image
+      run: CI=true dive ${{ env.IMAGE_TAG }}
+      env:
+        CI: "true"
+    ```
+  </Step>
+</Steps>
+
+<Tip>
+  You can combine the build and analysis steps into a single command using `dive build`. This builds the image and immediately analyzes it:
+
+  ```bash theme={null}
+  CI=true dive build -t <your-image-tag> .
+  ```
+</Tip>
+
+
+# Configuration file
+Source: https://wagoodman-dive.atlas.mintlify.me/configuration/config-file
+
+Customize dive behavior with a YAML configuration file.
+
+No configuration is required to run dive, but you can create a config file to override the default settings for any session.
+
+## Config file locations
+
+dive searches for a config file in the following locations, in order:
+
+* `$XDG_CONFIG_HOME/dive/*.yaml`
+* `$XDG_CONFIG_DIRS/dive/*.yaml`
+* `~/.config/dive/*.yaml`
+* `~/.dive.yaml`
+
+You can use `.yml` instead of `.yaml` if you prefer.
+
+## Full configuration example
+
+```yaml theme={null}
+# supported options are "docker" and "podman"
+container-engine: docker
+
+# continue with analysis even if there are errors parsing the image archive
+ignore-errors: false
+
+log:
+  enabled: true
+  path: ./dive.log
+  level: info
+
+# Note: you can specify multiple bindings by separating values with a comma.
+# Note: UI hinting is derived from the first binding
+keybinding:
+  # Global bindings
+  quit: ctrl+c
+  toggle-view: tab
+  filter-files: ctrl+f, ctrl+slash
+  close-filter-files: esc
+  up: up,k
+  down: down,j
+  left: left,h
+  right: right,l
+
+  # Layer view specific bindings
+  compare-all: ctrl+a
+  compare-layer: ctrl+l
+
+  # File view specific bindings
+  toggle-collapse-dir: space
+  toggle-collapse-all-dir: ctrl+space
+  toggle-added-files: ctrl+a
+  toggle-removed-files: ctrl+r
+  toggle-modified-files: ctrl+m
+  toggle-unmodified-files: ctrl+u
+  toggle-filetree-attributes: ctrl+b
+  toggle-sort-order: ctrl+o
+  toggle-wrap-tree: ctrl+p
+  extract-file: ctrl+e
+  page-up: pgup,u
+  page-down: pgdn,d
+
+diff:
+  # You can change the default files shown in the filetree (right pane).
+  # All diff types are shown by default.
+  hide:
+    - added
+    - removed
+    - modified
+    - unmodified
+
+filetree:
+  # The default directory-collapse state
+  collapse-dir: false
+
+  # The percentage of screen width the filetree should take on the screen (must be >0 and <1)
+  pane-width: 0.5
+
+  # Show the file attributes next to the filetree
+  show-attributes: true
+
+layer:
+  # Enable showing all changes from this layer and every previous layer
+  show-aggregated-changes: false
+```
+
+## Config options
+
+### Top-level options
+
+<ParamField type="string">
+  The container engine to use when pulling images. Accepted values are `docker` and `podman`.
+</ParamField>
+
+<ParamField type="boolean">
+  When `true`, dive continues analysis even if there are errors parsing the image archive.
+</ParamField>
+
+### log
+
+<ParamField type="boolean">
+  Enable or disable log output to a file.
+</ParamField>
+
+<ParamField type="string">
+  Path to the log file.
+</ParamField>
+
+<ParamField type="string">
+  Log level. Accepted values are `trace`, `debug`, `info`, `warn`, and `error`.
+</ParamField>
+
+### diff
+
+<ParamField type="string[]">
+  List of diff types to hide by default in the filetree pane. All diff types are shown by default. Accepted values are `added`, `removed`, `modified`, and `unmodified`.
+</ParamField>
+
+### filetree
+
+<ParamField type="boolean">
+  Default directory-collapse state in the filetree. Set to `true` to start with all directories collapsed.
+</ParamField>
+
+<ParamField type="number">
+  Percentage of the screen width that the filetree pane occupies. Must be greater than `0` and less than `1`.
+</ParamField>
+
+<ParamField type="boolean">
+  Show file attributes (permissions, owner, size) next to each entry in the filetree.
+</ParamField>
+
+### layer
+
+<ParamField type="boolean">
+  When `true`, the layer view shows all changes from the selected layer and every previous layer combined, instead of only the current layer's changes.
+</ParamField>
+
+### keybinding
+
+You can override any keybinding by adding a `keybinding` section to your config file. Separate multiple keys for the same action with a comma. The first binding listed is used for UI hints.
+
+See [Keybindings](/configuration/keybindings) for the full list of binding names and their defaults.
+
+
+# Keybindings
+Source: https://wagoodman-dive.atlas.mintlify.me/configuration/keybindings
+
+Keyboard shortcuts for navigating dive, and how to customize them.
+
+## Default keybindings
+
+### Global
+
+These bindings work from any view.
+
+| Key               | Action                                      |
+| ----------------- | ------------------------------------------- |
+| `Ctrl+C` or `Q`   | Exit                                        |
+| `Tab`             | Switch between the layer and filetree views |
+| `Ctrl+F`          | Filter files                                |
+| `ESC`             | Close file filter                           |
+| `PageUp` or `U`   | Scroll up a page                            |
+| `PageDown` or `D` | Scroll down a page                          |
+| `Up` or `K`       | Move up one line                            |
+| `Down` or `J`     | Move down one line                          |
+
+### Layer view
+
+| Key      | Action                                                          |
+| -------- | --------------------------------------------------------------- |
+| `Ctrl+A` | Show aggregated image modifications (all layers up to selected) |
+| `Ctrl+L` | Show current layer modifications only                           |
+
+### Filetree view
+
+| Key               | Action                                 |
+| ----------------- | -------------------------------------- |
+| `Space`           | Collapse or uncollapse a directory     |
+| `Ctrl+Space`      | Collapse or uncollapse all directories |
+| `Ctrl+A`          | Show or hide added files               |
+| `Ctrl+R`          | Show or hide removed files             |
+| `Ctrl+M`          | Show or hide modified files            |
+| `Ctrl+U`          | Show or hide unmodified files          |
+| `Ctrl+B`          | Show or hide file attributes           |
+| `Ctrl+O`          | Toggle sort order                      |
+| `Ctrl+P`          | Toggle word wrap on long paths         |
+| `Ctrl+E`          | Extract the selected file              |
+| `PageUp` or `U`   | Scroll up a page                       |
+| `PageDown` or `D` | Scroll down a page                     |
+
+## Customizing keybindings
+
+Add a `keybinding` section to your [config file](/configuration/config-file) to override any default binding.
+
+```yaml theme={null}
+keybinding:
+  # Global bindings
+  quit: ctrl+c
+  toggle-view: tab
+  filter-files: ctrl+f, ctrl+slash
+  close-filter-files: esc
+  up: up,k
+  down: down,j
+  left: left,h
+  right: right,l
+
+  # Layer view bindings
+  compare-all: ctrl+a
+  compare-layer: ctrl+l
+
+  # Filetree view bindings
+  toggle-collapse-dir: space
+  toggle-collapse-all-dir: ctrl+space
+  toggle-added-files: ctrl+a
+  toggle-removed-files: ctrl+r
+  toggle-modified-files: ctrl+m
+  toggle-unmodified-files: ctrl+u
+  toggle-filetree-attributes: ctrl+b
+  toggle-sort-order: ctrl+o
+  toggle-wrap-tree: ctrl+p
+  extract-file: ctrl+e
+  page-up: pgup,u
+  page-down: pgdn,d
+```
+
+<Note>
+  You can assign multiple keys to the same action by separating them with a comma — for example, `up: up,k`. The first binding in the list is used for UI hints shown at the bottom of the screen.
+</Note>
+
+## Binding names reference
+
+| Config key                   | Default              | Description                                |
+| ---------------------------- | -------------------- | ------------------------------------------ |
+| `quit`                       | `ctrl+c`             | Exit dive                                  |
+| `toggle-view`                | `tab`                | Switch between layer and filetree views    |
+| `filter-files`               | `ctrl+f, ctrl+slash` | Open file filter                           |
+| `close-filter-files`         | `esc`                | Close file filter                          |
+| `up`                         | `up,k`               | Move cursor up                             |
+| `down`                       | `down,j`             | Move cursor down                           |
+| `left`                       | `left,h`             | Move cursor left                           |
+| `right`                      | `right,l`            | Move cursor right                          |
+| `page-up`                    | `pgup,u`             | Scroll up a page                           |
+| `page-down`                  | `pgdn,d`             | Scroll down a page                         |
+| `compare-all`                | `ctrl+a`             | Show aggregated layer changes              |
+| `compare-layer`              | `ctrl+l`             | Show current layer changes                 |
+| `toggle-collapse-dir`        | `space`              | Collapse or expand a directory             |
+| `toggle-collapse-all-dir`    | `ctrl+space`         | Collapse or expand all directories         |
+| `toggle-added-files`         | `ctrl+a`             | Show or hide added files                   |
+| `toggle-removed-files`       | `ctrl+r`             | Show or hide removed files                 |
+| `toggle-modified-files`      | `ctrl+m`             | Show or hide modified files                |
+| `toggle-unmodified-files`    | `ctrl+u`             | Show or hide unmodified files              |
+| `toggle-filetree-attributes` | `ctrl+b`             | Show or hide file attributes               |
+| `toggle-sort-order`          | `ctrl+o`             | Toggle the sort order of files in the tree |
+| `toggle-wrap-tree`           | `ctrl+p`             | Toggle word wrap on long file paths        |
+| `extract-file`               | `ctrl+e`             | Extract the selected file's contents       |
+
+
+# Installation
+Source: https://wagoodman-dive.atlas.mintlify.me/installation
+
+Install dive on Linux, macOS, Windows, or run it as a Docker container.
+
+<Tabs>
+  <Tab title="Linux">
+    **Ubuntu/Debian**
+
+    Download and install the latest `.deb` package:
+
+    ```bash theme={null}
+    DIVE_VERSION=$(curl -sL "https://api.github.com/repos/wagoodman/dive/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
+    curl -fOL "https://github.com/wagoodman/dive/releases/download/v${DIVE_VERSION}/dive_${DIVE_VERSION}_linux_amd64.deb"
+    sudo apt install ./dive_${DIVE_VERSION}_linux_amd64.deb
+    ```
+
+    **RHEL/CentOS**
+
+    Download and install the latest `.rpm` package:
+
+    ```bash theme={null}
+    DIVE_VERSION=$(curl -sL "https://api.github.com/repos/wagoodman/dive/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
+    curl -fOL "https://github.com/wagoodman/dive/releases/download/v${DIVE_VERSION}/dive_${DIVE_VERSION}_linux_amd64.rpm"
+    rpm -i dive_${DIVE_VERSION}_linux_amd64.rpm
+    ```
+
+    **Arch Linux**
+
+    dive is available in the [extra repository](https://archlinux.org/packages/extra/x86_64/dive/):
+
+    ```bash theme={null}
+    pacman -S dive
+    ```
+
+    **Snap**
+
+    <Warning>
+      Do not use the Snap method if you installed Docker via `apt-get`. Installing Docker via Snap alongside an existing `apt-get` Docker installation may break your Docker daemon. See [GitHub issue #546](https://github.com/wagoodman/dive/issues/546) for details.
+    </Warning>
+
+    If you use Docker via Snap, you can install dive and connect it to the Docker snap:
+
+    ```bash theme={null}
+    sudo snap install docker
+    sudo snap install dive
+    sudo snap connect dive:docker-executables docker:docker-executables
+    sudo snap connect dive:docker-daemon docker:docker-daemon
+    ```
+  </Tab>
+
+  <Tab title="macOS">
+    **Homebrew**
+
+    ```bash theme={null}
+    brew install dive
+    ```
+
+    **MacPorts**
+
+    ```bash theme={null}
+    sudo port install dive
+    ```
+
+    You can also download the latest Darwin binary directly from the [releases page](https://github.com/wagoodman/dive/releases/latest).
+  </Tab>
+
+  <Tab title="Windows">
+    **Chocolatey**
+
+    ```powershell theme={null}
+    choco install dive
+    ```
+
+    **Scoop**
+
+    ```powershell theme={null}
+    scoop install main/dive
+    ```
+
+    **Winget**
+
+    ```powershell theme={null}
+    winget install --id wagoodman.dive
+    ```
+
+    You can also download the latest Windows binary from the [releases page](https://github.com/wagoodman/dive/releases/latest).
+  </Tab>
+
+  <Tab title="Docker">
+    Pull the image from Docker Hub or GitHub Container Registry:
+
+    ```bash theme={null}
+    docker pull docker.io/wagoodman/dive
+    # or
+    docker pull ghcr.io/wagoodman/dive
+    ```
+
+    Run dive with the Docker socket mounted so it can access your local images:
+
+    ```bash theme={null}
+    docker run --rm -it \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        docker.io/wagoodman/dive:latest <image>
+    ```
+
+    On Windows (PowerShell), use backtick line continuations:
+
+    ```powershell theme={null}
+    docker run --rm -it `
+        -v /var/run/docker.sock:/var/run/docker.sock `
+        docker.io/wagoodman/dive:latest <image>
+    ```
+
+    To make this convenient, add an alias to your shell profile:
+
+    ```bash theme={null}
+    alias dive="docker run -ti --rm -v /var/run/docker.sock:/var/run/docker.sock docker.io/wagoodman/dive"
+    ```
+
+    <Note>
+      Depending on your Docker version, you may need to set the `DOCKER_API_VERSION` environment variable explicitly:
+
+      ```bash theme={null}
+      DOCKER_API_VERSION=1.37 dive <image>
+      ```
+
+      When running via `docker run`, pass it as an environment variable:
+
+      ```bash theme={null}
+      docker run --rm -it \
+          -v /var/run/docker.sock:/var/run/docker.sock \
+          -e DOCKER_API_VERSION=1.37 \
+          docker.io/wagoodman/dive:latest <image>
+      ```
+    </Note>
+  </Tab>
+
+  <Tab title="Go tools">
+    If you have Go 1.10 or later installed, you can install dive directly with `go install`:
+
+    ```bash theme={null}
+    go install github.com/wagoodman/dive@latest
+    ```
+
+    <Note>
+      Installing via `go install` does not embed version information, so `dive -v` will not show a proper version string.
+    </Note>
+  </Tab>
+</Tabs>
+
+<AccordionGroup>
+  <Accordion title="Other package managers">
+    **Nix/NixOS**
+
+    On NixOS:
+
+    ```bash theme={null}
+    nix-env -iA nixos.dive
+    ```
+
+    On non-NixOS (Linux or macOS):
+
+    ```bash theme={null}
+    nix-env -iA nixpkgs.dive
+    ```
+
+    **X-CMD**
+
+    [x-cmd](https://www.x-cmd.com/) is a POSIX shell toolbox with a lightweight package manager:
+
+    ```sh theme={null}
+    x env use dive
+    ```
+  </Accordion>
+</AccordionGroup>
+
+
+# Introduction
+Source: https://wagoodman-dive.atlas.mintlify.me/introduction
+
+Explore Docker image layers, visualize file changes, and find wasted space with dive.
+
+dive is a terminal UI tool for exploring the contents of a Docker image layer by layer. It shows you exactly which files were added, modified, or removed at each build step, and estimates how much space is wasted by duplicated or overwritten files across layers.
+
+If you've ever wondered why your Docker image is larger than expected — or wanted to understand what `RUN apt-get install` actually adds — dive gives you a clear, interactive answer.
+
+## Key features
+
+<CardGroup>
+  <Card title="Interactive layer explorer" icon="layer-group">
+    Select any layer in the left pane to see the combined file tree up to that point. Navigate with arrow keys, collapse directories, and filter files by name.
+  </Card>
+
+  <Card title="File change indicators" icon="file-pen">
+    Every file in the tree is marked as added, modified, removed, or unmodified. Spot exactly what changed — and what didn't — at each layer.
+  </Card>
+
+  <Card title="Efficiency score" icon="gauge-high">
+    The lower pane shows an experimental efficiency metric and the total amount of wasted space — from duplicated files, files moved across layers, or files that were never fully removed.
+  </Card>
+
+  <Card title="Build and analyze in one command" icon="hammer">
+    Replace `docker build` with `dive build` to build your image and immediately open it in the TUI. No extra steps needed.
+  </Card>
+
+  <Card title="CI mode" icon="circle-check">
+    Set `CI=true` to skip the TUI and get a pass/fail result based on configurable thresholds for efficiency and wasted space.
+  </Card>
+
+  <Card title="Multiple image sources" icon="box">
+    Fetch images from the Docker engine, Podman, or load a `.tar` archive directly from disk using the `--source` flag.
+  </Card>
+
+  <Card title="JSON export" icon="file-code">
+    Export the full layer analysis as structured JSON for scripting and automation — no TUI required.
+  </Card>
+
+  <Card title="Flexible installation" icon="download">
+    Available on Linux, macOS, and Windows via package managers, Docker, or `go install`.
+  </Card>
+</CardGroup>
+
+## How it works
+
+When you run `dive <image>`, dive fetches the image from your container engine and analyzes each layer in the image manifest. It builds a merged file tree for each layer, tracks which files changed between layers, and calculates a wasted-space estimate based on files that were overwritten or deleted after being written.
+
+The result is an interactive TUI with three panes:
+
+* **Left pane** — the list of image layers, with size information
+* **Right pane** — the file tree for the selected layer (or all layers combined)
+* **Bottom pane** — image metadata, efficiency score, and wasted space totals
+
+## Get started
+
+<CardGroup>
+  <Card title="Installation" icon="download" href="/installation">
+    Install dive on Linux, macOS, Windows, or run it as a Docker container.
+  </Card>
+
+  <Card title="Quick Start" icon="rocket" href="/quickstart">
+    Analyze your first image and learn the TUI in a few minutes.
+  </Card>
+</CardGroup>
+
+
+# Quick Start
+Source: https://wagoodman-dive.atlas.mintlify.me/quickstart
+
+Analyze your first Docker image with dive in minutes.
+
+This guide walks you through analyzing a Docker image with dive for the first time.
+
+<Steps>
+  <Step title="Install dive">
+    Install dive using your preferred method. See [Installation](/installation) for all options.
+
+    <CodeGroup>
+      ```bash macOS theme={null}
+      brew install dive
+      ```
+
+      ```bash Ubuntu/Debian theme={null}
+      DIVE_VERSION=$(curl -sL "https://api.github.com/repos/wagoodman/dive/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
+      curl -fOL "https://github.com/wagoodman/dive/releases/download/v${DIVE_VERSION}/dive_${DIVE_VERSION}_linux_amd64.deb"
+      sudo apt install ./dive_${DIVE_VERSION}_linux_amd64.deb
+      ```
+
+      ```bash Docker theme={null}
+      docker pull docker.io/wagoodman/dive
+      ```
+    </CodeGroup>
+  </Step>
+
+  <Step title="Analyze an image">
+    Pass any image tag, ID, or digest to dive:
+
+    ```bash theme={null}
+    dive nginx:latest
+    ```
+
+    dive will fetch the image from your local Docker daemon and open the interactive TUI. If the image isn't pulled yet, Docker will pull it automatically.
+
+    <Tip>
+      If you're running dive via Docker, mount the Docker socket so it can access your images:
+
+      ```bash theme={null}
+      docker run --rm -it \
+          -v /var/run/docker.sock:/var/run/docker.sock \
+          docker.io/wagoodman/dive:latest nginx:latest
+      ```
+    </Tip>
+  </Step>
+
+  <Step title="Navigate the TUI">
+    The dive UI has three panes:
+
+    * **Left pane (Layers)**: lists every layer in the image with its size and the command that created it
+    * **Right pane (File tree)**: shows the cumulative filesystem at the selected layer
+    * **Bottom left (Image details)**: shows total size, wasted bytes, and efficiency score
+
+    Use these keys to get started:
+
+    | Key                    | Action                                       |
+    | ---------------------- | -------------------------------------------- |
+    | `Tab`                  | Switch between layer list and file tree      |
+    | `↑` / `↓` or `K` / `J` | Move up/down in the current pane             |
+    | `Space`                | Collapse/expand a directory in the file tree |
+    | `Ctrl+F`               | Filter files by name                         |
+    | `ESC`                  | Close the filter                             |
+    | `Ctrl+C` or `Q`        | Quit                                         |
+  </Step>
+
+  <Step title="Inspect file changes per layer">
+    Select different layers in the left pane to see what changed. Each file in the tree is marked:
+
+    * **A** — Added in this layer
+    * **M** — Modified compared to a previous layer
+    * **R** — Removed (deleted) in this layer
+    * **U** — Unmodified
+
+    Toggle between viewing just the current layer's changes or all accumulated changes:
+
+    | Key      | Action                                      |
+    | -------- | ------------------------------------------- |
+    | `Ctrl+L` | Show only the current layer's modifications |
+    | `Ctrl+A` | Show aggregated changes up to this layer    |
+  </Step>
+
+  <Step title="Review efficiency results">
+    The bottom-left pane shows your image's efficiency score. A score close to 1.0 (100%) means minimal waste. Lower scores indicate files duplicated or overwritten across layers.
+
+    Press `Ctrl+U` in the file tree to hide unmodified files and focus only on what changed.
+  </Step>
+</Steps>
+
+## Build and analyze in one command
+
+Instead of building then separately running dive, replace `docker build` with `dive build`:
+
+```bash theme={null}
+dive build -t my-app:latest .
+```
+
+This builds your image and immediately opens the TUI for analysis. All standard `docker build` flags are passed through.
+
+## Run in CI mode
+
+To skip the interactive UI and get a pass/fail result based on efficiency thresholds:
+
+```bash theme={null}
+CI=true dive nginx:latest
+```
+
+Returns exit code `0` if the image passes your configured rules, non-zero if it fails. See [CI Integration](/configuration/ci-integration) for configuring thresholds.
+
+## Set up a Docker alias
+
+If you regularly run dive via Docker, create an alias:
+
+```bash theme={null}
+alias dive="docker run -ti --rm -v /var/run/docker.sock:/var/run/docker.sock docker.io/wagoodman/dive"
+```
+
+Then use it like a native install:
+
+```bash theme={null}
+dive nginx:latest
+```
+
+## Next steps
+
+<CardGroup>
+  <Card title="Exploring Layers" icon="layer-group" href="/usage/exploring-layers">
+    Learn all the navigation shortcuts and file tree controls.
+  </Card>
+
+  <Card title="Analyzing Efficiency" icon="gauge-high" href="/usage/analyzing-efficiency">
+    Understand the efficiency score and how to improve it.
+  </Card>
+
+  <Card title="Configuration" icon="gear" href="/configuration/config-file">
+    Customize dive's behavior with a config file.
+  </Card>
+
+  <Card title="CI Integration" icon="circle-check" href="/configuration/ci-integration">
+    Add image quality gates to your CI pipeline.
+  </Card>
+</CardGroup>
+
+
+# CI rules reference
+Source: https://wagoodman-dive.atlas.mintlify.me/reference/ci-rules
+
+Complete reference for dive CI rules, configuration, and pass/fail behavior.
+
+## Overview
+
+When you run dive in CI mode (by setting `CI=true` or passing `--ci`), it skips the interactive TUI and evaluates your image against a set of configurable rules. Each rule produces one of four statuses:
+
+| Status         | Meaning                                         |
+| -------------- | ----------------------------------------------- |
+| `RulePassed`   | The image meets the rule's threshold.           |
+| `RuleFailed`   | The image violates the rule's threshold.        |
+| `RuleDisabled` | The rule is explicitly disabled; it is skipped. |
+| `RuleUnknown`  | The rule could not be evaluated.                |
+
+<Warning>
+  If any rule has a `RuleFailed` status, dive exits with a non-zero return code. Make sure your CI pipeline checks the exit code.
+</Warning>
+
+Rules are read from a `.dive-ci` file at the root of your repository, and can be overridden with CLI flags.
+
+***
+
+## Configuration file
+
+Create a `.dive-ci` file in your repository root:
+
+```yaml theme={null}
+rules:
+  # Fail if image efficiency drops below this ratio (0-1).
+  lowestEfficiency: 0.9
+
+  # Fail if wasted bytes exceed this amount.
+  # Accepts: B, KB, MB, GB. Set to "disabled" to skip.
+  highestWastedBytes: disabled
+
+  # Fail if wasted space exceeds this percentage of user-added bytes (0-1).
+  # The base image layer is NOT included in the calculation.
+  highestUserWastedPercent: 0.1
+```
+
+<Note>
+  The `.dive-ci` file uses camelCase keys (`lowestEfficiency`, `highestWastedBytes`, `highestUserWastedPercent`). These keys are different from the snake-case keys used in the main dive application config file.
+</Note>
+
+To use a config file at a different path, pass `--ci-config`:
+
+```bash theme={null}
+CI=true dive my-image:latest --ci-config ./ci/dive-rules.yaml
+```
+
+***
+
+## Rules
+
+### `lowestEfficiency`
+
+<ParamField type="float">
+  The lowest allowable image efficiency ratio. Dive fails the CI check if the measured efficiency is **below** this threshold.
+
+  * Range: `0` to `1` (e.g. `0.9` = 90% efficient)
+  * `.dive-ci` key: `lowestEfficiency`
+  * CLI flag: `--lowestEfficiency`
+  * Disable: set to `"disabled"`, `"off"`, or `"false"`
+
+  **Example**: To require at least 95% image efficiency:
+
+  ```yaml theme={null}
+  rules:
+    lowestEfficiency: 0.95
+  ```
+
+  ```bash theme={null}
+  CI=true dive my-image:latest --lowestEfficiency 0.95
+  ```
+
+  The rule fails with a message similar to:
+
+  ```
+  image efficiency is too low (efficiency=0.88 < threshold=0.95)
+  ```
+</ParamField>
+
+***
+
+### `highestWastedBytes`
+
+<ParamField type="string">
+  The highest allowable number of bytes wasted in the image. Dive fails the CI check if the wasted byte count **exceeds** this threshold.
+
+  * Accepted formats: `B`, `KB`, `MB`, `GB` (e.g. `20MB`, `512KB`)
+  * `.dive-ci` key: `highestWastedBytes`
+  * CLI flag: `--highestWastedBytes`
+  * Disable: set to `"disabled"`, `"off"`, or `"false"` (this is the default)
+
+  **Example**: To fail if more than 20 MB is wasted:
+
+  ```yaml theme={null}
+  rules:
+    highestWastedBytes: 20MB
+  ```
+
+  ```bash theme={null}
+  CI=true dive my-image:latest --highestWastedBytes 20MB
+  ```
+
+  The rule fails with a message similar to:
+
+  ```
+  too many bytes wasted (wasted-bytes=25165824 > threshold=20971520)
+  ```
+</ParamField>
+
+***
+
+### `highestUserWastedPercent`
+
+<ParamField type="float">
+  The highest allowable percentage of user-added bytes that are wasted. Dive fails the CI check if the wasted percentage **exceeds** this threshold.
+
+  * Range: `0` to `1` (e.g. `0.1` = 10%)
+  * The **base image layer is not included** in the user size calculation — only layers you add on top of the base image are counted.
+  * `.dive-ci` key: `highestUserWastedPercent`
+  * CLI flag: `--highestUserWastedPercent`
+  * Disable: set to `"disabled"`, `"off"`, or `"false"`
+
+  **Example**: To fail if more than 20% of user-added bytes are wasted:
+
+  ```yaml theme={null}
+  rules:
+    highestUserWastedPercent: 0.20
+  ```
+
+  ```bash theme={null}
+  CI=true dive my-image:latest --highestUserWastedPercent 0.20
+  ```
+
+  The rule fails with a message similar to:
+
+  ```
+  too many bytes wasted, relative to the user bytes added (%-user-wasted-bytes=0.25 > threshold=0.20)
+  ```
+</ParamField>
+
+***
+
+## Disabling a rule
+
+To disable a rule entirely, set its value to `"disabled"`, `"off"`, or `"false"` in your `.dive-ci` file:
+
+```yaml theme={null}
+rules:
+  lowestEfficiency: 0.9
+  highestWastedBytes: disabled
+  highestUserWastedPercent: disabled
+```
+
+A disabled rule always results in `RuleDisabled` and never causes a CI failure.
+
+***
+
+## Full example
+
+A complete `.dive-ci` file covering all rules:
+
+```yaml theme={null}
+rules:
+  # Fail if efficiency drops below 90%.
+  lowestEfficiency: 0.9
+
+  # Fail if more than 50 MB is wasted.
+  highestWastedBytes: 50MB
+
+  # Fail if more than 20% of user-added bytes are wasted.
+  highestUserWastedPercent: 0.20
+```
+
+Run in CI:
+
+```bash theme={null}
+CI=true dive my-image:latest
+```
+
+Or use a non-default config path:
+
+```bash theme={null}
+CI=true dive my-image:latest --ci-config ./ci/dive-rules.yaml
+```
+
+
+# CLI reference
+Source: https://wagoodman-dive.atlas.mintlify.me/reference/cli
+
+Complete reference for all dive commands and flags.
+
+## `dive [IMAGE]`
+
+Explore the contents of a Docker image layer by layer, and identify sources of wasted space.
+
+```bash theme={null}
+dive <image-tag>
+```
+
+The image argument accepts a tag, ID, digest, or a URL with a source scheme:
+
+```bash theme={null}
+dive nginx:latest
+dive sha256:abc123...
+dive docker://nginx:latest
+dive podman://my-image:v1
+dive docker-archive:///path/to/image.tar
+```
+
+### Global flags
+
+<ParamField type="string">
+  The container engine to fetch the image from. Accepted values: `docker`, `podman`, `docker-archive`.
+
+  You can also specify the source inline using a URL scheme:
+
+  ```bash theme={null}
+  dive docker://nginx:latest
+  dive podman://my-image:v1
+  dive docker-archive:///path/to/image.tar
+  ```
+</ParamField>
+
+<ParamField type="boolean">
+  Ignore image parsing errors and run the analysis anyway. Useful for malformed or non-standard images.
+
+  Short form: `-i`
+
+  ```bash theme={null}
+  dive my-image:latest --ignore-errors
+  ```
+</ParamField>
+
+<ParamField type="string">
+  Skip the interactive TUI and write the layer analysis statistics to the specified file path as JSON.
+
+  Short form: `-j`
+
+  ```bash theme={null}
+  dive my-image:latest --json ./analysis.json
+  ```
+</ParamField>
+
+<ParamField type="string">
+  CI rule: the lowest allowable image efficiency, expressed as a ratio between `0` and `1`. The build fails if the measured efficiency falls below this threshold.
+
+  Only evaluated when CI mode is active.
+
+  ```bash theme={null}
+  dive my-image:latest --ci --lowestEfficiency 0.95
+  ```
+</ParamField>
+
+<ParamField type="string">
+  CI rule: the highest allowable number of wasted bytes. Accepts human-readable sizes: `B`, `KB`, `MB`, `GB`. The build fails if wasted bytes exceed this value.
+
+  Only evaluated when CI mode is active.
+
+  ```bash theme={null}
+  dive my-image:latest --ci --highestWastedBytes 20MB
+  ```
+</ParamField>
+
+<ParamField type="string">
+  CI rule: the highest allowable percentage of user-added bytes that are wasted, expressed as a ratio between `0` and `1`. The base image layer is not included in the calculation.
+
+  Only evaluated when CI mode is active.
+
+  ```bash theme={null}
+  dive my-image:latest --ci --highestUserWastedPercent 0.20
+  ```
+</ParamField>
+
+<ParamField type="boolean">
+  Skip the interactive TUI and validate the image against CI rules. Equivalent to setting `CI=true` in the environment.
+
+  ```bash theme={null}
+  dive my-image:latest --ci
+  ```
+</ParamField>
+
+<ParamField type="string">
+  Path to the YAML CI rules config file. Overrides the default `.dive-ci` location.
+
+  ```bash theme={null}
+  dive my-image:latest --ci --ci-config ./config/dive-ci.yaml
+  ```
+</ParamField>
+
+<ParamField type="string">
+  Path to the dive configuration file. By default, dive searches several standard locations.
+
+  ```bash theme={null}
+  dive my-image:latest -c ~/.config/dive/config.yaml
+  ```
+</ParamField>
+
+<ParamField type="count">
+  Increase log verbosity. Pass multiple times to increase further (e.g. `-vv`).
+
+  ```bash theme={null}
+  dive my-image:latest -v
+  ```
+</ParamField>
+
+<ParamField type="boolean">
+  Quiet mode. Suppress non-essential output.
+
+  ```bash theme={null}
+  dive my-image:latest -q
+  ```
+</ParamField>
+
+### CI mode
+
+Set the `CI=true` environment variable to enable CI mode without using the `--ci` flag. In CI mode, dive skips the interactive TUI, analyzes the image, and exits with a non-zero code if any rule fails.
+
+```bash theme={null}
+CI=true dive my-image:latest
+```
+
+See [CI rules reference](/reference/ci-rules) for details on configuring pass/fail rules.
+
+***
+
+## `dive build`
+
+Build a Docker image from a Dockerfile and immediately analyze it.
+
+```bash theme={null}
+dive build [any valid docker build arguments]
+```
+
+This is a thin wrapper around `docker build`. All flags and arguments are passed through to Docker directly.
+
+```bash theme={null}
+dive build -t my-image:latest .
+dive build -t my-image:latest --build-arg VERSION=1.0 -f Dockerfile.prod .
+```
+
+<Note>
+  Flag parsing is disabled for this subcommand — every argument is forwarded to `docker build` as-is. dive-specific flags (like `--source`) are not available here.
+</Note>
+
+***
+
+## `dive version`
+
+Print version information for the installed dive binary.
+
+```bash theme={null}
+dive version
+```
+
+***
+
+## `dive config`
+
+Print the current resolved configuration, including all defaults and any overrides from config files or environment variables.
+
+```bash theme={null}
+dive config
+```
+
+
+# Troubleshooting
+Source: https://wagoodman-dive.atlas.mintlify.me/reference/troubleshooting
+
+Solutions to common problems when running dive.
+
+<Note>
+  If you run into a problem that isn't covered here, search for existing reports or file a new issue at [github.com/wagoodman/dive/issues](https://github.com/wagoodman/dive/issues).
+</Note>
+
+<AccordionGroup>
+  <Accordion title="Cannot connect to Docker daemon">
+    Dive needs the Docker daemon to be running before it can pull or analyze images.
+
+    **Check that the daemon is running:**
+
+    ```bash theme={null}
+    docker ps
+    ```
+
+    If this fails, start Docker and try again.
+
+    **Check socket permissions:**
+
+    You may need to run dive with `sudo`, or add your user to the `docker` group:
+
+    ```bash theme={null}
+    sudo usermod -aG docker $USER
+    newgrp docker
+    ```
+
+    **Docker Desktop on macOS:**
+
+    Open Docker Desktop and wait until the status shows "Running" before invoking dive.
+
+    **Alternative runtimes (Colima, Rancher Desktop, etc.):**
+
+    Set `DOCKER_HOST` to point at the correct socket:
+
+    ```bash theme={null}
+    export DOCKER_HOST=$(docker context inspect -f '{{ .Endpoints.docker.Host }}')
+    dive my-image:latest
+    ```
+  </Accordion>
+
+  <Accordion title="Image not found / invalid reference format">
+    Dive couldn't locate the image you specified.
+
+    **Verify the image exists locally:**
+
+    ```bash theme={null}
+    docker image ls
+    ```
+
+    **Pull the image first:**
+
+    ```bash theme={null}
+    docker pull nginx:latest
+    dive nginx:latest
+    ```
+
+    **Check the image tag spelling:**
+
+    Image references are case-sensitive. Confirm the tag name matches exactly what is returned by `docker image ls`.
+  </Accordion>
+
+  <Accordion title="Permission denied when using the Docker socket">
+    When you run dive via a Docker container, you must mount the host Docker socket into the container. Without it, the containerized dive process cannot reach the Docker daemon.
+
+    ```bash theme={null}
+    docker run --rm -it \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        docker.io/wagoodman/dive:latest my-image:latest
+    ```
+
+    The `-v /var/run/docker.sock:/var/run/docker.sock` flag gives the container access to the host Docker daemon. Without it, you will see permission errors.
+  </Accordion>
+
+  <Accordion title="API version mismatch errors">
+    If your local Docker client and daemon have different API versions, you may see errors like `client version X.X is too new`.
+
+    **Set the API version explicitly:**
+
+    ```bash theme={null}
+    DOCKER_API_VERSION=1.37 dive my-image:latest
+    ```
+
+    **When running via Docker image:**
+
+    ```bash theme={null}
+    docker run --rm -it \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        -e DOCKER_API_VERSION=1.37 \
+        docker.io/wagoodman/dive:latest my-image:latest
+    ```
+
+    Adjust `1.37` to match the API version your daemon supports. You can check this with `docker version`.
+  </Accordion>
+
+  <Accordion title="Snap installation conflicts with Docker">
+    If you installed Docker via `apt-get` and dive via Snap, the Snap-managed Docker may conflict with your existing Docker daemon and break it.
+
+    <Warning>
+      Do not install dive via Snap if you installed Docker using `apt-get`. Use the deb package or Homebrew instead.
+    </Warning>
+
+    **Install via deb package instead:**
+
+    ```bash theme={null}
+    DIVE_VERSION=$(curl -sL "https://api.github.com/repos/wagoodman/dive/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
+    curl -fOL "https://github.com/wagoodman/dive/releases/download/v${DIVE_VERSION}/dive_${DIVE_VERSION}_linux_amd64.deb"
+    sudo apt install ./dive_${DIVE_VERSION}_linux_amd64.deb
+    ```
+
+    For more context, see [GitHub issue #546](https://github.com/wagoodman/dive/issues/546).
+  </Accordion>
+
+  <Accordion title="Podman is not working">
+    Podman support in dive is **Linux only**. Podman is not supported on macOS or Windows.
+
+    **Check that the Podman socket is running:**
+
+    ```bash theme={null}
+    systemctl --user start podman.socket
+    ```
+
+    **Tell dive to use Podman:**
+
+    ```bash theme={null}
+    dive my-image:latest --source podman
+    # or using the URL scheme:
+    dive podman://my-image:latest
+    ```
+
+    If dive still cannot connect, verify the socket path and that Podman is installed correctly on your system.
+  </Accordion>
+
+  <Accordion title="&#x22;exactly one argument is required&#x22; error">
+    Dive requires exactly one positional argument: the image reference. If you omit it or pass extra arguments, dive exits with this error.
+
+    **Correct usage:**
+
+    ```bash theme={null}
+    dive my-image:latest
+    ```
+
+    If you are passing flags, make sure they come after the image name or use `--` to separate them:
+
+    ```bash theme={null}
+    dive my-image:latest --source docker
+    ```
+  </Accordion>
+
+  <Accordion title="CI mode always passes / rules are ignored">
+    If dive exits with code `0` in CI even though you expect failures, check the following:
+
+    **Ensure `CI=true` is set:**
+
+    ```bash theme={null}
+    CI=true dive my-image:latest
+    ```
+
+    Or pass the `--ci` flag explicitly:
+
+    ```bash theme={null}
+    dive my-image:latest --ci
+    ```
+
+    **Check your `.dive-ci` file location:**
+
+    By default, dive looks for `.dive-ci` at the current working directory. If your file is elsewhere, specify the path:
+
+    ```bash theme={null}
+    CI=true dive my-image:latest --ci-config ./config/.dive-ci
+    ```
+
+    **Verify your rule values are valid:**
+
+    * Efficiency and percent ratios must be between `0` and `1`.
+    * Byte values must include a unit: `20MB`, `512KB`, `1GB`.
+    * Invalid values may be silently ignored or cause the rule to be disabled.
+
+    See [CI rules reference](/reference/ci-rules) for valid formats.
+  </Accordion>
+
+  <Accordion title="TUI display issues or garbled output">
+    If the interactive TUI looks broken, shows garbled characters, or doesn't render correctly:
+
+    **Try a different terminal emulator.** Some minimal or older terminals do not support the control sequences dive uses.
+
+    **Check your `TERM` variable:**
+
+    ```bash theme={null}
+    echo $TERM
+    ```
+
+    For best results, use a terminal that reports `xterm-256color` or similar.
+
+    **Ensure 256-color support:**
+
+    ```bash theme={null}
+    TERM=xterm-256color dive my-image:latest
+    ```
+
+    If you only need the analysis output without the TUI, use `--json` to export results to a file:
+
+    ```bash theme={null}
+    dive my-image:latest --json ./analysis.json
+    ```
+  </Accordion>
+</AccordionGroup>
+
+
+# Analyzing image efficiency
+Source: https://wagoodman-dive.atlas.mintlify.me/usage/analyzing-efficiency
+
+Understand the efficiency score, wasted bytes metrics, and how to reduce image size.
+
+dive calculates an efficiency score and wasted-space metrics every time you analyze an image. These numbers appear in the bottom-left pane of the TUI and in the JSON export.
+
+## The efficiency score
+
+The efficiency score is a ratio between `0` and `1` that represents how efficiently your image uses the space it occupies. A score of `1.0` means every byte stored in the image is unique across all layers — nothing is duplicated or wasted. A lower score indicates that some bytes are being stored redundantly.
+
+The score is calculated as:
+
+```
+efficiency = minimum_unique_bytes / total_discovered_bytes
+```
+
+For each file path seen across all layers, dive records the smallest version of that file (minimum size) and the total cumulative size across every occurrence. Paths that appear only once do not affect the score. Paths that appear multiple times reduce it, weighted by how large they are.
+
+## Metrics at a glance
+
+| Metric             | Description                                                                            |
+| ------------------ | -------------------------------------------------------------------------------------- |
+| **Efficiency**     | Score from `0` to `1`; higher is better                                                |
+| **Image size**     | Total compressed size of all layers combined                                           |
+| **Wasted bytes**   | Bytes consumed by files that are duplicated or removed across layers                   |
+| **Wasted (user%)** | Wasted bytes as a fraction of the user image size                                      |
+| **Inefficiencies** | Ranked list of file paths that contribute the most wasted space, with cumulative sizes |
+
+<Note>
+  The base image layer (layer index `0`) is excluded from user-size calculations. The `highestUserWastedPercent` CI rule and the wasted-user-percent metric both measure waste relative to everything *above* the base image.
+</Note>
+
+## What causes wasted space
+
+Three patterns inflate your wasted-bytes count:
+
+1. **Files duplicated across layers** — A file written in layer 2 and then written again (with the same or different content) in layer 4 means both copies are stored in the image.
+2. **Files overwritten or moved** — Copying a file to a new path and deleting the original still keeps the original bytes in the earlier layer.
+3. **Files added then deleted later** — Adding a package cache in one `RUN` step and removing it in a later step stores the cache in the earlier layer permanently.
+
+## Interpreting results
+
+| Score range     | Interpretation                                                 |
+| --------------- | -------------------------------------------------------------- |
+| `0.95` – `1.0`  | Efficient — minimal or no wasted space                         |
+| `0.85` – `0.95` | Acceptable — some room for improvement                         |
+| Below `0.85`    | Needs attention — significant wasted space worth investigating |
+
+These thresholds are a guideline. The default CI threshold for `lowestEfficiency` is `0.95`. Review the inefficiencies list to identify which specific files are driving the waste.
+
+## Practical tips for reducing wasted space
+
+**Combine `RUN` commands**
+
+Each `RUN` instruction creates a new layer. Splitting installation and cleanup into separate `RUN` steps means the cleanup layer marks files as deleted, but those files still exist in the installation layer.
+
+```dockerfile theme={null}
+# Inefficient — cache is stored in the first layer
+RUN apt-get update && apt-get install -y curl
+RUN rm -rf /var/lib/apt/lists/*
+
+# Efficient — update, install, and clean up in one layer
+RUN apt-get update && apt-get install -y curl \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+**Clean up in the same `RUN` step**
+
+Package managers leave behind caches, lock files, and temporary downloads. Remove them in the same command that installs packages so they never make it into a layer.
+
+```dockerfile theme={null}
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+**Use multi-stage builds**
+
+Multi-stage builds let you compile or build in one stage and copy only the final artifact into the production image. Build tools, source code, and intermediate files stay out of the final image entirely.
+
+```dockerfile theme={null}
+FROM golang:1.22 AS builder
+WORKDIR /app
+COPY . .
+RUN go build -o myapp .
+
+FROM debian:bookworm-slim
+COPY --from=builder /app/myapp /usr/local/bin/myapp
+ENTRYPOINT ["myapp"]
+```
+
+**Be careful with `COPY` commands**
+
+`COPY`ing a directory that already exists in the image overwrites individual files but leaves the previous versions of those files in the earlier layer. Use `.dockerignore` to exclude unnecessary files before they ever enter the build context.
+
+
+# Exploring layers
+Source: https://wagoodman-dive.atlas.mintlify.me/usage/exploring-layers
+
+Navigate the dive TUI to inspect image layers and file tree changes.
+
+When you run `dive <image>`, the terminal UI opens with three panes that give you a complete picture of your image's layer structure and file contents.
+
+## TUI layout
+
+The interface is divided into three areas:
+
+* **Left pane (layers)** — lists every layer in the image, showing the Dockerfile command that produced it and its size.
+* **Right pane (file tree)** — shows the cumulative file system at the selected layer, including all files from previous layers.
+* **Bottom-left pane (image stats)** — displays total image size, wasted bytes, and the efficiency score.
+
+Use <kbd>Tab</kbd> to move focus between the layer pane and the file tree pane.
+
+## Selecting a layer
+
+When you select a layer in the left pane, the file tree on the right updates to reflect the cumulative state of the file system up to and including that layer. You are always looking at a snapshot of the full file system at that point in the image build, not just the files changed in that single layer.
+
+Switch between two comparison modes with these bindings while the layer pane is focused:
+
+| Key               | Action                                                                              |
+| ----------------- | ----------------------------------------------------------------------------------- |
+| <kbd>Ctrl+A</kbd> | Show aggregated modifications (all changes from every layer up to the selected one) |
+| <kbd>Ctrl+L</kbd> | Show only the modifications introduced by the currently selected layer              |
+
+<Tip>
+  Start with <kbd>Ctrl+A</kbd> (aggregate view) to see everything that has changed across all layers at once. Switch to <kbd>Ctrl+L</kbd> when you want to isolate exactly what a single layer contributed.
+</Tip>
+
+## File change indicators
+
+Each entry in the file tree is prefixed with a single character that indicates what happened to that file in the current view:
+
+| Indicator | Meaning                                                        |
+| --------- | -------------------------------------------------------------- |
+| `A`       | Added — the file was created in this layer                     |
+| `M`       | Modified — the file existed before and was changed             |
+| `R`       | Removed — the file was deleted (whiteout)                      |
+| `U`       | Unmodified — the file exists but was not touched by this layer |
+
+## Navigating the file tree
+
+Use these bindings while the file tree pane is focused:
+
+| Key                                | Action                                 |
+| ---------------------------------- | -------------------------------------- |
+| <kbd>Up</kbd> / <kbd>K</kbd>       | Move up one line                       |
+| <kbd>Down</kbd> / <kbd>J</kbd>     | Move down one line                     |
+| <kbd>PageUp</kbd> / <kbd>U</kbd>   | Scroll up a page                       |
+| <kbd>PageDown</kbd> / <kbd>D</kbd> | Scroll down a page                     |
+| <kbd>Space</kbd>                   | Collapse or uncollapse a directory     |
+| <kbd>Ctrl+Space</kbd>              | Collapse or uncollapse all directories |
+| <kbd>Ctrl+F</kbd>                  | Open the file filter                   |
+| <kbd>Esc</kbd>                     | Close the file filter                  |
+
+## Filtering what you see
+
+You can show or hide specific change types to focus on what matters:
+
+| Key               | Action                                               |
+| ----------------- | ---------------------------------------------------- |
+| <kbd>Ctrl+A</kbd> | Show/hide added files                                |
+| <kbd>Ctrl+R</kbd> | Show/hide removed files                              |
+| <kbd>Ctrl+M</kbd> | Show/hide modified files                             |
+| <kbd>Ctrl+U</kbd> | Show/hide unmodified files                           |
+| <kbd>Ctrl+B</kbd> | Show/hide file attributes (permissions, owner, size) |
+
+Use <kbd>Ctrl+F</kbd> to filter files by name. Type part of a path and the tree narrows to matching entries. Press <kbd>Esc</kbd> to clear the filter.
+
+## Additional file tree actions
+
+| Key               | Action                                 |
+| ----------------- | -------------------------------------- |
+| <kbd>Ctrl+O</kbd> | Toggle sort order of files in the tree |
+| <kbd>Ctrl+P</kbd> | Toggle word wrap on long file paths    |
+| <kbd>Ctrl+E</kbd> | Extract the selected file's contents   |
+
+
+# Image sources
+Source: https://wagoodman-dive.atlas.mintlify.me/usage/image-sources
+
+Pull images from Docker, Podman, or a local tar archive.
+
+dive supports three image sources. You can point it at a running container engine or load an image directly from a tar file on disk.
+
+## Available sources
+
+| Source         | Value            | Description                                                  |
+| -------------- | ---------------- | ------------------------------------------------------------ |
+| Docker engine  | `docker`         | Fetches the image from your local Docker daemon (default)    |
+| Podman engine  | `podman`         | Fetches the image from your local Podman daemon (Linux only) |
+| Docker archive | `docker-archive` | Loads the image from a `.tar` file on disk                   |
+
+<Note>
+  Podman support is Linux only. The `podman` source is not available on macOS or Windows.
+</Note>
+
+## Specifying the source
+
+You can specify the image source in two ways.
+
+### Using the `--source` flag
+
+Pass `--source` followed by the source name and the image reference as a separate argument:
+
+```bash theme={null}
+dive --source docker nginx:latest
+dive --source podman my-image:tag
+dive --source docker-archive /path/to/image.tar
+```
+
+### Using a URL scheme prefix
+
+Prefix the image argument with `<source>://` to encode the source directly in the image reference:
+
+```bash theme={null}
+dive docker://nginx:latest
+dive podman://my-image:tag
+dive docker-archive:///path/to/image.tar
+```
+
+## Examples by source
+
+<Tabs>
+  <Tab title="Docker">
+    Analyze an image from your local Docker daemon (this is the default — no `--source` flag is needed):
+
+    ```bash theme={null}
+    dive nginx:latest
+    ```
+
+    Equivalent explicit form:
+
+    ```bash theme={null}
+    dive --source docker nginx:latest
+    # or
+    dive docker://nginx:latest
+    ```
+
+    If you run dive as a Docker container itself, you must mount the Docker socket so it can reach the daemon:
+
+    ```bash theme={null}
+    docker run --rm -it \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        docker.io/wagoodman/dive:latest nginx:latest
+    ```
+  </Tab>
+
+  <Tab title="Podman">
+    Analyze an image from your local Podman daemon on Linux:
+
+    ```bash theme={null}
+    dive --source podman my-image:tag
+    # or
+    dive podman://my-image:tag
+    ```
+
+    <Warning>
+      Podman is only supported on Linux. Running with `--source podman` on macOS or Windows will fail.
+    </Warning>
+  </Tab>
+
+  <Tab title="Docker archive">
+    Analyze an image saved as a tar file on disk:
+
+    ```bash theme={null}
+    dive --source docker-archive /path/to/image.tar
+    # or
+    dive docker-archive:///path/to/image.tar
+    ```
+
+    To export an image from Docker and then analyze it:
+
+    ```bash theme={null}
+    docker save nginx > nginx.tar
+    dive docker-archive://nginx.tar
+    ```
+
+    This is useful when the image was built on another machine, pulled from a registry offline, or produced by a build system that outputs OCI archives.
+  </Tab>
+</Tabs>
+
+
+# JSON export
+Source: https://wagoodman-dive.atlas.mintlify.me/usage/json-export
+
+Write layer analysis results to a JSON file for CI scripting and custom tooling.
+
+The `--json` flag (short: `-j`) skips the interactive TUI and writes the full analysis to a JSON file. This is useful for CI pipelines, custom reporting tools, or any workflow where you want to process dive's output programmatically.
+
+## Basic usage
+
+```bash theme={null}
+dive --json output.json nginx:latest
+```
+
+dive analyzes the image, writes the results to `output.json`, and exits. No TUI is opened.
+
+<Note>
+  The directory containing the output file must already exist. dive will return an error if the parent directory does not exist.
+</Note>
+
+## Use in CI
+
+Combine `--json` with `CI=true` to get both a machine-readable file and a pass/fail exit code in one run:
+
+```bash theme={null}
+CI=true dive --json analysis.json nginx:latest
+```
+
+You can then parse `analysis.json` in subsequent steps — for example, to post the efficiency score to a dashboard or fail the build based on custom thresholds beyond what the built-in CI rules support.
+
+## JSON structure
+
+The output file contains a single JSON object with two top-level keys: `layer` and `image`.
+
+### Top-level object
+
+<ResponseField name="layer" type="array">
+  An ordered array of layer objects, one per image layer.
+</ResponseField>
+
+<ResponseField name="image" type="object">
+  Aggregate efficiency and size metrics for the full image.
+</ResponseField>
+
+### Layer object
+
+Each element in the `layer` array describes one image layer.
+
+<ResponseField name="index" type="integer">
+  Zero-based position of the layer in the image stack. Layer `0` is the base layer.
+</ResponseField>
+
+<ResponseField name="id" type="string">
+  Short layer ID.
+</ResponseField>
+
+<ResponseField name="digestId" type="string">
+  Full digest identifier for the layer.
+</ResponseField>
+
+<ResponseField name="sizeBytes" type="integer">
+  Uncompressed size of this layer in bytes.
+</ResponseField>
+
+<ResponseField name="command" type="string">
+  The Dockerfile instruction that produced this layer (e.g., `RUN apt-get install -y curl`).
+</ResponseField>
+
+<ResponseField name="fileList" type="array">
+  Array of file info objects listing every file touched by this layer.
+</ResponseField>
+
+### Image object
+
+<ResponseField name="sizeBytes" type="integer">
+  Total uncompressed size of the image across all layers, in bytes.
+</ResponseField>
+
+<ResponseField name="inefficientBytes" type="integer">
+  Total bytes wasted by files that are duplicated, overwritten, or deleted across layers.
+</ResponseField>
+
+<ResponseField name="efficiencyScore" type="float">
+  Efficiency ratio between `0` and `1`. A score of `1.0` means no wasted space. See [Analyzing image efficiency](/usage/analyzing-efficiency) for details.
+</ResponseField>
+
+<ResponseField name="fileReference" type="array">
+  List of inefficient files sorted by wasted bytes (descending). Each entry has:
+
+  <Expandable title="fileReference fields">
+    <ResponseField name="count" type="integer">
+      Number of times this file path appears across all layers.
+    </ResponseField>
+
+    <ResponseField name="sizeBytes" type="integer">
+      Cumulative bytes consumed by all occurrences of this file path.
+    </ResponseField>
+
+    <ResponseField name="file" type="string">
+      Absolute path of the file inside the image.
+    </ResponseField>
+  </Expandable>
+</ResponseField>
+
+## Example output
+
+```json theme={null}
+{
+  "layer": [
+    {
+      "index": 0,
+      "id": "a3ed95caeb02",
+      "digestId": "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4",
+      "sizeBytes": 0,
+      "command": "#(nop) ADD file:... in /",
+      "fileList": []
+    },
+    {
+      "index": 1,
+      "id": "b4d181a07f80",
+      "digestId": "sha256:b4d181a07f800bab09a8b95ad1aea5b5e8a82cb47e7524af18d58fe6b9c1c9ce",
+      "sizeBytes": 27145728,
+      "command": "RUN apt-get update && apt-get install -y curl",
+      "fileList": [
+        {
+          "path": "/usr/bin/curl",
+          "size": 194560,
+          "uid": 0,
+          "gid": 0,
+          "isDir": false,
+          "linkName": ""
+        }
+      ]
+    }
+  ],
+  "image": {
+    "sizeBytes": 109051904,
+    "inefficientBytes": 8388608,
+    "efficiencyScore": 0.9231,
+    "fileReference": [
+      {
+        "count": 2,
+        "sizeBytes": 8388608,
+        "file": "/var/cache/apt/pkgcache.bin"
+      }
+    ]
+  }
+}
+```
+
+

--- a/docs/research/mintlify-cache/wagoodman/dive/llms.txt
+++ b/docs/research/mintlify-cache/wagoodman/dive/llms.txt
@@ -1,0 +1,20 @@
+# dive
+
+## Docs
+
+- [CI integration](https://www.mintlify.com/wagoodman/dive/configuration/ci-integration.md): Run dive in CI pipelines to enforce image efficiency rules with pass/fail output.
+- [Configuration file](https://www.mintlify.com/wagoodman/dive/configuration/config-file.md): Customize dive behavior with a YAML configuration file.
+- [Keybindings](https://www.mintlify.com/wagoodman/dive/configuration/keybindings.md): Keyboard shortcuts for navigating dive, and how to customize them.
+- [Installation](https://www.mintlify.com/wagoodman/dive/installation.md): Install dive on Linux, macOS, Windows, or run it as a Docker container.
+- [Introduction](https://www.mintlify.com/wagoodman/dive/introduction.md): Explore Docker image layers, visualize file changes, and find wasted space with dive.
+- [Quick Start](https://www.mintlify.com/wagoodman/dive/quickstart.md): Analyze your first Docker image with dive in minutes.
+- [CI rules reference](https://www.mintlify.com/wagoodman/dive/reference/ci-rules.md): Complete reference for dive CI rules, configuration, and pass/fail behavior.
+- [CLI reference](https://www.mintlify.com/wagoodman/dive/reference/cli.md): Complete reference for all dive commands and flags.
+- [Troubleshooting](https://www.mintlify.com/wagoodman/dive/reference/troubleshooting.md): Solutions to common problems when running dive.
+- [Analyzing image efficiency](https://www.mintlify.com/wagoodman/dive/usage/analyzing-efficiency.md): Understand the efficiency score, wasted bytes metrics, and how to reduce image size.
+- [Exploring layers](https://www.mintlify.com/wagoodman/dive/usage/exploring-layers.md): Navigate the dive TUI to inspect image layers and file tree changes.
+- [Image sources](https://www.mintlify.com/wagoodman/dive/usage/image-sources.md): Pull images from Docker, Podman, or a local tar archive.
+- [JSON export](https://www.mintlify.com/wagoodman/dive/usage/json-export.md): Write layer analysis results to a JSON file for CI scripting and custom tooling.
+
+
+Built with [Mintlify](https://mintlify.com).

--- a/docs/research/mintlify-cache/yeachan-heo/oh-my-claudecode/llms-full.txt
+++ b/docs/research/mintlify-cache/yeachan-heo/oh-my-claudecode/llms-full.txt
@@ -1,0 +1,5859 @@
+# Agent catalog
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/agents/catalog
+
+All 29 OMC agents with their default model, lane, and role description.
+
+OMC provides 29 agents organized into 4 lanes. Many roles have tiered variants (e.g., `executor-low` on Haiku, `executor` on Sonnet, `executor-high` on Opus) to balance cost and reasoning depth. Every agent is invoked with the `oh-my-claudecode:` prefix.
+
+## Agent routing table
+
+| Domain                  | LOW (Haiku)             | MEDIUM (Sonnet)       | HIGH (Opus)         |
+| ----------------------- | ----------------------- | --------------------- | ------------------- |
+| Analysis/Architecture   | `architect-low`         | `architect-medium`    | `architect`         |
+| Execution               | `executor-low`          | `executor`            | `executor-high`     |
+| Search                  | `explore`               | —                     | `explore-high`      |
+| Research                | —                       | `document-specialist` | —                   |
+| Frontend/Design         | `designer-low`          | `designer`            | `designer-high`     |
+| Documentation           | `writer`                | —                     | —                   |
+| Visual analysis         | —                       | `vision`              | —                   |
+| Planning                | —                       | —                     | `planner`           |
+| Critique                | —                       | —                     | `critic`            |
+| Pre-planning analysis   | —                       | —                     | `analyst`           |
+| QA testing              | —                       | `qa-tester`           | —                   |
+| Evidence tracing        | —                       | `tracer`              | —                   |
+| Security review         | `security-reviewer-low` | —                     | `security-reviewer` |
+| Build/Debug             | —                       | `debugger`            | —                   |
+| Test-driven development | —                       | `test-engineer`       | —                   |
+| Code review             | —                       | —                     | `code-reviewer`     |
+| Data science            | —                       | `scientist`           | `scientist-high`    |
+| Git operations          | —                       | `git-master`          | —                   |
+| Code simplification     | —                       | —                     | `code-simplifier`   |
+
+<AccordionGroup>
+  <Accordion title="Build/Analysis lane" icon="hammer">
+    Covers the full development lifecycle from codebase exploration through verified completion.
+
+    <AccordionGroup>
+      <Accordion title="explore — Haiku">
+        **Role:** Codebase discovery, file and symbol mapping.
+
+        `explore` is the fastest and cheapest agent in the build lane. Use it to answer questions like "which files use this symbol?" or "where is the config loaded?" before any heavier agent work begins.
+
+        ```typescript theme={null}
+        Task(
+          subagent_type="oh-my-claudecode:explore",
+          prompt="Find all files that import the auth middleware"
+        )
+        ```
+
+        **Does:** File search, symbol lookup, directory mapping, pattern matching.
+
+        **Does not:** Analyze requirements, implement changes, or run builds.
+      </Accordion>
+
+      <Accordion title="analyst — Opus">
+        **Role:** Requirements analysis, hidden constraint discovery.
+
+        `analyst` reads product intent and surfaces what is missing before any planning or implementation begins. It finds acceptance criteria gaps, implicit assumptions, and scope ambiguities that would cause rework later.
+
+        ```typescript theme={null}
+        Task(
+          subagent_type="oh-my-claudecode:analyst",
+          prompt="Review the requirements for the payment flow and identify hidden constraints"
+        )
+        ```
+
+        **Does:** Requirement gap detection, constraint identification, acceptance criteria formulation.
+
+        **Does not:** Code analysis, planning, or implementation.
+      </Accordion>
+
+      <Accordion title="planner — Opus">
+        **Role:** Task sequencing, execution plan creation.
+
+        `planner` takes a set of requirements and produces a dependency-ordered execution plan. It flags risks, parallelization opportunities, and external blockers. Its output is the input for `critic` review before `executor` begins.
+
+        ```typescript theme={null}
+        Task(
+          subagent_type="oh-my-claudecode:planner",
+          prompt="Create an execution plan for migrating the user table to the new schema"
+        )
+        ```
+
+        **Does:** Task decomposition, dependency ordering, risk flagging.
+
+        **Does not:** Requirements analysis, plan quality review.
+      </Accordion>
+
+      <Accordion title="architect — Opus">
+        **Role:** System design, interface definition, trade-off analysis.
+
+        `architect` reasons about long-horizon structural decisions. It defines module boundaries, data flow, API contracts, and technology trade-offs. Use it when changes affect the shape of the system, not just its behavior.
+
+        ```typescript theme={null}
+        Task(
+          subagent_type="oh-my-claudecode:architect",
+          prompt="Design the caching layer for the API gateway"
+        )
+        ```
+
+        **Does:** System design, interface definition, trade-off analysis, code analysis, debugging, verification.
+
+        **Does not:** Requirements gathering, planning.
+      </Accordion>
+
+      <Accordion title="debugger — Sonnet">
+        **Role:** Root-cause analysis, build error resolution.
+
+        `debugger` traces failures to their source. It reads build output, stack traces, and test failures, then hypothesizes causes and verifies them with evidence. Use it for compilation errors, runtime crashes, and regressions.
+
+        ```typescript theme={null}
+        Task(
+          subagent_type="oh-my-claudecode:debugger",
+          prompt="Find the root cause of the failing integration test in src/api/auth.test.ts"
+        )
+        ```
+
+        **Does:** Root-cause analysis, hypothesis generation and testing, build error resolution.
+
+        **Does not:** Requirements analysis, architectural decisions.
+      </Accordion>
+
+      <Accordion title="executor — Sonnet">
+        **Role:** Code implementation, refactoring.
+
+        `executor` writes and modifies code. It is the primary implementation agent for feature work, bug fixes, and refactoring. For complex changes, promote it to Opus. For trivial changes, demote it to Haiku.
+
+        ```typescript theme={null}
+        Task(
+          subagent_type="oh-my-claudecode:executor",
+          model="sonnet",
+          prompt="Implement the password reset endpoint per the plan in .omc/plans/auth-reset.md"
+        )
+        ```
+
+        **Does:** Code implementation, refactoring, applying plans from other agents.
+
+        **Does not:** Root-cause analysis, design decisions, test strategy.
+      </Accordion>
+
+      <Accordion title="verifier — Sonnet">
+        **Role:** Completion verification, test adequacy confirmation.
+
+        `verifier` checks that work is actually done. It runs builds, tests, and lint; reads output; and confirms each acceptance criterion is met with fresh evidence. It does not accept stale output or assumed success.
+
+        ```typescript theme={null}
+        Task(
+          subagent_type="oh-my-claudecode:verifier",
+          prompt="Verify that all acceptance criteria in .omc/prd.json are met"
+        )
+        ```
+
+        Verification checks include: BUILD, TEST, LINT, FUNCTIONALITY, TODO, ERROR\_FREE. Evidence must be fresh (within 5 minutes) and include actual command output.
+
+        **Does:** Completion verification, evidence collection, test adequacy assessment.
+
+        **Does not:** Implementation, design, or root-cause analysis.
+      </Accordion>
+
+      <Accordion title="tracer — Sonnet">
+        **Role:** Evidence-driven causal tracing, competing hypothesis analysis.
+
+        `tracer` builds a causal chain from symptom to root cause using only observable evidence. It generates multiple competing hypotheses and eliminates them systematically rather than guessing.
+
+        ```typescript theme={null}
+        Task(
+          subagent_type="oh-my-claudecode:tracer",
+          prompt="Trace why the API returns 403 intermittently for authenticated users"
+        )
+        ```
+
+        **Does:** Evidence-driven causal tracing, hypothesis generation and elimination, timeline reconstruction.
+
+        **Does not:** Implementation, planning, or architectural decisions.
+      </Accordion>
+    </AccordionGroup>
+  </Accordion>
+
+  <Accordion title="Review lane" icon="shield-check">
+    Quality gates applied before work is considered done. Catches correctness, compatibility, and security issues.
+
+    <AccordionGroup>
+      <Accordion title="security-reviewer — Sonnet">
+        **Role:** Security vulnerabilities, trust boundaries, authn/authz review.
+
+        `security-reviewer` audits code for exploitable flaws. It examines input validation, authentication flows, authorization checks, secrets handling, and injection vectors. Use it before any auth-related or externally-facing code ships.
+
+        ```typescript theme={null}
+        Task(
+          subagent_type="oh-my-claudecode:security-reviewer",
+          prompt="Review the new OAuth2 callback handler for security vulnerabilities"
+        )
+        ```
+
+        **Does:** Vulnerability identification, trust boundary mapping, authn/authz review.
+
+        **Does not:** Code correctness review, performance analysis.
+      </Accordion>
+
+      <Accordion title="code-reviewer — Opus">
+        **Role:** Comprehensive code review, API contracts, backward compatibility.
+
+        `code-reviewer` is the highest-tier reviewer. It checks logic correctness, maintainability, anti-patterns, API contract stability, and backward compatibility. Use it for changes spanning many files or touching public interfaces.
+
+        ```typescript theme={null}
+        Task(
+          subagent_type="oh-my-claudecode:code-reviewer",
+          prompt="Review the changes in PR #142 for correctness and API contract stability"
+        )
+        ```
+
+        **Does:** Logic review, API contract review, backward compatibility check, maintainability assessment.
+
+        **Does not:** Security-specific review (use `security-reviewer` for that).
+      </Accordion>
+    </AccordionGroup>
+  </Accordion>
+
+  <Accordion title="Domain lane" icon="layers">
+    Domain experts called in when a task requires specialized knowledge beyond the core build cycle.
+
+    <AccordionGroup>
+      <Accordion title="test-engineer — Sonnet">
+        **Role:** Test strategy, coverage, flaky-test hardening.
+
+        `test-engineer` designs and writes tests. It identifies coverage gaps, recommends test types (unit, integration, end-to-end), and hardens flaky tests. Use it when you need a test strategy rather than just a few test cases.
+
+        ```typescript theme={null}
+        Task(
+          subagent_type="oh-my-claudecode:test-engineer",
+          prompt="Design a test strategy for the payment processing module"
+        )
+        ```
+      </Accordion>
+
+      <Accordion title="designer — Sonnet">
+        **Role:** UI/UX architecture, interaction design.
+
+        `designer` works on visual and interaction problems. It structures component hierarchies, defines interaction flows, and recommends design patterns. Use it for UI components, layout systems, and user-facing interaction design.
+
+        ```typescript theme={null}
+        Task(
+          subagent_type="oh-my-claudecode:designer",
+          prompt="Design the component hierarchy for the dashboard layout"
+        )
+        ```
+      </Accordion>
+
+      <Accordion title="writer — Haiku">
+        **Role:** Documentation, migration notes.
+
+        `writer` produces human-readable text: API docs, migration guides, changelogs, and inline comments. It runs on Haiku because documentation tasks rarely require deep reasoning — they require clarity and speed.
+
+        ```typescript theme={null}
+        Task(
+          subagent_type="oh-my-claudecode:writer",
+          prompt="Write migration notes for the v3 to v4 API changes"
+        )
+        ```
+      </Accordion>
+
+      <Accordion title="qa-tester — Sonnet">
+        **Role:** Interactive CLI/service runtime validation via tmux.
+
+        `qa-tester` validates running software by interacting with it directly — starting servers, sending requests, checking responses, and exercising edge cases. It uses tmux to manage interactive sessions.
+
+        ```typescript theme={null}
+        Task(
+          subagent_type="oh-my-claudecode:qa-tester",
+          prompt="Start the dev server and validate the login flow end-to-end"
+        )
+        ```
+      </Accordion>
+
+      <Accordion title="scientist — Sonnet">
+        **Role:** Data analysis, statistical research.
+
+        `scientist` applies analytical methods to data problems. It writes analysis scripts, interprets results, and surfaces statistically significant findings. Use it for benchmark analysis, experiment result interpretation, and data pipeline validation.
+
+        ```typescript theme={null}
+        Task(
+          subagent_type="oh-my-claudecode:scientist",
+          prompt="Analyze the latency data in .omc/research/benchmark.csv and identify regressions"
+        )
+        ```
+      </Accordion>
+
+      <Accordion title="git-master — Sonnet">
+        **Role:** Git operations, commits, rebase, history management.
+
+        `git-master` handles all version control work. It writes commit messages, manages branch history, performs interactive rebases, and resolves merge conflicts with awareness of semantic history.
+
+        ```typescript theme={null}
+        Task(
+          subagent_type="oh-my-claudecode:git-master",
+          prompt="Create atomic commits for the changes in the auth module"
+        )
+        ```
+      </Accordion>
+
+      <Accordion title="document-specialist — Sonnet">
+        **Role:** External documentation, API/SDK reference lookup.
+
+        `document-specialist` researches external sources — library docs, API references, SDK guides — to answer questions that require reading third-party documentation. Use it before implementing with an unfamiliar API or library.
+
+        ```typescript theme={null}
+        Task(
+          subagent_type="oh-my-claudecode:document-specialist",
+          prompt="Look up the correct way to handle pagination in the Stripe API"
+        )
+        ```
+      </Accordion>
+
+      <Accordion title="vision — Sonnet">
+        **Role:** Image, screenshot, and diagram analysis.
+
+        `vision` processes visual inputs — UI screenshots, architecture diagrams, wireframes — and produces structured descriptions, comparisons, or action recommendations. Use it to compare a reference design with an implementation, or to extract structure from a diagram.
+
+        ```typescript theme={null}
+        Task(
+          subagent_type="oh-my-claudecode:vision",
+          prompt="Compare the reference screenshot against the current UI and list visual differences"
+        )
+        ```
+
+        **Does:** Image description, visual diff, diagram extraction.
+
+        **Does not:** Implement UI changes or write code.
+      </Accordion>
+
+      <Accordion title="code-simplifier — Opus">
+        **Role:** Code clarity, simplification, maintainability improvement.
+
+        `code-simplifier` reduces complexity without changing behavior. It eliminates dead code, flattens unnecessary abstractions, and improves naming. It runs on Opus because simplification requires deep reasoning about what is and is not needed.
+
+        ```typescript theme={null}
+        Task(
+          subagent_type="oh-my-claudecode:code-simplifier",
+          prompt="Simplify the auth middleware without changing its behavior"
+        )
+        ```
+
+        `code-simplifier` can also run automatically via the Stop hook when enabled in config:
+
+        ```json theme={null}
+        {
+          "codeSimplifier": {
+            "enabled": true,
+            "extensions": [".ts", ".tsx", ".js", ".jsx", ".py", ".go", ".rs"],
+            "maxFiles": 10
+          }
+        }
+        ```
+      </Accordion>
+    </AccordionGroup>
+  </Accordion>
+
+  <Accordion title="Coordination lane" icon="git-merge">
+    Challenges plans and designs produced by other agents. A plan passes only when `critic` can find no remaining gaps.
+
+    <AccordionGroup>
+      <Accordion title="critic — Opus">
+        **Role:** Gap analysis of plans and designs, multi-angle review.
+
+        `critic` adversarially reviews plans and designs. It looks for unstated assumptions, missing edge cases, contradictions, and scope gaps. In the `ralplan` skill, `critic` participates in a consensus loop with `planner` and `architect` until all three agree.
+
+        ```typescript theme={null}
+        Task(
+          subagent_type="oh-my-claudecode:critic",
+          prompt="Review the execution plan in .omc/plans/auth-refactor.md for gaps and risks"
+        )
+        ```
+
+        **Does:** Plan gap analysis, design challenge, multi-angle review, consensus participation.
+
+        **Does not:** Requirements analysis, code analysis, implementation.
+      </Accordion>
+    </AccordionGroup>
+  </Accordion>
+</AccordionGroup>
+
+## Tier variants
+
+Several agents have explicit tier variants for cost optimization. These are separate agent entries in the registry:
+
+| Base agent          | Haiku variant                | Opus variant                          |
+| ------------------- | ---------------------------- | ------------------------------------- |
+| `executor`          | `executor-low`               | `executor-high`                       |
+| `architect`         | `architect-low`              | `architect` (default is Opus)         |
+| `designer`          | `designer-low`               | `designer-high`                       |
+| `security-reviewer` | `security-reviewer-low`      | `security-reviewer` (default is Opus) |
+| `explore`           | `explore` (default is Haiku) | `explore-high`                        |
+| `scientist`         | —                            | `scientist-high`                      |
+
+Use `explore-high` for large codebases where Haiku misses complex symbol relationships. Use `executor-low` for trivial single-line fixes to minimize cost.
+
+
+# Agents overview
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/agents/overview
+
+Specialized AI processes that handle distinct phases of development work. OMC provides 29 agents organized into 4 lanes, each running on the model tier best suited to its task.
+
+Agents are focused subprocesses delegated work through the Task tool. Rather than having one general-purpose model handle everything, OMC routes each phase of a task to the specialist best equipped for it. An agent that maps the codebase runs on Haiku (fast and cheap). One that designs architecture runs on Opus (highest reasoning). The result is higher quality at lower cost.
+
+## How agents are invoked
+
+Agents are referenced with the `oh-my-claudecode:` prefix and called via the Task tool:
+
+```typescript theme={null}
+Task(
+  subagent_type="oh-my-claudecode:executor",
+  model="sonnet",
+  prompt="Implement the password reset flow..."
+)
+```
+
+You can also invoke agents directly using slash commands:
+
+```bash theme={null}
+/prompts:architect "review the auth module"
+/prompts:explorer "find all files importing utils"
+```
+
+OMC selects and delegates to agents automatically based on task type. You rarely need to invoke them directly unless you want to target a specific specialist.
+
+## The 4 agent lanes
+
+<AccordionGroup>
+  <Accordion title="Build/Analysis lane">
+    Covers the full development lifecycle from initial exploration through verified completion.
+
+    | Agent       | Default model | Role                                                          |
+    | ----------- | ------------- | ------------------------------------------------------------- |
+    | `explore`   | Haiku         | Codebase discovery, file and symbol mapping                   |
+    | `analyst`   | Opus          | Requirements analysis, hidden constraint discovery            |
+    | `planner`   | Opus          | Task sequencing, execution plan creation                      |
+    | `architect` | Opus          | System design, interface definition, trade-off analysis       |
+    | `debugger`  | Sonnet        | Root-cause analysis, build error resolution                   |
+    | `executor`  | Sonnet        | Code implementation, refactoring                              |
+    | `verifier`  | Sonnet        | Completion verification, test adequacy confirmation           |
+    | `tracer`    | Sonnet        | Evidence-driven causal tracing, competing hypothesis analysis |
+  </Accordion>
+
+  <Accordion title="Review lane">
+    Quality gates applied before handoff. Catches correctness and security issues.
+
+    | Agent               | Default model | Role                                                             |
+    | ------------------- | ------------- | ---------------------------------------------------------------- |
+    | `security-reviewer` | Sonnet        | Security vulnerabilities, trust boundaries, authn/authz review   |
+    | `code-reviewer`     | Opus          | Comprehensive code review, API contracts, backward compatibility |
+  </Accordion>
+
+  <Accordion title="Domain lane">
+    Specialists called in when a task requires domain expertise beyond the core build cycle.
+
+    | Agent                 | Default model | Role                                                      |
+    | --------------------- | ------------- | --------------------------------------------------------- |
+    | `test-engineer`       | Sonnet        | Test strategy, coverage, flaky-test hardening             |
+    | `designer`            | Sonnet        | UI/UX architecture, interaction design                    |
+    | `writer`              | Haiku         | Documentation, migration notes                            |
+    | `qa-tester`           | Sonnet        | Interactive CLI/service runtime validation via tmux       |
+    | `scientist`           | Sonnet        | Data analysis, statistical research                       |
+    | `git-master`          | Sonnet        | Git operations, commits, rebase, history management       |
+    | `document-specialist` | Sonnet        | External documentation, API/SDK reference lookup          |
+    | `vision`              | Sonnet        | Image, screenshot, and diagram analysis                   |
+    | `code-simplifier`     | Opus          | Code clarity, simplification, maintainability improvement |
+  </Accordion>
+
+  <Accordion title="Coordination lane">
+    Challenges plans and designs made by other agents. A plan passes only when no gaps remain.
+
+    | Agent    | Default model | Role                                                  |
+    | -------- | ------------- | ----------------------------------------------------- |
+    | `critic` | Opus          | Gap analysis of plans and designs, multi-angle review |
+  </Accordion>
+</AccordionGroup>
+
+## Tiered variants
+
+Several agents have LOW and HIGH variants that let you pin the model tier explicitly rather than relying on automatic routing:
+
+| Base agent          | LOW (Haiku)                  | HIGH (Opus)                 |
+| ------------------- | ---------------------------- | --------------------------- |
+| `executor`          | `executor-low`               | `executor-high`             |
+| `architect`         | `architect-low`              | — (default is already Opus) |
+| `architect-medium`  | —                            | —                           |
+| `explore`           | — (default is already Haiku) | `explore-high`              |
+| `designer`          | `designer-low`               | `designer-high`             |
+| `security-reviewer` | `security-reviewer-low`      | — (default is Opus)         |
+| `scientist`         | —                            | `scientist-high`            |
+
+Use `executor-low` for trivial single-line fixes to minimize cost. Use `explore-high` for large codebases where Haiku misses complex symbol relationships.
+
+## Model routing
+
+OMC maps agents to three model tiers based on the cognitive load their role demands:
+
+| Tier   | Model  | Agents                                                                                                                                                                   |
+| ------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Low    | Haiku  | `explore`, `writer`, `executor-low`, `architect-low`, `designer-low`, `security-reviewer-low`                                                                            |
+| Medium | Sonnet | `executor`, `debugger`, `test-engineer`, `designer`, `qa-tester`, `scientist`, `git-master`, `document-specialist`, `verifier`, `tracer`, `vision`                       |
+| High   | Opus   | `architect`, `analyst`, `planner`, `critic`, `code-reviewer`, `code-simplifier`, `security-reviewer`, `executor-high`, `explore-high`, `designer-high`, `scientist-high` |
+
+<Tip>
+  Model tier is a default, not a constraint. You can also override it per-call: `Task(subagent_type="oh-my-claudecode:executor", model="opus", ...)`.
+</Tip>
+
+## Typical agent workflow
+
+For most feature work, agents run in this sequence:
+
+```
+explore → analyst → planner → critic → executor → verifier
+(discover)  (analyze)  (sequence)  (review)   (implement)  (confirm)
+```
+
+1. `explore` maps the codebase to understand what exists
+2. `analyst` identifies requirements and hidden constraints
+3. `planner` sequences tasks into an execution plan
+4. `critic` reviews the plan for gaps before any code is written
+5. `executor` implements the changes
+6. `verifier` confirms all criteria are met with fresh evidence
+
+Not every task needs every agent. Simple bug fixes may go straight to `debugger` then `verifier`. OMC selects the minimal effective path.
+
+## When to delegate vs. handle directly
+
+**Delegate to agents when:**
+
+* Multiple files need to change
+* Refactoring is required
+* Debugging or root-cause analysis is needed
+* Code review or security review is needed
+* Planning or research is required
+
+**Handle directly when:**
+
+* Simple file lookups
+* Straightforward question answering
+* Single-command sequential operations
+
+## Agent role boundaries
+
+Each agent operates within a defined scope. Understanding these boundaries prevents agents from being misused:
+
+| Agent       | Does                                   | Does not                             |
+| ----------- | -------------------------------------- | ------------------------------------ |
+| `architect` | Code analysis, debugging, verification | Requirements gathering, planning     |
+| `analyst`   | Find requirements gaps                 | Code analysis, planning              |
+| `planner`   | Create task plans                      | Requirements analysis, plan review   |
+| `critic`    | Review plan quality                    | Requirements analysis, code analysis |
+
+## Agent selection guide
+
+| Task type              | Recommended agent       | Model  |
+| ---------------------- | ----------------------- | ------ |
+| Quick code lookup      | `explore`               | Haiku  |
+| Feature implementation | `executor`              | Sonnet |
+| Complex refactoring    | `executor` (model=opus) | Opus   |
+| Simple bug fix         | `debugger`              | Sonnet |
+| Complex debugging      | `architect`             | Opus   |
+| UI component           | `designer`              | Sonnet |
+| Documentation          | `writer`                | Haiku  |
+| Test strategy          | `test-engineer`         | Sonnet |
+| Security review        | `security-reviewer`     | Sonnet |
+| Code review            | `code-reviewer`         | Opus   |
+| Data analysis          | `scientist`             | Sonnet |
+
+
+# Environment variables
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/configuration/environment-variables
+
+Environment variables for controlling OMC hooks, model routing, OpenClaw integration, and the omc ask command.
+
+Environment variables are the highest-priority configuration layer in OMC. They override both user config (`~/.config/claude-omc/config.jsonc`) and project config (`.claude/omc.jsonc`). Set them in your shell profile, `.env` file, or CI environment.
+
+## Hook control
+
+<ParamField type="string">
+  Disable all OMC hooks. Set to any non-empty value (`1`, `true`, etc.) to bypass the entire hook system. Claude Code runs as if OMC is not installed.
+
+  ```bash theme={null}
+  export DISABLE_OMC=1
+  ```
+
+  Use this when troubleshooting hook conflicts or when running Claude Code in a context where OMC intervention is not wanted. `DISABLE_OMC=1` takes precedence over `OMC_SKIP_HOOKS`.
+</ParamField>
+
+<ParamField type="string">
+  Comma-separated list of hook names to skip. Other hooks remain active.
+
+  ```bash theme={null}
+  export OMC_SKIP_HOOKS="keyword-detector,notepad"
+  ```
+
+  Available hook names: `keyword-detector`, `persistent-mode`, `notepad`, `project-memory`, `pre-compact`, `permission-handler`, `subagent-tracker`, `code-simplifier`.
+</ParamField>
+
+## Model routing
+
+<ParamField type="string">
+  Override the MEDIUM tier model for all agents assigned to the sonnet tier. Useful when running OMC on Bedrock or Vertex AI where model strings are provider-specific ARNs or deployment names.
+
+  ```bash theme={null}
+  # Bedrock cross-region inference profile
+  export OMC_MODEL_MEDIUM="us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+
+  # Standard model alias
+  export OMC_MODEL_MEDIUM="claude-sonnet-4-6-override"
+  ```
+
+  This variable is checked as part of the model resolution precedence chain:
+
+  1. Explicit `--model` in worker launch args
+  2. `ANTHROPIC_MODEL` / `CLAUDE_MODEL`
+  3. Provider tier env vars (e.g., `CLAUDE_CODE_BEDROCK_SONNET_MODEL`)
+  4. `OMC_MODEL_MEDIUM`
+  5. Claude Code default
+</ParamField>
+
+<ParamField type="string">
+  Set the Anthropic provider model directly. Takes precedence over `OMC_MODEL_MEDIUM`.
+
+  ```bash theme={null}
+  export ANTHROPIC_MODEL="claude-sonnet-4-6"
+  ```
+</ParamField>
+
+<ParamField type="string">
+  Alias for `ANTHROPIC_MODEL`. Both variables are supported; `ANTHROPIC_MODEL` takes precedence if both are set.
+
+  ```bash theme={null}
+  export CLAUDE_MODEL="claude-sonnet-4-6"
+  ```
+</ParamField>
+
+## OpenClaw integration
+
+OpenClaw is an external integration layer that allows OMC to send and receive messages via an HTTP endpoint. It is disabled by default.
+
+<ParamField type="string">
+  Enable OpenClaw integration. Must be set to exactly `"1"` to activate. Any other value (including `"true"`) leaves OpenClaw disabled.
+
+  ```bash theme={null}
+  export OMC_OPENCLAW=1
+  ```
+
+  When enabled, OMC calls the OpenClaw wake endpoint at session end and passes reply routing metadata from the `OPENCLAW_REPLY_*` variables.
+</ParamField>
+
+<ParamField type="string">
+  Enable verbose debug logging for OpenClaw. Set to `"1"` to print request and response details to stderr.
+
+  ```bash theme={null}
+  export OMC_OPENCLAW_DEBUG=1
+  ```
+
+  Use this when troubleshooting connectivity issues with the OpenClaw endpoint. Debug output appears in the Claude Code terminal, not in the session.
+</ParamField>
+
+### OpenClaw reply routing
+
+These variables control where OpenClaw delivers its reply after processing a session-end event. They are only used when `OMC_OPENCLAW=1`.
+
+<ParamField type="string">
+  The channel name to route the OpenClaw reply to (e.g., `#general`, `#alerts`).
+
+  ```bash theme={null}
+  export OPENCLAW_REPLY_CHANNEL="#general"
+  ```
+
+  If both this env var and a value from the OpenClaw context payload are present, the context payload takes precedence.
+</ParamField>
+
+<ParamField type="string">
+  The target recipient for the OpenClaw reply. Typically a user mention or bot identifier (e.g., `@bot`, `@alice`).
+
+  ```bash theme={null}
+  export OPENCLAW_REPLY_TARGET="@bot"
+  ```
+</ParamField>
+
+<ParamField type="string">
+  The thread ID to post the OpenClaw reply into. Use this when the originating request came from a specific thread that should receive the response.
+
+  ```bash theme={null}
+  export OPENCLAW_REPLY_THREAD="thread-123"
+  ```
+</ParamField>
+
+## omc ask configuration
+
+The `omc ask` command routes a prompt to Claude, Codex, or Gemini and saves the result as a reusable artifact.
+
+<ParamField type="string">
+  Path to the advisor script used by `omc ask`. Override this to point at a custom script that wraps your preferred CLI invocation.
+
+  ```bash theme={null}
+  export OMC_ASK_ADVISOR_SCRIPT="/path/to/custom-advisor.sh"
+  ```
+
+  <Note>
+    The legacy alias `OMX_ASK_ADVISOR_SCRIPT` still works but is deprecated and will print a warning. Migrate to `OMC_ASK_ADVISOR_SCRIPT`.
+  </Note>
+</ParamField>
+
+<ParamField type="string">
+  The original task description passed to `omc ask`. OMC sets this automatically when invoking an advisor; you can set it manually to inject context into programmatic ask calls.
+
+  ```bash theme={null}
+  export OMC_ASK_ORIGINAL_TASK="review the authentication module for security issues"
+  ```
+
+  <Note>
+    The legacy alias `OMX_ASK_ORIGINAL_TASK` still works but is deprecated. Migrate to `OMC_ASK_ORIGINAL_TASK`.
+  </Note>
+</ParamField>
+
+## State management
+
+<ParamField type="string">
+  Override the directory where OMC stores state. By default, state is written to `{worktree}/.omc/` and is lost when the worktree is deleted.
+
+  Setting this variable moves state storage to a centralized location, preserving it across worktree lifecycles:
+
+  ```bash theme={null}
+  # Add to ~/.bashrc or ~/.zshrc
+  export OMC_STATE_DIR="$HOME/.claude/omc"
+  ```
+
+  OMC derives a stable project identifier from the git remote URL (or a hash of the directory path for local-only repos) and stores state at `$OMC_STATE_DIR/{project-identifier}/`.
+
+  If both a legacy `{worktree}/.omc/` directory and the centralized directory exist, OMC logs a notice and uses the centralized directory.
+</ParamField>
+
+## Other variables
+
+<ParamField type="string">
+  Enable or disable parallel agent execution. Set to `false` to force sequential execution, which can help with debugging or resource-constrained environments.
+
+  ```bash theme={null}
+  export OMC_PARALLEL_EXECUTION=false
+  ```
+</ParamField>
+
+<ParamField type="string">
+  Timeout in milliseconds for LSP requests. Increase this value for large repositories or slow language servers.
+
+  ```bash theme={null}
+  export OMC_LSP_TIMEOUT_MS=30000
+  ```
+</ParamField>
+
+
+# Hooks
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/configuration/hooks
+
+How OMC hooks extend Claude Code lifecycle events to inject context, enforce continuation, and manage state.
+
+Hooks are scripts that fire automatically in response to Claude Code lifecycle events. OMC ships with 20 hooks that extend Claude Code with magic keyword detection, context-resistant memory, quality enforcement, and mode persistence.
+
+## How hooks work
+
+Hooks are defined in a `hooks.json` file that Claude Code reads at startup. Each entry maps a lifecycle event to one or more scripts:
+
+```json theme={null}
+{
+  "EventName": [
+    {
+      "matcher": "*",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "node scripts/hook-script.mjs",
+          "timeout": 5
+        }
+      ]
+    }
+  ]
+}
+```
+
+| Field       | Description                                      |
+| ----------- | ------------------------------------------------ |
+| `EventName` | The Claude Code lifecycle event to listen for    |
+| `matcher`   | Condition for running the hook (`*` matches all) |
+| `command`   | The script to execute                            |
+| `timeout`   | Maximum execution time in seconds                |
+
+Hook scripts write their output to stdout. Claude Code injects this output into the session via `<system-reminder>` tags, making it visible to Claude without interrupting the conversation flow.
+
+## Hook categories
+
+### Core hooks
+
+Core hooks handle orchestration, keyword detection, and mode persistence — the foundational behaviors that enable OMC's skill system.
+
+<AccordionGroup>
+  <Accordion title="keyword-detector">
+    **Event**: `UserPromptSubmit`
+
+    Detects magic keywords in user prompts and activates the corresponding skill. When you type `autopilot build me a REST API`, the keyword-detector recognizes `autopilot` and injects the autopilot skill invocation before Claude processes the message.
+
+    The detector sanitizes the prompt first (stripping code blocks, URLs, and file paths) to avoid false positives, then matches keyword patterns against what remains.
+
+    Conflict resolution order (highest priority first): `cancel` > `ralph` > `autopilot` > `ultrawork`.
+
+    The detector is disabled inside team workers to prevent infinite spawning.
+
+    **Configurable keywords** (via `magicKeywords` in `config.jsonc`):
+
+    | Category     | Default keywords              |
+    | ------------ | ----------------------------- |
+    | `ultrawork`  | ultrawork, ulw, parallel      |
+    | `search`     | search, find, locate          |
+    | `analyze`    | analyze, investigate, examine |
+    | `ultrathink` | ultrathink, think, reason     |
+
+    Keywords like `autopilot`, `ralph`, and `ccg` are hardcoded and cannot be changed via config.
+  </Accordion>
+
+  <Accordion title="persistent-mode">
+    **Event**: `Stop`
+
+    Keeps active execution modes (ralph, autopilot, ultrawork, ultraqa, team, pipeline) running by injecting a reinforcement message when Claude would otherwise stop.
+
+    When a mode is active, the hook injects: `"The boulder never stops"` — a signal to Claude to continue working rather than concluding.
+
+    The hook checks `.omc/state/` for active mode state files. State files older than 2 hours are treated as inactive to prevent stale state from blocking new sessions.
+
+    To cancel an active mode:
+
+    ```bash theme={null}
+    /oh-my-claudecode:cancel
+    ```
+
+    or type `cancelomc` in the chat.
+  </Accordion>
+</AccordionGroup>
+
+### Context management hooks
+
+These hooks preserve information across context compaction events, where Claude's context window fills and older content is summarized away.
+
+<AccordionGroup>
+  <Accordion title="notepad">
+    A compaction-resistant memory system that survives context window resets.
+
+    * **Storage**: `.omc/notepad.md`
+    * **Fires on**: `SessionStart`, `PreCompact`
+
+    Supports three priority levels:
+
+    | Priority | MCP tool                 | Use for                             |
+    | -------- | ------------------------ | ----------------------------------- |
+    | Priority | `notepad_write_priority` | Information that must never be lost |
+    | Working  | `notepad_write_working`  | Current work-in-progress status     |
+    | Manual   | `notepad_write_manual`   | Manually recorded session notes     |
+
+    Use `notepad_prune` to remove stale entries and `notepad_stats` to check storage usage.
+  </Accordion>
+
+  <Accordion title="project-memory">
+    Manages permanent project-level memory that persists across all sessions.
+
+    * **Storage**: `.omc/project-memory.json`
+    * **Fires on**: `SessionStart`, `PostToolUse`, `PreCompact`
+
+    Two types of stored data:
+
+    * **Notes**: Learned facts about the project (architecture patterns, bug history, past decisions)
+    * **Directives**: Standing instructions to follow when working on the project
+
+    Available MCP tools: `project_memory_read`, `project_memory_write`, `project_memory_add_note`, `project_memory_add_directive`.
+  </Accordion>
+
+  <Accordion title="pre-compact">
+    Fires immediately before context compaction to save work-in-progress state.
+
+    * **Event**: `PreCompact`
+    * **Behavior**: Summarizes and saves the current work state, in-progress TODOs, and critical context so work can resume after compaction without losing track.
+  </Accordion>
+</AccordionGroup>
+
+### Quality and verification hooks
+
+These hooks enforce code quality, track subagent activity, and handle permission validation.
+
+<AccordionGroup>
+  <Accordion title="permission-handler">
+    **Event**: `PermissionRequest` (Bash tool only)
+
+    Handles permission requests that arise during Bash command execution. Validates whether the requested operation is within the agent's allowed scope.
+  </Accordion>
+
+  <Accordion title="subagent-tracker">
+    **Events**: `SubagentStart`, `SubagentStop`
+
+    Records subagent spawn and completion events, including agent name, start time, and session information. After a subagent completes, the `verify-deliverables.mjs` script checks that expected outputs were produced.
+  </Accordion>
+
+  <Accordion title="code-simplifier">
+    **Event**: `Stop` (opt-in)
+
+    Automatically simplifies recently modified files when Claude finishes a response. This hook is disabled by default and must be explicitly enabled in your config.
+
+    The default model for `code-simplifier` is opus, since it performs deep reasoning about code structure and abstraction boundaries.
+  </Accordion>
+</AccordionGroup>
+
+## Lifecycle events
+
+OMC attaches hooks to 11 Claude Code lifecycle events:
+
+| Event                | When it fires                            |
+| -------------------- | ---------------------------------------- |
+| `UserPromptSubmit`   | User submits a prompt                    |
+| `SessionStart`       | New session begins                       |
+| `PreToolUse`         | Immediately before a tool call           |
+| `PermissionRequest`  | Permission request during Bash execution |
+| `PostToolUse`        | After a tool call completes              |
+| `PostToolUseFailure` | After a tool call fails                  |
+| `SubagentStart`      | A subagent is spawned                    |
+| `SubagentStop`       | A subagent completes                     |
+| `PreCompact`         | Immediately before context compaction    |
+| `Stop`               | Claude finishes a response               |
+| `SessionEnd`         | Session ends                             |
+
+## Disabling hooks
+
+### Disable all hooks
+
+Set `DISABLE_OMC` to any non-empty value to bypass every hook:
+
+```bash theme={null}
+export DISABLE_OMC=1
+```
+
+This is useful when troubleshooting or when you need to run Claude Code without any OMC intervention.
+
+### Disable specific hooks
+
+Use `OMC_SKIP_HOOKS` with a comma-separated list of hook names:
+
+```bash theme={null}
+export OMC_SKIP_HOOKS="keyword-detector,notepad"
+```
+
+<Warning>
+  Disabling `keyword-detector` prevents magic keywords from activating skills. Disabling `persistent-mode` allows active modes to terminate early.
+</Warning>
+
+## Mode state files
+
+Execution modes write state to `.omc/state/`. The persistent-mode hook reads these files on every `Stop` event to decide whether to inject a continuation message.
+
+```json theme={null}
+{
+  "active": true,
+  "started_at": "2025-01-15T10:30:00Z",
+  "prompt": "ultrawork implement auth",
+  "session_id": "abc123",
+  "project_path": "/path/to/project",
+  "iteration": 0,
+  "max_iterations": 10,
+  "last_checked_at": "2025-01-15T10:30:00Z"
+}
+```
+
+State files older than 2 hours are automatically treated as inactive. To manually clear all active mode state, run `/oh-my-claudecode:cancel`.
+
+
+# Model routing
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/configuration/model-routing
+
+How OMC assigns AI models to agents by task complexity, and how to override the defaults.
+
+OMC assigns agents to one of three model tiers based on task complexity. Heavier tasks use more capable (and more expensive) models; lightweight tasks use faster, cheaper ones. You can override any assignment in `config.jsonc`.
+
+## Model tiers
+
+| Tier     | Default model | Characteristics                                                                 |
+| -------- | ------------- | ------------------------------------------------------------------------------- |
+| `LOW`    | haiku         | Fast, low cost. Best for lookups, search, and simple tasks.                     |
+| `MEDIUM` | sonnet        | Balanced. Handles standard implementation, debugging, and general tasks.        |
+| `HIGH`   | opus          | Highest capability. Best for architecture, deep analysis, and complex planning. |
+
+<Tip>
+  Using haiku for agents that perform repetitive or search-heavy tasks (like `explore` and `writer`) saves 30–50% on token costs compared to running everything on sonnet.
+</Tip>
+
+## Default agent–model mapping
+
+All 19 primary agents ship with a default tier assignment:
+
+| Agent                 | Default model | Role                                            |
+| --------------------- | ------------- | ----------------------------------------------- |
+| `explore`             | haiku         | Codebase discovery and file search              |
+| `writer`              | haiku         | Documentation writing                           |
+| `executor`            | sonnet        | Code implementation                             |
+| `debugger`            | sonnet        | Build and runtime debugging                     |
+| `designer`            | sonnet        | UI/UX design                                    |
+| `verifier`            | sonnet        | Completion verification                         |
+| `tracer`              | sonnet        | Evidence-driven causal tracing                  |
+| `security-reviewer`   | sonnet        | Security vulnerabilities and trust boundaries   |
+| `test-engineer`       | sonnet        | Test strategy and coverage                      |
+| `qa-tester`           | sonnet        | Interactive CLI and service runtime validation  |
+| `scientist`           | sonnet        | Data and statistical analysis                   |
+| `git-master`          | sonnet        | Git operations and history management           |
+| `document-specialist` | sonnet        | External documentation and API reference lookup |
+| `architect`           | opus          | System design                                   |
+| `planner`             | opus          | Strategic planning                              |
+| `critic`              | opus          | Plan review and challenge                       |
+| `analyst`             | opus          | Requirements analysis                           |
+| `code-reviewer`       | opus          | Comprehensive code review                       |
+| `code-simplifier`     | opus          | Code clarity and simplification                 |
+
+## Overriding per-agent model
+
+Set the `agents` key in `config.jsonc` to override any agent's model. You can use `"haiku"`, `"sonnet"`, or `"opus"` as shorthand:
+
+```jsonc theme={null}
+{
+  "agents": {
+    // Upgrade explore for complex repository-wide search
+    "explore": { "model": "sonnet" },
+
+    // Use opus for implementation on a critical project
+    "executor": { "model": "opus" },
+
+    // Save cost on documentation tasks
+    "writer": { "model": "haiku" }
+  }
+}
+```
+
+<Note>
+  Model shorthand values (`haiku`, `sonnet`, `opus`) map to the provider's current recommended versions. To pin a specific version, set `OMC_MODEL_MEDIUM` or another provider env var directly.
+</Note>
+
+## Routing configuration
+
+The `routing` section controls global model routing behavior:
+
+```jsonc theme={null}
+{
+  "routing": {
+    // Enable or disable smart tier routing
+    "enabled": true,
+
+    // Default tier when no explicit assignment exists
+    "defaultTier": "MEDIUM",
+
+    // Force all agents to inherit the parent session's model.
+    // Automatically activated when using CC Switch, Bedrock, or Vertex AI.
+    "forceInherit": false
+  }
+}
+```
+
+### `forceInherit` for alternative providers
+
+When running OMC through AWS Bedrock, Google Vertex AI, or a CC Switch profile, the model string is often a provider-specific ARN or deployment name. In these cases, `forceInherit: true` tells all agents to use the same model as the parent session rather than trying to resolve a tier name:
+
+```jsonc theme={null}
+{
+  "routing": {
+    "enabled": true,
+    "forceInherit": true
+  }
+}
+```
+
+You can also set this at runtime with the `OMC_MODEL_MEDIUM` environment variable (see [Environment variables](/configuration/environment-variables)).
+
+## Smart routing examples
+
+<Tabs>
+  <Tab title="Cost-optimized">
+    Use haiku for all search and documentation tasks. Reserve sonnet and opus for implementation and review.
+
+    ```jsonc theme={null}
+    {
+      "agents": {
+        "explore": { "model": "haiku" },
+        "writer": { "model": "haiku" },
+        "document-specialist": { "model": "haiku" },
+        "executor": { "model": "sonnet" },
+        "debugger": { "model": "sonnet" },
+        "architect": { "model": "opus" },
+        "code-reviewer": { "model": "opus" }
+      }
+    }
+    ```
+  </Tab>
+
+  <Tab title="Quality-maximized">
+    Upgrade the critical path agents to opus for a high-stakes project.
+
+    ```jsonc theme={null}
+    {
+      "agents": {
+        "executor": { "model": "opus" },
+        "architect": { "model": "opus" },
+        "planner": { "model": "opus" },
+        "analyst": { "model": "opus" },
+        "critic": { "model": "opus" }
+      }
+    }
+    ```
+  </Tab>
+
+  <Tab title="Bedrock / Vertex">
+    Use `forceInherit` so all agents use the provider-configured model.
+
+    ```jsonc theme={null}
+    {
+      "routing": {
+        "enabled": true,
+        "forceInherit": true
+      }
+    }
+    ```
+
+    Then set your provider model via environment variable:
+
+    ```bash theme={null}
+    export OMC_MODEL_MEDIUM="us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+    ```
+  </Tab>
+</Tabs>
+
+## Tiered agent variants
+
+Some agents ship with explicit tier variants that you can call directly. These are useful when you want to lock in a tier at call time rather than relying on config:
+
+| Domain       | LOW (haiku)             | MEDIUM (sonnet) | HIGH (opus)         |
+| ------------ | ----------------------- | --------------- | ------------------- |
+| Analysis     | `architect-low`         | —               | `architect`         |
+| Execution    | `executor-low`          | `executor`      | `executor-high`     |
+| Search       | `explore`               | —               | `explore-high`      |
+| Frontend     | `designer-low`          | `designer`      | `designer-high`     |
+| Security     | `security-reviewer-low` | —               | `security-reviewer` |
+| Data science | —                       | `scientist`     | `scientist-high`    |
+
+Always prefix with `oh-my-claudecode:` when invoking via the Task tool (e.g., `oh-my-claudecode:executor-high`).
+
+
+# Setup and configuration
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/configuration/setup
+
+Configure oh-my-claudecode for a single project or across all Claude Code sessions.
+
+OMC supports two configuration levels: a user-level file that applies globally, and a project-level file that overrides it for a specific repository. Most settings live in JSONC files; Claude Code behavior (agent instructions, skill injection) lives in generated `CLAUDE.md` files.
+
+## Config file locations
+
+| Scope         | Path                                | Applied when             |
+| ------------- | ----------------------------------- | ------------------------ |
+| User (global) | `~/.config/claude-omc/config.jsonc` | All Claude Code sessions |
+| Project       | `.claude/omc.jsonc`                 | Current project only     |
+
+<Note>
+  Both files use JSONC format (JSON with comment support). They are not TypeScript config files — do not use `.ts` or `.json` extensions.
+</Note>
+
+## Configuration priority
+
+When the same setting appears in multiple places, the highest-priority source wins. Sources are resolved in this order, with later entries taking precedence:
+
+```
+Defaults
+  → User config   (~/.config/claude-omc/config.jsonc)
+  → Project config (.claude/omc.jsonc)
+  → Environment variables
+```
+
+Environment variables always override file-based config, making them suitable for CI overrides or one-off model changes.
+
+## Basic config structure
+
+A minimal `config.jsonc` covers three sections: per-agent model assignments, feature toggles, and magic keyword aliases.
+
+```jsonc theme={null}
+{
+  // Per-agent model assignments
+  "agents": {
+    "explore": { "model": "haiku" },
+    "executor": { "model": "sonnet" },
+    "architect": { "model": "opus" }
+  },
+
+  // Feature toggles
+  "features": {
+    "parallelExecution": true,
+    "lspTools": true,
+    "astTools": true
+  },
+
+  // Magic keyword customization
+  "magicKeywords": {
+    "ultrawork": ["ultrawork", "ulw", "parallel"],
+    "search": ["search", "find", "locate"],
+    "analyze": ["analyze", "investigate", "examine"],
+    "ultrathink": ["ultrathink", "think", "reason"]
+  }
+}
+```
+
+<Note>
+  The `magicKeywords` section only allows customizing four categories: `ultrawork`, `search`, `analyze`, and `ultrathink`. Keywords like `autopilot`, `ralph`, and `ccg` are hardcoded in the keyword-detector hook and cannot be changed via config files.
+</Note>
+
+## Running setup
+
+OMC generates `CLAUDE.md` files during setup. These files inject agent instructions and skill configuration into Claude Code sessions. You must run setup at least once before using OMC.
+
+### Project-scoped setup (recommended)
+
+Applies OMC only to the current project:
+
+<Steps>
+  <Step title="Open Claude Code in your project directory">
+    Navigate to the project you want to enable OMC for.
+  </Step>
+
+  <Step title="Run the project setup command">
+    ```bash theme={null}
+    /oh-my-claudecode:omc-setup --local
+    ```
+  </Step>
+
+  <Step title="Verify the generated file">
+    OMC creates `./.claude/CLAUDE.md` in your project. Your global `~/.claude/CLAUDE.md` is left unchanged.
+  </Step>
+</Steps>
+
+Project-scoped setup keeps OMC isolated to that repository. Other projects are unaffected.
+
+### Global setup
+
+Applies OMC to all Claude Code sessions on your machine:
+
+<Steps>
+  <Step title="Run the global setup command">
+    ```bash theme={null}
+    /oh-my-claudecode:omc-setup
+    ```
+  </Step>
+
+  <Step title="Choose overwrite or preserve mode">
+    The wizard will ask how to handle your existing `~/.claude/CLAUDE.md`.
+
+    * **Overwrite** (default): replaces the file with OMC's config
+    * **Preserve**: keeps your existing file as-is; OMC writes its config to `~/.claude/CLAUDE-omc.md` and force-loads it when you run `omc`
+  </Step>
+</Steps>
+
+<Warning>
+  Global setup modifies `~/.claude/CLAUDE.md`, which affects all Claude Code projects. Use project-scoped setup if you only want OMC active in specific repositories.
+</Warning>
+
+### Verifying setup
+
+Run the diagnostics tool after setup to confirm everything is working:
+
+```bash theme={null}
+/oh-my-claudecode:omc-doctor
+```
+
+The doctor checks dependency installation, configuration file validity, hook registration status, agent availability, and skill registration.
+
+## CLAUDE.md files
+
+Setup generates `CLAUDE.md` files in addition to `config.jsonc`. These files carry agent behavior instructions that Claude Code reads at session start.
+
+| Scope   | File                  | Controls                             |
+| ------- | --------------------- | ------------------------------------ |
+| Global  | `~/.claude/CLAUDE.md` | Default behavior across all projects |
+| Project | `.claude/CLAUDE.md`   | Per-project overrides and context    |
+
+You can edit `.claude/CLAUDE.md` directly to add project-specific context such as tech stack details, conventions, or architecture notes:
+
+```markdown theme={null}
+# Project context
+
+This is a TypeScript monorepo using Bun, React, and PostgreSQL.
+
+## Conventions
+
+- Use functional components
+- All API routes in /src/api
+- Tests alongside source files
+```
+
+## When to re-run setup
+
+<AccordionGroup>
+  <Accordion title="After initial installation">
+    Setup must be run once before OMC is active. Without it, hooks and agent instructions are not loaded.
+  </Accordion>
+
+  <Accordion title="After a plugin update">
+    OMC updates may include changes to `CLAUDE.md`. Re-run setup to apply the latest configuration:
+
+    ```bash theme={null}
+    /oh-my-claudecode:omc-setup
+    ```
+  </Accordion>
+
+  <Accordion title="On a new machine">
+    Run setup on each machine where you use Claude Code. Config files and generated `CLAUDE.md` files are not synced automatically.
+  </Accordion>
+
+  <Accordion title="When starting a new project">
+    Use the `--local` flag to create a project-scoped config without affecting your global setup:
+
+    ```bash theme={null}
+    /oh-my-claudecode:omc-setup --local
+    ```
+  </Accordion>
+</AccordionGroup>
+
+
+# Installation
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/installation
+
+Install oh-my-claudecode via the Claude Code plugin marketplace and configure it for your project or globally.
+
+## Prerequisites
+
+| Requirement    | Details                                                 |
+| -------------- | ------------------------------------------------------- |
+| Claude Code    | Must be installed and working                           |
+| Authentication | Claude Max/Pro subscription, or `ANTHROPIC_API_KEY` set |
+
+<Note>
+  Only the Claude Code plugin method is supported. Direct npm or bun global installs are not supported and may not work correctly.
+</Note>
+
+## Plugin marketplace install
+
+Install OMC by running two commands inside a Claude Code session:
+
+<Steps>
+  <Step title="Add the marketplace source">
+    Register the OMC GitHub repository as a Claude Code plugin source:
+
+    ```bash theme={null}
+    /plugin marketplace add https://github.com/Yeachan-Heo/oh-my-claudecode
+    ```
+  </Step>
+
+  <Step title="Install the plugin">
+    Download and install the plugin from the registered source:
+
+    ```bash theme={null}
+    /plugin install oh-my-claudecode
+    ```
+
+    The plugin system handles dependency installation and hook setup automatically.
+  </Step>
+
+  <Step title="Run setup">
+    Initialize OMC configuration. Choose project-scoped or global based on your needs (see below):
+
+    ```bash theme={null}
+    /omc-setup
+    ```
+  </Step>
+
+  <Step title="Verify the installation">
+    Confirm everything is working correctly:
+
+    ```bash theme={null}
+    /oh-my-claudecode:omc-doctor
+    ```
+  </Step>
+</Steps>
+
+## Setup scopes
+
+Running `/omc-setup` configures OMC by writing a `CLAUDE.md` file that activates agents, skills, hooks, and keyword detection. You choose whether that configuration applies to one project or all your projects.
+
+<Tabs>
+  <Tab title="Project-scoped (recommended)">
+    Apply OMC only to the current project:
+
+    ```bash theme={null}
+    /oh-my-claudecode:omc-setup --local
+    ```
+
+    * Writes configuration to `./.claude/CLAUDE.md` in the current directory
+    * Has no effect on other projects or your global Claude Code settings
+    * Safe to commit to version control to share OMC settings with your team
+    * Your existing global `~/.claude/CLAUDE.md` is preserved unchanged
+
+    Use project-scoped setup when you want per-project isolation or when working in a shared repository.
+  </Tab>
+
+  <Tab title="Global">
+    Apply OMC to all Claude Code sessions across all projects:
+
+    ```bash theme={null}
+    /oh-my-claudecode:omc-setup
+    ```
+
+    * Writes configuration to `~/.claude/CLAUDE.md`
+    * Takes effect in every project you open with Claude Code
+
+    <Warning>
+      Global setup will ask whether to overwrite your existing `~/.claude/CLAUDE.md`. The default action is overwrite. If you choose preserve mode instead, plain `claude` keeps your base config unchanged and `omc` force-loads a companion config file at launch.
+    </Warning>
+  </Tab>
+</Tabs>
+
+### Configuration precedence
+
+When both a project-scoped and a global config exist, the project-scoped config takes precedence:
+
+```
+./.claude/CLAUDE.md  (project)  →  overrides  →  ~/.claude/CLAUDE.md  (global)
+```
+
+## Verifying the installation
+
+Run the diagnostics command after setup to confirm everything is working:
+
+```bash theme={null}
+/oh-my-claudecode:omc-doctor
+```
+
+The doctor checks:
+
+* Dependency installation status
+* Configuration file validity
+* Hook installation status
+* Agent availability
+* Skill registration status
+
+If any check fails, the output will tell you what is missing and how to fix it.
+
+## Platform support
+
+<Warning>
+  OMC features like `omc team` and rate-limit detection require **tmux**. Install tmux for your platform before using those features.
+</Warning>
+
+| Platform              | Installation method           | Hook type        | tmux install            |
+| --------------------- | ----------------------------- | ---------------- | ----------------------- |
+| macOS                 | Claude Code plugin            | Bash (`.sh`)     | `brew install tmux`     |
+| Linux (Ubuntu/Debian) | Claude Code plugin            | Bash (`.sh`)     | `sudo apt install tmux` |
+| Linux (Fedora)        | Claude Code plugin            | Bash (`.sh`)     | `sudo dnf install tmux` |
+| Linux (Arch)          | Claude Code plugin            | Bash (`.sh`)     | `sudo pacman -S tmux`   |
+| Windows (WSL2)        | Claude Code plugin inside WSL | Bash (`.sh`)     | `sudo apt install tmux` |
+| Windows (native)      | Experimental                  | Node.js (`.mjs`) | `winget install psmux`  |
+
+<Note>
+  Native Windows support is experimental. For production use on Windows, WSL2 is recommended. On native Windows, [psmux](https://github.com/marlocarlo/psmux) provides a tmux-compatible binary with 76 tmux-compatible commands — no WSL required.
+</Note>
+
+## Optional: multi-AI providers
+
+OMC can orchestrate Codex CLI and Gemini CLI workers alongside Claude. These are entirely optional — OMC works fully without them. Install them only if you want cross-model validation or access to Gemini's 1M-token context window.
+
+| Provider                                                  | Install command                     | What it enables                                    |
+| --------------------------------------------------------- | ----------------------------------- | -------------------------------------------------- |
+| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `npm install -g @google/gemini-cli` | Design review, UI consistency, large-context tasks |
+| [Codex CLI](https://github.com/openai/codex)              | `npm install -g @openai/codex`      | Architecture validation, code review cross-check   |
+
+Once installed, spawn workers with:
+
+```bash theme={null}
+omc team 2:codex "review auth module for security issues"
+omc team 2:gemini "redesign UI components for accessibility"
+```
+
+## Updating
+
+<Tabs>
+  <Tab title="Plugin marketplace">
+    If you installed via the Claude Code marketplace:
+
+    ```bash theme={null}
+    /plugin marketplace update omc
+    ```
+
+    After updating, re-run setup to apply the latest configuration:
+
+    ```bash theme={null}
+    /omc-setup
+    ```
+
+    <Note>
+      If marketplace auto-update is not enabled, you must run the update command manually before re-running setup.
+    </Note>
+  </Tab>
+
+  <Tab title="npm (legacy)">
+    If you are using the CLI tools via npm (the npm package is named differently from the plugin):
+
+    ```bash theme={null}
+    npm i -g oh-my-claude-sisyphus@latest
+    ```
+
+    Note: the repo, plugin, and slash commands are branded **oh-my-claudecode**, but the published npm package name is `oh-my-claude-sisyphus`.
+  </Tab>
+</Tabs>
+
+### When to re-run setup
+
+Re-run `/omc-setup` (or `/oh-my-claudecode:omc-setup --local` for project scope) after:
+
+* Initial installation
+* Any OMC plugin update
+* Moving to a different machine
+* Starting a new project where you want project-scoped configuration
+
+### Troubleshooting after updates
+
+If you experience issues after updating, run the diagnostics tool to check the installation state:
+
+```bash theme={null}
+/oh-my-claudecode:omc-doctor
+```
+
+## Uninstalling
+
+```bash theme={null}
+/plugin uninstall oh-my-claudecode@oh-my-claudecode
+```
+
+This removes the plugin from Claude Code. You can also manually delete the generated `CLAUDE.md` files if you want to remove OMC configuration:
+
+* Project scope: `./.claude/CLAUDE.md`
+* Global scope: `~/.claude/CLAUDE.md`
+
+
+# Introduction
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/introduction
+
+Multi-agent orchestration for Claude Code. Zero learning curve. Maximum power.
+
+oh-my-claudecode (OMC) is a plugin for Claude Code that turns it into a fully orchestrated multi-agent system. You describe what you want — OMC dispatches specialized agents, parallelizes work across them, routes each task to the right model tier, and loops until everything is verified complete.
+
+There are no configuration files to learn, no new DSL to memorize, and no manual wiring of agents. OMC intercepts Claude Code lifecycle events through hooks, detects magic keywords in your prompts, and activates the right workflow automatically.
+
+## Why oh-my-claudecode?
+
+Two problems make large AI-assisted development sessions difficult:
+
+**Cognitive overhead.** Getting the most out of Claude Code requires knowing which agents exist, when to delegate, which model to use, and how to coordinate parallel work. Most developers either under-use the primitives or spend more time managing the system than building.
+
+**Partial completion.** Individual AI sessions stop when they hit complexity. A real project needs planning, execution, testing, and verification to actually complete — not just a single response.
+
+OMC solves both. It wraps Claude Code's primitives into proven workflows so you get the power of multi-agent orchestration without the learning curve.
+
+<CardGroup>
+  <Card title="Zero configuration" icon="wand-magic-sparkles">
+    Works out of the box with intelligent defaults. No YAML, no config files, no setup beyond a single `/omc-setup` command.
+  </Card>
+
+  <Card title="Team-first orchestration" icon="people-group">
+    Team is the canonical multi-agent surface — a staged pipeline that plans, executes, verifies, and fixes in coordinated loops.
+  </Card>
+
+  <Card title="Natural language interface" icon="comment">
+    No commands to memorize. Type `autopilot: build a REST API` and OMC handles the rest. Magic keywords activate workflows inline.
+  </Card>
+
+  <Card title="Automatic parallelization" icon="bolt">
+    Complex tasks are decomposed and distributed across specialized agents. The right agent runs the right sub-task at the right time.
+  </Card>
+
+  <Card title="Persistent execution" icon="arrows-rotate">
+    OMC won't silently stop on a hard task. Ralph mode loops with verify-and-fix cycles until the task is fully done or explicitly cancelled.
+  </Card>
+
+  <Card title="Smart model routing" icon="route">
+    Haiku for fast lookups, Sonnet for implementation, Opus for architecture decisions. Routing is automatic and saves 30–50% on token costs.
+  </Card>
+
+  <Card title="Skill learning" icon="graduation-cap">
+    Extract hard-won debugging knowledge into portable skill files. Skills auto-inject into context when their triggers match your next task.
+  </Card>
+
+  <Card title="Real-time visibility" icon="gauge">
+    The HUD statusline shows active agents, task progress, and context usage while work is in flight — no guessing what is happening.
+  </Card>
+</CardGroup>
+
+## Core concepts
+
+### Orchestration modes
+
+OMC provides several modes for different use cases. Each is activated by a magic keyword directly in your prompt:
+
+| Mode          | Keyword                  | Best for                                            |
+| ------------- | ------------------------ | --------------------------------------------------- |
+| **Team**      | `/team N:executor "..."` | Coordinated staged pipeline across Claude agents    |
+| **Autopilot** | `autopilot: ...`         | End-to-end feature work with minimal ceremony       |
+| **Ralph**     | `ralph: ...`             | Tasks that must complete fully — no silent partials |
+| **Ultrawork** | `ulw ...`                | Burst parallel fixes and refactors                  |
+| **CCG**       | `/ccg ...`               | Tri-model synthesis using Codex, Gemini, and Claude |
+
+### Specialized agents
+
+OMC ships with 19+ specialized agents covering every phase of development: exploration, requirements analysis, planning, architecture, implementation, testing, code review, security review, and documentation. Each agent has a defined role, a default model tier, and a focused tool set. OMC picks the right agent automatically based on the task.
+
+### Skill system
+
+Skills are reusable prompt files that encode hard-won knowledge from real sessions — debugging techniques, architecture patterns, project-specific gotchas. Skills are stored in `.omc/skills/` (project-scoped) or `~/.omc/skills/` (global). When their trigger keywords appear in your prompt, they auto-inject into the agent's context — no manual recall needed.
+
+### HUD statusline
+
+While OMC is working, a live statusline in Claude Code shows you what is happening:
+
+```
+[OMC] autopilot:execution | agents:3 | todos:2/5 | ctx:45%
+```
+
+This tells you the active pipeline stage, how many agents are running, task progress, and context window usage.
+
+## Multi-AI providers (optional)
+
+OMC can optionally spawn workers using Codex CLI or Gemini CLI alongside Claude. This is not required — OMC works fully without either. When available, they extend OMC's reach:
+
+| Provider   | What it enables                                                      |
+| ---------- | -------------------------------------------------------------------- |
+| Gemini CLI | Design review, UI consistency, large-context tasks (1M token window) |
+| Codex CLI  | Architecture validation, security analysis, code review cross-check  |
+
+Use `omc team N:codex "..."` or `omc team N:gemini "..."` to spawn tmux workers from either provider on demand.
+
+## Ready to start?
+
+<CardGroup>
+  <Card title="Quickstart" icon="rocket" href="/quickstart">
+    Install OMC and run your first orchestrated task in under 5 minutes.
+  </Card>
+
+  <Card title="Installation" icon="download" href="/installation">
+    Full installation reference with setup scopes, verification, and update procedures.
+  </Card>
+</CardGroup>
+
+
+# Autopilot
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/modes/autopilot
+
+Full autonomous 5-stage pipeline from idea to working, verified code. Triggered by 'autopilot', 'auto pilot', 'full auto', or 'fullsend'.
+
+Autopilot takes a brief description of what you want to build and autonomously handles the full lifecycle: requirements analysis, technical design, planning, parallel implementation, QA cycling, and multi-perspective validation.
+
+## Magic keyword triggers
+
+Autopilot activates automatically when your prompt contains any of these phrases:
+
+* `autopilot`
+* `auto pilot` (with space or hyphen)
+* `full auto`
+* `fullsend`
+
+```
+autopilot: build a REST API for managing tasks
+full auto: refactor the auth module
+```
+
+## The 5 stages
+
+<Steps>
+  <Step title="Phase 0 — Expansion">
+    Converts your idea into a detailed specification. `analyst` (Opus) extracts requirements; `architect` (Opus) produces the technical spec, written to `.omc/autopilot/spec.md`.
+
+    **Skipped when** a ralplan consensus plan (`.omc/plans/ralplan-*.md`) already exists, or when a deep-interview spec (`.omc/specs/deep-interview-*.md`) is present.
+
+    If your input is vague (no file paths, function names, or concrete anchors), autopilot offers to redirect to `/deep-interview` for Socratic clarification first.
+  </Step>
+
+  <Step title="Phase 1 — Planning">
+    `architect` (Opus) creates an implementation plan from the spec; `critic` (Opus) validates it. Output: `.omc/plans/autopilot-impl.md`.
+
+    **Skipped when** a ralplan consensus plan is already present — the plan has already been architecture-reviewed and critic-validated.
+  </Step>
+
+  <Step title="Phase 2 — Execution">
+    Implements the plan using Ralph + Ultrawork for parallel execution. Agents are routed by task complexity:
+
+    * Simple tasks → `executor` (Haiku)
+    * Standard tasks → `executor` (Sonnet)
+    * Complex tasks → `executor` (Opus)
+
+    Independent tasks run simultaneously; dependent tasks run sequentially.
+  </Step>
+
+  <Step title="Phase 3 — QA">
+    Cycles build, lint, test, and fix until all checks pass (UltraQA mode). Repeats up to 5 cycles. If the same error persists across 3 consecutive cycles, autopilot stops and reports the fundamental issue for human input.
+  </Step>
+
+  <Step title="Phase 4 — Validation">
+    Three reviewers run in parallel; all must approve before autopilot completes:
+
+    * `architect` — functional completeness
+    * `security-reviewer` — vulnerability check
+    * `code-reviewer` — quality review
+
+    Rejected items are fixed and re-validated. If validation keeps failing after 3 rounds, autopilot stops and reports.
+  </Step>
+</Steps>
+
+After all phases pass, autopilot deletes state files and runs `/oh-my-claudecode:cancel` for a clean exit.
+
+## Agents involved
+
+| Phase      | Agent                                             | Model                 |
+| ---------- | ------------------------------------------------- | --------------------- |
+| Expansion  | `analyst`, `architect`                            | Opus                  |
+| Planning   | `architect`, `critic`                             | Opus                  |
+| Execution  | `executor`                                        | Haiku / Sonnet / Opus |
+| QA         | build/lint/test tools                             | —                     |
+| Validation | `architect`, `security-reviewer`, `code-reviewer` | Opus / Sonnet / Opus  |
+
+## HUD display
+
+While autopilot runs, the HUD statusline shows the current phase and active agent count. Configure the HUD with `/oh-my-claudecode:hud setup`.
+
+## When to use autopilot vs Team mode
+
+|                 | Autopilot                               | Team                                             |
+| --------------- | --------------------------------------- | ------------------------------------------------ |
+| **Trigger**     | Magic keyword                           | `/team` or `omc team`                            |
+| **Workers**     | Single lead + delegated agents          | N coordinated agents with task list              |
+| **Best for**    | End-to-end feature work, full pipelines | Parallel subtask distribution, mixed CLI workers |
+| **State**       | `.omc/state/autopilot-state.json`       | `.omc/state/team/` + `~/.claude/teams/`          |
+| **Persistence** | Resumes from last phase                 | Resumes from last stage                          |
+
+Use autopilot when you want hands-off execution of a complete feature from idea to working code. Use Team when you need to distribute work across many agents simultaneously or mix Claude, Codex, and Gemini workers.
+
+## Resuming
+
+If autopilot is cancelled or fails, run it again with the same invocation — it resumes from the last completed phase automatically:
+
+```
+/oh-my-claudecode:autopilot
+```
+
+## Configuration
+
+Optional settings in `.claude/settings.json`:
+
+```json theme={null}
+{
+  "omc": {
+    "autopilot": {
+      "maxIterations": 10,
+      "maxQaCycles": 5,
+      "maxValidationRounds": 3,
+      "pauseAfterExpansion": false,
+      "pauseAfterPlanning": false,
+      "skipQa": false,
+      "skipValidation": false
+    }
+  }
+}
+```
+
+## 3-stage pipeline
+
+For the highest-quality output, chain three quality gates before autopilot:
+
+```
+/deep-interview "vague idea"
+  → Socratic Q&A → spec (ambiguity ≤ 20%)
+  → /ralplan --direct → consensus plan (Planner/Architect/Critic approved)
+  → autopilot → skips Phase 0 + Phase 1, starts at Phase 2 (Execution)
+```
+
+When autopilot detects a ralplan consensus plan, Phases 0 and 1 are skipped because requirements have already been validated by the deep-interview ambiguity gate and architecture-reviewed by the ralplan Architect and Critic agents.
+
+<Tip>
+  For vague or open-ended requests, run `/deep-interview` first. It uses Socratic questioning to eliminate hidden assumptions before any code is written.
+</Tip>
+
+
+# CCG
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/modes/ccg
+
+Claude-Codex-Gemini tri-model advisor synthesis. Routes via /ask codex and /ask gemini in parallel, then Claude synthesizes both outputs into one answer.
+
+CCG (Claude-Codex-Gemini) fans out your request to Codex and Gemini simultaneously as advisors, then Claude synthesizes both outputs into a single unified answer. It is designed for situations where you need backend/analysis and frontend/design perspectives on the same task.
+
+## How to invoke
+
+```bash theme={null}
+/ccg Review this PR — architecture (Codex) and UI components (Gemini)
+/oh-my-claudecode:ccg Review this PR - architecture/security via Codex and UX/readability via Gemini
+```
+
+## How it works
+
+<Steps>
+  <Step title="Decompose the request">
+    Claude splits your request into two advisor prompts:
+
+    * **Codex prompt** — architecture, correctness, backend, risks, test strategy
+    * **Gemini prompt** — UX/content clarity, alternatives, edge-case usability, docs polish
+    * **Synthesis plan** — how to reconcile conflicts between the two perspectives
+  </Step>
+
+  <Step title="Invoke both advisors in parallel">
+    Claude runs both CLI tools:
+
+    ```bash theme={null}
+    omc ask codex "<codex prompt>"
+    omc ask gemini "<gemini prompt>"
+    ```
+
+    Artifacts are written under `.omc/artifacts/ask/`.
+  </Step>
+
+  <Step title="Collect artifacts">
+    Claude reads the latest outputs:
+
+    ```
+    .omc/artifacts/ask/codex-*.md
+    .omc/artifacts/ask/gemini-*.md
+    ```
+  </Step>
+
+  <Step title="Synthesize">
+    Claude returns one unified answer containing:
+
+    * Agreed recommendations
+    * Conflicting recommendations (explicitly called out)
+    * Chosen final direction with rationale
+    * Action checklist
+  </Step>
+</Steps>
+
+## Requirements
+
+CCG requires both external CLIs installed:
+
+```bash theme={null}
+npm install -g @openai/codex
+npm install -g @google/gemini-cli
+```
+
+The `omc ask` command must also be available. Run `/omc-setup` if it is not.
+
+<Warning>
+  If either CLI is unavailable, CCG continues with whichever provider is available and notes the missing perspective. If both are unavailable, CCG falls back to a Claude-only answer and states that external advisors were unavailable.
+</Warning>
+
+## When to use CCG
+
+CCG is the right choice when a single task genuinely spans both backend and frontend concerns:
+
+* Code review needing both architecture analysis (Codex) and UI/UX assessment (Gemini)
+* Feature design needing backend risk analysis and frontend usability review
+* PR review where correctness and readability both matter
+
+## CCG vs `omc team N:codex`
+
+|             | `/ccg`                                      | `omc team N:codex`                           |
+| ----------- | ------------------------------------------- | -------------------------------------------- |
+| **Workers** | `/ask codex` + `/ask gemini` (advisor mode) | N Codex CLI panes (autonomous executor mode) |
+| **Output**  | Synthesized advisor report                  | Code changes written to disk                 |
+| **Session** | Single-shot, no team state                  | tmux panes, team state tracked               |
+| **Use for** | Perspective synthesis, reviews, planning    | Autonomous code changes, refactors           |
+
+Use `/ccg` when you want advisor-style parallel input without launching a team runtime. Use `omc team N:codex` when you need Codex to autonomously make changes to the codebase.
+
+## Example
+
+Review a PR from two perspectives:
+
+```bash theme={null}
+/ccg Review this PR — architecture (Codex) and UI components (Gemini)
+```
+
+Get a balanced view on a proposed API design:
+
+```bash theme={null}
+/ccg Should we use REST or GraphQL for the new search endpoint?
+```
+
+## Artifacts
+
+Each advisor run saves a markdown artifact under `.omc/artifacts/ask/`:
+
+```bash theme={null}
+omc ask codex "<prompt>"   # → .omc/artifacts/ask/codex-<timestamp>.md
+omc ask gemini "<prompt>"  # → .omc/artifacts/ask/gemini-<timestamp>.md
+```
+
+You can also invoke the providers individually using the `omc ask` command:
+
+```bash theme={null}
+omc ask codex --prompt "identify architecture risks"
+omc ask gemini --prompt "propose UI polish ideas"
+omc ask claude "review this migration plan"
+```
+
+
+# Ralph
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/modes/ralph
+
+PRD-driven persistence loop that keeps working until every acceptance criterion is verified complete. Triggered by the 'ralph' keyword.
+
+Ralph is a PRD-driven persistence loop that keeps working on a task until all user stories in `prd.json` have `passes: true` and are reviewer-verified. It wraps ultrawork's parallel execution with session persistence, automatic retry on failure, structured story tracking, and mandatory verification before completion.
+
+## Magic keyword triggers
+
+Ralph activates when the word `ralph` appears in your prompt:
+
+```
+ralph: refactor the auth module
+must complete: migrate the database schema
+```
+
+## The execution loop
+
+Ralph does not stop until all stories are verified or a fundamental blocker is hit:
+
+<Steps>
+  <Step title="PRD setup (first iteration only)">
+    Ralph auto-generates a `prd.json` scaffold at `.omc/prd.json` if none exists. You **must** refine this scaffold — replace generic acceptance criteria ("Implementation is complete") with task-specific, verifiable criteria before implementation begins.
+
+    Example of proper criteria refinement:
+
+    ```json theme={null}
+    // Before (generic — do not leave as-is)
+    { "acceptanceCriteria": ["Implementation is complete", "Code compiles"] }
+
+    // After (task-specific)
+    {
+      "acceptanceCriteria": [
+        "detectNoPrdFlag('ralph --no-prd fix') returns true",
+        "detectNoPrdFlag('ralph fix this') returns false",
+        "TypeScript compiles with no errors (npm run build)"
+      ]
+    }
+    ```
+  </Step>
+
+  <Step title="Pick next story">
+    Read `prd.json` and select the highest-priority story with `passes: false`.
+  </Step>
+
+  <Step title="Implement">
+    Delegate to specialist agents in parallel using ultrawork's execution engine:
+
+    * Simple lookups → `executor` (Haiku)
+    * Standard work → `executor` (Sonnet)
+    * Complex analysis → `executor` (Opus)
+
+    Independent tasks fire simultaneously. Long operations (builds, installs, test suites) run in the background with `run_in_background: true`.
+  </Step>
+
+  <Step title="Verify acceptance criteria">
+    For each acceptance criterion in the story, verify it is met with fresh evidence (fresh test run output, fresh build output). If any criterion is not met, continue working — do not mark the story complete.
+  </Step>
+
+  <Step title="Mark story complete">
+    When all criteria pass, set `passes: true` in `prd.json` and record learnings in `progress.txt`.
+  </Step>
+
+  <Step title="Check PRD completion">
+    If any story still has `passes: false`, loop back to "Pick next story". If all stories pass, proceed to reviewer verification.
+  </Step>
+
+  <Step title="Reviewer verification">
+    A reviewer verifies against the specific acceptance criteria from `prd.json`:
+
+    | Change size                            | Reviewer tier     |
+    | -------------------------------------- | ----------------- |
+    | \<5 files, \<100 lines with full tests | STANDARD (Sonnet) |
+    | Standard changes                       | STANDARD (Sonnet) |
+    | >20 files or security/architectural    | THOROUGH (Opus)   |
+
+    Override the reviewer with a flag: `--critic=architect` (default), `--critic=critic`, or `--critic=codex`.
+  </Step>
+
+  <Step title="Mandatory deslop pass">
+    Unless `--no-deslop` is specified, `ai-slop-cleaner` runs on all files changed during the Ralph session. Scope is bounded to the changed-file set only.
+  </Step>
+
+  <Step title="Regression re-verification">
+    After the deslop pass, all relevant tests, build, and lint checks run again. If regression fails, the deslop changes are rolled back or fixed before proceeding.
+  </Step>
+</Steps>
+
+On approval after all checks pass, ralph runs `/oh-my-claudecode:cancel` for clean state cleanup.
+
+## Ralph includes ultrawork
+
+When you activate ralph, it automatically includes ultrawork's parallel execution engine. You do not need to invoke both separately.
+
+```
+ralph (persistence + verification)
+ └── includes: ultrawork (parallel execution)
+```
+
+## Planning gate (ralplan-first enforcement)
+
+Ralph enforces a planning gate: implementation cannot begin until both of these artifacts exist:
+
+* `.omc/plans/prd-*.md`
+* `.omc/plans/test-spec-*.md`
+
+If planning is not complete when ralph is invoked, ralph stays in the planning phase and creates the required artifacts before any implementation work begins.
+
+<Tip>
+  Use `ralplan` before ralph for high-stakes tasks. The `ralplan` skill runs Planner, Architect, and Critic in consensus until the plan is approved, producing the required PRD and test spec artifacts that unlock ralph's implementation phase.
+</Tip>
+
+## Example
+
+```
+ralph: refactor the auth module
+```
+
+With explicit reviewer selection:
+
+```
+ralph --critic=codex refactor the payment service
+```
+
+Skip the PRD for a trivial fix:
+
+```
+ralph --no-prd fix the missing null check in src/utils/parse.ts
+```
+
+## Iteration limits and failure conditions
+
+Ralph loops indefinitely until all acceptance criteria pass or a stop condition is hit:
+
+* **Fundamental blocker**: missing credentials, unclear requirements, external service unavailable — ralph stops and reports for human input
+* **Same issue 3+ iterations**: reported as a potential fundamental problem
+* **User cancel**: `stopomc`, `cancelomc`, or `/oh-my-claudecode:cancel` — ralph stops immediately
+
+There is no hard max-iteration cap for ralph itself, but the reviewer can reject the implementation and send it back to the fix loop.
+
+## State files
+
+Ralph persists state across context resets:
+
+* `.omc/prd.json` — user stories with acceptance criteria and `passes` flags
+* `progress.txt` — implementation details, learnings, and discovered patterns per iteration
+* `.omc/state/ralph-state.json` — current iteration, phase, and timestamps
+
+## Flags
+
+| Flag                 | Effect                                                         |
+| -------------------- | -------------------------------------------------------------- |
+| `--no-prd`           | Skip PRD generation; run in legacy mode without story tracking |
+| `--no-deslop`        | Skip the mandatory post-review deslop pass                     |
+| `--critic=architect` | Use `architect` agent for reviewer verification (default)      |
+| `--critic=critic`    | Use `critic` agent for reviewer verification                   |
+| `--critic=codex`     | Use `omc ask codex` for reviewer verification                  |
+
+
+# Team mode
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/modes/team
+
+The canonical multi-agent surface in OMC. Coordinates N agents through a staged pipeline with built-in task tracking, inter-agent messaging, and dependency management.
+
+Team is the recommended orchestration surface starting in **v4.1.7**. It replaces the legacy `swarm` keyword, which has been removed.
+
+<Note>
+  Enable Claude Code native teams before using Team mode. Without this flag, OMC will warn you and fall back to non-team execution where possible.
+
+  ```json ~/.claude/settings.json theme={null}
+  {
+    "env": {
+      "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+    }
+  }
+  ```
+</Note>
+
+## How to invoke
+
+<Tabs>
+  <Tab title="Slash command">
+    ```bash theme={null}
+    /team N:agent-type "task description"
+    ```
+
+    ```bash theme={null}
+    /team 3:executor "fix all TypeScript errors"
+    /team 5:executor "fix all TypeScript errors across the project"
+    /team 3:debugger "fix build errors in src/"
+    /team 4:designer "implement responsive layouts for all page components"
+    /team "refactor the auth module with security review"
+    /team ralph "build a complete REST API for user management"
+    ```
+  </Tab>
+
+  <Tab title="omc team CLI">
+    The `omc team` command spawns real tmux worker panes running the specified CLI:
+
+    ```bash theme={null}
+    omc team N:worker-type "task description"
+    ```
+
+    ```bash theme={null}
+    omc team 2:codex "review auth module for security issues"
+    omc team 2:gemini "redesign UI components for accessibility"
+    omc team 1:claude "implement the payment flow"
+    ```
+  </Tab>
+</Tabs>
+
+### Parameters
+
+| Parameter    | Description                                                                                                              |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| `N`          | Number of worker agents (1–20). Defaults to auto-sizing based on task decomposition.                                     |
+| `agent-type` | Agent for the `team-exec` stage: `executor`, `debugger`, `designer`, `codex`, `gemini`. Defaults to stage-aware routing. |
+| `task`       | High-level description to decompose and distribute.                                                                      |
+| `ralph`      | Optional modifier — wraps the pipeline in Ralph's persistence loop.                                                      |
+
+## Pipeline stages
+
+Team execution always follows this staged pipeline:
+
+```
+team-plan → team-prd → team-exec → team-verify → team-fix (loop)
+```
+
+<Steps>
+  <Step title="team-plan">
+    The lead uses `explore` (Haiku) and `planner` (Opus) to analyze the codebase and decompose the task into a dependency-ordered graph of subtasks. `analyst` and `architect` are added for unclear requirements or complex system boundaries.
+  </Step>
+
+  <Step title="team-prd">
+    Only entered when scope is ambiguous or acceptance criteria are missing. `analyst` (Opus) extracts requirements; `critic` (Opus) optionally challenges scope. Exit when criteria and boundaries are explicit.
+  </Step>
+
+  <Step title="team-exec">
+    Workers are spawned in parallel, each claiming pre-assigned subtasks. Workers report progress via `SendMessage` to the team lead. The lead monitors via `TaskList` polling and coordinates blockers.
+  </Step>
+
+  <Step title="team-verify">
+    `verifier` (Sonnet) checks all criteria. `security-reviewer` is added for auth/crypto changes; `code-reviewer` (Opus) is added for changes spanning more than 20 files. If verification passes, the pipeline is complete.
+  </Step>
+
+  <Step title="team-fix (loop)">
+    If verification found defects, `executor` or `debugger` applies fixes. Control returns to `team-exec` then `team-verify`. The loop is bounded by `max_fix_loops` (default: 3); exceeding it transitions to a terminal `failed` state.
+  </Step>
+</Steps>
+
+## Worker types
+
+<CardGroup>
+  <Card title="codex" icon="code">
+    Codex CLI worker running in a dedicated tmux pane. Best for code review, security analysis, architecture validation, and refactoring. Requires `npm install -g @openai/codex`.
+  </Card>
+
+  <Card title="gemini" icon="sparkles">
+    Gemini CLI worker with 1M token context. Best for UI/UX design, documentation, large-context tasks. Requires `npm install -g @google/gemini-cli`.
+  </Card>
+
+  <Card title="claude" icon="robot">
+    Standard Claude CLI worker in tmux. Best for general implementation tasks via `omc team N:claude`. Inherits the user's configured model.
+  </Card>
+</CardGroup>
+
+| Surface                   | Workers                      | Best for                                     |
+| ------------------------- | ---------------------------- | -------------------------------------------- |
+| `omc team N:codex "..."`  | N Codex CLI panes            | Code review, security analysis, architecture |
+| `omc team N:gemini "..."` | N Gemini CLI panes           | UI/UX design, docs, large-context tasks      |
+| `omc team N:claude "..."` | N Claude CLI panes           | General tasks via Claude CLI in tmux         |
+| `/ccg`                    | `/ask codex` + `/ask gemini` | Tri-model advisor synthesis                  |
+
+<Note>
+  CLI workers (codex, gemini, claude via `omc team`) are one-shot autonomous jobs. They have full filesystem access but cannot participate in team messaging (no `TaskList`/`SendMessage`). The lead manages their lifecycle: writes prompt file, spawns worker, reads output file, marks task complete.
+</Note>
+
+## Managing teams
+
+```bash theme={null}
+# Check status of a running team
+omc team status auth-review
+
+# Shut down a team gracefully
+omc team shutdown auth-review
+
+# Cancel from within Claude Code
+/oh-my-claudecode:cancel
+```
+
+## Example
+
+Review the auth module with two Codex workers:
+
+```bash theme={null}
+omc team 2:codex "review auth module for security issues"
+```
+
+Run a full staged pipeline with three executor workers:
+
+```bash theme={null}
+/team 3:executor "fix all TypeScript errors"
+```
+
+## Fallback behavior
+
+When `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` is not set to `"1"`, OMC emits a warning and falls back to non-team execution. The task still runs, but without the staged pipeline, inter-agent messaging, or task dependency management.
+
+## State and handoffs
+
+Each stage writes a handoff document to `.omc/handoffs/<stage-name>.md` before transitioning. Handoffs capture decisions made, alternatives rejected, risks identified, and files modified. The next stage's agents receive this context in their spawn prompts.
+
+State is persisted in `.omc/state/` so the pipeline can resume if the lead crashes mid-run:
+
+```
+state_read(mode="team")  # returns current_phase, team_name, fix_loop_count, ...
+```
+
+Terminal states are `complete`, `failed`, and `cancelled`.
+
+
+# Ultrawork
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/modes/ultrawork
+
+Maximum parallelism execution engine. Launches multiple agents simultaneously for independent tasks. Triggered by 'ultrawork' or 'ulw'.
+
+Ultrawork is a parallel execution engine that runs multiple agents simultaneously. It is a composable component — not a standalone persistence mode — providing parallelism and smart model routing without persistence, verification loops, or state management.
+
+## Magic keyword triggers
+
+Ultrawork activates automatically when your prompt contains:
+
+* `ultrawork`
+* `ulw`
+
+```
+ulw fix all TypeScript errors
+ultrawork implement user authentication with OAuth
+```
+
+## How it works
+
+When ultrawork activates, it:
+
+1. Classifies tasks by independence — which can run in parallel vs which have dependencies
+2. Routes each task to the correct model tier based on complexity
+3. Fires all independent tasks simultaneously using parallel agent calls
+4. Runs dependent tasks sequentially once their prerequisites complete
+5. Uses `run_in_background: true` for long operations (builds, installs, test suites)
+
+```
+Task 1 ──────────────────────────────> complete
+Task 2 ──────────────────────────────> complete   (all fired at once)
+Task 3 ──────────────────────────────> complete
+         └── Task 4 (depends on 3) ──> complete   (runs after Task 3)
+```
+
+## Model routing
+
+Ultrawork routes each task to the appropriate tier:
+
+| Complexity                    | Tier   | Model  |
+| ----------------------------- | ------ | ------ |
+| Simple lookups, definitions   | LOW    | Haiku  |
+| Standard implementation       | MEDIUM | Sonnet |
+| Complex analysis, refactoring | HIGH   | Opus   |
+
+## Difference from Team mode
+
+|                   | Ultrawork                                | Team                                   |
+| ----------------- | ---------------------------------------- | -------------------------------------- |
+| **Workers**       | Agents fired in parallel by orchestrator | N coordinated agents with task list    |
+| **Communication** | No inter-agent messaging                 | `SendMessage` between workers and lead |
+| **Persistence**   | None (use ralph for persistence)         | Full state machine with resume         |
+| **Verification**  | Lightweight (build + tests pass)         | `verifier` agent + staged gates        |
+| **Best for**      | Burst fixes, parallel refactors          | Coordinated multi-agent work           |
+
+## When to use ultrawork
+
+Ultrawork is the right choice when:
+
+* You have multiple independent changes that don't need inter-agent coordination
+* You want fast parallel execution without Team's orchestration overhead
+* You need burst fixes across many files simultaneously (e.g., TypeScript errors, lint violations, naming refactors)
+* You are running a one-off parallel refactor where resume capability is not required
+
+<Warning>
+  Ultrawork provides only lightweight verification (build passes, tests pass, no new errors introduced). For tasks that require guaranteed completion with architect sign-off, use `ralph` instead — ralph includes ultrawork.
+</Warning>
+
+## Relationship to other modes
+
+```
+ralph (persistence + verification)
+ └── includes: ultrawork (parallel execution)
+
+autopilot (full lifecycle pipeline)
+ └── includes: ralph
+      └── includes: ultrawork
+```
+
+Ultrawork is the parallelism layer. Ralph adds persistence and comprehensive verification. Autopilot adds the full 5-phase lifecycle on top.
+
+## Example
+
+Fix TypeScript errors in parallel across the project:
+
+```
+ulw fix all TypeScript errors
+```
+
+Implement multiple independent features simultaneously:
+
+```
+ultrawork implement user authentication with OAuth
+```
+
+## Stopping ultrawork
+
+```
+stopomc
+cancelomc
+/oh-my-claudecode:cancel
+```
+
+
+# Quickstart
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/quickstart
+
+Install oh-my-claudecode and run your first orchestrated task in under 5 minutes.
+
+## Prerequisites
+
+Before installing OMC, make sure you have:
+
+* **[Claude Code](https://docs.anthropic.com/claude-code)** installed and working
+* **Claude Max or Pro subscription**, or an `ANTHROPIC_API_KEY` environment variable set
+
+<Note>
+  OMC is installed as a Claude Code plugin. You run the install commands from inside a Claude Code session, not from your terminal.
+</Note>
+
+## Install the plugin
+
+Open Claude Code and run these two commands:
+
+```bash theme={null}
+/plugin marketplace add https://github.com/Yeachan-Heo/oh-my-claudecode
+```
+
+```bash theme={null}
+/plugin install oh-my-claudecode
+```
+
+The first command registers the OMC GitHub repository as a plugin source. The second command downloads and installs the plugin into Claude Code.
+
+## Run setup
+
+After installation, initialize OMC by running:
+
+```bash theme={null}
+/omc-setup
+```
+
+This generates a `CLAUDE.md` configuration file, registers hooks into the Claude Code lifecycle, and makes all OMC agents and skills available. By default, setup writes to `~/.claude/CLAUDE.md` (global). To scope it to the current project only, use:
+
+```bash theme={null}
+/oh-my-claudecode:omc-setup --local
+```
+
+<Tip>
+  Use `--local` when you want OMC configuration checked into a specific project repository, or when you share a machine and need per-project isolation.
+</Tip>
+
+## Your first task
+
+OMC is now ready. Type the following directly in Claude Code:
+
+```
+autopilot: build a hello world app
+```
+
+That single line activates the full autopilot pipeline. OMC will handle everything from requirements through working, verified code.
+
+## What happens during autopilot
+
+When OMC detects the `autopilot` keyword, it runs a five-stage pipeline automatically:
+
+<Steps>
+  <Step title="Expansion">
+    The `analyst` and `architect` agents analyze the task, clarify hidden requirements, and produce a technical specification. Ambiguities are resolved before a single line of code is written.
+  </Step>
+
+  <Step title="Planning">
+    The `planner` agent decomposes the specification into a sequenced execution plan. The `critic` agent independently reviews the plan and flags gaps or risks. Both must reach consensus before execution begins.
+  </Step>
+
+  <Step title="Execution">
+    The `executor` agent (or multiple agents in parallel, when tasks are independent) writes the code. OMC distributes work across agents automatically based on the plan.
+  </Step>
+
+  <Step title="QA">
+    The build is run, tests are executed, and any failures are fixed automatically. OMC loops through build-and-fix cycles until the build succeeds and all tests pass.
+  </Step>
+
+  <Step title="Validation">
+    Specialist agents perform a final review covering functionality, security, and code quality. Work is marked complete only after all reviewers pass. If issues are found, they are fixed and reviewed again.
+  </Step>
+</Steps>
+
+## Reading the HUD
+
+While the pipeline runs, the Claude Code statusline shows live progress:
+
+```
+[OMC] autopilot:execution | agents:3 | todos:2/5 | ctx:45%
+```
+
+| Field                 | What it means                      |
+| --------------------- | ---------------------------------- |
+| `autopilot:execution` | Current stage in the pipeline      |
+| `agents:3`            | Number of agents currently active  |
+| `todos:2/5`           | Tasks completed out of total tasks |
+| `ctx:45%`             | Context window consumed so far     |
+
+To configure the HUD display or switch presets, run:
+
+```bash theme={null}
+/oh-my-claudecode:hud setup
+```
+
+## Other ways to start
+
+Autopilot runs the full five-stage pipeline, which is right for feature-sized work. For smaller tasks, use a targeted keyword instead:
+
+<CodeGroup>
+  ```bash Code analysis theme={null}
+  analyze why this test is failing
+  ```
+
+  ```bash Parallel fixes theme={null}
+  ulw fix all TypeScript errors
+  ```
+
+  ```bash Codebase search theme={null}
+  deepsearch for files that handle authentication
+  ```
+
+  ```bash Persistent completion theme={null}
+  ralph: refactor the auth module
+  ```
+</CodeGroup>
+
+Each keyword activates a single appropriate agent or mode — no full pipeline required.
+
+## If you are not sure what to build
+
+If your idea is vague or you want OMC to help clarify requirements before writing any code, use the deep interview skill:
+
+```
+/deep-interview "I want to build a task management app"
+```
+
+The deep interview uses Socratic questioning to surface hidden assumptions, measure clarity across weighted dimensions, and produce a concrete specification before execution begins.
+
+## Next steps
+
+<CardGroup>
+  <Card title="Installation" icon="download" href="/installation">
+    Setup scopes, verification, update procedure, and platform support details.
+  </Card>
+
+  <Card title="Team mode" icon="people-group" href="/modes/team">
+    The canonical staged pipeline for coordinated multi-agent work.
+  </Card>
+
+  <Card title="Magic keywords" icon="wand-magic-sparkles" href="/reference/magic-keywords">
+    Full list of keywords that activate OMC workflows inline.
+  </Card>
+
+  <Card title="Agents" icon="robot" href="/agents/overview">
+    The 19+ specialized agents OMC uses and when each is activated.
+  </Card>
+</CardGroup>
+
+
+# Architecture
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/reference/architecture
+
+How oh-my-claudecode orchestrates multi-agent workflows through four interlocking systems: Hooks, Skills, Agents, and State.
+
+oh-my-claudecode enables Claude Code to orchestrate specialized agents through a skill-based routing system built on four interlocking systems. Hooks detect lifecycle events, Skills inject behaviors, Agents execute specialized work, and State tracks progress across context resets.
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                         OH-MY-CLAUDECODE                                 │
+│                     Intelligent Skill Activation                         │
+└─────────────────────────────────────────────────────────────────────────┘
+
+  User Input                      Skill Detection                 Execution
+  ──────────                      ───────────────                 ─────────
+       │                                │                              │
+       ▼                                ▼                              ▼
+┌─────────────┐              ┌──────────────────┐           ┌─────────────────┐
+│  "ultrawork │              │   CLAUDE.md      │           │ SKILL ACTIVATED │
+│   refactor  │─────────────▶│   Auto-Routing   │──────────▶│                 │
+│   the API"  │              │                  │           │ ultrawork +     │
+└─────────────┘              │ Task Type:       │           │ default +       │
+                             │  - Implementation│           │ git-master      │
+                             │  - Multi-file    │           │                 │
+                             │  - Parallel OK   │           │ ┌─────────────┐ │
+                             │                  │           │ │ Parallel    │ │
+                             │ Skills:          │           │ │ agents      │ │
+                             │  - ultrawork ✓   │           │ │ launched    │ │
+                             │  - default ✓     │           │ └─────────────┘ │
+                             │  - git-master ✓  │           │                 │
+                             └──────────────────┘           │ ┌─────────────┐ │
+                                                            │ │ Atomic      │ │
+                                                            │ │ commits     │ │
+                                                            │ └─────────────┘ │
+                                                            └─────────────────┘
+```
+
+The four systems flow in sequence:
+
+```
+User Input → Hooks (event detection) → Skills (behavior injection)
+           → Agents (task execution) → State (progress tracking)
+```
+
+***
+
+## Agent system
+
+OMC provides 19 specialized agents organized into four lanes. Each agent is invoked as `oh-my-claudecode:<agent-name>` and runs on the appropriate model tier.
+
+### Build/analysis lane
+
+Covers the full development lifecycle from exploration to verification.
+
+| Agent       | Default model | Role                                                          |
+| ----------- | ------------- | ------------------------------------------------------------- |
+| `explore`   | haiku         | Codebase discovery, file and symbol mapping                   |
+| `analyst`   | opus          | Requirements analysis, hidden constraint discovery            |
+| `planner`   | opus          | Task sequencing, execution plan creation                      |
+| `architect` | opus          | System design, interface definition, trade-off analysis       |
+| `debugger`  | sonnet        | Root-cause analysis, build error resolution                   |
+| `executor`  | sonnet        | Code implementation, refactoring                              |
+| `verifier`  | sonnet        | Completion verification, test adequacy confirmation           |
+| `tracer`    | sonnet        | Evidence-driven causal tracing, competing hypothesis analysis |
+
+### Review lane
+
+Quality gates before handoff. Catches correctness and security issues.
+
+| Agent               | Default model | Role                                                             |
+| ------------------- | ------------- | ---------------------------------------------------------------- |
+| `security-reviewer` | sonnet        | Security vulnerabilities, trust boundaries, authn/authz review   |
+| `code-reviewer`     | opus          | Comprehensive code review, API contracts, backward compatibility |
+
+### Domain lane
+
+Domain experts called in when needed.
+
+| Agent                 | Default model | Role                                                      |
+| --------------------- | ------------- | --------------------------------------------------------- |
+| `test-engineer`       | sonnet        | Test strategy, coverage, flaky-test hardening             |
+| `designer`            | sonnet        | UI/UX architecture, interaction design                    |
+| `writer`              | haiku         | Documentation, migration notes                            |
+| `qa-tester`           | sonnet        | Interactive CLI/service runtime validation via tmux       |
+| `scientist`           | sonnet        | Data analysis, statistical research                       |
+| `git-master`          | sonnet        | Git operations, commits, rebase, history management       |
+| `document-specialist` | sonnet        | External documentation, API/SDK reference lookup          |
+| `code-simplifier`     | opus          | Code clarity, simplification, maintainability improvement |
+
+### Coordination lane
+
+Challenges plans and designs made by other agents. A plan passes only when no gaps can be found.
+
+| Agent    | Default model | Role                                                  |
+| -------- | ------------- | ----------------------------------------------------- |
+| `critic` | opus          | Gap analysis of plans and designs, multi-angle review |
+
+### Model routing
+
+OMC uses three model tiers matched to task complexity:
+
+| Tier   | Model  | Characteristics               | Cost   |
+| ------ | ------ | ----------------------------- | ------ |
+| LOW    | haiku  | Fast and inexpensive          | Low    |
+| MEDIUM | sonnet | Balanced performance and cost | Medium |
+| HIGH   | opus   | Highest-quality reasoning     | High   |
+
+Default assignments by role:
+
+* **haiku** — fast lookups and simple tasks (`explore`, `writer`)
+* **sonnet** — code implementation, debugging, testing (`executor`, `debugger`, `test-engineer`)
+* **opus** — architecture, strategic analysis, review (`architect`, `planner`, `critic`, `code-reviewer`)
+
+### Delegation
+
+Work is delegated through the Task tool with intelligent model routing:
+
+```typescript theme={null}
+Task(
+  subagent_type="oh-my-claudecode:executor",
+  model="sonnet",
+  prompt="Implement feature..."
+)
+```
+
+**Delegate to agents when:**
+
+* Multiple files need to change
+* Refactoring is required
+* Debugging or root-cause analysis is needed
+* Code review or security review is needed
+* Planning or research is required
+
+**Handle directly when:**
+
+* Simple file lookups
+* Straightforward question answering
+* Single-command sequential operations
+
+### Typical agent workflow
+
+```
+explore → analyst → planner → critic → executor → verifier
+(discover) (analyze)  (sequence) (review)  (implement) (confirm)
+```
+
+<Tip>
+  Override the model for any agent by passing `model=opus` in the Task call. For example, use `executor` with `model=opus` for complex refactoring that benefits from deeper reasoning.
+</Tip>
+
+***
+
+## Skills system
+
+Skills are **behavior injections** that modify how the orchestrator operates. Instead of swapping agents, skills add capabilities on top of existing agents. OMC provides 31 skills total (28 user-invocable + 3 internal/pipeline).
+
+### Three-layer composition model
+
+Skills compose in three layers:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  GUARANTEE LAYER (optional)                                  │
+│  ralph: "Cannot stop until verified done"                   │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│  ENHANCEMENT LAYER (0-N skills)                              │
+│  ultrawork (parallel) | git-master (commits) | frontend-ui-ux│
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│  EXECUTION LAYER (primary skill)                             │
+│  default (build) | orchestrate (coordinate) | planner (plan) │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Formula:** `[Execution skill] + [0-N enhancements] + [optional guarantee]`
+
+Example:
+
+```
+Task: "ultrawork: refactor API with proper commits"
+Active skills: ultrawork + default + git-master
+```
+
+### Invoking skills
+
+<Tabs>
+  <Tab title="Slash commands">
+    ```bash theme={null}
+    /oh-my-claudecode:autopilot build me a todo app
+    /oh-my-claudecode:ralph refactor the auth module
+    /oh-my-claudecode:team 3:executor "implement fullstack app"
+    ```
+  </Tab>
+
+  <Tab title="Magic keywords">
+    Include a keyword anywhere in natural language and the skill activates automatically:
+
+    ```bash theme={null}
+    autopilot build me a todo app      # activates autopilot
+    ralph: refactor the auth module    # activates ralph
+    ultrawork implement OAuth          # activates ultrawork
+    ```
+  </Tab>
+</Tabs>
+
+### Core workflow skills
+
+<AccordionGroup>
+  <Accordion title="autopilot — full autonomous pipeline">
+    Full autonomous 5-stage pipeline from idea to working code.
+
+    **Triggers:** `autopilot`, `build me`, `I want a`
+
+    ```bash theme={null}
+    autopilot build me a REST API with authentication
+    ```
+  </Accordion>
+
+  <Accordion title="ralph — repeating loop until verified complete">
+    Repeating loop that does not stop until work is verified complete. The `verifier` agent confirms completion before the loop exits.
+
+    **Triggers:** `ralph`, `don't stop`, `must complete`
+
+    ```bash theme={null}
+    ralph: refactor the authentication module
+    ```
+  </Accordion>
+
+  <Accordion title="ultrawork — maximum parallelism">
+    Launches multiple agents simultaneously for maximum throughput.
+
+    **Triggers:** `ultrawork`, `ulw`
+
+    ```bash theme={null}
+    ultrawork implement user authentication with OAuth
+    ```
+  </Accordion>
+
+  <Accordion title="team — N coordinated agents">
+    Coordinates N Claude agents with a 5-stage pipeline: `plan → prd → exec → verify → fix`.
+
+    ```bash theme={null}
+    /oh-my-claudecode:team 3:executor "implement fullstack todo app"
+    ```
+  </Accordion>
+
+  <Accordion title="ccg — Claude + Codex + Gemini">
+    Fans out to Codex and Gemini simultaneously; Claude synthesizes the results.
+
+    **Triggers:** `ccg`, `claude-codex-gemini`
+
+    ```bash theme={null}
+    ccg: review this authentication implementation
+    ```
+  </Accordion>
+
+  <Accordion title="ralplan — consensus-based planning">
+    Iterative planning: Planner, Architect, and Critic loop until they reach consensus.
+
+    **Triggers:** `ralplan`
+
+    ```bash theme={null}
+    ralplan this feature
+    ```
+  </Accordion>
+</AccordionGroup>
+
+### Magic keyword reference
+
+| Keyword                                              | Effect                         |
+| ---------------------------------------------------- | ------------------------------ |
+| `ultrawork`, `ulw`, `uw`                             | Parallel agent orchestration   |
+| `autopilot`, `build me`, `I want a`, `e2e this`      | Autonomous execution pipeline  |
+| `ralph`, `don't stop`, `must complete`, `until done` | Loop until verified complete   |
+| `ccg`, `claude-codex-gemini`                         | 3-model orchestration          |
+| `ralplan`                                            | Consensus-based planning       |
+| `code review`, `review code`                         | Comprehensive code review mode |
+| `deepsearch`, `search the codebase`                  | Codebase search mode           |
+| `ultrathink`, `think hard`, `think deeply`           | Deep reasoning mode            |
+| `tdd`, `test first`, `red green`                     | TDD workflow                   |
+| `cancelomc`, `stopomc`                               | Cancel active execution mode   |
+
+<Note>
+  The `autopilot`, `ralph`, and `ccg` triggers are hardcoded in the `keyword-detector` hook and cannot be changed through `config.jsonc`. The four configurable keyword categories (ultrawork, search, analyze, ultrathink) live under `magicKeywords` in `config.jsonc`.
+</Note>
+
+***
+
+## Hooks system
+
+Hooks are code that reacts to Claude Code lifecycle events. They run automatically when a user submits a prompt, uses a tool, or starts and ends a session. OMC implements agent delegation, keyword detection, and state persistence through 20 hooks across 11 lifecycle events.
+
+### Lifecycle events
+
+| Event                | When it fires             | OMC usage                                          |
+| -------------------- | ------------------------- | -------------------------------------------------- |
+| `UserPromptSubmit`   | User submits a prompt     | Magic keyword detection, skill injection           |
+| `SessionStart`       | Session begins            | Initial setup, project memory load                 |
+| `PreToolUse`         | Before a tool is used     | Permission validation, parallel execution hints    |
+| `PermissionRequest`  | Permission requested      | Bash command permission handling                   |
+| `PostToolUse`        | After a tool is used      | Result validation, project memory update           |
+| `PostToolUseFailure` | After a tool fails        | Error recovery handling                            |
+| `SubagentStart`      | Subagent starts           | Agent tracking                                     |
+| `SubagentStop`       | Subagent stops            | Agent tracking, output verification                |
+| `PreCompact`         | Before context compaction | Preserve critical information, save project memory |
+| `Stop`               | Claude is about to stop   | Persistent mode enforcement, code simplification   |
+| `SessionEnd`         | Session ends              | Session data cleanup                               |
+
+### system-reminder injection
+
+Hooks inject additional context to Claude via `<system-reminder>` tags:
+
+| Pattern                        | Meaning                                         |
+| ------------------------------ | ----------------------------------------------- |
+| `hook success: Success`        | Hook ran normally, continue as planned          |
+| `hook additional context: ...` | Additional context information, take note       |
+| `[MAGIC KEYWORD: ...]`         | Magic keyword detected, execute indicated skill |
+| `The boulder never stops`      | ralph/ultrawork mode is active                  |
+
+### Key hooks
+
+**keyword-detector** — fires on `UserPromptSubmit`. Detects magic keywords in user input and activates the corresponding skill.
+
+**persistent-mode** — fires on `Stop`. When a persistent mode (ralph, ultrawork) is active, prevents Claude from stopping until work is verified complete.
+
+**pre-compact** — fires on `PreCompact`. Saves critical information to the notepad before the context window is compressed.
+
+**subagent-tracker** — fires on `SubagentStart` and `SubagentStop`. Tracks currently running agents and validates output on stop.
+
+**context-guard-stop** — fires on `Stop`. Monitors context usage and warns when approaching the limit.
+
+**code-simplifier** — fires on `Stop`. Disabled by default. When enabled, automatically simplifies modified files when Claude stops.
+
+Enable `code-simplifier` via config:
+
+```json theme={null}
+{
+  "codeSimplifier": {
+    "enabled": true,
+    "extensions": [".ts", ".tsx", ".js", ".jsx", ".py", ".go", ".rs"],
+    "maxFiles": 10
+  }
+}
+```
+
+### Hook registration structure
+
+OMC hooks are declared in `hooks.json`. Each hook is a Node.js script with a timeout:
+
+```json theme={null}
+{
+  "UserPromptSubmit": [
+    {
+      "matcher": "*",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "node scripts/keyword-detector.mjs",
+          "timeout": 5
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Disabling hooks
+
+<Tabs>
+  <Tab title="Disable all hooks">
+    ```bash theme={null}
+    export DISABLE_OMC=1
+    ```
+  </Tab>
+
+  <Tab title="Skip specific hooks">
+    ```bash theme={null}
+    export OMC_SKIP_HOOKS="keyword-detector,persistent-mode"
+    ```
+  </Tab>
+</Tabs>
+
+***
+
+## State management
+
+OMC stores task progress and project knowledge in the `.omc/` directory. The state system preserves critical information even when context compaction resets the context window.
+
+### Directory structure
+
+```
+.omc/
+├── state/                    # Per-mode state files
+│   ├── autopilot-state.json  # autopilot progress
+│   ├── ralph-state.json      # ralph loop state
+│   ├── team/                 # team task state
+│   └── sessions/             # per-session state
+│       └── {sessionId}/
+├── notepad.md                # Compaction-resistant memo pad
+├── project-memory.json       # Project knowledge store
+├── plans/                    # Execution plans
+├── notepads/                 # Per-plan knowledge capture
+│   └── {plan-name}/
+│       ├── learnings.md
+│       ├── decisions.md
+│       ├── issues.md
+│       └── problems.md
+├── autopilot/                # autopilot artifacts
+│   └── spec.md
+├── research/                 # Research results
+└── logs/                     # Execution logs
+```
+
+Global state lives at `~/.omc/state/{name}.json`. Legacy locations are auto-migrated on read.
+
+### Notepad
+
+**File:** `.omc/notepad.md`
+
+The notepad survives context compaction. Content written here persists even after the context window is reset.
+
+**MCP tools:**
+
+| Tool                     | Description                                    |
+| ------------------------ | ---------------------------------------------- |
+| `notepad_read`           | Read notepad contents                          |
+| `notepad_write_priority` | Write high-priority memo (permanent retention) |
+| `notepad_write_working`  | Write working memo                             |
+| `notepad_write_manual`   | Write manual memo                              |
+| `notepad_prune`          | Clean up old memos                             |
+| `notepad_stats`          | View notepad statistics                        |
+
+**How it works:**
+
+1. On `PreCompact`, important information is saved to the notepad.
+2. After compaction, notepad contents are re-injected into context.
+3. Agents use the notepad to recover previous context.
+
+### Project memory
+
+**File:** `.omc/project-memory.json`
+
+Project memory is a persistent store for project-level knowledge that survives across sessions.
+
+**MCP tools:**
+
+| Tool                           | Description                     |
+| ------------------------------ | ------------------------------- |
+| `project_memory_read`          | Read project memory             |
+| `project_memory_write`         | Overwrite entire project memory |
+| `project_memory_add_note`      | Add a note                      |
+| `project_memory_add_directive` | Add a directive                 |
+
+**Lifecycle integration:**
+
+* `SessionStart` — load project memory and inject into context
+* `PostToolUse` — extract project knowledge from tool results and save
+* `PreCompact` — save project memory before context compaction
+
+### Per-plan knowledge capture
+
+**Path:** `.omc/notepads/{plan-name}/`
+
+| File           | Contents                                   |
+| -------------- | ------------------------------------------ |
+| `learnings.md` | Discovered patterns, successful approaches |
+| `decisions.md` | Architecture decisions and rationale       |
+| `issues.md`    | Problems and blockers                      |
+| `problems.md`  | Technical debt and cautions                |
+
+All entries are timestamped automatically.
+
+### Persistent memory tags
+
+For critical information, use `<remember>` tags directly in context:
+
+```xml theme={null}
+<!-- Retained for 7 days -->
+<remember>API endpoint changed to /v2</remember>
+
+<!-- Retained permanently -->
+<remember priority>Never access production DB directly</remember>
+```
+
+| Tag                   | Retention |
+| --------------------- | --------- |
+| `<remember>`          | 7 days    |
+| `<remember priority>` | Permanent |
+
+### Centralizing state across worktrees
+
+By default, state lives in the project's `.omc/` directory and is deleted when the worktree is removed. To persist state across worktree deletions:
+
+```bash theme={null}
+# Add to ~/.bashrc or ~/.zshrc
+export OMC_STATE_DIR="$HOME/.claude/omc"
+```
+
+State is then stored at `~/.claude/omc/{project-identifier}/`. The project identifier is a hash of the Git remote URL, so the same repository shares state across different worktrees.
+
+***
+
+## Team pipeline mechanics
+
+Team is the default multi-agent orchestrator and uses a canonical staged pipeline:
+
+```
+team-plan → team-prd → team-exec → team-verify → team-fix (loop)
+```
+
+| Stage                                    | Transition condition                       |
+| ---------------------------------------- | ------------------------------------------ |
+| `team-plan` → `team-prd`                 | Planning and decomposition complete        |
+| `team-prd` → `team-exec`                 | Acceptance criteria and scope are explicit |
+| `team-exec` → `team-verify`              | All execution tasks reach terminal states  |
+| `team-verify` → `team-fix` or `complete` | Verification decides next step             |
+| `team-fix` → `team-exec` or `complete`   | Fixes feed back into execution             |
+
+The `team-fix` loop is bounded by a maximum attempt count. Exceeding that bound transitions the pipeline to `failed`. Terminal states are `complete`, `failed`, and `cancelled`. If a team run is interrupted, OMC detects existing team state and resumes from the last incomplete stage.
+
+***
+
+## MCP tool integration
+
+OMC registers MCP servers on setup. Tools are available to all agents within a session.
+
+<AccordionGroup>
+  <Accordion title="State and memory tools">
+    * `state_read`, `state_write`, `state_clear`, `state_list_active`, `state_get_status`
+    * `project_memory_read`, `project_memory_write`, `project_memory_add_note`, `project_memory_add_directive`
+    * `notepad_read`, `notepad_write_priority`, `notepad_write_working`, `notepad_write_manual`, `notepad_prune`, `notepad_stats`
+  </Accordion>
+
+  <Accordion title="Code intelligence tools">
+    * `lsp_diagnostics` — type errors for a single file
+    * `lsp_diagnostics_directory` — project-wide type checking
+    * `lsp_document_symbols` — function/class/variable outline for a file
+    * `lsp_workspace_symbols` — search symbols by name across the workspace
+    * `lsp_hover` — type info at a position
+    * `lsp_find_references` — find all references to a symbol
+    * `ast_grep_search` — structural code pattern search
+    * `ast_grep_replace` — structural code transformation
+  </Accordion>
+
+  <Accordion title="Trace tools">
+    * `trace_timeline` — chronological agent turn and mode event timeline
+    * `trace_summary` — aggregate statistics (turn counts, timing, token usage)
+  </Accordion>
+</AccordionGroup>
+
+
+# CLI commands
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/reference/cli-commands
+
+Complete reference for all omc CLI commands, flags, and usage examples.
+
+The `omc` CLI is installed alongside the oh-my-claudecode plugin and provides utilities for team orchestration, provider queries, rate-limit management, live monitoring, and notification configuration. All commands run in your terminal, not inside a Claude Code session.
+
+<Note>
+  Most `omc` commands that spawn worker processes require an active **tmux** session. See [platform support](/installation#platform--tmux) for install instructions per OS.
+</Note>
+
+***
+
+## omc team
+
+Spawn real tmux worker panes running the specified CLI provider and coordinate them on a shared task.
+
+### Starting a team
+
+```bash theme={null}
+omc team N:provider "task description"
+```
+
+| Parameter  | Description                                   |
+| ---------- | --------------------------------------------- |
+| `N`        | Number of worker panes to spawn.              |
+| `provider` | Worker type: `claude`, `codex`, or `gemini`.  |
+| `task`     | High-level description passed to each worker. |
+
+<CodeGroup>
+  ```bash Claude workers theme={null}
+  omc team 1:claude "implement the payment flow"
+  ```
+
+  ```bash Codex workers theme={null}
+  omc team 2:codex "review auth module for security issues"
+  ```
+
+  ```bash Gemini workers theme={null}
+  omc team 2:gemini "redesign UI components for accessibility"
+  ```
+</CodeGroup>
+
+Workers are on-demand: they spawn when the command runs and exit when their task completes. There is no idle resource usage between tasks.
+
+| Surface                   | Workers            | Best for                                     |
+| ------------------------- | ------------------ | -------------------------------------------- |
+| `omc team N:claude "..."` | N Claude CLI panes | General implementation via Claude CLI        |
+| `omc team N:codex "..."`  | N Codex CLI panes  | Code review, security analysis, architecture |
+| `omc team N:gemini "..."` | N Gemini CLI panes | UI/UX design, docs, large-context tasks      |
+
+<Note>
+  `codex` and `gemini` workers require their respective CLIs to be installed and authenticated:
+
+  ```bash theme={null}
+  npm install -g @openai/codex
+  npm install -g @google/gemini-cli
+  ```
+</Note>
+
+### Topology behavior
+
+| Context                                         | Behavior                                                                 |
+| ----------------------------------------------- | ------------------------------------------------------------------------ |
+| Inside classic tmux (`$TMUX` set)               | Reuses the current tmux surface for split-pane or `--new-window` layouts |
+| Inside cmux (`CMUX_SURFACE_ID` without `$TMUX`) | Launches a detached tmux session for workers                             |
+| Plain terminal                                  | Launches a detached tmux session for workers                             |
+
+### omc team status
+
+Check the current state of a running team job.
+
+```bash theme={null}
+omc team status <team-name>
+```
+
+```bash theme={null}
+omc team status auth-review
+```
+
+The team name is derived from the task description (slugified). OMC prints the state to stdout.
+
+### omc team shutdown
+
+Stop all workers in a team and clean up its state.
+
+```bash theme={null}
+omc team shutdown <team-name> [--force]
+```
+
+```bash theme={null}
+omc team shutdown auth-review
+omc team shutdown auth-review --force
+```
+
+| Flag      | Description                                                      |
+| --------- | ---------------------------------------------------------------- |
+| `--force` | Terminate workers immediately without waiting for graceful exit. |
+
+<Note>
+  Shutdown only clears `.omc/state/team/<team-name>` for the targeted team. It never affects sibling teams running in the same session.
+</Note>
+
+***
+
+## omc ask
+
+Run a provider CLI against a prompt and save a reusable markdown artifact.
+
+```bash theme={null}
+omc ask <provider> "<prompt>"
+omc ask <provider> --prompt "<prompt>"
+omc ask <provider> --agent-prompt <agent> --prompt "<prompt>"
+```
+
+| Argument   | Description                                        |
+| ---------- | -------------------------------------------------- |
+| `provider` | Provider to query: `claude`, `codex`, or `gemini`. |
+| `"prompt"` | Prompt string (positional or via `--prompt`).      |
+
+### Flags
+
+| Flag                    | Description                                                                             |
+| ----------------------- | --------------------------------------------------------------------------------------- |
+| `--prompt <text>`       | Prompt passed to the provider CLI. Equivalent to the positional argument.               |
+| `--agent-prompt <name>` | Named agent role to inject as a system prompt before the user prompt (e.g. `executor`). |
+
+### Examples
+
+<CodeGroup>
+  ```bash Positional prompt theme={null}
+  omc ask claude "review this migration plan"
+  ```
+
+  ```bash --prompt flag theme={null}
+  omc ask codex --prompt "identify architecture risks"
+  omc ask gemini --prompt "propose UI polish ideas"
+  ```
+
+  ```bash With agent role theme={null}
+  omc ask claude --agent-prompt executor --prompt "draft implementation steps"
+  ```
+</CodeGroup>
+
+### Artifacts
+
+Every `omc ask` invocation writes a markdown artifact to:
+
+```
+.omc/artifacts/ask/<provider>-<slug>-<timestamp>.md
+```
+
+Artifacts are plain markdown files containing the provider's full response. Use them as input for subsequent tasks or slash commands.
+
+### Environment variables
+
+| Variable                 | Description                                                    |
+| ------------------------ | -------------------------------------------------------------- |
+| `OMC_ASK_ADVISOR_SCRIPT` | Override the advisor script path.                              |
+| `OMC_ASK_ORIGINAL_TASK`  | Inject the original task description into the advisor context. |
+
+<Warning>
+  The phase-1 aliases `OMX_ASK_ADVISOR_SCRIPT` and `OMX_ASK_ORIGINAL_TASK` still work but emit deprecation warnings. Migrate to the `OMC_` prefix.
+</Warning>
+
+***
+
+## omc wait
+
+Detect Claude Code rate limits and optionally auto-resume the session when the limit resets.
+
+```bash theme={null}
+omc wait           # Check status and display guidance
+omc wait --start   # Enable the auto-resume daemon
+omc wait --stop    # Disable the auto-resume daemon
+```
+
+<Warning>
+  `omc wait` requires an active tmux session. It uses tmux session detection to monitor and resume Claude Code automatically.
+</Warning>
+
+### Flags
+
+| Flag      | Description                                                                                                                       |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `--start` | Enable the background daemon. The daemon polls for rate-limit recovery and resumes the Claude Code session when the limit resets. |
+| `--stop`  | Disable the daemon and stop auto-resume behavior.                                                                                 |
+
+### Usage
+
+Run `omc wait` without flags to check whether you are currently rate-limited and get guidance on when the limit will reset:
+
+```bash theme={null}
+omc wait
+```
+
+To enable continuous monitoring so Claude Code resumes automatically without manual intervention:
+
+```bash theme={null}
+omc wait --start
+```
+
+To turn off auto-resume when you no longer need it:
+
+```bash theme={null}
+omc wait --stop
+```
+
+***
+
+## omc session search
+
+Search previous Claude Code session transcripts for content across the current project or all local projects.
+
+```bash theme={null}
+omc session search "<query>"
+omc session search "<query>" [--since <duration>] [--project all] [--limit N] [--json]
+```
+
+### Examples
+
+```bash theme={null}
+omc session search "team leader stale"
+omc session search notify-hook --since 7d
+omc session search provider-routing --project all --json
+```
+
+### Flags
+
+| Flag                 | Description                                                                                |
+| -------------------- | ------------------------------------------------------------------------------------------ |
+| `--since <duration>` | Limit results to sessions within the given duration (e.g., `7d`, `24h`).                   |
+| `--project all`      | Search across all local Claude project transcripts, not just the current project/worktree. |
+| `--session <id>`     | Restrict search to a specific session ID.                                                  |
+| `--limit <N>`        | Maximum number of results to return.                                                       |
+| `--context <N>`      | Number of context lines to include around each match.                                      |
+| `--case-sensitive`   | Perform a case-sensitive match.                                                            |
+| `--json`             | Output structured JSON for use in scripts and automations.                                 |
+
+The MCP surface `session_search` exposes the same functionality for agents that need to query session history programmatically.
+
+***
+
+## omc hud
+
+Render the current HUD statusline to stdout.
+
+```bash theme={null}
+omc hud
+```
+
+The HUD displays live orchestration metrics — active agent count, todo progress, context window usage, mode status, and more — in a compact format suitable for embedding in a tmux status bar.
+
+<Tip>
+  To configure which HUD elements are shown, use the `/oh-my-claudecode:hud` slash command inside Claude Code. HUD presets include `minimal`, `focused`, `full`, `dense`, `analytics`, and `opencode`.
+</Tip>
+
+Example output:
+
+```
+[OMC] ralph:iteration-2 | agents:3 | todos:4/7 | ctx:62%
+```
+
+Session state files and replay logs are written alongside the HUD:
+
+```bash theme={null}
+# Session summaries
+.omc/sessions/*.json
+
+# Replay event logs
+.omc/state/agent-replay-*.jsonl
+```
+
+***
+
+## omc config-stop-callback
+
+Configure notification integrations that fire when a Claude Code session ends (the `stop` lifecycle event).
+
+```bash theme={null}
+omc config-stop-callback <platform> [flags]
+```
+
+| Platform   | Description                                        |
+| ---------- | -------------------------------------------------- |
+| `telegram` | Send a Telegram message via bot token and chat ID. |
+| `discord`  | Send a Discord message via webhook URL.            |
+| `slack`    | Send a Slack message via incoming webhook URL.     |
+
+### Common flags
+
+| Flag                  | Description                                                                      |
+| --------------------- | -------------------------------------------------------------------------------- |
+| `--enable`            | Activate this notification channel.                                              |
+| `--tag-list "<tags>"` | Set the full list of mention tags, comma-separated (replaces any existing list). |
+| `--add-tag <tag>`     | Append a single tag to the existing list.                                        |
+| `--remove-tag <tag>`  | Remove a single tag from the existing list.                                      |
+| `--clear-tags`        | Remove all tags from the list.                                                   |
+| `--show`              | Print the current configuration for this platform.                               |
+
+### Telegram-specific flags
+
+| Flag                  | Description                           |
+| --------------------- | ------------------------------------- |
+| `--token <bot_token>` | Telegram bot token.                   |
+| `--chat <chat_id>`    | Telegram chat ID to send messages to. |
+
+### Discord-specific flags
+
+| Flag              | Description                   |
+| ----------------- | ----------------------------- |
+| `--webhook <url>` | Discord incoming webhook URL. |
+
+### Slack-specific flags
+
+| Flag              | Description                 |
+| ----------------- | --------------------------- |
+| `--webhook <url>` | Slack incoming webhook URL. |
+
+### Examples
+
+<Tabs>
+  <Tab title="Telegram">
+    ```bash theme={null}
+    # Full setup
+    omc config-stop-callback telegram --enable --token <bot_token> --chat <chat_id> --tag-list "@alice,bob"
+
+    # Incremental tag management
+    omc config-stop-callback telegram --add-tag charlie
+    omc config-stop-callback telegram --remove-tag @alice
+
+    # Inspect current config
+    omc config-stop-callback telegram --show
+    ```
+  </Tab>
+
+  <Tab title="Discord">
+    ```bash theme={null}
+    # Full setup
+    omc config-stop-callback discord --enable --webhook <url> --tag-list "@here,123456789012345678,role:987654321098765432"
+
+    # Incremental tag management
+    omc config-stop-callback discord --add-tag @everyone
+    omc config-stop-callback discord --remove-tag @here
+    omc config-stop-callback discord --clear-tags
+
+    # Inspect current config
+    omc config-stop-callback discord --show
+    ```
+  </Tab>
+
+  <Tab title="Slack">
+    ```bash theme={null}
+    # Full setup
+    omc config-stop-callback slack --enable --webhook <url> --tag-list "<!here>,<@U1234567890>"
+
+    # Inspect current config
+    omc config-stop-callback slack --show
+    ```
+  </Tab>
+</Tabs>
+
+### Tag format by platform
+
+| Platform     | Supported tag formats                                                                             |
+| ------------ | ------------------------------------------------------------------------------------------------- |
+| **Telegram** | Plain names are normalized to `@name` automatically (e.g. `alice` → `@alice`).                    |
+| **Discord**  | `@here`, `@everyone`, numeric user IDs (rendered as `<@id>`), `role:<id>` (rendered as `<@&id>`). |
+| **Slack**    | `<@MEMBER_ID>`, `<!channel>`, `<!here>`, `<!everyone>`, `<!subteam^GROUP_ID>`.                    |
+
+<Note>
+  `file` callbacks ignore all tag options. Tags only affect platform message payloads.
+</Note>
+
+For interactive notification setup, use the slash command inside Claude Code:
+
+```bash theme={null}
+/oh-my-claudecode:configure-notifications
+```
+
+
+# Magic keywords
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/reference/magic-keywords
+
+Natural-language trigger phrases that activate OMC orchestration modes inline, without running a slash command.
+
+Magic keywords are phrases you type directly in a Claude Code prompt. When OMC detects a keyword, it activates the corresponding mode immediately — no confirmation required. They are optional shortcuts; natural language works fine without them.
+
+<Note>
+  Some keywords are **configurable** via `magicKeywords` in your OMC config file. Others are **hardcoded** and cannot be remapped. See [configurable vs. hardcoded](#configurable-vs-hardcoded) below.
+</Note>
+
+## Keyword reference
+
+| Keyword                 | Effect                                                    | Example                                        |
+| ----------------------- | --------------------------------------------------------- | ---------------------------------------------- |
+| `team`                  | Canonical Team orchestration via staged pipeline          | `/team 3:executor "fix all TypeScript errors"` |
+| `omc team`              | tmux CLI workers (codex / gemini / claude)                | `omc team 2:codex "security review"`           |
+| `ccg`                   | `/ask codex` + `/ask gemini` synthesis by Claude          | `/ccg review this PR`                          |
+| `autopilot`             | Full autonomous execution (5-stage pipeline)              | `autopilot: build a todo app`                  |
+| `ralph`                 | Persistence mode — loops until verified complete          | `ralph: refactor auth`                         |
+| `ulw` / `ultrawork`     | Maximum parallelism with parallel agent orchestration     | `ulw fix all errors`                           |
+| `ralplan`               | Iterative planning with consensus structured deliberation | `ralplan this feature`                         |
+| `deep-interview`        | Socratic requirements clarification with ambiguity gating | `deep-interview "vague idea"`                  |
+| `deepsearch`            | Codebase-focused search routing                           | `deepsearch for auth middleware`               |
+| `ultrathink`            | Deep reasoning mode                                       | `ultrathink about this architecture`           |
+| `cancelomc` / `stopomc` | Stop all active OMC modes                                 | `stopomc`                                      |
+
+***
+
+## Keyword details
+
+### team
+
+Activates the canonical staged pipeline: `team-plan → team-prd → team-exec → team-verify → team-fix (loop)`.
+
+Team is the recommended multi-agent surface starting in **v4.1.7**. The legacy `swarm` keyword has been removed — migrate to `/team`.
+
+```bash theme={null}
+/team 3:executor "fix all TypeScript errors"
+/team 4:designer "implement responsive layouts for all page components"
+/team "refactor the auth module with security review"
+```
+
+For the full Team mode reference, see [Team mode](/modes/team).
+
+***
+
+### omc team
+
+Spawns real tmux worker panes running `claude`, `codex`, or `gemini` CLI processes. Workers are on-demand — they spawn for the task and exit when done.
+
+```bash theme={null}
+omc team 2:codex "security review"
+omc team 2:gemini "redesign UI components for accessibility"
+omc team 1:claude "implement the payment flow"
+```
+
+`omc team` is a CLI command, not a prompt keyword. See [CLI commands — omc team](/reference/cli-commands#omc-team) for the full reference including `status` and `shutdown`.
+
+***
+
+### ccg
+
+Runs a tri-model advisor workflow: Claude routes the prompt through `/ask codex` and `/ask gemini`, then synthesizes all three responses into a final answer.
+
+```bash theme={null}
+/ccg review this PR — architecture (Codex) and UI components (Gemini)
+```
+
+Best for work that spans both backend logic (Codex's strength) and UI/UX concerns (Gemini's strength) in a single task.
+
+***
+
+### autopilot
+
+Activates full autonomous execution. OMC runs the five-stage pipeline — expansion, planning, execution, QA, validation — and does not stop until the task is verified complete.
+
+```bash theme={null}
+autopilot: build a REST API for managing tasks
+autopilot: add OAuth login to the existing app
+```
+
+Additional trigger phrases: `auto pilot`, `full auto`, `fullsend`.
+
+***
+
+### ralph
+
+Activates persistence mode. Claude loops through verify-and-fix cycles until the task is definitively complete. Ralph will not stop on a partial result.
+
+```bash theme={null}
+ralph: refactor auth
+ralph: fix all failing tests
+```
+
+<Tip>
+  **ralph includes ultrawork automatically.** When you activate ralph, it enables ultrawork's parallel execution alongside the persistence loop. You do not need to type both.
+</Tip>
+
+<Note>
+  The keyword detector matches only the word `ralph`. Phrases like `don't stop` and `must complete` are interpreted by Claude through the configured CLAUDE.md instructions, not by the hook-based keyword detector.
+</Note>
+
+***
+
+### ulw / ultrawork
+
+Activates maximum parallelism mode. OMC spawns multiple agents and distributes independent work items across them simultaneously for burst throughput.
+
+```bash theme={null}
+ulw fix all errors
+ultrawork implement user authentication with OAuth
+```
+
+<Note>
+  Use Team mode (`/team`) for coordinated multi-agent work with task dependency management. Use `ultrawork` for burst parallelism where Team overhead is disproportionate to the task.
+</Note>
+
+***
+
+### ralplan
+
+Activates iterative planning with consensus structured deliberation (RALPLAN-DR). Three agents — `planner`, `architect`, and `critic` — independently produce and challenge a plan until they reach consensus.
+
+```bash theme={null}
+ralplan this feature
+ralplan the migration from REST to GraphQL
+```
+
+Use `--deliberate` for high-risk work that needs deeper structured deliberation before any execution starts.
+
+<Note>
+  The `plan this` and `plan the` keyword triggers were removed. Use `ralplan` or `/oh-my-claudecode:omc-plan` instead.
+</Note>
+
+***
+
+### deep-interview
+
+Activates the Socratic requirements interview. OMC uses ambiguity-gated questioning to surface hidden assumptions and measure clarity across weighted dimensions before writing any code.
+
+```bash theme={null}
+deep-interview "I want to build a task management app"
+deep-interview "vague idea about a recommendation system"
+```
+
+Additional trigger phrase: `ouroboros`.
+
+***
+
+### deepsearch
+
+Routes the query to the `explore` agent for thorough codebase search using multiple parallel search strategies.
+
+```bash theme={null}
+deepsearch for auth middleware
+deepsearch for files that import the utils module
+```
+
+Additional trigger phrases: `search the codebase`, `find in codebase`.
+
+***
+
+### ultrathink
+
+Activates deep reasoning mode. Claude applies extended deliberation before responding, useful for architecture decisions, complex debugging, and design tradeoffs.
+
+```bash theme={null}
+ultrathink about this architecture
+ultrathink why the caching layer is causing stale reads
+```
+
+Additional trigger phrases: `think hard`, `think deeply`.
+
+***
+
+### cancelomc / stopomc
+
+Cancels all active OMC modes. Clears state files and stops any running persistence or pipeline loops.
+
+```bash theme={null}
+stopomc
+cancelomc
+```
+
+Additional trigger phrase: `cancel`.
+
+***
+
+## Configurable vs. hardcoded
+
+Some keywords can be remapped in your OMC configuration file (`config.jsonc`) using the `magicKeywords` field:
+
+**Configurable keywords** (can be changed):
+
+* `ultrawork` (alias: `ulw`)
+* `deepsearch`
+* `deepanalyze`
+* `ultrathink`
+
+**Hardcoded keywords** (cannot be changed):
+
+* `autopilot`
+* `ralph`
+* `ccg`
+* `ralplan`
+* `cancelomc` / `stopomc`
+
+***
+
+## Removed keywords
+
+The following keywords existed in earlier versions and have been removed:
+
+| Removed keyword | Replacement                                   |
+| --------------- | --------------------------------------------- |
+| `swarm`         | Use `/team` or `omc team`                     |
+| `plan this`     | Use `ralplan` or `/oh-my-claudecode:omc-plan` |
+| `plan the`      | Use `ralplan` or `/oh-my-claudecode:omc-plan` |
+
+
+# Migration
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/reference/migration
+
+Upgrade guides for oh-my-claudecode, covering breaking changes, renamed commands, removed providers, and step-by-step migration paths across versions.
+
+This guide covers migration paths between oh-my-claudecode versions. Find your current version and follow the steps for your target version.
+
+<Note>
+  The npm package name is `oh-my-claude-sisyphus` — not `oh-my-claudecode`. The project, GitHub repository, plugin, and all slash commands use `oh-my-claudecode`. The npm package name was kept for backward compatibility.
+
+  ```bash theme={null}
+  npm install -g oh-my-claude-sisyphus@latest
+  ```
+</Note>
+
+***
+
+## Upgrade steps (any version)
+
+<Steps>
+  <Step title="Update the plugin">
+    In Claude Code, open the plugin marketplace and update oh-my-claudecode to the latest version.
+  </Step>
+
+  <Step title="Re-run setup">
+    After updating, always re-run setup to refresh CLAUDE.md, hooks, and MCP server registrations:
+
+    ```bash theme={null}
+    /oh-my-claudecode:omc-setup
+    ```
+
+    Your existing project CLAUDE.md is preserved by default. Pass `--overwrite` to replace it with the latest OMC defaults.
+  </Step>
+
+  <Step title="Verify installation">
+    ```bash theme={null}
+    /oh-my-claudecode:omc-doctor
+    ```
+
+    Review the output and resolve any flagged issues before continuing.
+  </Step>
+</Steps>
+
+***
+
+## Team MCP runtime → CLI (unreleased/current)
+
+The legacy team MCP runtime tools (`omc_run_team_start`, `omc_run_team_status`, `omc_run_team_wait`, `omc_run_team_cleanup`) are hard-deprecated. Calls to these tools now return:
+
+```json theme={null}
+{
+  "code": "deprecated_cli_only",
+  "message": "Legacy team MCP runtime tools are deprecated. Use the omc team CLI instead."
+}
+```
+
+### Command mapping
+
+| Old (deprecated MCP runtime)                  | New (CLI-first)                                                |
+| --------------------------------------------- | -------------------------------------------------------------- |
+| `mcp__team__omc_run_team_start(...)`          | `omc team 2:codex "task"`                                      |
+| `mcp__team__omc_run_team_status({ job_id })`  | `omc team status <team-name>`                                  |
+| `mcp__team__omc_run_team_wait({ job_id })`    | `omc team shutdown <team-name> --force`                        |
+| `mcp__team__omc_run_team_cleanup({ job_id })` | `omc team api list-tasks --input '{"team_name":"..."}' --json` |
+
+### Migration steps
+
+<Steps>
+  <Step title="Replace MCP runtime calls with CLI equivalents">
+    Update any scripts or skills that call the deprecated MCP tools.
+  </Step>
+
+  <Step title="Update /omc-teams references">
+    If you use the `/omc-teams` legacy skill, it now routes internally to `omc team ...` syntax. No action is required if you use the skill, but direct MCP calls must be updated.
+  </Step>
+
+  <Step title="Update OMC_ASK_* environment variables">
+    `OMC_ASK_*` is now canonical. The old `OMX_ASK_ADVISOR_SCRIPT` and `OMX_ASK_ORIGINAL_TASK` aliases emit deprecation warnings and will be removed on **2026-06-30**.
+
+    ```bash theme={null}
+    # Old (deprecated, will stop working 2026-06-30)
+    export OMX_ASK_ADVISOR_SCRIPT=...
+
+    # New
+    export OMC_ASK_ADVISOR_SCRIPT=...
+    ```
+  </Step>
+</Steps>
+
+***
+
+## v4.4.0 — Codex/Gemini MCP providers removed
+
+The dedicated MCP server providers for Codex (`x`) and Gemini (`g`) were removed in v4.4.0.
+
+<Warning>
+  If you have skills or automations that reference `x` or `g` as provider shortcodes in agent invocations, they will no longer work. Update them to use the CLI team syntax.
+</Warning>
+
+### Before and after
+
+```bash theme={null}
+# Old — no longer works
+omc team 2:x "review auth flow"     # x = Codex provider (removed)
+omc team 2:g "review auth flow"     # g = Gemini provider (removed)
+
+# New
+omc team 2:codex "review auth flow"
+omc team 2:gemini "review auth flow"
+```
+
+The `ccg` skill (Claude + Codex + Gemini) continues to work and now uses the CLI-based worker spawning internally.
+
+***
+
+## v4.1.7 — Team is now canonical (swarm removed)
+
+The `swarm` keyword and `/omc-swarm` skill were removed in v4.1.7. `team` is the single canonical multi-agent coordination primitive.
+
+### Command mapping
+
+| Old                               | New                          |
+| --------------------------------- | ---------------------------- |
+| `swarm 3:executor "task"`         | `omc team 3:executor "task"` |
+| `/oh-my-claudecode:omc-swarm ...` | `/oh-my-claudecode:team ...` |
+
+Update any scripts, CLAUDE.md customizations, or muscle memory that references `swarm`.
+
+***
+
+## v3.5.3 — Skill consolidation
+
+Eight deprecated skills were removed. The unified `/cancel` and `/omc-setup` commands replace them.
+
+### Removed skills
+
+| Removed skill        | Replacement                            |
+| -------------------- | -------------------------------------- |
+| `cancel-autopilot`   | `/oh-my-claudecode:cancel`             |
+| `cancel-ralph`       | `/oh-my-claudecode:cancel`             |
+| `cancel-ultrawork`   | `/oh-my-claudecode:cancel`             |
+| `cancel-ultraqa`     | `/oh-my-claudecode:cancel`             |
+| `omc-default`        | `/oh-my-claudecode:omc-setup --local`  |
+| `omc-default-global` | `/oh-my-claudecode:omc-setup --global` |
+| `planner`            | `/oh-my-claudecode:plan`               |
+
+### plan and ralplan keywords
+
+The `plan this` and `plan the` magic keywords were removed as standalone triggers. Use `ralplan` instead for consensus-based iterative planning:
+
+```bash theme={null}
+# Old
+plan this feature
+
+# New
+ralplan this feature
+# or use the slash command
+/oh-my-claudecode:ralplan "this feature"
+```
+
+`ralplan` runs Planner, Architect, and Critic in a loop until they reach consensus. It supports `--deliberate` for high-risk tasks.
+
+***
+
+## v3.0 — Package rename and auto-activation
+
+Version 3.0 rebranded the project and introduced automatic skill activation via magic keywords.
+
+### Package name
+
+The project was renamed to `oh-my-claudecode`. The npm package name `oh-my-claude-sisyphus` was kept unchanged for backward compatibility.
+
+```bash theme={null}
+# Still the correct install command
+npm install -g oh-my-claude-sisyphus@latest
+```
+
+### Before and after
+
+<Tabs>
+  <Tab title="v2.x — explicit commands">
+    ```bash theme={null}
+    /oh-my-claudecode:ralph "implement user authentication"
+    /oh-my-claudecode:ultrawork "refactor the API layer"
+    /oh-my-claudecode:planner "plan the new dashboard"
+    /oh-my-claudecode:deepsearch "find database schema files"
+    ```
+  </Tab>
+
+  <Tab title="v3.0 — auto-activation + keywords">
+    ```bash theme={null}
+    "don't stop until user auth is done"   # auto-activates ralph
+    ultrawork: refactor the entire API     # keyword activates ultrawork
+    "plan the new dashboard"               # auto-activates planning
+    "find all database schema files"       # auto-activates search mode
+    ```
+  </Tab>
+</Tabs>
+
+All v2.x slash commands continue to work. Auto-activation is additive — you can still use explicit commands.
+
+### /omc-teams legacy skill
+
+The `/omc-teams` skill from v2.x continues to function but now routes internally to `omc team ...` syntax. No migration is required if you use the skill.
+
+### v2.x command compatibility table
+
+| v2.x command                           | v3.0 equivalent                                    | Status |
+| -------------------------------------- | -------------------------------------------------- | ------ |
+| `/oh-my-claudecode:ralph "task"`       | Say "don't stop until done" or use `ralph` keyword | Works  |
+| `/oh-my-claudecode:ultrawork "task"`   | `ulw:` keyword or say "fast"/"parallel"            | Works  |
+| `/oh-my-claudecode:planner "task"`     | `/oh-my-claudecode:plan "task"` (redirects)        | Works  |
+| `/oh-my-claudecode:deepsearch "query"` | Say "find" or "search"                             | Works  |
+| `/oh-my-claudecode:cancel-ralph`       | `/oh-my-claudecode:cancel` or say "stop"           | Works  |
+| `/oh-my-claudecode:omc-doctor`         | Unchanged                                          | Works  |
+
+***
+
+## Preserving your CLAUDE.md during setup
+
+By default, `/omc-setup` does not overwrite an existing CLAUDE.md. This is **preserve mode** — it installs everything else (hooks, MCP servers, config) but leaves your customizations intact.
+
+To explicitly overwrite:
+
+```bash theme={null}
+/oh-my-claudecode:omc-setup --overwrite
+```
+
+To apply setup to the current project only (without touching the global config):
+
+```bash theme={null}
+/oh-my-claudecode:omc-setup --local
+```
+
+To apply globally for all Claude Code sessions:
+
+```bash theme={null}
+/oh-my-claudecode:omc-setup --global
+```
+
+<Tip>
+  Back up your CLAUDE.md before running `--overwrite` if you have project-specific agent instructions, custom memory directives, or tuned delegation rules you want to preserve.
+</Tip>
+
+***
+
+## Frequently asked questions
+
+<AccordionGroup>
+  <Accordion title="Do I have to update my keywords after upgrading?">
+    For minor version upgrades (within a major version), keywords are additive and backward compatible. Breaking keyword changes only happen across major versions and are documented in this guide.
+  </Accordion>
+
+  <Accordion title="How do I know what version I'm running?">
+    Run `/oh-my-claudecode:omc-doctor`. The output includes the installed plugin version and flags any mismatch between the installed hooks and the current plugin.
+  </Accordion>
+
+  <Accordion title="My scripts use the npm package name. Do I need to change them?">
+    No. The npm package name `oh-my-claude-sisyphus` is stable and will not change. Only the plugin name and slash command prefix use `oh-my-claudecode`.
+  </Accordion>
+
+  <Accordion title="What happened to analytics — omc cost and omc backfill?">
+    The `omc-analytics`, `omc cost`, `omc backfill`, and the `analytics` HUD preset from older docs are not part of the current release. The supported monitoring surfaces are the Agent Observatory (via HUD or API), Session Replay JSONL logs, and session-end summary JSON files. See the [performance monitoring](/reference/performance-monitoring) reference for details.
+  </Accordion>
+</AccordionGroup>
+
+
+# Performance monitoring
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/reference/performance-monitoring
+
+Monitor agent performance, token usage, costs, and bottlenecks in multi-agent workflows using the Agent Observatory, session replays, and HUD integration.
+
+oh-my-claudecode provides comprehensive monitoring for tracking agent performance, token usage, costs, and identifying bottlenecks in multi-agent workflows.
+
+## What you can monitor
+
+| Metric              | Tool              | Granularity   |
+| ------------------- | ----------------- | ------------- |
+| Agent lifecycle     | Agent Observatory | Per-agent     |
+| Tool timing         | Session Replay    | Per-tool call |
+| Session-end summary | Session-end hook  | Per-session   |
+| File ownership      | Subagent Tracker  | Per-file      |
+| Parallel efficiency | Observatory       | Real-time     |
+
+***
+
+## Agent Observatory
+
+The Agent Observatory provides real-time visibility into all running agents, their performance metrics, and potential issues.
+
+### Accessing the Observatory
+
+<Tabs>
+  <Tab title="HUD">
+    The Observatory is automatically displayed in the HUD when agents are running. Run `/oh-my-claudecode:hud` and select the `focused` or `full` preset to enable agent visibility.
+  </Tab>
+
+  <Tab title="Programmatic">
+    ```typescript theme={null}
+    import { getAgentObservatory } from 'oh-my-claudecode/hooks/subagent-tracker';
+
+    const obs = getAgentObservatory(process.cwd());
+    console.log(obs.header);  // "Agent Observatory (3 active, 85% efficiency)"
+    obs.lines.forEach(line => console.log(line));
+    ```
+  </Tab>
+
+  <Tab title="CLI">
+    ```bash theme={null}
+    omc hud
+    ```
+  </Tab>
+</Tabs>
+
+### Observatory output format
+
+```
+Agent Observatory (3 active, 85% efficiency)
+🟢 [a1b2c3d] executor 45s tools:12 tokens:8k $0.15 files:3
+🟢 [e4f5g6h] document-specialist 30s tools:5 tokens:3k $0.08
+🟡 [i7j8k9l] architect 120s tools:8 tokens:15k $0.42
+   └─ bottleneck: Grep (2.3s avg)
+⚠ architect: Cost $0.42 exceeds threshold
+```
+
+Each line reports: agent ID, role, duration, tool call count, approximate token usage, estimated cost in USD, and files being modified.
+
+### Status indicators
+
+| Icon | Meaning                          |
+| ---- | -------------------------------- |
+| 🟢   | Healthy — agent running normally |
+| 🟡   | Warning — intervention suggested |
+| 🔴   | Critical — stale agent (>5 min)  |
+
+### Efficiency metric
+
+The efficiency percentage in the Observatory header reflects what proportion of tracked agents are actively working versus stale or waiting:
+
+* **100%** — all agents actively working
+* **\<80%** — some agents stale or waiting
+* **\<50%** — significant parallelization issues
+
+```typescript theme={null}
+import { calculateParallelEfficiency } from 'oh-my-claudecode/hooks/subagent-tracker';
+
+const eff = calculateParallelEfficiency(process.cwd());
+console.log(`Efficiency: ${eff.score}%`);
+console.log(`Active: ${eff.active}, Stale: ${eff.stale}, Total: ${eff.total}`);
+```
+
+***
+
+## Session-end summaries
+
+Session summaries are written at the end of each session and stored as JSON files.
+
+**Location:** `.omc/sessions/<sessionId>.json`
+
+```bash theme={null}
+# List available session summaries
+ls .omc/sessions/*.json
+```
+
+<Warning>
+  Session summaries are only written when the session ends normally so the `session-end` hook runs. If you terminate Claude Code forcefully, the summary file may not be created. Use the Session Replay JSONL logs as a fallback for timing and activity evidence.
+</Warning>
+
+If summary files are missing after a session:
+
+1. Verify HUD and hooks are installed: `/oh-my-claudecode:hud setup`
+2. Check the current workspace `.omc/sessions/` directory (not the global `~/.omc/` path)
+3. Review `.omc/state/agent-replay-*.jsonl` for equivalent activity data
+
+***
+
+## Session Replay
+
+Session Replay records agent lifecycle events as JSONL for post-session analysis and timeline visualization.
+
+**Location:** `.omc/state/agent-replay-{sessionId}.jsonl`
+
+### Event types
+
+| Event          | Description                             |
+| -------------- | --------------------------------------- |
+| `agent_start`  | Agent spawned with task info            |
+| `agent_stop`   | Agent completed or failed with duration |
+| `tool_start`   | Tool invocation begins                  |
+| `tool_end`     | Tool completes with timing              |
+| `file_touch`   | File modified by agent                  |
+| `intervention` | System intervention triggered           |
+
+### Replay file format
+
+Each line is a self-contained JSON event:
+
+```json theme={null}
+{"t":0.0,"agent":"a1b2c3d","agent_type":"executor","event":"agent_start","task":"Implement feature","parent_mode":"ultrawork"}
+{"t":5.2,"agent":"a1b2c3d","event":"tool_start","tool":"Read"}
+{"t":5.4,"agent":"a1b2c3d","event":"tool_end","tool":"Read","duration_ms":200,"success":true}
+```
+
+### Analyzing replay data
+
+```typescript theme={null}
+import { getReplaySummary } from 'oh-my-claudecode/hooks/subagent-tracker/session-replay';
+
+const summary = getReplaySummary(process.cwd(), sessionId);
+
+console.log(`Duration: ${summary.duration_seconds}s`);
+console.log(`Agents: ${summary.agents_spawned} spawned, ${summary.agents_completed} completed`);
+console.log(`Bottlenecks:`, summary.bottlenecks);
+console.log(`Files touched:`, summary.files_touched);
+```
+
+The replay system automatically identifies bottlenecks: tools averaging more than 1 second with two or more calls, sorted by impact (highest average time first).
+
+```bash theme={null}
+# View recent events without any extra tooling
+tail -20 .omc/state/agent-replay-*.jsonl
+```
+
+***
+
+## HUD integration
+
+The HUD provides a live status bar updated in real time as agents run.
+
+### Presets
+
+| Preset      | Focus         | Elements                  |
+| ----------- | ------------- | ------------------------- |
+| `minimal`   | Clean status  | Context bar only          |
+| `focused`   | Task progress | Todos, agents, modes      |
+| `full`      | Everything    | All elements enabled      |
+| `analytics` | Cost tracking | Tokens, costs, efficiency |
+| `dense`     | Compact all   | Compressed format         |
+
+### Configuration
+
+Edit `~/.claude/settings.json`:
+
+```json theme={null}
+{
+  "omcHud": {
+    "preset": "focused",
+    "elements": {
+      "agents": true,
+      "todos": true,
+      "contextBar": true,
+      "analytics": true
+    }
+  }
+}
+```
+
+### Available elements
+
+| Element      | Description                     |
+| ------------ | ------------------------------- |
+| `agents`     | Active agent count and status   |
+| `todos`      | Todo progress (completed/total) |
+| `ralph`      | Ralph loop iteration count      |
+| `autopilot`  | Autopilot phase indicator       |
+| `contextBar` | Context window usage percentage |
+| `analytics`  | Token and cost summary          |
+
+<Tip>
+  Use the `contextBar` element to watch the `ctx%` indicator. When context usage is high, the `pre-compact` hook saves critical information to `.omc/notepad.md` automatically before compaction runs.
+</Tip>
+
+***
+
+## Debugging techniques
+
+### Identifying slow agents
+
+<Steps>
+  <Step title="Check the Observatory">
+    Look for agents running longer than 2 minutes or showing 🟡/🔴 status indicators.
+  </Step>
+
+  <Step title="Inspect bottleneck indicators">
+    The Observatory shows a `bottleneck:` line for any agent with a tool averaging more than 1 second.
+  </Step>
+
+  <Step title="Review tool timings programmatically">
+    ```typescript theme={null}
+    import { getAgentPerformance } from 'oh-my-claudecode/hooks/subagent-tracker';
+
+    const perf = getAgentPerformance(process.cwd(), agentId);
+    console.log('Tool timings:', perf.tool_timings);
+    console.log('Bottleneck:', perf.bottleneck);
+    ```
+  </Step>
+</Steps>
+
+### Agent flow timeline with `omc trace`
+
+Use `omc trace` (or the `/oh-my-claudecode:trace` skill) to view a chronological timeline of agent turns and mode events:
+
+```bash theme={null}
+omc trace
+```
+
+For programmatic access via MCP:
+
+| Tool             | Description                                            |
+| ---------------- | ------------------------------------------------------ |
+| `trace_timeline` | Chronological agent turn and mode event timeline       |
+| `trace_summary`  | Aggregate statistics: turn counts, timing, token usage |
+
+### Detecting file conflicts
+
+When multiple agents modify the same file, merge conflicts can occur. Detect conflicts before they happen:
+
+```typescript theme={null}
+import { detectFileConflicts } from 'oh-my-claudecode/hooks/subagent-tracker';
+
+const conflicts = detectFileConflicts(process.cwd());
+conflicts.forEach(c => {
+  console.log(`File ${c.file} touched by: ${c.agents.join(', ')}`);
+});
+```
+
+<Tip>
+  Use `team N:executor` mode for automatic file ownership tracking. The team pipeline assigns exclusive file ownership per agent, preventing conflicts entirely.
+</Tip>
+
+### Intervention system
+
+OMC automatically detects problematic agents and surfaces interventions:
+
+| Intervention     | Trigger                      | Action         |
+| ---------------- | ---------------------------- | -------------- |
+| `timeout`        | Agent running >5 min         | Kill suggested |
+| `excessive_cost` | Cost >\$1.00                 | Warning        |
+| `file_conflict`  | Multiple agents on same file | Warning        |
+
+```typescript theme={null}
+import { suggestInterventions } from 'oh-my-claudecode/hooks/subagent-tracker';
+
+const interventions = suggestInterventions(process.cwd());
+interventions.forEach(i => {
+  console.log(`${i.type}: ${i.reason} → ${i.suggested_action}`);
+});
+```
+
+***
+
+## Monitoring metrics reference
+
+| Metric                                  | Source                     | Granularity   | Notes                                            |
+| --------------------------------------- | -------------------------- | ------------- | ------------------------------------------------ |
+| Agent lifecycle (start, stop, duration) | Agent Observatory / Replay | Per-agent     | Available in real time via HUD                   |
+| Tool timing (per-call duration)         | Session Replay JSONL       | Per-tool call | Bottlenecks flagged automatically                |
+| Session-end summary                     | `.omc/sessions/*.json`     | Per-session   | Only written on clean session exit               |
+| File ownership                          | Subagent Tracker           | Per-file      | Use `getFileOwnershipMap()` to inspect           |
+| Parallel efficiency score               | Observatory API            | Real-time     | 0–100%; \<80% indicates stale agents             |
+| Token usage                             | HUD analytics element      | Per-session   | Approximate; shown in Observatory as `tokens:Nk` |
+| Cost estimate                           | HUD analytics element      | Per-agent     | Default alert threshold is \$1.00 USD per agent  |
+| Context window usage                    | HUD `contextBar`           | Real-time     | Shown as `ctx%`; triggers compaction hooks       |
+
+***
+
+## State files reference
+
+| File                                     | Purpose                  | Format |
+| ---------------------------------------- | ------------------------ | ------ |
+| `.omc/state/subagent-tracking.json`      | Current agent states     | JSON   |
+| `.omc/state/agent-replay-{id}.jsonl`     | Session event timeline   | JSONL  |
+| `.omc/state/token-tracking.jsonl`        | Token usage log          | JSONL  |
+| `.omc/state/analytics-summary-{id}.json` | Cached session summaries | JSON   |
+| `.omc/state/subagent-tracker.lock`       | Concurrent access lock   | Text   |
+
+To reset stale agent state, delete `.omc/state/subagent-tracking.json`. To clean up old replay files (keeps the last 10 sessions):
+
+```typescript theme={null}
+import { cleanupReplayFiles } from 'oh-my-claudecode/hooks/subagent-tracker/session-replay';
+
+cleanupReplayFiles(process.cwd());
+```
+
+
+# Slash commands
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/reference/slash-commands
+
+Complete reference for all /oh-my-claudecode: slash commands available after installing the OMC plugin.
+
+Every skill installed by oh-my-claudecode is exposed as a slash command with the `/oh-my-claudecode:` prefix. Run these commands from inside a Claude Code session.
+
+<Note>
+  All commands require the plugin to be installed and setup to have been run at least once. If a command is not found, re-run `/oh-my-claudecode:omc-setup`.
+</Note>
+
+***
+
+## Setup and diagnostics
+
+### /oh-my-claudecode:omc-setup
+
+Initialize OMC configuration for Claude Code. Generates a `CLAUDE.md` file, registers lifecycle hooks, and makes all agents and skills available.
+
+```bash theme={null}
+/oh-my-claudecode:omc-setup
+/oh-my-claudecode:omc-setup --local
+```
+
+| Flag      | Description                                                                                   |
+| --------- | --------------------------------------------------------------------------------------------- |
+| *(none)*  | Write configuration to `~/.claude/CLAUDE.md` (global — applies to all projects).              |
+| `--local` | Write configuration to `./.claude/CLAUDE.md` (project-scoped — applies to this project only). |
+
+<Tip>
+  Use `--local` when you want OMC configuration checked into a specific repository, or when you need per-project isolation on a shared machine. Project-scoped configuration takes precedence over global.
+</Tip>
+
+Re-run this command after updating the plugin to apply the latest `CLAUDE.md` changes.
+
+***
+
+### /oh-my-claudecode:omc-doctor
+
+Run diagnostics to identify and fix installation issues.
+
+```bash theme={null}
+/oh-my-claudecode:omc-doctor
+```
+
+The doctor checks for:
+
+* Missing dependencies
+* Configuration errors
+* Hook installation status
+* Agent availability
+* Skill registration
+
+Run this command after an update if commands stop working or agents stop delegating correctly.
+
+***
+
+## Orchestration modes
+
+### /oh-my-claudecode:autopilot
+
+Activate the full autonomous execution pipeline. OMC runs expansion → planning → execution → QA → validation and does not stop until the task is verified complete.
+
+```bash theme={null}
+/oh-my-claudecode:autopilot <task>
+```
+
+```bash theme={null}
+/oh-my-claudecode:autopilot build a REST API for managing tasks
+```
+
+You can also trigger this mode by typing the `autopilot:` keyword directly in a prompt. See [Magic keywords — autopilot](/reference/magic-keywords#autopilot).
+
+***
+
+### /oh-my-claudecode:ralph
+
+Activate ralph persistence mode. Claude loops through verify-and-fix cycles until the task reaches a definitively verified complete state.
+
+```bash theme={null}
+/oh-my-claudecode:ralph <task>
+```
+
+```bash theme={null}
+/oh-my-claudecode:ralph refactor the authentication module
+```
+
+| Flag               | Description                                                                  |
+| ------------------ | ---------------------------------------------------------------------------- |
+| `--critic=<agent>` | Choose the critic agent for verification: `architect`, `critic`, or `codex`. |
+
+<Note>
+  Ralph includes ultrawork automatically. Parallel execution is enabled alongside the persistence loop without any additional flags.
+</Note>
+
+***
+
+### /oh-my-claudecode:ultrawork
+
+Activate maximum parallelism mode. OMC distributes independent work items across multiple agents simultaneously.
+
+```bash theme={null}
+/oh-my-claudecode:ultrawork <task>
+```
+
+```bash theme={null}
+/oh-my-claudecode:ultrawork fix all TypeScript errors
+```
+
+You can also trigger this mode with the `ulw` or `ultrawork` keywords. See [Magic keywords — ultrawork](/reference/magic-keywords#ulw--ultrawork).
+
+***
+
+### /oh-my-claudecode:team
+
+Launch the canonical staged Team pipeline: `team-plan → team-prd → team-exec → team-verify → team-fix (loop)`.
+
+```bash theme={null}
+/oh-my-claudecode:team <N>:<agent-type> "<task>"
+```
+
+```bash theme={null}
+/oh-my-claudecode:team 3:executor "fix all TypeScript errors"
+/oh-my-claudecode:team 2:debugger "fix build errors in src/"
+/oh-my-claudecode:team 4:designer "implement responsive layouts for all page components"
+```
+
+| Parameter    | Description                                                                    |
+| ------------ | ------------------------------------------------------------------------------ |
+| `N`          | Number of worker agents (1–20).                                                |
+| `agent-type` | Worker agent type for the execution stage: `executor`, `debugger`, `designer`. |
+| `task`       | High-level description to decompose and distribute.                            |
+
+For CLI-based team workers (codex/gemini/claude in tmux panes), use the `omc team` CLI command. See [CLI commands — omc team](/reference/cli-commands#omc-team).
+
+***
+
+## Planning
+
+### /oh-my-claudecode:ralplan
+
+Activate iterative consensus planning with RALPLAN-DR structured deliberation. Three agents — `planner`, `architect`, and `critic` — independently produce and challenge a plan until they reach consensus.
+
+```bash theme={null}
+/oh-my-claudecode:ralplan <description>
+/oh-my-claudecode:ralplan <description> --deliberate
+```
+
+```bash theme={null}
+/oh-my-claudecode:ralplan add OAuth login to the existing app
+/oh-my-claudecode:ralplan migrate from REST to GraphQL --deliberate
+```
+
+| Flag           | Description                                                                                  |
+| -------------- | -------------------------------------------------------------------------------------------- |
+| `--deliberate` | Enable high-risk deliberation mode with deeper structured challenge rounds before consensus. |
+
+<Note>
+  The `plan this` and `plan the` keyword triggers have been removed. Use `ralplan` or `/oh-my-claudecode:omc-plan` instead.
+</Note>
+
+***
+
+### /oh-my-claudecode:deep-interview
+
+Activate the Socratic requirements interview. OMC uses ambiguity-gated questioning to surface hidden assumptions and measure clarity across weighted dimensions before any code is written.
+
+```bash theme={null}
+/oh-my-claudecode:deep-interview "<idea>"
+```
+
+```bash theme={null}
+/oh-my-claudecode:deep-interview "I want to build a task management app"
+```
+
+Use this command when requirements are vague, stakeholder intent is unclear, or you want to validate your own assumptions before committing to an implementation plan.
+
+***
+
+## Monitoring and configuration
+
+### /oh-my-claudecode:hud
+
+Open HUD setup and configuration. Install or repair the live statusline that shows orchestration metrics in your terminal.
+
+```bash theme={null}
+/oh-my-claudecode:hud
+/oh-my-claudecode:hud setup
+```
+
+After setup, configure display elements in `~/.claude/settings.json`:
+
+```json theme={null}
+{
+  "omcHud": {
+    "preset": "focused",
+    "elements": {
+      "showTokens": true,
+      "gitBranch": true
+    }
+  }
+}
+```
+
+Available presets: `minimal`, `focused`, `full`, `dense`, `analytics`, `opencode`.
+
+To render the current HUD from your terminal without entering Claude Code, use `omc hud`. See [CLI commands — omc hud](/reference/cli-commands#omc-hud).
+
+***
+
+### /oh-my-claudecode:configure-notifications
+
+Run interactive notification setup for Telegram, Discord, Slack, and OpenClaw integrations.
+
+```bash theme={null}
+/oh-my-claudecode:configure-notifications
+```
+
+This command guides you through the full configuration via natural language — no flags or manual JSON editing required. To configure programmatically or incrementally, use the `omc config-stop-callback` CLI command. See [CLI commands — omc config-stop-callback](/reference/cli-commands#omc-config-stop-callback).
+
+***
+
+## Skills management
+
+### /oh-my-claudecode:skill
+
+Manage custom local skills — reusable problem-solving patterns that auto-inject into context when relevant.
+
+```bash theme={null}
+/oh-my-claudecode:skill list
+/oh-my-claudecode:skill add
+/oh-my-claudecode:skill remove <name>
+/oh-my-claudecode:skill edit <name>
+/oh-my-claudecode:skill search <query>
+```
+
+| Subcommand       | Description                                                 |
+| ---------------- | ----------------------------------------------------------- |
+| `list`           | Show all skills registered for this project and user scope. |
+| `add`            | Add a new skill interactively.                              |
+| `remove <name>`  | Remove a skill by name.                                     |
+| `edit <name>`    | Open a skill for editing.                                   |
+| `search <query>` | Search registered skills by name or trigger.                |
+
+Skills are stored in `.omc/skills/` (project scope, version-controlled) or `~/.omc/skills/` (user scope, shared across all projects). Project-scoped skills take precedence.
+
+***
+
+### /oh-my-claudecode:learner
+
+Extract reusable skill patterns from the current Claude Code session. The learner applies strict quality gates to ensure only high-signal patterns are saved.
+
+```bash theme={null}
+/oh-my-claudecode:learner
+```
+
+The extracted skill is written to `.omc/skills/` and becomes available for automatic injection in future sessions where the trigger conditions match.
+
+***
+
+## Full command list
+
+| Command                                                  | Description                                                                        |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `/oh-my-claudecode:ai-slop-cleaner <target>`             | Anti-slop cleanup workflow. Use `--review` for a reviewer-only pass without edits. |
+| `/oh-my-claudecode:ask <claude\|codex\|gemini> <prompt>` | Route a prompt through the selected provider CLI and capture an artifact.          |
+| `/oh-my-claudecode:autopilot <task>`                     | Full autonomous execution pipeline.                                                |
+| `/oh-my-claudecode:cancel`                               | Cancel all active OMC modes and clear state.                                       |
+| `/oh-my-claudecode:ccg <prompt>`                         | Tri-model workflow via `ask codex` + `ask gemini`, synthesized by Claude.          |
+| `/oh-my-claudecode:configure-notifications`              | Interactive notification setup (Telegram, Discord, Slack, OpenClaw).               |
+| `/oh-my-claudecode:deep-dive <problem>`                  | Two-stage trace → deep-interview pipeline with context handoff.                    |
+| `/oh-my-claudecode:deep-interview "<idea>"`              | Socratic interview with ambiguity scoring before execution.                        |
+| `/oh-my-claudecode:deepinit [path]`                      | Generate hierarchical `AGENTS.md` files to index the codebase.                     |
+| `/oh-my-claudecode:hud`                                  | Configure or repair the HUD statusline.                                            |
+| `/oh-my-claudecode:learner`                              | Extract reusable skill patterns from the current session.                          |
+| `/oh-my-claudecode:mcp-setup`                            | Configure MCP servers.                                                             |
+| `/oh-my-claudecode:omc-doctor`                           | Diagnose and fix installation issues.                                              |
+| `/oh-my-claudecode:omc-plan <description>`               | Start a planning session with optional consensus structured deliberation.          |
+| `/oh-my-claudecode:omc-setup [--local]`                  | Initialize OMC configuration (global or project-scoped).                           |
+| `/oh-my-claudecode:omc-teams <N>:<agent> <task>`         | Legacy compatibility skill — routes to `omc team`.                                 |
+| `/oh-my-claudecode:project-session-manager <args>`       | Manage isolated dev environments with git worktrees and tmux.                      |
+| `/oh-my-claudecode:ralph <task>`                         | Persistence loop until verified completion.                                        |
+| `/oh-my-claudecode:ralplan <description>`                | Consensus planning with RALPLAN-DR structured deliberation.                        |
+| `/oh-my-claudecode:release`                              | Automated release workflow.                                                        |
+| `/oh-my-claudecode:sciomc <topic>`                       | Parallel scientist orchestration for research tasks.                               |
+| `/oh-my-claudecode:setup`                                | Unified setup entrypoint (`setup`, `setup doctor`, `setup mcp`).                   |
+| `/oh-my-claudecode:skill`                                | Manage local skills (list / add / remove / edit / search).                         |
+| `/oh-my-claudecode:team <N>:<agent> "<task>"`            | Coordinated native Team staged pipeline.                                           |
+| `/oh-my-claudecode:trace`                                | Evidence-driven tracing with parallel tracer hypotheses.                           |
+| `/oh-my-claudecode:ultraqa <goal>`                       | Autonomous QA cycling — test, verify, fix, repeat.                                 |
+| `/oh-my-claudecode:ultrawork <task>`                     | Maximum performance mode with parallel agents.                                     |
+| `/oh-my-claudecode:visual-verdict <task>`                | Structured visual QA verdict for screenshot and reference comparisons.             |
+
+
+# Troubleshooting
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/reference/troubleshooting
+
+Solutions for common oh-my-claudecode issues including hook failures, team configuration, rate limits, platform compatibility, and context window management.
+
+When something is not working as expected, start with `/omc-doctor`. It runs a suite of diagnostics and prints what is installed, what is missing, and what needs attention.
+
+```bash theme={null}
+/oh-my-claudecode:omc-doctor
+```
+
+`omc-doctor` checks:
+
+* Plugin installation and version
+* MCP server registration
+* Hook registration in `hooks.json`
+* `.omc/` directory structure and permissions
+* Environment variable conflicts
+* Node.js version compatibility
+
+<Tip>
+  Run `/omc-doctor` as the first step for any issue before digging deeper. Most problems — missing hooks, broken MCP tools, stale config — surface here with actionable fixes.
+</Tip>
+
+***
+
+## Installation and setup
+
+<AccordionGroup>
+  <Accordion title="Issues after update">
+    After updating OMC from the plugin marketplace, configuration files are not automatically refreshed. Re-run setup to apply the latest CLAUDE.md and hook definitions:
+
+    ```bash theme={null}
+    /oh-my-claudecode:omc-setup
+    ```
+
+    This downloads the latest CLAUDE.md, reconfigures agents, and re-registers hooks and MCP servers. Your existing project CLAUDE.md is preserved unless you explicitly request overwrite.
+  </Accordion>
+
+  <Accordion title="Plugin cache issues">
+    If Claude Code is loading a stale version of OMC after an update, run `/omc-doctor` first. It will identify whether the plugin cache is stale and guide you through clearing it.
+
+    ```bash theme={null}
+    /oh-my-claudecode:omc-doctor
+    ```
+  </Accordion>
+
+  <Accordion title="Configuration not applying">
+    OMC configuration follows this precedence order (highest to lowest):
+
+    1. Project-scoped `./.claude/CLAUDE.md`
+    2. Global `~/.claude/CLAUDE.md`
+    3. Built-in defaults
+
+    If your configuration is not taking effect, check which level is active and whether a higher-priority config is shadowing your changes. Run `/omc-setup --local` to write a project-scoped config, or `/omc-setup --global` for global.
+
+    <Note>
+      When both project and global CLAUDE.md files exist, the project-scoped file takes precedence. Changes to the global file will not apply to projects that have their own CLAUDE.md.
+    </Note>
+  </Accordion>
+
+  <Accordion title="Preserving existing CLAUDE.md">
+    By default, `/omc-setup` runs in preserve mode: it will not overwrite a CLAUDE.md file that already exists. To force an overwrite and get the latest OMC defaults:
+
+    ```bash theme={null}
+    /oh-my-claudecode:omc-setup --overwrite
+    ```
+
+    If you want to merge changes manually, back up your existing CLAUDE.md before running setup.
+  </Accordion>
+</AccordionGroup>
+
+***
+
+## Hooks
+
+<AccordionGroup>
+  <Accordion title="Hooks not firing">
+    If magic keywords are not triggering skills or lifecycle hooks are not running, check whether the `DISABLE_OMC` environment variable is set:
+
+    ```bash theme={null}
+    echo $DISABLE_OMC
+    ```
+
+    If it is set to `1`, hooks are globally disabled. Unset it:
+
+    ```bash theme={null}
+    unset DISABLE_OMC
+    ```
+
+    To skip only specific hooks without disabling all of OMC:
+
+    ```bash theme={null}
+    export OMC_SKIP_HOOKS="keyword-detector,persistent-mode"
+    ```
+
+    After adjusting environment variables, restart Claude Code for the changes to take effect.
+  </Accordion>
+
+  <Accordion title="Context window full — compaction hooks">
+    When the context window approaches capacity, the `ctx%` indicator in the HUD climbs toward 100%. The `pre-compact` hook fires automatically on `PreCompact` events to save critical information to `.omc/notepad.md` before compaction.
+
+    To monitor context usage in real time, enable the `contextBar` HUD element:
+
+    ```json theme={null}
+    {
+      "omcHud": {
+        "preset": "focused",
+        "elements": {
+          "contextBar": true
+        }
+      }
+    }
+    ```
+
+    If you find context filling repeatedly on long tasks, break the task into smaller units or use `ralph` with `ralplan` so planning artifacts persist across compaction events.
+  </Accordion>
+</AccordionGroup>
+
+***
+
+## Teams and multi-agent
+
+<AccordionGroup>
+  <Accordion title="Teams not working">
+    The team pipeline requires the experimental agent teams feature to be enabled. If `omc team` commands return errors or agents are not spawning, set the environment variable before launching Claude Code:
+
+    ```bash theme={null}
+    export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
+    ```
+
+    Add this to your `~/.bashrc` or `~/.zshrc` to make it permanent. Restart Claude Code after setting it.
+
+    Verify the variable is set in the current session:
+
+    ```bash theme={null}
+    echo $CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS
+    ```
+  </Accordion>
+
+  <Accordion title="Codex or Gemini workers not spawning">
+    The `ccg` skill and `omc team N:codex|gemini` require the respective CLI tools to be installed and accessible on your `PATH`:
+
+    * **Codex**: Install the OpenAI Codex CLI and ensure it is authenticated
+    * **Gemini**: Install the Google Gemini CLI and ensure it is authenticated
+
+    Additionally, an active tmux session is required for Codex and Gemini workers. If tmux is not running, workers cannot be launched.
+
+    Check that the CLIs resolve correctly:
+
+    ```bash theme={null}
+    which codex
+    which gemini
+    ```
+
+    If either command fails, install or add it to your `PATH`.
+
+    <Warning>
+      As of v4.4.0, the `x` (Codex) and `g` (Gemini) MCP server providers were removed. Use `omc team N:codex` or `omc team N:gemini` via the CLI instead.
+    </Warning>
+  </Accordion>
+</AccordionGroup>
+
+***
+
+## Rate limits and long-running tasks
+
+<AccordionGroup>
+  <Accordion title="Rate limits — omc wait and auto-resume">
+    When you hit Claude API rate limits during a long task, use `omc wait` to pause and auto-resume when the limit window resets:
+
+    ```bash theme={null}
+    omc wait
+    ```
+
+    To auto-resume from the beginning of a new session when the limit clears:
+
+    ```bash theme={null}
+    omc wait --start
+    ```
+
+    `omc wait` monitors the rate limit state and restarts the active workflow automatically when capacity is available again, so you do not need to manually retry.
+  </Accordion>
+</AccordionGroup>
+
+***
+
+## Platform compatibility
+
+<AccordionGroup>
+  <Accordion title="tmux not found">
+    Several OMC features — including Codex/Gemini worker spawning, the `qa-tester` agent, and some HUD modes — require tmux.
+
+    <Tabs>
+      <Tab title="macOS">
+        ```bash theme={null}
+        brew install tmux
+        ```
+      </Tab>
+
+      <Tab title="Ubuntu / Debian">
+        ```bash theme={null}
+        sudo apt-get install tmux
+        ```
+      </Tab>
+
+      <Tab title="Fedora / RHEL">
+        ```bash theme={null}
+        sudo dnf install tmux
+        ```
+      </Tab>
+
+      <Tab title="Arch Linux">
+        ```bash theme={null}
+        sudo pacman -S tmux
+        ```
+      </Tab>
+    </Tabs>
+
+    After installing, start a tmux session before launching Claude Code:
+
+    ```bash theme={null}
+    tmux new-session -s main
+    ```
+  </Accordion>
+
+  <Accordion title="Windows — WSL2 or psmux">
+    OMC is not natively supported on Windows. Use one of these approaches:
+
+    **WSL2 (recommended):** Run Claude Code inside Windows Subsystem for Linux 2. This gives you a full Linux environment with native tmux support.
+
+    ```powershell theme={null}
+    # Enable WSL2 (run as Administrator)
+    wsl --install
+    ```
+
+    Then install tmux inside your WSL2 distribution and run Claude Code there.
+
+    **psmux:** If you need tmux compatibility without WSL2, `psmux` provides a PowerShell-compatible tmux alternative. Install it and configure OMC to use it:
+
+    ```bash theme={null}
+    export OMC_TMUX_CMD=psmux
+    ```
+
+    <Note>
+      WSL2 is the recommended path for Windows users. psmux may not support all OMC features that depend on tmux.
+    </Note>
+  </Accordion>
+</AccordionGroup>
+
+***
+
+## Common error reference
+
+<AccordionGroup>
+  <Accordion title="'omc-doctor' shows missing MCP servers">
+    MCP servers are registered during `/omc-setup`. If they are missing, re-run setup:
+
+    ```bash theme={null}
+    /oh-my-claudecode:omc-setup
+    ```
+
+    If the problem persists, check that Claude Code has write permission to its settings directory (`~/.claude/`) and that no other process is locking the settings file.
+  </Accordion>
+
+  <Accordion title="Subagent type not recognized">
+    If an agent delegation fails with "subagent\_type not recognized", verify the agent name uses the full prefix:
+
+    ```
+    oh-my-claudecode:executor   ✓
+    executor                    ✗
+    ```
+
+    Also check that you are not passing a bare Anthropic model ID as the `subagent_type` on Bedrock. OMC enforces this at the `pre-tool-enforcer` hook level.
+  </Accordion>
+
+  <Accordion title="HUD shows 'CLI error' instead of status">
+    This error appears when the OMC npm package cannot be located outside a Node.js project directory. It is a diagnostic message, not a crash.
+
+    Fix: ensure the `oh-my-claude-sisyphus` package is installed globally:
+
+    ```bash theme={null}
+    npm list -g oh-my-claude-sisyphus
+    ```
+
+    If it is missing:
+
+    ```bash theme={null}
+    npm install -g oh-my-claude-sisyphus@latest
+    ```
+  </Accordion>
+
+  <Accordion title="State tools — cancel does not clear skill-active mode">
+    In older versions, the `skill-active` state was not registered as a clearable mode. As of v4.10.2 this is fixed. Update to the latest version and re-run `/omc-setup`:
+
+    ```bash theme={null}
+    # Update via the plugin marketplace, then:
+    /oh-my-claudecode:omc-setup
+    ```
+  </Accordion>
+</AccordionGroup>
+
+
+# Custom skills
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/skills/custom-skills
+
+Create project-specific or personal skill files that auto-inject when relevant context is detected.
+
+Custom skills are YAML-frontmatter Markdown files that you write and store locally. When OMC detects matching context in a prompt, the skill file is loaded into the agent's context automatically — no manual recall needed. Skills capture hard-won debugging knowledge, project-specific conventions, and reusable workflows so they are never lost between sessions.
+
+## Scope and priority
+
+Custom skills live in one of two locations depending on who needs them:
+
+<CardGroup>
+  <Card title="Project scope" icon="folder">
+    `.omc/skills/` in your repository root. Version-controlled and shared with your team. Takes priority over user-scope skills with the same name.
+  </Card>
+
+  <Card title="User scope" icon="user">
+    `~/.omc/skills/` in your home directory. Available across all your projects. Used as a fallback when no project-scope skill matches.
+  </Card>
+</CardGroup>
+
+|                 | Project scope             | User scope        |
+| --------------- | ------------------------- | ----------------- |
+| **Path**        | `.omc/skills/`            | `~/.omc/skills/`  |
+| **Shared with** | Team (version-controlled) | All your projects |
+| **Priority**    | Higher (overrides user)   | Lower (fallback)  |
+
+## Skill file format
+
+Each skill is a single `.md` file with a YAML frontmatter block followed by the skill content in Markdown.
+
+```yaml theme={null}
+# .omc/skills/fix-proxy-crash.md
+---
+name: Fix Proxy Crash
+description: aiohttp proxy crashes on ClientDisconnectedError
+triggers: ["proxy", "aiohttp", "disconnected"]
+source: extracted
+---
+Wrap handler at server.py:42 in try/except ClientDisconnectedError.
+The crash occurs when the client disconnects before the response is sent.
+Always catch ClientDisconnectedError silently — do not re-raise or log it.
+```
+
+### Frontmatter fields
+
+| Field         | Required | Description                                                     |
+| ------------- | -------- | --------------------------------------------------------------- |
+| `name`        | Yes      | Human-readable skill name shown in `/skill list`                |
+| `description` | Yes      | One-line summary of what the skill addresses                    |
+| `triggers`    | Yes      | Array of strings; any match in the prompt loads the skill       |
+| `source`      | No       | How the skill was created: `extracted`, `manual`, or `imported` |
+
+The body after the frontmatter is injected as-is into the agent context when any trigger word appears in the user's prompt.
+
+## Managing skills
+
+Use the `/skill` command to manage your local skill library:
+
+```bash theme={null}
+/skill list              # List all available skills (project + user scope)
+/skill add               # Create a new skill interactively
+/skill remove <name>     # Delete a skill by name
+/skill edit <name>       # Open a skill for editing
+/skill search <query>    # Search skill names and descriptions
+```
+
+<Note>
+  `/skill list` shows skills from both scopes. Project-scope skills are marked separately from user-scope skills so you can see which are shared with your team.
+</Note>
+
+## Auto-injection
+
+OMC scans every incoming prompt for trigger words. When a match is found, the skill file is appended to the agent's context before execution begins. This happens automatically — you do not need to reference the skill manually.
+
+<Steps>
+  <Step title="Trigger detected">
+    A prompt contains one or more words from a skill's `triggers` array. Detection is case-insensitive.
+  </Step>
+
+  <Step title="Skill loaded">
+    The matching skill file's body is injected into the agent context alongside the user's prompt.
+  </Step>
+
+  <Step title="Agent executes">
+    The agent reads the skill content as additional context before responding. Project-scope skills take priority when multiple skills match.
+  </Step>
+</Steps>
+
+**Example:** If you have a skill with `triggers: ["proxy", "aiohttp"]` and you ask `why does the proxy crash on disconnect?`, the skill is loaded automatically.
+
+## Auto-learning with `/learner`
+
+Instead of writing skill files by hand, use `/learner` to extract reusable patterns from a completed session:
+
+```bash theme={null}
+/learner
+```
+
+The `learner` analyzes recent tool use and conversation history, identifies patterns worth preserving, and generates a skill file with appropriate triggers and body content. Quality gates prevent low-value or overly specific patterns from being extracted.
+
+<Tip>
+  Run `/learner` at the end of any session where you discovered a non-obvious fix or learned how a tricky part of the codebase works. The extracted skill will activate automatically in future sessions when the same context arises.
+</Tip>
+
+## Example: team workflow skill
+
+A project-scope skill for enforcing commit conventions across the team:
+
+```yaml theme={null}
+# .omc/skills/commit-conventions.md
+---
+name: Commit Conventions
+description: Project commit message format and branch naming rules
+triggers: ["commit", "git commit", "branch name", "pr title"]
+source: manual
+---
+Commit format: <type>(<scope>): <summary>
+
+Types: feat, fix, docs, refactor, test, chore
+Scope: api, auth, ui, db, infra
+
+Examples:
+  feat(auth): add OAuth2 PKCE flow
+  fix(api): handle empty pagination cursor
+  refactor(db): extract query builder to separate module
+
+Branch naming: <type>/<issue-number>-<short-description>
+  feat/142-oauth-pkce
+  fix/198-pagination-cursor
+
+PR titles must match the commit format of the primary commit.
+```
+
+When any team member types `commit` or `git commit`, this skill is loaded and the conventions are enforced without anyone needing to remember or look them up.
+
+
+# Skills overview
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/skills/overview
+
+Behavior injections that modify how the orchestrator operates. Skills add capabilities on top of existing agents without swapping the underlying model.
+
+Skills are loaded behavior sets that change what the orchestrator does and how. When a skill is active, it does not replace agents — it changes the rules that govern how work is delegated, sequenced, verified, and repeated. OMC provides 32 skills total (31 canonical + 1 deprecated alias `psm`).
+
+## The 3-layer composition model
+
+Skills compose in three layers. The formula for any active skill set is:
+
+```
+[Execution Skill] + [0-N Enhancements] + [Optional Guarantee]
+```
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  GUARANTEE LAYER (optional)                                  │
+│  ralph: "Cannot stop until verified done"                   │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│  ENHANCEMENT LAYER (0-N skills)                              │
+│  ultrawork (parallel) | git-master (commits)                │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│  EXECUTION LAYER (primary skill)                             │
+│  default (build) | orchestrate (coordinate) | planner (plan) │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Example:** The prompt `ultrawork: refactor API with proper commits` activates three skills simultaneously:
+
+* `ultrawork` (enhancement) — parallel agent execution
+* `default` (execution) — standard build workflow
+* `git-master` (enhancement) — atomic commits after changes
+
+## How to invoke skills
+
+**Magic keywords** — include a trigger word anywhere in your prompt:
+
+```
+autopilot build me a REST API with authentication
+ralph: refactor the auth module
+ultrawork implement OAuth
+```
+
+**Slash commands** — explicit invocation by name:
+
+```bash theme={null}
+/oh-my-claudecode:autopilot build me a todo app
+/oh-my-claudecode:ralph refactor the auth module
+/oh-my-claudecode:team 3:executor "implement fullstack app"
+```
+
+**Skills browser** — interactive selection:
+
+```bash theme={null}
+/skills
+```
+
+## Core workflow skills
+
+<AccordionGroup>
+  <Accordion title="autopilot">
+    Full autonomous 5-stage pipeline from idea to working code.
+
+    **Triggers:** `autopilot`, `build me`, `I want a`, `handle it all`, `end to end`, `e2e this`
+
+    ```bash theme={null}
+    autopilot build me a REST API with authentication
+    /oh-my-claudecode:autopilot build a task management app
+    ```
+
+    Stages: `expansion → planning → execution → qa → validation → complete`
+
+    State is persisted in `.omc/state/autopilot-state.json`. If Claude crashes mid-run, autopilot resumes from the last completed stage.
+  </Accordion>
+
+  <Accordion title="ralph">
+    Persistence loop that does not stop until work is verified complete. The `verifier` agent confirms every acceptance criterion before the loop exits. Includes ultrawork's parallel execution automatically.
+
+    **Triggers:** `ralph`, `don't stop`, `must complete`, `until done`
+
+    ```bash theme={null}
+    ralph: refactor the authentication module
+    /oh-my-claudecode:ralph implement the payment service
+    ```
+
+    Ralph enforces a planning gate: implementation cannot begin until `.omc/plans/prd-*.md` and `.omc/plans/test-spec-*.md` exist. Use `ralplan` before ralph on high-stakes tasks.
+
+    See [Ralph mode](/modes/ralph) for the full execution loop and flags.
+  </Accordion>
+
+  <Accordion title="ultrawork">
+    Maximum parallelism — launches multiple agents simultaneously on independent subtasks.
+
+    **Triggers:** `ultrawork`, `ulw`, `uw`
+
+    ```bash theme={null}
+    ultrawork implement user authentication with OAuth
+    /oh-my-claudecode:ultrawork fix all TypeScript errors
+    ```
+
+    Independent tasks fire simultaneously. Long operations (builds, installs, test suites) run in the background with `run_in_background: true`.
+  </Accordion>
+
+  <Accordion title="team">
+    Coordinates N Claude agents through a staged pipeline with built-in task tracking and dependency management.
+
+    ```bash theme={null}
+    /oh-my-claudecode:team 3:executor "implement fullstack todo app"
+    ```
+
+    Pipeline: `team-plan → team-prd → team-exec → team-verify → team-fix (loop)`
+
+    See [Team mode](/modes/team) for the full pipeline documentation.
+  </Accordion>
+
+  <Accordion title="ralplan">
+    Iterative planning: `planner`, `architect`, and `critic` loop until they reach consensus on a plan. Produces `.omc/plans/prd-*.md` and `.omc/plans/test-spec-*.md` artifacts that unlock ralph's implementation phase.
+
+    **Triggers:** `ralplan`
+
+    ```bash theme={null}
+    ralplan this feature
+    /oh-my-claudecode:ralplan design the notification system
+    /oh-my-claudecode:ralplan --deliberate migrate the database schema
+    ```
+
+    Use `--deliberate` for high-risk tasks that require structured deliberation before consensus is reached.
+  </Accordion>
+
+  <Accordion title="deep-interview">
+    Socratic deep interview with ambiguity gating. Uses weighted dimensions to measure clarity across your idea before any code is written. Execution does not begin until clarity meets the required threshold.
+
+    **Triggers:** `deep interview`, `ouroboros`
+
+    ```bash theme={null}
+    /oh-my-claudecode:deep-interview "I want to build a task management app"
+    deep interview: vague idea about notifications
+    ```
+
+    Best used when requirements are unclear, assumptions are unstated, or you want to micromanage the design before handing off to autopilot.
+  </Accordion>
+
+  <Accordion title="ultraqa">
+    Autonomous QA cycle: test, verify, fix, repeat until the stated goal is met.
+
+    ```bash theme={null}
+    /oh-my-claudecode:ultraqa "all integration tests pass with no flaky tests"
+    ```
+  </Accordion>
+
+  <Accordion title="ai-slop-cleaner">
+    Regression-safe cleanup workflow for AI-generated patterns: duplicate code, dead code, needless abstractions, and boundary violations. Runs separate writer and reviewer passes.
+
+    **Triggers:** `deslop`, `anti-slop`
+
+    ```bash theme={null}
+    /oh-my-claudecode:ai-slop-cleaner src/api/
+    deslop the auth module
+    ```
+
+    Use `--review` for a reviewer-only pass without making changes.
+  </Accordion>
+
+  <Accordion title="visual-verdict">
+    Structured visual QA verdict for screenshot and reference comparisons. Run every iteration when working on UI to gate the next edit.
+
+    ```bash theme={null}
+    /oh-my-claudecode:visual-verdict
+    ```
+
+    Persists verdict JSON in `.omc/state/{scope}/ralph-progress.json` with numeric score, pass/fail threshold, and qualitative feedback.
+  </Accordion>
+
+  <Accordion title="web-clone">
+    URL-driven website cloning pipeline with visual and functional verification.
+
+    **Triggers:** `web-clone`, `clone site`, `clone website`, `copy webpage`
+
+    ```bash theme={null}
+    /oh-my-claudecode:web-clone https://example.com
+    ```
+  </Accordion>
+
+  <Accordion title="cancel">
+    Unified cancellation for all active execution modes. Clears state files and stops active loops immediately.
+
+    **Triggers:** `cancelomc`, `stopomc`
+
+    ```bash theme={null}
+    /oh-my-claudecode:cancel
+    stopomc
+    ```
+  </Accordion>
+
+  <Accordion title="omc-plan">
+    Planning workflow with optional consensus structured deliberation (RALPLAN-DR). Safe alias: `/plan`.
+
+    ```bash theme={null}
+    /oh-my-claudecode:omc-plan design the caching layer
+    /oh-my-claudecode:ralplan --deliberate migrate the auth system
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Agent shortcut skills
+
+These skills map directly to a specialist agent without launching a full workflow:
+
+| Skill             | Routes to           | Use for                               |
+| ----------------- | ------------------- | ------------------------------------- |
+| `analyze`         | `debugger`          | Investigation and root-cause analysis |
+| `deepsearch`      | `explore`           | Thorough codebase search              |
+| `tdd`             | `test-engineer`     | Test-driven development workflow      |
+| `build-fix`       | `debugger`          | Build error resolution                |
+| `code-review`     | `code-reviewer`     | Comprehensive code review             |
+| `security-review` | `security-reviewer` | Security audit                        |
+| `frontend-ui-ux`  | `designer`          | UI component and styling work         |
+| `git-master`      | `git-master`        | Git commit and history management     |
+
+**Triggers:**
+
+```
+deepsearch for auth middleware
+code review the payment module
+tdd: implement password validation
+security review the OAuth callback
+```
+
+## Utility skills
+
+| Skill        | Description                                                  | Command                        |
+| ------------ | ------------------------------------------------------------ | ------------------------------ |
+| `note`       | Save notes for session persistence                           | `/oh-my-claudecode:note`       |
+| `omc-doctor` | Diagnose and fix installation issues                         | `/oh-my-claudecode:omc-doctor` |
+| `help`       | Usage guidance                                               | `/oh-my-claudecode:help`       |
+| `trace`      | Evidence-driven tracing lane with parallel tracer hypotheses | `/oh-my-claudecode:trace`      |
+| `skill`      | Manage local skills (list/add/remove/search/edit)            | `/oh-my-claudecode:skill`      |
+| `learner`    | Extract reusable skill from session with quality gates       | `/oh-my-claudecode:learner`    |
+| `skillify`   | Extract patterns from the current session into a skill file  | `/oh-my-claudecode:skillify`   |
+| `remember`   | Save critical information with `<remember>` tags             | `/oh-my-claudecode:remember`   |
+
+## Magic keyword reference
+
+| Keyword                                                                        | Skill activated     |
+| ------------------------------------------------------------------------------ | ------------------- |
+| `ultrawork`, `ulw`, `uw`                                                       | `ultrawork`         |
+| `autopilot`, `build me`, `I want a`, `handle it all`, `end to end`, `e2e this` | `autopilot`         |
+| `ralph`, `don't stop`, `must complete`, `until done`                           | `ralph`             |
+| `ralplan`, `consensus plan`                                                    | `ralplan`           |
+| `deep interview`, `ouroboros`                                                  | `deep-interview`    |
+| `code review`, `review code`                                                   | `code-review`       |
+| `security review`, `review security`                                           | `security-review`   |
+| `deepsearch`, `search the codebase`, `find in codebase`                        | `deepsearch`        |
+| `deepanalyze`, `deep-analyze`                                                  | deep analysis mode  |
+| `ultrathink`, `think hard`, `think deeply`                                     | deep reasoning mode |
+| `tdd`, `test first`, `red green`                                               | `tdd`               |
+| `deslop`, `anti-slop`                                                          | `ai-slop-cleaner`   |
+| `cancelomc`, `stopomc`                                                         | `cancel`            |
+
+<Note>
+  The `autopilot`, `ralph`, and `ccg` triggers are processed by the `keyword-detector` hook and cannot be changed through `config.jsonc`. The `ultrawork`, `deepsearch`, `deepanalyze`, and `ultrathink` triggers are configurable via the `magicKeywords` field in `config.jsonc`.
+</Note>
+
+
+# HUD
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/utilities/hud
+
+Real-time orchestration metrics in your Claude Code statusline.
+
+The HUD (Heads-Up Display) is a live statusline rendered inside Claude Code that surfaces orchestration state at a glance — active agents, todo progress, context usage, and the current execution mode — without interrupting your workflow.
+
+## Output format
+
+The HUD renders a single line prefixed with `[OMC]`:
+
+```
+[OMC] autopilot:execution | agents:3 | todos:2/5 | ctx:45%
+```
+
+### Field reference
+
+| Field          | Format                | Description                                                                |
+| -------------- | --------------------- | -------------------------------------------------------------------------- |
+| Mode and stage | `autopilot:execution` | The active orchestration mode and its current phase, separated by a colon. |
+| Agents         | `agents:3`            | Number of child agents currently running.                                  |
+| Todos          | `todos:2/5`           | Completed todos out of the total in the active task list.                  |
+| Context        | `ctx:45%`             | Percentage of the context window currently consumed.                       |
+
+## Setup
+
+Run the HUD setup slash command inside Claude Code:
+
+```
+/oh-my-claudecode:hud setup
+```
+
+This registers the HUD hook and writes the initial configuration to `~/.claude/settings.json`.
+
+## Presets
+
+Presets control which elements are displayed and how densely they are packed.
+
+| Preset      | Focus         | What it shows                     |
+| ----------- | ------------- | --------------------------------- |
+| `minimal`   | Clean status  | Context bar only                  |
+| `focused`   | Task progress | Todos, agents, active mode        |
+| `full`      | Everything    | All elements enabled              |
+| `analytics` | Cost tracking | Tokens, costs, efficiency         |
+| `dense`     | Compact all   | All elements in compressed format |
+
+<Tip>
+  The `focused` preset is the recommended starting point. It shows the information most useful during active development without overwhelming the statusline.
+</Tip>
+
+## Configuration
+
+Set your chosen preset in `~/.claude/settings.json`:
+
+```json theme={null}
+{
+  "omcHud": {
+    "preset": "focused"
+  }
+}
+```
+
+For fine-grained control, enable or disable individual elements alongside a preset:
+
+```json theme={null}
+{
+  "omcHud": {
+    "preset": "focused",
+    "elements": {
+      "agents": true,
+      "todos": true,
+      "contextBar": true,
+      "analytics": false
+    }
+  }
+}
+```
+
+### Available elements
+
+| Element      | Description                       |
+| ------------ | --------------------------------- |
+| `agents`     | Active agent count and status     |
+| `todos`      | Todo progress (completed / total) |
+| `ralph`      | Ralph loop iteration count        |
+| `autopilot`  | Autopilot phase indicator         |
+| `contextBar` | Context window usage percentage   |
+| `analytics`  | Token and cost summary            |
+
+## CLI command
+
+Render the current HUD state directly from the terminal:
+
+```bash theme={null}
+omc hud
+```
+
+This prints the same line that would appear in the statusline, which is useful for scripting or quick inspection outside an active Claude Code session.
+
+## Session data
+
+The HUD draws from state files that persist on disk throughout and after a session.
+
+<CardGroup>
+  <Card title="Session summaries" icon="file-lines">
+    Structured JSON summaries written at session end.
+
+    ```
+    .omc/sessions/*.json
+    ```
+  </Card>
+
+  <Card title="Replay logs" icon="clock-rotate-left">
+    Append-only JSONL files recording every agent lifecycle and tool event.
+
+    ```
+    .omc/state/agent-replay-*.jsonl
+    ```
+  </Card>
+</CardGroup>
+
+### Replay log event types
+
+Each line in a replay log is a JSON object. The following event types are recorded:
+
+| Event          | Description                                  |
+| -------------- | -------------------------------------------- |
+| `agent_start`  | Agent spawned with task info and parent mode |
+| `agent_stop`   | Agent completed or failed, with duration     |
+| `tool_start`   | Tool invocation begins                       |
+| `tool_end`     | Tool completes with timing and success flag  |
+| `file_touch`   | File modified by an agent                    |
+| `intervention` | System intervention triggered                |
+
+#### Example replay entries
+
+```jsonl theme={null}
+{"t":0.0,"agent":"a1b2c3d","agent_type":"executor","event":"agent_start","task":"Implement feature","parent_mode":"ultrawork"}
+{"t":5.2,"agent":"a1b2c3d","event":"tool_start","tool":"Read"}
+{"t":5.4,"agent":"a1b2c3d","event":"tool_end","tool":"Read","duration_ms":200,"success":true}
+```
+
+<Note>
+  Replay logs and session summaries are written by the subagent tracker hook. They are available even when the HUD preset is set to `minimal`.
+</Note>
+
+
+# MCP tools
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/utilities/mcp-tools
+
+Internal MCP tools used by oh-my-claudecode agents for state management, code intelligence, and coordination.
+
+oh-my-claudecode registers a set of MCP (Model Context Protocol) servers that expose tools for state management, persistent memory, code intelligence, and inter-agent coordination. These tools are used internally by agents during task execution — you do not invoke them directly.
+
+Run `omc setup` to register all MCP servers. Run `omc doctor` to verify that they are active.
+
+<Note>
+  All tools listed here are available to agents once `omc setup` has been run. Users interact with the higher-level skills and slash commands; agents call these tools under the hood.
+</Note>
+
+## State tools
+
+State tools manage the lifecycle of OMC execution modes (autopilot, ralph, ultrawork, team, and others). Each mode records its current phase, active status, and configuration in a state file.
+
+**Storage path:** `.omc/state/`
+
+```
+.omc/state/
+├── sessions/{sessionId}/
+│   ├── autopilot-state.json
+│   ├── ralph-state.json
+│   └── ultrawork-state.json
+├── autopilot-state.json
+├── ralph-state.json
+└── ultrawork-state.json
+```
+
+<CardGroup>
+  <Card title="state_read" icon="folder-open">
+    Reads the persisted state for a given mode. Returns an empty response if no state file exists.
+
+    ```
+    state_read(mode="ralph")
+    state_read(mode="ralph", session_id="abc123")
+    ```
+  </Card>
+
+  <Card title="state_write" icon="floppy-disk">
+    Saves state for a given mode. Called on mode start, phase transitions, and completion.
+
+    ```
+    state_write(mode="ralph", state={
+      active: true,
+      current_phase: "execution",
+      iteration: 3
+    })
+    ```
+  </Card>
+
+  <Card title="state_clear" icon="trash">
+    Deletes the state file for a given mode. Used during cancel and cleanup flows.
+
+    ```
+    state_clear(mode="ralph")
+    ```
+  </Card>
+
+  <Card title="state_list_active" icon="list">
+    Returns all session IDs and their active modes under `.omc/state/sessions/`.
+
+    ```
+    state_list_active()
+    ```
+  </Card>
+</CardGroup>
+
+## Notepad tools
+
+Notepad is a persistent note system that survives context window compaction. When long sessions push early context out of the window, notepad contents are restored automatically.
+
+**Storage path:** `.omc/notepad.md`
+
+| Tool                     | Purpose                                                                                                                           |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| `notepad_read`           | Reads the full contents of the notepad                                                                                            |
+| `notepad_write_priority` | Saves a note at the highest priority — restored first during compaction. Use for critical constraints and architecture decisions. |
+| `notepad_write_working`  | Saves the current working context. Use for progress tracking and next steps.                                                      |
+| `notepad_prune`          | Cleans up old or unnecessary notes to prevent unbounded growth                                                                    |
+
+## Project memory tools
+
+Project memory stores long-term per-project knowledge that persists across sessions. Agents use it to quickly understand project structure, rules, and learned patterns without re-reading the codebase.
+
+**Storage path:** `.omc/project-memory.json`
+
+| Tool                      | Purpose                                                              |
+| ------------------------- | -------------------------------------------------------------------- |
+| `project_memory_read`     | Reads all stored notes and directives for the project                |
+| `project_memory_write`    | Overwrites project memory entirely — use with caution                |
+| `project_memory_add_note` | Adds a factual note (project structure, patterns, learned knowledge) |
+
+<Tip>
+  Prefer `project_memory_add_note` over `project_memory_write` for incremental updates. `project_memory_write` replaces all existing content.
+</Tip>
+
+## LSP tools
+
+LSP tools provide Language Server Protocol-based code intelligence. A language server must be installed for the target language (e.g. `typescript-language-server`, `pylsp`, `rust-analyzer`).
+
+Run `lsp_servers()` to check which language servers are installed and active.
+
+<CardGroup>
+  <Card title="Diagnostics" icon="triangle-exclamation">
+    **`lsp_diagnostics`** — errors, warnings, and hints for a single file
+
+    **`lsp_diagnostics_directory`** — project-wide diagnostics for a directory
+  </Card>
+
+  <Card title="Symbol navigation" icon="magnifying-glass">
+    **`lsp_document_symbols`** — structural outline of a file (functions, classes, interfaces)
+
+    **`lsp_workspace_symbols`** — search symbols by name across the entire workspace
+  </Card>
+
+  <Card title="Type information" icon="circle-info">
+    **`lsp_hover`** — type information and documentation at a source position
+
+    **`lsp_find_references`** — all usage locations of a symbol
+  </Card>
+
+  <Card title="Refactoring" icon="arrows-rotate">
+    **`lsp_prepare_rename`** — validate whether a rename is safe at a position
+
+    **`lsp_rename`** — rename a symbol across the entire project
+  </Card>
+</CardGroup>
+
+Additional LSP tools: `lsp_goto_definition`, `lsp_code_actions`, `lsp_code_action_resolve`, `lsp_servers`.
+
+Set `OMC_LSP_TIMEOUT_MS` to increase the request timeout for large repositories (default: `15000` ms).
+
+## AST Grep tools
+
+AST Grep tools use [@ast-grep/napi](https://ast-grep.github.io/) to search and transform code at the structural level. Because they operate on the Abstract Syntax Tree rather than raw text, they match code structure precisely regardless of whitespace or formatting.
+
+| Tool               | Purpose                                                                               |
+| ------------------ | ------------------------------------------------------------------------------------- |
+| `ast_grep_search`  | Search code by structural pattern                                                     |
+| `ast_grep_replace` | Transform code by structural pattern. Run with `dryRun=true` first to review changes. |
+
+**Supported languages:** TypeScript, JavaScript, TSX, JSX, Python, Go, Rust, Java, C, C++, C#, Ruby, Swift, Kotlin, and most major languages.
+
+<CodeGroup>
+  ```text ast_grep_search theme={null}
+  ast_grep_search(
+    pattern="console.log($$$ARGS)",
+    lang="typescript"
+  )
+  ```
+
+  ```text ast_grep_replace theme={null}
+  ast_grep_replace(
+    pattern="console.log($$$ARGS)",
+    replacement="logger.info($$$ARGS)",
+    lang="typescript",
+    dryRun=true
+  )
+  ```
+</CodeGroup>
+
+## Trace tools
+
+Trace tools analyze agent flow data for debugging and performance analysis. They read from the replay logs written during session execution.
+
+| Tool             | Output                                                                                                |
+| ---------------- | ----------------------------------------------------------------------------------------------------- |
+| `trace_timeline` | Chronological list of hook events, keyword detections, skill activations, agent turns, and tool calls |
+| `trace_summary`  | Aggregate statistics: turn counts, timing, token usage, tool bottlenecks, and mode transitions        |
+
+## Session search
+
+`session_search` searches previous local session history and returns matching excerpts with session IDs, timestamps, and source paths.
+
+```
+session_search(query="authentication refactor")
+```
+
+## Python REPL
+
+`python_repl` provides a persistent Python execution environment where state (variables, imports, functions) is maintained across calls within a session. Used by the `scientist` agent for data analysis, cost estimation, and file processing.
+
+```python theme={null}
+python_repl(code="import pandas as pd; df = pd.read_csv('data.csv')")
+python_repl(code="print(df.describe())")  # df is still available
+```
+
+## Shared memory tools
+
+Shared memory enables agents to exchange data across team boundaries during coordinated workflows.
+
+| Tool                    | Purpose                         |
+| ----------------------- | ------------------------------- |
+| `shared_memory_write`   | Write a value under a named key |
+| `shared_memory_read`    | Read a value by key             |
+| `shared_memory_list`    | List all active keys            |
+| `shared_memory_delete`  | Remove a specific key           |
+| `shared_memory_cleanup` | Remove all entries              |
+
+## Skills tools
+
+Internal tools used by the runtime to load and list available skills. These are called automatically when a session starts.
+
+| Tool                     | Purpose                                                 |
+| ------------------------ | ------------------------------------------------------- |
+| `load_omc_skills_local`  | Load skills from `.omc/skills/` in the current project  |
+| `load_omc_skills_global` | Load skills from `~/.claude/skills/`                    |
+| `list_omc_skills`        | List all available skills (built-in, local, and global) |
+
+
+# Notifications
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/utilities/notifications
+
+Send stop-callback notifications to Telegram, Discord, or Slack when a Claude Code session completes.
+
+oh-my-claudecode can notify you the moment a session ends. Notifications are delivered via a **stop callback** — a hook that fires when Claude finishes responding — and can tag specific people or channels so the right person knows their task is done.
+
+## Supported providers
+
+<CardGroup>
+  <Card title="Telegram" icon="telegram">
+    Notify a chat or group via a Telegram bot token.
+  </Card>
+
+  <Card title="Discord" icon="discord">
+    Post to a Discord channel via an incoming webhook URL.
+  </Card>
+
+  <Card title="Slack" icon="slack">
+    Post to a Slack channel via an incoming webhook URL.
+  </Card>
+</CardGroup>
+
+## Interactive setup
+
+The fastest way to configure any provider is the interactive wizard:
+
+```
+/oh-my-claudecode:configure-notifications
+```
+
+Follow the prompts to choose a provider and enter your credentials.
+
+## Manual setup
+
+### Telegram
+
+```bash theme={null}
+omc config-stop-callback telegram \
+  --enable \
+  --token <bot_token> \
+  --chat <chat_id> \
+  --tag-list "@alice,bob"
+```
+
+| Flag         | Description                                  |
+| ------------ | -------------------------------------------- |
+| `--token`    | Telegram bot token from @BotFather           |
+| `--chat`     | Target chat ID (user, group, or channel)     |
+| `--tag-list` | Comma-separated list of usernames to mention |
+
+### Discord
+
+```bash theme={null}
+omc config-stop-callback discord \
+  --enable \
+  --webhook <webhook_url> \
+  --tag-list "@here,123456789012345678,role:987654321098765432"
+```
+
+| Flag         | Description                                       |
+| ------------ | ------------------------------------------------- |
+| `--webhook`  | Discord incoming webhook URL                      |
+| `--tag-list` | Comma-separated mentions (see tag behavior below) |
+
+### Slack
+
+```bash theme={null}
+omc config-stop-callback slack \
+  --enable \
+  --webhook <webhook_url> \
+  --tag-list "<!here>,<@U1234567890>"
+```
+
+| Flag         | Description                                       |
+| ------------ | ------------------------------------------------- |
+| `--webhook`  | Slack incoming webhook URL                        |
+| `--tag-list` | Comma-separated mentions (see tag behavior below) |
+
+## Tag behavior
+
+Tags are appended to the notification message to mention individuals or groups. Each provider has its own mention syntax.
+
+<Tabs>
+  <Tab title="Telegram">
+    Tags without a leading `@` are prefixed automatically.
+
+    | Input   | Sent as  |
+    | ------- | -------- |
+    | `alice` | `@alice` |
+    | `@bob`  | `@bob`   |
+
+    Telegram mentions require the recipient to have a public username set.
+  </Tab>
+
+  <Tab title="Discord">
+    Supports special mentions, numeric user IDs, and role references.
+
+    | Format                    | Effect                               |
+    | ------------------------- | ------------------------------------ |
+    | `@here`                   | Notify online members in the channel |
+    | `@everyone`               | Notify all members in the channel    |
+    | `123456789012345678`      | Mention a specific user by ID        |
+    | `role:987654321098765432` | Mention a role by ID                 |
+  </Tab>
+
+  <Tab title="Slack">
+    Uses Slack's mrkdwn mention format.
+
+    | Format                | Effect                            |
+    | --------------------- | --------------------------------- |
+    | `<@U1234567890>`      | Mention a member by user ID       |
+    | `<!channel>`          | Notify all members of the channel |
+    | `<!here>`             | Notify currently active members   |
+    | `<!everyone>`         | Notify all workspace members      |
+    | `<!subteam^GROUP_ID>` | Mention a user group              |
+  </Tab>
+</Tabs>
+
+<Note>
+  `file` callbacks do not support tag options. Tags are silently ignored when using the `file` provider.
+</Note>
+
+## Incremental tag updates
+
+You can add or remove individual tags without rewriting the entire list.
+
+```bash theme={null}
+# Add a single tag
+omc config-stop-callback telegram --add-tag charlie
+
+# Remove a specific tag
+omc config-stop-callback discord --remove-tag @here
+
+# Remove all tags
+omc config-stop-callback discord --clear-tags
+```
+
+These flags work for all three notification providers and can be combined with `--enable` or `--disable` in the same command.
+
+## File callbacks
+
+The `file` provider writes the session summary to a local file instead of sending a network request. Configure it the same way but omit the tag flags:
+
+```bash theme={null}
+omc config-stop-callback file --enable --path /path/to/output.json
+```
+
+<Tip>
+  File callbacks are useful for piping session data into your own tooling or logging pipeline without setting up a messaging integration.
+</Tip>
+
+
+# OpenClaw
+Source: https://www.mintlify.com/yeachan-heo/oh-my-claudecode/utilities/openclaw
+
+Forward Claude Code session events to an OpenClaw gateway to trigger automated workflows.
+
+OpenClaw integration lets oh-my-claudecode forward session events — session start, tool use, user questions, and more — to an OpenClaw gateway. The gateway can then trigger any automation you define: posting to Discord, running a webhook, or waking an external agent.
+
+## Quick setup
+
+Run the notification configuration wizard and choose **openclaw** when prompted:
+
+```
+/oh-my-claudecode:configure-notifications
+```
+
+At the provider prompt, type `openclaw` and select **OpenClaw Gateway**. The wizard writes `~/.claude/omc_config.openclaw.json` for you.
+
+## Manual configuration
+
+Create `~/.claude/omc_config.openclaw.json` with your gateway definition and hook assignments:
+
+```json theme={null}
+{
+  "enabled": true,
+  "gateways": {
+    "my-gateway": {
+      "url": "https://your-gateway.example.com/wake",
+      "headers": { "Authorization": "Bearer YOUR_TOKEN" },
+      "method": "POST",
+      "timeout": 10000
+    }
+  },
+  "hooks": {
+    "session-start": {
+      "gateway": "my-gateway",
+      "instruction": "Session started for {{projectName}}",
+      "enabled": true
+    },
+    "stop": {
+      "gateway": "my-gateway",
+      "instruction": "Session stopping for {{projectName}}",
+      "enabled": true
+    }
+  }
+}
+```
+
+You can define multiple named gateways and assign each hook to a different one.
+
+## Supported hook events
+
+Six hook events are active in the bridge. Each event fires automatically at the corresponding point in the session lifecycle.
+
+<Note>
+  `pre-tool-use` and `post-tool-use` fire on every tool invocation. Enable them only if your gateway can handle high-frequency payloads.
+</Note>
+
+| Event               | Trigger                    | Key template variables                                |
+| ------------------- | -------------------------- | ----------------------------------------------------- |
+| `session-start`     | Session begins             | `{{sessionId}}`, `{{projectName}}`, `{{projectPath}}` |
+| `stop`              | Claude response completes  | `{{sessionId}}`, `{{projectName}}`                    |
+| `keyword-detector`  | Every prompt submission    | `{{prompt}}`, `{{sessionId}}`                         |
+| `ask-user-question` | Claude requests user input | `{{question}}`, `{{sessionId}}`                       |
+| `pre-tool-use`      | Before tool invocation     | `{{toolName}}`, `{{sessionId}}`                       |
+| `post-tool-use`     | After tool invocation      | `{{toolName}}`, `{{sessionId}}`                       |
+
+Template variables are interpolated into the `instruction` string before the payload is sent to the gateway.
+
+## Environment variables
+
+<CardGroup>
+  <Card title="Core variables" icon="gear">
+    | Variable                                   | Description                               |
+    | ------------------------------------------ | ----------------------------------------- |
+    | `OMC_OPENCLAW=1`                           | Enable OpenClaw forwarding                |
+    | `OMC_OPENCLAW_DEBUG=1`                     | Enable debug logging for gateway requests |
+    | `OMC_OPENCLAW_CONFIG=/path/to/config.json` | Override the default config file path     |
+  </Card>
+
+  <Card title="Reply channel variables" icon="reply">
+    Set these when your gateway needs to route responses back to a specific channel.
+
+    | Variable                 | Description                         |
+    | ------------------------ | ----------------------------------- |
+    | `OPENCLAW_REPLY_CHANNEL` | Reply channel type (e.g. `discord`) |
+    | `OPENCLAW_REPLY_TARGET`  | Channel ID                          |
+    | `OPENCLAW_REPLY_THREAD`  | Thread ID                           |
+  </Card>
+</CardGroup>
+
+## Gateway reference implementation
+
+A working demo gateway is included in the repository:
+
+```
+scripts/openclaw-gateway-demo.mjs
+```
+
+The demo gateway listens for incoming OpenClaw payloads and relays them to Discord via ClawdBot. Use it as a starting point for your own gateway implementation.
+
+```bash theme={null}
+node scripts/openclaw-gateway-demo.mjs
+```
+
+<Tip>
+  Set `OMC_OPENCLAW_DEBUG=1` while testing to log every outbound request and response in the terminal, which makes it easier to verify your gateway is receiving events correctly.
+</Tip>
+
+

--- a/docs/research/mintlify-cache/yeachan-heo/oh-my-claudecode/llms.txt
+++ b/docs/research/mintlify-cache/yeachan-heo/oh-my-claudecode/llms.txt
@@ -1,0 +1,38 @@
+# oh-my-claudecode
+
+## Docs
+
+- [Agent catalog](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/agents/catalog.md): All 29 OMC agents with their default model, lane, and role description.
+- [Agents overview](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/agents/overview.md): Specialized AI processes that handle distinct phases of development work. OMC provides 29 agents organized into 4 lanes, each running on the model tier best suited to its task.
+- [Environment variables](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/configuration/environment-variables.md): Environment variables for controlling OMC hooks, model routing, OpenClaw integration, and the omc ask command.
+- [Hooks](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/configuration/hooks.md): How OMC hooks extend Claude Code lifecycle events to inject context, enforce continuation, and manage state.
+- [Model routing](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/configuration/model-routing.md): How OMC assigns AI models to agents by task complexity, and how to override the defaults.
+- [Setup and configuration](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/configuration/setup.md): Configure oh-my-claudecode for a single project or across all Claude Code sessions.
+- [Installation](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/installation.md): Install oh-my-claudecode via the Claude Code plugin marketplace and configure it for your project or globally.
+- [Introduction](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/introduction.md): Multi-agent orchestration for Claude Code. Zero learning curve. Maximum power.
+- [Autopilot](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/modes/autopilot.md): Full autonomous 5-stage pipeline from idea to working, verified code. Triggered by 'autopilot', 'auto pilot', 'full auto', or 'fullsend'.
+- [CCG](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/modes/ccg.md): Claude-Codex-Gemini tri-model advisor synthesis. Routes via /ask codex and /ask gemini in parallel, then Claude synthesizes both outputs into one answer.
+- [Ralph](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/modes/ralph.md): PRD-driven persistence loop that keeps working until every acceptance criterion is verified complete. Triggered by the 'ralph' keyword.
+- [Team mode](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/modes/team.md): The canonical multi-agent surface in OMC. Coordinates N agents through a staged pipeline with built-in task tracking, inter-agent messaging, and dependency management.
+- [Ultrawork](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/modes/ultrawork.md): Maximum parallelism execution engine. Launches multiple agents simultaneously for independent tasks. Triggered by 'ultrawork' or 'ulw'.
+- [Quickstart](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/quickstart.md): Install oh-my-claudecode and run your first orchestrated task in under 5 minutes.
+- [Architecture](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/reference/architecture.md): How oh-my-claudecode orchestrates multi-agent workflows through four interlocking systems: Hooks, Skills, Agents, and State.
+- [CLI commands](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/reference/cli-commands.md): Complete reference for all omc CLI commands, flags, and usage examples.
+- [Magic keywords](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/reference/magic-keywords.md): Natural-language trigger phrases that activate OMC orchestration modes inline, without running a slash command.
+- [Migration](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/reference/migration.md): Upgrade guides for oh-my-claudecode, covering breaking changes, renamed commands, removed providers, and step-by-step migration paths across versions.
+- [Performance monitoring](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/reference/performance-monitoring.md): Monitor agent performance, token usage, costs, and bottlenecks in multi-agent workflows using the Agent Observatory, session replays, and HUD integration.
+- [Slash commands](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/reference/slash-commands.md): Complete reference for all /oh-my-claudecode: slash commands available after installing the OMC plugin.
+- [Troubleshooting](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/reference/troubleshooting.md): Solutions for common oh-my-claudecode issues including hook failures, team configuration, rate limits, platform compatibility, and context window management.
+- [Custom skills](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/skills/custom-skills.md): Create project-specific or personal skill files that auto-inject when relevant context is detected.
+- [Skills overview](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/skills/overview.md): Behavior injections that modify how the orchestrator operates. Skills add capabilities on top of existing agents without swapping the underlying model.
+- [HUD](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/utilities/hud.md): Real-time orchestration metrics in your Claude Code statusline.
+- [MCP tools](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/utilities/mcp-tools.md): Internal MCP tools used by oh-my-claudecode agents for state management, code intelligence, and coordination.
+- [Notifications](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/utilities/notifications.md): Send stop-callback notifications to Telegram, Discord, or Slack when a Claude Code session completes.
+- [OpenClaw](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/utilities/openclaw.md): Forward Claude Code session events to an OpenClaw gateway to trigger automated workflows.
+
+## OpenAPI Specs
+
+- [openapi](https://www.mintlify.com/yeachan-heo/oh-my-claudecode/api-reference/openapi.json)
+
+
+Built with [Mintlify](https://mintlify.com).

--- a/docs/research/mintlify-catalog.md
+++ b/docs/research/mintlify-catalog.md
@@ -1,16 +1,30 @@
 # Mintlify Catalog — Probed Sites + Request Queue
 
+> 💾 **Local cache available at `docs/research/mintlify-cache/`.**
+> As of 2026-04-07, every repo in the verified table below has both
+> `llms.txt` AND `llms-full.txt` downloaded into
+> `docs/research/mintlify-cache/<owner>/<repo>/`. **Prefer the cached
+> files over `curl` round-trips** — zero latency, greppable across
+> the whole cache with `grep -rHi <topic> docs/research/mintlify-cache/`.
+> See `docs/research/mintlify-cache/README.md` for per-repo line
+> counts, sha256s, and refresh protocol.
+>
 > ⚠️ **Read `docs/research/mintlify-catalog-validation-log.md` first.**
 > A full end-to-end validation run (2026-04-07) found that the `mcp`
 > column below (`307` for every row) is **misleading**: the redirect
 > does resolve `200`, but that URL serves only a JSON descriptor, not
-> a live MCP protocol endpoint. The real per-repo MCP servers are
-> **auth-gated** and cannot be reached via `mcp2cli` without
-> credentials. The only `mcp2cli`-against-mintlify path that actually
-> works is the central MCP at `https://mintlify.com/docs/mcp`. The
-> validation log has the per-site probe evidence, nanosecond
-> timestamps, content sha256s, and the full follow-up list (skill +
-> rule corrections needed).
+> a live MCP protocol endpoint. Per-repo `/mcp` URLs are GET-only
+> preview endpoints — `POST` (which `mcp2cli` sends to speak MCP
+> protocol) returns `404 Not found`. An earlier revision of this
+> banner claimed the cause was auth-gating; that was an over-read
+> of Mintlify's authentication docs. The real cause is that the
+> per-repo `/mcp` URLs have no live MCP server behind them; only
+> the customer's own documentation domain hosts a live one (e.g.,
+> `resend.com/docs/mcp`, `docs.anthropic.com/mcp`), and none of the
+> 16 catalog repos do. Even the central MCP at
+> `https://mintlify.com/docs/mcp` is scope-limited to Mintlify's
+> own platform docs, not customer sites. See the validation log
+> for per-site probe evidence.
 
 Single source of truth for **which repos have mintlify-hosted docs with
 working AI-optimized endpoints**, used by `.claude/skills/mintlify/` and
@@ -26,9 +40,17 @@ and probe on the next research-tooling commit.
 |---|---|
 | `owner/repo` | GitHub `owner/repo` coordinate. |
 | `llms.txt` | HTTP status from `curl https://www.mintlify.com/<owner>/<repo>/llms.txt`. `200` means the llms.txt index is reachable and usable (this is the preferred access path per `.claude/rules/research-doc-sources.md`). |
-| `mcp` | HTTP status from `curl -A "Mozilla/5.0" https://mintlify.com/<owner>/<repo>/mcp`. **This column reports only the descriptor URL's HTTP status, NOT protocol reachability.** A `307` entry means "redirects to `https://www.mintlify.com/<owner>/<repo>/mcp` and resolves 200 after `-L`"; the response body is a JSON MCP *descriptor* listing declared tools. **The live MCP protocol endpoint behind that descriptor is auth-gated** and returns 404 to unauthenticated `mcp2cli` calls — see the validation log for full evidence. Use the **central** Mintlify MCP at `https://mintlify.com/docs/mcp` for actual queries. |
+| `mcp` | HTTP status from `curl -A "Mozilla/5.0" https://mintlify.com/<owner>/<repo>/mcp`. **This column reports only the descriptor URL's HTTP status, NOT protocol reachability.** A `307` entry means "redirects to `https://www.mintlify.com/<owner>/<repo>/mcp` and resolves 200 after `-L`"; the response body is a JSON MCP *descriptor* listing declared tools. **The per-repo URL has no live MCP server behind it** — `POST` (the method `mcp2cli` uses to speak MCP protocol) returns `404 Not found`. See the validation log for full evidence. Do not use `mcp2cli` against per-repo mintlify URLs. |
 | `verified` | Date of most recent probe (`YYYY-MM-DD`). |
 | `status` | `ok` / `llms-only` / `broken` / `queued`. In this catalog, `ok` means "llms.txt + descriptor JSON both return 200". It does **not** mean "MCP protocol endpoint is reachable" — that would be `ok-mcp`, which currently applies only to the central Mintlify MCP. |
+
+## Local cache
+
+Every verified row below has both `llms.txt` and `llms-full.txt`
+cached under `docs/research/mintlify-cache/<owner>/<repo>/`. The
+cached paths are the preferred access method; upstream `curl`
+invocations are only needed for per-page `.md` fetches (not cached)
+and for refreshing the cache.
 
 ## Verified sites
 


### PR DESCRIPTION
## Summary

Downloads every catalog repo's `llms.txt` AND `llms-full.txt` into `docs/research/mintlify-cache/<owner>/<repo>/` so future sessions can `grep` locally instead of running `curl`. All 16 repos in the verified catalog cached.

## Why

`llms-full.txt` — a previously-undocumented mintlify endpoint discovered during the Session-K precursor probe — inlines the full content of every page (e.g., jdx/mise is 5,436 lines) and is a much better grep target than `llms.txt` alone. Caching avoids network round-trips and gives zero-latency cross-site grep via `grep -rHi <topic> docs/research/mintlify-cache/`.

## Also fixes

- **Catalog banner auth-gating claim corrected.** The old text said per-repo MCP was "auth-gated" — that was an over-read of Mintlify's auth docs. The real reason is the per-repo `/mcp` URL has no live MCP server behind it (`POST` returns 404). An API key does not and cannot help (keys are org-scoped).
- **Catalog "How to use" section** rewritten as cache-first.
- **`.claude/skills/mintlify/SKILL.md`** rewritten as cache-first with `llms-full.txt` worked example.

## Secret scanner false positives (handled)

GitHub push protection initially rejected the push: the cached mintlify docs contain example API key placeholders (`sk_live_xxx...`, `ghp_xxx...`, `AKIA...EXAMPLE`, `glpat-xxx...`, `sk-xxx...`) in chezmoi/fnox/mise/devcontainers-cli vault/secret-management example sections. All redacted to `[REDACTED-<SERVICE>-DOCS-EXAMPLE]` form that preserves context but breaks the scanner's regex prefix match. Re-scanned: clean.

## Test plan

- [x] `HK_PKL_BACKEND=pkl hk run pre-commit --stash none` → exit 0 (39 files)
- [x] Secret-pattern re-scan after redaction: clean
- [x] All 16 repos have both `llms.txt` + `llms-full.txt` (cache README table verifies)
- [ ] CI lint/contract-preflight/build all green
- [ ] merge with `--squash --delete-branch`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established local documentation cache for instant offline reference access without network latency.
  * Optimized documentation lookup workflow to prioritize cached content over online fetches.
  * Expanded documentation coverage with indexed reference materials for multiple supported projects and tools.
  * Added comprehensive documentation indexes including summary and full-content references for enhanced search capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->