### PR TITLE
feat(ci): wire p2996_ref override + repository_dispatch caller (Phase D, #120)

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -13,20 +13,21 @@ post-failure reporting.
 | File | Purpose |
 |------|---------|
 | `ci.yml` | Thin caller (Phase B, #118): lint → contract-preflight → `changes` (path-gate) → `build-publish` (the reusable build chain, gated on `changes.build` + push-to-main exemption); OR lint → promote (push to main) |
-| `build-publish.yml` | Reusable (`on: workflow_call`) build chain: base-prep → p2996-prep → dev-prep → build → smoke-test (smoke+Dive) → dev-tag. dev-prep/dev-tag are the third content-hash tier (#122). Inputs `{tag_strategy, publish, target, ref, p2996_ref*, platform*}` (*reserved, Phase D); outputs `{image_ref, digest}`. `github` context = caller's event, so sha/pr tags resolve identically |
+| `build-publish.yml` | Reusable (`on: workflow_call`) build chain: base-prep → p2996-prep → dev-prep → build → smoke-test (smoke+Dive) → dev-tag. dev-prep/dev-tag are the third content-hash tier (#122). Inputs `{tag_strategy, publish, target, ref, p2996_ref, platform*}` (`p2996_ref` active Phase D #120; `*platform` reserved); outputs `{image_ref, digest}`. `github` context = caller's event, so sha/pr tags resolve identically |
 | `ci-failure-report.yml` | Post-failure diagnostics / issue filing |
 | `image-analysis.yml` | Async (`workflow_run` on CI success): benchmark metrics + Trivy CVE scan, off the PR critical path |
 | `refresh.yml` | Daily cron (00:00): two independent jobs — `snapshot-refresh` (refresh `mise-system-resolved.json` on conda-forge drift, **auto-merges**) and `p2996-refresh` (bump `CLANG_P2996_REF` to latest `bloomberg/clang-p2996` HEAD, **review-required**, #100). Each mints a GitHub App token (Phase C, #119) so its PR fires CI on its own; both open a PR via `open-refresh-pr`. See **GitHub App** below. |
+| `dispatch-build.yml` | Thin `repository_dispatch` caller (Phase D, #120, type `build-p2996`): calls `build-publish.yml` with `client_payload.{p2996_ref,ref?}` + `tag_strategy: dispatch` for an on-demand exact-upstream-SHA build. Never moves `:dev`/`:latest`; warms `:p2996-<hash>`/`:dev-<hash>`. See **Phase D** below. |
 
 ## Composite actions (`.github/actions/`)
 
 Self-documented in each `action.yml`: `setup-mise` (wraps `jdx/mise-action`
 + `install_args`, all 8 mise jobs) and `open-refresh-pr` (App-token create-PR
 + optional squash auto-merge, both `refresh.yml` jobs). **Local-composite
-checkout gotcha:** a `./.github/actions/*` action resolves from
-`$GITHUB_WORKSPACE` (empty until checkout), so jobs run `actions/checkout`
-FIRST, then the composite — neither wraps checkout. **Composites can't read
-`secrets`** — the App token is minted in `refresh.yml`, passed in.
+checkout gotcha:** `./.github/actions/*` resolves from `$GITHUB_WORKSPACE`
+(empty until checkout), so jobs run `actions/checkout` FIRST, then the
+composite. **Composites can't read `secrets`** — the App token is minted in
+`refresh.yml`, passed in.
 
 ## Pipeline stages
 
@@ -35,10 +36,9 @@ PR / schedule / workflow_dispatch path (stages 3–6 run inside the reusable
 behavior unchanged):
 
 1. **lint** — mise install, hk pre-commit, agnix agent-doc validation
-   (`agnix .`; `.agnix.toml` `severity = "Warning"` keeps warnings
-   non-blocking), `mise doctor --json`, `mise.lock` upload, mise cache
-   keyed on `mise.lock`. agnix uses the `github:agent-sh/agnix` backend
-   (not `npm:agnix` — see `mise.toml`).
+   (`agnix .`; `.agnix.toml` `severity = "Warning"` = non-blocking),
+   `mise doctor --json`, `mise.lock` upload + cache. agnix uses the
+   `github:agent-sh/agnix` backend (not `npm:agnix` — see `mise.toml`).
 2. **contract-preflight** — Python 3.14 + uv; runs `dotfiles-setup
    verify run` over `python/verification/suites.toml`.
 3. **base-prep** — `dotfiles-setup base-hash` → probe `:base-<hash16>`
@@ -51,24 +51,21 @@ behavior unchanged):
 5. **dev-prep** (#122, PR builds only) — `dotfiles-setup dev-hash` → probe
    `:dev-<hash16>`. Hit: retag the validated image to `:sha`/`:pr-NNN`,
    skip build+smoke. Miss: fall through. Nightly skips this (always builds).
-6. **build** — `docker buildx bake dev` with
-   `dev.args.P2996_SOURCE=<cache_ref>`. On p2996 hit the `clang-builder`
-   stage is `FROM <cache_ref>`, skipping the multi-hour clang compile.
-   Pushes `:pr-NNN`/`:sha-<sha>` (PR) or `:dev`/`:latest` (nightly).
-7. **smoke-test** — pulls `:sha-<github.sha>`, runs the PR-blocking image
-   gates: `image smoke` + Dive (`.dive-ci`). Benchmark + Trivy moved to
-   async `image-analysis.yml`. On success **dev-tag** stamps `:dev-<hash>`
-   (the validated marker). The smoked image is the one retagged `:dev`/`:latest` on
-   merge.
+6. **build** — `docker buildx bake dev` with `dev.args.P2996_SOURCE=<cache_ref>`;
+   on a p2996 hit `clang-builder` is `FROM <cache_ref>`, skipping the
+   multi-hour compile. Pushes `:pr-NNN`/`:sha` (PR) or `:dev`/`:latest` (nightly).
+7. **smoke-test** — pulls `:sha-<github.sha>`, runs the PR-blocking gates
+   `image smoke` + Dive (`.dive-ci`); benchmark + Trivy are async in
+   `image-analysis.yml`. On success **dev-tag** stamps the `:dev-<hash>`
+   validated marker — the smoked image is what's retagged `:dev`/`:latest`.
 
 Push-to-main path (after a PR merge):
 
 1. **lint** — same as PR path, validates the merge commit's tree.
-2. **promote** — looks up the merged PR via `gh api graphql
-   associatedPullRequests`. On hit, runs `docker buildx imagetools
-   create -t :dev -t :latest <:pr-NNN>` — a manifest-only retag,
-   ~30 sec, no rebuild. On miss (direct push, force-push), dispatches
-   `ci.yml` with `force_dev_tag=true` to fall back to a full build.
+2. **promote** — looks up the merged PR (`gh api graphql
+   associatedPullRequests`). On hit: `docker buildx imagetools create
+   -t :dev -t :latest <:pr-NNN>` — manifest-only retag, ~30s, no rebuild.
+   On miss (direct/force push): dispatch `ci.yml` `force_dev_tag=true`.
 
 ## Invariants
 
@@ -77,19 +74,15 @@ Push-to-main path (after a PR merge):
 - **Build chain is path-gated.** A `changes` job (dorny/paths-filter,
   `list-files: json`) matches image/test inputs (`.devcontainer/**`,
   `docker-bake.hcl`, `hk-common.pkl`, `hk-image.pkl`, `python/**`,
-  `.dive-ci`, `install.sh`, `ci.yml`); the `decide` step drops markdown-only
-  matches via `jq` (a `!**/*.md` pattern can't — `**/*.md` skips dot-dirs).
-  base-prep→smoke-test AND `promote` gate on the result. So docs (incl. under
-  `.devcontainer/`/`python/`), root-mise, hk.pkl, home PRs run
-  lint+contract-preflight only; schedule + workflow_dispatch always build.
-- **Concurrency cancels superseded runs per branch.** `ci.yml` and
-  `autofix.yml` group by
-  `${{ github.workflow }}-${{ github.head_ref || github.ref }}` so all
-  events for one source branch share a group; pushing a new commit
-  cancels the older in-flight run. `head_ref` is the PR source branch;
-  `ref` covers push/schedule/dispatch. **main is exempt**
+  `.dive-ci`, `install.sh`, `ci.yml`); `decide` drops markdown-only matches
+  via `jq` (`!**/*.md` can't — `**/*.md` skips dot-dirs). So docs, root-mise,
+  hk.pkl, home PRs run lint+contract-preflight only; schedule +
+  workflow_dispatch always build.
+- **Concurrency cancels superseded runs per branch.** `ci.yml`/`autofix.yml`
+  group by `${{ github.workflow }}-${{ github.head_ref || github.ref }}`; a
+  new commit cancels the older in-flight run. **main is exempt**
   (`cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`) so its
-  push-path `promote` manifest-retag is never interrupted mid-flight.
+  push-path `promote` retag is never interrupted mid-flight.
 - **Python 3.14 + uv via the `setup-mise` composite** for contract-preflight
   and smoke-test (`install_args: python uv`). lint caches mise data on `mise.lock`.
 - **build job** passes GitHub token via BuildKit **secret mount**
@@ -98,18 +91,15 @@ Push-to-main path (after a PR merge):
   collision with the `REGISTRY` target in `docker-bake.hcl`).
 - **PR builds push** `:pr-NNN` + `:sha-<github.sha>` to GHCR so smoke-test
   validates the exact image promote retags on merge. No `cacheonly` mode.
-- **Push-to-main does NOT rebuild.** The `build-publish` caller in ci.yml is
-  gated `if: (github.event_name != 'push' || github.ref != 'refs/heads/main')`,
-  so the whole reusable chain is skipped on main; the merge commit is published
-  via `promote`'s manifest-retag of the PR's `:pr-NNN`.
-- **Three-tier content-hash probe cache** (#122): `:base-<hash>`,
-  `:p2996-<hash>`, `:dev-<hash>` — each `docker manifest inspect`-probed
-  (`dotfiles-setup {base,p2996,dev}-hash`) before its build. `:dev-<hash>`
-  (dev-prep/dev-tag jobs) is the top tier = base+p2996 hashes + whole
-  Dockerfile + dev bake target; tagged only AFTER smoke passes (validated
-  marker), so a PR hit skips build+smoke (retag to `:sha`/`:pr-NNN`).
-  Nightly skips the dev probe and always rebuilds (catches rolling-tool
-  drift the hash can't see, e.g. the gcc-latest .deb URL).
+- **Push-to-main does NOT rebuild.** The `build-publish` caller is gated
+  `if: github.event_name != 'push' || github.ref != 'refs/heads/main'`, so the
+  reusable chain is skipped on main; `promote` retags the PR's `:pr-NNN`.
+- **Three-tier content-hash probe cache** (#122): `:base-`/`:p2996-`/`:dev-<hash>`,
+  each `docker manifest inspect`-probed (`dotfiles-setup {base,p2996,dev}-hash`)
+  before its build. `:dev-<hash>` (= base+p2996 hashes + whole Dockerfile + dev
+  target) is tagged only AFTER smoke passes (validated marker), so a PR hit
+  skips build+smoke (retag to `:sha`/`:pr-NNN`). Nightly skips the dev probe
+  and always rebuilds (catches rolling-tool drift the hash can't see).
 - **P2996 cache invalidation.** Key = `CLANG_P2996_REF`, `BASE_IMAGE`,
   `PLATFORM`, Dockerfile, bake file, `mise-system-resolved.json`. Bust via
   `mise run capture-mise-system-resolved`. Details: `.devcontainer/P2996-CACHE.md`.
@@ -119,16 +109,14 @@ Push-to-main path (after a PR merge):
   `gh run watch --exit-status` exit code is unreliable, cross-verify with
   `--json conclusion`. Authority: `.claude/rules/gh-cli-watch.md`.
 - **No `type=gha` cache on `base`/`p2996-cache` targets** — registry tag +
-  `Probe cache` (`docker manifest inspect`) IS the durable cache;
-  `mode=max` gha export exceeds the 1h Azure SAS TTL → `403` on cold runs.
-  Documented in `docker-bake.hcl`. `dev` target keeps gha cache (small).
-- **Trivy lives in `image-analysis.yml` (async), not ci.yml smoke-test.**
-  `scanners: vuln` + `timeout: 15m`, warn-only: default scanners timeout
-  at 5min exporting the multi-GB image; scope is CVE-only (issue #92).
+  `Probe cache` IS the durable cache; `mode=max` gha export exceeds the 1h
+  Azure SAS TTL → `403` on cold runs. `dev` keeps gha cache (small).
+- **Trivy lives in `image-analysis.yml` (async), not smoke-test.**
+  `scanners: vuln` + `timeout: 15m`, warn-only (default scanners timeout
+  at 5min on the multi-GB image); CVE-only scope (issue #92).
 - **`wagoodman/dive` action is broken upstream** (v0.13.1 `ARG
-  DOCKER_CLI_VERSION` has no default → fetches `docker-.tgz`, 404s). Use
-  the binary release tarball in a `run:` step; do NOT use
-  `uses: wagoodman/dive@<sha>`.
+  DOCKER_CLI_VERSION` empty → 404s on `docker-.tgz`). Install the binary
+  release tarball in a `run:` step; never `uses: wagoodman/dive@<sha>`.
 
 ## Cron schedules (`schedule:`)
 
@@ -157,16 +145,31 @@ snapshot auto-merges (squash) once smoke passes; p2996 is review-required.
 `ci-gate` (always-run: passes when upstream succeed/skip) lets non-build
 PRs merge without admin.
 
+## Phase D — on-demand p2996 build (#120)
+
+`dispatch-build.yml` builds an exact upstream clang-p2996 SHA on demand
+(no cron wait). Dispatch (needs a `contents: write` token):
+
+```sh
+gh api repos/ray-manaloto/dotfiles/dispatches -f event_type=build-p2996 \
+  -f 'client_payload[p2996_ref]=<upstream-sha-or-ref>'
+```
+
+`p2996_ref` flows into build-publish.yml's **Resolve p2996 ref override**
+steps (p2996-prep, dev-prep, dev-tag): they export `CLANG_P2996_REF` so
+BOTH `dotfiles-setup {p2996,dev}-hash` AND docker bake's native variable
+override resolve the same SHA — the cache tag tracks the override, never
+poisoning the pinned cache. Empty input exports nothing → the
+`docker-bake.hcl` pin wins (byte-identical build). `tag_strategy: dispatch`
+emits `:sha` only; merge the `p2996-refresh` PR to make a bump permanent.
+
 ## Dependabot (`.github/dependabot.yml`)
 
 - **`interval: "cron"` enforces a 24h minimum.** The schema accepts
   `interval: "cron"` + `cronjob: "<expr>"` + `timezone: "<tz>"`, but
-  `dependabot-api.githubapp.com` rejects sub-daily expressions:
-  *"Cronjob expression has a minimum interval of 1 hours which is less
-  than the minimum allowed interval of 24 hours."* Use `0 0 * * *`
-  (daily at midnight) or longer; do NOT try `0 * * * *` (hourly). The
-  validation runs as a check named `.github/dependabot.yml` on every
-  PR that touches the file. (PR #86.)
+  `dependabot-api.githubapp.com` rejects sub-daily (min allowed 24h). Use
+  `0 0 * * *` or longer, never `0 * * * *`. Validated as a check named
+  `.github/dependabot.yml` on every PR touching the file. (PR #86.)
 
 ## Debugging CI failures
 
@@ -175,20 +178,15 @@ PRs merge without admin.
   build log.
 - `mise doctor --json` output in the lint job shows tool resolution
   issues.
-- **App-installed check error detail** (dependabot, CodeRabbit, etc.)
-  lives in the check-runs API: `gh api
-  'repos/OWNER/REPO/commits/BRANCH/check-runs' --jq '.check_runs[] |
-  select(.name|contains("NAME")) | .output.summary'`.
+- **App-installed check error detail** (dependabot, CodeRabbit) lives in
+  the check-runs API: `gh api 'repos/OWNER/REPO/commits/BRANCH/check-runs'
+  --jq '.check_runs[]|select(.name|contains("NAME"))|.output.summary'`.
 - For Docker warning triage, see the `ci-warning-investigator` skill.
-- Use `gh run watch <id> --exit-status` / `gh pr checks <n> --watch` —
-  **never sleep-poll** (`feedback_gh_run_watch`). Cross-verify with
-  `--json conclusion`; `--exit-status` has reported exit 0 prematurely.
 - **`gh run list` returns multiple workflows.** A branch has both a `CI`
   and an `autofix.ci` run per push; filter `--workflow CI` to disambiguate.
-- **Manual autofix-fix recipe** (when `autofix-ci/action` can't push back,
-  `500 ... not installed`): the diff is in the run's `autofix.ci.zip`
-  artifact — `gh run download RUN_ID`, base64-decode the `additions[].contents`
-  from `autofix.json`, apply, commit, push (PR #94 `cb186ac`).
+- **Manual autofix-fix recipe** (`autofix-ci/action` can't push back,
+  `500 ... not installed`): `gh run download RUN_ID`, base64-decode
+  `additions[].contents` from `autofix.json`, apply, commit, push (PR #94).
 - **Re-run a failed job** — `gh run rerun RUN_ID --failed` refires only the
   failed jobs against the same commit (verify a config fix without a fresh
   push; validated on the autofix.ci app install, `ee079c5`).

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -25,7 +25,7 @@ on:
   workflow_call:
     inputs:
       tag_strategy:
-        description: "Tag set to emit: 'pr' (=> :pr-NNN + :sha) or 'nightly' (=> :dev + :latest + :sha)"
+        description: "Tag set to emit: 'pr' (=> :pr-NNN + :sha), 'nightly' (=> :dev + :latest + :sha), or 'dispatch' (=> :sha only; on-demand p2996 build, Phase D #120 — never moves :dev/:latest)"
         required: true
         type: string
       publish:
@@ -44,7 +44,7 @@ on:
         default: ""
         type: string
       p2996_ref:
-        description: "Reserved (Phase D, #120): override CLANG_P2996_REF to build an exact upstream SHA. Unused when empty; the docker-bake.hcl pin is authoritative today."
+        description: "Phase D (#120): override CLANG_P2996_REF to build an exact upstream clang-p2996 SHA on demand. Exported as CLANG_P2996_REF so BOTH the content hash (p2996/dev) AND docker bake's variable override resolve the same ref. Empty => the docker-bake.hcl pin is authoritative (byte-identical canonical build)."
         required: false
         default: ""
         type: string
@@ -208,6 +208,20 @@ jobs:
         with:
           install_args: "python uv"
 
+      - name: Resolve p2996 ref override
+        # Phase D (#120): when a caller passes p2996_ref, export it as
+        # CLANG_P2996_REF so BOTH `dotfiles-setup p2996-hash` AND docker
+        # bake's native variable override resolve the SAME upstream SHA —
+        # the cache tag tracks the overridden ref, never poisoning the
+        # canonical pinned-ref cache. Empty input exports nothing, so the
+        # docker-bake.hcl pin stays authoritative (byte-identical to the
+        # canonical build). Value passed via env (not inline ${{ }}) to
+        # keep an untrusted client_payload out of the shell.
+        if: inputs.p2996_ref != ''
+        env:
+          P2996_REF: ${{ inputs.p2996_ref }}
+        run: echo "CLANG_P2996_REF=${P2996_REF}" >> "$GITHUB_ENV"
+
       - name: Compute P2996 cache hash
         id: hash
         run: |
@@ -326,6 +340,15 @@ jobs:
         uses: ./.github/actions/setup-mise
         with:
           install_args: "python uv"
+
+      - name: Resolve p2996 ref override
+        # Phase D (#120): keep `dotfiles-setup dev-hash` in lockstep with
+        # the p2996 override so the probed :dev-<hash> matches the image
+        # the dispatch path actually builds. See p2996-prep for rationale.
+        if: inputs.p2996_ref != ''
+        env:
+          P2996_REF: ${{ inputs.p2996_ref }}
+        run: echo "CLANG_P2996_REF=${P2996_REF}" >> "$GITHUB_ENV"
 
       - name: Compute dev cache hash
         id: hash
@@ -647,6 +670,17 @@ jobs:
           registry: ${{ env.CONTAINER_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve p2996 ref override
+        # Phase D (#120): the validated marker is content-addressed by
+        # dev-hash, which folds in CLANG_P2996_REF. dev-tag MUST honor the
+        # same override the p2996 cache built with — otherwise it would
+        # stamp a pinned-ref hash onto overridden-ref content, poisoning a
+        # later canonical build's probe. See p2996-prep for rationale.
+        if: inputs.p2996_ref != ''
+        env:
+          P2996_REF: ${{ inputs.p2996_ref }}
+        run: echo "CLANG_P2996_REF=${P2996_REF}" >> "$GITHUB_ENV"
 
       - name: Tag validated image as :dev-<hash>
         env:

--- a/.github/workflows/dispatch-build.yml
+++ b/.github/workflows/dispatch-build.yml
@@ -1,0 +1,56 @@
+name: dispatch-build
+
+# ============================================================
+# Phase D (#120): on-demand "build this exact upstream clang-p2996 SHA"
+# without waiting for the daily refresh cron. A repository_dispatch of
+# type `build-p2996` with client_payload `{p2996_ref, ref?}` calls the
+# reusable build-publish.yml with that ref.
+#
+# The override flows into build-publish.yml's "Resolve p2996 ref
+# override" steps, which export CLANG_P2996_REF so BOTH the content hash
+# (dotfiles-setup p2996-hash / dev-hash) AND docker bake's native
+# variable override resolve the SAME SHA. The p2996/dev cache tags thus
+# track the overridden ref and never poison the canonical pinned-ref
+# cache.
+#
+# Reproducibility preserved: the committed docker-bake.hcl pin is
+# unchanged, so :dev/:latest (the canonical path) are untouched. This
+# path uses tag_strategy=dispatch (=> :sha only, never :dev/:latest),
+# warms the content-addressed :p2996-<hash> / :dev-<hash> markers, and
+# smoke-validates the result. To make a bump PERMANENT, merge a
+# CLANG_P2996_REF refresh PR (refresh.yml p2996-refresh job).
+#
+# Dispatch (needs a token with `contents: write` on this repo):
+#   gh api repos/ray-manaloto/dotfiles/dispatches \
+#     -f event_type=build-p2996 \
+#     -f 'client_payload[p2996_ref]=<upstream-sha-or-ref>'
+# Optionally pin the checkout ref too:
+#     -f 'client_payload[ref]=<git-ref>'
+# Spec: docs/research/gha-workflow-optimization.md § "Phase D".
+# ============================================================
+
+on:
+  repository_dispatch:
+    types: [build-p2996]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-p2996:
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/build-publish.yml
+    secrets: inherit
+    with:
+      # 'dispatch' emits :sha only (dev-prep is skipped → always builds;
+      # metadata-action enables :dev/:latest only for 'nightly'), so an
+      # ad-hoc upstream SHA never moves the canonical floating tags.
+      tag_strategy: dispatch
+      # publish=true is required: smoke-test pulls the pushed :sha image
+      # to validate it. The canonical :dev/:latest are still untouched.
+      publish: true
+      ref: ${{ github.event.client_payload.ref }}
+      p2996_ref: ${{ github.event.client_payload.p2996_ref }}

--- a/docs/research/gha-workflow-optimization.md
+++ b/docs/research/gha-workflow-optimization.md
@@ -26,7 +26,11 @@ breaking the repo's reproducibility invariants.
 >   hack removed); snapshot auto-merges (squash), p2996 review-required.
 >   Validated live: snapshot drift → App-token PR #134 → CI fired → auto-merge
 >   enabled, gated on the new `ci-gate` aggregator.
-> - ⬜ Phase D — not started.
+> - ✅ **Phase D** done — PR #137 (2026-06-29): `p2996_ref` wired end-to-end
+>   (content hash + bake's native `CLANG_P2996_REF` override, both gated on a
+>   non-empty input so the canonical pinned build stays byte-identical) plus a
+>   `dispatch-build.yml` `repository_dispatch` caller (type `build-p2996`) for
+>   on-demand "build this exact upstream SHA". Epic #116 complete.
 
 ## Inventory
 
@@ -362,8 +366,14 @@ flowchart TD
    Client ID `Iv…`); the App must be installed on the **org** (not a personal
    account); `refresh.yml` needs `packages: read` to pull `:dev`; the snapshot
    capture must run `mise ls --json` in-container as the default user (#131).
-4. **Phase D (optional):** `p2996_ref` input + a `repository_dispatch` caller
-   for on-demand "build exactly this upstream SHA" without a cron wait.
+4. **Phase D (optional):** ✅ **done, PR #137 (2026-06-29).** `p2996_ref`
+   wired through build-publish.yml — a *Resolve p2996 ref override* step in
+   p2996-prep/dev-prep/dev-tag exports `CLANG_P2996_REF` only on a non-empty
+   input, so BOTH `dotfiles-setup {p2996,dev}-hash` AND docker bake's native
+   variable override resolve the same SHA (empty input = byte-identical
+   canonical build). A thin `dispatch-build.yml` (`repository_dispatch`, type
+   `build-p2996`) calls it with `tag_strategy=dispatch` (emits `:sha` only —
+   never moves `:dev`/`:latest`, so the committed pin stays authoritative).
 
 ## Decision points for sign-off
 

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import platform
 import sys
 from pathlib import Path
@@ -397,10 +398,28 @@ def _hash_command_handlers(project_root: Path) -> dict[str, Any]:
     def _emit(compute: Callable[[Path], str]) -> None:
         sys.stdout.write(compute(project_root) + "\n")
 
+    # Phase D (#120): an on-demand "build this exact upstream SHA" run
+    # exports CLANG_P2996_REF (mirroring docker bake's own variable
+    # override). The p2996/dev hashes must reflect it so the
+    # content-addressed cache tags track the overridden ref and never
+    # poison the canonical pinned-ref cache. Empty/unset => the committed
+    # pin, byte-identical to the canonical build.
+    p2996_ref = os.environ.get("CLANG_P2996_REF") or None
+
+    def _emit_p2996() -> None:
+        sys.stdout.write(
+            compute_repo_p2996_hash(project_root, clang_p2996_ref=p2996_ref) + "\n"
+        )
+
+    def _emit_dev() -> None:
+        sys.stdout.write(
+            compute_repo_dev_hash(project_root, clang_p2996_ref=p2996_ref) + "\n"
+        )
+
     return {
         "base-hash": lambda: _emit(compute_repo_base_hash),
-        "p2996-hash": lambda: _emit(compute_repo_p2996_hash),
-        "dev-hash": lambda: _emit(compute_repo_dev_hash),
+        "p2996-hash": _emit_p2996,
+        "dev-hash": _emit_dev,
     }
 
 

--- a/python/src/dotfiles_setup/p2996_hash.py
+++ b/python/src/dotfiles_setup/p2996_hash.py
@@ -272,12 +272,22 @@ def compute_repo_base_hash(repo_root: Path) -> str:
     return compute_base_hash(gather_base_inputs(repo_root))
 
 
-def gather_p2996_inputs(repo_root: Path, *, base_hash: str) -> P2996HashInputs:
+def gather_p2996_inputs(
+    repo_root: Path, *, base_hash: str, clang_p2996_ref: str | None = None
+) -> P2996HashInputs:
     """Read every input that contributes to the `:p2996-<hash>` cache.
 
     `base_hash` is passed in (rather than recomputed) so the caller
     controls when the base reference is captured — same value reused
     across multiple p2996 hash computations.
+
+    `clang_p2996_ref`, when given, overrides the `CLANG_P2996_REF`
+    default read from docker-bake.hcl — the Phase D (#120) "build this
+    exact upstream SHA" path. `None` (the default) reads the committed
+    pin, so the hash is byte-identical to the canonical build. The
+    override must mirror docker bake's own variable override so the
+    content-addressed cache tag tracks the overridden ref and never
+    poisons the canonical pinned-ref cache.
     """
     bake_text = (repo_root / "docker-bake.hcl").read_text()
     dockerfile_text = (repo_root / ".devcontainer" / "Dockerfile").read_text()
@@ -285,7 +295,11 @@ def gather_p2996_inputs(repo_root: Path, *, base_hash: str) -> P2996HashInputs:
         dockerfile_text, P2996_SECTION_BEGIN, P2996_SECTION_END
     )
     return P2996HashInputs(
-        clang_p2996_ref=_extract_bake_variable(bake_text, "CLANG_P2996_REF"),
+        clang_p2996_ref=(
+            clang_p2996_ref
+            if clang_p2996_ref is not None
+            else _extract_bake_variable(bake_text, "CLANG_P2996_REF")
+        ),
         base_hash=base_hash,
         platform=_extract_bake_variable(bake_text, "PLATFORM"),
         p2996_section_digest=_sha256_hex(p2996_section),
@@ -307,10 +321,20 @@ def compute_p2996_hash(inputs: P2996HashInputs) -> str:
     return _sha256_hex(canonical)[:HASH_LENGTH]
 
 
-def compute_repo_p2996_hash(repo_root: Path) -> str:
-    """Top-level helper: compute base hash, then p2996 hash on top."""
+def compute_repo_p2996_hash(
+    repo_root: Path, *, clang_p2996_ref: str | None = None
+) -> str:
+    """Top-level helper: compute base hash, then p2996 hash on top.
+
+    `clang_p2996_ref` overrides the committed `CLANG_P2996_REF` pin for
+    the Phase D (#120) on-demand build path; `None` uses the pin.
+    """
     base_hash = compute_repo_base_hash(repo_root)
-    return compute_p2996_hash(gather_p2996_inputs(repo_root, base_hash=base_hash))
+    return compute_p2996_hash(
+        gather_p2996_inputs(
+            repo_root, base_hash=base_hash, clang_p2996_ref=clang_p2996_ref
+        )
+    )
 
 
 def gather_dev_inputs(
@@ -350,10 +374,24 @@ def compute_dev_hash(inputs: DevHashInputs) -> str:
     return _sha256_hex(canonical)[:HASH_LENGTH]
 
 
-def compute_repo_dev_hash(repo_root: Path) -> str:
-    """Top-level helper: compute base + p2996 hashes, then the dev hash."""
+def compute_repo_dev_hash(
+    repo_root: Path, *, clang_p2996_ref: str | None = None
+) -> str:
+    """Top-level helper: compute base + p2996 hashes, then the dev hash.
+
+    `clang_p2996_ref` overrides the committed `CLANG_P2996_REF` pin (it
+    flows through the nested p2996 hash) for the Phase D (#120) on-demand
+    build path; `None` uses the pin. dev-tag stamps the `:dev-<hash>`
+    validated marker, so this MUST honor the same override the p2996
+    cache built with — else the marker would point a pinned-ref hash at
+    overridden-ref content.
+    """
     base_hash = compute_repo_base_hash(repo_root)
-    p2996_hash = compute_p2996_hash(gather_p2996_inputs(repo_root, base_hash=base_hash))
+    p2996_hash = compute_p2996_hash(
+        gather_p2996_inputs(
+            repo_root, base_hash=base_hash, clang_p2996_ref=clang_p2996_ref
+        )
+    )
     return compute_dev_hash(
         gather_dev_inputs(repo_root, base_hash=base_hash, p2996_hash=p2996_hash)
     )

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -505,6 +505,25 @@ tokens = [
 ]
 
 [[suite]]
+name = "ci.p2996-ref-dispatch-wired"
+description = "Phase D (#120): the p2996_ref override must be wired end-to-end. build-publish.yml resolves inputs.p2996_ref into CLANG_P2996_REF (a 'Resolve p2996 ref override' step) so BOTH the content hash AND docker bake's variable override track the same upstream SHA — never poisoning the canonical pinned-ref cache. A repository_dispatch caller (dispatch-build.yml, type build-p2996) threads client_payload.p2996_ref through. Empty override => the committed docker-bake.hcl pin is authoritative (byte-identical canonical build)."
+category = "ci"
+check_type = "static"
+handler = "require_tokens"
+paths = [
+  ".github/workflows/build-publish.yml",
+  ".github/workflows/dispatch-build.yml",
+]
+tokens = [
+  "inputs.p2996_ref != ''",
+  "CLANG_P2996_REF=${P2996_REF}",
+  "repository_dispatch",
+  "build-p2996",
+  "client_payload.p2996_ref",
+  "tag_strategy: dispatch",
+]
+
+[[suite]]
 name = "ci.refresh-uses-app-token"
 description = "Phase C (#119): refresh.yml must mint a GitHub App token (actions/create-github-app-token) for the PR push so downstream pull_request CI fires on its own (GITHUB_TOKEN-created PRs don't), and the snapshot job must enable auto-merge. App ID/private-key come from REFRESH_APP_ID / REFRESH_APP_PRIVATE_KEY secrets."
 category = "ci"

--- a/tests/test_p2996_hash.py
+++ b/tests/test_p2996_hash.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 import sys
@@ -349,6 +350,55 @@ def test_repo_p2996_hash_changes_when_base_section_modified(tmp_path: Path) -> N
 
 
 # ──────────────────────────────────────────────────────────────────────
+# Phase D (#120): clang_p2996_ref override
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_gather_p2996_inputs_override_replaces_bake_pin(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    pinned = gather_p2996_inputs(tmp_path, base_hash="0" * 16)
+    assert pinned.clang_p2996_ref == "abc123"  # the seeded bake default
+    overridden = gather_p2996_inputs(
+        tmp_path, base_hash="0" * 16, clang_p2996_ref="deadbeef"
+    )
+    assert overridden.clang_p2996_ref == "deadbeef"
+
+
+def test_gather_p2996_inputs_none_override_uses_pin(tmp_path: Path) -> None:
+    # Explicit None must be byte-identical to omitting the arg — the
+    # canonical-build invariant the empty dispatch input relies on.
+    _seed_repo(tmp_path)
+    assert gather_p2996_inputs(
+        tmp_path, base_hash="0" * 16, clang_p2996_ref=None
+    ) == gather_p2996_inputs(tmp_path, base_hash="0" * 16)
+
+
+def test_repo_p2996_hash_override_differs_from_pin(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    pinned = compute_repo_p2996_hash(tmp_path)
+    overridden = compute_repo_p2996_hash(tmp_path, clang_p2996_ref="deadbeef")
+    assert pinned != overridden
+
+
+def test_repo_p2996_hash_override_equal_to_pin_matches(tmp_path: Path) -> None:
+    # Overriding with the SAME value the bake file pins must reproduce the
+    # canonical hash exactly — proves the override channel is pure.
+    _seed_repo(tmp_path)
+    assert compute_repo_p2996_hash(
+        tmp_path, clang_p2996_ref="abc123"
+    ) == compute_repo_p2996_hash(tmp_path)
+
+
+def test_repo_dev_hash_override_differs_from_pin(tmp_path: Path) -> None:
+    # The override must propagate through the nested p2996 hash into the
+    # dev hash so the dev-tag validated marker tracks overridden content.
+    _seed_repo(tmp_path)
+    pinned = compute_repo_dev_hash(tmp_path)
+    overridden = compute_repo_dev_hash(tmp_path, clang_p2996_ref="deadbeef")
+    assert pinned != overridden
+
+
+# ──────────────────────────────────────────────────────────────────────
 # Failure modes
 # ──────────────────────────────────────────────────────────────────────
 
@@ -379,13 +429,20 @@ def test_gather_p2996_inputs_missing_marker_raises(tmp_path: Path) -> None:
 # ──────────────────────────────────────────────────────────────────────
 
 
-def _run_dotfiles_setup(subcommand: str) -> str:
+def _run_dotfiles_setup(subcommand: str, *, env_override: str | None = None) -> str:
+    env = dict(os.environ)
+    # Phase D (#120): the CLI reads CLANG_P2996_REF from the environment to
+    # override the committed pin. None leaves the ambient env untouched.
+    env.pop("CLANG_P2996_REF", None)
+    if env_override is not None:
+        env["CLANG_P2996_REF"] = env_override
     result = subprocess.run(
         [sys.executable, "-m", "dotfiles_setup.main", subcommand],
         capture_output=True,
         text=True,
         check=True,
         cwd=Path(__file__).resolve().parent.parent,
+        env=env,
     )
     return result.stdout.strip()
 
@@ -410,6 +467,38 @@ def test_cli_dev_hash_returns_16_char_hex() -> None:
     output = _run_dotfiles_setup("dev-hash")
     assert len(output) == HASH_LENGTH
     assert re.fullmatch(r"[0-9a-f]+", output)
+
+
+def test_cli_p2996_hash_honors_clang_ref_env_override() -> None:
+    # Phase D (#120): an exported CLANG_P2996_REF must change the emitted
+    # p2996 hash so the dispatch path's cache tag tracks the overridden SHA.
+    pinned = _run_dotfiles_setup("p2996-hash")
+    overridden = _run_dotfiles_setup("p2996-hash", env_override="0" * 40)
+    assert pinned != overridden
+    assert len(overridden) == HASH_LENGTH
+
+
+def test_cli_dev_hash_honors_clang_ref_env_override() -> None:
+    pinned = _run_dotfiles_setup("dev-hash")
+    overridden = _run_dotfiles_setup("dev-hash", env_override="0" * 40)
+    assert pinned != overridden
+
+
+def test_cli_empty_clang_ref_env_is_treated_as_unset() -> None:
+    # An empty string must mean "use the pin" — the workflow only exports
+    # CLANG_P2996_REF on a non-empty input, but defense-in-depth here keeps
+    # the canonical build byte-identical even if an empty value leaks in.
+    assert _run_dotfiles_setup("p2996-hash", env_override="") == _run_dotfiles_setup(
+        "p2996-hash"
+    )
+
+
+def test_cli_base_hash_ignores_clang_ref_env_override() -> None:
+    # The base hash predates the clang compile and must be invariant under
+    # a p2996 ref override (only p2996/dev tiers depend on it).
+    assert _run_dotfiles_setup("base-hash", env_override="0" * 40) == (
+        _run_dotfiles_setup("base-hash")
+    )
 
 
 # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Phase D of the GHA redesign epic (#116) — closes #120. Builds an exact
upstream clang-p2996 SHA **on demand**, without waiting for the daily
`refresh.yml` cron.

## What

The reusable `build-publish.yml` has declared (but never consumed) a
`p2996_ref` input since Phase B. This wires it end-to-end:

- **`p2996_hash.py`** — thread an optional `clang_p2996_ref` override
  through `gather_p2996_inputs` / `compute_repo_p2996_hash` /
  `compute_repo_dev_hash`. `None` (default) reads the committed
  `docker-bake.hcl` pin → byte-identical to the canonical build.
- **`main.py`** — the `p2996-hash` / `dev-hash` CLI handlers read
  `CLANG_P2996_REF` from the env (mirroring docker bake's own variable
  override) so the content-addressed cache tags track the overridden ref
  and never poison the canonical pinned-ref cache.
- **`build-publish.yml`** — a *Resolve p2996 ref override* step in
  `p2996-prep`, `dev-prep`, and `dev-tag` exports `CLANG_P2996_REF` **only
  when `inputs.p2996_ref` is non-empty**, so BOTH the content hash AND
  bake's native variable override resolve the same SHA. Empty input is a
  true no-op. `dev-tag` honoring the override is load-bearing — it stamps
  the `:dev-<hash>` validated marker, which must track overridden content.
- **`dispatch-build.yml`** — thin `repository_dispatch` caller (type
  `build-p2996`) passing `client_payload.{p2996_ref,ref?}` with
  `tag_strategy: dispatch` (emits `:sha` only — never moves `:dev`/`:latest`,
  so reproducibility via the committed pin is preserved).

## Reproducibility / safety

The committed `docker-bake.hcl` pin stays authoritative for the canonical
path. The dispatch path warms `:p2996-<hash>` / `:dev-<hash>` content
markers and smoke-validates, but never moves the floating `:dev`/`:latest`
tags. To make a bump permanent, merge the `p2996-refresh` PR.

## Tests / gates

- New `ci.p2996-ref-dispatch-wired` verification contract (mirrors
  `ci.dev-prep-gate-exists`).
- 9 new hash-override tests (function-level + CLI env-override, incl.
  empty-input no-op and base-hash invariance).
- Local gate green: `actionlint`, `pin-actions`, `mise run lint`, pytest
  (153), `dotfiles-setup verify run` (71).

🤖 Generated with [Claude Code](https://claude.com/claude-code)