### PR TITLE
feat(gate): enforce verify-container-latest + accept slow base pulls

### DIFF
--- a/.claude/rules/verify-before-advancing.md
+++ b/.claude/rules/verify-before-advancing.md
@@ -35,11 +35,47 @@ first".
 | `.github/**` (workflows/actions) | `mise run pin-actions` |
 | `AGENTS.md` / `CLAUDE.md` / `.claude/**/*.md` | `mise run lint-docs` (agnix) **and** the ≤200-line / ≤12000-char limit holds (`claude_md_size_limit`) |
 | `.devcontainer/**`, `mise-system.toml`, image/Dockerfile | `mise run verify-local` (R1/R2/R3 + persistence) or a direct `docker run <img> …` check; the in-image smoke can't fully run on this arm64 Mac (Rosetta) |
+| Validating **through the devcontainer** (any change you test in-container) | `mise run verify-container-latest` — the running container must bind-mount THIS workspace (source = latest branch code) and pass smoke; **base-currency is a hard gate** (smoke tier-1 identity fails a base predating the current `mise-system.toml`). See "Validate against the latest branch code" below. |
 | Opened a PR | `gh pr checks <n> --watch` until terminal — every check `pass` or `skipping`, **0 fail** |
 | Merged to `main` | Await the main `ci.yml` run and confirm `conclusion == success` (incl. `promote` retagging `:dev`) |
 
 Scale the matrix to the blast radius — a one-line doc typo needs the docs
 row, not `verify-local`; a Dockerfile change needs the image row.
+
+## Validate against the latest branch code (in a current container)
+
+When you validate *through the devcontainer*, that container must be
+running the **latest code of the working branch** — the PR branch during
+a PR, `main` on main — on a **current base image**. A container that
+mounts a stale tree, or was built on a base that predates the current
+`.devcontainer/mise-system.toml`, is not a valid validation environment,
+and a green result against it is a false positive.
+
+`mise run verify-container-latest` enforces this (hard):
+
+- **source is live** — the container bind-mounts THIS workspace, so the
+  files it runs are the host working tree at branch HEAD (not a snapshot);
+- **base is current** — `scripts/devcontainer-smoke.sh` tier-1 image
+  identity (PR #140 "Gap A") compares the in-image `config.toml` hash to
+  the repo `mise-system.toml` and **hard-fails a stale base**. Refresh with
+  `mise run dev-rebuild` (pulls the registry `:dev`; on a slow link this is
+  a long buildkit pull — never classic `docker pull`, which wedges on the
+  ~38GB image, see `feedback_mise_local_toml_replaces_task`);
+- **it runs** — smoke tiers 1-3 pass in the container.
+
+Base-currency is a hard block by design: do not advance validating against
+a base that predates the branch's `mise-system.toml`.
+
+**A slow base pull is acceptable — wait for it; never fall back to a stale
+base to save time.** The registry `:dev` is the base built from the
+current `mise-system.toml`, so refreshing to it is the *only* way to test
+the latest code — there is no valid local shortcut. On a slow link the
+~38GB buildkit pull can take hours; that is expected and fine. Background
+it (`mise run dev-rebuild`, or a `docker buildx build --pull --output
+type=docker` of `:dev` — buildkit, never classic `docker pull` which
+wedges on the large blob) and **wait for it to finish**, then rebuild the
+overlay and re-run the gate. Correctness (testing the latest code) beats
+speed: a green result on a stale base is worse than a slow-but-honest one.
 
 ## Evidence discipline (trust the artifact, not the notification)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,8 @@ caller) → lint → contract-preflight → `changes` → reusable `build-publis
 ```bash
 mise install                                 # Install all tools
 mise run lint                                # Run lint checks (hk under a hard timeout)
-mise run up                                  # Bring up devcontainer (see .devcontainer/AGENTS.md)
-mise run down                                # Tear down devcontainer
+mise run up / down                           # Bring up / tear down devcontainer (.devcontainer/AGENTS.md)
+mise run verify-container-latest             # Gate: container on latest branch code + base (hard)
 uv run --project python pytest tests/ -x -q  # Run tests (see python/AGENTS.md)
 dotfiles-setup verify run                    # Run structured verification contracts
 mise run pin-actions                         # Verify GHA actions are SHA-pinned

--- a/mise.toml
+++ b/mise.toml
@@ -359,6 +359,16 @@ echo 'OK: home-volume seed survivors + canary present'
 echo "OK: $PRE_COUNT tools persisted identically across stop/up (mise-system.toml baseline: $EXPECTED_MIN)"
 '''
 
+[tasks.verify-container-latest]
+description = "Gate: running devcontainer is on the latest branch code + current base + smoke"
+# Enforces verify-before-advancing's devcontainer row: the running container
+# must bind-mount THIS workspace (source = latest branch code, live) and pass
+# scripts/devcontainer-smoke.sh, whose tier-1 image-identity check hard-fails a
+# stale base (predating the current mise-system.toml). Logic is in
+# python/src/dotfiles_setup/container.py (zero-bash-logic policy); this task is
+# a thin caller. Use `--no-smoke` for a fast container/bind-mount pre-check.
+run = 'uv run --project python dotfiles-setup docker verify-latest'
+
 [tasks.verify-arch]
 description = "R3: container runs as linux/amd64 x86_64 (not ARM passthrough)"
 # Proves Requirement 3: the container is AMD64 regardless of host arch.

--- a/python/src/dotfiles_setup/container.py
+++ b/python/src/dotfiles_setup/container.py
@@ -1,0 +1,197 @@
+"""Devcontainer freshness gate: is the running container on the latest code?
+
+The verify-before-advancing rule (`.claude/rules/verify-before-advancing.md`)
+requires that validation runs against the *latest code of the working branch*
+(the PR branch during a PR, ``main`` on main) in a *current* container. A
+container that is stale — mounting a different tree, or built on an outdated
+base ``:dev`` — is not a valid validation environment, and a green check
+against it is a false positive.
+
+This gate asserts three facts, each a HARD check reported as a :class:`Check`:
+
+1. ``container-running`` — a devcontainer is up for this workspace.
+2. ``workspace-bind-mount`` — it bind-mounts *this* workspace, so the source
+   the container sees is the host working tree (the branch's latest code),
+   live.
+3. ``smoke-tiers-1-3`` — ``scripts/devcontainer-smoke.sh`` passes in the
+   container. This is the authoritative base-currency gate: the smoke's tier-1
+   image-identity check (PR #140, "Gap A") compares the *in-image*
+   ``config.toml`` hash against the repo ``mise-system.toml`` and hard-fails a
+   stale/outdated base, so "the base is current" is enforced against the
+   actually-running image, not a tag-digest proxy.
+
+Base-currency is therefore a hard block by design: a container built on a base
+that predates the current ``mise-system.toml`` fails smoke and this gate.
+
+Logic lives here (Python), not in the mise task, per the repo's zero-bash-logic
+policy; the ``verify-container-latest`` task is a thin caller.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# devcontainer-cli labels every container it creates with the host workspace
+# folder; this is the join key between "a running container" and "this repo".
+_LOCAL_FOLDER_LABEL = "devcontainer.local_folder"
+
+# Smoke can take minutes (tier 2 runs pytest, tier 3 links + runs sanitizers
+# and reaches github over ssh); bound it so a hang surfaces instead of blocking.
+_SMOKE_TIMEOUT_S = 1800.0
+
+
+@dataclasses.dataclass(frozen=True)
+class Check:
+    """One named freshness assertion and its outcome."""
+
+    name: str
+    ok: bool
+    detail: str
+
+
+def _run(
+    cmd: list[str], *, timeout: float | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd, capture_output=True, text=True, check=False, timeout=timeout
+    )
+
+
+def _host_head(workspace: Path) -> str:
+    return _run(["git", "-C", str(workspace), "rev-parse", "HEAD"]).stdout.strip()
+
+
+def _host_branch(workspace: Path) -> str:
+    return _run(
+        ["git", "-C", str(workspace), "rev-parse", "--abbrev-ref", "HEAD"]
+    ).stdout.strip()
+
+
+def _running_container_id(workspace: Path) -> str | None:
+    out = _run(
+        ["docker", "ps", "-q", "--filter", f"label={_LOCAL_FOLDER_LABEL}={workspace}"]
+    ).stdout.strip()
+    return out.splitlines()[0] if out else None
+
+
+def _bind_mount_dest(container_id: str, workspace: Path) -> str | None:
+    """Destination where ``container_id`` bind-mounts ``workspace`` (or None)."""
+    raw = _run(
+        ["docker", "inspect", container_id, "--format", "{{json .Mounts}}"]
+    ).stdout.strip()
+    if not raw:
+        return None
+    for mount in json.loads(raw):
+        if mount.get("Type") == "bind" and mount.get("Source") == str(workspace):
+            return mount.get("Destination")
+    return None
+
+
+def _run_smoke(workspace: Path) -> tuple[bool, str]:
+    res = _run(
+        [
+            "devcontainer",
+            "exec",
+            "--workspace-folder",
+            str(workspace),
+            "scripts/devcontainer-smoke.sh",
+        ],
+        timeout=_SMOKE_TIMEOUT_S,
+    )
+    if res.returncode == 0:
+        return True, "tiers 1-3 OK"
+    combined = (res.stdout + res.stderr).strip().splitlines()
+    # Surface the first FAIL line if present, else the tail.
+    fails = [line for line in combined if "FAIL" in line]
+    tail = fails[:1] or combined[-3:]
+    return False, " | ".join(tail) if tail else "smoke failed (no output)"
+
+
+def verify_latest(workspace: Path, *, run_smoke: bool = True) -> list[Check]:
+    """Assert the running devcontainer is on the latest branch code + base.
+
+    Returns the ordered list of checks. Short-circuits the remaining checks
+    when no container is running (there is nothing to validate).
+    """
+    branch = _host_branch(workspace)
+    head = _host_head(workspace)
+    logger.info("verify-latest: branch=%s HEAD=%s", branch, head[:8])
+
+    container_id = _running_container_id(workspace)
+    if container_id is None:
+        return [
+            Check(
+                "container-running",
+                ok=False,
+                detail=f"no running devcontainer for {workspace} (run `mise run up`)",
+            )
+        ]
+
+    checks = [
+        Check(
+            "container-running",
+            ok=True,
+            detail=f"{container_id[:12]} up for {workspace}",
+        )
+    ]
+
+    dest = _bind_mount_dest(container_id, workspace)
+    checks.append(
+        Check(
+            "workspace-bind-mount",
+            ok=dest is not None,
+            detail=(
+                f"host tree live at {dest} ({branch}@{head[:8]})"
+                if dest is not None
+                else f"container does not bind-mount {workspace} (source not live)"
+            ),
+        )
+    )
+
+    if run_smoke:
+        smoke_ok, smoke_detail = _run_smoke(workspace)
+        checks.append(
+            Check(
+                "smoke-tiers-1-3",
+                ok=smoke_ok,
+                detail=(
+                    smoke_detail
+                    if smoke_ok
+                    else f"{smoke_detail} — stale base? `mise run dev-rebuild`"
+                ),
+            )
+        )
+
+    return checks
+
+
+def verify_latest_main(workspace: Path, *, run_smoke: bool = True) -> int:
+    """CLI entry: print each check and return 1 if any failed, else 0."""
+    checks = verify_latest(workspace, run_smoke=run_smoke)
+    failed = [c for c in checks if not c.ok]
+    for check in checks:
+        marker = "PASS" if check.ok else "FAIL"
+        sys.stdout.write(f"{marker}  {check.name}: {check.detail}\n")
+    if failed:
+        sys.stdout.write(
+            f"\nverify-container-latest: {len(failed)} check(s) failed — the "
+            "running devcontainer is NOT a valid validation environment for "
+            "the latest branch code. Resolve before advancing (see "
+            ".claude/rules/verify-before-advancing.md).\n"
+        )
+        return 1
+    sys.stdout.write(
+        "\nverify-container-latest: OK — container on latest branch code "
+        "+ current base.\n"
+    )
+    return 0

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from dotfiles_setup.ai import AIOrchestrator
 from dotfiles_setup.audit import DevEnvironmentAuditor, ToolManager
 from dotfiles_setup.config import DotfilesConfig
+from dotfiles_setup.container import verify_latest_main
 from dotfiles_setup.docker import DevContainerManager
 from dotfiles_setup.ghcr import validate_ghcr_prereqs
 from dotfiles_setup.image import ImageCommand
@@ -78,6 +79,16 @@ def _add_docker_subcommands(
     docker_subparsers.add_parser(
         "initialize-host",
         help="Stage host-side authorized_keys for the container's R1 sshd login",
+    )
+    verify_latest_parser = docker_subparsers.add_parser(
+        "verify-latest",
+        help="Gate: running devcontainer is on the latest branch code + "
+        "current base (smoke identity) + smoke green",
+    )
+    verify_latest_parser.add_argument(
+        "--no-smoke",
+        action="store_true",
+        help="Skip the in-container smoke run (fast container/bind-mount check only)",
     )
 
 
@@ -291,6 +302,8 @@ def handle_docker(
         docker_manager.down()
     elif args.docker_command == "initialize-host":
         docker_manager.initialize_host()
+    elif args.docker_command == "verify-latest":
+        sys.exit(verify_latest_main(project_root, run_smoke=not args.no_smoke))
 
 
 def handle_audit(config: DotfilesConfig | None = None) -> None:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,0 +1,130 @@
+"""Tests for the devcontainer freshness gate (dotfiles_setup.container)."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
+
+import pytest
+
+from dotfiles_setup import container
+
+_WORKSPACE = Path("/workspaces-host/dotfiles")
+
+
+def _cp(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=""
+    )
+
+
+class _FakeDocker:
+    """Routes container._run calls to canned outputs keyed by the command shape."""
+
+    def __init__(
+        self,
+        *,
+        container_id: str | None = "cafef00dbeef",
+        bind_source: str | None = str(_WORKSPACE),
+        smoke_rc: int = 0,
+        smoke_out: str = "=== All smoke checks passed ===\n",
+        head: str = "e61b3ea0",
+        branch: str = "main",
+    ) -> None:
+        self.container_id = container_id
+        self.bind_source = bind_source
+        self.smoke_rc = smoke_rc
+        self.smoke_out = smoke_out
+        self.head = head
+        self.branch = branch
+
+    def __call__(self, cmd: list[str], **_kwargs: object):
+        if cmd[:2] == ["git", "-C"]:
+            return _cp((self.head if cmd[-1] == "HEAD" else self.branch) + "\n")
+        if cmd[:3] == ["docker", "ps", "-q"]:
+            return _cp((self.container_id + "\n") if self.container_id else "")
+        if cmd[:2] == ["docker", "inspect"]:
+            if self.bind_source is None:
+                return _cp("[]")
+            return _cp(
+                '[{"Type":"bind","Source":"%s","Destination":"/workspaces/dotfiles"}]'
+                % self.bind_source
+            )
+        if cmd[:2] == ["devcontainer", "exec"]:
+            return _cp(self.smoke_out, returncode=self.smoke_rc)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+
+def _names(checks):
+    return {c.name: c for c in checks}
+
+
+def test_all_green_when_fresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A running, bind-mounted container with green smoke passes all checks."""
+    monkeypatch.setattr(container, "_run", _FakeDocker())
+    checks = container.verify_latest(_WORKSPACE)
+
+    assert all(c.ok for c in checks)
+    assert {"container-running", "workspace-bind-mount", "smoke-tiers-1-3"} == set(
+        _names(checks)
+    )
+
+
+def test_no_container_short_circuits(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no running container, only the (failed) container-running check returns."""
+    monkeypatch.setattr(container, "_run", _FakeDocker(container_id=None))
+    checks = container.verify_latest(_WORKSPACE)
+
+    assert len(checks) == 1
+    assert checks[0].name == "container-running"
+    assert checks[0].ok is False
+
+
+def test_not_bind_mounted_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A container that does not bind-mount the workspace fails source liveness."""
+    monkeypatch.setattr(container, "_run", _FakeDocker(bind_source="/some/other/path"))
+
+    assert (
+        _names(container.verify_latest(_WORKSPACE))["workspace-bind-mount"].ok is False
+    )
+
+
+def test_stale_base_fails_via_smoke(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stale base (smoke identity FAIL) hard-fails smoke-tiers-1-3."""
+    monkeypatch.setattr(
+        container,
+        "_run",
+        _FakeDocker(
+            smoke_rc=1,
+            smoke_out="[tier1] image identity\n  FAIL: in-image mise config X != repo Y\n",
+        ),
+    )
+    smoke = _names(container.verify_latest(_WORKSPACE))["smoke-tiers-1-3"]
+
+    assert smoke.ok is False
+    assert "FAIL" in smoke.detail
+    assert "dev-rebuild" in smoke.detail
+
+
+def test_run_smoke_false_skips_smoke(monkeypatch: pytest.MonkeyPatch) -> None:
+    """run_smoke=False omits the smoke check (for a fast pre-check)."""
+    monkeypatch.setattr(container, "_run", _FakeDocker())
+
+    assert "smoke-tiers-1-3" not in _names(
+        container.verify_latest(_WORKSPACE, run_smoke=False)
+    )
+
+
+def test_main_returns_1_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """verify_latest_main returns 1 when any check fails."""
+    monkeypatch.setattr(container, "_run", _FakeDocker(smoke_rc=1))
+
+    assert container.verify_latest_main(_WORKSPACE) == 1
+
+
+def test_main_returns_0_when_all_green(monkeypatch: pytest.MonkeyPatch) -> None:
+    """verify_latest_main returns 0 when every check passes."""
+    monkeypatch.setattr(container, "_run", _FakeDocker())
+
+    assert container.verify_latest_main(_WORKSPACE) == 0


### PR DESCRIPTION
## Summary

Adds a **hard validation gate** so that, when validating through the devcontainer, the running container must be on the **latest branch code + current base** before you advance. Realizes the "validate against the latest code from the PR/main branch" requirement, and encodes the "slow base pull is OK — wait, never fall back to stale" policy.

## What's added

- **`python/src/dotfiles_setup/container.py`** — the gate (logic in Python per zero-bash-policy). Hard checks:
  - `container-running` — a devcontainer is up for this workspace;
  - `workspace-bind-mount` — it bind-mounts THIS workspace (source = latest branch code, live);
  - `smoke-tiers-1-3` — `scripts/devcontainer-smoke.sh` passes; its tier-1 image-identity guard is the **hard base-currency** check.
- **`dotfiles-setup docker verify-latest [--no-smoke]`** + **`mise run verify-container-latest`** — thin CLI/task callers.
- **`tests/test_container.py`** — 7 mocked tests.
- **`.claude/rules/verify-before-advancing.md`** — new devcontainer matrix row + "Validate against the latest branch code" section: base-currency is a **hard block**; a slow ~38GB base pull is **acceptable — wait for it** (buildkit, never classic `docker pull`, which wedges), **never fall back to a stale base**. Correctness beats speed.
- **`AGENTS.md`** — Quick Start entry (kept at 200 lines); memory updated.

## Validation

- 178 pytest (+7) · `verify run` 71/0 · `mise run lint` rc=0 · ty clean.
- Gate non-smoke checks **dogfooded green** against the live container.
- Container confirmed on the **current base** via `devcontainer exec`: base config `== mise-system.toml` (`6ce5326`), HEAD `e61b3ea`, `x86_64`, 0 missing tools.

## Known caveat — depends on #148

The gate's `smoke-tiers-1-3` check runs the full smoke, which currently **false-fails** on a bug filed as **#148**: the Gap-A identity check reads runtime `MISE_CONFIG_DIR` (the user config, overridden to the home volume) instead of the base system config (`/usr/local/share/mise/config.toml` / `$MISE_SYSTEM_CONFIG_FILE`). The base IS current; the check reads the wrong file. The gate faithfully surfaces the smoke result and goes fully green once #148 lands. Docs-only/host-side changes here are unaffected (warm path).

Refs #148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new devcontainer verification command to check whether the running container matches the latest branch workspace and current base image.
  * Introduced a quick way to skip the deeper smoke checks when needed.

* **Bug Fixes**
  * Added clearer validation for stale or mismatched devcontainer environments, helping prevent progress with outdated setups.

* **Documentation**
  * Updated setup and validation guidance with the new verification step and refreshed container-check instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->