### PR TITLE
fix(smoke): #141 clang-p2996 libc++ binaries link + run via rpath

### DIFF
--- a/.claude/skills/devcontainer-workflow/SKILL.md
+++ b/.claude/skills/devcontainer-workflow/SKILL.md
@@ -38,7 +38,7 @@ scripts/devcontainer-smoke.sh --include-up   # also runs `devcontainer up` first
 Tiers:
 
 - **Tier 1** — `mise ls`, `which clang++ python uv hk`, `hk run pre-commit --all`
-- **Tier 2** — `pytest 65/65`, `stat ~/.ssh ~/.claude /workspaces/dotfiles`
+- **Tier 2** — `pytest 171/171`, `stat ~/.ssh ~/.claude /workspaces/dotfiles`
 - **Tier 3** — `clang++ -fsanitize=address,undefined hello.cc && ./hello`
 
 Tier 4 (CLion remote toolchain) is manual.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ the official `@devcontainers/cli` (pinned in `mise.toml`).
 | `.claude/` | Claude-specific agents, skills, rules. Has its own `CLAUDE.md` with OMC orchestration |
 | `home/` | Chezmoi-managed dotfiles — see `home/AGENTS.md` |
 | `python/` | Python package `dotfiles_setup` — see `python/AGENTS.md` |
-| `tests/` | Pytest + Bats test suite (101 pytest tests) — see `tests/AGENTS.md` |
+| `tests/` | Pytest + Bats test suite (171 pytest tests) — see `tests/AGENTS.md` |
 | `scripts/` | Utility scripts (`benchmark-docker.sh`, `devcontainer-smoke.sh`) |
 | `docs/` | Documentation, research findings, design specs |
 
@@ -85,7 +85,7 @@ changes don't take effect.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q               # All 101 tests
+uv run --project python pytest tests/ -x -q               # All 171 tests
 uv run --project python pytest tests/test_audit.py -x -q  # Single file
 hk run pre-commit --all --stash none                      # Lint checks only
 dotfiles-setup verify run                                 # Verification contracts (suites.toml)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A highly resilient, declarative dotfiles setup using **Chezmoi**, **Mise**, and 
 ```bash
 mise install                                       # Install all tools
 hk run pre-commit --all                            # Run lint checks (requires HK_PKL_BACKEND=pkl)
-uv run --project python pytest tests/ -x -q      # Run all 101 tests
+uv run --project python pytest tests/ -x -q      # Run all 171 tests
 ```
 
 ### Docker Build

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -37,7 +37,7 @@ Requires **Python 3.14**.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q                # All 101 tests
+uv run --project python pytest tests/ -x -q                # All 171 tests
 uv run --project python pytest tests/test_audit.py -x -q   # Single file
 ```
 

--- a/python/src/dotfiles_setup/image.py
+++ b/python/src/dotfiles_setup/image.py
@@ -242,25 +242,43 @@ else
 fi
 cat >/tmp/refl-func.cpp <<'CPP'
 #include <meta>
+#include <iostream>
 enum class Color { Red, Green, Blue };
 consteval int count_enumerators() {
   return static_cast<int>(enumerators_of(^^Color).size());
 }
 static_assert(count_enumerators() == 3);
-int main() { return 0; }
+int main() {
+  int n = count_enumerators();
+  std::cout << "reflection enumerators=" << n << std::endl;
+  return n == 3 ? 0 : 1;
+}
 CPP
-# -fsyntax-only is intentional: the static_assert above forces the reflection
-# (enumerators_of(^^Color)) to be EVALUATED at compile time, so a broken
-# reflection front-end fails the compile. Full link+run is avoided because
-# clang-p2996's -stdlib=libc++ binary needs libc++.so.1 at runtime, which is
-# not on the default loader path (the Dockerfile build-time smoke is
-# -fsyntax-only for the same reason).
-/opt/gcc-latest/bin/g++ -std=c++26 -freflection /tmp/refl-func.cpp -fsyntax-only \
-  || { echo "FAIL: gcc-latest reflection compile failed"; exit 1; }
+# Gap C (#141): link + RUN, not merely a syntax check. The static_assert
+# still forces enumerators_of(^^Color) evaluation at COMPILE time (a broken
+# reflection front-end fails the build); the RUN then materializes that
+# consteval result into a runtime value and asserts on it via the exit code,
+# proving the emitted binary actually executes. clang-p2996's -stdlib=libc++
+# binary needs libc++.so.1 at runtime, which is off the default loader path,
+# so we bake an rpath pointing at the in-image libc++ dir — discovered, not
+# hard-coded, so a triple change can't silently break it. Link-flag-only fix:
+# no Dockerfile change, hence no cold base rebuild. A p2996 libc++ binary runs
+# under Rosetta/QEMU (verified #141), so unlike TSan the RUN needs no
+# emulation gate.
+P2996_LIBCXX_SO=$(find /opt/clang-p2996/lib -name 'libc++.so.1' 2>/dev/null | head -n1)
+if [ -z "$P2996_LIBCXX_SO" ]; then
+  echo "FAIL: clang-p2996 libc++.so.1 not found in image"; exit 1
+fi
+P2996_LIBCXX_DIR=$(dirname "$P2996_LIBCXX_SO")
+/opt/gcc-latest/bin/g++ -std=c++26 -freflection /tmp/refl-func.cpp -o /tmp/refl-gcc \
+  || { echo "FAIL: gcc-latest reflection link failed"; exit 1; }
+/tmp/refl-gcc || { echo "FAIL: gcc-latest reflection binary did not run"; exit 1; }
 /opt/clang-p2996/bin/clang++ -std=c++2c -freflection -freflection-latest \
-  -fexpansion-statements -stdlib=libc++ /tmp/refl-func.cpp -fsyntax-only \
-  || { echo "FAIL: clang-p2996 reflection compile failed"; exit 1; }
-rm -f /tmp/refl-func.cpp
+  -fexpansion-statements -stdlib=libc++ -Wl,-rpath,"$P2996_LIBCXX_DIR" \
+  /tmp/refl-func.cpp -o /tmp/refl-clang \
+  || { echo "FAIL: clang-p2996 reflection link failed"; exit 1; }
+/tmp/refl-clang || { echo "FAIL: clang-p2996 reflection binary did not run"; exit 1; }
+rm -f /tmp/refl-func.cpp /tmp/refl-gcc /tmp/refl-clang
 echo "=== AI CLI checks ==="
 for tool in claude codex gemini; do
   command -v "$tool" >/dev/null 2>&1 || { echo "FAIL: missing $tool"; exit 1; }

--- a/scripts/devcontainer-smoke.sh
+++ b/scripts/devcontainer-smoke.sh
@@ -7,7 +7,7 @@
 #
 # Tiers (per ralplan-consensus-devcontainer-build-mise-chezmoi-resync §5):
 #   Tier 1 — Tools+hk:      mise ls; which clang++ python uv hk; hk run pre-commit --all
-#   Tier 2 — Python+mounts: uv pytest 65/65; stat ~/.ssh ~/.claude /workspaces/${ws}
+#   Tier 2 — Python+mounts: uv pytest 171/171; stat ~/.ssh ~/.claude /workspaces/${ws}
 #   Tier 3 — Sanitizers+lifecycle: clang++ asan+ubsan; mise-user volume owner; github ssh
 #
 # Tier 4 (CLion remote toolchain) is manual and out of scope here.
@@ -99,20 +99,36 @@ if [ "${actual_ref}" != "${expected_ref}" ]; then
 	exit 1
 fi
 echo "  OK: clang-p2996 ref ${actual_ref} matches docker-bake.hcl"
+# Gap C (#141): link + RUN, not just -fsyntax-only. The static_assert forces
+# compile-time reflection evaluation; the RUN proves the emitted binary
+# executes. clang-p2996's -stdlib=libc++ binary needs libc++.so.1, which is off
+# the default loader path, so bake an rpath at the discovered in-image libc++
+# dir (link-flag-only — no Dockerfile change, no cold rebuild). A p2996 libc++
+# binary runs under Rosetta/QEMU (verified #141), so no emulation gate needed.
+p2996_libcxx_so="$(find /opt/clang-p2996/lib -name 'libc++.so.1' 2>/dev/null | head -n1)"
+[ -n "${p2996_libcxx_so}" ] || { echo "  FAIL: clang-p2996 libc++.so.1 not found in image" >&2; exit 1; }
+p2996_libcxx_dir="$(dirname "${p2996_libcxx_so}")"
 rd="$(mktemp -d)"
 cat >"${rd}/refl.cpp" <<'CPP'
 #include <meta>
+#include <iostream>
 enum class Color { Red, Green, Blue };
 consteval int count_enumerators() {
   return static_cast<int>(enumerators_of(^^Color).size());
 }
 static_assert(count_enumerators() == 3);
-int main() { return 0; }
+int main() {
+  int n = count_enumerators();
+  std::cout << "reflection enumerators=" << n << std::endl;
+  return n == 3 ? 0 : 1;
+}
 CPP
-/opt/gcc-latest/bin/g++ -std=c++26 -freflection "${rd}/refl.cpp" -fsyntax-only || { echo "  FAIL: gcc-latest reflection compile failed" >&2; exit 1; }
-/opt/clang-p2996/bin/clang++ -std=c++2c -freflection -freflection-latest -fexpansion-statements -stdlib=libc++ "${rd}/refl.cpp" -fsyntax-only || { echo "  FAIL: clang-p2996 reflection compile failed" >&2; exit 1; }
+/opt/gcc-latest/bin/g++ -std=c++26 -freflection "${rd}/refl.cpp" -o "${rd}/refl-gcc" || { echo "  FAIL: gcc-latest reflection link failed" >&2; exit 1; }
+"${rd}/refl-gcc" || { echo "  FAIL: gcc-latest reflection binary did not run to return 0" >&2; exit 1; }
+/opt/clang-p2996/bin/clang++ -std=c++2c -freflection -freflection-latest -fexpansion-statements -stdlib=libc++ -Wl,-rpath,"${p2996_libcxx_dir}" "${rd}/refl.cpp" -o "${rd}/refl-clang" || { echo "  FAIL: clang-p2996 reflection link failed" >&2; exit 1; }
+"${rd}/refl-clang" || { echo "  FAIL: clang-p2996 reflection binary did not run to return 0" >&2; exit 1; }
 rm -rf "${rd}"
-echo "  OK: both reflection compilers compile a std::meta program"
+echo "  OK: both reflection compilers link + run a std::meta program"
 
 echo "[tier3] home volume ownership + seed survivors"
 # v6 single-home-volume contract: the whole /home/${USER} dir is a

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -23,7 +23,7 @@ Docker image smoke outputs.
 | `infra/foundation.bats` | Bats | Bash-level foundation checks (shell script integration) |
 | `infra/runtimes.bats` | Bats | Runtime installation checks (bash) |
 
-Total: **101 pytest tests** (pytest runs all `test_*.py` files) plus Bats
+Total: **171 pytest tests** (pytest runs all `test_*.py` files) plus Bats
 scenarios under `infra/`.
 
 ## Running tests

--- a/tests/test_image_smoke.py
+++ b/tests/test_image_smoke.py
@@ -85,17 +85,45 @@ def test_smoke_script_injects_p2996_ref_and_strict_match() -> None:
     assert "bloomberg/clang-p2996" in script
 
 
-def test_smoke_script_p2996_reflection_is_evaluated_at_compile_time() -> None:
-    """The reflection check forces compile-time evaluation via static_assert."""
+def test_smoke_script_p2996_reflection_links_and_runs() -> None:
+    """Gap C (#141): reflection is compiled AND the emitted binary is run."""
     script = build_smoke_script(_FAKE_P2996_SHA)
 
-    # static_assert forces enumerators_of(^^Color) to be evaluated, so a
-    # broken reflection front-end fails the -fsyntax-only compile.
+    # static_assert still forces enumerators_of(^^Color) to be evaluated at
+    # compile time, so a broken reflection front-end fails the build...
     assert "static_assert(count_enumerators() == 3);" in script
     assert "enumerators_of(^^Color)" in script
-    # Both reflection compilers are exercised.
+    # ...and both reflection compilers now link (-o) + RUN their binary,
+    # replacing the old -fsyntax-only-only smoke entirely.
+    assert "-fsyntax-only" not in script
     assert "/opt/gcc-latest/bin/g++" in script
+    assert "-o /tmp/refl-gcc" in script
+    assert "/tmp/refl-gcc ||" in script
     assert "/opt/clang-p2996/bin/clang++" in script
+    assert "-o /tmp/refl-clang" in script
+    assert "/tmp/refl-clang ||" in script
+
+
+def test_smoke_script_p2996_reflection_rpath_discovers_libcxx() -> None:
+    """Gap C (#141): clang-p2996 links with an rpath at the discovered libc++."""
+    script = build_smoke_script(_FAKE_P2996_SHA)
+
+    # The libc++ dir is discovered at runtime (not hard-coded) so a triple
+    # rename can't silently break the rpath, then baked into the binary.
+    assert "find /opt/clang-p2996/lib -name 'libc++.so.1'" in script
+    assert '-Wl,-rpath,"$P2996_LIBCXX_DIR"' in script
+
+
+def test_smoke_script_p2996_reflection_runs_even_under_emulation() -> None:
+    """Gap C (#141): the reflection RUN is not emulation-gated.
+
+    Unlike TSan (gap B), a clang-p2996 -stdlib=libc++ binary runs fine under
+    Rosetta/QEMU, so the RUN must fire even when ``emulated=True``.
+    """
+    script = build_smoke_script(_FAKE_P2996_SHA, emulated=True)
+
+    assert "/tmp/refl-clang ||" in script
+    assert "/tmp/refl-gcc ||" in script
 
 
 def test_smoke_script_non_sha_ref_skips_strict_match() -> None:


### PR DESCRIPTION
## Summary

Closes #141. clang-p2996's `-stdlib=libc++` reflection binaries failed at runtime with `libc++.so.1: cannot open shared object file` — the libc++ runtime lives at `/opt/clang-p2996/lib/x86_64-unknown-linux-gnu/`, off the default dynamic-loader path. Smoke could therefore only validate reflection at **compile time** (`-fsyntax-only`); it could not prove a reflection program **runs**.

## Fix

Smoke now **discovers** the in-image libc++ dir (`find /opt/clang-p2996/lib -name libc++.so.1` — not hard-coded, so a triple rename can't silently break the rpath), links with `-Wl,-rpath,<dir>`, and **runs** the emitted binary (returns nonzero on a wrong reflection result). The `static_assert` still guards compile-time reflection; the RUN + `std::cout` proves the binary loads libc++ and executes to `return 0`. Applied to **both** reflection compilers (gcc-latest + clang-p2996) in:

- `python/src/dotfiles_setup/image.py::build_smoke_script`
- `scripts/devcontainer-smoke.sh` tier 3

**Link-flag-only change — no Dockerfile change, hence no ~2.5h cold base rebuild.** `ldconfig`/`LD_LIBRARY_PATH` alternatives were rejected as global side-effects on every process.

## Key finding

A p2996 `-stdlib=libc++` binary **runs under Rosetta/QEMU** (verified against the live `:dev` image — printed `enumerators=3`, exit 0 in the emulated container). So unlike TSan (gap B), the reflection RUN needs **no `_is_emulated` gate**.

## Validation

- Reflection section runs both binaries to exit 0 against the live `:dev` image
- `mise run lint` rc=0 (0 failures)
- 171 pytest pass (+2 net; replaced the compile-time-only test with link+run, rpath-discovery, and emulation-independence tests)
- `dotfiles-setup verify run` — 71 passed, 0 failed
- ruff clean; pre-commit hook passed on commit

## Notes

- Also synced stale pytest counts (169/65 → 171) across AGENTS/README/tests docs, the devcontainer-workflow skill, and the smoke header.

## Acceptance (from #141)

- [x] A reflection program compiled with clang-p2996 `-stdlib=libc++` links and **runs** to `return 0`
- [x] Smoke exercises a runtime reflection assertion (not just `-fsyntax-only`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated smoke checks and test expectations to match the current test suite size.
  * Improved reflection validation so the checks now verify real runtime execution, including proper loading of required libraries.

* **Documentation**
  * Refreshed setup and testing instructions to show the current total of 171 tests.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->