### PR TITLE
docs: sync CI docs with the path-gate + async image-analysis + agnix changes

### DIFF
--- a/.claude/skills/devcontainer-workflow/SKILL.md
+++ b/.claude/skills/devcontainer-workflow/SKILL.md
@@ -73,14 +73,17 @@ Tier 4 (CLion remote toolchain) is manual.
 
 ## Telemetry
 
-The CI smoke-test job emits `artifacts/build/devcontainer-metrics.json`
-with the existing benchmark fields plus `startup_seconds` (wall-clock for
-`devcontainer up`).
+The async `image-analysis.yml` workflow (triggered on CI success via
+`workflow_run`) emits `artifacts/build/devcontainer-metrics.json` (benchmark
+fields; compressed size now read from the registry manifest, not
+`docker save | gzip`). The PR-blocking `smoke-test` job runs only smoke +
+Dive and no longer emits metrics.
 
 ## References
 
 - `mise.toml` — `[tasks.up]`, `[tasks.stop]`, `[tasks.build]`, alias `down`
 - `hk.pkl` — `dockerfile_host_user_thin_overlay` step
-- `.github/workflows/ci.yml` — hard-gate assertion (lint job) + tier 1-3 smoke (smoke-test job)
+- `.github/workflows/ci.yml` — hard-gate assertion (lint job) + tier 1-3 smoke + Dive (smoke-test job)
+- `.github/workflows/image-analysis.yml` — async benchmark + Trivy (on CI success)
 - `home/.chezmoiignore` — the gate itself
 - `scripts/devcontainer-smoke.sh` — shared tier runner

--- a/.devcontainer/P2996-CACHE.md
+++ b/.devcontainer/P2996-CACHE.md
@@ -35,20 +35,37 @@ The final `devcontainer` stage's `COPY --from=clang-builder
 
 ## Hash inputs
 
-The hash is sha256 (truncated to 16 hex chars) over a canonical
-concatenation of:
+There are two content-hashes (each sha256 truncated to 16 hex chars),
+and the p2996 hash folds in the base hash so changes cascade.
 
-- `CLANG_P2996_REF` value (parsed from `docker-bake.hcl`)
-- `BASE_IMAGE` value (parsed from `docker-bake.hcl`)
-- `PLATFORM` value (parsed from `docker-bake.hcl`)
-- sha256 of `.devcontainer/Dockerfile` content
-- sha256 of `docker-bake.hcl` content
-- sha256 of `.devcontainer/mise-system-resolved.json` content
+The **base** hash (`dotfiles-setup base-hash`) covers:
+
+- `BASE_IMAGE` and `PLATFORM` values (parsed from `docker-bake.hcl`)
+- sha256 of the `Dockerfile` section between the `BASE_HASH_BEGIN` /
+  `BASE_HASH_END` sentinels (NOT the whole file)
+- sha256 of `.devcontainer/mise-system-resolved.json`
+
+The **p2996** hash (`dotfiles-setup p2996-hash`) covers:
+
+- `CLANG_P2996_REF` and `PLATFORM` values (parsed from `docker-bake.hcl`)
+- the base hash above
+- sha256 of the `Dockerfile` section between the `P2996_HASH_BEGIN` /
+  `P2996_HASH_END` sentinels
+
+Only the *sentinel-delimited* Dockerfile sections feed the hashes —
+editing unrelated parts of the `Dockerfile` or `docker-bake.hcl` does NOT
+bust either cache. Implementation: `python/src/dotfiles_setup/p2996_hash.py`.
 
 The resolved-snapshot file pins the conda-forge resolutions of `cmake`,
 `ninja`, `clang`, `lld`, etc. — `mise-system.toml` declares them as
 `"latest"`, so without the snapshot the hash would not change on
 upstream conda-forge drift.
+
+> **Planned (issue #100):** `CLANG_P2996_REF` will be auto-bumped by a
+> scheduled workflow tracking the `bloomberg/clang-p2996` `p2996` branch
+> HEAD (opening a PR when it changes). The pin stays in `docker-bake.hcl`
+> so the hash above keeps caching correctly — an unchanged SHA hits the
+> cache, a changed SHA triggers exactly one rebuild.
 
 ## Operator workflow
 

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -12,7 +12,7 @@ post-failure reporting.
 
 | File | Purpose |
 |------|---------|
-| `ci.yml` | Main pipeline: lint → contract-preflight → p2996-prep → build → smoke-test (PR/schedule) OR lint → promote (push to main) |
+| `ci.yml` | Main pipeline: lint → contract-preflight → `changes` (path-gate) → base-prep → p2996-prep → build → smoke-test (smoke+Dive), build chain gated on `changes.build`; OR lint → promote (push to main) |
 | `ci-failure-report.yml` | Post-failure diagnostics / issue filing |
 | `image-analysis.yml` | Async (`workflow_run` on CI success): benchmark metrics + Trivy CVE scan, off the PR critical path |
 
@@ -123,11 +123,9 @@ Push-to-main path (after a PR merge):
   `403 AuthenticationFailed` after wasting ~1h of the runner. Documented
   in `docker-bake.hcl`. The `dev` target keeps gha cache (small overlay,
   no probe gate, well under 1-hour SAS limit).
-- **Trivy is `scanners: vuln` + `timeout: 15m`.** Default scanners
-  (`vuln,secret,misconfig`) timeout at 5min exporting our multi-GB
-  image through the Docker socket. Scope is intentionally CVE-only
-  (warn-only mode, see issue #92); secret + misconfig are out of
-  scope here.
+- **Trivy lives in `image-analysis.yml` (async), not ci.yml smoke-test.**
+  `scanners: vuln` + `timeout: 15m`, warn-only: default scanners timeout
+  at 5min exporting the multi-GB image; scope is CVE-only (issue #92).
 - **`wagoodman/dive` action is broken upstream.** v0.13.1's
   auto-built Dockerfile has `ARG DOCKER_CLI_VERSION=${DOCKER_CLI_VERSION}`
   with no default, fetches `docker-.tgz` and 404s. Use the binary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,9 @@ containers on macOS ARM hosts. Two build types:
 2. **Docker env image** (CI/CD → ghcr.io): published from `main` via GHA
 
 Registry: `ghcr.io/ray-manaloto/dotfiles-devcontainer`. CI pipeline:
-lint → contract-preflight → build → smoke-test.
+lint → contract-preflight → `changes` path-gate → base-prep → p2996-prep →
+build → smoke-test (smoke + Dive); `promote` retags on main; benchmark +
+Trivy run async in `image-analysis.yml`.
 
 ## Quick Start
 


### PR DESCRIPTION
Brings the canonical docs in line with the CI changes shipped this session (#97/#98/#99) and files tracking issues for the pending work.

## Doc fixes
- **AGENTS.md (root)** — pipeline line now reflects the `changes` path-gate, base-prep → p2996-prep, promote-on-main, and async `image-analysis.yml`.
- **.github/workflows/AGENTS.md** — ci.yml Key Files row includes the `changes` gate + base-prep; corrected the Trivy invariant (Trivy lives in `image-analysis.yml` now, not smoke-test).
- **.claude/skills/devcontainer-workflow/SKILL.md** — benchmark metrics emitted by async `image-analysis.yml`; smoke-test = smoke + Dive; added image-analysis.yml reference.
- **.devcontainer/P2996-CACHE.md** — fixes a doc/code bug: the hash covers only the *sentinel-delimited* Dockerfile sections + parsed bake vars, not the full files; documents the two-level base→p2996 hash; links the planned p2996 auto-bump (#100).

## Tracking issues filed
- **#100** p2996 auto-bump (track clang-p2996 `p2996` branch HEAD via scheduled PR; design embedded)
- **#101** Phase 2 CI lint matrix · **#102** Phase 3 multi-arch · **#103** rtk@0.42.0 url_api lock bug · **#104** Phase 1a slim lint
- **#92** updated (Trivy moved to image-analysis.yml)

Docs-only — should run lint + contract-preflight only (build chain skipped by the #98 path-gate, which this PR exercises).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI/CD and devcontainer documentation to reflect the latest build and testing flow.
  * Clarified when image analysis, vulnerability scanning, and build metrics are generated.
  * Expanded cache documentation to explain the new hashing approach and which Dockerfile changes affect cache invalidation.
  * Added notes about future cache-related automation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->