### PR TITLE
fix(config): delete dead /etc/mise + /opt/mise defaults (closes #62)

### DIFF
--- a/python/src/dotfiles_setup/config.py
+++ b/python/src/dotfiles_setup/config.py
@@ -18,8 +18,6 @@ class MiseConfig(BaseSettings):
 
     model_config = SettingsConfigDict(env_prefix="MISE_")
 
-    config_dir: Path = Path("/etc/mise")
-    data_dir: Path = Path("/opt/mise")
     install_path: Path = Path("/usr/local/bin/mise")
     strict: bool = False
     shell: str | None = None

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -439,7 +439,7 @@ tokens = ["\"updateRemoteUserUID\": false"]
 
 [[suite]]
 name = "arch.no-mise-home-volume"
-description = "No mise-home volume mount (mise is image-baked at /opt/mise)"
+description = "No mise-home volume mount (mise is image-baked at /usr/local/share/mise)"
 category = "architecture"
 check_type = "static"
 handler = "forbid_tokens"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -53,16 +53,6 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
 class TestMiseConfigDefaults:
     """Verify MiseConfig default values match the previous hardcoded constants."""
 
-    def test_config_dir(self) -> None:
-        """Verify default config_dir is /etc/mise."""
-        cfg = MiseConfig()
-        assert cfg.config_dir == Path("/etc/mise")
-
-    def test_data_dir(self) -> None:
-        """Verify default data_dir is /opt/mise."""
-        cfg = MiseConfig()
-        assert cfg.data_dir == Path("/opt/mise")
-
     def test_install_path(self) -> None:
         """Verify default install_path is /usr/local/bin/mise."""
         cfg = MiseConfig()


### PR DESCRIPTION
## Summary

- Delete `MiseConfig.config_dir` and `data_dir` fields — dead code with zero call sites, left behind by PR #58's cookbook refactor.
- Delete the matching `test_config_dir` / `test_data_dir` assertions that perfectly mirrored the stale literals (the Pydantic Settings rot-symmetry trap from issue #62).
- Fix the `suites.toml` comment that still referenced `/opt/mise`.

This is **Option C** from #62: rather than updating the literals to `/usr/local/share/mise`, delete the fields entirely. Python never consumed them — the Dockerfile sets `MISE_CONFIG_DIR` / `MISE_DATA_DIR` for mise itself, not for Python. Removing the fields eliminates the rot-symmetry trap for the next refactor.

Closes #62.

## Test plan

- [x] \`uv run --project python pytest tests/ -x -q\` — 63 passed (was 65, minus the 2 deleted)
- [x] \`hk run pre-commit --all --stash none\` — all checks green
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated mise configuration path management by removing hardcoded default directories. Configuration path resolution mechanisms have been refactored to improve system flexibility and maintainability. Default path handling now uses alternative resolution approaches, enhancing configuration management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->