### PR TITLE
ci: run snapshot-refresh + p2996-refresh daily instead of weekly

### DIFF
--- a/.devcontainer/P2996-CACHE.md
+++ b/.devcontainer/P2996-CACHE.md
@@ -81,7 +81,7 @@ upstream conda-forge drift.
 - **Bump to latest p2996 HEAD**: `mise run p2996-refresh` — rewrites
   `CLANG_P2996_REF` in `docker-bake.hcl` to the latest
   `bloomberg/clang-p2996` `p2996`-branch HEAD (no-op write when already
-  current). The scheduled `p2996-refresh.yml` workflow does this weekly
+  current). The scheduled `p2996-refresh.yml` workflow does this daily
   and opens a PR on change.
 - **Manual cache bust**: bump `CLANG_P2996_REF` in `docker-bake.hcl`,
   OR refresh the snapshot, OR edit any of the hash-input files. The

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -15,8 +15,8 @@ post-failure reporting.
 | `ci.yml` | Main pipeline: lint → contract-preflight → `changes` (path-gate) → base-prep → p2996-prep → build → smoke-test (smoke+Dive), build chain gated on `changes.build`; OR lint → promote (push to main) |
 | `ci-failure-report.yml` | Post-failure diagnostics / issue filing |
 | `image-analysis.yml` | Async (`workflow_run` on CI success): benchmark metrics + Trivy CVE scan, off the PR critical path |
-| `snapshot-refresh.yml` | Weekly cron: refresh `mise-system-resolved.json` (conda-forge drift), open PR on change |
-| `p2996-refresh.yml` | Weekly cron: bump `CLANG_P2996_REF` to latest `bloomberg/clang-p2996` `p2996`-branch HEAD, open PR on change (issue #100) |
+| `snapshot-refresh.yml` | Daily cron: refresh `mise-system-resolved.json` (conda-forge drift), open PR on change |
+| `p2996-refresh.yml` | Daily cron: bump `CLANG_P2996_REF` to latest `bloomberg/clang-p2996` `p2996`-branch HEAD, open PR on change (issue #100) |
 
 ## Pipeline stages
 

--- a/.github/workflows/p2996-refresh.yml
+++ b/.github/workflows/p2996-refresh.yml
@@ -11,16 +11,17 @@ name: Refresh CLANG_P2996_REF
 # `.devcontainer/P2996-CACHE.md`.
 #
 # Triggers:
-#   - Weekly cron, Mondays at 00:00 maintainer-local — mirrors
-#     snapshot-refresh.yml so both auto-PRs land at the start of the work
-#     week and drift is bounded to ~one week. GHA honors `timezone:`.
+#   - Daily cron at 00:00 maintainer-local — mirrors snapshot-refresh.yml
+#     so a build on the latest p2996 HEAD is always available; drift is
+#     bounded to ~one day. No-op on days with no new HEAD. GHA honors
+#     `timezone:`.
 #   - workflow_dispatch — manual trigger via `gh workflow run` or web UI.
 #
 # Outcome: opens a PR if the pinned SHA advanced; no-op if not.
 
 on:
   schedule:
-    - cron: "0 0 * * MON"
+    - cron: "0 0 * * *"
       timezone: "America/Chicago"
   workflow_dispatch:
 
@@ -71,7 +72,7 @@ jobs:
           commit-message: "chore: bump CLANG_P2996_REF to latest p2996 HEAD"
           title: "chore: bump CLANG_P2996_REF to latest p2996 HEAD"
           body: |
-            Automated weekly bump of `CLANG_P2996_REF` in `docker-bake.hcl`
+            Automated daily bump of `CLANG_P2996_REF` in `docker-bake.hcl`
             to the latest `bloomberg/clang-p2996` `p2996`-branch HEAD.
 
             clang-p2996 ships no releases or tags, so the active P2996 work

--- a/.github/workflows/snapshot-refresh.yml
+++ b/.github/workflows/snapshot-refresh.yml
@@ -6,17 +6,17 @@ name: Refresh mise-system snapshot
 # cached image are last-snapshot, not latest).
 #
 # Triggers:
-#   - Weekly cron, Mondays at 00:00 in maintainer-local timezone so the
-#     auto-PR lands at the start of the work week and bounds drift to
-#     roughly one week. The `timezone:` field is honored by GitHub
-#     Actions cron natively.
+#   - Daily cron at 00:00 maintainer-local so a build with the latest
+#     conda-forge snapshots is always available; drift is bounded to ~one
+#     day. No-op on days with no drift. The `timezone:` field is honored
+#     by GitHub Actions cron natively.
 #   - workflow_dispatch — manual trigger via `gh workflow run` or web UI.
 #
 # Outcome: opens a PR if the snapshot file changed; no-op if not.
 
 on:
   schedule:
-    - cron: "0 0 * * MON"
+    - cron: "0 0 * * *"
       timezone: "America/Chicago"
   workflow_dispatch:
 
@@ -78,7 +78,7 @@ jobs:
           commit-message: "chore: refresh mise-system-resolved snapshot"
           title: "chore: refresh mise-system-resolved snapshot"
           body: |
-            Automated weekly refresh of `.devcontainer/mise-system-resolved.json`.
+            Automated daily refresh of `.devcontainer/mise-system-resolved.json`.
 
             Captures conda-forge resolutions of system-mise tools whose
             `mise-system.toml` versions are pinned to `"latest"`. Diff


### PR DESCRIPTION
## What

Switches both auto-refresh workflows from **weekly** (Mondays) to
**daily** cron, so a build on the latest `p2996` HEAD + conda-forge
snapshots is always available (drift bounded to ~1 day instead of ~1 week).

- `.github/workflows/p2996-refresh.yml` — cron `MON` → `* * *`
- `.github/workflows/snapshot-refresh.yml` — cron `MON` → `* * *`
- Docs (`workflows/AGENTS.md`, `.devcontainer/P2996-CACHE.md`, PR-body
  text) updated weekly → daily.

## Why this doesn't add rebuild cost

Both workflows are **no-ops on days with no upstream change**, and each
only triggers a rebuild when its content-hash actually changes. Daily
cadence shortens *detection latency*; it does not increase the number of
rebuilds (still exactly one per real upstream change).

## Validation

- ✅ `mise run lint` — exit 0
- `workflows/AGENTS.md` stays at the 200-line `claude_md_size_limit` cap.

## Dependency

⚠️ The daily automation only fully works once **Settings → Actions →
General → "Allow GitHub Actions to create and approve pull requests"** is
enabled (currently off → the scheduled `create-pull-request` step fails;
see #113). Without it the runs push their branch but can't open the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated refresh schedules from weekly to daily for snapshot and P2996-related workflows.
  * Adjusted related documentation and PR messaging to match the new daily cadence.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->