### PR TITLE
ci: path-gate the build chain to skip non-image changes (Phase 1b)

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -69,6 +69,12 @@ Push-to-main path (after a PR merge):
 
 - **All actions SHA-pinned** via pinact. Run `mise run pin-actions`
   locally to verify before committing workflow changes.
+- **Build chain is path-gated.** A `changes` job (dorny/paths-filter)
+  sets `build` true only when image/test inputs change (`.devcontainer/**`,
+  `docker-bake.hcl`, `hk-common.pkl`, `hk-image.pkl`, `python/**`,
+  `.dive-ci`, `install.sh`, `ci.yml`); base-prep→smoke-test AND `promote`
+  gate on it. Docs/root-mise/hk.pkl/home PRs run lint+contract-preflight
+  only; schedule + workflow_dispatch always build.
 - **Concurrency cancels superseded runs per branch.** `ci.yml` and
   `autofix.yml` group by
   `${{ github.workflow }}-${{ github.head_ref || github.ref }}` so all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,69 @@ jobs:
             --json
 
   # ============================================================
+  # Change detection: gate the Docker build chain (base-prep →
+  # p2996-prep → build → smoke-test) AND `promote` on whether the
+  # change actually touches image- or test-relevant paths. Skips the
+  # whole chain for PRs/merges that only touch docs, root mise.toml/
+  # mise.lock (host-only — the image uses .devcontainer/mise-system.toml),
+  # hk.pkl, home/**, .claude/**, etc.
+  #
+  # Build-relevant paths = the image's actual inputs:
+  #   - .devcontainer/** (Dockerfile, mise-system.toml, resolved snapshot,
+  #     devcontainer.json), docker-bake.hcl, hk-common.pkl, hk-image.pkl
+  #     (all COPYd into the image or feed the bake/base/p2996 hashes)
+  #   - python/** + .dive-ci (drive base-hash/p2996-hash, contract-preflight
+  #     verify, and smoke-test) and ci.yml itself (build behaviour).
+  #
+  # schedule + workflow_dispatch always build (nightly full rebuild is
+  # intentional; do NOT gate it). The build jobs keep their existing
+  # push-to-main exemption; `promote` additionally skips when the merge
+  # changed no build paths (the image is unchanged, so :dev/:latest is
+  # already current and needs no retag/rebuild).
+  # ============================================================
+  changes:
+    needs: lint
+    runs-on: ubuntu-latest
+    outputs:
+      build: ${{ steps.decide.outputs.build }}
+    steps:
+      - name: Checkout code
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Filter build-relevant paths
+        id: filter
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            build:
+              - '.devcontainer/**'
+              - 'docker-bake.hcl'
+              - 'hk-common.pkl'
+              - 'hk-image.pkl'
+              - 'install.sh'
+              - 'python/**'
+              - '.dive-ci'
+              - '.github/workflows/ci.yml'
+
+      - name: Decide whether the build chain runs
+        id: decide
+        env:
+          EVENT: ${{ github.event_name }}
+          FILTER_BUILD: ${{ steps.filter.outputs.build }}
+        run: |
+          # Non-PR/non-push events (schedule, workflow_dispatch) always
+          # build; PRs and main pushes build only when a build-relevant
+          # path changed.
+          case "$EVENT" in
+            pull_request|push) echo "build=${FILTER_BUILD}" >> "$GITHUB_OUTPUT" ;;
+            *) echo "build=true" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+  # ============================================================
   # Base cache prep: compute content-hash of devcontainer-base inputs
   # (apt + mise install + cargo crates layer) and ensure
   # ghcr.io/<owner>/<repo>:base-<hash16> exists. On hit, exits in <30s.
@@ -186,8 +249,8 @@ jobs:
   # base layer.
   # ============================================================
   base-prep:
-    needs: contract-preflight
-    if: github.event_name != 'push' || github.ref != 'refs/heads/main'
+    needs: [contract-preflight, changes]
+    if: (github.event_name != 'push' || github.ref != 'refs/heads/main') && needs.changes.outputs.build == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -290,8 +353,8 @@ jobs:
   # See .devcontainer/P2996-CACHE.md for the cache mechanism.
   # ============================================================
   p2996-prep:
-    needs: [contract-preflight, base-prep]
-    if: github.event_name != 'push' || github.ref != 'refs/heads/main'
+    needs: [contract-preflight, base-prep, changes]
+    if: (github.event_name != 'push' || github.ref != 'refs/heads/main') && needs.changes.outputs.build == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -393,8 +456,8 @@ jobs:
   # Build Type 2: Dotfiles environment image (Docker → ghcr.io)
   # ============================================================
   build:
-    needs: [contract-preflight, base-prep, p2996-prep]
-    if: github.event_name != 'push' || github.ref != 'refs/heads/main'
+    needs: [contract-preflight, base-prep, p2996-prep, changes]
+    if: (github.event_name != 'push' || github.ref != 'refs/heads/main') && needs.changes.outputs.build == 'true'
     runs-on: ubuntu-latest
     outputs:
       image-tag: ${{ steps.meta.outputs.tags }}
@@ -484,8 +547,8 @@ jobs:
   # and main publication.
   # ============================================================
   smoke-test:
-    needs: build
-    if: github.event_name != 'push' || github.ref != 'refs/heads/main'
+    needs: [build, changes]
+    if: (github.event_name != 'push' || github.ref != 'refs/heads/main') && needs.changes.outputs.build == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -624,8 +687,12 @@ jobs:
   # push), fall back to a workflow_dispatch with force_dev_tag=true.
   # ============================================================
   promote:
-    needs: lint
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [lint, changes]
+    # Only promote when the merge changed build-relevant paths. A docs-only
+    # merge skipped the PR build (no :pr-NNN image) and left the image
+    # unchanged, so :dev/:latest is already current — promoting would
+    # needlessly trigger the fallback rebuild.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.build == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Find source PR for this commit

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -440,12 +440,12 @@ tokens = ["packages: write"]
 
 [[suite]]
 name = "ci.push-to-main-skips-build"
-description = "Push-to-main must skip the heavy rebuild path. The build job (and p2996-prep, smoke-test which depend on it) must be gated 'if: github.event_name != \"push\" || github.ref != \"refs/heads/main\"'. Promote job retags the PR's image instead."
+description = "Push-to-main must skip the heavy rebuild path. The build job (and p2996-prep, smoke-test which depend on it) must carry the push-to-main skip clause '(github.event_name != \"push\" || github.ref != \"refs/heads/main\")'. Promote job retags the PR's image instead. The clause is now parenthesized because the build jobs additionally gate on the path-filter (&& needs.changes.outputs.build == 'true'), so this checks for the clause as a sub-expression rather than a bare 'if:'."
 category = "ci"
 check_type = "static"
 handler = "require_tokens"
 paths = [".github/workflows/ci.yml"]
-tokens = ["if: github.event_name != 'push' || github.ref != 'refs/heads/main'"]
+tokens = ["(github.event_name != 'push' || github.ref != 'refs/heads/main')"]
 
 [[suite]]
 name = "ci.promote-job-exists"


### PR DESCRIPTION
## Why

PR iterations and merges that can't change the devcontainer image still spin up the full `base-prep → p2996-prep → build → smoke-test` chain (cache hits make base/p2996 fast, but `build` + `smoke-test` still run). This skips that chain for changes that can't affect the image — the biggest remaining source of wasted CI minutes.

## How

A new **`changes`** job (`dorny/paths-filter`, SHA-pinned) outputs `build = true` only when an image- or test-relevant path changed:

- `.devcontainer/**`, `docker-bake.hcl`, `hk-common.pkl`, `hk-image.pkl` — COPY'd into the image / feed the base+p2996 content hashes
- `python/**`, `.dive-ci` — base-hash/p2996-hash, contract-preflight verify, smoke-test
- `install.sh`, `.github/workflows/ci.yml`

Root `mise.toml`/`mise.lock` are **deliberately excluded** — host-only, zero effect on the image (the container uses `.devcontainer/mise-system.toml`). So a host-tool-bump PR like #97 would now skip the build entirely.

`base-prep`/`p2996-prep`/`build`/`smoke-test` additionally require `needs.changes.outputs.build == 'true'`. **`promote` gates on it too** — critical, because a docs-only merge skips the PR build (no `:pr-NNN` image), so without gating, promote's fallback would trigger a needless full rebuild on main. With the gate, the image is left untouched and `:dev`/`:latest` stay current.

`schedule` + `workflow_dispatch` always build (nightly full rebuild intact).

## Result

| Change type | Before | After |
|---|---|---|
| docs / root-mise / hk.pkl / home | full 6-job chain | lint + contract-preflight |
| `.devcontainer/**` / bake / python | full chain | full chain (unchanged) |
| nightly schedule | full | full (unchanged) |

This PR touches `ci.yml` (build-relevant), so it runs the full chain — validating the `changes` job + build path end-to-end.

Phase 1c (concurrency) shipped in #97. Validated locally: actionlint + hk pre-commit (0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI now skips build and test work when changes don’t affect build-related areas, reducing unnecessary pipeline runs.
  * Pull requests with only documentation or similar non-build changes will run a lighter set of checks.
  * Scheduled and manual workflow runs still perform full builds and validations as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->