### PR TITLE
fix(base-image): set MISE_DATA_DIR to match cookbook canonical layout

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,11 +14,19 @@ ARG MISE_VERSION
 # .devcontainer/mise-system.toml [env] so mise owns them.
 #
 # Cookbook canonical layout per https://mise.jdx.dev/mise-cookbook/docker:
-#   - System tools baked at /usr/local/share/mise/installs (via MISE_INSTALL_MODE=system).
-#   - User installs land at ~/.local/share/mise/installs at runtime and
-#     shadow system tools per cookbook semantics.
-#   - MISE_DATA_DIR is left UNSET so mise uses XDG defaults per user.
-ENV MISE_INSTALL_PATH=/usr/local/bin/mise \
+#   - MISE_DATA_DIR pins all installs/shims/cache to one system path
+#     (the cookbook's `/mise`, our `/usr/local/share/mise`). Without this,
+#     build-time `mise install` (running as root) writes shims to
+#     /root/.local/share/mise/shims per XDG defaults — invisible to
+#     non-root users and to PATH. The cookbook explicitly sets this var
+#     and so must we.
+#   - System tools baked at /usr/local/share/mise/installs.
+#   - PR-2 will layer per-user overlays via named volumes at
+#     ~/.local/share/mise (devcontainer feature mount), so the system
+#     path remains the canonical baked location while users get mutable
+#     overlays at runtime.
+ENV MISE_DATA_DIR=/usr/local/share/mise \
+    MISE_INSTALL_PATH=/usr/local/bin/mise \
     MISE_TRUSTED_CONFIG_PATHS=/usr/local/share/mise:/workspaces/dotfiles \
     CARGO_HOME=/opt/cargo \
     RUSTUP_HOME=/opt/rustup \


### PR DESCRIPTION
## Summary

Hotfix for the smoke-test regression introduced by PR #58 (cookbook refactor).

PR #58 removed `MISE_DATA_DIR` on the assumption that `MISE_INSTALL_MODE=system` would land tool shims at `/usr/local/share/mise/shims` (where PATH points). That assumption was wrong: `MISE_INSTALL_MODE` controls where mise reads system **config** from, NOT where it writes installs/shims/cache. Without `MISE_DATA_DIR`, build-time \`mise install\` (running as root) writes shims to `/root/.local/share/mise/shims` per XDG defaults — invisible to non-root users and to the PATH that points at `/usr/local/share/mise/shims`.

The smoke-test job on the post-merge `main` CI run caught this immediately:

\`\`\`
Smoke test FAILED:
=== hk validate ===
bash: command not found: hk
\`\`\`

(CI run [24069595408](https://github.com/ray-manaloto/dotfiles/actions/runs/24069595408))

## Fix

Restore `MISE_DATA_DIR=/usr/local/share/mise` to ENV. This matches the canonical [mise docker cookbook](https://mise.jdx.dev/mise-cookbook/docker) 1:1 — the cookbook example explicitly sets `ENV MISE_DATA_DIR="/mise"` for the same reason. PR-2 will layer per-user mutable overlays via named volumes mounted at `~/.local/share/mise` (per the cookbook's "Devcontainers with home directory mounts" variant), so the system path remains the canonical baked location.

The removed comment claimed *"MISE_DATA_DIR is left UNSET so mise uses XDG defaults per user,"* but that reasoning conflated build-time-as-root with runtime-as-user; those have different identity and HOME, so a single ENV cannot serve both.

## Test plan

- [x] `HK_PKL_BACKEND=pkl hk run pre-commit --all --stash none` → 0 (locally)
- [x] `uv run --project python pytest tests/ -x -q` → 65 passed (pre-push hook)
- [ ] CI lint + contract-preflight + build → green
- [ ] Post-merge: CI smoke-test on \`main\` validates `hk validate` + `mise ls` end-to-end against the republished `:dev`

## Refs

- PR #58 — refactor that introduced the regression
- [mise cookbook docker](https://mise.jdx.dev/mise-cookbook/docker) — canonical ENV block
- CI run [24069595408](https://github.com/ray-manaloto/dotfiles/actions/runs/24069595408) — failure that caught it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development container environment configuration to ensure consistent handling of tool installations and configurations across different user contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->