### PR TITLE
fix(ci): unblock lint (agnix→github backend) + cancel superseded runs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -53,7 +53,8 @@
     "auto-memory@claude-community": false,
     "guide@claude-code-guide": false,
     "codex@openai-codex": false,
-    "astral@astral-sh": true
+    "astral@astral-sh": true,
+    "cli-anything@cli-anything": true
   },
   "prefersReducedMotion": true
 }

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -20,9 +20,15 @@ post-failure reporting.
 PR / schedule / workflow_dispatch path:
 
 1. **lint** — mise install, hk pre-commit, agnix agent-doc validation
-   (`agnix --target claude-code --strict .`), `mise doctor --json`
-   health check, `mise.lock` artifact upload, mise data cache keyed on
-   `mise.lock`.
+   (`agnix .`; the target + severity come from `.agnix.toml`, which sets
+   `tools = ["claude-code"]` and `severity = "Warning"` — warnings do NOT
+   fail the build, so `agnix .` exits 0 even with warnings present),
+   `mise doctor --json` health check, `mise.lock` artifact upload, mise
+   data cache keyed on `mise.lock`. agnix is installed via the
+   `github:agent-sh/agnix` backend (NOT `npm:agnix`): the npm package only
+   ships a launcher that downloads its native binary in a `postinstall`
+   script, which mise's bun-based npm backend skips, leaving the binary
+   missing (`agnix binary not found`). See the `mise.toml` comment.
 2. **contract-preflight** — Python 3.14 + uv; runs `dotfiles-setup
    verify run` over `python/verification/suites.toml`.
 3. **base-prep** — computes content-hash of base inputs via
@@ -63,6 +69,14 @@ Push-to-main path (after a PR merge):
 
 - **All actions SHA-pinned** via pinact. Run `mise run pin-actions`
   locally to verify before committing workflow changes.
+- **Concurrency cancels superseded runs per branch.** `ci.yml` and
+  `autofix.yml` group by
+  `${{ github.workflow }}-${{ github.head_ref || github.ref }}` so all
+  events for one source branch share a group; pushing a new commit
+  cancels the older in-flight run. `head_ref` is the PR source branch;
+  `ref` covers push/schedule/dispatch. **main is exempt**
+  (`cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`) so its
+  push-path `promote` manifest-retag is never interrupted mid-flight.
 - **Python 3.14** for contract-preflight and smoke-test jobs
   (`actions/setup-python@v6`, `astral-sh/setup-uv@v8`).
 - **lint job** caches mise data directory keyed on `mise.lock`.

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -25,8 +25,9 @@ env:
   MISE_LOG_FILE: /tmp/mise.log
   MISE_LOG_FILE_LEVEL: debug
 
+# Match ci.yml: group per source branch and cancel superseded autofix runs.
 concurrency:
-  group: autofix-${{ github.ref }}
+  group: autofix-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,14 @@ on:
         default: false
         type: boolean
 
+# Serialize runs per branch and cancel superseded ones — only the latest
+# commit's run survives; in-flight runs for older commits on the same branch
+# are cancelled. `head_ref` groups by source branch for pull_request events;
+# `ref` covers push / schedule / workflow_dispatch. main is exempt from
+# cancellation: its push-path runs `promote` (a manifest-retag of
+# :dev/:latest) which must not be interrupted mid-flight.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:

--- a/mise.lock
+++ b/mise.lock
@@ -40,137 +40,138 @@ url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_
 provenance = "github-attestations"
 
 [[tools."aqua:jackchuka/mdschema"]]
-version = "0.12.9"
+version = "0.13.1"
 backend = "aqua:jackchuka/mdschema"
 
 [tools."aqua:jackchuka/mdschema"."platforms.linux-arm64"]
-checksum = "sha256:a833ee8cb49935af0338638033c7914924fd7e551a13c8cd594d32c17be1e667"
-url = "https://github.com/jackchuka/mdschema/releases/download/v0.12.9/mdschema_0.12.9_linux_arm64.tar.gz"
+checksum = "sha256:f05d59619c880a96a98f2f214a641c68ed95aef03392fe4562145552cc190c6e"
+url = "https://github.com/jackchuka/mdschema/releases/download/v0.13.1/mdschema_0.13.1_linux_arm64.tar.gz"
 
 [tools."aqua:jackchuka/mdschema"."platforms.linux-arm64-musl"]
-checksum = "sha256:a833ee8cb49935af0338638033c7914924fd7e551a13c8cd594d32c17be1e667"
-url = "https://github.com/jackchuka/mdschema/releases/download/v0.12.9/mdschema_0.12.9_linux_arm64.tar.gz"
+checksum = "sha256:f05d59619c880a96a98f2f214a641c68ed95aef03392fe4562145552cc190c6e"
+url = "https://github.com/jackchuka/mdschema/releases/download/v0.13.1/mdschema_0.13.1_linux_arm64.tar.gz"
 
 [tools."aqua:jackchuka/mdschema"."platforms.linux-x64"]
-checksum = "sha256:aec26472681104e3a4e7a22a59903dc88753e05acc8040a08773ed1771aabfaf"
-url = "https://github.com/jackchuka/mdschema/releases/download/v0.12.9/mdschema_0.12.9_linux_amd64.tar.gz"
+checksum = "sha256:9389f2d627050a2f550cda788b8f67e5737d17eab990ef64285a7a64edce8806"
+url = "https://github.com/jackchuka/mdschema/releases/download/v0.13.1/mdschema_0.13.1_linux_amd64.tar.gz"
 
 [tools."aqua:jackchuka/mdschema"."platforms.linux-x64-musl"]
-checksum = "sha256:aec26472681104e3a4e7a22a59903dc88753e05acc8040a08773ed1771aabfaf"
-url = "https://github.com/jackchuka/mdschema/releases/download/v0.12.9/mdschema_0.12.9_linux_amd64.tar.gz"
+checksum = "sha256:9389f2d627050a2f550cda788b8f67e5737d17eab990ef64285a7a64edce8806"
+url = "https://github.com/jackchuka/mdschema/releases/download/v0.13.1/mdschema_0.13.1_linux_amd64.tar.gz"
 
 [tools."aqua:jackchuka/mdschema"."platforms.macos-arm64"]
-checksum = "sha256:08eb57289a2eecaee8438946fee58656387deb933756c9f1f1ce7405aa2c42ef"
-url = "https://github.com/jackchuka/mdschema/releases/download/v0.12.9/mdschema_0.12.9_darwin_arm64.tar.gz"
+checksum = "sha256:31c18f53f8016bce0e39b2186dba46ee6a33ec7c856e52bd267375d3bb11c74c"
+url = "https://github.com/jackchuka/mdschema/releases/download/v0.13.1/mdschema_0.13.1_darwin_arm64.tar.gz"
 
 [tools."aqua:jackchuka/mdschema"."platforms.macos-x64"]
-checksum = "sha256:47c8c4dfae90a46e0c7e186bc1fe6e26de4f21b490ef620eeae45ab40d8f53e4"
-url = "https://github.com/jackchuka/mdschema/releases/download/v0.12.9/mdschema_0.12.9_darwin_amd64.tar.gz"
+checksum = "sha256:5e3dd536fe91555987795e45de7c7ff85a6743664b3ad25658a6266194d76bbe"
+url = "https://github.com/jackchuka/mdschema/releases/download/v0.13.1/mdschema_0.13.1_darwin_amd64.tar.gz"
 
 [tools."aqua:jackchuka/mdschema"."platforms.windows-x64"]
-checksum = "sha256:622c75142948bc47ad265bcc5a77197a696074cbc5757359977e40dc81d4ea9c"
-url = "https://github.com/jackchuka/mdschema/releases/download/v0.12.9/mdschema_0.12.9_windows_amd64.zip"
+checksum = "sha256:2bc5da014297042fd7c50699c920de17f7559061764418ac30a15da2ea5be65b"
+url = "https://github.com/jackchuka/mdschema/releases/download/v0.13.1/mdschema_0.13.1_windows_amd64.zip"
 
 [[tools.aws-cli]]
-version = "2.34.38"
+version = "2.34.58"
 backend = "aqua:aws/aws-cli"
 
 [tools.aws-cli."platforms.linux-arm64"]
-url = "https://awscli.amazonaws.com/awscli-exe-linux-aarch64-2.34.38.zip"
+url = "https://awscli.amazonaws.com/awscli-exe-linux-aarch64-2.34.58.zip"
 
 [tools.aws-cli."platforms.linux-arm64-musl"]
-url = "https://awscli.amazonaws.com/awscli-exe-linux-aarch64-2.34.38.zip"
+url = "https://awscli.amazonaws.com/awscli-exe-linux-aarch64-2.34.58.zip"
 
 [tools.aws-cli."platforms.linux-x64"]
-checksum = "blake3:c52af4f90e41e95b0606616acb54cbbddee7758d891f795cf3433b189e60b4a7"
-url = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.34.38.zip"
+checksum = "blake3:2cce2eb28599783e52918c81f956b28b0b4dbd4e4c6f2dbaae81378a5c2cde1a"
+url = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.34.58.zip"
 
 [tools.aws-cli."platforms.linux-x64-musl"]
-url = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.34.38.zip"
+url = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.34.58.zip"
 
 [tools.aws-cli."platforms.macos-arm64"]
-url = "https://awscli.amazonaws.com/AWSCLIV2-2.34.38.pkg"
+checksum = "blake3:f68ee8a82845799f4ba6f5146631e58750b012c8928ceac67b57d71cb36ecf57"
+url = "https://awscli.amazonaws.com/AWSCLIV2-2.34.58.pkg"
 
 [tools.aws-cli."platforms.macos-x64"]
-url = "https://awscli.amazonaws.com/AWSCLIV2-2.34.38.pkg"
+url = "https://awscli.amazonaws.com/AWSCLIV2-2.34.58.pkg"
 
 [[tools.azure-cli]]
-version = "2.85.0"
+version = "2.86.0"
 backend = "pipx:azure-cli"
 
 [tools.azure-cli.options]
 uvx_args = "--prerelease=allow"
 
 [[tools.biome]]
-version = "2.4.13"
+version = "2.4.16"
 backend = "aqua:biomejs/biome"
 
 [tools.biome."platforms.linux-arm64"]
-checksum = "sha256:8aff839821c82ba5ba8455a52d8beacb02229697e781ebaa095f8442fdb6ae51"
-url = "https://github.com/biomejs/biome/releases/download/%40biomejs/biome%402.4.13/biome-linux-arm64"
+checksum = "sha256:e81067782ddd9a9d45e13b8fe18bbef54c490cf26126f05d67bb370caf47502a"
+url = "https://github.com/biomejs/biome/releases/download/%40biomejs/biome%402.4.16/biome-linux-arm64"
 provenance = "github-attestations"
 
 [tools.biome."platforms.linux-arm64-musl"]
-checksum = "sha256:948bbe5fb63d95372d391d42694ce5d553032f66043a178221166da2a76e8614"
-url = "https://github.com/biomejs/biome/releases/download/%40biomejs/biome%402.4.13/biome-linux-arm64-musl"
+checksum = "sha256:f288ac4e33d35ef08ee333419525df8cf9e74a617447d651a3fad052a9612731"
+url = "https://github.com/biomejs/biome/releases/download/%40biomejs/biome%402.4.16/biome-linux-arm64-musl"
 provenance = "github-attestations"
 
 [tools.biome."platforms.linux-x64"]
-checksum = "sha256:f5a3cf9cbe40ba7dd8ecd469567cac00635462589a3acfe97e5d8cab8b866c1c"
-url = "https://github.com/biomejs/biome/releases/download/%40biomejs/biome%402.4.13/biome-linux-x64"
+checksum = "sha256:f6904c208ce8884cf859460178f32f885250b375da1810c551912a029f4abf79"
+url = "https://github.com/biomejs/biome/releases/download/%40biomejs/biome%402.4.16/biome-linux-x64"
 provenance = "github-attestations"
 
 [tools.biome."platforms.linux-x64-musl"]
-checksum = "sha256:a1939a267e2077dadd9134cfa582a2f3ca153f06f882c30d37314fea187667fc"
-url = "https://github.com/biomejs/biome/releases/download/%40biomejs/biome%402.4.13/biome-linux-x64-musl"
+checksum = "sha256:e7102113e10c57772ce969ce088f54ec2cc37331bb4601e5f5369fd94a6fe1d9"
+url = "https://github.com/biomejs/biome/releases/download/%40biomejs/biome%402.4.16/biome-linux-x64-musl"
 provenance = "github-attestations"
 
 [tools.biome."platforms.macos-arm64"]
-checksum = "sha256:22eb03789d405ea84e7b01192a9b5a4885802468dd0f369613837f5b5935178b"
-url = "https://github.com/biomejs/biome/releases/download/%40biomejs/biome%402.4.13/biome-darwin-arm64"
+checksum = "sha256:8cf9e92a161e26bdbfc0896c208864e1de8b160dfb90f61040609c2743cf433b"
+url = "https://github.com/biomejs/biome/releases/download/%40biomejs/biome%402.4.16/biome-darwin-arm64"
 provenance = "github-attestations"
 
 [tools.biome."platforms.macos-x64"]
-checksum = "sha256:2180d3467d67773daccea90855d8d65e1026ffa429ceba3edcb4553c8664627b"
-url = "https://github.com/biomejs/biome/releases/download/%40biomejs/biome%402.4.13/biome-darwin-x64"
+checksum = "sha256:42329e159a2f35b3776a01e7a16a53582d53e126fbc55bfdd5825e873a87b338"
+url = "https://github.com/biomejs/biome/releases/download/%40biomejs/biome%402.4.16/biome-darwin-x64"
 provenance = "github-attestations"
 
 [tools.biome."platforms.windows-x64"]
-checksum = "sha256:bc7d1f26be936aec1423f70ed94fd8c5aa80c3ba199d991dcaf13476daa5f786"
-url = "https://github.com/biomejs/biome/releases/download/%40biomejs/biome%402.4.13/biome-win32-x64.exe"
+checksum = "sha256:1247239dae8f57aafeaeb9914e30b92efcc51c632eee3be4463a95969558f6a3"
+url = "https://github.com/biomejs/biome/releases/download/%40biomejs/biome%402.4.16/biome-win32-x64.exe"
 provenance = "github-attestations"
 
 [[tools.chezmoi]]
-version = "2.70.2"
+version = "2.70.4"
 backend = "aqua:twpayne/chezmoi"
 
 [tools.chezmoi."platforms.linux-arm64"]
-checksum = "sha256:99e402af70f457dbf3ad545f62f78892375f2d9361db1c9c354e6d924a3b4fae"
-url = "https://github.com/twpayne/chezmoi/releases/download/v2.70.2/chezmoi_2.70.2_linux_arm64.tar.gz"
+checksum = "sha256:b2dc1e0ddf8beff09ee14f212271dd9e943d1d97d5f17a3d070ce35a6ada9e14"
+url = "https://github.com/twpayne/chezmoi/releases/download/v2.70.4/chezmoi_2.70.4_linux_arm64.tar.gz"
 
 [tools.chezmoi."platforms.linux-arm64-musl"]
-checksum = "sha256:99e402af70f457dbf3ad545f62f78892375f2d9361db1c9c354e6d924a3b4fae"
-url = "https://github.com/twpayne/chezmoi/releases/download/v2.70.2/chezmoi_2.70.2_linux_arm64.tar.gz"
+checksum = "sha256:b2dc1e0ddf8beff09ee14f212271dd9e943d1d97d5f17a3d070ce35a6ada9e14"
+url = "https://github.com/twpayne/chezmoi/releases/download/v2.70.4/chezmoi_2.70.4_linux_arm64.tar.gz"
 
 [tools.chezmoi."platforms.linux-x64"]
-checksum = "sha256:dda79928bf8428c1bb3d48497be00237a6ecc95a2bef7ded573608436ec7270b"
-url = "https://github.com/twpayne/chezmoi/releases/download/v2.70.2/chezmoi_2.70.2_linux_amd64.tar.gz"
+checksum = "sha256:7382f585d35647ebb492bd6345466e7f35564068b78285bb029cb2f35056ecf4"
+url = "https://github.com/twpayne/chezmoi/releases/download/v2.70.4/chezmoi_2.70.4_linux_amd64.tar.gz"
 
 [tools.chezmoi."platforms.linux-x64-musl"]
-checksum = "sha256:d57f46e19fff897b34e5b46f5fc372d48fdc09cc0a5afa6be3c47dda2b90fb85"
-url = "https://github.com/twpayne/chezmoi/releases/download/v2.70.2/chezmoi_2.70.2_linux-musl_amd64.tar.gz"
+checksum = "sha256:cd34113833a1d4eb22f78a83583c3e967e22a05653304e106d45df0066cc4713"
+url = "https://github.com/twpayne/chezmoi/releases/download/v2.70.4/chezmoi_2.70.4_linux-musl_amd64.tar.gz"
 
 [tools.chezmoi."platforms.macos-arm64"]
-checksum = "sha256:30dd21291a9d623fd334d83d97313660beea86f0053f483a30dbbb7a0d5b78ba"
-url = "https://github.com/twpayne/chezmoi/releases/download/v2.70.2/chezmoi_2.70.2_darwin_arm64.tar.gz"
+checksum = "sha256:0093fa436e9ccccf423323315c0146f6dc77985294bd845cee1f3cf3f63eeb0f"
+url = "https://github.com/twpayne/chezmoi/releases/download/v2.70.4/chezmoi_2.70.4_darwin_arm64.tar.gz"
 
 [tools.chezmoi."platforms.macos-x64"]
-checksum = "sha256:e421d3941db71242350afe5759e2cc12036b3edc14b9370b51df9109f4065ac5"
-url = "https://github.com/twpayne/chezmoi/releases/download/v2.70.2/chezmoi_2.70.2_darwin_amd64.tar.gz"
+checksum = "sha256:df605c409f16ff9ce002bd2690755c4c0aa6357ca4a065ed2f3cc7936a9f448e"
+url = "https://github.com/twpayne/chezmoi/releases/download/v2.70.4/chezmoi_2.70.4_darwin_amd64.tar.gz"
 
 [tools.chezmoi."platforms.windows-x64"]
-checksum = "sha256:0dec4f62a04c203da809c670b11c4271315ba1dc3f5d5571883c9d7a6f45bec6"
-url = "https://github.com/twpayne/chezmoi/releases/download/v2.70.2/chezmoi_2.70.2_windows_amd64.zip"
+checksum = "sha256:760e6f772255c062afb2b370666fc5cbef2116fe110ede18a72d4fa57a6eaea7"
+url = "https://github.com/twpayne/chezmoi/releases/download/v2.70.4/chezmoi_2.70.4_windows_amd64.zip"
 
 [[tools.colima]]
 version = "0.10.1"
@@ -201,122 +202,156 @@ checksum = "sha256:c927d411f70b7b40aced1caeef36cf3b19e0318cfad3606a0292cd488e9c4
 url = "https://github.com/abiosoft/colima/releases/download/v0.10.1/colima-Darwin-x86_64"
 
 [[tools.docker-cli]]
-version = "29.4.1"
+version = "29.5.2"
 backend = "aqua:docker/cli"
 
 [tools.docker-cli."platforms.linux-arm64"]
-url = "https://download.docker.com/linux/static/stable/aarch64/docker-29.4.1.tgz"
+url = "https://download.docker.com/linux/static/stable/aarch64/docker-29.5.2.tgz"
 
 [tools.docker-cli."platforms.linux-arm64-musl"]
-url = "https://download.docker.com/linux/static/stable/aarch64/docker-29.4.1.tgz"
+url = "https://download.docker.com/linux/static/stable/aarch64/docker-29.5.2.tgz"
 
 [tools.docker-cli."platforms.linux-x64"]
-checksum = "blake3:f5ccbcbfe962ddaa6209c58d4bd4d5a29b1e51298cb9687d76319ef7ad50303f"
-url = "https://download.docker.com/linux/static/stable/x86_64/docker-29.4.1.tgz"
+checksum = "blake3:a7224ea47bb95b20363ffa6a85f30c2c6455c674f56249f77e9d5f6249b8c1cc"
+url = "https://download.docker.com/linux/static/stable/x86_64/docker-29.5.2.tgz"
 
 [tools.docker-cli."platforms.linux-x64-musl"]
-url = "https://download.docker.com/linux/static/stable/x86_64/docker-29.4.1.tgz"
+url = "https://download.docker.com/linux/static/stable/x86_64/docker-29.5.2.tgz"
 
 [tools.docker-cli."platforms.macos-arm64"]
-url = "https://download.docker.com/mac/static/stable/aarch64/docker-29.4.1.tgz"
+url = "https://download.docker.com/mac/static/stable/aarch64/docker-29.5.2.tgz"
 
 [tools.docker-cli."platforms.macos-x64"]
-url = "https://download.docker.com/mac/static/stable/x86_64/docker-29.4.1.tgz"
+url = "https://download.docker.com/mac/static/stable/x86_64/docker-29.5.2.tgz"
 
 [tools.docker-cli."platforms.windows-x64"]
-url = "https://download.docker.com/win/static/stable/x86_64/docker-29.4.1.zip"
+url = "https://download.docker.com/win/static/stable/x86_64/docker-29.5.2.zip"
 
 [[tools.ghalint]]
-version = "1.5.5"
+version = "1.5.6"
 backend = "aqua:suzuki-shunsuke/ghalint"
 
 [tools.ghalint."platforms.linux-arm64"]
-checksum = "sha256:c3ab464130015d733bfc75a2851f4fc5b3cb966aca2ed8bc0fa2a029bc0ee6af"
-url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.5/ghalint_1.5.5_linux_arm64.tar.gz"
+checksum = "sha256:203a22c70b40bb161626973ad2a8dd06aeb736699fc8e03dd425dee8ff3406e6"
+url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/ghalint_1.5.6_linux_arm64.tar.gz"
 
 [tools.ghalint."platforms.linux-arm64".provenance.slsa]
-url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.5/multiple.intoto.jsonl"
+url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/multiple.intoto.jsonl"
 
 [tools.ghalint."platforms.linux-arm64-musl"]
-checksum = "sha256:c3ab464130015d733bfc75a2851f4fc5b3cb966aca2ed8bc0fa2a029bc0ee6af"
-url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.5/ghalint_1.5.5_linux_arm64.tar.gz"
+checksum = "sha256:203a22c70b40bb161626973ad2a8dd06aeb736699fc8e03dd425dee8ff3406e6"
+url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/ghalint_1.5.6_linux_arm64.tar.gz"
 
 [tools.ghalint."platforms.linux-arm64-musl".provenance.slsa]
-url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.5/multiple.intoto.jsonl"
+url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/multiple.intoto.jsonl"
 
 [tools.ghalint."platforms.linux-x64"]
-checksum = "sha256:579cbf9024f86a8255ce8acdd56c7792f0f9a7e76063d64cfb7b66ff65c396e4"
-url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.5/ghalint_1.5.5_linux_amd64.tar.gz"
+checksum = "sha256:98ee0e3330de7286f470d1e89c03ff7ce70d7a5998ba0f15969c400447be579c"
+url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/ghalint_1.5.6_linux_amd64.tar.gz"
 
 [tools.ghalint."platforms.linux-x64".provenance.slsa]
-url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.5/multiple.intoto.jsonl"
+url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/multiple.intoto.jsonl"
 
 [tools.ghalint."platforms.linux-x64-musl"]
-checksum = "sha256:579cbf9024f86a8255ce8acdd56c7792f0f9a7e76063d64cfb7b66ff65c396e4"
-url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.5/ghalint_1.5.5_linux_amd64.tar.gz"
+checksum = "sha256:98ee0e3330de7286f470d1e89c03ff7ce70d7a5998ba0f15969c400447be579c"
+url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/ghalint_1.5.6_linux_amd64.tar.gz"
 
 [tools.ghalint."platforms.linux-x64-musl".provenance.slsa]
-url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.5/multiple.intoto.jsonl"
+url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/multiple.intoto.jsonl"
 
 [tools.ghalint."platforms.macos-arm64"]
-checksum = "sha256:db969e288fc788348aa7c1323096d69df28b457c70b4194fb76f14ad058c0be7"
-url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.5/ghalint_1.5.5_darwin_arm64.tar.gz"
+checksum = "sha256:1262cac411e27b4653e6b66b7b06580ebcc2026fdd903e12e6cb0e4591639de6"
+url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/ghalint_1.5.6_darwin_arm64.tar.gz"
 
 [tools.ghalint."platforms.macos-arm64".provenance.slsa]
-url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.5/multiple.intoto.jsonl"
+url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/multiple.intoto.jsonl"
 
 [tools.ghalint."platforms.macos-x64"]
-checksum = "sha256:ce76aeb46f051d19a618c4e89ae5ca1d37c5a06f1bac3afb261ff619fd33045f"
-url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.5/ghalint_1.5.5_darwin_amd64.tar.gz"
+checksum = "sha256:d2a0e8605333068065dcf4c9b7b7a24891eda1750ac01fb755dfba426a390883"
+url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/ghalint_1.5.6_darwin_amd64.tar.gz"
 
 [tools.ghalint."platforms.macos-x64".provenance.slsa]
-url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.5/multiple.intoto.jsonl"
+url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/multiple.intoto.jsonl"
 
 [tools.ghalint."platforms.windows-x64"]
-checksum = "sha256:58c2589e7455fc05d83a28051f9098984db3fe6294f0f88aedc9691ae25eaff9"
-url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.5/ghalint_1.5.5_windows_amd64.zip"
+checksum = "sha256:109ea9b39c8e263cef924bd3b4fe5505964204f934ca60d986f4090d01a99ba5"
+url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/ghalint_1.5.6_windows_amd64.zip"
 
 [tools.ghalint."platforms.windows-x64".provenance.slsa]
-url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.5/multiple.intoto.jsonl"
+url = "https://github.com/suzuki-shunsuke/ghalint/releases/download/v1.5.6/multiple.intoto.jsonl"
+
+[[tools."github:agent-sh/agnix"]]
+version = "0.36.2"
+backend = "github:agent-sh/agnix"
+
+[tools."github:agent-sh/agnix"."platforms.linux-arm64"]
+checksum = "sha256:74639fcbf0765f4b20c2666cb00b917287ec00a3953c94b1e65eced6800fb0c6"
+url = "https://github.com/agent-sh/agnix/releases/download/v0.36.2/agnix-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/agent-sh/agnix/releases/assets/459759648"
+
+[tools."github:agent-sh/agnix"."platforms.linux-arm64-musl"]
+checksum = "sha256:74639fcbf0765f4b20c2666cb00b917287ec00a3953c94b1e65eced6800fb0c6"
+url = "https://github.com/agent-sh/agnix/releases/download/v0.36.2/agnix-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/agent-sh/agnix/releases/assets/459759648"
+
+[tools."github:agent-sh/agnix"."platforms.linux-x64"]
+checksum = "sha256:8c18db488cc4392f807f44925e8f4d9f589340209cf23969ef687574370a49b8"
+url = "https://github.com/agent-sh/agnix/releases/download/v0.36.2/agnix-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/agent-sh/agnix/releases/assets/459759636"
+
+[tools."github:agent-sh/agnix"."platforms.linux-x64-musl"]
+checksum = "sha256:714f2526efc4b4a6578350d3b31a2baffbf2fbb1066fb23699e58a43b2998906"
+url = "https://github.com/agent-sh/agnix/releases/download/v0.36.2/agnix-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/agent-sh/agnix/releases/assets/459759642"
+
+[tools."github:agent-sh/agnix"."platforms.macos-arm64"]
+checksum = "sha256:fe32b2789920568f320e517c6da823fd7069351e26976d87670ea27c3e65b42c"
+url = "https://github.com/agent-sh/agnix/releases/download/v0.36.2/agnix-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/agent-sh/agnix/releases/assets/459759655"
+
+[tools."github:agent-sh/agnix"."platforms.windows-x64"]
+checksum = "sha256:d09b878b572098b33df592b2241a45aba028728a6e32c46c30c91e7baa8607f7"
+url = "https://github.com/agent-sh/agnix/releases/download/v0.36.2/agnix-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/agent-sh/agnix/releases/assets/459759633"
 
 [[tools."github:ast-grep/ast-grep"]]
-version = "0.42.1"
+version = "0.43.0"
 backend = "github:ast-grep/ast-grep"
 
 [tools."github:ast-grep/ast-grep"."platforms.linux-arm64"]
-checksum = "sha256:3ba383839044cf9817929435f5ce0027f91d06931e8efb32d942e58d73d92be5"
-url = "https://github.com/ast-grep/ast-grep/releases/download/0.42.1/app-aarch64-unknown-linux-gnu.zip"
-url_api = "https://api.github.com/repos/ast-grep/ast-grep/releases/assets/388772218"
+checksum = "sha256:e706846148493967f3ab8011334817edd86ce5acbec10718b2a7b40799c640ff"
+url = "https://github.com/ast-grep/ast-grep/releases/download/0.43.0/app-aarch64-unknown-linux-gnu.zip"
+url_api = "https://api.github.com/repos/ast-grep/ast-grep/releases/assets/429542920"
 
 [tools."github:ast-grep/ast-grep"."platforms.linux-arm64-musl"]
-checksum = "sha256:3ba383839044cf9817929435f5ce0027f91d06931e8efb32d942e58d73d92be5"
-url = "https://github.com/ast-grep/ast-grep/releases/download/0.42.1/app-aarch64-unknown-linux-gnu.zip"
-url_api = "https://api.github.com/repos/ast-grep/ast-grep/releases/assets/388772218"
+checksum = "sha256:e706846148493967f3ab8011334817edd86ce5acbec10718b2a7b40799c640ff"
+url = "https://github.com/ast-grep/ast-grep/releases/download/0.43.0/app-aarch64-unknown-linux-gnu.zip"
+url_api = "https://api.github.com/repos/ast-grep/ast-grep/releases/assets/429542920"
 
 [tools."github:ast-grep/ast-grep"."platforms.linux-x64"]
-checksum = "sha256:5de8b87cba67fc8dc3e239d54b6484802ad745a7ae3de76be4fe89661dc52657"
-url = "https://github.com/ast-grep/ast-grep/releases/download/0.42.1/app-x86_64-unknown-linux-gnu.zip"
-url_api = "https://api.github.com/repos/ast-grep/ast-grep/releases/assets/388771275"
+checksum = "sha256:a26253a9c821d935f7e383e40f0de7c2ca62a4121de1f73a6d81ec32eae631e0"
+url = "https://github.com/ast-grep/ast-grep/releases/download/0.43.0/app-x86_64-unknown-linux-gnu.zip"
+url_api = "https://api.github.com/repos/ast-grep/ast-grep/releases/assets/429542387"
 
 [tools."github:ast-grep/ast-grep"."platforms.linux-x64-musl"]
-checksum = "sha256:5de8b87cba67fc8dc3e239d54b6484802ad745a7ae3de76be4fe89661dc52657"
-url = "https://github.com/ast-grep/ast-grep/releases/download/0.42.1/app-x86_64-unknown-linux-gnu.zip"
-url_api = "https://api.github.com/repos/ast-grep/ast-grep/releases/assets/388771275"
+checksum = "sha256:a26253a9c821d935f7e383e40f0de7c2ca62a4121de1f73a6d81ec32eae631e0"
+url = "https://github.com/ast-grep/ast-grep/releases/download/0.43.0/app-x86_64-unknown-linux-gnu.zip"
+url_api = "https://api.github.com/repos/ast-grep/ast-grep/releases/assets/429542387"
 
 [tools."github:ast-grep/ast-grep"."platforms.macos-arm64"]
-checksum = "sha256:c3961d8e8a4ee0ce2d0d98c7beeb168bb331cdc766b53630118a7b6c4fd39015"
-url = "https://github.com/ast-grep/ast-grep/releases/download/0.42.1/app-aarch64-apple-darwin.zip"
-url_api = "https://api.github.com/repos/ast-grep/ast-grep/releases/assets/388770234"
+checksum = "sha256:8c847d0a29aa4b3101b3361e0b3ee7fb53c7e497adc9ed1afc9615538cd40782"
+url = "https://github.com/ast-grep/ast-grep/releases/download/0.43.0/app-aarch64-apple-darwin.zip"
+url_api = "https://api.github.com/repos/ast-grep/ast-grep/releases/assets/429542766"
 
 [tools."github:ast-grep/ast-grep"."platforms.macos-x64"]
-checksum = "sha256:a038965bfd7fe44257c771cdf8918dc3467dd8ec0eef673b8b14f639b144cdbd"
-url = "https://github.com/ast-grep/ast-grep/releases/download/0.42.1/app-x86_64-apple-darwin.zip"
-url_api = "https://api.github.com/repos/ast-grep/ast-grep/releases/assets/388770498"
+checksum = "sha256:6d703090b106747b2f56086b6ccc7e798fe78bcae70257aa20519b220153555b"
+url = "https://github.com/ast-grep/ast-grep/releases/download/0.43.0/app-x86_64-apple-darwin.zip"
+url_api = "https://api.github.com/repos/ast-grep/ast-grep/releases/assets/429542599"
 
 [tools."github:ast-grep/ast-grep"."platforms.windows-x64"]
-checksum = "sha256:fe34f631bb24c08ad146f92ca2a92971a53d179461b509fd8d32dc863bff9f83"
-url = "https://github.com/ast-grep/ast-grep/releases/download/0.42.1/app-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/ast-grep/ast-grep/releases/assets/388771363"
+checksum = "sha256:a4febbc8c48671e5729d85e29e4ebe5a051b7250d19545bca18e725ccf40ef61"
+url = "https://github.com/ast-grep/ast-grep/releases/download/0.43.0/app-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/ast-grep/ast-grep/releases/assets/429546361"
 
 [[tools.hadolint]]
 version = "2.14.0"
@@ -351,32 +386,32 @@ checksum = "sha256:8e0ee174f88edb14f207a68430c7a53c2883ed509cdbde9a3a26fffa140fa
 url = "https://github.com/hadolint/hadolint/releases/download/v2.14.0/hadolint-windows-x86_64.exe"
 
 [[tools.hk]]
-version = "1.44.2"
+version = "1.46.0"
 backend = "aqua:jdx/hk"
 
 [tools.hk."platforms.linux-arm64"]
-checksum = "sha256:075411c60b897504ed6d0ab8d82cab89d376ef9b476e98b2543852aadec71908"
-url = "https://github.com/jdx/hk/releases/download/v1.44.2/hk-aarch64-unknown-linux-gnu.tar.gz"
+checksum = "sha256:bad1b4e52cce2147646d943baa06a7bdb3d182ae0876853897a72225626411ae"
+url = "https://github.com/jdx/hk/releases/download/v1.46.0/hk-aarch64-unknown-linux-gnu.tar.gz"
 
 [tools.hk."platforms.linux-arm64-musl"]
-checksum = "sha256:5a595804cf56b1ce1b03659e3202769b1f74a42173a7b31de5c5b03f3c5d9e59"
-url = "https://github.com/jdx/hk/releases/download/v1.44.2/hk-aarch64-unknown-linux-musl.tar.gz"
+checksum = "sha256:ad11b69485096ec5b1822f5bad298d2a44664b85d10d0308c812473b17b1321a"
+url = "https://github.com/jdx/hk/releases/download/v1.46.0/hk-aarch64-unknown-linux-musl.tar.gz"
 
 [tools.hk."platforms.linux-x64"]
-checksum = "sha256:01b564318f88c2726634c689bea1475d90b8e68e2b67d969442d645cfb1a867f"
-url = "https://github.com/jdx/hk/releases/download/v1.44.2/hk-x86_64-unknown-linux-gnu.tar.gz"
+checksum = "sha256:85b2cc167443cd27b49e323ef9b9d1a946d4bc18196eccb66112842d30fb90cb"
+url = "https://github.com/jdx/hk/releases/download/v1.46.0/hk-x86_64-unknown-linux-gnu.tar.gz"
 
 [tools.hk."platforms.linux-x64-musl"]
-checksum = "sha256:4313d2f452c901ec4ccd5af821822444eb364c05f8ce7708854ec115124eabb3"
-url = "https://github.com/jdx/hk/releases/download/v1.44.2/hk-x86_64-unknown-linux-musl.tar.gz"
+checksum = "sha256:4ff45e1bfc9672b1b00572b4a50fac3b57e4add622ed56e9e2587745299932eb"
+url = "https://github.com/jdx/hk/releases/download/v1.46.0/hk-x86_64-unknown-linux-musl.tar.gz"
 
 [tools.hk."platforms.macos-arm64"]
-checksum = "sha256:b1d6b50682055ff7b92a6f17122f6a6a49d03f611199a9a470c19ec70d5df770"
-url = "https://github.com/jdx/hk/releases/download/v1.44.2/hk-aarch64-apple-darwin.tar.gz"
+checksum = "sha256:9db3fac25754cfb929dc3f92b294fffdb966d4e838b8e0adeaf5b9b7eccc4f6c"
+url = "https://github.com/jdx/hk/releases/download/v1.46.0/hk-aarch64-apple-darwin.tar.gz"
 
 [tools.hk."platforms.windows-x64"]
-checksum = "sha256:58d1c25b42fd103a4df7f549591b46fa7049f1858c3b4ea463123b8b163577d5"
-url = "https://github.com/jdx/hk/releases/download/v1.44.2/hk-x86_64-pc-windows-msvc.zip"
+checksum = "sha256:5af7e769acb7f70d8630ed53ae1fb2cc4b205117f29df5d83619fa0ff72a3bf1"
+url = "https://github.com/jdx/hk/releases/download/v1.46.0/hk-x86_64-pc-windows-msvc.zip"
 
 [[tools.jq]]
 version = "1.8.1"
@@ -418,112 +453,108 @@ url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-windows-amd64.
 provenance = "github-attestations"
 
 [[tools.lefthook]]
-version = "2.1.6"
+version = "2.1.9"
 backend = "aqua:evilmartians/lefthook"
 
 [tools.lefthook."platforms.linux-arm64"]
-checksum = "sha256:f85cc031da8e3571418170ab53f1e6e184a086b58683e13660bd5248974159a4"
-url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.6/lefthook_2.1.6_Linux_aarch64.gz"
+checksum = "sha256:d1bae1c9c26b35270dd675c93c33cecead885368ed078b3976ec23cdcedd28e8"
+url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.9/lefthook_2.1.9_Linux_aarch64.gz"
 provenance = "github-attestations"
 
 [tools.lefthook."platforms.linux-arm64-musl"]
-checksum = "sha256:f85cc031da8e3571418170ab53f1e6e184a086b58683e13660bd5248974159a4"
-url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.6/lefthook_2.1.6_Linux_aarch64.gz"
+checksum = "sha256:d1bae1c9c26b35270dd675c93c33cecead885368ed078b3976ec23cdcedd28e8"
+url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.9/lefthook_2.1.9_Linux_aarch64.gz"
 provenance = "github-attestations"
 
 [tools.lefthook."platforms.linux-x64"]
-checksum = "sha256:fab3d2715a922d9625c9024e6ffb6e1271edd613aa9b213c2049482cde8ae183"
-url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.6/lefthook_2.1.6_Linux_x86_64.gz"
+checksum = "sha256:e938f34bd05bafe1155888879a045ef4ee8cf5b4a56c9e5e9b0c2649f295636e"
+url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.9/lefthook_2.1.9_Linux_x86_64.gz"
 provenance = "github-attestations"
 
 [tools.lefthook."platforms.linux-x64-musl"]
-checksum = "sha256:fab3d2715a922d9625c9024e6ffb6e1271edd613aa9b213c2049482cde8ae183"
-url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.6/lefthook_2.1.6_Linux_x86_64.gz"
+checksum = "sha256:e938f34bd05bafe1155888879a045ef4ee8cf5b4a56c9e5e9b0c2649f295636e"
+url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.9/lefthook_2.1.9_Linux_x86_64.gz"
 provenance = "github-attestations"
 
 [tools.lefthook."platforms.macos-arm64"]
-checksum = "sha256:f07c97c32376749edb5b34179c16c6d87dd3e7ca0040aee911f38c821de0daab"
-url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.6/lefthook_2.1.6_MacOS_arm64.gz"
+checksum = "sha256:808f8ef81a61e01eb41c1a2951e5639804f2372dc6a484bbeff726406745c77f"
+url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.9/lefthook_2.1.9_MacOS_arm64.gz"
 provenance = "github-attestations"
 
 [tools.lefthook."platforms.macos-x64"]
-checksum = "sha256:93c6d51823f94a7f26a2bbb84f59504378b178f55d6c90744169693ed3e89013"
-url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.6/lefthook_2.1.6_MacOS_x86_64.gz"
+checksum = "sha256:371c3c75cb07a8cdf41295596d3981adc1f92dee7795001f7d471e1f36fe2a0e"
+url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.9/lefthook_2.1.9_MacOS_x86_64.gz"
 provenance = "github-attestations"
 
 [tools.lefthook."platforms.windows-x64"]
-checksum = "sha256:6704b01a72414affcc921740a7d6c621fe60c3082b291c9730900a2c6a352516"
-url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.6/lefthook_2.1.6_Windows_x86_64.gz"
+checksum = "sha256:1f29681dfbc36b9bdde52139cca6c4668ea4d51fd81e9127a3b78f49369db67e"
+url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.9/lefthook_2.1.9_Windows_x86_64.gz"
 provenance = "github-attestations"
 
 [[tools.lima]]
-version = "2.1.1"
+version = "2.1.2"
 backend = "aqua:lima-vm/lima"
 
 [tools.lima."platforms.linux-arm64"]
-checksum = "sha256:1011d18701697e2a559c044932309728fd6488a5380673c489556784924bf3ca"
-url = "https://github.com/lima-vm/lima/releases/download/v2.1.1/lima-2.1.1-Linux-aarch64.tar.gz"
+checksum = "sha256:c2deb0aad9ba375b0d1cc37bf3e01402f2d9ef6cf63db924171d2627823626b0"
+url = "https://github.com/lima-vm/lima/releases/download/v2.1.2/lima-2.1.2-Linux-aarch64.tar.gz"
 provenance = "github-attestations"
 
 [tools.lima."platforms.linux-arm64-musl"]
-checksum = "sha256:1011d18701697e2a559c044932309728fd6488a5380673c489556784924bf3ca"
-url = "https://github.com/lima-vm/lima/releases/download/v2.1.1/lima-2.1.1-Linux-aarch64.tar.gz"
+checksum = "sha256:c2deb0aad9ba375b0d1cc37bf3e01402f2d9ef6cf63db924171d2627823626b0"
+url = "https://github.com/lima-vm/lima/releases/download/v2.1.2/lima-2.1.2-Linux-aarch64.tar.gz"
 provenance = "github-attestations"
 
 [tools.lima."platforms.linux-x64"]
-checksum = "sha256:0f89235de8c3676d988d863cfef37ac7cf4b8a14ba05d5d678a99dfea1db2d3c"
-url = "https://github.com/lima-vm/lima/releases/download/v2.1.1/lima-2.1.1-Linux-x86_64.tar.gz"
+checksum = "sha256:648ed5f599012a0864bd0c4809063b18116bca57f2593d30547dfedbef3c2ce0"
+url = "https://github.com/lima-vm/lima/releases/download/v2.1.2/lima-2.1.2-Linux-x86_64.tar.gz"
 provenance = "github-attestations"
 
 [tools.lima."platforms.linux-x64-musl"]
-checksum = "sha256:0f89235de8c3676d988d863cfef37ac7cf4b8a14ba05d5d678a99dfea1db2d3c"
-url = "https://github.com/lima-vm/lima/releases/download/v2.1.1/lima-2.1.1-Linux-x86_64.tar.gz"
+checksum = "sha256:648ed5f599012a0864bd0c4809063b18116bca57f2593d30547dfedbef3c2ce0"
+url = "https://github.com/lima-vm/lima/releases/download/v2.1.2/lima-2.1.2-Linux-x86_64.tar.gz"
 provenance = "github-attestations"
 
 [tools.lima."platforms.macos-arm64"]
-checksum = "sha256:b6b0e6701189cd8c4e549cc39e6d054dc681487798b9b774ad2cbd30c08b2bd8"
-url = "https://github.com/lima-vm/lima/releases/download/v2.1.1/lima-2.1.1-Darwin-arm64.tar.gz"
+checksum = "sha256:7081d03d01511f20c4a3b38d8120428ef1c66e4b21ec9b54017bc65da60b031f"
+url = "https://github.com/lima-vm/lima/releases/download/v2.1.2/lima-2.1.2-Darwin-arm64.tar.gz"
 provenance = "github-attestations"
 
 [tools.lima."platforms.macos-x64"]
-checksum = "sha256:2dc5b10aa3a4f26d08c1f3fe83e37e01f85a7d9db0d1d5cb6985b18af96ab07d"
-url = "https://github.com/lima-vm/lima/releases/download/v2.1.1/lima-2.1.1-Darwin-x86_64.tar.gz"
+checksum = "sha256:3dc5218c7b0cc14126fb6e3ae6f174f026660e4e2cdffcb34b16e5a2f415eb45"
+url = "https://github.com/lima-vm/lima/releases/download/v2.1.2/lima-2.1.2-Darwin-x86_64.tar.gz"
 provenance = "github-attestations"
 
 [[tools."npm:@claude-flow/cli"]]
-version = "3.5.82"
+version = "3.10.31"
 backend = "npm:@claude-flow/cli"
 
 [[tools."npm:@contextlint/cli"]]
-version = "0.9.1"
+version = "1.1.1"
 backend = "npm:@contextlint/cli"
 
 [[tools."npm:@devcontainers/cli"]]
-version = "0.86.0"
+version = "0.87.0"
 backend = "npm:@devcontainers/cli"
 
 [[tools."npm:@ralph-orchestrator/ralph-cli"]]
-version = "2.9.2"
+version = "2.9.3"
 backend = "npm:@ralph-orchestrator/ralph-cli"
 
 [[tools."npm:agent-browser"]]
-version = "0.26.0"
+version = "0.27.0"
 backend = "npm:agent-browser"
 
 [[tools."npm:agents-lint"]]
 version = "0.5.0"
 backend = "npm:agents-lint"
 
-[[tools."npm:agnix"]]
-version = "0.22.1"
-backend = "npm:agnix"
-
 [[tools."npm:claude-code-lint"]]
-version = "0.3.0"
+version = "0.5.0"
 backend = "npm:claude-code-lint"
 
 [[tools."npm:ctx7"]]
-version = "0.4.0"
+version = "0.4.4"
 backend = "npm:ctx7"
 
 [[tools."npm:markdownlint-cli2"]]
@@ -531,159 +562,159 @@ version = "0.22.1"
 backend = "npm:markdownlint-cli2"
 
 [[tools."npm:oh-my-claude-sisyphus"]]
-version = "4.13.4"
+version = "4.14.4"
 backend = "npm:oh-my-claude-sisyphus"
 
 [[tools."npm:portless"]]
-version = "0.11.0"
+version = "0.13.1"
 backend = "npm:portless"
 
 [[tools."npm:skills"]]
-version = "1.5.2"
+version = "1.5.9"
 backend = "npm:skills"
 
 [[tools.opencode]]
-version = "1.0.205"
+version = "1.15.13"
 backend = "aqua:anomalyco/opencode"
 
 [tools.opencode."platforms.linux-arm64"]
-checksum = "sha256:a2032b585d980bd305b4e9864ee059dc63ed7f97ec07866a5d8fc20b8055636e"
-url = "https://github.com/anomalyco/opencode/releases/download/v1.0.205/opencode-linux-arm64.tar.gz"
+checksum = "sha256:7a0e5da2427c7804314fe0f87b74b4408467f94e3b8b1a61ba25a1d71fe0b4d2"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.15.13/opencode-linux-arm64.tar.gz"
 
 [tools.opencode."platforms.linux-arm64-musl"]
-checksum = "sha256:d03deebb3abf45ef2829480cc6755f00c8d1f544b299eff208ce06c9a1a43908"
-url = "https://github.com/anomalyco/opencode/releases/download/v1.0.205/opencode-linux-arm64-musl.tar.gz"
+checksum = "sha256:a98c2da185a059c29a9b6764dc7da05e91a63c8c0480163d138e7d812882c9bf"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.15.13/opencode-linux-arm64-musl.tar.gz"
 
 [tools.opencode."platforms.linux-x64"]
-checksum = "sha256:ce0af6e5219da0d22c5587e1f712c2776441e5d2844e71494883c357f573b377"
-url = "https://github.com/anomalyco/opencode/releases/download/v1.0.205/opencode-linux-x64.tar.gz"
+checksum = "sha256:51785a07c009f27c5125a5235c5a0ff78433dace07f73fbc44eb672ead4b3d79"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.15.13/opencode-linux-x64.tar.gz"
 
 [tools.opencode."platforms.linux-x64-musl"]
-checksum = "sha256:f9af69caef27e59f63187d345dd602cc8c6a9bc150f69124474758e4258a14db"
-url = "https://github.com/anomalyco/opencode/releases/download/v1.0.205/opencode-linux-x64-musl.tar.gz"
+checksum = "sha256:61f0eed6cbe3114bd22fad53098bcf397e298b51d6e113194b30c32f19002db7"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.15.13/opencode-linux-x64-musl.tar.gz"
 
 [tools.opencode."platforms.macos-arm64"]
-checksum = "sha256:c3799b28882a975f33aee56cd26821d7c01442b07aadd927697ed74586894e04"
-url = "https://github.com/anomalyco/opencode/releases/download/v1.0.205/opencode-darwin-arm64.zip"
+checksum = "sha256:be369a38d15a22e83fad34874d1bc7ddead8084e07df292b28d079287d54ab0c"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.15.13/opencode-darwin-arm64.zip"
 
 [tools.opencode."platforms.macos-x64"]
-checksum = "sha256:c88898b6e682d97abe75fde44e969e9c7bc3c36a75a19b5ca1b13858e92d06aa"
-url = "https://github.com/anomalyco/opencode/releases/download/v1.0.205/opencode-darwin-x64.zip"
+checksum = "sha256:e0da1f0c011daa8717479014968d7ec8ce672801a8ba4710f49471dc9fbb2c7b"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.15.13/opencode-darwin-x64.zip"
 
 [tools.opencode."platforms.windows-x64"]
-checksum = "sha256:8cc1beaea84974bcc80dba51086bef358a14564e8609aa2e365d4702d317c88f"
-url = "https://github.com/anomalyco/opencode/releases/download/v1.0.205/opencode-windows-x64.zip"
+checksum = "sha256:186c5d42c3540e401b3e112ee28c964873cb04f61f1a8b0b43c3c88337efed85"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.15.13/opencode-windows-x64.zip"
 
 [[tools.pinact]]
-version = "3.9.0"
+version = "4.0.0"
 backend = "aqua:suzuki-shunsuke/pinact"
 
 [tools.pinact."platforms.linux-arm64"]
-checksum = "sha256:34a957423002662c6289782b571660beda6a37449a76d763c8ad8b1b9a500a54"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.9.0/pinact_linux_arm64.tar.gz"
+checksum = "sha256:c5d8ef4b253a749b754ad04f484d93c78fade5470bb549d58df6a8aeca9b18bf"
+url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.0.0/pinact_linux_arm64.tar.gz"
 provenance = "github-attestations"
 
 [tools.pinact."platforms.linux-arm64-musl"]
-checksum = "sha256:34a957423002662c6289782b571660beda6a37449a76d763c8ad8b1b9a500a54"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.9.0/pinact_linux_arm64.tar.gz"
+checksum = "sha256:c5d8ef4b253a749b754ad04f484d93c78fade5470bb549d58df6a8aeca9b18bf"
+url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.0.0/pinact_linux_arm64.tar.gz"
 provenance = "github-attestations"
 
 [tools.pinact."platforms.linux-x64"]
-checksum = "sha256:3829da718de38b1e914b974c3e77045a256999af84789437a7305b09130d8a6a"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.9.0/pinact_linux_amd64.tar.gz"
+checksum = "sha256:cc220902615325b10bd3bc52ed3de27488f79adaec52adcd12bd2194c2d2c592"
+url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.0.0/pinact_linux_amd64.tar.gz"
 provenance = "github-attestations"
 
 [tools.pinact."platforms.linux-x64-musl"]
-checksum = "sha256:3829da718de38b1e914b974c3e77045a256999af84789437a7305b09130d8a6a"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.9.0/pinact_linux_amd64.tar.gz"
+checksum = "sha256:cc220902615325b10bd3bc52ed3de27488f79adaec52adcd12bd2194c2d2c592"
+url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.0.0/pinact_linux_amd64.tar.gz"
 provenance = "github-attestations"
 
 [tools.pinact."platforms.macos-arm64"]
-checksum = "sha256:23c8a4eda8fd7949c8cbb1cfe6f3d01279402fe6201e9cb0a90447a5ecfdef89"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.9.0/pinact_darwin_arm64.tar.gz"
+checksum = "sha256:3260e0d6fa7d89e4b9a7cc6c120345db9217c4e0571742e9a76db2ba3ff63650"
+url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.0.0/pinact_darwin_arm64.tar.gz"
 provenance = "github-attestations"
 
 [tools.pinact."platforms.macos-x64"]
-checksum = "sha256:70f68407a05fa88843fbf9b400d979e6205489ef8af251dacc21841a07989df4"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.9.0/pinact_darwin_amd64.tar.gz"
+checksum = "sha256:242d0697152d31bf04f3759ec5c55cf8ccbf47b6e2680dd24531e63a6d890468"
+url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.0.0/pinact_darwin_amd64.tar.gz"
 provenance = "github-attestations"
 
 [tools.pinact."platforms.windows-x64"]
-checksum = "sha256:b923a567f88417d79ce183e59c2a2372d9cae9b697a472ce1f95d745932746b1"
-url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v3.9.0/pinact_windows_amd64.zip"
+checksum = "sha256:800554b9f87c5136e9469ec9075a1f51fbea5ac402914d99f8afc4ec98a87901"
+url = "https://github.com/suzuki-shunsuke/pinact/releases/download/v4.0.0/pinact_windows_amd64.zip"
 provenance = "github-attestations"
 
 [[tools."pipx:check-jsonschema"]]
-version = "0.37.1"
+version = "0.37.2"
 backend = "pipx:check-jsonschema"
 
 [[tools."pipx:deepagents-cli"]]
-version = "0.0.41"
+version = "0.1.2"
 backend = "pipx:deepagents-cli"
 
 [[tools."pipx:mcp2cli"]]
-version = "3.0.2"
+version = "3.2.0"
 backend = "pipx:mcp2cli"
 
 [[tools.pixi]]
-version = "0.66.0"
+version = "0.70.0"
 backend = "github:prefix-dev/pixi"
 
 [tools.pixi."platforms.linux-arm64"]
-checksum = "sha256:2a33639323d6f35832371ea8ac79e86381ae16561ca63f830d3fa1f586223fc0"
-url = "https://github.com/prefix-dev/pixi/releases/download/v0.66.0/pixi-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/prefix-dev/pixi/releases/assets/375845367"
+checksum = "sha256:18ea84042f9c50f899afe6e98dac6656fa9f07f39753ee4d155235fa036c07a1"
+url = "https://github.com/prefix-dev/pixi/releases/download/v0.70.0/pixi-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/prefix-dev/pixi/releases/assets/435151827"
 
 [tools.pixi."platforms.linux-arm64".provenance.slsa]
-url = "https://github.com/prefix-dev/pixi/releases/download/v0.66.0/attestations-aarch64-unknown-linux-musl.intoto.jsonl"
+url = "https://github.com/prefix-dev/pixi/releases/download/v0.70.0/attestations-aarch64-unknown-linux-musl.intoto.jsonl"
 
 [tools.pixi."platforms.linux-arm64-musl"]
-checksum = "sha256:2a33639323d6f35832371ea8ac79e86381ae16561ca63f830d3fa1f586223fc0"
-url = "https://github.com/prefix-dev/pixi/releases/download/v0.66.0/pixi-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/prefix-dev/pixi/releases/assets/375845367"
+checksum = "sha256:18ea84042f9c50f899afe6e98dac6656fa9f07f39753ee4d155235fa036c07a1"
+url = "https://github.com/prefix-dev/pixi/releases/download/v0.70.0/pixi-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/prefix-dev/pixi/releases/assets/435151827"
 
 [tools.pixi."platforms.linux-arm64-musl".provenance.slsa]
-url = "https://github.com/prefix-dev/pixi/releases/download/v0.66.0/attestations-aarch64-unknown-linux-musl.intoto.jsonl"
+url = "https://github.com/prefix-dev/pixi/releases/download/v0.70.0/attestations-aarch64-unknown-linux-musl.intoto.jsonl"
 
 [tools.pixi."platforms.linux-x64"]
-checksum = "sha256:a13a31ada2495ba6eeeeb3b8007d5521d519bdf98921668aa211ea946e63ea28"
-url = "https://github.com/prefix-dev/pixi/releases/download/v0.66.0/pixi-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/prefix-dev/pixi/releases/assets/375845446"
+checksum = "sha256:23cb0b727b187a7c57aafe9456a76272bdbff30372be6e6f72187df948ad89df"
+url = "https://github.com/prefix-dev/pixi/releases/download/v0.70.0/pixi-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/prefix-dev/pixi/releases/assets/435151922"
 
 [tools.pixi."platforms.linux-x64".provenance.slsa]
-url = "https://github.com/prefix-dev/pixi/releases/download/v0.66.0/attestations-x86_64-unknown-linux-musl.intoto.jsonl"
+url = "https://github.com/prefix-dev/pixi/releases/download/v0.70.0/attestations-x86_64-unknown-linux-musl.intoto.jsonl"
 
 [tools.pixi."platforms.linux-x64-musl"]
-checksum = "sha256:a13a31ada2495ba6eeeeb3b8007d5521d519bdf98921668aa211ea946e63ea28"
-url = "https://github.com/prefix-dev/pixi/releases/download/v0.66.0/pixi-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/prefix-dev/pixi/releases/assets/375845446"
+checksum = "sha256:23cb0b727b187a7c57aafe9456a76272bdbff30372be6e6f72187df948ad89df"
+url = "https://github.com/prefix-dev/pixi/releases/download/v0.70.0/pixi-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/prefix-dev/pixi/releases/assets/435151922"
 
 [tools.pixi."platforms.linux-x64-musl".provenance.slsa]
-url = "https://github.com/prefix-dev/pixi/releases/download/v0.66.0/attestations-x86_64-unknown-linux-musl.intoto.jsonl"
+url = "https://github.com/prefix-dev/pixi/releases/download/v0.70.0/attestations-x86_64-unknown-linux-musl.intoto.jsonl"
 
 [tools.pixi."platforms.macos-arm64"]
-checksum = "sha256:1e2461c2b6865f5b9c2351c5dd7a1ea0cfa27ddad825a00619a10f4988ecf881"
-url = "https://github.com/prefix-dev/pixi/releases/download/v0.66.0/pixi-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/prefix-dev/pixi/releases/assets/375845280"
+checksum = "sha256:3a64eab1df606a0c8b3dd4b68afd8566d4ef4801568effd2e8c12a6b3f2a4a3e"
+url = "https://github.com/prefix-dev/pixi/releases/download/v0.70.0/pixi-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/prefix-dev/pixi/releases/assets/435151774"
 
 [tools.pixi."platforms.macos-arm64".provenance.slsa]
-url = "https://github.com/prefix-dev/pixi/releases/download/v0.66.0/attestations-aarch64-apple-darwin.intoto.jsonl"
+url = "https://github.com/prefix-dev/pixi/releases/download/v0.70.0/attestations-aarch64-apple-darwin.intoto.jsonl"
 
 [tools.pixi."platforms.macos-x64"]
-checksum = "sha256:7183c812fda4f84026f8a9f1834e7b22e5929fbf301ce3f3ca68a60b47840492"
-url = "https://github.com/prefix-dev/pixi/releases/download/v0.66.0/pixi-x86_64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/prefix-dev/pixi/releases/assets/375845390"
+checksum = "sha256:2ee35617a1bc99e0a17a4b1d904461ebf7800f88c7d1ab1976cb51f19a3b0a54"
+url = "https://github.com/prefix-dev/pixi/releases/download/v0.70.0/pixi-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/prefix-dev/pixi/releases/assets/435151871"
 
 [tools.pixi."platforms.macos-x64".provenance.slsa]
-url = "https://github.com/prefix-dev/pixi/releases/download/v0.66.0/attestations-x86_64-apple-darwin.intoto.jsonl"
+url = "https://github.com/prefix-dev/pixi/releases/download/v0.70.0/attestations-x86_64-apple-darwin.intoto.jsonl"
 
 [tools.pixi."platforms.windows-x64"]
-checksum = "sha256:75b961f2d447b82122f702146977db43e351164236476f012fdefec5b8634894"
-url = "https://github.com/prefix-dev/pixi/releases/download/v0.66.0/pixi-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/prefix-dev/pixi/releases/assets/375845422"
+checksum = "sha256:5c933109a9c572ebab8ad6939bcac66ecb77639c4dc83c589f461e6422080e22"
+url = "https://github.com/prefix-dev/pixi/releases/download/v0.70.0/pixi-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/prefix-dev/pixi/releases/assets/435151911"
 
 [tools.pixi."platforms.windows-x64".provenance.slsa]
-url = "https://github.com/prefix-dev/pixi/releases/download/v0.66.0/attestations-x86_64-pc-windows-msvc.intoto.jsonl"
+url = "https://github.com/prefix-dev/pixi/releases/download/v0.70.0/attestations-x86_64-pc-windows-msvc.intoto.jsonl"
 
 [[tools.pkl]]
 version = "0.31.1"
@@ -718,42 +749,42 @@ checksum = "sha256:a8834481667325b44c539dbb758d7365a16389070f343c04b639bbe525ede
 url = "https://github.com/apple/pkl/releases/download/0.31.1/pkl-windows-amd64.exe"
 
 [[tools.python]]
-version = "3.14.4"
+version = "3.14.5"
 backend = "core:python"
 
 [tools.python."platforms.linux-arm64"]
-checksum = "sha256:b8b597fdb2f8dccdc502c11947b60a4b65eb6bce79cfa60c7ccf9b6e8352c60a"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260414/cpython-3.14.4+20260414-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
+checksum = "sha256:1d3ea1b3cd9b8f3d53afb629e82e9bc8f6dab6cbb1a7d23524bd86ba5bc22570"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260602/cpython-3.14.5+20260602-aarch64-unknown-linux-gnu-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [tools.python."platforms.linux-arm64-musl"]
-checksum = "sha256:a10687b226e0941632569836bc1d8fa6353a8e3e8424316467ca9cdf220b983d"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260414/cpython-3.14.4+20260414-aarch64-unknown-linux-musl-install_only_stripped.tar.gz"
+checksum = "sha256:23dfd69917f1c693b7ce857f014a72da546c8132c277bb6ac98fdbe12334e221"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260602/cpython-3.14.5+20260602-aarch64-unknown-linux-musl-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [tools.python."platforms.linux-x64"]
-checksum = "sha256:fe9a9c32d13870af632cbac3dfc7528ae53597e94472aa4c7d6a42e8166136cd"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260414/cpython-3.14.4+20260414-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
+checksum = "sha256:982a60fc7f11bbe405ab54afcd4eb145f1134797bbbffac9f5c49df4ec98b13e"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260602/cpython-3.14.5+20260602-x86_64-unknown-linux-gnu-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [tools.python."platforms.linux-x64-musl"]
-checksum = "sha256:d6005226cd24e780630626232c7a63243d4885fdf975dcf930a0758a0759ce14"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260414/cpython-3.14.4+20260414-x86_64-unknown-linux-musl-install_only_stripped.tar.gz"
+checksum = "sha256:09fb97b20df0ed9336d39468007619b3458489c33fa4166b43155587b382f84a"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260602/cpython-3.14.5+20260602-x86_64-unknown-linux-musl-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [tools.python."platforms.macos-arm64"]
-checksum = "sha256:6f304f4ec30854611f23316578302235fb517cd970519ecdd11a8c4db87fd843"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260414/cpython-3.14.4+20260414-aarch64-apple-darwin-install_only_stripped.tar.gz"
+checksum = "sha256:3a0373cc39fefd494754ef555267f245c720cddbaaabf63a7c9a4269f1e56532"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260602/cpython-3.14.5+20260602-aarch64-apple-darwin-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [tools.python."platforms.macos-x64"]
-checksum = "sha256:d51250a32fa5d9f0799c7bcb71720c27b10a3afd4a7de288120f96085d508a5a"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260414/cpython-3.14.4+20260414-x86_64-apple-darwin-install_only_stripped.tar.gz"
+checksum = "sha256:d44ff6ec301cabc91eb0c756b1948b28579fb07feba36aaf1990e535649d5ea6"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260602/cpython-3.14.5+20260602-x86_64-apple-darwin-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [tools.python."platforms.windows-x64"]
-checksum = "sha256:a976991dcd085c1bb5d9a8084823a6bc8b7f9b079d8c432574a6ddd68c3a6fe1"
-url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260414/cpython-3.14.4+20260414-x86_64-pc-windows-msvc-install_only_stripped.tar.gz"
+checksum = "sha256:66b065143e538c07f069f764d831d8ffae95507907d4ca211304e6f3a056435c"
+url = "https://github.com/astral-sh/python-build-standalone/releases/download/20260602/cpython-3.14.5+20260602-x86_64-pc-windows-msvc-install_only_stripped.tar.gz"
 provenance = "github-attestations"
 
 [[tools.rtk]]
@@ -796,42 +827,42 @@ url = "https://github.com/rtk-ai/rtk/releases/download/v0.37.2/rtk-x86_64-pc-win
 url_api = "https://api.github.com/repos/rtk-ai/rtk/releases/assets/400927838"
 
 [[tools.rumdl]]
-version = "0.1.83"
+version = "0.2.4"
 backend = "aqua:rvben/rumdl"
 
 [tools.rumdl."platforms.linux-arm64"]
-checksum = "sha256:0991912871809170a6c780690bac58b22147e210558623e9bcf23fe2a07c603f"
-url = "https://github.com/rvben/rumdl/releases/download/v0.1.83/rumdl-v0.1.83-aarch64-unknown-linux-musl.tar.gz"
+checksum = "sha256:dbebfff0b8069550f12a833572c3caf7177baebbe7aec7dbcc0cadbba01125a0"
+url = "https://github.com/rvben/rumdl/releases/download/v0.2.4/rumdl-v0.2.4-aarch64-unknown-linux-musl.tar.gz"
 provenance = "github-attestations"
 
 [tools.rumdl."platforms.linux-arm64-musl"]
-checksum = "sha256:0991912871809170a6c780690bac58b22147e210558623e9bcf23fe2a07c603f"
-url = "https://github.com/rvben/rumdl/releases/download/v0.1.83/rumdl-v0.1.83-aarch64-unknown-linux-musl.tar.gz"
+checksum = "sha256:dbebfff0b8069550f12a833572c3caf7177baebbe7aec7dbcc0cadbba01125a0"
+url = "https://github.com/rvben/rumdl/releases/download/v0.2.4/rumdl-v0.2.4-aarch64-unknown-linux-musl.tar.gz"
 provenance = "github-attestations"
 
 [tools.rumdl."platforms.linux-x64"]
-checksum = "sha256:5bbe124101d85a75c4ce170dc3bef701205b7c31cb61628d0f0731d5fe43e945"
-url = "https://github.com/rvben/rumdl/releases/download/v0.1.83/rumdl-v0.1.83-x86_64-unknown-linux-musl.tar.gz"
+checksum = "sha256:b0ae99a215671311d425d49abe65bd69b9fe153f3662b489b8243e73e036959f"
+url = "https://github.com/rvben/rumdl/releases/download/v0.2.4/rumdl-v0.2.4-x86_64-unknown-linux-musl.tar.gz"
 provenance = "github-attestations"
 
 [tools.rumdl."platforms.linux-x64-musl"]
-checksum = "sha256:5bbe124101d85a75c4ce170dc3bef701205b7c31cb61628d0f0731d5fe43e945"
-url = "https://github.com/rvben/rumdl/releases/download/v0.1.83/rumdl-v0.1.83-x86_64-unknown-linux-musl.tar.gz"
+checksum = "sha256:b0ae99a215671311d425d49abe65bd69b9fe153f3662b489b8243e73e036959f"
+url = "https://github.com/rvben/rumdl/releases/download/v0.2.4/rumdl-v0.2.4-x86_64-unknown-linux-musl.tar.gz"
 provenance = "github-attestations"
 
 [tools.rumdl."platforms.macos-arm64"]
-checksum = "sha256:6f853bb7bf1397a490ee382ab22e23cb2d3332037f050ccf6d09028659f7f562"
-url = "https://github.com/rvben/rumdl/releases/download/v0.1.83/rumdl-v0.1.83-aarch64-apple-darwin.tar.gz"
+checksum = "sha256:83aeb436ea758e9ac8524c580fe5d995d893fbd0544e1cda534cdc5ebbce7a1f"
+url = "https://github.com/rvben/rumdl/releases/download/v0.2.4/rumdl-v0.2.4-aarch64-apple-darwin.tar.gz"
 provenance = "github-attestations"
 
 [tools.rumdl."platforms.macos-x64"]
-checksum = "sha256:217676cbbdff24be588e0dac661918f196a15f8f95d6a3212c46806fce23243d"
-url = "https://github.com/rvben/rumdl/releases/download/v0.1.83/rumdl-v0.1.83-x86_64-apple-darwin.tar.gz"
+checksum = "sha256:64bcc51604ce5e2af47b990b8fed5cb81d5766fabc42ccb9917b7d4fcb356e74"
+url = "https://github.com/rvben/rumdl/releases/download/v0.2.4/rumdl-v0.2.4-x86_64-apple-darwin.tar.gz"
 provenance = "github-attestations"
 
 [tools.rumdl."platforms.windows-x64"]
-checksum = "sha256:9c585326265ed5591ca543c76d3787eb95a77af812738918f6f5e15b62def161"
-url = "https://github.com/rvben/rumdl/releases/download/v0.1.83/rumdl-v0.1.83-x86_64-pc-windows-msvc.zip"
+checksum = "sha256:d3bb0de583f4a01c110e47cefb7b5c048cfba38707e4c828c18aca4cda4a5e4e"
+url = "https://github.com/rvben/rumdl/releases/download/v0.2.4/rumdl-v0.2.4-x86_64-pc-windows-msvc.zip"
 provenance = "github-attestations"
 
 [[tools.shellcheck]]
@@ -925,74 +956,74 @@ url = "https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-darwin-x8
 url = "https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-windows-x86_64.zip"
 
 [[tools.typos]]
-version = "1.45.1"
+version = "1.47.0"
 backend = "aqua:crate-ci/typos"
 
 [tools.typos."platforms.linux-arm64"]
-checksum = "sha256:0d3688c607a49ffb6dedaca6de44e4217abeaa5b93228d673dc5caf76f60489f"
-url = "https://github.com/crate-ci/typos/releases/download/v1.45.1/typos-v1.45.1-aarch64-unknown-linux-musl.tar.gz"
+checksum = "sha256:0349ec65605216136b57c3ea6f1a02034e7e8bc128788474b635396997015d54"
+url = "https://github.com/crate-ci/typos/releases/download/v1.47.0/typos-v1.47.0-aarch64-unknown-linux-musl.tar.gz"
 
 [tools.typos."platforms.linux-arm64-musl"]
-checksum = "sha256:0d3688c607a49ffb6dedaca6de44e4217abeaa5b93228d673dc5caf76f60489f"
-url = "https://github.com/crate-ci/typos/releases/download/v1.45.1/typos-v1.45.1-aarch64-unknown-linux-musl.tar.gz"
+checksum = "sha256:0349ec65605216136b57c3ea6f1a02034e7e8bc128788474b635396997015d54"
+url = "https://github.com/crate-ci/typos/releases/download/v1.47.0/typos-v1.47.0-aarch64-unknown-linux-musl.tar.gz"
 
 [tools.typos."platforms.linux-x64"]
-checksum = "sha256:33447531a0eff29796d6fb9b555b4628723db72c6bad129e168d97ac86ceb0f1"
-url = "https://github.com/crate-ci/typos/releases/download/v1.45.1/typos-v1.45.1-x86_64-unknown-linux-musl.tar.gz"
+checksum = "sha256:6f8a935cea6c60b060082b862a7e777bfd92d939a4fd4194d8085b086dfe24e4"
+url = "https://github.com/crate-ci/typos/releases/download/v1.47.0/typos-v1.47.0-x86_64-unknown-linux-musl.tar.gz"
 
 [tools.typos."platforms.linux-x64-musl"]
-checksum = "sha256:33447531a0eff29796d6fb9b555b4628723db72c6bad129e168d97ac86ceb0f1"
-url = "https://github.com/crate-ci/typos/releases/download/v1.45.1/typos-v1.45.1-x86_64-unknown-linux-musl.tar.gz"
+checksum = "sha256:6f8a935cea6c60b060082b862a7e777bfd92d939a4fd4194d8085b086dfe24e4"
+url = "https://github.com/crate-ci/typos/releases/download/v1.47.0/typos-v1.47.0-x86_64-unknown-linux-musl.tar.gz"
 
 [tools.typos."platforms.macos-arm64"]
-checksum = "sha256:2c31ed16286f26c08ae477faf001af8542ff23aeb6e7323be5f620710c192fb5"
-url = "https://github.com/crate-ci/typos/releases/download/v1.45.1/typos-v1.45.1-aarch64-apple-darwin.tar.gz"
+checksum = "sha256:9baa4690960c82cdc3d28bc4744c6ca84df24d99cc1f709869cc14fa8717601a"
+url = "https://github.com/crate-ci/typos/releases/download/v1.47.0/typos-v1.47.0-aarch64-apple-darwin.tar.gz"
 
 [tools.typos."platforms.macos-x64"]
-checksum = "sha256:70767b5d8d920cbb17b452a6b068e36e1b3fd649089bce883d3512eb85990326"
-url = "https://github.com/crate-ci/typos/releases/download/v1.45.1/typos-v1.45.1-x86_64-apple-darwin.tar.gz"
+checksum = "sha256:aae88e65ed25c091dd4c4a9767b2d36f7913d08f76b38c1bb8ccd189284870d7"
+url = "https://github.com/crate-ci/typos/releases/download/v1.47.0/typos-v1.47.0-x86_64-apple-darwin.tar.gz"
 
 [tools.typos."platforms.windows-x64"]
-checksum = "sha256:a4ae081cb7a403f2b75e8c066aa4a4484207547c4e9eb2b4df3f68ecdbc5dd3e"
-url = "https://github.com/crate-ci/typos/releases/download/v1.45.1/typos-v1.45.1-x86_64-pc-windows-msvc.zip"
+checksum = "sha256:8773b1b3029b1e149b7bd676785b065b236173a7509bc9ab19fa64e638ae989a"
+url = "https://github.com/crate-ci/typos/releases/download/v1.47.0/typos-v1.47.0-x86_64-pc-windows-msvc.zip"
 
 [[tools.uv]]
-version = "0.11.7"
+version = "0.11.17"
 backend = "aqua:astral-sh/uv"
 
 [tools.uv."platforms.linux-arm64"]
-checksum = "sha256:46647dc16cbb7d6700f762fdd7a67d220abe18570914732bc310adc91308d272"
-url = "https://github.com/astral-sh/uv/releases/download/0.11.7/uv-aarch64-unknown-linux-musl.tar.gz"
+checksum = "sha256:9e5eaf16ffad968fc689f18c2733ace914ed417d4e5572e92d807fd51a90228c"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.17/uv-aarch64-unknown-linux-musl.tar.gz"
 provenance = "github-attestations"
 
 [tools.uv."platforms.linux-arm64-musl"]
-checksum = "sha256:46647dc16cbb7d6700f762fdd7a67d220abe18570914732bc310adc91308d272"
-url = "https://github.com/astral-sh/uv/releases/download/0.11.7/uv-aarch64-unknown-linux-musl.tar.gz"
+checksum = "sha256:9e5eaf16ffad968fc689f18c2733ace914ed417d4e5572e92d807fd51a90228c"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.17/uv-aarch64-unknown-linux-musl.tar.gz"
 provenance = "github-attestations"
 
 [tools.uv."platforms.linux-x64"]
-checksum = "sha256:64ddb5f1087649e3f75aa50d139aa4f36ddde728a5295a141e0fa9697bfb7b0f"
-url = "https://github.com/astral-sh/uv/releases/download/0.11.7/uv-x86_64-unknown-linux-musl.tar.gz"
+checksum = "sha256:4231a429d4e0f7c1937d8916658c08a7706cd7872afebeb87203a18c2e0dc28e"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.17/uv-x86_64-unknown-linux-musl.tar.gz"
 provenance = "github-attestations"
 
 [tools.uv."platforms.linux-x64-musl"]
-checksum = "sha256:64ddb5f1087649e3f75aa50d139aa4f36ddde728a5295a141e0fa9697bfb7b0f"
-url = "https://github.com/astral-sh/uv/releases/download/0.11.7/uv-x86_64-unknown-linux-musl.tar.gz"
+checksum = "sha256:4231a429d4e0f7c1937d8916658c08a7706cd7872afebeb87203a18c2e0dc28e"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.17/uv-x86_64-unknown-linux-musl.tar.gz"
 provenance = "github-attestations"
 
 [tools.uv."platforms.macos-arm64"]
-checksum = "sha256:66e37d91f839e12481d7b932a1eccbfe732560f42c1cfb89faddfa2454534ba8"
-url = "https://github.com/astral-sh/uv/releases/download/0.11.7/uv-aarch64-apple-darwin.tar.gz"
+checksum = "sha256:2a162f6b90ff3691a2f9cae1622e066a3ce592e110f66670cdcc841324b28226"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.17/uv-aarch64-apple-darwin.tar.gz"
 provenance = "github-attestations"
 
 [tools.uv."platforms.macos-x64"]
-checksum = "sha256:0a4bc8fcde4974ea3560be21772aeecab600a6f43fa6e58169f9fa7b3b71d302"
-url = "https://github.com/astral-sh/uv/releases/download/0.11.7/uv-x86_64-apple-darwin.tar.gz"
+checksum = "sha256:6c66e41eaf4d15abeda58d3f268161b6e3f742d98390341b174a7cfc1b48841d"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.17/uv-x86_64-apple-darwin.tar.gz"
 provenance = "github-attestations"
 
 [tools.uv."platforms.windows-x64"]
-checksum = "sha256:fe0c7815acf4fc45f8a5eff58ed3cf7ae2e15c3cf1dceadbd10c816ec1690cc1"
-url = "https://github.com/astral-sh/uv/releases/download/0.11.7/uv-x86_64-pc-windows-msvc.zip"
+checksum = "sha256:35fc29e03e62f3cda769bc12773f3cb70ce305d0d36c0d8bd0c117dd0b3fcd14"
+url = "https://github.com/astral-sh/uv/releases/download/0.11.17/uv-x86_64-pc-windows-msvc.zip"
 provenance = "github-attestations"
 
 [[tools.yamlfmt]]

--- a/mise.toml
+++ b/mise.toml
@@ -2,57 +2,57 @@
 # These are Build Type 1 tools: run locally before commits
 
 [tools]
-hk = "1.44.2"
+hk = "1.46.0"
 pkl = "0.31.1"
 hadolint = "2.14.0"
 shellcheck = "0.11.0"
 shfmt = "3.13.1"
 taplo = "0.10.0"
 actionlint = "1.7.12"
-typos = "1.45.1"
+typos = "1.47.0"
 yamllint = "1.38.0"
 yamlfmt = "0.21.0"
 yq = "4.53.2"
-ghalint = "1.5.5"
+ghalint = "1.5.6"
 jq = "1.8.1"
 # Python toolchain for the mde-py package in python/
-python = "3.14.4"
-uv = "0.11.7"
-pixi = "0.66.0"  # Pinned: 0.67.2 ships only source tarball under mise's core backend (binary missing). Bump after verifying install layout. Also in mise-system.toml; needed locally for tests/test_bootstrap.py + test_shell_integration.py.
-pinact = "3.9.0"
-chezmoi = "2.70.2"
-"npm:@devcontainers/cli" = "0.86.0"
+python = "3.14.5"
+uv = "0.11.17"
+pixi = "0.70.0"
+pinact = "4.0.0"
+chezmoi = "2.70.4"
+"npm:@devcontainers/cli" = "0.87.0"
 colima = "0.10.1"  # Alternate Docker runtime (VZ + Rosetta); Docker Desktop is the CURRENT supported runtime — see AGENTS.md Docker Runtimes + .omc/research/research-20260409c-dockerdesktop-ssh/
-lima = "2.1.1"     # Runtime dependency for colima (provides limactl); kept for deferred Colima follow-up
-"npm:agnix" = "0.22.1"
+lima = "2.1.2"
+"github:agent-sh/agnix" = "0.36.2"  # prebuilt release binary; npm: backend needs a postinstall download that bun skips (binary-not-found). Release tag is v0.36.2.
 "npm:agents-lint" = "0.5.0"
-"pipx:mcp2cli" = "3.0.2"
-"pipx:check-jsonschema" = "0.37.1"  # Full JSON Schema URL validation for .devcontainer/devcontainer.json (needs JSONC→JSON preprocessing)
-biome = "2.4.13"
+"pipx:mcp2cli" = "3.2.0"
+"pipx:check-jsonschema" = "0.37.2"
+biome = "2.4.16"
 # Markdown + Claude-docs linters. Installed now; hk.pkl integration is
 # scheduled for post-devcontainer-work review (see GH issue tracking
 # follow-up). claude_md_size_limit (below in hk.pkl) provides the
 # immediate 200-line enforcement per Claude Code memory docs.
-"npm:claude-code-lint" = "0.3.0"       # https://github.com/pdugan20/claudelint — CLAUDE.md size limits, import syntax, frontmatter
-"npm:@contextlint/cli" = "0.9.1"       # https://github.com/nozomi-koborinai/contextlint — structured markdown cross-file integrity
+"npm:claude-code-lint" = "0.5.0"
+"npm:@contextlint/cli" = "1.1.1"
 "npm:markdownlint-cli2" = "0.22.1"      # https://github.com/DavidAnson/markdownlint — general markdown quality (MD013 line-length, etc.)
-"aqua:jackchuka/mdschema" = "0.12.9"     # https://github.com/jackchuka/mdschema — markdown frontmatter schema validation
-"rumdl" = "0.1.83"            # https://github.com/rvben/rumdl — Rust-fast markdown linter (71 rules)
-"npm:oh-my-claude-sisyphus" = "4.13.4"
-"github:ast-grep/ast-grep" = "0.42.1"
-lefthook = "2.1.6"
-"npm:ctx7" = "0.4.0"
-rtk = "0.37.2"
-"npm:skills" = "1.5.2"
-"npm:agent-browser" = "0.26.0"
-"npm:portless" = "0.11.0"
-"pipx:deepagents-cli" = "0.0.41"
-aws-cli = { version = "2.34.38", symlink_bins = "true" }
-azure-cli = { version = "2.85.0", uvx_args = "--prerelease=allow" }
-docker-cli = "29.4.1"
-opencode = "1.0.205"
-"npm:@claude-flow/cli" = "3.5.82"
-"npm:@ralph-orchestrator/ralph-cli" = "2.9.2"
+"aqua:jackchuka/mdschema" = "0.13.1"
+rumdl = "0.2.4"
+"npm:oh-my-claude-sisyphus" = "4.14.4"
+"github:ast-grep/ast-grep" = "0.43.0"
+lefthook = "2.1.9"
+"npm:ctx7" = "0.4.4"
+rtk = "0.37.2"  # held at 0.37.2: github backend for rtk@0.42.0 fails to populate url_api in mise.lock → CI install errors "relative URL without a base". Revisit bump separately.
+"npm:skills" = "1.5.9"
+"npm:agent-browser" = "0.27.0"
+"npm:portless" = "0.13.1"
+"pipx:deepagents-cli" = "0.1.2"
+aws-cli = { version = "2.34.58", symlink_bins = "true" }
+azure-cli = { version = "2.86.0", uvx_args = "--prerelease=allow" }
+docker-cli = "29.5.2"
+opencode = "1.15.13"
+"npm:@claude-flow/cli" = "3.10.31"
+"npm:@ralph-orchestrator/ralph-cli" = "2.9.3"
 
 [settings]
 experimental = true


### PR DESCRIPTION
## Why

CI's `lint` job — and therefore every PR and the daily nightly — has been **red since ~June 5** with `agnix binary not found`. `main` was effectively un-mergeable. This PR fixes that and hardens CI run-deduplication.

## 1. agnix backend fix (unblocks lint)

`npm:agnix` ships a Node launcher that spawns a sibling native `agnix-binary`, which its `postinstall` (`node install.js`) downloads from GitHub releases. mise's npm backend uses **bun** (`npm.package_manager = "bun"`), and **bun skips postinstall scripts by default**, so the native binary is never fetched → launcher exits 1. Reproduces on macOS host and in CI; a version bump doesn't help because the *backend* is the problem.

Fix: switch to **`github:agent-sh/agnix`** (prebuilt release binary, no postinstall). Chosen over `ubi:` because the github backend pins all 7 platforms in `mise.lock` with URLs + checksums (matching `ast-grep`/`mdschema`), resolving the correct CLI asset for linux-x64 (CI) and macos-arm64 (host) — not the `agnix-lsp`/`agnix-mcp` decoys.

**Audit:** agnix was the only repo-relevant npm tool with the download-postinstall pattern.

## 2. Concurrency: cancel superseded runs per branch

`ci.yml` / `autofix.yml` now group by `github.workflow`-`github.head_ref || github.ref`, so all events for a source branch share one concurrency group and **only the latest commit's run survives** — older in-flight runs on the same branch are cancelled. main stays exempt from cancellation (`cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`) because its push-path `promote` manifest-retag must not be interrupted.

## Bundled

In-progress tool bumps (hk 1.46.0, python 3.14.5, uv 0.11.17, pixi 0.70.0, pinact 4.0.0, chezmoi 2.70.4, @devcontainers/cli 0.87.0, biome 2.4.16, ast-grep 0.43.0, aws-cli 2.34.58, docker-cli 29.5.2, +more) and a settings.json plugin enable.

`rtk` held at 0.37.2 — github backend for rtk@0.42.0 fails to populate `url_api` in `mise.lock` (CI install errors "relative URL without a base"). Parked for separate investigation.

`mise.lock` carries the linux-x64 checksums for aws-cli/docker-cli that CI computes, so the autofix lint pass finds no drift to commit back.

## Validation (local, all green)

- `hk run pre-commit --all --stash none` — 0 failures
- `uv run --project python pytest tests/ -x -q` — 97 passed
- `dotfiles-setup verify run` — 66 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)