### PR TITLE
ci: fix markdown exclusion in the build path-filter (#106 regression)

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -69,13 +69,14 @@ Push-to-main path (after a PR merge):
 
 - **All actions SHA-pinned** via pinact. Run `mise run pin-actions`
   locally to verify before committing workflow changes.
-- **Build chain is path-gated.** A `changes` job (dorny/paths-filter)
-  sets `build` true only when image/test inputs change (`.devcontainer/**`,
+- **Build chain is path-gated.** A `changes` job (dorny/paths-filter,
+  `list-files: json`) matches image/test inputs (`.devcontainer/**`,
   `docker-bake.hcl`, `hk-common.pkl`, `hk-image.pkl`, `python/**`,
-  `.dive-ci`, `install.sh`, `ci.yml`) — but `**/*.md` is excluded, so docs
-  under those dirs skip too; base-prep→smoke-test AND `promote` gate on it.
-  Docs/root-mise/hk.pkl/home PRs run lint+contract-preflight only; schedule
-  + workflow_dispatch always build.
+  `.dive-ci`, `install.sh`, `ci.yml`); the `decide` step drops markdown-only
+  matches via `jq` (a `!**/*.md` pattern can't — `**/*.md` skips dot-dirs).
+  base-prep→smoke-test AND `promote` gate on the result. So docs (incl. under
+  `.devcontainer/`/`python/`), root-mise, hk.pkl, home PRs run
+  lint+contract-preflight only; schedule + workflow_dispatch always build.
 - **Concurrency cancels superseded runs per branch.** `ci.yml` and
   `autofix.yml` group by
   `${{ github.workflow }}-${{ github.head_ref || github.ref }}` so all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,11 @@ jobs:
         if: github.event_name == 'pull_request' || github.event_name == 'push'
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
+          # Emit the matched-file list so `decide` can drop markdown-only
+          # matches (a pattern-level `!**/*.md` can't: dorny's default `some`
+          # quantifier OR-matches the negation, and `**/*.md` skips dot-dirs
+          # like .devcontainer/).
+          list-files: json
           filters: |
             build:
               - '.devcontainer/**'
@@ -225,24 +230,25 @@ jobs:
               - 'python/**'
               - '.dive-ci'
               - '.github/workflows/ci.yml'
-              # Markdown never affects the image or build/verify logic, so a
-              # docs-only change under a build-relevant dir (e.g.
-              # .devcontainer/P2996-CACHE.md, python/AGENTS.md) does not need a
-              # build. The trailing negation excludes all .md (dorny/paths-filter
-              # honors `!`; a non-.md change in the same PR still triggers build).
-              - '!**/*.md'
 
       - name: Decide whether the build chain runs
         id: decide
         env:
           EVENT: ${{ github.event_name }}
-          FILTER_BUILD: ${{ steps.filter.outputs.build }}
+          BUILD_FILES: ${{ steps.filter.outputs.build_files }}
         run: |
-          # Non-PR/non-push events (schedule, workflow_dispatch) always
-          # build; PRs and main pushes build only when a build-relevant
-          # path changed.
+          # schedule / workflow_dispatch always build. For PR/push, build only
+          # when a changed build-relevant file is NOT markdown — docs (incl.
+          # docs under .devcontainer/** or python/**) never affect the image or
+          # build/verify logic. `jq` is preinstalled on the runner.
           case "$EVENT" in
-            pull_request|push) echo "build=${FILTER_BUILD}" >> "$GITHUB_OUTPUT" ;;
+            pull_request|push)
+              if printf '%s' "${BUILD_FILES:-[]}" \
+                | jq -e 'map(select(endswith(".md") | not)) | length > 0' >/dev/null; then
+                echo "build=true" >> "$GITHUB_OUTPUT"
+              else
+                echo "build=false" >> "$GITHUB_OUTPUT"
+              fi ;;
             *) echo "build=true" >> "$GITHUB_OUTPUT" ;;
           esac
 


### PR DESCRIPTION
## Problem

#106's `- '!**/*.md'` was a non-fix that quietly **broadened** the gate:

1. dorny/paths-filter's default `predicate-quantifier: some` is OR — a negation doesn't subtract, it **adds**. Any non-`.md` file (e.g. `hk.pkl`, `.agnix.toml`) matched `!**/*.md` → `build=true`, so changes that aren't build inputs started triggering full builds.
2. `**/*.md` also **skips dot-directories** (picomatch without `dot:true`), so it never matched `.devcontainer/AGENTS.md` — the exact case we wanted to skip.

Caught on **#107** (docs + `.agnix.toml` only) which still ran the entire build chain.

## Fix

Emit the matched-file list (`list-files: json`) and drop markdown-only matches in the `decide` step with `jq` (preinstalled on ubuntu runners): `build=true` iff a matched build-relevant file does **not** end in `.md`. Verified the jq logic locally:

| changed (build-matched) | build |
|---|---|
| `[".devcontainer/AGENTS.md","python/AGENTS.md"]` | false |
| `[".devcontainer/Dockerfile",".devcontainer/AGENTS.md"]` | true |
| `["python/x.py"]` | true |
| `[]` | false |

This PR changes `ci.yml` (non-`.md`) so it runs the full chain (validates the happy path); the `.md`-only skip is exercised by the next docs PR. Validated: actionlint + hk (0 failures).