### PR TITLE
ci: async image-analysis (benchmark + Trivy off the PR path) + 20m benchmark fix

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -14,21 +14,19 @@ post-failure reporting.
 |------|---------|
 | `ci.yml` | Main pipeline: lint → contract-preflight → p2996-prep → build → smoke-test (PR/schedule) OR lint → promote (push to main) |
 | `ci-failure-report.yml` | Post-failure diagnostics / issue filing |
+| `image-analysis.yml` | Async (`workflow_run` on CI success): benchmark metrics + Trivy CVE scan, off the PR critical path |
 
 ## Pipeline stages
 
 PR / schedule / workflow_dispatch path:
 
 1. **lint** — mise install, hk pre-commit, agnix agent-doc validation
-   (`agnix .`; the target + severity come from `.agnix.toml`, which sets
-   `tools = ["claude-code"]` and `severity = "Warning"` — warnings do NOT
-   fail the build, so `agnix .` exits 0 even with warnings present),
-   `mise doctor --json` health check, `mise.lock` artifact upload, mise
-   data cache keyed on `mise.lock`. agnix is installed via the
-   `github:agent-sh/agnix` backend (NOT `npm:agnix`): the npm package only
-   ships a launcher that downloads its native binary in a `postinstall`
-   script, which mise's bun-based npm backend skips, leaving the binary
-   missing (`agnix binary not found`). See the `mise.toml` comment.
+   (`agnix .`; target + severity come from `.agnix.toml`:
+   `severity = "Warning"` so warnings don't fail), `mise doctor --json`,
+   `mise.lock` artifact upload, mise cache keyed on `mise.lock`. agnix uses
+   the `github:agent-sh/agnix` backend (NOT `npm:agnix`, whose postinstall
+   binary-download is skipped by mise's bun npm backend → `agnix binary not
+   found`); see the `mise.toml` comment.
 2. **contract-preflight** — Python 3.14 + uv; runs `dotfiles-setup
    verify run` over `python/verification/suites.toml`.
 3. **base-prep** — computes content-hash of base inputs via
@@ -51,10 +49,12 @@ PR / schedule / workflow_dispatch path:
    `.devcontainer/P2996-CACHE.md` for the current baseline).
    Always pushes (`:pr-NNN` or `:sha-<sha>` for PRs; `:dev`/`:latest`
    for schedule and `force_dev_tag=true` workflow_dispatch).
-6. **smoke-test** — pulls `:sha-<github.sha>` (the freshly-built
-   image) and runs the same checks against PR images that previously
-   only ran on main builds. The image smoked on the PR is the exact
-   image that gets retagged as `:dev`/`:latest` on merge.
+6. **smoke-test** — pulls `:sha-<github.sha>` and runs the PR-blocking
+   image gates only: `image smoke` (functional) + Dive (`.dive-ci` layer
+   thresholds). The non-gating benchmark metrics + Trivy CVE scan moved to
+   the async `image-analysis.yml` (on CI success) to keep them off the PR
+   critical path. The smoked image is the one retagged `:dev`/`:latest` on
+   merge.
 
 Push-to-main path (after a PR merge):
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -553,7 +553,6 @@ jobs:
     permissions:
       contents: read
       packages: read
-      security-events: write  # for Trivy SARIF upload to GitHub code scanning
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -582,12 +581,6 @@ jobs:
           uv run --project python dotfiles-setup image smoke \
             --image-ref ${{ env.CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.smoke-tag.outputs.tag }}
 
-      - name: Benchmark published image
-        run: |
-          uv run --project python dotfiles-setup image benchmark \
-            --image-ref ${{ env.CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.smoke-tag.outputs.tag }} \
-            --output-path artifacts/build/devcontainer-metrics.json > /tmp/devcontainer-metrics.stdout.json
-
       - name: Analyze image layer efficiency (Dive)
         # Dive --ci enforces .dive-ci thresholds (lowestEfficiency,
         # highestWastedBytes). Pass/fail gate; replaces the dead-letter
@@ -612,73 +605,18 @@ jobs:
           sudo install -m 0755 /tmp/dive /usr/local/bin/dive
           dive --ci --ci-config .dive-ci "${IMAGE_REF}"
 
-      - name: Scan image for CVEs (Trivy, warn-only)
-        # Day-1 mode: exit-code: '0' (warn-only). Once the baseline is
-        # clean, a follow-up PR flips to exit-code: '1' to gate PRs on
-        # regressions. SARIF still uploads to GitHub code scanning so
-        # alerts surface in the Security tab regardless.
-        # Tracked: https://github.com/ray-manaloto/dotfiles/issues/92
-        #
-        # `scanners: vuln` narrows scope to CVE detection only —
-        # secret + misconfig scans are out of scope for this step
-        # (separate concerns, separate tooling) and Trivy's own log
-        # advises disabling secret scanning on large images. Without
-        # this scope narrowing the run on PR #93 hit the default 5min
-        # timeout exporting the multi-GB image through the Docker
-        # socket and failed with "context deadline exceeded" before
-        # producing a SARIF.
-        #
-        # `timeout: 15m` is a safety margin on top of the scope
-        # narrowing — even a vuln-only scan of a heavy image takes
-        # several minutes once the vuln-DB download is included.
-        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
-        with:
-          image-ref: ${{ env.CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.smoke-tag.outputs.tag }}
-          format: sarif
-          output: trivy.sarif
-          severity: CRITICAL,HIGH
-          exit-code: "0"
-          scanners: vuln
-          timeout: 15m
-
-      - name: Upload Trivy SARIF to GitHub code scanning
-        # `hashFiles` guard: if Trivy was skipped or bailed without
-        # writing trivy.sarif (e.g. an earlier step failed), don't
-        # ask codeql-action to upload a missing file — that turns a
-        # benign "Trivy didn't run" into a hard "smoke-test failed".
-        # Bare `if: always()` was the previous shape and produced
-        # exactly that cascade in run 25193971770.
-        if: always() && hashFiles('trivy.sarif') != ''
-        uses: github/codeql-action/upload-sarif@65216971a11ded447a6b76263d5a144519e5eee1 # codeql-bundle-v2.25.2
-        with:
-          sarif_file: trivy.sarif
-          category: trivy-image
-
+      # smoke + Dive are the PR-blocking image gates. The benchmark metrics
+      # and the Trivy CVE scan run asynchronously in `image-analysis.yml`
+      # (triggered on CI success) so their minutes are off the PR critical
+      # path — see .github/workflows/AGENTS.md.
+      #
       # Note: the host-user overlay (Dockerfile.host-user + `devcontainer up`)
-      # is a Mac-local concern — it exists to wrap the published base image
-      # with the host user's UID/GID for bind-mount permission parity on
-      # macOS. CI has no meaningful "host user" to match, no ~/.ssh/.claude/
-      # mount sources, and no need to rebuild the overlay. The steps above
-      # (Pull / Smoke / Benchmark / Dive / Trivy) fully validate the
-      # published base image; overlay behavior is validated locally via
+      # is a Mac-local concern — it wraps the published base image with the
+      # host user's UID/GID for bind-mount permission parity on macOS. CI has
+      # no meaningful "host user" to match, no mount sources, and no overlay
+      # to rebuild; the Pull / Smoke / Dive steps above fully validate the
+      # published base image. Overlay behavior is validated locally via
       # `mise run up` on the Mac.
-
-      - name: Upload build metrics artifact
-        # `if: always()` so artifacts upload even when Dive fails the
-        # threshold gate or Trivy bails on a malformed SARIF — the
-        # artifact is the diagnostic surface most needed exactly when
-        # the build regressed. Bundles the mise log so diagnose sequence
-        # is one-stop in the artifact tab.
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: devcontainer-metrics
-          path: |
-            artifacts/build/devcontainer-metrics.json
-            /tmp/devcontainer-metrics.stdout.json
-            trivy.sarif
-            /tmp/mise.log
-          if-no-files-found: ignore
 
   # ============================================================
   # Promote: tag-only retag of the PR-built image as :dev / :latest.

--- a/.github/workflows/image-analysis.yml
+++ b/.github/workflows/image-analysis.yml
@@ -1,0 +1,135 @@
+name: image-analysis
+
+# Async image analysis: benchmark metrics + Trivy CVE scan, decoupled from the
+# PR critical path. Runs after a successful CI run that actually built an image
+# (pull_request / schedule / workflow_dispatch — NOT push-to-main, which skips
+# the build and lets `promote` retag instead). smoke + Dive remain the blocking
+# image gates in ci.yml; this workflow only carries the slow, non-gating checks.
+#
+# SECURITY: this is a privileged `workflow_run` context. It checks out the
+# DEFAULT branch's trusted code (no `ref:` → main), never the PR head, and runs
+# that trusted benchmark code against the PR-built *image*. So untrusted PR code
+# never executes here with the workflow token.
+#
+# GOTCHA: `workflow_run` always uses this file as it exists on the default
+# branch, so edits here only take effect once merged to main.
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: read
+  packages: read
+  security-events: write # Trivy SARIF → GitHub code scanning
+
+concurrency:
+  group: image-analysis-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
+env:
+  CONTAINER_REGISTRY: ghcr.io
+  IMAGE_NAME: ray-manaloto/dotfiles-devcontainer
+
+jobs:
+  analyze:
+    # Only for successful CI runs whose event built a fresh image. push-to-main
+    # skips the build (promote retags), so there is no new :sha image to scan.
+    if: >-
+      github.event.workflow_run.conclusion == 'success'
+      && github.event.workflow_run.event != 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout trusted code (default branch)
+        # No `ref:` — checks out the default branch (main), NOT the PR head.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install mise (python + uv)
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          install_args: "python uv"
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.CONTAINER_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Derive image tag from analyzed commit
+        id: tag
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: echo "tag=$(printf '%s' "$HEAD_SHA" | head -c 7)" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve image ref (skip when no image was built)
+        id: image
+        env:
+          REF: ${{ env.CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # A path-gated PR (docs / root-mise / etc.) skips the build, so the
+          # :sha image will not exist — analyze nothing rather than fail.
+          if docker buildx imagetools inspect "$REF" >/dev/null 2>&1; then
+            echo "ref=$REF" >> "$GITHUB_OUTPUT"
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No image at $REF (build skipped for this run); nothing to analyze."
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Pull image
+        if: steps.image.outputs.present == 'true'
+        env:
+          REF: ${{ steps.image.outputs.ref }}
+        run: docker pull "$REF"
+
+      - name: Benchmark image (size + smoke metrics)
+        # Compressed-size now comes from the registry manifest (instant), not
+        # `docker save | gzip`. See python/src/dotfiles_setup/image.py.
+        if: steps.image.outputs.present == 'true'
+        env:
+          REF: ${{ steps.image.outputs.ref }}
+        run: |
+          uv run --project python dotfiles-setup image benchmark \
+            --image-ref "$REF" \
+            --output-path artifacts/build/devcontainer-metrics.json \
+            > /tmp/devcontainer-metrics.stdout.json
+
+      - name: Scan image for CVEs (Trivy, warn-only)
+        # warn-only (exit-code 0): SARIF surfaces in the Security tab; does not
+        # gate. `scanners: vuln` + `timeout: 15m` per the heavy-image notes that
+        # previously lived in ci.yml (issue #92).
+        if: steps.image.outputs.present == 'true'
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        with:
+          image-ref: ${{ steps.image.outputs.ref }}
+          format: sarif
+          output: trivy.sarif
+          severity: CRITICAL,HIGH
+          exit-code: "0"
+          scanners: vuln
+          timeout: 15m
+
+      - name: Upload Trivy SARIF to code scanning
+        # Associate the result with the analyzed commit/branch (workflow_run
+        # context defaults to the default branch otherwise).
+        if: steps.image.outputs.present == 'true' && hashFiles('trivy.sarif') != ''
+        uses: github/codeql-action/upload-sarif@65216971a11ded447a6b76263d5a144519e5eee1 # codeql-bundle-v2.25.2
+        with:
+          sarif_file: trivy.sarif
+          category: trivy-image
+          ref: refs/heads/${{ github.event.workflow_run.head_branch }}
+          sha: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Upload metrics artifact
+        if: always() && steps.image.outputs.present == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: devcontainer-metrics
+          path: |
+            artifacts/build/devcontainer-metrics.json
+            /tmp/devcontainer-metrics.stdout.json
+            trivy.sarif
+          if-no-files-found: ignore

--- a/python/src/dotfiles_setup/image.py
+++ b/python/src/dotfiles_setup/image.py
@@ -198,6 +198,65 @@ def _gzip_size_for_image(image_ref: str) -> int:
     return compressed_size
 
 
+def _repo_without_tag(image_ref: str) -> str:
+    """Strip a ``:tag`` suffix, preserving a registry ``:port`` and ``@digest``."""
+    if "@" in image_ref:
+        return image_ref.split("@", 1)[0]
+    last_slash = image_ref.rfind("/")
+    last_colon = image_ref.rfind(":")
+    if last_colon > last_slash:
+        return image_ref[:last_colon]
+    return image_ref
+
+
+def _sum_manifest_layer_sizes(raw: str, image_ref: str) -> int:
+    """Sum compressed layer sizes from an OCI/Docker manifest JSON.
+
+    Registry manifests record each layer's *compressed* (download) size, so
+    summing them yields the compressed image size without a ``docker save``.
+    Handles a single-platform manifest (``layers``) directly and a manifest
+    list / OCI index (``manifests``) by recursing into the linux/amd64 entry.
+    """
+    doc = json.loads(raw)
+    layers = doc.get("layers")
+    if layers is not None:
+        return sum(int(layer.get("size", 0)) for layer in layers)
+    for entry in doc.get("manifests", []):
+        platform = entry.get("platform", {})
+        if platform.get("os") == "linux" and platform.get("architecture") == "amd64":
+            digest = entry.get("digest")
+            sub = _run(
+                [
+                    "docker",
+                    "buildx",
+                    "imagetools",
+                    "inspect",
+                    f"{_repo_without_tag(image_ref)}@{digest}",
+                    "--raw",
+                ],
+            ).stdout
+            return _sum_manifest_layer_sizes(sub, image_ref)
+    # Not a recognized manifest shape — fall back to the local gzip measure.
+    return _gzip_size_for_image(image_ref)
+
+
+def _compressed_size_for_image(image_ref: str) -> int:
+    """Compressed (download) size of an image.
+
+    Prefers the registry manifest (``docker buildx imagetools inspect --raw``),
+    whose layer sizes are already gzip-compressed — instant and exact for a
+    pushed image. Falls back to streaming ``docker image save`` through gzip
+    when the ref is not resolvable in a registry (e.g. a local-only image).
+    """
+    try:
+        raw = _run(
+            ["docker", "buildx", "imagetools", "inspect", image_ref, "--raw"],
+        ).stdout
+    except subprocess.CalledProcessError, FileNotFoundError:
+        return _gzip_size_for_image(image_ref)
+    return _sum_manifest_layer_sizes(raw, image_ref)
+
+
 def _parse_human_size(size: str) -> int:
     cleaned = size.strip()
     match = re.fullmatch(r"(?i)\s*([0-9]+(?:\.[0-9]+)?)\s*([kmgt]?b)\s*", cleaned)
@@ -229,7 +288,7 @@ def size_report(
             ["docker", "image", "inspect", "--format", "{{.Size}}", image_ref],
         ).stdout.strip()
     )
-    compressed_size_bytes = _gzip_size_for_image(image_ref)
+    compressed_size_bytes = _compressed_size_for_image(image_ref)
 
     history_lines = _run(
         ["docker", "history", "--no-trunc", "--format", "{{json .}}", image_ref],

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -505,11 +505,11 @@ tokens = ["lowestEfficiency"]
 
 [[suite]]
 name = "ci.trivy-scan-wired"
-description = "smoke-test job must include the Trivy CVE scan + SARIF upload via codeql-action so vulnerabilities surface in GitHub code scanning"
+description = "The async image-analysis workflow must include the Trivy CVE scan + SARIF upload via codeql-action so vulnerabilities surface in GitHub code scanning. (Moved out of ci.yml smoke-test into image-analysis.yml so the slow CVE scan is off the PR critical path.)"
 category = "ci"
 check_type = "static"
 handler = "require_tokens"
-paths = [".github/workflows/ci.yml"]
+paths = [".github/workflows/image-analysis.yml"]
 tokens = [
   "aquasecurity/trivy-action",
   "github/codeql-action/upload-sarif",

--- a/tests/test_image_smoke.py
+++ b/tests/test_image_smoke.py
@@ -5,14 +5,23 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
 
+import json
+
 from dotfiles_setup.image import (
     _parse_human_size,
+    _repo_without_tag,
+    _sum_manifest_layer_sizes,
     build_smoke_docker_cmd,
     build_smoke_script,
 )
 
 # Named constant for plain byte values in size parsing tests.
 _PLAIN_BYTES_VALUE = 512
+
+# Layer sizes (compressed bytes) used by the manifest-sum tests.
+_LAYER_A_BYTES = 1000
+_LAYER_B_BYTES = 2500
+_LAYERS_TOTAL_BYTES = _LAYER_A_BYTES + _LAYER_B_BYTES
 
 
 def test_smoke_script_pins_hk_file() -> None:
@@ -57,3 +66,44 @@ def test_parse_human_size_handles_lowercase_kilobytes() -> None:
 def test_parse_human_size_handles_plain_bytes() -> None:
     """Verify plain byte strings without suffix are parsed correctly."""
     assert _parse_human_size("512") == _PLAIN_BYTES_VALUE
+
+
+def test_repo_without_tag_strips_tag() -> None:
+    """A :tag suffix is removed, leaving the bare repo."""
+    assert (
+        _repo_without_tag("ghcr.io/ray-manaloto/dotfiles-devcontainer:abc1234")
+        == "ghcr.io/ray-manaloto/dotfiles-devcontainer"
+    )
+
+
+def test_repo_without_tag_preserves_registry_port() -> None:
+    """A registry :port (colon before the last slash) is not mistaken for a tag."""
+    assert _repo_without_tag("localhost:5000/img") == "localhost:5000/img"
+
+
+def test_repo_without_tag_strips_digest() -> None:
+    """An @digest suffix is removed."""
+    assert (
+        _repo_without_tag("ghcr.io/owner/repo@sha256:deadbeef") == "ghcr.io/owner/repo"
+    )
+
+
+def test_sum_manifest_layer_sizes_single_manifest() -> None:
+    """Compressed size is the sum of a single manifest's layer sizes."""
+    raw = json.dumps(
+        {
+            "layers": [
+                {
+                    "size": _LAYER_A_BYTES,
+                    "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                },
+                {
+                    "size": _LAYER_B_BYTES,
+                    "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                },
+            ]
+        }
+    )
+    assert (
+        _sum_manifest_layer_sizes(raw, "ghcr.io/owner/repo:tag") == _LAYERS_TOTAL_BYTES
+    )


### PR DESCRIPTION
## Why

`smoke-test` was **~37 min serial**, dominated by two steps that aren't PR gates:
- **benchmark 20.7 min** — `_gzip_size_for_image` streamed `docker image save | gzip` over the multi-GB image
- **Trivy 6 min** — CVE scan, already `exit-code: 0` (warn-only)

Only **smoke** (functional) and **Dive** (`.dive-ci` thresholds) are real gates (~10 min incl. pull).

## Changes

**1. Benchmark cost fix** (`python/src/dotfiles_setup/image.py`) — replace the save|gzip with `_compressed_size_for_image`: read the registry manifest (`docker buildx imagetools inspect --raw`) and sum layer sizes. Registry layer sizes are *already* gzip-compressed → instant + exact. Falls back to local gzip for non-registry refs. New helpers `_repo_without_tag` + `_sum_manifest_layer_sizes` with unit tests. **20m → ~0.**

**2. Slim smoke-test** (`ci.yml`) — keep only pull + smoke + Dive (the PR gates). Dropped `security-events: write` (no Trivy here now).

**3. New `image-analysis.yml`** — `workflow_run` on CI success, non-push events only (push-to-main skips the build → no fresh `:sha`). Runs the now-fast benchmark + Trivy + SARIF upload async, off the PR path.
  - **Security:** checks out the **default branch's** trusted code (never the PR head) and analyzes the PR-built *image* — untrusted PR code never runs in this privileged `workflow_run` context.
  - Skips gracefully when a path-gated build produced no `:sha` image.

**4. Contract** — `ci.trivy-scan-wired` now targets `image-analysis.yml`.

## Result

| | Before | After |
|---|---|---|
| PR-blocking smoke-test | ~37 min | ~10 min (smoke + Dive) |
| benchmark | 20.7 min | ~seconds |
| Trivy + metrics | in smoke-test (blocking minutes) | async, off PR path |

## Note

`workflow_run` always uses **main's** copy of `image-analysis.yml`, so it won't fire until this merges. First real run is post-merge; I'll verify it then (and tweak SARIF ref/sha association if needed).

Validated locally: hk (0 failures), pytest (101 passed), verify (66 passed, 0 failed), actionlint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a separate post-merge image analysis workflow for benchmark metrics and vulnerability scanning.

- **Bug Fixes**
  - Reduced PR pipeline load by keeping only the essential image smoke checks in the main CI run.
  - Improved image size reporting to use registry data when available for more accurate results.

- **Documentation**
  - Updated CI workflow documentation to reflect the new split between critical checks and asynchronous analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->