### PR TITLE
ci: add always-run ci-gate aggregator for branch protection (#119)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,6 +285,42 @@ jobs:
       target: ${{ github.event.inputs.target || 'dev' }}
 
   # ============================================================
+  # CI gate (#119/#129): a single ALWAYS-run aggregator that branch
+  # protection requires INSTEAD of the path-gated `build-publish /
+  # smoke-test`. A non-build PR (docs/hk/home/refresh) skips the
+  # `build-publish` caller, so `build-publish / smoke-test` produces NO
+  # check run — requiring it directly would block every such PR ("Expected
+  # — waiting"). ci-gate sidesteps that: it passes when every upstream job
+  # SUCCEEDED or was legitimately SKIPPED, and fails if any FAILED/
+  # cancelled. Auto-merge safety is preserved — a failed smoke-test fails
+  # `build-publish`, which fails ci-gate — while letting non-build PRs
+  # merge normally. See .github/workflows/AGENTS.md § GitHub App.
+  # ============================================================
+  ci-gate:
+    needs: [lint, contract-preflight, changes, build-publish]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require all upstream jobs to succeed or skip
+        env:
+          RESULTS: >-
+            ${{ needs.lint.result }} ${{ needs.contract-preflight.result }}
+            ${{ needs.changes.result }} ${{ needs.build-publish.result }}
+        run: |
+          set -euo pipefail
+          rc=0
+          for r in $RESULTS; do
+            case "$r" in
+              success|skipped) ;;
+              *) echo "FAIL: an upstream job result is '$r'" >&2; rc=1 ;;
+            esac
+          done
+          if [ "$rc" -eq 0 ]; then
+            echo "ci-gate: all upstream jobs success or skipped — mergeable"
+          fi
+          exit "$rc"
+
+  # ============================================================
   # Promote: tag-only retag of the PR-built image as :dev / :latest.
   # No rebuild — the PR's :pr-<NNN> manifest digest is reused. If the
   # merge commit has no associated PR (e.g., direct push to main, force

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -448,6 +448,20 @@ paths = [".github/workflows/ci.yml"]
 tokens = ["(github.event_name != 'push' || github.ref != 'refs/heads/main')"]
 
 [[suite]]
+name = "ci.ci-gate-aggregator-exists"
+description = "Branch protection requires the always-run `ci-gate` aggregator (not the path-gated `build-publish / smoke-test`, which produces no check run on non-build PRs and would block them). ci-gate must `needs` the upstream jobs, run `if: always()`, and fail unless each result is success or skipped — preserving auto-merge safety while unblocking non-build PRs (#119)."
+category = "ci"
+check_type = "static"
+handler = "require_tokens"
+paths = [".github/workflows/ci.yml"]
+tokens = [
+  "ci-gate:",
+  "needs.build-publish.result",
+  "if: always()",
+  "success|skipped",
+]
+
+[[suite]]
 name = "ci.promote-job-exists"
 description = "Push-to-main must trigger the promote job (manifest-only retag of the PR image as :dev/:latest, no rebuild). Direct-push fallback dispatches workflow with force_dev_tag=true."
 category = "ci"


### PR DESCRIPTION
Branch protection requiring `build-publish / smoke-test` blocks **every non-build PR** (docs/hk/home/refresh): they skip the path-gated `build-publish` caller, so no `build-publish / smoke-test` check run is produced → the required check sits "Expected — waiting" forever. This session needed **3 admin-merges** (#128/#129/#130) for exactly that.

**Fix:** a single always-run **`ci-gate`** job that `needs` lint + contract-preflight + changes + build-publish, passing when each result is `success` **or** `skipped`, failing on any failure/cancellation. After this merges I'll swap branch protection to require `ci-gate` instead of `build-publish / smoke-test` (one API call).

**Auto-merge safety preserved:** a failed smoke-test fails the `build-publish` reusable workflow → fails `ci-gate` → blocks the merge. Non-build PRs (build-publish skipped) pass `ci-gate` and merge normally — no admin override.

`suites.toml`: `ci.ci-gate-aggregator-exists` enforces the shape. Gates green: actionlint, pin-actions, lint, pytest (143), verify (70/0).

> This PR touches `ci.yml` (a build path), but the image is unchanged → `dev-prep` hits → smoke-test skipped (satisfies current protection) → merges normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an always-run CI status check so pull requests consistently report a final pass/fail result, even when some build-related checks are skipped.

* **Tests**
  * Added verification coverage to ensure the new CI status check is present and behaves as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->