### PR TITLE
ci: auto-bump CLANG_P2996_REF via scheduled p2996-branch tracking (#100)

### DIFF
--- a/.devcontainer/P2996-CACHE.md
+++ b/.devcontainer/P2996-CACHE.md
@@ -61,11 +61,14 @@ The resolved-snapshot file pins the conda-forge resolutions of `cmake`,
 `"latest"`, so without the snapshot the hash would not change on
 upstream conda-forge drift.
 
-> **Planned (issue #100):** `CLANG_P2996_REF` will be auto-bumped by a
-> scheduled workflow tracking the `bloomberg/clang-p2996` `p2996` branch
-> HEAD (opening a PR when it changes). The pin stays in `docker-bake.hcl`
-> so the hash above keeps caching correctly — an unchanged SHA hits the
-> cache, a changed SHA triggers exactly one rebuild.
+> **Auto-bump (issue #100):** `CLANG_P2996_REF` is auto-bumped by the
+> scheduled `.github/workflows/p2996-refresh.yml` workflow, which tracks
+> the `bloomberg/clang-p2996` `p2996` branch HEAD (no releases/tags exist)
+> and opens a PR when it advances. The pin stays in `docker-bake.hcl` so
+> the hash above keeps caching correctly — an unchanged SHA hits the
+> cache, a changed SHA triggers exactly one rebuild. Run it on demand with
+> `mise run p2996-refresh` (writes only on change) or `gh workflow run
+> p2996-refresh.yml`. Logic: `python/src/dotfiles_setup/p2996_refresh.py`.
 
 ## Operator workflow
 
@@ -75,6 +78,11 @@ upstream conda-forge drift.
   bust the cache): `mise run capture-mise-system-resolved` inside the
   devcontainer, then commit the updated
   `.devcontainer/mise-system-resolved.json`.
+- **Bump to latest p2996 HEAD**: `mise run p2996-refresh` — rewrites
+  `CLANG_P2996_REF` in `docker-bake.hcl` to the latest
+  `bloomberg/clang-p2996` `p2996`-branch HEAD (no-op write when already
+  current). The scheduled `p2996-refresh.yml` workflow does this weekly
+  and opens a PR on change.
 - **Manual cache bust**: bump `CLANG_P2996_REF` in `docker-bake.hcl`,
   OR refresh the snapshot, OR edit any of the hash-input files. The
   next CI run detects a cache miss and rebuilds + pushes a new
@@ -92,6 +100,8 @@ shell branching.
 ## See also
 
 - `python/src/dotfiles_setup/p2996_hash.py` — hash computation source.
+- `python/src/dotfiles_setup/p2996_refresh.py` — auto-bump source.
 - `python/src/dotfiles_setup/mise_snapshot.py` — snapshot capture source.
 - `docker-bake.hcl` — the `dev` and `p2996-cache` targets.
 - `.github/workflows/ci.yml` — `p2996-prep` and `build` jobs.
+- `.github/workflows/p2996-refresh.yml` — scheduled CLANG_P2996_REF bump.

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -15,18 +15,18 @@ post-failure reporting.
 | `ci.yml` | Main pipeline: lint → contract-preflight → `changes` (path-gate) → base-prep → p2996-prep → build → smoke-test (smoke+Dive), build chain gated on `changes.build`; OR lint → promote (push to main) |
 | `ci-failure-report.yml` | Post-failure diagnostics / issue filing |
 | `image-analysis.yml` | Async (`workflow_run` on CI success): benchmark metrics + Trivy CVE scan, off the PR critical path |
+| `snapshot-refresh.yml` | Weekly cron: refresh `mise-system-resolved.json` (conda-forge drift), open PR on change |
+| `p2996-refresh.yml` | Weekly cron: bump `CLANG_P2996_REF` to latest `bloomberg/clang-p2996` `p2996`-branch HEAD, open PR on change (issue #100) |
 
 ## Pipeline stages
 
 PR / schedule / workflow_dispatch path:
 
 1. **lint** — mise install, hk pre-commit, agnix agent-doc validation
-   (`agnix .`; target + severity come from `.agnix.toml`:
-   `severity = "Warning"` so warnings don't fail), `mise doctor --json`,
-   `mise.lock` artifact upload, mise cache keyed on `mise.lock`. agnix uses
-   the `github:agent-sh/agnix` backend (NOT `npm:agnix`, whose postinstall
-   binary-download is skipped by mise's bun npm backend → `agnix binary not
-   found`); see the `mise.toml` comment.
+   (`agnix .`; `.agnix.toml` sets `severity = "Warning"` so warnings
+   don't fail), `mise doctor --json`, `mise.lock` artifact upload, mise
+   cache keyed on `mise.lock`. agnix uses the `github:agent-sh/agnix`
+   backend (NOT `npm:agnix`; bun skips its postinstall — see `mise.toml`).
 2. **contract-preflight** — Python 3.14 + uv; runs `dotfiles-setup
    verify run` over `python/verification/suites.toml`.
 3. **base-prep** — computes content-hash of base inputs via

--- a/.github/workflows/p2996-refresh.yml
+++ b/.github/workflows/p2996-refresh.yml
@@ -1,0 +1,107 @@
+name: Refresh CLANG_P2996_REF
+
+# Auto-bumps the pinned `CLANG_P2996_REF` in `docker-bake.hcl` to the
+# latest `bloomberg/clang-p2996` `p2996`-branch HEAD. clang-p2996 has no
+# releases or tags, so "latest stable" is that branch's HEAD commit.
+#
+# The SHA stays pinned (reproducible, hermetic): it feeds the
+# content-addressed cache key in `dotfiles_setup.p2996_hash`, so an
+# unchanged HEAD hits the `:p2996-<hash>` cache (no rebuild) and a
+# changed HEAD triggers exactly one rebuild. See issue #100 and
+# `.devcontainer/P2996-CACHE.md`.
+#
+# Triggers:
+#   - Weekly cron, Mondays at 00:00 maintainer-local — mirrors
+#     snapshot-refresh.yml so both auto-PRs land at the start of the work
+#     week and drift is bounded to ~one week. GHA honors `timezone:`.
+#   - workflow_dispatch — manual trigger via `gh workflow run` or web UI.
+#
+# Outcome: opens a PR if the pinned SHA advanced; no-op if not.
+
+on:
+  schedule:
+    - cron: "0 0 * * MON"
+      timezone: "America/Chicago"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: p2996-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install mise (python + uv)
+        # Subset install: only python + uv, both pinned in mise.toml.
+        # Mirrors ci.yml's contract-preflight setup.
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          install_args: "python uv"
+
+      - name: Bump CLANG_P2996_REF to latest p2996 HEAD
+        # `git ls-remote` the p2996 branch, compare to the pinned SHA, and
+        # rewrite docker-bake.hcl only when it advanced. Emits a one-line
+        # JSON result (changed/old_ref/new_ref) to the step summary.
+        id: bump
+        run: |
+          set -euo pipefail
+          result=$(uv run --project python dotfiles-setup p2996-refresh)
+          echo "$result"
+          {
+            echo "## CLANG_P2996_REF refresh"
+            echo ""
+            echo '```json'
+            echo "$result"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open PR if the pinned ref advanced
+        id: cpr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: bump CLANG_P2996_REF to latest p2996 HEAD"
+          title: "chore: bump CLANG_P2996_REF to latest p2996 HEAD"
+          body: |
+            Automated weekly bump of `CLANG_P2996_REF` in `docker-bake.hcl`
+            to the latest `bloomberg/clang-p2996` `p2996`-branch HEAD.
+
+            clang-p2996 ships no releases or tags, so the active P2996 work
+            on the `p2996` branch HEAD is tracked as "latest". The pinned
+            SHA feeds the content-addressed P2996 cache key, so this PR will
+            trigger exactly one clang rebuild (ccache gives ~80% object
+            reuse). Review the upstream commit range before merging.
+
+            Trigger: ${{ github.event_name }}.
+          branch: chore/p2996-refresh
+          base: main
+          add-paths: docker-bake.hcl
+          delete-branch: true
+          labels: |
+            enhancement
+
+      - name: Re-trigger CI on the auto-PR
+        # GH limitation: PRs created via secrets.GITHUB_TOKEN do NOT
+        # trigger workflows on `pull_request` events. Dispatch ci.yml on
+        # the auto-PR branch so the full pipeline (incl. a P2996 cache
+        # probe + rebuild against the new SHA) validates the bump. Skipped
+        # when no PR was created (no drift).
+        if: steps.cpr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh workflow run ci.yml --ref chore/p2996-refresh
+          {
+            echo ""
+            echo "- PR: #${{ steps.cpr.outputs.pull-request-number }} (${{ steps.cpr.outputs.pull-request-url }})"
+            echo "- Dispatched ci.yml on \`chore/p2996-refresh\` to validate the bump."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/mise.toml
+++ b/mise.toml
@@ -569,6 +569,10 @@ run = "mise lock"
 description = "Print the content-hash of P2996 cache inputs (matches the CI :p2996-<hash> tag)"
 run = "uv run --project python dotfiles-setup p2996-hash"
 
+[tasks.p2996-refresh]
+description = "Bump CLANG_P2996_REF in docker-bake.hcl to the latest bloomberg/clang-p2996 p2996-branch HEAD (writes only on change; the scheduled p2996-refresh.yml workflow does this in CI)"
+run = "uv run --project python dotfiles-setup p2996-refresh"
+
 [tasks.capture-mise-system-resolved]
 description = "Refresh .devcontainer/mise-system-resolved.json — run inside the devcontainer when conda-forge tool drift should bust the P2996 cache"
 run = "uv run --project python dotfiles-setup mise-snapshot"

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -22,6 +22,7 @@ from dotfiles_setup.p2996_hash import (
     compute_repo_base_hash,
     compute_repo_p2996_hash,
 )
+from dotfiles_setup.p2996_refresh import refresh as refresh_p2996_ref
 from dotfiles_setup.verify import main as verify_main
 
 logger = logging.getLogger(__name__)
@@ -190,6 +191,11 @@ def setup_parser() -> argparse.ArgumentParser:
     subparsers.add_parser(
         "base-hash",
         help="Print the content-addressed hash of devcontainer-base inputs",
+    )
+    subparsers.add_parser(
+        "p2996-refresh",
+        help="Bump CLANG_P2996_REF in docker-bake.hcl to the latest "
+        "bloomberg/clang-p2996 p2996-branch HEAD (writes only on change)",
     )
     subparsers.add_parser(
         "mise-snapshot",
@@ -375,6 +381,9 @@ def _build_command_handlers(
     def _base_hash() -> None:
         sys.stdout.write(compute_repo_base_hash(project_root) + "\n")
 
+    def _p2996_refresh() -> None:
+        sys.stdout.write(refresh_p2996_ref(project_root).as_json() + "\n")
+
     def _mise_snapshot() -> None:
         resolved = capture()
         write_snapshot(
@@ -396,6 +405,7 @@ def _build_command_handlers(
         "sync-versions": lambda: handle_sync_versions(project_root),
         "p2996-hash": _p2996_hash,
         "base-hash": _base_hash,
+        "p2996-refresh": _p2996_refresh,
         "mise-snapshot": _mise_snapshot,
     }
 

--- a/python/src/dotfiles_setup/p2996_refresh.py
+++ b/python/src/dotfiles_setup/p2996_refresh.py
@@ -1,0 +1,167 @@
+"""Auto-bump `CLANG_P2996_REF` to the latest `bloomberg/clang-p2996` HEAD.
+
+clang-p2996 publishes **no releases or tags**; its default branch is ~a
+year stale and the active P2996 work lives on the **`p2996`** branch. So
+"latest stable" is defined as that branch's HEAD commit.
+
+The SHA stays **pinned** in `docker-bake.hcl` (reproducible, hermetic).
+This module only rewrites the pin to a newer HEAD when one exists — it
+does NOT resolve "latest" at build time. The pinned SHA feeds the
+content-addressed cache key in `p2996_hash.py`, so:
+
+- SHA unchanged -> same hash -> `:p2996-<hash>` cache **hit** -> no rebuild.
+- SHA changed   -> new hash  -> cache **miss** -> exactly one rebuild.
+
+The scheduled `.github/workflows/p2996-refresh.yml` runs this, then opens
+a PR via `peter-evans/create-pull-request` when the file actually changed.
+
+See `.devcontainer/P2996-CACHE.md` and issue #100 for the full design.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import subprocess
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING
+
+from dotfiles_setup.p2996_hash import _extract_bake_variable
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+CLANG_P2996_REPO = "https://github.com/bloomberg/clang-p2996"
+TRACKED_BRANCH = "p2996"
+BAKE_VARIABLE = "CLANG_P2996_REF"
+GIT_SHA1_LEN = 40
+
+# Rewrites only the quoted SHA inside the variable block, preserving the
+# surrounding HCL formatting. Mirrors `_extract_bake_variable`'s shape.
+_PINNED_REF_PATTERN = re.compile(
+    r'(variable\s+"' + re.escape(BAKE_VARIABLE) + r'"\s*\{[^}]*?'
+    r'default\s*=\s*")([0-9a-fA-F]+)(")',
+    re.DOTALL,
+)
+
+
+@dataclass(frozen=True)
+class RefreshResult:
+    """Outcome of a refresh attempt."""
+
+    changed: bool
+    old_ref: str
+    new_ref: str
+
+    def as_json(self) -> str:
+        """Render the result as a one-line JSON object."""
+        return json.dumps(asdict(self))
+
+
+def _validate_sha(value: str, source: str) -> str:
+    """Return `value` if it is a full 40-char lowercase-hex git SHA-1.
+
+    Raises:
+        ValueError: when `value` is not a well-formed full SHA-1.
+    """
+    if len(value) != GIT_SHA1_LEN or not all(c in "0123456789abcdef" for c in value):
+        msg = (
+            f"{source} must be a {GIT_SHA1_LEN}-char lowercase-hex git SHA-1; "
+            f"got {value!r}"
+        )
+        raise ValueError(msg)
+    return value
+
+
+def _default_runner(repo_url: str, branch: str) -> str:
+    """Run `git ls-remote <repo_url> refs/heads/<branch>` and return stdout.
+
+    Raises:
+        subprocess.CalledProcessError: when git exits non-zero (stderr logged).
+    """
+    cmd = ["git", "ls-remote", repo_url, f"refs/heads/{branch}"]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    except subprocess.CalledProcessError as exc:
+        logger.exception(
+            "git ls-remote failed (rc=%d). stderr:\n%s", exc.returncode, exc.stderr
+        )
+        raise
+    return result.stdout
+
+
+def fetch_latest_ref(
+    runner: Callable[[str, str], str] | None = None,
+    *,
+    repo_url: str = CLANG_P2996_REPO,
+    branch: str = TRACKED_BRANCH,
+) -> str:
+    """Resolve the HEAD SHA of `branch` on `repo_url` via git ls-remote.
+
+    `runner` is a test seam: a callable `(repo_url, branch) -> stdout`.
+
+    Raises:
+        ValueError: when ls-remote returns no matching ref or a malformed SHA.
+    """
+    run = runner or _default_runner
+    stdout = run(repo_url, branch)
+    first_line = stdout.strip().splitlines()[0] if stdout.strip() else ""
+    sha = first_line.split()[0].lower() if first_line else ""
+    if not sha:
+        msg = (
+            f"git ls-remote returned no ref for refs/heads/{branch} on "
+            f"{repo_url}; got {stdout!r}"
+        )
+        raise ValueError(msg)
+    return _validate_sha(sha, f"ls-remote SHA for refs/heads/{branch}")
+
+
+def read_pinned_ref(repo_root: Path) -> str:
+    """Read the currently-pinned `CLANG_P2996_REF` from docker-bake.hcl."""
+    bake_text = (repo_root / "docker-bake.hcl").read_text()
+    return _extract_bake_variable(bake_text, BAKE_VARIABLE)
+
+
+def replace_pinned_ref(bake_text: str, new_ref: str) -> str:
+    """Return `bake_text` with the `CLANG_P2996_REF` default set to `new_ref`.
+
+    Raises:
+        ValueError: when the variable block is missing (so a silent no-op
+            rewrite can never mask a renamed/removed pin).
+    """
+    new_text, count = _PINNED_REF_PATTERN.subn(rf"\g<1>{new_ref}\g<3>", bake_text)
+    if count != 1:
+        msg = (
+            f"expected exactly one {BAKE_VARIABLE} default in docker-bake.hcl, "
+            f"found {count}"
+        )
+        raise ValueError(msg)
+    return new_text
+
+
+def refresh(
+    repo_root: Path,
+    *,
+    runner: Callable[[str, str], str] | None = None,
+) -> RefreshResult:
+    """Bump the pinned ref to the latest `p2996` HEAD if it has advanced.
+
+    Writes `docker-bake.hcl` only when the SHA changed, so an unchanged
+    HEAD leaves the file byte-identical (no spurious PR).
+    """
+    bake_path = repo_root / "docker-bake.hcl"
+    bake_text = bake_path.read_text()
+    old_ref = _extract_bake_variable(bake_text, BAKE_VARIABLE)
+    new_ref = fetch_latest_ref(runner)
+    if new_ref == old_ref:
+        logger.info(
+            "%s already at latest %s HEAD %s", BAKE_VARIABLE, TRACKED_BRANCH, new_ref
+        )
+        return RefreshResult(changed=False, old_ref=old_ref, new_ref=new_ref)
+    bake_path.write_text(replace_pinned_ref(bake_text, new_ref))
+    logger.info("Bumped %s: %s -> %s", BAKE_VARIABLE, old_ref, new_ref)
+    return RefreshResult(changed=True, old_ref=old_ref, new_ref=new_ref)

--- a/tests/test_p2996_refresh.py
+++ b/tests/test_p2996_refresh.py
@@ -1,0 +1,123 @@
+"""Tests for `dotfiles_setup.p2996_refresh`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dotfiles_setup.p2996_refresh import (
+    GIT_SHA1_LEN,
+    RefreshResult,
+    fetch_latest_ref,
+    read_pinned_ref,
+    refresh,
+    replace_pinned_ref,
+)
+
+OLD_SHA = "9ffb96e3ce362289008e14ad2a79a249f58aa90a"
+NEW_SHA = "a56e7036fc1dcc8d4325f79230809b6ee678e5f2"
+
+
+def _seed_bake(tmp_path: Path, ref: str = OLD_SHA) -> Path:
+    """Write a docker-bake.hcl whose CLANG_P2996_REF default is `ref`."""
+    (tmp_path / "docker-bake.hcl").write_text(
+        'variable "BASE_IMAGE" {\n  default = "ubuntu:26.04"\n}\n\n'
+        'variable "CLANG_P2996_REF" {\n'
+        "  # Pinned commit SHA for Bloomberg's clang-p2996 fork.\n"
+        f'  default = "{ref}"\n'
+        "}\n",
+    )
+    return tmp_path
+
+
+# ──────────────────────────────────────────────────────────────────────
+# fetch_latest_ref
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_fetch_latest_ref_parses_sha_from_ls_remote() -> None:
+    def runner(_url: str, _branch: str) -> str:
+        return f"{NEW_SHA}\trefs/heads/p2996\n"
+
+    assert fetch_latest_ref(runner) == NEW_SHA
+
+
+def test_fetch_latest_ref_lowercases_sha() -> None:
+    def runner(_url: str, _branch: str) -> str:
+        return f"{NEW_SHA.upper()}\trefs/heads/p2996\n"
+
+    assert fetch_latest_ref(runner) == NEW_SHA
+
+
+def test_fetch_latest_ref_rejects_empty_output() -> None:
+    with pytest.raises(ValueError, match="no ref"):
+        fetch_latest_ref(lambda _u, _b: "")
+
+
+def test_fetch_latest_ref_rejects_malformed_sha() -> None:
+    with pytest.raises(ValueError, match="SHA-1"):
+        fetch_latest_ref(lambda _u, _b: "not-a-sha\trefs/heads/p2996\n")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# read_pinned_ref / replace_pinned_ref
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_read_pinned_ref(tmp_path: Path) -> None:
+    assert read_pinned_ref(_seed_bake(tmp_path)) == OLD_SHA
+
+
+def test_replace_pinned_ref_swaps_only_the_sha(tmp_path: Path) -> None:
+    bake_text = (_seed_bake(tmp_path) / "docker-bake.hcl").read_text()
+    new_text = replace_pinned_ref(bake_text, NEW_SHA)
+    assert NEW_SHA in new_text
+    assert OLD_SHA not in new_text
+    # Surrounding HCL (comment, other variable) is preserved.
+    assert "ubuntu:26.04" in new_text
+    assert "Bloomberg's clang-p2996 fork" in new_text
+
+
+def test_replace_pinned_ref_is_idempotent_for_same_sha(tmp_path: Path) -> None:
+    bake_text = (_seed_bake(tmp_path) / "docker-bake.hcl").read_text()
+    assert replace_pinned_ref(bake_text, OLD_SHA) == bake_text
+
+
+def test_replace_pinned_ref_raises_when_variable_missing() -> None:
+    with pytest.raises(ValueError, match="exactly one"):
+        replace_pinned_ref('variable "OTHER" { default = "x" }\n', NEW_SHA)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# refresh orchestration
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_refresh_bumps_and_writes_when_head_advanced(tmp_path: Path) -> None:
+    repo = _seed_bake(tmp_path)
+    result = refresh(repo, runner=lambda _u, _b: f"{NEW_SHA}\trefs/heads/p2996\n")
+    assert result == RefreshResult(changed=True, old_ref=OLD_SHA, new_ref=NEW_SHA)
+    assert read_pinned_ref(repo) == NEW_SHA
+
+
+def test_refresh_is_noop_when_already_latest(tmp_path: Path) -> None:
+    repo = _seed_bake(tmp_path)
+    before = (repo / "docker-bake.hcl").read_text()
+    result = refresh(repo, runner=lambda _u, _b: f"{OLD_SHA}\trefs/heads/p2996\n")
+    assert result.changed is False
+    # File is left byte-identical so create-pull-request sees no diff.
+    assert (repo / "docker-bake.hcl").read_text() == before
+
+
+def test_refresh_result_as_json_roundtrips() -> None:
+    import json
+
+    result = RefreshResult(changed=True, old_ref=OLD_SHA, new_ref=NEW_SHA)
+    parsed = json.loads(result.as_json())
+    assert parsed == {"changed": True, "old_ref": OLD_SHA, "new_ref": NEW_SHA}
+
+
+def test_old_and_new_shas_are_full_length() -> None:
+    assert len(OLD_SHA) == GIT_SHA1_LEN
+    assert len(NEW_SHA) == GIT_SHA1_LEN


### PR DESCRIPTION
## What

Adds a scheduled workflow that auto-bumps the pinned `CLANG_P2996_REF`
in `docker-bake.hcl` to the latest `bloomberg/clang-p2996` `p2996`-branch
HEAD, opening a PR when it advances. Implements #100.

clang-p2996 ships **no releases or tags** and its default branch is ~a
year stale; the active P2996 work lives on the `p2996` branch, so its
HEAD commit is "latest".

## Why the SHA stays pinned (not resolved at build time)

The pinned SHA feeds the content-addressed cache key in
`dotfiles_setup.p2996_hash`, so:

- SHA unchanged → same hash → `:p2996-<hash>` cache **hit** → no rebuild.
- SHA changed → new hash → cache **miss** → exactly one rebuild (ccache
  gives ~80% object reuse).

Resolving "latest" inside the build was rejected: it decouples the cache
key from what is actually compiled (stale-but-valid hits,
non-reproducible builds).

## Changes

- **`python/src/dotfiles_setup/p2996_refresh.py`** — `git ls-remote` the
  `p2996` branch, compare to the pinned SHA, rewrite `docker-bake.hcl`
  only on change. Pure host Python; `runner` test-seam means no network
  in tests.
- **`main.py`** — `dotfiles-setup p2996-refresh` subcommand → `{changed,
  old_ref, new_ref}` JSON. **`mise.toml`** — `mise run p2996-refresh`.
- **`.github/workflows/p2996-refresh.yml`** — weekly cron + dispatch,
  mirrors `snapshot-refresh.yml`: bump → `peter-evans/create-pull-request`
  → re-dispatch `ci.yml` on the auto-PR branch (PRs opened with
  `GITHUB_TOKEN` don't auto-trigger CI).
- **12 tests** + docs (`P2996-CACHE.md`, workflows `AGENTS.md`).

## Scope note

Mechanism only — **no ref bump is bundled** in this PR, so it triggers no
clang rebuild. (Live-validated the command against the real repo: HEAD is
still `a56e7036…`, correctly resolved; the file edit was reverted.) The
first scheduled or `gh workflow run p2996-refresh.yml` run opens the
actual bump PR.

## Local validation

- ✅ `hk run pre-commit --all --stash none` — exit 0
- ✅ `uv run --project python pytest tests/ -x -q` — 113 passed
- ✅ `dotfiles-setup verify run` — 66 passed, 0 failed

> ⚠️ Heads-up (pre-existing, **not** in this PR): `mise run pin-actions`
> currently fails on `image-analysis.yml` (trivy-action + codeql-action
> SHA/version-comment mismatches, present on `main` since #99). Worth a
> separate fix/issue.

Closes #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated refresh flow to keep the pinned compiler reference up to date.
  * Added a new command and task to manually trigger the refresh from the local environment.
  * Added scheduled workflow support that opens a change request only when the pinned value changes.

* **Tests**
  * Added coverage for refresh, validation, and no-op behavior.

* **Documentation**
  * Updated workflow and operator docs to describe the new refresh process and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->