### PR TITLE
ci: grant packages:read to refresh.yml so snapshot pull :dev works (#119)

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -47,6 +47,10 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: read  # snapshot-refresh pulls the private :dev image to capture
+                  # the mise snapshot; an explicit permissions block defaults
+                  # all unlisted scopes to `none`, so this must be declared
+                  # or `docker pull :dev` fails with "denied".
 
 jobs:
   snapshot-refresh:


### PR DESCRIPTION
Live Phase C validation surfaced a latent bug (unrelated to the App token, which works): `snapshot-refresh` failed at `docker pull ghcr.io/.../:dev` with **`denied`**.

**Cause:** refresh.yml declares an explicit `permissions:` block, which sets every *unlisted* scope to `none`. So the `GITHUB_TOKEN` had `packages: none` and couldn't pull the private `:dev` image. Fix: add `packages: read`.

Local gate: actionlint, verify (69/0).

> Non-build PR → admin escape hatch (the `ci-gate` aggregator would remove this friction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)