### PR TITLE
ci: Phase C — App-token refresh PRs + auto-merge (snapshot auto, p2996 review) (#119)

### DIFF
--- a/.github/actions/open-refresh-pr/action.yml
+++ b/.github/actions/open-refresh-pr/action.yml
@@ -1,17 +1,19 @@
 name: "Open refresh PR"
 description: >-
   Shared create-PR tail for the refresh jobs. Opens (or updates) a PR via
-  peter-evans/create-pull-request, then dispatches ci.yml on its branch.
-  The dispatch is required because PRs created with secrets.GITHUB_TOKEN do
-  NOT fire `pull_request` workflows, so without it the auto-PR would sit
-  with no CI. Skipped when no file changed (no PR created). This composite
-  is local, so the calling job must run actions/checkout first.
+  peter-evans/create-pull-request using a GitHub App token (passed in by the
+  caller — composites can't read `secrets`), so the PR's normal
+  `pull_request` CI fires automatically: NO ci.yml dispatch hack needed.
+  Optionally enables squash auto-merge. No-op when no tracked file changed.
+  This composite is local, so the calling job must run actions/checkout first.
 
 inputs:
   token:
     description: >-
-      Token used both for create-pull-request and the ci.yml dispatch
-      (typically secrets.GITHUB_TOKEN).
+      GitHub App installation token (from actions/create-github-app-token).
+      An App token — NOT secrets.GITHUB_TOKEN — is required: GITHUB_TOKEN-
+      created PRs do NOT trigger downstream `pull_request` workflows (GitHub's
+      recursion guard), which is the whole reason this phase exists.
     required: true
   commit-message:
     description: "Commit message for the refresh PR."
@@ -23,7 +25,7 @@ inputs:
     description: "Body of the refresh PR (markdown, may be multiline)."
     required: true
   branch:
-    description: "Head branch for the PR; also the ref ci.yml is dispatched on."
+    description: "Head branch for the PR."
     required: true
   paths:
     description: "add-paths value — only these paths are staged into the PR."
@@ -32,8 +34,29 @@ inputs:
     description: "Newline- or comma-separated labels for the PR."
     required: true
   summary-heading:
-    description: "Heading for the GITHUB_STEP_SUMMARY block written after dispatch."
+    description: "Heading for the GITHUB_STEP_SUMMARY block."
     required: true
+  auto-merge:
+    description: >-
+      When 'true', enable squash auto-merge on the opened PR — it lands
+      unattended once the branch-protection-required checks
+      (build-publish / smoke-test) pass. When 'false' (default), the PR is
+      left open for human review. Auto-merge requires the repo "Allow
+      auto-merge" setting AND a required smoke-test check on main, else the
+      PR could merge before smoke runs — see .github/workflows/AGENTS.md.
+    required: false
+    default: "false"
+
+outputs:
+  pull-request-number:
+    description: "Number of the opened/updated PR (empty when no change)."
+    value: ${{ steps.cpr.outputs.pull-request-number }}
+  pull-request-url:
+    description: "URL of the opened/updated PR (empty when no change)."
+    value: ${{ steps.cpr.outputs.pull-request-url }}
+  pull-request-operation:
+    description: "create | update | close | '' (none)."
+    value: ${{ steps.cpr.outputs.pull-request-operation }}
 
 runs:
   using: composite
@@ -52,25 +75,29 @@ runs:
         delete-branch: true
         labels: ${{ inputs.labels }}
 
-    - name: Re-trigger CI on the auto-PR
-      # GH limitation: PRs created via secrets.GITHUB_TOKEN do NOT trigger
-      # `pull_request` workflows. Dispatch ci.yml on the auto-PR branch so
-      # the full pipeline (incl. a P2996 cache probe against the new hash)
-      # validates the change. Skipped when no PR was created (no drift).
+    - name: Enable auto-merge or note review-required
+      # The App-token PR already fires `pull_request` CI on its own, so all
+      # that remains is the merge policy. Skipped when no PR was created
+      # (no drift). `--auto` waits for the required smoke-test check; without
+      # branch protection requiring it, the PR could merge before smoke runs.
       if: steps.cpr.outputs.pull-request-number != ''
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
-        PR_BRANCH: ${{ inputs.branch }}
         PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
         PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
+        AUTO_MERGE: ${{ inputs.auto-merge }}
         SUMMARY_HEADING: ${{ inputs.summary-heading }}
       run: |
         set -euo pipefail
-        gh workflow run ci.yml --ref "$PR_BRANCH"
         {
           echo "## ${SUMMARY_HEADING}"
           echo ""
           echo "- PR: #${PR_NUMBER} (${PR_URL})"
-          echo "- Dispatched ci.yml on \`${PR_BRANCH}\` to validate the change."
         } >> "$GITHUB_STEP_SUMMARY"
+        if [ "${AUTO_MERGE}" = "true" ]; then
+          gh pr merge "${PR_NUMBER}" --auto --squash
+          echo "- Auto-merge enabled — lands when the required \`build-publish / smoke-test\` check passes." >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo "- Review-required — left open for human merge (smoke-test is the safety net)." >> "$GITHUB_STEP_SUMMARY"
+        fi

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -16,16 +16,17 @@ post-failure reporting.
 | `build-publish.yml` | Reusable (`on: workflow_call`) build chain: base-prep → p2996-prep → dev-prep → build → smoke-test (smoke+Dive) → dev-tag. dev-prep/dev-tag are the third content-hash tier (#122). Inputs `{tag_strategy, publish, target, ref, p2996_ref*, platform*}` (*reserved, Phase D); outputs `{image_ref, digest}`. `github` context = caller's event, so sha/pr tags resolve identically |
 | `ci-failure-report.yml` | Post-failure diagnostics / issue filing |
 | `image-analysis.yml` | Async (`workflow_run` on CI success): benchmark metrics + Trivy CVE scan, off the PR critical path |
-| `refresh.yml` | Daily cron (00:00): two independent jobs — `snapshot-refresh` (refresh `mise-system-resolved.json` on conda-forge drift) and `p2996-refresh` (bump `CLANG_P2996_REF` to latest `bloomberg/clang-p2996` `p2996`-branch HEAD, issue #100). Both open a PR on change via the shared `open-refresh-pr` composite. |
+| `refresh.yml` | Daily cron (00:00): two independent jobs — `snapshot-refresh` (refresh `mise-system-resolved.json` on conda-forge drift, **auto-merges**) and `p2996-refresh` (bump `CLANG_P2996_REF` to latest `bloomberg/clang-p2996` HEAD, **review-required**, #100). Each mints a GitHub App token (Phase C, #119) so its PR fires CI on its own; both open a PR via `open-refresh-pr`. See **GitHub App** below. |
 
 ## Composite actions (`.github/actions/`)
 
 Self-documented in each `action.yml`: `setup-mise` (wraps `jdx/mise-action`
-+ `install_args`, all 8 mise jobs) and `open-refresh-pr` (create-PR +
-ci.yml dispatch tail, both `refresh.yml` jobs). **Local-composite checkout
-gotcha:** a `./.github/actions/*` action resolves from `$GITHUB_WORKSPACE`
-(empty until checkout), so jobs run `actions/checkout` FIRST, then the
-composite — neither wraps checkout.
++ `install_args`, all 8 mise jobs) and `open-refresh-pr` (App-token create-PR
++ optional squash auto-merge, both `refresh.yml` jobs). **Local-composite
+checkout gotcha:** a `./.github/actions/*` action resolves from
+`$GITHUB_WORKSPACE` (empty until checkout), so jobs run `actions/checkout`
+FIRST, then the composite — neither wraps checkout. **Composites can't read
+`secrets`** — the App token is minted in `refresh.yml`, passed in.
 
 ## Pipeline stages
 
@@ -34,10 +35,10 @@ PR / schedule / workflow_dispatch path (stages 3–6 run inside the reusable
 behavior unchanged):
 
 1. **lint** — mise install, hk pre-commit, agnix agent-doc validation
-   (`agnix .`; `.agnix.toml` sets `severity = "Warning"` so warnings
-   don't fail), `mise doctor --json`, `mise.lock` artifact upload, mise
-   cache keyed on `mise.lock`. agnix uses the `github:agent-sh/agnix`
-   backend (not `npm:agnix` — see `mise.toml`).
+   (`agnix .`; `.agnix.toml` `severity = "Warning"` keeps warnings
+   non-blocking), `mise doctor --json`, `mise.lock` upload, mise cache
+   keyed on `mise.lock`. agnix uses the `github:agent-sh/agnix` backend
+   (not `npm:agnix` — see `mise.toml`).
 2. **contract-preflight** — Python 3.14 + uv; runs `dotfiles-setup
    verify run` over `python/verification/suites.toml`.
 3. **base-prep** — `dotfiles-setup base-hash` → probe `:base-<hash16>`
@@ -143,6 +144,19 @@ daily crons, **distinct, complementary** roles:
 The 2h gap lets a 00:00 refresh PR, merged before 02:00, be what the
 nightly publishes. Do NOT collapse onto one cron (issue #116).
 
+## GitHub App — refresh auto-merge (Phase C, #119)
+
+`refresh.yml` mints an App token (`actions/create-github-app-token`) so its
+PR fires `pull_request` CI on its own — GITHUB_TOKEN PRs don't. **One-time
+repo-admin setup:** (1) create a GitHub App with **contents: write +
+pull-requests: write**, install it here, add secrets `REFRESH_APP_ID` +
+`REFRESH_APP_PRIVATE_KEY`; (2) enable **Allow auto-merge**; (3) branch
+protection on `main` requiring
+**`build-publish / smoke-test`** — CRITICAL, else `--auto` lands before
+smoke runs. Policy: snapshot auto-merges (squash) once smoke passes; p2996
+is review-required. Caveat: docs-only PRs skip smoke (reported "skipped" =
+neutral for required checks) — verify after enabling protection.
+
 ## Dependabot (`.github/dependabot.yml`)
 
 - **`interval: "cron"` enforces a 24h minimum.** The schema accepts
@@ -152,7 +166,7 @@ nightly publishes. Do NOT collapse onto one cron (issue #116).
   than the minimum allowed interval of 24 hours."* Use `0 0 * * *`
   (daily at midnight) or longer; do NOT try `0 * * * *` (hourly). The
   validation runs as a check named `.github/dependabot.yml` on every
-  PR that touches the file. (PR #86 commit `b5022c0`.)
+  PR that touches the file. (PR #86.)
 
 ## Debugging CI failures
 
@@ -162,38 +176,21 @@ nightly publishes. Do NOT collapse onto one cron (issue #116).
 - `mise doctor --json` output in the lint job shows tool resolution
   issues.
 - **App-installed check error detail** (dependabot, CodeRabbit, etc.)
-  lives in the check-runs API, not in `gh pr checks` output. Use:
-  `gh api 'repos/OWNER/REPO/commits/BRANCH/check-runs' --jq
-  '.check_runs[] | select(.name | contains("NAME")) |
-  .output.summary'` (substitute uppercase placeholders) to surface the
-  actual rejection message.
-- For Docker warning triage, see the `ci-warning-investigator` skill
-  under `.claude/skills/`.
-- Use `gh run watch <id> --exit-status` (or `gh pr checks <n> --watch`)
-  to monitor workflows — **never sleep-poll**. See
-  `feedback_gh_run_watch`. But always cross-verify with
-  `gh pr checks <n> --json` because `--exit-status` has reported exit 0
-  before runs were actually complete.
-- **`gh run list` returns multiple workflows.** A branch with both
-  `ci.yml` and `autofix.yml` has a `CI` run AND an `autofix.ci` run
-  per push; `gh run list --limit 1` may surface the wrong one. Filter
-  with `--workflow CI` (or `--workflow autofix.ci`) to disambiguate.
-- **Manual autofix-fix recipe** — if `autofix-ci/action` can't push
-  back (e.g. app uninstalled, `500 autofix.ci app is not installed`),
-  the diff is in the run's `autofix.ci.zip` artifact (substitute
-  uppercase RUN_ID and FILE placeholders):
-  ```bash
-  gh run download RUN_ID -D /tmp/autofix
-  jq -r '.changes.additions[] | select(.path=="FILE") | .contents' \
-    /tmp/autofix/autofix.ci/autofix.json | base64 -d > /tmp/FILE
-  cp /tmp/FILE FILE
-  ```
-  Apply locally, commit, push. Validated on PR #94 commit `cb186ac`
-  (mise.lock linux-x64 blake3 checksum drift).
-- **Re-run a failed job to verify a fix** — `gh run rerun RUN_ID --failed`
-  refires only the failed jobs against the same commit. Useful for
-  verifying that a config change (e.g. installing a GitHub app)
-  actually fixes the failure mode without forcing a fresh push (validated
-  on the autofix.ci app install, session 2026-05-01, commit `ee079c5`).
+  lives in the check-runs API: `gh api
+  'repos/OWNER/REPO/commits/BRANCH/check-runs' --jq '.check_runs[] |
+  select(.name|contains("NAME")) | .output.summary'`.
+- For Docker warning triage, see the `ci-warning-investigator` skill.
+- Use `gh run watch <id> --exit-status` / `gh pr checks <n> --watch` —
+  **never sleep-poll** (`feedback_gh_run_watch`). Cross-verify with
+  `--json conclusion`; `--exit-status` has reported exit 0 prematurely.
+- **`gh run list` returns multiple workflows.** A branch has both a `CI`
+  and an `autofix.ci` run per push; filter `--workflow CI` to disambiguate.
+- **Manual autofix-fix recipe** (when `autofix-ci/action` can't push back,
+  `500 ... not installed`): the diff is in the run's `autofix.ci.zip`
+  artifact — `gh run download RUN_ID`, base64-decode the `additions[].contents`
+  from `autofix.json`, apply, commit, push (PR #94 `cb186ac`).
+- **Re-run a failed job** — `gh run rerun RUN_ID --failed` refires only the
+  failed jobs against the same commit (verify a config fix without a fresh
+  push; validated on the autofix.ci app install, `ee079c5`).
 
 <!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -2,10 +2,22 @@ name: Refresh upstream pins
 
 # Two independent daily-refresh jobs merged into one workflow. Each detects
 # a different upstream drift and opens a PR via the shared
-# `./.github/actions/open-refresh-pr` composite (create-PR + ci.yml
-# dispatch). The jobs share nothing but that tail — distinct detection,
-# distinct concurrency groups, distinct cache needs — so they run fully in
-# parallel and one failing never blocks the other.
+# `./.github/actions/open-refresh-pr` composite. Each job mints a GitHub
+# App token (actions/create-github-app-token) for the PR push so the PR's
+# normal `pull_request` CI fires on its own — no `gh workflow run ci.yml`
+# dispatch hack, and no dependency on the "Allow Actions to create PRs"
+# repo setting (Phase C, #119). The jobs share nothing but that tail —
+# distinct detection, concurrency groups, and cache needs — so they run
+# fully in parallel and one failing never blocks the other.
+#
+# Merge policy: snapshot-refresh AUTO-MERGES (squash) once smoke-test
+# passes — fully unattended; p2996-refresh is REVIEW-REQUIRED (the clang
+# compiler bump gets human eyes; smoke-test is the safety net either way).
+#
+# One-time setup (repo admin) — see .github/workflows/AGENTS.md § GitHub
+# App: install an App with contents:write + pull-requests:write, add
+# `REFRESH_APP_ID` + `REFRESH_APP_PRIVATE_KEY` secrets, enable "Allow
+# auto-merge", and require the `build-publish / smoke-test` check on main.
 #
 #   - snapshot-refresh: refreshes `.devcontainer/mise-system-resolved.json`
 #     so the P2996 cache hash picks up conda-forge drift on `"latest"`-pinned
@@ -50,6 +62,16 @@ jobs:
       MISE_LOG_FILE: /tmp/mise.log
       MISE_LOG_FILE_LEVEL: debug
     steps:
+      - name: Mint GitHub App token
+        # App-token PR push fires `pull_request` CI on its own (unlike
+        # secrets.GITHUB_TOKEN). Token is scoped to this repo via the App
+        # installation; permissions = the App's grant (contents + PRs write).
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.REFRESH_APP_ID }}
+          private-key: ${{ secrets.REFRESH_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -85,22 +107,24 @@ jobs:
       - name: Open PR if snapshot drifted
         uses: ./.github/actions/open-refresh-pr
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: "chore: refresh mise-system-resolved snapshot"
           title: "chore: refresh mise-system-resolved snapshot"
           body: |
             Automated daily refresh of `.devcontainer/mise-system-resolved.json`.
 
             Captures conda-forge resolutions of system-mise tools whose
-            `mise-system.toml` versions are pinned to `"latest"`. Diff
-            below shows the upstream version drift since the last refresh
-            — review before merging to ensure no major-version surprises.
+            `mise-system.toml` versions are pinned to `"latest"`. This PR
+            auto-merges (squash) once `build-publish / smoke-test` passes —
+            the smoke test validates the rebuilt image, so the snapshot
+            drift lands unattended.
 
             Trigger: ${{ github.event_name }}.
           branch: chore/snapshot-refresh
           paths: .devcontainer/mise-system-resolved.json
           labels: mise-snapshot
           summary-heading: Snapshot refresh
+          auto-merge: "true"
 
   p2996-refresh:
     runs-on: ubuntu-latest
@@ -108,6 +132,16 @@ jobs:
       group: p2996-refresh
       cancel-in-progress: false
     steps:
+      - name: Mint GitHub App token
+        # App-token PR push fires `pull_request` CI on its own (unlike
+        # secrets.GITHUB_TOKEN). This job does NOT auto-merge — the clang
+        # compiler bump is review-required.
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.REFRESH_APP_ID }}
+          private-key: ${{ secrets.REFRESH_APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -137,7 +171,7 @@ jobs:
       - name: Open PR if the pinned ref advanced
         uses: ./.github/actions/open-refresh-pr
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: "chore: bump CLANG_P2996_REF to latest p2996 HEAD"
           title: "chore: bump CLANG_P2996_REF to latest p2996 HEAD"
           body: |
@@ -148,10 +182,12 @@ jobs:
             on the `p2996` branch HEAD is tracked as "latest". The pinned
             SHA feeds the content-addressed P2996 cache key, so this PR will
             trigger exactly one clang rebuild (ccache gives ~80% object
-            reuse). Review the upstream commit range before merging.
+            reuse). **Review-required** — the compiler bump gets human eyes;
+            review the upstream commit range before merging.
 
             Trigger: ${{ github.event_name }}.
           branch: chore/p2996-refresh
           paths: docker-bake.hcl
           labels: enhancement
           summary-heading: CLANG_P2996_REF refresh validation
+          auto-merge: "false"

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -491,6 +491,29 @@ tokens = [
 ]
 
 [[suite]]
+name = "ci.refresh-uses-app-token"
+description = "Phase C (#119): refresh.yml must mint a GitHub App token (actions/create-github-app-token) for the PR push so downstream pull_request CI fires on its own (GITHUB_TOKEN-created PRs don't), and the snapshot job must enable auto-merge. App ID/private-key come from REFRESH_APP_ID / REFRESH_APP_PRIVATE_KEY secrets."
+category = "ci"
+check_type = "static"
+handler = "require_tokens"
+paths = [".github/workflows/refresh.yml"]
+tokens = [
+  "actions/create-github-app-token",
+  "REFRESH_APP_ID",
+  "REFRESH_APP_PRIVATE_KEY",
+  "auto-merge:",
+]
+
+[[suite]]
+name = "ci.refresh-no-dispatch-hack"
+description = "Phase C (#119): the open-refresh-pr composite must NOT re-trigger CI via 'gh workflow run ci.yml' — the App token makes the PR fire pull_request CI on its own, so the dispatch hack is removed. (The unrelated promote-fallback dispatch in ci.yml is a different path and is allowed.)"
+category = "ci"
+check_type = "static"
+handler = "forbid_tokens"
+paths = [".github/actions/open-refresh-pr/action.yml"]
+tokens = ["gh workflow run ci.yml"]
+
+[[suite]]
 name = "ci.regex-managers-enabled"
 description = "Renovate's customManagers must be enabled via 'custom.regex' in enabledManagers — without it, every regex manager block is silently inactive (the existing CLANG_P2996_REF tracker hit this in 2026-04)"
 category = "ci"


### PR DESCRIPTION
Epic #116 **Phase C** — the unattended-publish unlock. `refresh.yml`'s PRs now fire downstream CI on their own, so the snapshot refresh lands without a human while the clang compiler bump stays review-gated.

## Why

`GITHUB_TOKEN`-created PRs do **not** trigger downstream `pull_request` workflows (GitHub's recursion guard) — that's why the old composite re-triggered CI via `gh workflow run ci.yml --ref`. A **GitHub App token is exempt**, so the PR's normal CI fires and `gh pr merge --auto` becomes viable.

## Changes

- **`refresh.yml`** — each job mints an App token via `actions/create-github-app-token` (pinned v3.2.0) from `REFRESH_APP_ID` + `REFRESH_APP_PRIVATE_KEY` secrets, passes it to `open-refresh-pr`. snapshot-refresh → `auto-merge: "true"` (squash, lands once `build-publish / smoke-test` passes); p2996-refresh → `auto-merge: "false"` (review-required).
- **`open-refresh-pr` composite** — takes the App token, **removes the `gh workflow run ci.yml` dispatch hack**, gains an `auto-merge` input (`gh pr merge --auto --squash`), and exposes `pull-request-{number,url,operation}` outputs. (Composites can't read `secrets`, so the token is minted in the workflow and passed in.)
- **`suites.toml`** — `ci.refresh-uses-app-token` + `ci.refresh-no-dispatch-hack` machine-enforce the invariants.
- **`workflows/AGENTS.md`** — new **GitHub App** section with the one-time setup + the docs-only-PR skipped-check caveat.

## ⚠️ One-time repo-admin setup required (INERT until done)

This PR is **code-complete but inert** until you:

1. **Create a GitHub App** with **`contents: write` + `pull-requests: write`**, install it on this repo, and add two repo secrets: `REFRESH_APP_ID` (the App's ID) and `REFRESH_APP_PRIVATE_KEY` (a generated private-key `.pem`).
2. **Settings → General → enable "Allow auto-merge".**
3. **Branch protection on `main`: require the `build-publish / smoke-test` status check.** **CRITICAL** — without it, `--auto` would land the PR *before* smoke runs.

Then validate end-to-end via `gh workflow run refresh.yml` (manual dispatch fires both jobs). I can't test the live App flow locally — it needs the install above.

## Local gate (all exit 0)

`actionlint` · `mise run pin-actions` · `mise run lint` (agnix 0 errors / 0 warnings) · `pytest` (143) · `dotfiles-setup verify run` (69, incl. 2 new Phase C contracts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)