### PR TITLE
fix(devcontainer): lifecycle audit — silent failures + raw docker pull cleanup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -77,6 +77,7 @@
     "dotfiles-${localWorkspaceFolderBasename}-${localEnv:USER}-${localEnv:DEVCONTAINER_WORKSPACE_HASH}-${localEnv:DEVCONTAINER_SSH_PORT}",
     "--env-file",
     "${localEnv:HOME}/.local/state/dotfiles/doppler.env",
+    "--platform=linux/amd64/v2",
   ],
   "remoteUser": "${localEnv:USER}",
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
@@ -107,9 +108,9 @@
   "forwardPorts": [2222],
   "updateRemoteUserUID": false,
   "init": true,
-  "initializeCommand": "mkdir -p ~/.local/state/dotfiles && doppler secrets download --format docker --no-file --project \"$DOPPLER_PROJECT\" --config \"$DOPPLER_CONFIG\" > ~/.local/state/dotfiles/doppler.env && uv run --project python dotfiles-setup docker initialize-host",
+  "initializeCommand": "mkdir -p ~/.local/state/dotfiles && doppler secrets download --format docker --no-file --project \"${DOPPLER_PROJECT:-dotfiles}\" --config \"${DOPPLER_CONFIG:-dev}\" > ~/.local/state/dotfiles/doppler.env && [ -s ~/.local/state/dotfiles/doppler.env ] && uv run --project python dotfiles-setup docker initialize-host",
   "onCreateCommand": "bash /workspaces/${localWorkspaceFolderBasename}/.devcontainer/scripts/on-create.sh /workspaces/${localWorkspaceFolderBasename}",
-  "postCreateCommand": "sudo chown ${localEnv:USER}:${localEnv:USER} /run/host-services/ssh-auth.sock && install -d -m 700 ~/.ssh && install -m 600 /tmp/dotfiles-host-state/authorized_keys ~/.ssh/authorized_keys && ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> ~/.ssh/known_hosts 2>/dev/null && chmod 600 ~/.ssh/known_hosts && scripts/devcontainer-smoke.sh",
+  "postCreateCommand": "sudo chown ${localEnv:USER}:${localEnv:USER} /run/host-services/ssh-auth.sock && install -d -m 700 ~/.ssh && install -m 600 /tmp/dotfiles-host-state/authorized_keys ~/.ssh/authorized_keys && ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> ~/.ssh/known_hosts && [ -s ~/.ssh/known_hosts ] && chmod 600 ~/.ssh/known_hosts && scripts/devcontainer-smoke.sh",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/mise.toml
+++ b/mise.toml
@@ -82,7 +82,7 @@ HK_MISE = "1"
 dcu     = "mise run up"
 dcd     = "mise run down"
 dcdev   = "mise run dev"
-dcpull  = "mise run pull"
+dcrb    = "mise run dev-rebuild"
 dcsh    = "mise run sh"
 dcps    = "mise run ps"
 dcsmoke = "mise run smoke"
@@ -130,46 +130,45 @@ description = "Bring the devcontainer up via the official @devcontainers/cli (Ma
 # socket proxy pattern spawned from initializeCommand/postStartCommand.
 # Research: .omc/research/research-20260407-ssh-devcontainer/report.md.
 #
-# --pull flag (default true) implements "pull only if missing": first run
-# pulls the base image, subsequent restarts reuse the local copy. Force a
-# fresh pull with `mise run pull` or `mise run up --no-pull=false` after
-# CI republishes :dev. Bypass entirely with `mise run up --no-pull`.
-env = { BASE_IMAGE = "ghcr.io/ray-manaloto/dotfiles-devcontainer:dev", DOCKER_DEFAULT_PLATFORM = "linux/amd64", DEVCONTAINER_SSH_PORT = "4444", DOPPLER_PROJECT = "dotfiles", DOPPLER_CONFIG = "dev" }
-usage = '''
-flag "--pull" default=#true help="Pull :dev if the image is missing locally (default: true)"
-'''
+# Image pull: handled inside `devcontainer up` via buildx (the
+# Dockerfile.host-user `FROM ${BASE_IMAGE}` triggers a registry pull
+# when the base layer is missing). DO NOT add a standalone `docker
+# pull` here — it bypasses the devcontainer-cli lifecycle (no
+# initializeCommand etc.) and recreates the silent-failure surface
+# from PR #86. To force-refresh, use `mise run dev-rebuild`.
+env = { BASE_IMAGE = "ghcr.io/ray-manaloto/dotfiles-devcontainer:dev", DOCKER_DEFAULT_PLATFORM = "linux/amd64/v2", DEVCONTAINER_SSH_PORT = "4444", DOPPLER_PROJECT = "dotfiles", DOPPLER_CONFIG = "dev" }
 run = '''
-if [[ "${usage_pull:-true}" == "true" ]]; then
-  if ! docker image inspect "$BASE_IMAGE" >/dev/null 2>&1; then
-    echo "==> base image $BASE_IMAGE not present locally — pulling"
-    docker pull "$BASE_IMAGE"
-  fi
-fi
+set -euo pipefail
 # v6 collision guard: compute an 8-char hash of $PWD so sibling clones
 # of `dotfiles` on the same host get distinct Docker volume + container
 # names. Exported so devcontainer.json ${localEnv:DEVCONTAINER_WORKSPACE_HASH}
-# substitution picks it up. Portable hash detection: sha256sum is Linux
-# default, shasum is macOS default — try both.
-if command -v sha256sum >/dev/null 2>&1; then
-  DEVCONTAINER_WORKSPACE_HASH="$(printf '%s' "$PWD" | sha256sum | cut -c1-8)"
-elif command -v shasum >/dev/null 2>&1; then
-  DEVCONTAINER_WORKSPACE_HASH="$(printf '%s' "$PWD" | shasum -a 256 | cut -c1-8)"
-else
-  echo "ERROR: neither sha256sum nor shasum found — cannot compute workspace hash" >&2
-  exit 1
-fi
+# substitution picks it up. Single source of truth at scripts/workspace-hash.sh.
+DEVCONTAINER_WORKSPACE_HASH="$(scripts/workspace-hash.sh)"
 export DEVCONTAINER_WORKSPACE_HASH
 # Clear stale host keys for the devcontainer SSH port — each container
 # recreate generates new host keys, causing "REMOTE HOST IDENTIFICATION
-# HAS CHANGED" warnings. ssh-keygen -R removes the old entry.
+# HAS CHANGED" warnings. ssh-keygen -R removes the old entry. The
+# `|| true` is acceptable here: keygen exits 1 when the entry doesn't
+# exist (first run on a fresh host), which is the normal case.
 ssh-keygen -R "[localhost]:${DEVCONTAINER_SSH_PORT}" 2>/dev/null || true
 devcontainer up --workspace-folder .
 '''
 
-[tasks.pull]
-description = "Force-pull the latest :dev base image from ghcr"
-env = { BASE_IMAGE = "ghcr.io/ray-manaloto/dotfiles-devcontainer:dev", DOCKER_DEFAULT_PLATFORM = "linux/amd64" }
-run = 'docker pull "$BASE_IMAGE"'
+[tasks.dev-rebuild]
+description = "Force a full rebuild + re-pull of :dev (lifecycle hooks fire)"
+# Equivalent to a force-refresh. `--remove-existing-container` ensures
+# `devcontainer up` recreates the container (which re-fetches the base
+# layer if the registry has a new digest), and `--build-no-cache` rebuilds
+# the host-user overlay without cached layers. Lifecycle hooks
+# (initializeCommand → onCreateCommand → postCreateCommand) all fire.
+env = { BASE_IMAGE = "ghcr.io/ray-manaloto/dotfiles-devcontainer:dev", DOCKER_DEFAULT_PLATFORM = "linux/amd64/v2", DEVCONTAINER_SSH_PORT = "4444", DOPPLER_PROJECT = "dotfiles", DOPPLER_CONFIG = "dev" }
+run = '''
+set -euo pipefail
+DEVCONTAINER_WORKSPACE_HASH="$(scripts/workspace-hash.sh)"
+export DEVCONTAINER_WORKSPACE_HASH
+ssh-keygen -R "[localhost]:${DEVCONTAINER_SSH_PORT}" 2>/dev/null || true
+devcontainer up --workspace-folder . --remove-existing-container --build-no-cache
+'''
 
 [tasks.verify-image]
 description = "Spot-check cookbook paths in :dev (cargo/rustup cookbook layout + core toolchains)"
@@ -177,7 +176,7 @@ description = "Spot-check cookbook paths in :dev (cargo/rustup cookbook layout +
 # NOT root mise.toml. Root mise.toml tools (hk, pkl, the 5 markdown
 # linters, etc.) live on the HOST, not in the image. Keep assertions here
 # scoped to what mise-system.toml actually provides.
-env = { BASE_IMAGE = "ghcr.io/ray-manaloto/dotfiles-devcontainer:dev", DOCKER_DEFAULT_PLATFORM = "linux/amd64" }
+env = { BASE_IMAGE = "ghcr.io/ray-manaloto/dotfiles-devcontainer:dev", DOCKER_DEFAULT_PLATFORM = "linux/amd64/v2" }
 run = '''
 docker run --rm "$BASE_IMAGE" bash -lc '
   set -euo pipefail
@@ -205,28 +204,25 @@ run = "devcontainer exec --workspace-folder . bash -l"
 [tasks.ps]
 description = "Show the running devcontainer + its named volumes"
 run = '''
-# Portable hash detection for the workspace collision suffix.
-if command -v sha256sum >/dev/null 2>&1; then
-  _hash="$(printf '%s' "$PWD" | sha256sum | cut -c1-8)"
-elif command -v shasum >/dev/null 2>&1; then
-  _hash="$(printf '%s' "$PWD" | shasum -a 256 | cut -c1-8)"
-else
-  echo "ERROR: neither sha256sum nor shasum found" >&2
-  exit 1
-fi
+set -euo pipefail
+_hash="$(scripts/workspace-hash.sh)"
 docker ps --filter "label=devcontainer.local_folder=$PWD" --format 'table {{"{{"}}.Names{{"}}"}}\t{{"{{"}}.Status{{"}}"}}\t{{"{{"}}.Ports{{"}}"}}'
 # Scoped to this clone's hashed home volume (v6 single-volume consolidation).
 docker volume ls --format '{{"{{"}}.Name{{"}}"}}' | grep -E "dotfiles-$(basename "$PWD")-${USER}-${_hash}" || true
 '''
 
 [tasks.dev]
-description = "Full devloop: pull :dev → up → smoke (sequential)"
+description = "Full devloop: up → smoke (sequential)"
 # NOTE: `depends = [...]` in mise runs tasks in parallel when independent
 # — not what we want here. A sequential shell body forces ordering while
 # keeping each sub-task independently runnable.
+#
+# Image pulling is delegated to devcontainer-cli (called by `mise run up`).
+# Standalone `docker pull` was removed — it bypassed the lifecycle and
+# masked silent failures (PR #86 review). Use `mise run dev-rebuild`
+# for an explicit force-refresh.
 run = '''
 set -euo pipefail
-mise run pull
 mise run up
 mise run smoke
 '''
@@ -427,16 +423,19 @@ echo "OK: S1 doppler env file has ${count} secrets (project=${DOPPLER_PROJECT}, 
 '''
 
 [tasks.verify-local]
-description = "Full local devcontainer validation (pull → verify-image → up → ps → smoke → persistence → verify-ssh-inbound → verify-secrets)"
+description = "Full local devcontainer validation (verify-image → up → ps → smoke → persistence → verify-ssh-inbound → verify-secrets)"
 # Sequential shell body (not `depends = [...]`) so mise can't parallelize
-# the steps — smoke/persistence rely on up finishing first, and
-# verify-image relies on pull finishing first. verify-ssh-inbound (R1)
-# runs last because it needs postCreateCommand to have installed
-# ~/.ssh/authorized_keys from the host-state bind mount. verify-secrets
-# (S1) validates the host-side doppler env file.
+# the steps — smoke/persistence rely on up finishing first.
+# verify-ssh-inbound (R1) runs last because it needs postCreateCommand
+# to have installed ~/.ssh/authorized_keys from the host-state bind
+# mount. verify-secrets (S1) validates the host-side doppler env file.
+#
+# Image pulling: verify-image's `docker run --rm` and `up`'s
+# `devcontainer up` both auto-pull when the layer is missing — no
+# standalone `docker pull` step needed. To force-refresh, use
+# `mise run dev-rebuild` instead of this task.
 run = '''
 set -euo pipefail
-mise run pull
 mise run verify-image
 mise run up
 mise run ps
@@ -454,28 +453,50 @@ set -euo pipefail
 # Portable hash for this workspace (v6 single-volume collision guard).
 # Scoped prune prevents deleting sibling-clone hashed home volumes
 # (Codex v3 finding — broad-prefix prune was cross-clone destructive).
-if command -v sha256sum >/dev/null 2>&1; then
-  _hash="$(printf '%s' "$PWD" | sha256sum | cut -c1-8)"
-elif command -v shasum >/dev/null 2>&1; then
-  _hash="$(printf '%s' "$PWD" | shasum -a 256 | cut -c1-8)"
-else
-  echo "ERROR: neither sha256sum nor shasum found" >&2
-  exit 1
-fi
+_hash="$(scripts/workspace-hash.sh)"
+
+# Differentiate "no match" (acceptable, idempotent) from "docker command
+# failed" (must be loud) per feedback_never_suppress_warnings. Pattern:
+# capture command output, check non-empty, then act. Daemon failures
+# propagate via set -e on the capturing subshell.
 echo "==> stopping container"
-docker rm -f $(docker ps -aq --filter "label=devcontainer.local_folder=$PWD") 2>/dev/null || true
+container_ids="$(docker ps -aq --filter "label=devcontainer.local_folder=$PWD")"
+if [ -n "${container_ids}" ]; then
+  # shellcheck disable=SC2086
+  docker rm -f ${container_ids}
+else
+  echo "    (no container labeled for $PWD — already stopped)"
+fi
+
 echo "==> removing named volumes (scoped to hash ${_hash})"
-docker volume ls --format '{{"{{"}}.Name{{"}}"}}' | grep -E "dotfiles-$(basename "$PWD")-${USER}-${_hash}" | xargs -r docker volume rm 2>/dev/null || true
+all_volumes="$(docker volume ls --format '{{"{{"}}.Name{{"}}"}}')"
+hashed_volumes="$(echo "${all_volumes}" | grep -E "dotfiles-$(basename "$PWD")-${USER}-${_hash}" || true)"
+if [ -n "${hashed_volumes}" ]; then
+  echo "${hashed_volumes}" | xargs docker volume rm
+else
+  echo "    (no hashed volumes for ${_hash} — already removed)"
+fi
+
 # Also clean up any ORPHANED legacy volumes from the pre-v6 per-directory
-# layout (mise-user / cargo-user / rustup-user). These were cross-clone
-# shared before the hash was introduced; once no container references
-# them they can be safely removed for ANY clone. Bounded by the
+# layout (mise-user / cargo-user / rustup-user). Bounded by the
 # basename+user prefix so only this repo's orphans are targeted.
-docker volume ls --format '{{"{{"}}.Name{{"}}"}}' | grep -E "dotfiles-$(basename "$PWD")-${USER}-(mise-user|cargo-user|rustup-user)$" | xargs -r docker volume rm 2>/dev/null || true
+legacy_volumes="$(echo "${all_volumes}" | grep -E "dotfiles-$(basename "$PWD")-${USER}-(mise-user|cargo-user|rustup-user)$" || true)"
+if [ -n "${legacy_volumes}" ]; then
+  echo "==> removing legacy v5 volumes"
+  echo "${legacy_volumes}" | xargs docker volume rm
+fi
+
 echo "==> removing overlay images"
-docker images --format '{{"{{"}}.Repository{{"}}"}}:{{"{{"}}.Tag{{"}}"}}' | grep vsc-dotfiles | xargs -r docker rmi 2>/dev/null || true
+all_images="$(docker images --format '{{"{{"}}.Repository{{"}}"}}:{{"{{"}}.Tag{{"}}"}}')"
+overlay_images="$(echo "${all_images}" | grep vsc-dotfiles || true)"
+if [ -n "${overlay_images}" ]; then
+  echo "${overlay_images}" | xargs docker rmi
+else
+  echo "    (no vsc-dotfiles overlay images — already removed)"
+fi
+
 echo "==> pruning build cache"
-docker builder prune -f 2>&1 | tail -1
+docker builder prune -f
 echo "==> done"
 '''
 
@@ -491,7 +512,14 @@ alias = "down"
 # R2 outbound now uses Docker Desktop's native magic socket — no host
 # proxy to tear down (deleted in #77 stage 2).
 run = '''
-docker rm -f $(docker ps -aq --filter "label=devcontainer.local_folder=$PWD") || true
+set -euo pipefail
+container_ids="$(docker ps -aq --filter "label=devcontainer.local_folder=$PWD")"
+if [ -n "${container_ids}" ]; then
+  # shellcheck disable=SC2086
+  docker rm -f ${container_ids}
+else
+  echo "(no container labeled for $PWD — already stopped)"
+fi
 '''
 
 [tasks.build]

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -109,6 +109,17 @@ tokens = [
 ]
 
 [[suite]]
+name = "build.amd64-platform-wired-mise"
+description = "R3 AMD64: mise.toml lifecycle tasks (up/pull/verify-image) must export DOCKER_DEFAULT_PLATFORM=linux/amd64/v2 to match devcontainer.json build.options. PR #86 missed these three task envs and shipped a split-brain (devcontainer.json said /v2, mise tasks said v1). This contract prevents the regression."
+category = "build"
+check_type = "static"
+handler = "require_tokens"
+paths = ["mise.toml"]
+tokens = [
+    "DOCKER_DEFAULT_PLATFORM = \"linux/amd64/v2\"",
+]
+
+[[suite]]
 name = "build.ssh-r1-inbound-wired"
 description = "R1 INBOUND: ssh ${USER}@localhost -p 4444 opens a shell in the container. Requires: (1) the ghcr.io/devcontainers/features/sshd feature (provides openssh-server, internal port 2222 hardcoded); (2) appPort mapping ${DEVCONTAINER_SSH_PORT}:2222; (3) postCreateCommand copies /tmp/dotfiles-host-state/authorized_keys into ~/.ssh/authorized_keys. DO NOT DROP — see AGENTS.md SSH Requirements section and .omc/plans/session-2026-04-09-ssh-rewrite.md."
 category = "build"

--- a/scripts/ensure-docker-up.sh
+++ b/scripts/ensure-docker-up.sh
@@ -40,21 +40,35 @@ echo "ensure-docker-up: Docker Desktop is not running — starting it..." >&2
 # Docker` launches the app, then `docker desktop start` brings up the
 # engines and is a no-op if they are already starting.
 if [ "$(uname -s)" = "Darwin" ] && ! pgrep -x "Docker Desktop" >/dev/null 2>&1; then
-	open -a Docker 2>/dev/null || true
+	# Don't suppress `open -a Docker` failure: a missing/corrupt Docker.app
+	# is the most actionable error we could surface here. Still tolerate
+	# non-zero exit because `pgrep` may race the app (already starting).
+	open -a Docker >&2 || echo "ensure-docker-up: 'open -a Docker' returned non-zero — continuing to docker desktop start" >&2
 fi
-docker desktop start >/dev/null 2>&1 &
+# Capture DD start stderr/stdout to a log so timeout diagnostics include
+# the actual failure reason (e.g., Electron tray IPC broken-pipe seen on
+# 2026-04-28). Without this, the user sees only a generic 60s timeout.
+DD_START_LOG="${TMPDIR:-/tmp}/ensure-docker-up.$$.log"
+docker desktop start >"${DD_START_LOG}" 2>&1 &
 start_pid=$!
+
+cleanup() {
+	kill "${start_pid}" 2>/dev/null || true
+	rm -f "${DD_START_LOG}" 2>/dev/null || true
+}
 
 deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
 while [ "$(date +%s)" -lt "${deadline}" ]; do
 	if docker info >/dev/null 2>&1; then
 		echo "ensure-docker-up: Docker Desktop is up." >&2
-		kill "${start_pid}" 2>/dev/null || true
+		cleanup
 		exit 0
 	fi
 	sleep 2
 done
 
-kill "${start_pid}" 2>/dev/null || true
 echo "ensure-docker-up: timed out after ${TIMEOUT_SECONDS}s waiting for Docker Desktop to become ready." >&2
+echo "ensure-docker-up: last 20 lines of 'docker desktop start' output:" >&2
+tail -20 "${DD_START_LOG}" >&2 || true
+cleanup
 exit 1

--- a/scripts/workspace-hash.sh
+++ b/scripts/workspace-hash.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# workspace-hash.sh — print an 8-char hash of $PWD to stdout.
+#
+# Used by mise.toml [tasks.up], [tasks.ps], [tasks.prune] to produce a
+# stable per-workspace suffix for Docker container/volume names. Sibling
+# clones of dotfiles/ on the same Mac get distinct hashes so volumes
+# don't collide (Codex v3 finding — see
+# .omc/plans/home-volume-consolidation-draft.md C10/C11/C12).
+#
+# Single source of truth replaces three identical-but-copy-pasted blocks
+# in mise.toml that risked drift on the next refactor.
+#
+# Portable hash detection: sha256sum is Linux default; shasum is macOS
+# default. Try both. Fail loud (no fallback to any other algorithm) if
+# neither is available — the contract is "8-char SHA-256 prefix"; using
+# md5 or another digest would change volume names across hosts.
+set -euo pipefail
+
+if command -v sha256sum >/dev/null 2>&1; then
+	printf '%s' "$PWD" | sha256sum | cut -c1-8
+elif command -v shasum >/dev/null 2>&1; then
+	printf '%s' "$PWD" | shasum -a 256 | cut -c1-8
+else
+	echo "workspace-hash: neither sha256sum nor shasum found — cannot compute workspace hash" >&2
+	exit 1
+fi


### PR DESCRIPTION
## Summary

Post-merge audit of `mise run {up,down,stop,dev,pull,sh,ps,prune,smoke,persistence,verify-*}` after PR #86. Three parallel agents (inventory / silent-failure-hunt / prior-art) plus a live lifecycle exercise (up → smoke → persistence → stop×2 → up×2) surfaced 6 real issues; all fixed + verified end-to-end on the Mac host.

### Fixes (high-leverage first)

1. **`linux/amd64/v2` regression in `mise.toml`** — PR #86's platform sweep missed `[tasks.up/pull/verify-image].env.DOCKER_DEFAULT_PLATFORM`. Local `mise run up` was sending v1 platform via env while `devcontainer.json build.options[]` baked v2. Updated to `linux/amd64/v2` everywhere; added new `build.amd64-platform-wired-mise` contract in `python/verification/suites.toml` so this can't drift again.
2. **Doppler empty-`doppler.env` silent failure** — `initializeCommand` chain `> doppler.env && uv run ...` truncates the file before doppler runs; if `DOPPLER_PROJECT`/`CONFIG` aren't in env (e.g. dock-launched IDE), doppler errors but the 0-byte file lingers. The user's existing `doppler.env` was 0 bytes from an earlier session — reproduced live during the audit. Fixed with `[ -s ... ]` assertion + `${VAR:-default}` fallback so the chain works in both mise-env and bare-shell launch contexts.
3. **`scripts/ensure-docker-up.sh` swallowed DD start stderr** — backgrounded `docker desktop start >/dev/null 2>&1 &` lost the actual diagnostic when Docker.app crashed. Now logs to `${TMPDIR:-/tmp}/ensure-docker-up.$$.log`, prints last 20 lines of the log on timeout, cleans up on exit.
4. **`[tasks.prune]` and `[tasks.stop]` blanket-suppression** — `2>/dev/null || true` on `docker rm`/`volume rm`/`rmi` masked real failures (daemon down, perms) along with the legitimate "no match" idempotency case. Refactored to capture command output explicitly, branch on non-empty, let `set -euo pipefail` propagate genuine failures. The "no container labeled for $PWD — already stopped" message is the new loud-but-idempotent shape. Also added `set -euo pipefail` to `[tasks.stop]` (was running with bash defaults).
5. **Hash compute extracted to `scripts/workspace-hash.sh`** — three identical `sha256sum || shasum` portable-detection blocks were copy-pasted across `[tasks.up/ps/prune]`. Currently in sync but vulnerable to drift. New shared helper is the single source of truth; all three tasks use `_hash="$(scripts/workspace-hash.sh)"`. Hash output cross-verified identical (`273897ea` for this repo).
6. **`postCreateCommand` ssh-keyscan made loud** — `ssh-keyscan ... >> known_hosts 2>/dev/null && chmod 600` could leave an empty known_hosts on network glitch and proceed to smoke test. Dropped `2>/dev/null` and added `[ -s ~/.ssh/known_hosts ]` assertion.

### Bonus — raw docker pull cleanup (do-not.md #3 compliance)

`[tasks.up]` and `[tasks.pull]` reached for raw `docker pull` for image-cache management, bypassing devcontainer-cli's lifecycle. Per `.claude/rules/do-not.md` #3: raw docker for lifecycle skips `initializeCommand`/`onCreateCommand`/`postCreateCommand`. Removed the explicit pull from `[tasks.up]` (devcontainer-cli pulls if missing); dropped `[tasks.pull]` entirely; added `[tasks.dev-rebuild]` (uses `devcontainer up --remove-existing-container --build-no-cache`) as the lifecycle-aware force-refresh primitive. `[tasks.dev]` simplified from `pull → up → smoke` to `up → smoke`.

devcontainer-cli 0.86.0 still has no `down`/`stop`/`rm` verb (verified via `devcontainer --help`), so the raw `docker rm -f` in `[tasks.stop]` and `[tasks.prune]` remain the only documented exceptions.

### Verified false positives

The silent-failure agent flagged a few patterns that, on direct verification, weren't bugs:
- `docker builder prune -f | tail -1` — `set -o pipefail` is in effect; pipe propagates.
- `--no-pull` flag on `mise run up` — mise's usage parser handles boolean negation correctly. (Moot now that the flag is removed entirely with the docker-pull cleanup.)
- `[tasks.dev]` doesn't wait for smoke — sequential shell body with `set -euo pipefail` does propagate exit.

## Test plan

- [x] `hk run pre-commit --all --stash none` → all 11 steps green
- [x] `dotfiles-setup verify run` → 57 passed (incl. new `build.amd64-platform-wired-mise`)
- [x] `pytest tests/ -x -q` → 61 passed
- [x] Live lifecycle exercise on this Mac:
  - `mise run up` cold → all hooks fired (`initializeCommand` → 7 Doppler keys → `onCreateCommand` → chezmoi + ownership → `postCreateCommand` → ssh-keyscan + smoke tier 1/2/3 + 61 pytest passed inside container). R1 + R3 verified.
  - `mise run persistence` → 107 tools preserved across stop/up cycle, canary + seed survivors intact (`/home/$USER/{.bashrc,.zshrc,.profile,.ssh,.local/share/mise,.local/tmp}` all OK).
  - `mise run stop` × 2 → 2nd shows the new loud noop message ("no container labeled for $PWD — already stopped").
  - `mise run up` × 2 → 2nd reuses the existing container in 4.5s vs 89s cold (`onCreateCommand` correctly didn't re-fire; `initializeCommand` did, per spec).
- [ ] CI build (~2.5h baseline per `feedback_ci_build_duration_baseline`) + smoke-test passes against the published `:dev` from this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Docker Desktop startup diagnostics with detailed error logging to surface actual failure reasons.
  * Added conditional command execution to prevent failures on empty outputs.

* **Chores**
  * Standardized container platform configuration across development environments.
  * Reorganized shell aliases and refactored build task workflows.
  * Added automated verification suite for platform configuration alignment.
  * Introduced centralized workspace hashing utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->