### PR TITLE
fix(devcontainer): build-time self-checks for mise install + reshim (closes #63)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -113,7 +113,7 @@ RUN --mount=type=cache,id=mise-cache,target=/usr/local/share/mise/cache,sharing=
       export MISE_GITHUB_TOKEN="$GITHUB_TOKEN"; \
     fi && \
     mise install -y && \
-    test "$(mise ls --installed 2>/dev/null | wc -l)" -gt 0 || { echo "ERROR: mise installed zero tools — system config not discovered (check MISE_CONFIG_DIR points at /usr/local/share/mise containing config.toml)"; exit 1; } && \
+    test "$(mise ls --installed | wc -l)" -gt 0 || { echo "ERROR: mise installed zero tools — system config not discovered (check MISE_CONFIG_DIR points at /usr/local/share/mise containing config.toml)"; exit 1; } && \
     test -d /usr/local/share/cargo/bin || { echo "ERROR: MISE_CARGO_HOME not honored — /usr/local/share/cargo/bin missing after mise install (rust cookbook regression)"; exit 1; } && \
     test -d /usr/local/share/rustup/toolchains || { echo "ERROR: MISE_RUSTUP_HOME not honored — /usr/local/share/rustup/toolchains missing after mise install (rust cookbook regression)"; exit 1; } && \
     chmod -R 777 /usr/local/share/mise /usr/local/share/cargo /usr/local/share/rustup
@@ -122,7 +122,7 @@ RUN --mount=type=cache,id=mise-cache,target=/usr/local/share/mise/cache,sharing=
 # shims like LICENSE, README — these are harmless and must not be deleted
 # or mise doctor will report them as missing)
 RUN mise reshim -f && \
-    test -n "$(find /usr/local/share/mise/shims -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" || { echo "ERROR: /usr/local/share/mise/shims empty after reshim — mise has no installed tools to shim"; exit 1; }
+    test -n "$(find /usr/local/share/mise/shims -mindepth 1 -maxdepth 1 -print -quit)" || { echo "ERROR: /usr/local/share/mise/shims empty after reshim — mise has no installed tools to shim"; exit 1; }
 
 # Final global permissions check
 RUN chmod -R 777 /usr/local/share/mise /usr/local/share/cargo /usr/local/share/rustup


### PR DESCRIPTION
## Summary

- After \`mise install -y\`: assert \`mise ls --installed\` reports >0 tools — catches the PR #58 silent zero-install regression class at build time.
- After \`mise reshim -f\`: assert \`/usr/local/share/mise/shims\` is non-empty. Uses \`find -mindepth 1 -maxdepth 1 -print -quit\` (hadolint SC2012-clean).
- Extends PR-2 commit F's prospective rust-cookbook assertions (validated empirically — see \`feedback_build_time_self_check.md\`) to the two general silent-failure points the rule's "How to apply" calls out.

Closes #63.

## Test plan

- [x] \`hadolint .devcontainer/Dockerfile\` — clean
- [x] \`hk run pre-commit --all --stash none\` — all checks green
- [ ] CI build job exercises both assertions (the only place this can be validated per \`feedback_base_image_ci_only.md\`)
- [ ] Smoke-test job remains green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development environment build validation with improved error detection to ensure proper tool installation and configuration during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->