### PR TITLE
ci: bump CLANG_P2996_REF to latest p2996 HEAD (a56e7036)

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -31,7 +31,7 @@ variable "DEVCONTAINER_USERNAME" {
 # Pinned commit SHA for Bloomberg's clang-p2996 fork (C++ P2996 reflection).
 # Changing this value invalidates the BuildKit cache for the clang-builder stage.
 variable "CLANG_P2996_REF" {
-  default = "9ffb96e3ce362289008e14ad2a79a249f58aa90a"
+  default = "a56e7036fc1dcc8d4325f79230809b6ee678e5f2"
 }
 
 // Default tags for local builds; overridden by docker/metadata-action


### PR DESCRIPTION
First use of the #100 auto-bump mechanism (opened manually because the
scheduled `p2996-refresh.yml` run pushed this branch but couldn't open the
PR — see note below).

Bumps `CLANG_P2996_REF` in `docker-bake.hcl`:
`9ffb96e3…` (2026-04-07) → **`a56e7036…`** (2026-06-16, current
`bloomberg/clang-p2996` `p2996`-branch HEAD; 7 commits ahead).

## Expected CI cost

This changes the p2996 content-hash → **p2996-prep cache MISS** → one
clang rebuild (base layer stays cached; ccache gives ~80% object reuse).
This is the designed "changed SHA → exactly one rebuild" path.

## Note for maintainer

The scheduled workflow's `create-pull-request` step failed with *"GitHub
Actions is not permitted to create or approve pull requests."* The repo
setting **Settings → Actions → General → "Allow GitHub Actions to create
and approve pull requests"** is off (`can_approve_pull_request_reviews:
false`). Until it's enabled, the daily `p2996-refresh.yml` and
`snapshot-refresh.yml` runs will push their branch but fail to open the
PR. Enabling it makes the automation fully unattended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)