### PR TITLE
fix(deps): bump pydantic-settings 2.13.1 → 2.14.2 (GHSA-4xgf-cpjx-pc3j)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,7 +5,7 @@ description = "Python orchestration library for dotfiles setup"
 requires-python = ">=3.14"
 dependencies = [
     "pydantic>=2.12.5",
-    "pydantic-settings>=2.13.1",
+    "pydantic-settings>=2.14.2",
 ]
 
 [project.scripts]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -39,7 +39,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5" },
-    { name = "pydantic-settings", specifier = ">=2.13.1" },
+    { name = "pydantic-settings", specifier = ">=2.14.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -132,16 +132,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.13.1"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Resolves Dependabot alert #2 (moderate). `pydantic-settings` `>=2.12.0,<2.14.2` has [GHSA-4xgf-cpjx-pc3j](https://github.com/advisories/GHSA-4xgf-cpjx-pc3j): `NestedSecretsSettingsSource` follows symlinks outside `secrets_dir`, enabling local file read and bypassing `secrets_dir_max_size`. Patched in **2.14.2**.

## Impact assessment

**Not exploitable in this codebase.** `DotfilesConfig`, `MiseConfig`, and `ContainerConfig` (`python/src/dotfiles_setup/config.py`) use `BaseSettings` with `env_prefix` only — no `secrets_dir`, no file-based secrets source, no `NestedSecretsSettingsSource`. Bumping regardless to clear the alert and keep the lock on a patched release.

## Changes

- `python/pyproject.toml`: constraint `>=2.13.1` → `>=2.14.2`
- `python/uv.lock`: regenerated — **only** `pydantic-settings 2.13.1 → 2.14.2` moved; no other packages changed

## Validation

- 169 pytest pass
- `dotfiles-setup verify run` — 71 passed, 0 failed
- `mise run lint` rc=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)