### PR TITLE
ci: refresh mint requires the NUMERIC App ID via app-id (revert client-id) (#119)

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -150,7 +150,7 @@ nightly publishes. Do NOT collapse onto one cron (issue #116).
 PR fires `pull_request` CI on its own — GITHUB_TOKEN PRs don't. **One-time
 repo-admin setup:** (1) create a GitHub App with **contents: write +
 pull-requests: write**, install it here, add secrets `REFRESH_APP_ID` (the
-App's **Client ID** `Iv…`, not the App ID) + `REFRESH_APP_PRIVATE_KEY`;
+**numeric App ID**, NOT the Client ID `Iv…`) + `REFRESH_APP_PRIVATE_KEY`;
 (2) enable **Allow auto-merge**; (3) branch protection on `main` requiring
 **`build-publish / smoke-test`** — else `--auto` lands before smoke. Policy:
 snapshot auto-merges (squash) once smoke passes; p2996 is review-required.

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -66,10 +66,15 @@ jobs:
         # App-token PR push fires `pull_request` CI on its own (unlike
         # secrets.GITHUB_TOKEN). Token is scoped to this repo via the App
         # installation; permissions = the App's grant (contents + PRs write).
+        # REFRESH_APP_ID must be the NUMERIC App ID — `app-id` signs the JWT
+        # `iss`, which GitHub requires be an integer. The Client ID (`Iv…`)
+        # fails with "'Issuer' claim must be an Integer" even via the
+        # newer `client-id` input (verified live, #119). The app-id
+        # deprecation warning is benign — client-id is not a usable path here.
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets.REFRESH_APP_ID }}
+          app-id: ${{ secrets.REFRESH_APP_ID }}
           private-key: ${{ secrets.REFRESH_APP_PRIVATE_KEY }}
 
       - name: Checkout code
@@ -139,7 +144,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets.REFRESH_APP_ID }}
+          app-id: ${{ secrets.REFRESH_APP_ID }}
           private-key: ${{ secrets.REFRESH_APP_PRIVATE_KEY }}
 
       - name: Checkout code


### PR DESCRIPTION
Reverts #128. Live validation showed `client-id` **also** fails: GitHub rejects the App JWT at `/repos/{owner}/{repo}/installation` with **"'Issuer' claim ('iss') must be an Integer"** (401). GitHub App JWT auth requires the **numeric App ID** as the `iss` claim — the Client ID (`Iv…`) isn't usable for this endpoint, regardless of the `app-id`/`client-id` input.

So the original `app-id` input was correct; the real problem is purely the **secret value**. Reverting to `app-id` and documenting that `REFRESH_APP_ID` must hold the numeric App ID. The `app-id` deprecation warning is benign (client-id is not a working alternative here) — explained inline.

**Operator action:** set `REFRESH_APP_ID` to the **numeric App ID** (App settings page → "App ID: `<number>`"), not the Client ID:
```
gh secret set REFRESH_APP_ID --body "<numeric App ID>"
```

Local gate: actionlint, pin-actions, `mise run lint` (agnix 0/0), verify (69/0).

> Non-build PR (no build paths) → `build-publish / smoke-test` produces no check run → merging via admin escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)