### PR TITLE
ci: dev-image content-hash gate — skip build+smoke on unchanged images (#122)

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -13,7 +13,7 @@ post-failure reporting.
 | File | Purpose |
 |------|---------|
 | `ci.yml` | Thin caller (Phase B, #118): lint → contract-preflight → `changes` (path-gate) → `build-publish` (the reusable build chain, gated on `changes.build` + push-to-main exemption); OR lint → promote (push to main) |
-| `build-publish.yml` | Reusable (`on: workflow_call`) build chain: base-prep → p2996-prep → build → smoke-test (smoke+Dive), lifted verbatim from ci.yml. Inputs `{tag_strategy, publish, target, ref, p2996_ref*, platform*}` (*reserved, Phase D); outputs `{image_ref, digest}`. `github` context = caller's event, so sha/pr tags resolve identically |
+| `build-publish.yml` | Reusable (`on: workflow_call`) build chain: base-prep → p2996-prep → dev-prep → build → smoke-test (smoke+Dive) → dev-tag. dev-prep/dev-tag are the third content-hash tier (#122). Inputs `{tag_strategy, publish, target, ref, p2996_ref*, platform*}` (*reserved, Phase D); outputs `{image_ref, digest}`. `github` context = caller's event, so sha/pr tags resolve identically |
 | `ci-failure-report.yml` | Post-failure diagnostics / issue filing |
 | `image-analysis.yml` | Async (`workflow_run` on CI success): benchmark metrics + Trivy CVE scan, off the PR critical path |
 | `refresh.yml` | Daily cron (00:00): two independent jobs — `snapshot-refresh` (refresh `mise-system-resolved.json` on conda-forge drift) and `p2996-refresh` (bump `CLANG_P2996_REF` to latest `bloomberg/clang-p2996` `p2996`-branch HEAD, issue #100). Both open a PR on change via the shared `open-refresh-pr` composite. |
@@ -40,31 +40,24 @@ behavior unchanged):
    backend (not `npm:agnix` — see `mise.toml`).
 2. **contract-preflight** — Python 3.14 + uv; runs `dotfiles-setup
    verify run` over `python/verification/suites.toml`.
-3. **base-prep** — computes content-hash of base inputs via
-   `dotfiles-setup base-hash`. Probes
-   `ghcr.io/<owner>/<repo>:base-<hash16>` with `docker manifest
-   inspect`. On hit, exits in <30s. On miss, builds the `base` bake
-   target (devcontainer-base stage = apt + mise install + cargo) and
-   pushes it. p2996-prep and build both pull this image so neither
-   rebuilds the heavy mise install when only p2996 inputs change.
-4. **p2996-prep** — computes content-hash of P2996 inputs via
-   `dotfiles-setup p2996-hash`. Probes
-   `ghcr.io/<owner>/<repo>:p2996-<hash16>` with `docker manifest
-   inspect`. On hit, exits in <30s. On miss, builds the `p2996-cache`
-   bake target (the scratch-based `p2996-export` stage holding just
-   `/opt/clang-p2996`, ~500 MB) and pushes it to GHCR.
-5. **build** — `docker buildx bake dev` with
-   `dev.args.P2996_SOURCE=<cache_ref>` from p2996-prep. On cache hit
-   the Dockerfile's `clang-builder` stage is `FROM <cache_ref>` instead
-   of `FROM p2996-export`, skipping the multi-hour clang compile (see
-   `.devcontainer/P2996-CACHE.md` for the current baseline).
-   Always pushes (`:pr-NNN` or `:sha-<sha>` for PRs; `:dev`/`:latest`
-   for schedule and `force_dev_tag=true` workflow_dispatch).
-6. **smoke-test** — pulls `:sha-<github.sha>` and runs the PR-blocking
-   image gates only: `image smoke` (functional) + Dive (`.dive-ci` layer
-   thresholds). The non-gating benchmark metrics + Trivy CVE scan moved to
-   the async `image-analysis.yml` (on CI success) to keep them off the PR
-   critical path. The smoked image is the one retagged `:dev`/`:latest` on
+3. **base-prep** — `dotfiles-setup base-hash` → probe `:base-<hash16>`
+   (`docker manifest inspect`). Hit: <30s. Miss: build the `base` bake
+   target (devcontainer-base = apt + mise install + cargo), push it.
+   p2996-prep + build pull it instead of rebuilding the mise layer.
+4. **p2996-prep** — `dotfiles-setup p2996-hash` → probe `:p2996-<hash16>`.
+   Hit: <30s. Miss: build the `p2996-cache` bake target (scratch
+   `p2996-export` with just `/opt/clang-p2996`, ~500 MB), push to GHCR.
+5. **dev-prep** (#122, PR builds only) — `dotfiles-setup dev-hash` → probe
+   `:dev-<hash16>`. Hit: retag the validated image to `:sha`/`:pr-NNN`,
+   skip build+smoke. Miss: fall through. Nightly skips this (always builds).
+6. **build** — `docker buildx bake dev` with
+   `dev.args.P2996_SOURCE=<cache_ref>`. On p2996 hit the `clang-builder`
+   stage is `FROM <cache_ref>`, skipping the multi-hour clang compile.
+   Pushes `:pr-NNN`/`:sha-<sha>` (PR) or `:dev`/`:latest` (nightly).
+7. **smoke-test** — pulls `:sha-<github.sha>`, runs the PR-blocking image
+   gates: `image smoke` + Dive (`.dive-ci`). Benchmark + Trivy moved to
+   async `image-analysis.yml`. On success **dev-tag** stamps `:dev-<hash>`
+   (the validated marker). The smoked image is the one retagged `:dev`/`:latest` on
    merge.
 
 Push-to-main path (after a PR merge):
@@ -108,10 +101,17 @@ Push-to-main path (after a PR merge):
   gated `if: (github.event_name != 'push' || github.ref != 'refs/heads/main')`,
   so the whole reusable chain is skipped on main; the merge commit is published
   via `promote`'s manifest-retag of the PR's `:pr-NNN`.
+- **Three-tier content-hash probe cache** (#122): `:base-<hash>`,
+  `:p2996-<hash>`, `:dev-<hash>` — each `docker manifest inspect`-probed
+  (`dotfiles-setup {base,p2996,dev}-hash`) before its build. `:dev-<hash>`
+  (dev-prep/dev-tag jobs) is the top tier = base+p2996 hashes + whole
+  Dockerfile + dev bake target; tagged only AFTER smoke passes (validated
+  marker), so a PR hit skips build+smoke (retag to `:sha`/`:pr-NNN`).
+  Nightly skips the dev probe and always rebuilds (catches rolling-tool
+  drift the hash can't see, e.g. the gcc-latest .deb URL).
 - **P2996 cache invalidation.** Key = `CLANG_P2996_REF`, `BASE_IMAGE`,
   `PLATFORM`, Dockerfile, bake file, `mise-system-resolved.json`. Bust via
-  `mise run capture-mise-system-resolved` in the devcontainer on conda-forge
-  drift. Details: `.devcontainer/P2996-CACHE.md`.
+  `mise run capture-mise-system-resolved`. Details: `.devcontainer/P2996-CACHE.md`.
 - **`uv run --project python`**, not `--directory` — `--directory`
   changes cwd and breaks relative test paths.
 - **Use `--watch`, never sleep-poll** (`gh pr checks <n> --watch`); the

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -290,10 +290,145 @@ jobs:
             *.secrets=id=github_token,src=/tmp/github_token
 
   # ============================================================
+  # Dev cache prep (#122): the THIRD content-hash tier. Computes
+  # `dotfiles-setup dev-hash` (= base-hash + p2996-hash + whole
+  # Dockerfile + dev bake target) and probes ghcr.io for
+  # `:dev-<hash16>`. That tag is a "built AND smoke-validated" marker —
+  # it is pushed by `dev-tag` ONLY after smoke-test passes — so a probe
+  # HIT means the identical image already exists and was validated:
+  #   HIT  → retag it to :sha-<sha> / :pr-NNN (so promote works on
+  #          merge) and skip build + smoke-test entirely (~12m → ~2m).
+  #   MISS → build + smoke-test as normal, then dev-tag pushes the marker.
+  # Runs for PR builds only (tag_strategy == 'pr'); schedule/dispatch
+  # (tag_strategy == 'nightly') is SKIPPED so the nightly always rebuilds
+  # — it exists to catch rolling-tool drift (gcc-latest .deb) that the
+  # content hash cannot see. See .devcontainer/P2996-CACHE.md +
+  # .github/workflows/AGENTS.md § three-tier probe cache.
+  # ============================================================
+  dev-prep:
+    needs: [base-prep, p2996-prep]
+    if: inputs.tag_strategy == 'pr'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      hash: ${{ steps.hash.outputs.hash }}
+      cache_ref: ${{ steps.hash.outputs.cache_ref }}
+      hit: ${{ steps.probe.outputs.hit }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Install mise (python + uv)
+        uses: ./.github/actions/setup-mise
+        with:
+          install_args: "python uv"
+
+      - name: Compute dev cache hash
+        id: hash
+        run: |
+          set -euo pipefail
+          hash=$(uv run --project python dotfiles-setup dev-hash)
+          cache_ref="${{ env.CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}:dev-${hash}"
+          {
+            echo "hash=${hash}"
+            echo "cache_ref=${cache_ref}"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "## Dev cache lookup"
+            echo ""
+            echo "- Hash: \`${hash}\`"
+            echo "- Cache ref: \`${cache_ref}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.CONTAINER_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Probe dev cache
+        id: probe
+        # Same miss/non-miss discrimination as base-prep / p2996-prep:
+        # a "manifest not found" is a legitimate MISS; anything else
+        # (auth/network/registry) fails loud rather than silently
+        # forcing a rebuild. Captures stderr (no `2>/dev/null`) to honor
+        # build.no-stderr-suppression.
+        run: |
+          set -euo pipefail
+          if out=$(docker manifest inspect "${{ steps.hash.outputs.cache_ref }}" 2>&1); then
+            echo "hit=true" >> "$GITHUB_OUTPUT"
+            echo "Dev cache HIT — image already built AND smoke-validated; skipping build + smoke-test" >> "$GITHUB_STEP_SUMMARY"
+          else
+            rc=$?
+            if printf '%s\n' "$out" | grep -qiE 'manifest unknown|not found|no such manifest'; then
+              echo "hit=false" >> "$GITHUB_OUTPUT"
+              echo "Dev cache MISS — building + smoke-testing, then tagging the validated marker" >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "FAIL: docker manifest inspect failed with non-miss error (rc=$rc):" >&2
+              printf '%s\n' "$out" >&2
+              exit "$rc"
+            fi
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.probe.outputs.hit == 'true'
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Retag validated image to :sha / :pr (cache hit)
+        if: steps.probe.outputs.hit == 'true'
+        # On a hit, build + smoke-test are skipped, so the tags they
+        # would have pushed (:sha-<sha>, :pr-NNN) must be created here
+        # from the already-validated :dev-<hash> image. `promote` then
+        # finds :pr-NNN on merge exactly as it would after a real build.
+        env:
+          IMAGE: ${{ env.CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}
+          SOURCE_REF: ${{ steps.hash.outputs.cache_ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          short_sha=$(printf '%s' "${{ github.sha }}" | head -c 7)
+          tags=(--tag "${IMAGE}:${short_sha}")
+          if [ -n "${PR_NUMBER}" ]; then
+            tags+=(--tag "${IMAGE}:pr-${PR_NUMBER}")
+          fi
+          docker buildx imagetools create "${tags[@]}" "${SOURCE_REF}"
+          source_digest=$(docker buildx imagetools inspect "${SOURCE_REF}" --format '{{.Manifest.Digest}}')
+          sha_digest=$(docker buildx imagetools inspect "${IMAGE}:${short_sha}" --format '{{.Manifest.Digest}}')
+          [ -n "${sha_digest}" ] || { echo "FAIL: empty digest after retag" >&2; exit 1; }
+          if [ "${sha_digest}" != "${source_digest}" ]; then
+            echo "FAIL: retag did not propagate the validated digest" >&2
+            echo "  source : ${source_digest}" >&2
+            echo "  :sha   : ${sha_digest}" >&2
+            exit 1
+          fi
+          {
+            echo "## Dev cache retag (validated image reused)"
+            echo ""
+            echo "- Source: \`${SOURCE_REF}\` (digest \`${source_digest}\`)"
+            echo "- New tags: \`:${short_sha}\`${PR_NUMBER:+, \`:pr-${PR_NUMBER}\`}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ============================================================
   # Build Type 2: Dotfiles environment image (Docker → ghcr.io)
   # ============================================================
   build:
-    needs: [base-prep, p2996-prep]
+    needs: [base-prep, p2996-prep, dev-prep]
+    # Run when the dev cache MISSED (PR, image changed) OR when dev-prep
+    # was SKIPPED (nightly/dispatch always rebuilds). Skip only on a hit,
+    # where dev-prep already retagged the validated image. `always()` is
+    # required so a skipped dev-prep doesn't cascade-skip this job; the
+    # explicit upstream success checks restore the failure gating.
+    if: |
+      always()
+      && needs.base-prep.result == 'success'
+      && needs.p2996-prep.result == 'success'
+      && (needs.dev-prep.result == 'skipped'
+          || (needs.dev-prep.result == 'success' && needs.dev-prep.outputs.hit != 'true'))
     runs-on: ubuntu-latest
     outputs:
       image_ref: ${{ steps.out.outputs.image_ref }}
@@ -474,3 +609,68 @@ jobs:
       # to rebuild; the Pull / Smoke / Dive steps above fully validate the
       # published base image. Overlay behavior is validated locally via
       # `mise run up` on the Mac.
+
+  # ============================================================
+  # Dev cache tag (#122): push `:dev-<hash>` as the "built AND
+  # smoke-validated" marker — ONLY after smoke-test passes. This is what
+  # makes the dev-prep probe-skip safe: the tag can only ever point at an
+  # image that cleared smoke + Dive, so a future probe HIT reuses a
+  # validated image, never an untested one. Runs whenever build+smoke ran
+  # and passed (PR cache-miss AND nightly), so the marker stays fresh.
+  # Recomputes dev-hash independently (deterministic) since dev-prep is
+  # skipped on the nightly path.
+  # ============================================================
+  dev-tag:
+    needs: [build, smoke-test]
+    if: needs.smoke-test.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Install mise (python + uv)
+        uses: ./.github/actions/setup-mise
+        with:
+          install_args: "python uv"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.CONTAINER_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag validated image as :dev-<hash>
+        env:
+          IMAGE: ${{ env.CONTAINER_REGISTRY }}/${{ env.IMAGE_NAME }}
+        run: |
+          set -euo pipefail
+          hash=$(uv run --project python dotfiles-setup dev-hash)
+          short_sha=$(printf '%s' "${{ github.sha }}" | head -c 7)
+          source_ref="${IMAGE}:${short_sha}"
+          marker_ref="${IMAGE}:dev-${hash}"
+          # The just-built + smoked image is published at :sha-<sha>;
+          # stamp the content-hash marker onto that exact digest.
+          docker buildx imagetools create --tag "${marker_ref}" "${source_ref}"
+          source_digest=$(docker buildx imagetools inspect "${source_ref}" --format '{{.Manifest.Digest}}')
+          marker_digest=$(docker buildx imagetools inspect "${marker_ref}" --format '{{.Manifest.Digest}}')
+          [ -n "${marker_digest}" ] || { echo "FAIL: empty digest after marker tag" >&2; exit 1; }
+          if [ "${marker_digest}" != "${source_digest}" ]; then
+            echo "FAIL: marker tag did not propagate the validated digest" >&2
+            echo "  source : ${source_digest}" >&2
+            echo "  marker : ${marker_digest}" >&2
+            exit 1
+          fi
+          {
+            echo "## Dev cache marker tagged"
+            echo ""
+            echo "- \`${marker_ref}\` → digest \`${source_digest}\` (smoke-validated)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/research/gha-workflow-optimization.md
+++ b/docs/research/gha-workflow-optimization.md
@@ -15,7 +15,13 @@ breaking the repo's reproducibility invariants.
 >   `snapshot-refresh.yml`+`p2996-refresh.yml` merged into `refresh.yml`
 >   (two jobs, shared `open-refresh-pr` composite), crons staggered
 >   (refresh 00:00, ci.yml nightly 02:00).
-> - ⬜ Phases B, C, D — not started.
+> - ✅ **Phase B** done — split into two stacked PRs (2026-06-29):
+>   **B1 (#125)** extracted the build chain into the reusable
+>   `build-publish.yml` (`workflow_call`); `ci.yml` is now a thin caller.
+>   **B2 (#126)** folded in #122 — the third `:dev-<hash>` content-hash
+>   tier (`dotfiles-setup dev-hash` + `dev-prep` probe + tag-after-smoke
+>   `dev-tag` marker) skips build+smoke on unchanged-image PRs.
+> - ⬜ Phases C, D — not started.
 
 ## Inventory
 
@@ -333,8 +339,13 @@ flowchart TD
    merged into `refresh.yml` (two jobs, shared `open-refresh-pr` composite);
    crons staggered (refresh 00:00, ci.yml nightly 00:00→02:00). No behavior
    change. v1 R4 satisfied.
-2. **Phase B (the unlock):** extract `build-publish.yml` (`workflow_call`);
-   `ci.yml` becomes a caller. Behavior-preserving — same jobs, same gates.
+2. **Phase B (the unlock):** ✅ **done, PRs #125 + #126 (2026-06-29).**
+   B1 (#125) extracted `build-publish.yml` (`workflow_call`); `ci.yml`
+   is a thin caller — behavior-preserving (same jobs, same gates, same
+   two-tier cache, `promote` retag). B2 (#126) folded in #122: the third
+   `:dev-<hash>` content-hash tier (`dev-prep` probe + `dev-tag`
+   tag-after-smoke validated marker) skips build+smoke on PRs that don't
+   change the image bytes (~12min → ~2min); nightly always rebuilds.
 3. **Phase C (automation):** App token for refresh PRs + `gh pr merge --auto`
    (policy: auto-merge snapshot; choose auto vs review for the p2996 compiler
    bump). Drops the `gh workflow run` dispatch hack and the create-PR setting.

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -8,7 +8,7 @@ import logging
 import platform
 import sys
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from dotfiles_setup.ai import AIOrchestrator
 from dotfiles_setup.audit import DevEnvironmentAuditor, ToolManager
@@ -26,10 +26,14 @@ from dotfiles_setup.lint import (
 from dotfiles_setup.mise_snapshot import capture, write_snapshot
 from dotfiles_setup.p2996_hash import (
     compute_repo_base_hash,
+    compute_repo_dev_hash,
     compute_repo_p2996_hash,
 )
 from dotfiles_setup.p2996_refresh import refresh as refresh_p2996_ref
 from dotfiles_setup.verify import main as verify_main
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 
@@ -213,6 +217,11 @@ def setup_parser() -> argparse.ArgumentParser:
         help="Print the content-addressed hash of devcontainer-base inputs",
     )
     subparsers.add_parser(
+        "dev-hash",
+        help="Print the content-addressed hash of the final dev-image inputs "
+        "(base + p2996 hashes + whole Dockerfile + dev bake target)",
+    )
+    subparsers.add_parser(
         "p2996-refresh",
         help="Bump CLANG_P2996_REF in docker-bake.hcl to the latest "
         "bloomberg/clang-p2996 p2996-branch HEAD (writes only on change)",
@@ -364,6 +373,24 @@ def handle_ghcr_check(args: argparse.Namespace, project_root: Path) -> None:
     sys.stdout.write(json.dumps(result, indent=2) + "\n")
 
 
+def _hash_command_handlers(project_root: Path) -> dict[str, Any]:
+    """Dispatch entries for the three content-hash CLI commands.
+
+    Extracted from `_build_command_handlers` so the three near-identical
+    stdout-emitting handlers don't push that function over the McCabe
+    complexity cap as tiers are added (base → p2996 → dev).
+    """
+
+    def _emit(compute: Callable[[Path], str]) -> None:
+        sys.stdout.write(compute(project_root) + "\n")
+
+    return {
+        "base-hash": lambda: _emit(compute_repo_base_hash),
+        "p2996-hash": lambda: _emit(compute_repo_p2996_hash),
+        "dev-hash": lambda: _emit(compute_repo_dev_hash),
+    }
+
+
 def _build_command_handlers(
     args: argparse.Namespace,
     project_root: Path,
@@ -395,12 +422,6 @@ def _build_command_handlers(
     def _version() -> None:
         sys.stdout.write("0.1.0\n")
 
-    def _p2996_hash() -> None:
-        sys.stdout.write(compute_repo_p2996_hash(project_root) + "\n")
-
-    def _base_hash() -> None:
-        sys.stdout.write(compute_repo_base_hash(project_root) + "\n")
-
     def _p2996_refresh() -> None:
         sys.stdout.write(refresh_p2996_ref(project_root).as_json() + "\n")
 
@@ -426,11 +447,10 @@ def _build_command_handlers(
         "image": lambda: handle_image(args),
         "ghcr-check": lambda: handle_ghcr_check(args, project_root),
         "sync-versions": lambda: handle_sync_versions(project_root),
-        "p2996-hash": _p2996_hash,
-        "base-hash": _base_hash,
         "p2996-refresh": _p2996_refresh,
         "mise-snapshot": _mise_snapshot,
         "lint": _lint,
+        **_hash_command_handlers(project_root),
     }
 
 

--- a/python/src/dotfiles_setup/p2996_hash.py
+++ b/python/src/dotfiles_setup/p2996_hash.py
@@ -43,6 +43,9 @@ BASE_SECTION_END = "# ──── BASE_HASH_END ────"
 P2996_SECTION_BEGIN = "# ──── P2996_HASH_BEGIN ────"
 P2996_SECTION_END = "# ──── P2996_HASH_END ────"
 
+# Bake target whose definition feeds the top-tier `:dev-<hash>` cache.
+DEV_BAKE_TARGET = "dev"
+
 
 @dataclass(frozen=True)
 class BaseHashInputs:
@@ -94,6 +97,50 @@ class P2996HashInputs:
         )
 
 
+@dataclass(frozen=True)
+class DevHashInputs:
+    """Inputs feeding the top-tier `:dev-<hash>` validated-image cache.
+
+    The final `devcontainer` Dockerfile stage COPYs nothing from the
+    repo build context — only `/opt/clang-p2996` from the (already
+    hashed) p2996 cache and a rolling `gcc-latest.deb` URL. So, given
+    fixed `base_hash` + `p2996_hash`, the dev image content is a pure
+    function of the Dockerfile instructions and the `dev` bake target.
+
+    `dockerfile_digest` covers the WHOLE Dockerfile (not a sentinel
+    slice): under-hashing here is the cardinal sin — a probe hit skips
+    smoke-test, so two different image contents must never collide to
+    one dev hash. Hashing the whole file is a safe superset (base/p2996
+    edits already bust their own tiers, which feed this hash too).
+    """
+
+    base_hash: str
+    p2996_hash: str
+    platform: str
+    dockerfile_digest: str
+    dev_target_digest: str
+
+    def __post_init__(self) -> None:
+        """Reject empty literals + ill-shaped hashes."""
+        if not self.platform:
+            msg = "DevHashInputs.platform must be non-empty"
+            raise ValueError(msg)
+        for field_name in ("base_hash", "p2996_hash"):
+            value = getattr(self, field_name)
+            if len(value) != HASH_LENGTH or not all(
+                c in "0123456789abcdef" for c in value
+            ):
+                msg = (
+                    f"DevHashInputs.{field_name} must be {HASH_LENGTH}-char "
+                    f"lowercase hex; got {value!r}"
+                )
+                raise ValueError(msg)
+        for field_name in ("dockerfile_digest", "dev_target_digest"):
+            _validate_hex_digest(
+                getattr(self, field_name), f"DevHashInputs.{field_name}"
+            )
+
+
 def _validate_hex_digest(value: str, field: str) -> None:
     if len(value) != SHA256_HEX_LEN or not all(c in "0123456789abcdef" for c in value):
         msg = (
@@ -118,6 +165,36 @@ def _extract_bake_variable(bake_text: str, name: str) -> str:
         msg = f"variable {name!r} not found with string default in docker-bake.hcl"
         raise ValueError(msg)
     return match.group(1)
+
+
+def _extract_bake_target_block(bake_text: str, name: str) -> str:
+    """Return the full `target "<name>" { ... }` block from bake HCL.
+
+    Brace-matched (not regex `[^}]*`) because bake targets nest blocks
+    (`args = { ... }`). The returned text spans the `target` keyword
+    through its closing brace, so any edit to the target's args, cache
+    config, or attestations changes the digest.
+
+    Raises:
+        ValueError: when the target is missing or its braces are
+            unbalanced (truncated file).
+    """
+    header = re.search(r'target\s+"' + re.escape(name) + r'"\s*\{', bake_text)
+    if header is None:
+        msg = f"target {name!r} not found in docker-bake.hcl"
+        raise ValueError(msg)
+    start = header.start()
+    depth = 0
+    for idx in range(header.end() - 1, len(bake_text)):
+        char = bake_text[idx]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return bake_text[start : idx + 1]
+    msg = f"target {name!r} has unbalanced braces in docker-bake.hcl"
+    raise ValueError(msg)
 
 
 def _extract_dockerfile_section(
@@ -234,6 +311,52 @@ def compute_repo_p2996_hash(repo_root: Path) -> str:
     """Top-level helper: compute base hash, then p2996 hash on top."""
     base_hash = compute_repo_base_hash(repo_root)
     return compute_p2996_hash(gather_p2996_inputs(repo_root, base_hash=base_hash))
+
+
+def gather_dev_inputs(
+    repo_root: Path, *, base_hash: str, p2996_hash: str
+) -> DevHashInputs:
+    """Read every input that contributes to the `:dev-<hash>` cache.
+
+    `base_hash` / `p2996_hash` are passed in (rather than recomputed) so
+    a caller can capture the whole chain from a single repo read.
+    """
+    bake_text = (repo_root / "docker-bake.hcl").read_text()
+    dockerfile_text = (repo_root / ".devcontainer" / "Dockerfile").read_text()
+    return DevHashInputs(
+        base_hash=base_hash,
+        p2996_hash=p2996_hash,
+        platform=_extract_bake_variable(bake_text, "PLATFORM"),
+        dockerfile_digest=_sha256_hex(dockerfile_text),
+        dev_target_digest=_sha256_hex(
+            _extract_bake_target_block(bake_text, DEV_BAKE_TARGET)
+        ),
+    )
+
+
+def compute_dev_hash(inputs: DevHashInputs) -> str:
+    """Reduce the dev inputs to a 16-char content hash."""
+    canonical = RECORD_SEPARATOR.join(
+        [
+            f"schema={SCHEMA_VERSION}",
+            "kind=dev",
+            f"base_hash={inputs.base_hash}",
+            f"p2996_hash={inputs.p2996_hash}",
+            f"platform={inputs.platform}",
+            f"dockerfile={inputs.dockerfile_digest}",
+            f"dev_target={inputs.dev_target_digest}",
+        ],
+    )
+    return _sha256_hex(canonical)[:HASH_LENGTH]
+
+
+def compute_repo_dev_hash(repo_root: Path) -> str:
+    """Top-level helper: compute base + p2996 hashes, then the dev hash."""
+    base_hash = compute_repo_base_hash(repo_root)
+    p2996_hash = compute_p2996_hash(gather_p2996_inputs(repo_root, base_hash=base_hash))
+    return compute_dev_hash(
+        gather_dev_inputs(repo_root, base_hash=base_hash, p2996_hash=p2996_hash)
+    )
 
 
 # Back-compat shim: existing callers used `compute_repo_hash` for the

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -477,6 +477,20 @@ tokens = [
 ]
 
 [[suite]]
+name = "ci.dev-prep-gate-exists"
+description = "The third-tier dev-image content-hash gate (#122) must exist: a dev-prep job probes ':dev-<hash>' (via dotfiles-setup dev-hash) to skip build+smoke on an unchanged image, and a dev-tag job pushes the ':dev-<hash>' marker ONLY after smoke-test passes (validated-marker invariant — what makes the probe-skip safe). Lives in the reusable build-publish.yml (Phase B / #118)."
+category = "ci"
+check_type = "static"
+handler = "require_tokens"
+paths = [".github/workflows/build-publish.yml"]
+tokens = [
+  "dev-prep:",
+  "dotfiles-setup dev-hash",
+  "dev-tag:",
+  "needs.smoke-test.result == 'success'",
+]
+
+[[suite]]
 name = "ci.regex-managers-enabled"
 description = "Renovate's customManagers must be enabled via 'custom.regex' in enabledManagers — without it, every regex manager block is silently inactive (the existing CLANG_P2996_REF tracker hit this in 2026-04)"
 category = "ci"

--- a/tests/test_p2996_hash.py
+++ b/tests/test_p2996_hash.py
@@ -17,14 +17,19 @@ from dotfiles_setup.p2996_hash import (
     P2996_SECTION_BEGIN,
     P2996_SECTION_END,
     BaseHashInputs,
+    DevHashInputs,
     P2996HashInputs,
+    _extract_bake_target_block,
     _extract_bake_variable,
     _extract_dockerfile_section,
     compute_base_hash,
+    compute_dev_hash,
     compute_p2996_hash,
     compute_repo_base_hash,
+    compute_repo_dev_hash,
     compute_repo_p2996_hash,
     gather_base_inputs,
+    gather_dev_inputs,
     gather_p2996_inputs,
 )
 
@@ -56,12 +61,35 @@ def _stub_p2996_inputs(**overrides: str) -> P2996HashInputs:
     return P2996HashInputs(**base)
 
 
+def _stub_dev_inputs(**overrides: str) -> DevHashInputs:
+    base = {
+        "base_hash": "0123456789abcdef",
+        "p2996_hash": "fedcba9876543210",
+        "platform": "linux/amd64/v2",
+        "dockerfile_digest": "d" * 64,
+        "dev_target_digest": "e" * 64,
+    }
+    base.update(overrides)
+    return DevHashInputs(**base)
+
+
 def _seed_repo(tmp_path: Path) -> Path:
-    """Write a minimal repo tree with valid Dockerfile section markers."""
+    """Write a minimal repo tree with valid Dockerfile section markers.
+
+    Includes a `dev` bake target (with nested `args` braces) and a
+    final-stage Dockerfile line OUTSIDE the sentinels so the dev-hash
+    tests can exercise whole-Dockerfile + dev-target hashing.
+    """
     (tmp_path / "docker-bake.hcl").write_text(
         'variable "BASE_IMAGE" { default = "ubuntu:26.04" }\n'
         'variable "PLATFORM" { default = "linux/amd64/v2" }\n'
-        'variable "CLANG_P2996_REF" { default = "abc123" }\n',
+        'variable "CLANG_P2996_REF" { default = "abc123" }\n'
+        'target "dev" {\n'
+        '  target = "devcontainer"\n'
+        "  args = {\n"
+        '    DEVCONTAINER_USERNAME = "devcontainer"\n'
+        "  }\n"
+        "}\n",
     )
     devcontainer = tmp_path / ".devcontainer"
     devcontainer.mkdir()
@@ -75,6 +103,9 @@ def _seed_repo(tmp_path: Path) -> Path:
         {P2996_SECTION_BEGIN}
         RUN cmake --build .
         {P2996_SECTION_END}
+
+        FROM devcontainer-base AS devcontainer
+        RUN echo final-stage
         """)
     )
     (devcontainer / "mise-system-resolved.json").write_text(
@@ -373,6 +404,183 @@ def test_cli_base_hash_returns_16_char_hex() -> None:
     output = _run_dotfiles_setup("base-hash")
     assert len(output) == HASH_LENGTH
     assert re.fullmatch(r"[0-9a-f]+", output)
+
+
+def test_cli_dev_hash_returns_16_char_hex() -> None:
+    output = _run_dotfiles_setup("dev-hash")
+    assert len(output) == HASH_LENGTH
+    assert re.fullmatch(r"[0-9a-f]+", output)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# DevHashInputs validation
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_dev_hash_is_stable_for_fixed_inputs() -> None:
+    inputs = _stub_dev_inputs()
+    assert compute_dev_hash(inputs) == compute_dev_hash(inputs)
+    assert len(compute_dev_hash(inputs)) == HASH_LENGTH
+
+
+def test_dev_hash_is_lowercase_hex() -> None:
+    assert re.fullmatch(r"[0-9a-f]+", compute_dev_hash(_stub_dev_inputs()))
+
+
+def test_dev_hash_changes_when_base_hash_changes() -> None:
+    base = _stub_dev_inputs()
+    bumped = _stub_dev_inputs(base_hash="ffffffffffffffff")
+    assert compute_dev_hash(base) != compute_dev_hash(bumped)
+
+
+def test_dev_hash_changes_when_p2996_hash_changes() -> None:
+    base = _stub_dev_inputs()
+    bumped = _stub_dev_inputs(p2996_hash="ffffffffffffffff")
+    assert compute_dev_hash(base) != compute_dev_hash(bumped)
+
+
+def test_dev_hash_changes_when_dockerfile_digest_changes() -> None:
+    base = _stub_dev_inputs()
+    bumped = _stub_dev_inputs(dockerfile_digest="f" * 64)
+    assert compute_dev_hash(base) != compute_dev_hash(bumped)
+
+
+def test_dev_hash_changes_when_dev_target_digest_changes() -> None:
+    base = _stub_dev_inputs()
+    bumped = _stub_dev_inputs(dev_target_digest="f" * 64)
+    assert compute_dev_hash(base) != compute_dev_hash(bumped)
+
+
+def test_dev_hash_changes_when_platform_changes() -> None:
+    base = _stub_dev_inputs()
+    bumped = _stub_dev_inputs(platform="linux/arm64")
+    assert compute_dev_hash(base) != compute_dev_hash(bumped)
+
+
+def test_dev_inputs_reject_short_base_hash() -> None:
+    with pytest.raises(ValueError, match="base_hash"):
+        _stub_dev_inputs(base_hash="abc")
+
+
+def test_dev_inputs_reject_uppercase_p2996_hash() -> None:
+    with pytest.raises(ValueError, match="p2996_hash"):
+        _stub_dev_inputs(p2996_hash="ABCDEF0123456789")
+
+
+def test_dev_inputs_reject_short_dockerfile_digest() -> None:
+    with pytest.raises(ValueError, match="dockerfile_digest"):
+        _stub_dev_inputs(dockerfile_digest="abc")
+
+
+def test_dev_inputs_reject_empty_platform() -> None:
+    with pytest.raises(ValueError, match="platform"):
+        _stub_dev_inputs(platform="")
+
+
+def test_dev_hash_kind_namespacing_differs_from_base_and_p2996() -> None:
+    # Even with colliding digest material, the kind= prefix keeps the
+    # three tiers in separate namespaces so a value can't be reused.
+    shared = "a" * 16
+    base = compute_base_hash(
+        BaseHashInputs(
+            base_image="x",
+            platform="x",
+            base_section_digest="a" * 64,
+            snapshot_digest="a" * 64,
+        )
+    )
+    dev = compute_dev_hash(_stub_dev_inputs())
+    assert base != dev
+    assert shared != dev
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Bake target extraction
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_extract_bake_target_block_handles_nested_braces() -> None:
+    bake = (
+        'target "dev" {\n'
+        "  args = {\n"
+        '    USER = "x"\n'
+        "  }\n"
+        "}\n"
+        'target "other" { target = "x" }\n'
+    )
+    block = _extract_bake_target_block(bake, "dev")
+    assert block.startswith('target "dev"')
+    assert block.endswith("}")
+    assert "USER" in block
+    # Must NOT bleed into the sibling target.
+    assert "other" not in block
+
+
+def test_extract_bake_target_block_missing_raises() -> None:
+    with pytest.raises(ValueError, match="not found"):
+        _extract_bake_target_block('target "dev" { }', "missing")
+
+
+def test_extract_bake_target_block_unbalanced_raises() -> None:
+    with pytest.raises(ValueError, match="unbalanced"):
+        _extract_bake_target_block('target "dev" {\n  args = {\n', "dev")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Repo-level dev hash (gather + compute roundtrips)
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_gather_and_compute_repo_dev_hash_roundtrip(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    inputs = gather_dev_inputs(tmp_path, base_hash="0" * 16, p2996_hash="1" * 16)
+    assert inputs.platform == "linux/amd64/v2"
+    digest_a = compute_repo_dev_hash(tmp_path)
+    digest_b = compute_repo_dev_hash(tmp_path)
+    assert digest_a == digest_b
+    assert len(digest_a) == HASH_LENGTH
+
+
+def test_repo_dev_hash_changes_when_final_stage_modified(tmp_path: Path) -> None:
+    # A final-stage edit (OUTSIDE the base/p2996 sentinels) leaves base
+    # and p2996 hashes untouched but MUST bust dev-hash — this is the
+    # whole-Dockerfile coverage that prevents skipping smoke on a
+    # changed image.
+    _seed_repo(tmp_path)
+    base_before = compute_repo_base_hash(tmp_path)
+    p2996_before = compute_repo_p2996_hash(tmp_path)
+    dev_before = compute_repo_dev_hash(tmp_path)
+    dockerfile = tmp_path / ".devcontainer" / "Dockerfile"
+    dockerfile.write_text(
+        dockerfile.read_text().replace("RUN echo final-stage", "RUN echo changed")
+    )
+    assert compute_repo_base_hash(tmp_path) == base_before
+    assert compute_repo_p2996_hash(tmp_path) == p2996_before
+    assert compute_repo_dev_hash(tmp_path) != dev_before
+
+
+def test_repo_dev_hash_changes_when_dev_target_modified(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    before = compute_repo_dev_hash(tmp_path)
+    bake = tmp_path / "docker-bake.hcl"
+    bake.write_text(
+        bake.read_text().replace(
+            'DEVCONTAINER_USERNAME = "devcontainer"',
+            'DEVCONTAINER_USERNAME = "ray"',
+        )
+    )
+    assert compute_repo_dev_hash(tmp_path) != before
+
+
+def test_repo_dev_hash_changes_when_base_section_modified(tmp_path: Path) -> None:
+    # Base-section edit bumps base-hash → p2996-hash → dev-hash (chain).
+    _seed_repo(tmp_path)
+    before = compute_repo_dev_hash(tmp_path)
+    dockerfile = tmp_path / ".devcontainer" / "Dockerfile"
+    dockerfile.write_text(
+        dockerfile.read_text().replace("RUN apt-get update", "RUN apt-get install foo")
+    )
+    assert compute_repo_dev_hash(tmp_path) != before
 
 
 def test_cli_base_and_p2996_hashes_are_distinct() -> None:


### PR DESCRIPTION
Phase B **part 2** (epic #116), **stacked on #125** (the build-publish.yml extraction). Targets the B1 branch — retarget to `main` before #125 merges. Adds the **third** content-hash tier so PRs that don't change the image bytes skip the warm build + smoke-test.

> ⚠️ Review/merge **after #125**. This PR's diff is only the dev-hash gate on top of B1.

## Impact

- Docs / `ci.yml` / `python` / test-only PRs (no image-input change): **~12min → ~2min** (3 fast probes + retag).
- Dockerfile / mise-system / p2996 PRs: unchanged (probe miss → full build + smoke as today).

## Python — `dotfiles-setup dev-hash`

- `dev-hash` = `base-hash` + `p2996-hash` + **whole-Dockerfile** digest + the `dev` bake-target block. Whole-Dockerfile (not a sentinel slice) is deliberate: a probe hit skips smoke, so **under-hashing is the cardinal sin** — hashing the whole file is a provably safe superset.
- `_extract_bake_target_block` brace-matches `target "dev" { ... }` (nested `args = {}`), so any dev-target edit busts the hash.
- 20 new tests (input validation, per-input change detection, kind namespacing, brace extraction, repo roundtrips incl. *"a final-stage edit busts dev-hash but NOT base/p2996"*). **143 tests total.**
- Refactored the 3 hash handlers into `_hash_command_handlers` so adding the dev tier doesn't push `_build_command_handlers` over McCabe `C901` (zero-suppression policy → refactor, not `# noqa`).

## Workflow — three-tier probe cache in `build-publish.yml`

- **`dev-prep`** (PR builds only): probe `:dev-<hash>`. **Hit** → retag the validated image to `:sha`/`:pr-NNN`, skip build+smoke (`promote` still finds `:pr-NNN` on merge). **Miss** → fall through. **Skipped on nightly/dispatch** so the scheduled run always rebuilds — it exists to catch rolling-tool drift the hash can't see (the `gcc-latest.deb` URL).
- **`build`/`smoke-test`** gated on the dev-prep miss/skip via an `always()`-guarded `if` (a skipped need must not cascade-skip the build).
- **`dev-tag`**: pushes `:dev-<hash>` **only after smoke-test passes** — the validated-marker invariant that makes a probe hit provably safe (it can only ever reuse a smoke+Dive-cleared image). Runs on PR-miss **and** nightly so the marker stays fresh.

## Contracts / docs

- `suites.toml`: new `ci.dev-prep-gate-exists` (asserts `dev-prep` + `dev-hash` + `dev-tag` + the tag-after-smoke gate).
- `workflows/AGENTS.md`: documents the three-tier (base/p2996/dev) probe cache.

## Local gate (all exit 0)

`actionlint` · `mise run pin-actions` · `mise run lint` (ruff + ty) · `pytest` (143 passed) · `dotfiles-setup verify run` (67 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `dev-hash` command and a third content-hash tier for PR builds.
  * PRs can now reuse validated images more efficiently, skipping build and smoke steps when nothing changed.
  * A validated marker image is now published only after smoke checks pass.

* **Documentation**
  * Updated workflow and optimization docs to describe the new caching flow and release pipeline stages.

* **Tests**
  * Expanded validation coverage for the new hash command, cache gating, and workflow rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->