### PR TITLE
fix(base-image): set MISE_CONFIG_DIR so mise discovers system config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,18 +14,24 @@ ARG MISE_VERSION
 # .devcontainer/mise-system.toml [env] so mise owns them.
 #
 # Cookbook canonical layout per https://mise.jdx.dev/mise-cookbook/docker:
-#   - MISE_DATA_DIR pins all installs/shims/cache to one system path
-#     (the cookbook's `/mise`, our `/usr/local/share/mise`). Without this,
-#     build-time `mise install` (running as root) writes shims to
-#     /root/.local/share/mise/shims per XDG defaults — invisible to
-#     non-root users and to PATH. The cookbook explicitly sets this var
+#   - MISE_DATA_DIR pins installs/shims to /usr/local/share/mise. Without
+#     it, build-time `mise install` (as root) writes to XDG default
+#     /root/.local/share/mise — invisible to PATH and to non-root users.
+#   - MISE_CONFIG_DIR tells mise WHERE to discover the system config
+#     (mise reads $MISE_CONFIG_DIR/config.toml). Without it, mise has
+#     no idea our COPY destination /usr/local/share/mise/config.toml is
+#     a config — `mise install -y` silently no-ops because it discovers
+#     zero configs. (MISE_TRUSTED_CONFIG_PATHS only AUTHORIZES a path,
+#     it does not DISCOVER configs there. Trust + discovery are
+#     orthogonal — both are required.)
+#   - The cookbook explicitly sets BOTH vars to the same path (`/mise`)
 #     and so must we.
-#   - System tools baked at /usr/local/share/mise/installs.
 #   - PR-2 will layer per-user overlays via named volumes at
 #     ~/.local/share/mise (devcontainer feature mount), so the system
 #     path remains the canonical baked location while users get mutable
 #     overlays at runtime.
 ENV MISE_DATA_DIR=/usr/local/share/mise \
+    MISE_CONFIG_DIR=/usr/local/share/mise \
     MISE_INSTALL_PATH=/usr/local/bin/mise \
     MISE_TRUSTED_CONFIG_PATHS=/usr/local/share/mise:/workspaces/dotfiles \
     CARGO_HOME=/opt/cargo \


### PR DESCRIPTION
## Summary

Second hotfix for the cookbook refactor regression. PR #59 restored `MISE_DATA_DIR` but the smoke-test still failed with `bash: command not found: hk` because mise was discovering **zero** configs and silently installing **zero** tools.

## Evidence

Live image inspection of `ghcr.io/ray-manaloto/dotfiles-devcontainer:7a74920`:

\`\`\`
$ docker run --rm <image> bash -lc 'ls /usr/local/share/mise/shims; mise trust --show; mise config'
(shims dir is empty)
mise No trusted config files found.
(empty)
\`\`\`

`/usr/local/share/mise/installs` does not exist either. `mise install -y` returned exit 0 because with zero discovered configs there is nothing to install — silent no-op.

## Root cause

PR #58's cookbook refactor renamed the config COPY destination to `/usr/local/share/mise/config.toml` but removed `MISE_CONFIG_DIR`. mise has no idea to read that path without `MISE_CONFIG_DIR` pointing at it.

`MISE_TRUSTED_CONFIG_PATHS` only **authorizes** a path; it does not **discover** configs there. Trust and discovery are orthogonal — both env vars are required, and the [mise docker cookbook](https://mise.jdx.dev/mise-cookbook/docker) explicitly sets BOTH:

\`\`\`dockerfile
ENV MISE_DATA_DIR="/mise"
ENV MISE_CONFIG_DIR="/mise"
\`\`\`

## Fix

Add `MISE_CONFIG_DIR=/usr/local/share/mise` to ENV. Combined with the prior `MISE_DATA_DIR` fix, the image now matches the cookbook canonical pattern 1:1.

The ENV-block comment is also expanded to document the trust-vs-discovery distinction so this regression cannot recur on a future cookbook revision.

## Test plan

- [x] `HK_PKL_BACKEND=pkl hk run pre-commit --all --stash none` → 0
- [x] `uv run --project python pytest tests/ -x -q` → 65 passed (pre-push)
- [ ] CI lint + contract-preflight + build → green
- [ ] **Post-merge: CI smoke-test on main validates `hk validate` + `mise ls` end-to-end** ← this is the real verdict
- [ ] Local: \`docker pull <new :dev>\` and confirm \`mise ls\` lists tools, \`/usr/local/share/mise/shims\` is non-empty

## Follow-up (deferred)

Add a build-time self-check inside the `mise install` RUN block:

\`\`\`bash
mise install -y && \\
test "$(mise ls --installed 2>/dev/null | wc -l)" -gt 0 || \\
  { echo "ERROR: mise installed zero tools — config not discovered"; exit 1; }
\`\`\`

This would have caught both PR #58's silent no-op and the gap between PR #59's partial fix and this PR. Filing as a follow-up issue rather than expanding scope here.

## Refs

- PR #58 — original refactor that introduced the regression
- PR #59 — first hotfix (partial — `MISE_DATA_DIR` only)
- [CI run 24070242956](https://github.com/ray-manaloto/dotfiles/actions/runs/24070242956) — second smoke-test failure
- [mise cookbook docker](https://mise.jdx.dev/mise-cookbook/docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)