### PR TITLE
ci: fix pinact verification for trivy + codeql in image-analysis.yml (#110)

### DIFF
--- a/.github/workflows/image-analysis.yml
+++ b/.github/workflows/image-analysis.yml
@@ -102,7 +102,7 @@ jobs:
         # gate. `scanners: vuln` + `timeout: 15m` per the heavy-image notes that
         # previously lived in ci.yml (issue #92).
         if: steps.image.outputs.present == 'true'
-        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ steps.image.outputs.ref }}
           format: sarif
@@ -116,7 +116,7 @@ jobs:
         # Associate the result with the analyzed commit/branch (workflow_run
         # context defaults to the default branch otherwise).
         if: steps.image.outputs.present == 'true' && hashFiles('trivy.sarif') != ''
-        uses: github/codeql-action/upload-sarif@65216971a11ded447a6b76263d5a144519e5eee1 # codeql-bundle-v2.25.2
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
         with:
           sarif_file: trivy.sarif
           category: trivy-image


### PR DESCRIPTION
## What

Makes `mise run pin-actions` (`pinact run --verify`) green on `main`.
Two SHA-pin defects in `.github/workflows/image-analysis.yml` (both
introduced with the file in #99):

| Action | Problem | Fix |
|---|---|---|
| `aquasecurity/trivy-action` | Pinned to `a9c7b0f0…`, the **annotated tag-object** SHA of `v0.36.0`, not the commit it points to. `gh api .../commits/a9c7b0f0` → *"No commit found for SHA"*. pinact requires the commit. | Repinned to the dereferenced commit `ed142fd0…` (still `# v0.36.0`). |
| `github/codeql-action/upload-sarif` | `# codeql-bundle-v2.25.2` comment — codeql ships bundle tags, not semver releases, so pinact can't verify it. | Repinned to the `v3` line; pinact normalized the comment to the specific `# v3.36.2` release at commit `dd903d2e…`. |

## Validation

- ✅ `mise run pin-actions` — exit 0 (was failing on `main`)
- ✅ `hk run pre-commit --all --stash none` — exit 0
- ✅ `dotfiles-setup verify run` — 66 passed, 0 failed

No `continue-on-error` or pinact ignores added (zero-skip policy).

Closes #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned versions of security scanning and report upload actions used in the image analysis workflow.
  * Improves workflow reliability and keeps automated vulnerability checks current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->