### PR TITLE
docs(agents): list new hk enforcement steps + trigger :dev retag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ the official `@devcontainers/cli` (pinned in `mise.toml`).
 | `mise.toml` | Tool versions and tasks (hk, pkl, hadolint, shellcheck, actionlint, pinact, python 3.14, uv, agnix) |
 | `mise.lock` | Locked tool versions for reproducible installs |
 | `mise.local.toml` | Gitignored per-clone overrides (e.g., `BASE_IMAGE`). See `mise.local.toml.example` |
-| `hk.pkl` | Project git hook config; imports `hk-common.pkl`; includes `no_lint_skip` + `no_mcp_registration` enforcement |
+| `hk.pkl` | Project git hook config; imports `hk-common.pkl`; enforces `no_lint_skip`, `no_mcp_registration`, `claude_md_import_stub`, `claude_agents_md_pairs` |
 | `hk-common.pkl` | Shared step definitions (hygiene, safety, security, typos) reused by `hk.pkl` and `hk-image.pkl` |
 | `hk-image.pkl` | Image-only hook config for devcontainer validation |
 | `docker-bake.hcl` | BuildKit bake config (`dev`, `cpp`, `dev-load`, `cpp-load` targets); `IMAGE_REF` consolidates registry+image |


### PR DESCRIPTION
## Summary

- One-line update to the `hk.pkl` row in root `AGENTS.md` to mention the four project-policy hk steps now in force (was 2: `no_lint_skip` + `no_mcp_registration`; now 4: also `claude_md_import_stub` + `claude_agents_md_pairs`).
- Net line count unchanged (still 198/200, well under the `claude_md_size_limit` cap).

## Context

This PR primarily exists to trigger the working `:dev` / `:latest` retag path. Three commits landed via direct push to `main` since PR #93 merged:

- `10682df` — ci(hk): enforce CLAUDE.md/AGENTS.md import-stub + pair invariants
- `4e9ae0f` — refactor: remove cargo-culted MISE_STRICT system end-to-end
- `ad19cd6` — this commit (docs touch-up to give the PR a reason to exist)

Direct pushes to `main` cannot use `promote`'s `gh api graphql associatedPullRequests` lookup, and the workflow's fallback rebuild path has a `failed to run git: fatal: not a git repository` bug. Net effect: `ghcr.io/.../dotfiles-devcontainer:dev` has been stale at `1dd95a1` (PR #93 merge) since 2026-05-01 03:57 UTC.

When this PR merges, `promote` will retag `:pr-NNN` (built from the PR head, which contains all three commits' content) to `:dev` and `:latest` in <30 sec via `docker buildx imagetools create` — the documented happy path.

## Test plan

- [x] Local: `hk run pre-commit --all --stash none` — all 14 active steps pass
- [x] Local: `pytest tests/ -x -q` — 97/97 pass
- [x] Local: `dotfiles-setup verify run` — 66 passed, 0 failed
- [ ] CI lint job — green
- [ ] CI contract-preflight — green (was failing pre-`4e9ae0f`)
- [ ] CI base-prep — manifest hit (no rebuild expected; only Python/AGENTS.md/scripts changed)
- [ ] CI p2996-prep — manifest hit
- [ ] CI build — warm cache (~10 min expected)
- [ ] CI smoke-test — passes against `:sha-${{github.sha}}`
- [ ] After merge: `:dev` / `:latest` retagged successfully via `promote`

## Follow-up (separate session)

The promote-job fallback-rebuild bug (`failed to run git` when no PR is associated with a direct push) should be fixed in `.github/workflows/ci.yml` so future direct-pushes don't strand `:dev`. Options:
1. Add a checkout step to the fallback path
2. Block direct-push-to-main via branch protection
3. Document that all `main` changes go through PRs

Tracked locally; will open a GH issue if not addressed in the next session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated enforcement documentation to reflect additional configuration rules being enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->