### PR TITLE
ci: fix snapshot-refresh capture — run mise ls in-container as default user (#131)

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -150,12 +150,12 @@ nightly publishes. Do NOT collapse onto one cron (issue #116).
 PR fires `pull_request` CI on its own — GITHUB_TOKEN PRs don't. **One-time
 repo-admin setup:** (1) create a GitHub App with **contents: write +
 pull-requests: write**, install it here, add secrets `REFRESH_APP_ID` (the
-**numeric App ID**, NOT the Client ID `Iv…`) + `REFRESH_APP_PRIVATE_KEY`;
+**numeric App ID**, not Client ID `Iv…`) + `REFRESH_APP_PRIVATE_KEY`;
 (2) enable **Allow auto-merge**; (3) branch protection on `main` requiring
-**`build-publish / smoke-test`** — else `--auto` lands before smoke. Policy:
+the **`ci-gate`** check — else `--auto` lands before smoke. Policy:
 snapshot auto-merges (squash) once smoke passes; p2996 is review-required.
-Caveat: docs-only PRs skip smoke (skipped = neutral) — verify after
-enabling protection.
+`ci-gate` (always-run: passes when upstream succeed/skip) lets non-build
+PRs merge without admin.
 
 ## Dependabot (`.github/dependabot.yml`)
 

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -84,6 +84,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Install mise (python + uv)
+        # Host-side python + uv: the snapshot JSON is captured in the
+        # container, but formatted + written to the repo on the HOST so
+        # the file is runner-owned (peter-evans/create-pull-request needs
+        # that). See the Capture step (#131).
+        uses: ./.github/actions/setup-mise
+        with:
+          install_args: "python uv"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
@@ -98,20 +107,21 @@ jobs:
         run: docker pull ghcr.io/ray-manaloto/dotfiles-devcontainer:dev
 
       - name: Capture mise-system resolved snapshot from container
-        # Run `mise ls --json` inside the container (where the system
-        # mise config is installed and resolved), feed through our Python
-        # snapshot helper to filter + format deterministically.
-        # `--user "$(id -u):$(id -g)"` matches the runner UID so the
-        # written file is owned by the runner, not root — otherwise
-        # peter-evans/create-pull-request fails to stage the change.
+        # Two-step capture (#131): run `mise ls --json` inside the :dev
+        # container AS ITS DEFAULT USER (no `--user` UID override, no repo
+        # mount, no `uv run`) so mise reads the system config and writes
+        # nothing — this avoids the prior "Permission denied" on the
+        # container's UID-1000 mise cache/state dirs AND the project
+        # mise.toml triggering a tool install. Then format + write the
+        # snapshot on the HOST runner, so the file is runner-owned for
+        # create-pull-request to stage.
         run: |
           set -euo pipefail
           docker run --rm \
-            --user "$(id -u):$(id -g)" \
-            -v "$PWD:/workspaces/dotfiles" \
-            -w /workspaces/dotfiles \
             ghcr.io/ray-manaloto/dotfiles-devcontainer:dev \
-            bash -lc 'uv run --project python dotfiles-setup mise-snapshot'
+            mise ls --json > /tmp/mise-ls.json
+          uv run --project python dotfiles-setup mise-snapshot \
+            --from-json /tmp/mise-ls.json
 
       - name: Open PR if snapshot drifted
         uses: ./.github/actions/open-refresh-pr

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -23,7 +23,11 @@ from dotfiles_setup.lint import (
     resolve_timeout,
     run_guarded,
 )
-from dotfiles_setup.mise_snapshot import capture, write_snapshot
+from dotfiles_setup.mise_snapshot import (
+    capture,
+    filter_conda_resolved,
+    write_snapshot,
+)
 from dotfiles_setup.p2996_hash import (
     compute_repo_base_hash,
     compute_repo_dev_hash,
@@ -226,10 +230,19 @@ def setup_parser() -> argparse.ArgumentParser:
         help="Bump CLANG_P2996_REF in docker-bake.hcl to the latest "
         "bloomberg/clang-p2996 p2996-branch HEAD (writes only on change)",
     )
-    subparsers.add_parser(
+    mise_snapshot_parser = subparsers.add_parser(
         "mise-snapshot",
         help="Capture mise system resolved versions to "
         ".devcontainer/mise-system-resolved.json",
+    )
+    mise_snapshot_parser.add_argument(
+        "--from-json",
+        metavar="PATH",
+        default=None,
+        help="Read `mise ls --json` output from PATH instead of running mise. "
+        "CI captures the JSON inside the :dev container (as its default user, "
+        "no UID override) and formats it on the host runner, avoiding the "
+        "container permission + project-config-install issues (#131).",
     )
 
     ghcr_parser = subparsers.add_parser(
@@ -426,7 +439,12 @@ def _build_command_handlers(
         sys.stdout.write(refresh_p2996_ref(project_root).as_json() + "\n")
 
     def _mise_snapshot() -> None:
-        resolved = capture()
+        from_json = getattr(args, "from_json", None)
+        if from_json:
+            data = json.loads(Path(from_json).read_text())
+            resolved = filter_conda_resolved(data)
+        else:
+            resolved = capture()
         write_snapshot(
             project_root / ".devcontainer" / "mise-system-resolved.json",
             resolved,

--- a/tests/test_mise_snapshot.py
+++ b/tests/test_mise_snapshot.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 from dotfiles_setup.mise_snapshot import (
     SCHEMA_VERSION,
@@ -71,3 +72,24 @@ def test_parse_snapshot_rejects_invalid_tools_field() -> None:
         return
     msg = "expected TypeError for non-dict tools field"
     raise AssertionError(msg)
+
+
+def test_filter_from_captured_mise_ls_json_file(tmp_path: Path) -> None:
+    # Mirrors the #131 CI data flow: `mise ls --json` is captured to a file
+    # inside the :dev container, then filtered + formatted on the host via
+    # `dotfiles-setup mise-snapshot --from-json <file>`.
+    ls_file = tmp_path / "mise-ls.json"
+    ls_file.write_text(
+        json.dumps(
+            {
+                "conda:cmake": [{"version": "4.3.2"}],
+                "conda:ninja": [{"version": "1.13.0"}],
+                "core:node": [{"version": "22.0.0"}],
+            }
+        )
+    )
+    data = json.loads(ls_file.read_text())
+    assert filter_conda_resolved(data) == {
+        "conda:cmake": "4.3.2",
+        "conda:ninja": "1.13.0",
+    }


### PR DESCRIPTION
Fixes #131. Live Phase C validation exposed the long-broken snapshot capture: `dotfiles-setup mise-snapshot` inside `:dev` with `--user "$(id -u):$(id -g)"` + the repo bind-mounted fails because (a) the runner UID can't write the container's UID-1000 mise cache/state dirs (`Permission denied`), and (b) the mounted project `mise.toml` triggers a tool install (hk/uv) that dies on the same unwritable dirs.

**Fix — split the capture so neither happens:**
- **Container:** `docker run --rm :dev mise ls --json` **as its default user** (no `--user`, no mount, no `uv`) → reads the system config, writes nothing, emits JSON to the host.
- **Host:** `dotfiles-setup mise-snapshot --from-json /tmp/mise-ls.json` formats + writes the snapshot, so the file is runner-owned for `create-pull-request`.

Changes: `main.py` adds `--from-json PATH` (+ test, 145 total); `refresh.yml` does the two-step capture + host `setup-mise`; `AGENTS.md` updates the branch-protection requirement to `ci-gate` (post-#132).

Gates green: ruff, ty, actionlint, pin-actions, lint (agnix 0/0), pytest (144), verify (70/0).

> First PR under the new `ci-gate` branch protection — touches `python/**` so build-publish runs, but the image is unchanged → dev-prep hits → ci-gate passes → **should merge without admin**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)