### PR TITLE
ci: refresh App-token mint uses client-id (not deprecated app-id) (#119)

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -149,13 +149,13 @@ nightly publishes. Do NOT collapse onto one cron (issue #116).
 `refresh.yml` mints an App token (`actions/create-github-app-token`) so its
 PR fires `pull_request` CI on its own — GITHUB_TOKEN PRs don't. **One-time
 repo-admin setup:** (1) create a GitHub App with **contents: write +
-pull-requests: write**, install it here, add secrets `REFRESH_APP_ID` +
-`REFRESH_APP_PRIVATE_KEY`; (2) enable **Allow auto-merge**; (3) branch
-protection on `main` requiring
-**`build-publish / smoke-test`** — CRITICAL, else `--auto` lands before
-smoke runs. Policy: snapshot auto-merges (squash) once smoke passes; p2996
-is review-required. Caveat: docs-only PRs skip smoke (reported "skipped" =
-neutral for required checks) — verify after enabling protection.
+pull-requests: write**, install it here, add secrets `REFRESH_APP_ID` (the
+App's **Client ID** `Iv…`, not the App ID) + `REFRESH_APP_PRIVATE_KEY`;
+(2) enable **Allow auto-merge**; (3) branch protection on `main` requiring
+**`build-publish / smoke-test`** — else `--auto` lands before smoke. Policy:
+snapshot auto-merges (squash) once smoke passes; p2996 is review-required.
+Caveat: docs-only PRs skip smoke (skipped = neutral) — verify after
+enabling protection.
 
 ## Dependabot (`.github/dependabot.yml`)
 

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -69,7 +69,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.REFRESH_APP_ID }}
+          client-id: ${{ secrets.REFRESH_APP_ID }}
           private-key: ${{ secrets.REFRESH_APP_PRIVATE_KEY }}
 
       - name: Checkout code
@@ -139,7 +139,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.REFRESH_APP_ID }}
+          client-id: ${{ secrets.REFRESH_APP_ID }}
           private-key: ${{ secrets.REFRESH_APP_PRIVATE_KEY }}
 
       - name: Checkout code


### PR DESCRIPTION
Follow-up to #127. The Phase C refresh-mint failed on the first live `gh workflow run refresh.yml`:

```
##[warning] Input 'app-id' has been deprecated... Use 'client-id' instead.
Failed to create token... 'Issuer' claim ('iss') must be an Integer (401)
```

**Root cause:** GitHub now shows the **Client ID** (`Iv…`) most prominently on the App page, not the numeric App ID. The `app-id` input wants the integer App ID, so it rejected the Client-ID value.

**Fix:** switch both refresh jobs to the non-deprecated **`client-id`** input (also clears the deprecation warning). `REFRESH_APP_ID` now holds the App's Client ID; `AGENTS.md` documents this. Secret name kept so you don't have to re-create it.

Local gate: actionlint, pin-actions, `mise run lint` (agnix 0/0), verify (refresh contracts pass).

> Note: this PR touches no build-relevant paths, so `build-publish` is path-gated off and `build-publish / smoke-test` produces no check run — the exact non-build-PR case the `enforce_admins: false` escape hatch covers. Merging via admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified setup guidance for GitHub App refresh automation, including the correct credential to use and the expected branch protection check.
  * Added a note to help confirm behavior for docs-only changes when smoke testing is skipped.

* **Bug Fixes**
  * Updated refresh jobs to use the proper GitHub App credential format, helping scheduled token refreshes run correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->