### PR TITLE
chore: guard the lint gate with a hard timeout + working-agreement rules

### DIFF
--- a/.claude/rules/clarify-before-acting.md
+++ b/.claude/rules/clarify-before-acting.md
@@ -1,0 +1,54 @@
+# Clarify Before Acting: Ask Until Sure on Ambiguous Work
+
+When a task is ambiguous, admits multiple reasonable approaches, or is
+hard to reverse, ask clarifying questions (via `AskUserQuestion`) and
+keep asking across rounds until you are confident what to do. Do not
+guess and proceed.
+
+## Why this rule exists
+
+Session 2026-06-29: the user asked for hk-hang prevention and explicitly
+said *"keep asking questions until 100% sure on what to do"* and to
+record the preference so it need not be repeated. In the same session the
+user's chosen approach ("per-step hk timeouts") turned out to be
+**impossible** — hk has no timeout support. Surfacing that and
+re-confirming the pivot (an outer timeout wrapper) before building
+avoided shipping the wrong thing.
+
+## Rules
+
+1. **Ask before acting on ambiguous / multi-path / irreversible work.**
+   If there is genuine uncertainty about scope, approach, or intent, or
+   the action is hard to undo (deletes, pushes, merges, external/
+   outward-facing effects), resolve it with the user first.
+
+2. **Recommend, don't just enumerate.** Lead with the option you'd pick,
+   marked `(Recommended)`, and give the trade-offs. A question is a
+   proposal to confirm, not a blank survey.
+
+3. **Proceed directly on clear, low-risk, reversible tasks.** Do not
+   manufacture questions for things with an obvious default or facts you
+   can verify yourself — over-asking is its own failure mode. Pick the
+   obvious option, state it, and move.
+
+4. **Surface infeasibility immediately.** If a chosen approach turns out
+   impossible or much worse than expected mid-flight, stop and
+   re-confirm the pivot with evidence — never silently substitute a
+   different solution for the one that was agreed.
+
+5. **Keep asking until sure.** A second clarifying round is cheaper than
+   rework. Don't stop at one question if the answer revealed new
+   ambiguity.
+
+## Applies to
+
+All non-trivial work: planning, multi-file changes, design choices,
+destructive or outward-facing actions, and any task where the request
+under-determines what to build.
+
+## See also
+
+- `do-not.md` — project invariants (some actions are never OK regardless
+  of clarification).
+- CLAUDE.md → `AGENTS.md` "Agent Instructions" — the policy index that
+  references this rule.

--- a/.claude/rules/long-running-command-hangs.md
+++ b/.claude/rules/long-running-command-hangs.md
@@ -1,0 +1,65 @@
+# Long-Running Commands: Never Run Blind — Bound Every Run
+
+Any command that can block on network, IO, a lock, or a prompt MUST be
+run with a hard time bound and an observable log. Never start a
+potentially-slow command and then wait on it indefinitely.
+
+## Why this rule exists
+
+Session 2026-06-29: a `hk run pre-commit --all --stash none` invocation
+hung at **0% CPU with no child processes for ~7 hours** before it was
+noticed. hk has no native timeout, so nothing aborted it. Worse, the run
+had been launched as `hk ... 2>&1 | tail -40`, so when it was finally
+killed the pipeline reported **exit 0** (tail's exit code) — masking the
+fact that the gate never actually passed. Two traps in one incident:
+unbounded wait + pipe-masked exit code.
+
+## Rules
+
+1. **Use `mise run lint`, not raw `hk run pre-commit`.** `mise run lint`
+   wraps hk in an out-of-process hard timeout (hk has none of its own —
+   verified against hk 1.46 and the live v1.48 docs: no `--timeout` flag,
+   no `timeout` step key, no `HK_*` timeout env var). On expiry it kills
+   hk's whole process group and prints the tail of the debug log. Default
+   600s; override with `--timeout <secs>` or
+   `DOTFILES_LINT_TIMEOUT=<secs> mise run lint`. Source:
+   `python/src/dotfiles_setup/lint.py`.
+
+2. **For any command expected to exceed ~30s, never wait blind.** Either
+   bound it with a timeout, or run it in the background and monitor its
+   debug log: hk → `~/.local/state/hk/hk.log` (or the per-run
+   `HK_LOG_FILE` that `mise run lint` sets), mise →
+   `~/.local/state/mise/mise.log` (`MISE_LOG_FILE`, debug level set in
+   `mise.toml [env]`). Use a count-diff monitor loop, not a fixed sleep.
+
+3. **Preserve real exit codes — never `cmd 2>&1 | tail -N` to capture.**
+   Bash returns the *last* pipeline command's exit code (tail's `0`),
+   silently swallowing the upstream failure or kill. Redirect to a file
+   (`cmd > /tmp/out.log 2>&1; echo "rc=$?" >> /tmp/out.log`) and read the
+   file + the recorded `rc`. Trust file content, not a piped tail.
+
+4. **A stalled process is a hang — kill it, don't keep waiting.** A
+   process sitting at 0% CPU with no children for minutes is wedged
+   (blocked on a lock, stdin, or a dead socket), not working. Kill it
+   (and its process group), then diagnose from the log tail. Re-running
+   under a timeout is cheaper than waiting on a corpse.
+
+5. **hk specifics.** hk parallelises via per-file read/write locks
+   *within* a run; a crashed/killed run can leave stale state under
+   `~/.local/state/hk/`. After editing `hk.pkl`, clear the pkl config
+   cache (`rm -rf ~/Library/Caches/hk/configs/`) — see `ci-local-parity.md`.
+
+## Applies to
+
+`hk` (use `mise run lint`), `mise install`, `docker buildx`/`devcontainer
+up`, `gh` waits (use `--watch`, see `gh-cli-watch.md`), and any other
+network- or IO-bound command an agent or human launches in this repo.
+
+## See also
+
+- `python/src/dotfiles_setup/lint.py` — the guarded hk runner.
+- `gh-cli-watch.md` — sibling rule: use `--watch`, never sleep-poll.
+- `ci-local-parity.md` — hk pkl-cache clearing after `hk.pkl` edits.
+- Memory: `feedback_long_running_tail_logs`, `feedback_pipe_kills_exit_code`.
+- CLAUDE.md → `AGENTS.md` "Validate before committing" — prefer
+  `mise run lint` for the lint gate.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Trivy run async in `image-analysis.yml`.
 
 ```bash
 mise install                                 # Install all tools
-hk run pre-commit --all --stash none         # Run lint checks
+mise run lint                                # Run lint checks (hk under a hard timeout)
 mise run up                                  # Bring up devcontainer (see .devcontainer/AGENTS.md)
 mise run down                                # Tear down devcontainer
 uv run --project python pytest tests/ -x -q  # Run tests (see python/AGENTS.md)
@@ -111,26 +111,26 @@ locally before pushing Dockerfile changes.
   `.claude/rules/zero-skip-policy.md`.
 - **Zero inline suppressions**: The `no_lint_skip` hk step rejects
   `noqa`/`type: ignore`/`pylint: disable`/`nosec` in Python source.
-- **No MCP registration**: Never `claude mcp add`. The `no_mcp_registration`
-  hk step enforces this. Use `mcp2cli` (process-spawn, no schema injection),
-  `llms.txt`, or per-page `.md` fetches instead. See
-  `.claude/rules/research-doc-sources.md`.
-- **CI-local parity**: Every CI lint step has a local hk equivalent. Every
-  hk tool is in `mise.toml`. Verify parity before committing. See
-  `.claude/rules/ci-local-parity.md`.
-- **Research before fixing**: Check docs, changelogs, and issue trackers
-  before attempting fixes. Don't guess at CI failures.
-- **Local validation first**: Run `hk run pre-commit --all --stash none`
-  AND `dotfiles-setup verify run` locally before pushing.
-- **Use tool built-ins**: Before inventing custom detection logic / data
-  variables / env-var parsing, check the tool's official docs for a
-  built-in fact (e.g., `chezmoi.os` discriminates Mac host vs devcontainer).
-  See `.claude/rules/use-tool-builtins.md`.
-- **Chezmoi is devcontainer-only on this Mac (for now)**: `chezmoi apply`
-  and `chezmoi update` are blocked on the host by `.claude/settings.json`.
-  Read-only chezmoi commands remain allowed. See `home/AGENTS.md`.
-- **Notepad enforcement**: Agents write findings to notepad during work,
-  not at session end. See `.claude/rules/notepad-enforcement.md`.
+- **No MCP registration**: Never `claude mcp add` (enforced by the
+  `no_mcp_registration` hk step). Use `mcp2cli`/`llms.txt`/`.md` instead.
+  See `.claude/rules/research-doc-sources.md`.
+- **CI-local parity**: Every CI lint step has a local hk equivalent; every
+  hk tool is in `mise.toml`. See `.claude/rules/ci-local-parity.md`.
+- **Research before fixing**: Check docs/changelogs/issues before fixing — don't guess at CI failures.
+- **Bound long-running commands**: Run the lint gate via `mise run lint`
+  (hk under a hard timeout; hk has none) — never wait blind or capture via
+  `| tail` (masks exit codes). See `.claude/rules/long-running-command-hangs.md`.
+- **Clarify before acting**: On ambiguous, multi-path, or irreversible
+  work, ask (with a recommended option) until sure; proceed directly on
+  clear low-risk tasks. See `.claude/rules/clarify-before-acting.md`.
+- **Local validation first**: Run `mise run lint`, `pytest`, AND
+  `dotfiles-setup verify run` locally before pushing.
+- **Use tool built-ins**: Prefer documented built-in facts (e.g.
+  `chezmoi.os`) over homegrown detection logic. See
+  `.claude/rules/use-tool-builtins.md`.
+- **Chezmoi is devcontainer-only on this Mac**: `chezmoi apply`/`update`
+  blocked on host by `.claude/settings.json`; read-only ok. See `home/AGENTS.md`.
+- **Notepad enforcement**: Agents write findings to notepad during work, not at session end. See `.claude/rules/notepad-enforcement.md`.
 - **OMC directory conventions**: Use standard `.omc/` paths, no ad-hoc
   directories. See `.claude/rules/omc-directory-conventions.md`.
 - **Zero-bash logic**: Non-trivial logic (env detection, tool config,
@@ -140,7 +140,7 @@ locally before pushing Dockerfile changes.
 ### Validate before committing
 
 ```bash
-hk run pre-commit --all --stash none          # All lint checks pass — then proceed
+mise run lint                                 # Lint gate (hk under a hard timeout) — then proceed
 uv run --project python pytest tests/ -x -q   # All tests pass — then proceed
 dotfiles-setup verify run                     # Verification contracts pass — then proceed
 ```

--- a/mise.toml
+++ b/mise.toml
@@ -114,6 +114,15 @@ run = "uv sync"
 description = "Run all hk pre-commit checks (≡ `hk run pre-commit --all`)"
 run = "hk run pre-commit --all"
 
+[tasks.lint]
+# Preferred manual/agent entrypoint for the lint gate. Wraps hk in a hard
+# timeout (hk has none of its own) so a hung step self-aborts with the
+# tail of the debug log instead of wedging for hours (see the 7h hang in
+# .claude/rules/long-running-command-hangs.md). Default 600s; override
+# with `--timeout <secs>` or `DOTFILES_LINT_TIMEOUT=<secs> mise run lint`.
+description = "Run hk pre-commit --all --stash none under a hard timeout (default 600s) so a hung lint self-aborts"
+run = "uv run --project python dotfiles-setup lint"
+
 [tasks.check]
 description = "Run full quality check (pre-commit + test)"
 depends = ["pre-commit", "test"]

--- a/python/src/dotfiles_setup/lint.py
+++ b/python/src/dotfiles_setup/lint.py
@@ -1,0 +1,130 @@
+"""Run hk pre-commit under a hard timeout so a hung lint self-aborts.
+
+hk has **no native timeout** — verified against hk 1.46 (installed) and
+the live v1.48 docs: `hk run` exposes only `--jobs`/`--fail-fast`,
+`configuration.md` has no `timeout` step key, and the full `HK_*` env-var
+list has none either. A step that blocks (network, stdin, a stuck
+`docker_bake_check` waiting on Docker) would otherwise wedge the whole
+run indefinitely; one such hang idled at 0% CPU for ~7h in session
+2026-06-29 before it was noticed and killed.
+
+This wraps the hk invocation in an out-of-process timeout. hk and its
+children run in a fresh process group (`start_new_session=True`) so the
+timeout kills the entire tree, not just the hk parent — the system
+`timeout(1)` binary is not portable (absent on stock macOS hosts), so the
+kill is done in-process. On expiry the tail of hk's debug log is printed
+for diagnosis and the GNU-`timeout` convention exit code 124 is returned.
+
+Default ceiling is 600s, overridable via `--timeout` or the
+`DOTFILES_LINT_TIMEOUT` env var. See
+`.claude/rules/long-running-command-hangs.md`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT_SECONDS = 600
+TIMEOUT_ENV_VAR = "DOTFILES_LINT_TIMEOUT"
+TIMEOUT_EXIT_CODE = 124  # GNU coreutils `timeout` convention
+KILL_GRACE_SECONDS = 10
+LOG_TAIL_LINES = 40
+HK_COMMAND = ("hk", "run", "pre-commit", "--all", "--stash", "none")
+DEFAULT_LOG_FILE = Path.home() / ".local" / "state" / "dotfiles" / "hk-lint.log"
+
+
+def resolve_timeout(cli_timeout: int | None = None) -> int:
+    """Resolve the timeout ceiling: `--timeout` > env var > default.
+
+    Raises:
+        ValueError: when the chosen override is not a positive integer.
+    """
+    if cli_timeout is not None:
+        candidate, source = cli_timeout, "--timeout"
+    else:
+        raw = os.environ.get(TIMEOUT_ENV_VAR)
+        if not raw:
+            return DEFAULT_TIMEOUT_SECONDS
+        try:
+            candidate = int(raw)
+        except ValueError as exc:
+            msg = f"{TIMEOUT_ENV_VAR}={raw!r} is not an integer"
+            raise ValueError(msg) from exc
+        source = TIMEOUT_ENV_VAR
+    if candidate <= 0:
+        msg = f"{source} must be a positive number of seconds; got {candidate}"
+        raise ValueError(msg)
+    return candidate
+
+
+def _terminate_group(proc: subprocess.Popen[bytes]) -> None:
+    """SIGTERM the process group led by `proc`, escalating to SIGKILL."""
+    try:
+        pgid = os.getpgid(proc.pid)
+    except ProcessLookupError:
+        return
+    os.killpg(pgid, signal.SIGTERM)
+    try:
+        proc.wait(timeout=KILL_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        os.killpg(pgid, signal.SIGKILL)
+
+
+def _print_log_tail(log_file: Path) -> None:
+    """Log the last `LOG_TAIL_LINES` of `log_file` to aid diagnosis."""
+    if not log_file.exists():
+        logger.error("hk log %s not found; nothing to tail", log_file)
+        return
+    lines = log_file.read_text(errors="replace").splitlines()
+    tail = lines[-LOG_TAIL_LINES:]
+    logger.error("Last %d line(s) of %s:", len(tail), log_file)
+    for line in tail:
+        logger.error("  %s", line)
+
+
+def run_guarded(
+    timeout: int,
+    *,
+    command: tuple[str, ...] = HK_COMMAND,
+    log_file: Path = DEFAULT_LOG_FILE,
+) -> int:
+    """Run `command` under `timeout` seconds; kill the group on expiry.
+
+    Returns the command's exit code, or `TIMEOUT_EXIT_CODE` on timeout.
+    Points `HK_LOG_FILE` at a dedicated per-run file (truncated up front)
+    so the on-timeout tail reflects only this run.
+    """
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    log_file.write_text("")  # truncate so the tail is this run only
+    env = {
+        **os.environ,
+        "HK_LOG_FILE": str(log_file),
+        "HK_LOG_FILE_LEVEL": "debug",
+    }
+    logger.info("Running %s (timeout %ds)", " ".join(command), timeout)
+    proc = subprocess.Popen(command, start_new_session=True, env=env)
+    try:
+        return proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return _handle_timeout(proc, timeout, command[0], log_file)
+
+
+def _handle_timeout(
+    proc: subprocess.Popen[bytes],
+    timeout: int,
+    name: str,
+    log_file: Path,
+) -> int:
+    """Kill a timed-out run's process group and surface the log tail."""
+    logger.error(
+        "%s exceeded %ds — killing the process group and aborting.", name, timeout
+    )
+    _terminate_group(proc)
+    _print_log_tail(log_file)
+    return TIMEOUT_EXIT_CODE

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -17,6 +17,12 @@ from dotfiles_setup.docker import DevContainerManager
 from dotfiles_setup.ghcr import validate_ghcr_prereqs
 from dotfiles_setup.image import ImageCommand
 from dotfiles_setup.image import main as image_main
+from dotfiles_setup.lint import (
+    DEFAULT_TIMEOUT_SECONDS,
+    TIMEOUT_ENV_VAR,
+    resolve_timeout,
+    run_guarded,
+)
 from dotfiles_setup.mise_snapshot import capture, write_snapshot
 from dotfiles_setup.p2996_hash import (
     compute_repo_base_hash,
@@ -178,6 +184,20 @@ def setup_parser() -> argparse.ArgumentParser:
 
     # install command
     subparsers.add_parser("install", help="Execute toolchain installation")
+
+    # lint command — hk pre-commit under a hard timeout so hangs self-abort
+    lint_parser = subparsers.add_parser(
+        "lint",
+        help="Run hk pre-commit under a hard timeout (default 600s) so a "
+        "hung lint self-aborts instead of wedging",
+    )
+    lint_parser.add_argument(
+        "--timeout",
+        type=int,
+        default=None,
+        help=f"Timeout in seconds; overrides ${TIMEOUT_ENV_VAR} "
+        f"(default {DEFAULT_TIMEOUT_SECONDS})",
+    )
 
     _add_docker_subcommands(subparsers)
     _add_verify_subcommands(subparsers)
@@ -382,6 +402,9 @@ def _build_command_handlers(
             resolved,
         )
 
+    def _lint() -> None:
+        sys.exit(run_guarded(resolve_timeout(getattr(args, "timeout", None))))
+
     return {
         "validate": _validate,
         "audit": lambda: handle_audit(config=config),
@@ -397,6 +420,7 @@ def _build_command_handlers(
         "p2996-hash": _p2996_hash,
         "base-hash": _base_hash,
         "mise-snapshot": _mise_snapshot,
+        "lint": _lint,
     }
 
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,0 +1,91 @@
+"""Tests for `dotfiles_setup.lint` (guarded hk runner)."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from dotfiles_setup.lint import (
+    DEFAULT_TIMEOUT_SECONDS,
+    TIMEOUT_ENV_VAR,
+    TIMEOUT_EXIT_CODE,
+    resolve_timeout,
+    run_guarded,
+)
+
+# A short timeout the kill-path tests can trip quickly without flaking.
+_SHORT_TIMEOUT = 1
+_SLEEP_LONGER_THAN_TIMEOUT = 30
+
+
+# ──────────────────────────────────────────────────────────────────────
+# resolve_timeout
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_resolve_timeout_defaults_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(TIMEOUT_ENV_VAR, raising=False)
+    assert resolve_timeout() == DEFAULT_TIMEOUT_SECONDS
+
+
+def test_resolve_timeout_cli_overrides_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(TIMEOUT_ENV_VAR, "300")
+    assert resolve_timeout(120) == 120
+
+
+def test_resolve_timeout_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(TIMEOUT_ENV_VAR, "450")
+    assert resolve_timeout() == 450
+
+
+def test_resolve_timeout_rejects_non_integer_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(TIMEOUT_ENV_VAR, "soon")
+    with pytest.raises(ValueError, match="not an integer"):
+        resolve_timeout()
+
+
+@pytest.mark.parametrize("bad", [0, -5])
+def test_resolve_timeout_rejects_non_positive_cli(bad: int) -> None:
+    with pytest.raises(ValueError, match="positive"):
+        resolve_timeout(bad)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# run_guarded
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_run_guarded_returns_command_exit_code(tmp_path: Path) -> None:
+    log_file = tmp_path / "hk.log"
+    rc = run_guarded(30, command=("sh", "-c", "exit 7"), log_file=log_file)
+    assert rc == 7
+
+
+def test_run_guarded_passes_through_success(tmp_path: Path) -> None:
+    rc = run_guarded(30, command=("true",), log_file=tmp_path / "hk.log")
+    assert rc == 0
+
+
+def test_run_guarded_kills_on_timeout(tmp_path: Path) -> None:
+    start = time.monotonic()
+    rc = run_guarded(
+        _SHORT_TIMEOUT,
+        command=("sleep", str(_SLEEP_LONGER_THAN_TIMEOUT)),
+        log_file=tmp_path / "hk.log",
+    )
+    elapsed = time.monotonic() - start
+    assert rc == TIMEOUT_EXIT_CODE
+    # The sleep was killed, not waited out.
+    assert elapsed < _SLEEP_LONGER_THAN_TIMEOUT
+
+
+def test_run_guarded_truncates_log_each_run(tmp_path: Path) -> None:
+    log_file = tmp_path / "hk.log"
+    log_file.write_text("stale content from a previous run\n")
+    run_guarded(30, command=("true",), log_file=log_file)
+    # The command writes nothing to HK_LOG_FILE, so truncation leaves it empty.
+    assert log_file.read_text() == ""


### PR DESCRIPTION
## What

Two related hardening changes prompted by session 2026-06-29.

### 1. Guard the lint gate against hangs

A raw `hk run pre-commit --all --stash none` **hung at 0% CPU for ~7h**
before it was noticed. hk has **no native timeout** — verified against
installed hk 1.46 and the live v1.48 docs: `hk run` has only
`--jobs`/`--fail-fast`, `configuration.md` has no `timeout` step key, and
the full `HK_*` env list has no timeout var. Worse, the run was launched
as `... | tail`, so the eventual kill reported **exit 0** (tail's code),
masking that the gate never passed.

Fix — wrap hk in an out-of-process hard timeout:

- **`python/src/dotfiles_setup/lint.py`** — runs hk in its own process
  group (`start_new_session=True`) under a timeout; on expiry kills the
  whole tree (in-process — the `timeout(1)` binary isn't on stock macOS)
  and prints the debug-log tail. Default **600s**, overridable via
  `--timeout` or `DOTFILES_LINT_TIMEOUT`.
- **`main.py`** — `dotfiles-setup lint`. **`mise.toml`** — `mise run lint`,
  now the preferred lint-gate entrypoint.
- **`tests/test_lint.py`** — 10 tests (timeout resolution precedence,
  exit-code passthrough, process-group kill on timeout, log truncation).

### 2. Working-agreement rules (so they need not be re-specified)

- **`.claude/rules/long-running-command-hangs.md`** — bound every long
  run, never wait blind, never `cmd | tail` (masks exit codes), kill
  stalled 0%-CPU processes.
- **`.claude/rules/clarify-before-acting.md`** — ask clarifying questions
  until sure on ambiguous / multi-path / irreversible work; lead with a
  recommended option; proceed directly on clear tasks; surface
  infeasibility before substituting.
- **`AGENTS.md`** — two new Policies bullets + `mise run lint` in Quick
  Start and the validate-before-committing block (condensed to stay at the
  200-line `claude_md_size_limit` cap).

## Local validation

- ✅ `dotfiles-setup lint` (the new wrapper, dogfooded) — exit 0
- ✅ `uv run --project python pytest tests/ -x -q` — 111 passed
- ✅ `dotfiles-setup verify run` — 66 passed, 0 failed

## Notes

- Independent of #109 (#100 auto-bump); only `main.py`/`mise.toml` overlap,
  in non-adjacent sections (auto-mergeable). Whichever merges second
  rebases cleanly.
- Durable preferences also persisted to auto-memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)