### PR TITLE
chore(rules): enforce verify-all-checks-green before advancing

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -41,7 +41,7 @@ If verification fails, keep iterating.
 Broad requests: explore first, then plan. 2+ independent tasks in parallel. `run_in_background` for builds/tests.
 Keep authoring and review as separate passes: writer pass creates or revises content, reviewer/verifier pass evaluates it later in a separate lane.
 Never self-approve in the same active context — instead, route the approval pass to `code-reviewer` or `verifier`.
-Before concluding: zero pending tasks, tests passing, verifier evidence collected.
+Before concluding OR advancing to the next task: zero pending tasks and EVERY applicable check green with evidence — local gates (lint, pytest, verify) plus PR checks and post-merge `main` CI where relevant. Verify from the real artifact (file `rc` / API `conclusion`), never a piped tail or a notification's exit code. See `.claude/rules/verify-before-advancing.md`.
 </execution_protocols>
 
 <hooks_and_context>

--- a/.claude/rules/do-not.md
+++ b/.claude/rules/do-not.md
@@ -43,6 +43,7 @@ self-contained block). Each item's context is preserved verbatim.
 ## See also
 
 - `zero-skip-policy.md` — no warning/error shall be dismissed
+- `verify-before-advancing.md` — every applicable check green before the next task
 - `ci-local-parity.md` — keep local checks in sync with CI
 - `clean-git-state.md` — stage all changes before validation
 - `use-tool-builtins.md` — prefer tool builtins over homegrown logic

--- a/.claude/rules/verify-before-advancing.md
+++ b/.claude/rules/verify-before-advancing.md
@@ -1,0 +1,77 @@
+# Verify Before Advancing: All Applicable Checks Green First
+
+Before moving to the next task, committing, opening or merging a PR, or
+claiming a task is "done", you MUST run **every check applicable to what
+changed** and confirm each is **green with evidence**. Not a subset. Not
+"should pass". Not an assumed outcome. Not a piped/notified exit code.
+
+"Done" means *verified* done — the checks actually ran and actually
+passed, and you read the real result.
+
+## Why this rule exists
+
+Repeatedly, the expensive failure mode is declaring a step complete on an
+*assumption*: "the warm path will skip the build", "that's a trivial
+edit", "lint should be fine". The assumption is sometimes wrong, and the
+gap is discovered a task later when it is costly to unwind. This rule
+makes verification a hard gate between every unit of work, not an
+optional courtesy. It is the operational teeth behind
+[[zero-skip-policy]] and CLAUDE.md → `AGENTS.md` "Local validation
+first".
+
+## The check matrix — run what applies to the change
+
+**Always (any code/config/docs change):**
+
+- `mise run lint` — must print `rc=0` / exit 0 (hk under the timeout
+  wrapper; never raw `hk` — see `long-running-command-hangs.md`).
+- `uv run --project python pytest tests/ -x -q` — all tests pass.
+- `dotfiles-setup verify run` — `0 failed`.
+
+**Conditional (only when that surface changed):**
+
+| Changed | Also required |
+|---|---|
+| `.github/**` (workflows/actions) | `mise run pin-actions` |
+| `AGENTS.md` / `CLAUDE.md` / `.claude/**/*.md` | `mise run lint-docs` (agnix) **and** the ≤200-line / ≤12000-char limit holds (`claude_md_size_limit`) |
+| `.devcontainer/**`, `mise-system.toml`, image/Dockerfile | `mise run verify-local` (R1/R2/R3 + persistence) or a direct `docker run <img> …` check; the in-image smoke can't fully run on this arm64 Mac (Rosetta) |
+| Opened a PR | `gh pr checks <n> --watch` until terminal — every check `pass` or `skipping`, **0 fail** |
+| Merged to `main` | Await the main `ci.yml` run and confirm `conclusion == success` (incl. `promote` retagging `:dev`) |
+
+Scale the matrix to the blast radius — a one-line doc typo needs the docs
+row, not `verify-local`; a Dockerfile change needs the image row.
+
+## Evidence discipline (trust the artifact, not the notification)
+
+- Read a **file-based `rc`** or the **API `conclusion` field**, never a
+  piped `… | tail` (bash returns tail's exit 0, masking upstream
+  failure) and never a background-task "completed" notification's exit
+  code. See `pipe-kills-exit-code.md`, and issue #142.
+- `gh run watch --exit-status` has reported 0 prematurely — cross-verify
+  with `gh run view <id> --json conclusion --jq .conclusion`. See
+  `gh-cli-watch.md` and `feedback_gh_run_watch`.
+- A "skipped" job is a *valid terminal state* (e.g. warm-path
+  build-publish), but confirm it skipped for the expected reason — do
+  not confuse "skipped because unchanged" with "silently not run".
+
+## The gate
+
+Only after every applicable check above is green do you: commit, push,
+merge, start the next task, or report completion. If any check is red,
+that is the current task — investigate and resolve it ([[zero-skip-policy]]),
+do not defer past it.
+
+## Applies to
+
+Every task in this repo — local edits, PRs, merges, multi-step work, and
+agent-delegated work (the delegating context is responsible for
+confirming the delegate's checks actually passed).
+
+## See also
+
+- `zero-skip-policy.md` — no red check is ever dismissed.
+- `long-running-command-hangs.md` — bound `mise run lint`; never wait blind.
+- `pipe-kills-exit-code.md` context in `feedback_pipe_kills_exit_code` — read the rc, not a piped tail.
+- `gh-cli-watch.md` — use `--watch`; cross-verify `gh run watch`.
+- `do-not.md` — project invariants that never bend regardless of green checks.
+- CLAUDE.md → `AGENTS.md` "Validate before committing".

--- a/.claude/rules/zero-skip-policy.md
+++ b/.claude/rules/zero-skip-policy.md
@@ -59,3 +59,9 @@ Before ANY git commit, you MUST run local validation:
 
 All tools in the project: ruff, ty, pytest, hadolint, hk, docker build,
 GitHub Actions, actionlint, pinact, agnix, and any future additions.
+
+## See also
+
+- `verify-before-advancing.md` — the sibling gate: every applicable check
+  must be green *with evidence* before advancing to the next task,
+  committing, opening/merging a PR, or claiming done.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,8 +145,8 @@ uv run --project python pytest tests/ -x -q   # All tests pass — then proceed
 dotfiles-setup verify run                     # Verification contracts pass — then proceed
 ```
 
-Commit only after all three exit 0. Run local validation instead of
-pushing to test in CI.
+Commit only after all three exit 0 — validate locally, don't push to test in CI.
+Before advancing to the next task or claiming done, EVERY applicable check must be green with evidence: `.claude/rules/verify-before-advancing.md`.
 
 ### Tool management
 


### PR DESCRIPTION
## Summary

Codifies a hard verification gate between every unit of work: **before moving to the next task, committing, opening/merging a PR, or claiming done, run every check applicable to what changed and confirm each green *with evidence*** — not a subset, not an assumption ("warm path will skip", "trivial edit"), not a piped/notified exit code.

## Changes

- **`.claude/rules/verify-before-advancing.md`** (new, authoritative) — the check matrix (always: `mise run lint` / pytest / `verify run`; conditional: `pin-actions`, `lint-docs`, `verify-local`, `gh pr checks --watch`, main `ci.yml` `conclusion`) plus evidence discipline (read the file `rc` / API `conclusion`; cross-verify `gh run watch`).
- **`AGENTS.md`** "Validate before committing" — adds the before-advancing gate + pointer. Unchanged line count; stays within the 200-line / 12000-char `claude_md_size_limit`.
- **`.claude/CLAUDE.md`** `<execution_protocols>` — strengthens "before concluding" → "before concluding **OR advancing**" with the evidence rule.
- **`do-not.md`** + **`zero-skip-policy.md`** — cross-link the new sibling rule.

## Validation (dogfooding the rule)

- `mise run lint` rc=0
- `mise run lint-docs` (agnix) — 0 errors, 0 warnings
- 171 pytest pass · `dotfiles-setup verify run` 71/0
- `AGENTS.md` 200 lines / 11241 chars (within limit)

Docs/rules only — no runtime code; expect the warm path (build-publish skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)