### PR TITLE
ci: exclude **/*.md from the build path-filter

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -72,9 +72,10 @@ Push-to-main path (after a PR merge):
 - **Build chain is path-gated.** A `changes` job (dorny/paths-filter)
   sets `build` true only when image/test inputs change (`.devcontainer/**`,
   `docker-bake.hcl`, `hk-common.pkl`, `hk-image.pkl`, `python/**`,
-  `.dive-ci`, `install.sh`, `ci.yml`); base-prep→smoke-test AND `promote`
-  gate on it. Docs/root-mise/hk.pkl/home PRs run lint+contract-preflight
-  only; schedule + workflow_dispatch always build.
+  `.dive-ci`, `install.sh`, `ci.yml`) — but `**/*.md` is excluded, so docs
+  under those dirs skip too; base-prep→smoke-test AND `promote` gate on it.
+  Docs/root-mise/hk.pkl/home PRs run lint+contract-preflight only; schedule
+  + workflow_dispatch always build.
 - **Concurrency cancels superseded runs per branch.** `ci.yml` and
   `autofix.yml` group by
   `${{ github.workflow }}-${{ github.head_ref || github.ref }}` so all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,12 @@ jobs:
               - 'python/**'
               - '.dive-ci'
               - '.github/workflows/ci.yml'
+              # Markdown never affects the image or build/verify logic, so a
+              # docs-only change under a build-relevant dir (e.g.
+              # .devcontainer/P2996-CACHE.md, python/AGENTS.md) does not need a
+              # build. The trailing negation excludes all .md (dorny/paths-filter
+              # honors `!`; a non-.md change in the same PR still triggers build).
+              - '!**/*.md'
 
       - name: Decide whether the build chain runs
         id: decide


### PR DESCRIPTION
Follow-up to #98. A docs-only change under a build-relevant dir (`.devcontainer/**`, `python/**`) still triggered the full build chain — observed on #105 where `.devcontainer/P2996-CACHE.md` ran base-prep→p2996-prep→build→smoke-test for no image change.

Markdown never affects the image or build/verify logic, so a trailing `- '!**/*.md'` negation now excludes all markdown from the build filter. dorny/paths-filter honors `!` (later patterns override); a PR that also changes a non-`.md` build input still triggers the build as before.

Note: this PR changes `ci.yml` (a non-`.md` build input), so it runs the full chain — validating the change end-to-end. The `.md`-only skip is exercised by the next docs-only PR under `.devcontainer/`/`python/`.

Validated: actionlint + hk (0 failures); workflows/AGENTS.md path-gate invariant updated.