### PR TITLE
fix(smoke): #148 identity check reads base system config, not runtime MISE_CONFIG_DIR

### DIFF
--- a/python/src/dotfiles_setup/image.py
+++ b/python/src/dotfiles_setup/image.py
@@ -134,7 +134,11 @@ def build_smoke_script(
     return (
         header
         + """\
-MISE_CFG="${MISE_CONFIG_DIR:-/usr/local/share/mise}/config.toml"
+# #148: the base SYSTEM config ($MISE_SYSTEM_CONFIG_FILE = the Dockerfile COPY
+# target /usr/local/share/mise/config.toml), NOT ${MISE_CONFIG_DIR}/config.toml
+# — MISE_CONFIG_DIR is overridden at runtime to the user config dir, a
+# different (chezmoi-rendered) file that false-fails identity on a current base.
+MISE_CFG="${MISE_SYSTEM_CONFIG_FILE:-/usr/local/share/mise/config.toml}"
 echo "=== image identity (mise-system config hash) ==="
 if [ -n "$EXPECTED_CONFIG_SHA256" ]; then
   actual_config_sha256=$(sha256sum "$MISE_CFG" | cut -d' ' -f1)

--- a/scripts/devcontainer-smoke.sh
+++ b/scripts/devcontainer-smoke.sh
@@ -20,12 +20,17 @@ WORKSPACE_FOLDER="${WORKSPACE_FOLDER:-/workspaces/$(basename "$PWD")}"
 echo "::group::Tier 1 — tools + hk"
 echo "[tier1] image identity — mise-system config hash"
 # Gap A (image identity): the Dockerfile COPYs .devcontainer/mise-system.toml
-# verbatim to $MISE_CONFIG_DIR/config.toml. If the in-image hash differs from
-# the mounted repo file, this container is running a STALE/cached image (e.g.
-# devcontainer-cli reused a vsc-dotfiles-<hash> overlay) — rebuild before
-# trusting any downstream check. Fails loud rather than silently validating
-# old content.
-sys_cfg="${MISE_CONFIG_DIR:-/usr/local/share/mise}/config.toml"
+# verbatim to the base SYSTEM config /usr/local/share/mise/config.toml. If the
+# in-image hash differs from the mounted repo file, this container is running a
+# STALE/cached image (e.g. devcontainer-cli reused a vsc-dotfiles-<hash>
+# overlay) — rebuild before trusting any downstream check.
+#
+# #148: read $MISE_SYSTEM_CONFIG_FILE (the COPY target), NOT
+# ${MISE_CONFIG_DIR}/config.toml. MISE_CONFIG_DIR is deliberately overridden at
+# runtime (Dockerfile.host-user + devcontainer.json) to the USER config dir
+# /home/<user>/.config/mise, a chezmoi-rendered file in the persistent home
+# volume — a different file that false-fails this check on a current base.
+sys_cfg="${MISE_SYSTEM_CONFIG_FILE:-/usr/local/share/mise/config.toml}"
 repo_cfg="${WORKSPACE_FOLDER}/.devcontainer/mise-system.toml"
 if [ -f "$repo_cfg" ]; then
   expected_cfg_hash="$(sha256sum "$repo_cfg" | cut -d' ' -f1)"

--- a/tests/test_image_smoke.py
+++ b/tests/test_image_smoke.py
@@ -207,6 +207,23 @@ def test_smoke_script_injects_config_identity_check() -> None:
     assert '"$actual_config_sha256" != "$EXPECTED_CONFIG_SHA256"' in script
 
 
+def test_smoke_script_identity_reads_system_config_not_config_dir() -> None:
+    """#148: identity/policy checks hash the base SYSTEM config, not MISE_CONFIG_DIR.
+
+    MISE_CONFIG_DIR is overridden at runtime (Dockerfile.host-user +
+    devcontainer.json) to the user config dir, a chezmoi-rendered file that
+    would false-fail identity on a current base. The check must read
+    $MISE_SYSTEM_CONFIG_FILE (the Dockerfile COPY target).
+    """
+    script = build_smoke_script(_FAKE_P2996_SHA)
+
+    assert (
+        'MISE_CFG="${MISE_SYSTEM_CONFIG_FILE:-/usr/local/share/mise/config.toml}"'
+        in script
+    )
+    assert "MISE_CONFIG_DIR:-/usr/local/share/mise}/config.toml" not in script
+
+
 def test_smoke_script_config_identity_dormant_without_hash() -> None:
     """Without a hash the identity guard is present but dormant (empty var)."""
     script = build_smoke_script(_FAKE_P2996_SHA)


### PR DESCRIPTION
## Summary

Closes #148. The Gap-A image-identity check (PR #140) hashed `${MISE_CONFIG_DIR:-/usr/local/share/mise}/config.toml`. But `MISE_CONFIG_DIR` is **deliberately overridden at runtime** (`Dockerfile.host-user:74` + `devcontainer.json:154`) to the **user** config dir `/home/<user>/.config/mise` — a chezmoi-rendered file (`home/dot_config/mise/config.toml.tmpl`) in the persistent home volume, a *different file* from the base system config.

So in a real devcontainer the check read the wrong file and **false-failed "stale/cached image — rebuild" on a genuinely-current base**. That failure aborts `postCreateCommand`, skipping SSH setup + the rest of smoke. (It "passed" in CI because CI runs smoke where `MISE_CONFIG_DIR` still points at the base `/usr/local/share/mise`.)

## Fix

Read the base **system** config — the Dockerfile COPY target, exposed as `$MISE_SYSTEM_CONFIG_FILE` (`= /usr/local/share/mise/config.toml`, `Dockerfile:66`) — in both:
- `scripts/devcontainer-smoke.sh` (tier 1)
- `python/src/dotfiles_setup/image.py` (`build_smoke_script`)

## Validation (dogfooded in the live container)

- Identity check now **PASSES**: system `6ce5326` == repo `mise-system.toml` `6ce5326`.
- **Full `devcontainer-smoke.sh` passes tiers 1-3** end-to-end — including `github ssh full auth via /run/host-services/ssh-auth.sock` (R2) and home-volume seed survivors.
- 172 pytest (+1 regression test) · `verify run` 71/0 · `mise run lint` rc=0 · ty clean.

## Relation to #149

This unblocks the `verify-container-latest` gate (#149): its `smoke-tiers-1-3` hard check runs this exact script and now passes on a current base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)