### PR TITLE
fix(smoke-test): update bash path assertions to cookbook paths

### DIFF
--- a/python/src/dotfiles_setup/image.py
+++ b/python/src/dotfiles_setup/image.py
@@ -38,7 +38,7 @@ def build_smoke_script() -> str:
     """Build the inline smoke test script."""
     return """\
 set -euo pipefail
-MISE_CFG="${MISE_CONFIG_DIR:-/etc/mise}/config.toml"
+MISE_CFG="${MISE_CONFIG_DIR:-/usr/local/share/mise}/config.toml"
 echo "=== hk validate ==="
 HK_FILE=/etc/hk/hk.pkl hk validate
 echo "=== mise ls (check no missing — system config only) ==="
@@ -69,8 +69,8 @@ echo "=== path constraints ==="
 if [ ! -x /usr/local/bin/mise ]; then
   echo "FAIL: /usr/local/bin/mise missing"; exit 1
 fi
-if [ ! -d /opt/mise/installs ]; then
-  echo "FAIL: /opt/mise/installs missing"; exit 1
+if [ ! -d /usr/local/share/mise/installs ]; then
+  echo "FAIL: /usr/local/share/mise/installs missing"; exit 1
 fi
 echo "=== backend policy checks ==="
 grep -q 'npm.package_manager = "bun"' "$MISE_CFG" || {


### PR DESCRIPTION
## Summary

Third (and final) hotfix for PR #58's incomplete cookbook refactor. PRs #59 and #60 restored the **build** to a working state — `:dev` now has tools at `/usr/local/share/mise/installs` and shims at `/usr/local/share/mise/shims`. The smoke test now correctly passes \`hk validate\`, \`mise ls\`, and shell-integration stages, then fails at:

\`\`\`
=== path constraints ===
FAIL: /opt/mise/installs missing
\`\`\`

The smoke-test bash heredoc in \`build_smoke_script\` still asserts the **pre-cookbook** path. Heredoc literals never went through the Pydantic config layer that would have surfaced them in tests.

## Fix

Two stale literals in \`python/src/dotfiles_setup/image.py\`:

1. **Line 41**: \`MISE_CFG\` fallback `${MISE_CONFIG_DIR:-/etc/mise}` → `${MISE_CONFIG_DIR:-/usr/local/share/mise}`. Dead code at runtime (image now sets `MISE_CONFIG_DIR` via PR #60), but stale.
2. **Line 72-73**: `[ ! -d /opt/mise/installs ]` → `[ ! -d /usr/local/share/mise/installs ]`. **This is the line that fails CI today.**

## No image rebuild needed

Smoke test code is built from source on the runner each run (\`uv run --directory python dotfiles-setup image smoke ...\`), NOT baked into `:dev`. So this fix needs **no image rebuild** — the next CI run will smoke-test the existing `e0dc52e` `:dev` image and pass. Saves ~16min of build time.

## Test plan

- [x] `HK_PKL_BACKEND=pkl hk run pre-commit --all --stash none` → 0
- [x] `uv run --project python pytest tests/ -x -q` → 65 passed
- [ ] CI lint + contract-preflight + build → green
- [ ] **Post-merge: CI smoke-test on main passes against existing e0dc52e :dev** ← real verdict

## Deferred (filing as GH issue)

A follow-up cleanup PR should update the dead-code stale defaults that didn't break anything because both sides rotted in lockstep:

- `python/src/dotfiles_setup/config.py:21-22` — \`MiseConfig\` defaults still point at `/etc/mise` + `/opt/mise`. Dead in the runtime image (Pydantic reads `MISE_*` env vars first), but stale.
- `tests/test_config.py:56-64` — asserts the same stale defaults. Both files agree, so tests pass — perfect rot symmetry.
- `python/verification/suites.toml:440` — comment string only.

## Refs

- PR #58 — original incomplete cookbook refactor
- PR #59 — `MISE_DATA_DIR` hotfix
- PR #60 — `MISE_CONFIG_DIR` hotfix
- [CI run 24071090409](https://github.com/ray-manaloto/dotfiles/actions/runs/24071090409) — smoke-test failure with `/opt/mise/installs missing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MISE configuration and installation directory paths used during system validation to reflect new default filesystem locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->