### PR TITLE
docs: sync pytest count 171→179 + test_container.py (clear-prep)

### DIFF
--- a/.claude/skills/devcontainer-workflow/SKILL.md
+++ b/.claude/skills/devcontainer-workflow/SKILL.md
@@ -38,7 +38,7 @@ scripts/devcontainer-smoke.sh --include-up   # also runs `devcontainer up` first
 Tiers:
 
 - **Tier 1** — `mise ls`, `which clang++ python uv hk`, `hk run pre-commit --all`
-- **Tier 2** — `pytest 171/171`, `stat ~/.ssh ~/.claude /workspaces/dotfiles`
+- **Tier 2** — `pytest 179/179`, `stat ~/.ssh ~/.claude /workspaces/dotfiles`
 - **Tier 3** — `clang++ -fsanitize=address,undefined hello.cc && ./hello`
 
 Tier 4 (CLion remote toolchain) is manual.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ the official `@devcontainers/cli` (pinned in `mise.toml`).
 | `.claude/` | Claude-specific agents, skills, rules. Has its own `CLAUDE.md` with OMC orchestration |
 | `home/` | Chezmoi-managed dotfiles — see `home/AGENTS.md` |
 | `python/` | Python package `dotfiles_setup` — see `python/AGENTS.md` |
-| `tests/` | Pytest + Bats test suite (171 pytest tests) — see `tests/AGENTS.md` |
+| `tests/` | Pytest + Bats test suite (179 pytest tests) — see `tests/AGENTS.md` |
 | `scripts/` | Utility scripts (`benchmark-docker.sh`, `devcontainer-smoke.sh`) |
 | `docs/` | Documentation, research findings, design specs |
 
@@ -85,7 +85,7 @@ changes don't take effect.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q               # All 171 tests
+uv run --project python pytest tests/ -x -q               # All 179 tests
 uv run --project python pytest tests/test_audit.py -x -q  # Single file
 hk run pre-commit --all --stash none                      # Lint checks only
 dotfiles-setup verify run                                 # Verification contracts (suites.toml)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A highly resilient, declarative dotfiles setup using **Chezmoi**, **Mise**, and 
 ```bash
 mise install                                       # Install all tools
 hk run pre-commit --all                            # Run lint checks (requires HK_PKL_BACKEND=pkl)
-uv run --project python pytest tests/ -x -q      # Run all 171 tests
+uv run --project python pytest tests/ -x -q      # Run all 179 tests
 ```
 
 ### Docker Build

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -37,7 +37,7 @@ Requires **Python 3.14**.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q                # All 171 tests
+uv run --project python pytest tests/ -x -q                # All 179 tests
 uv run --project python pytest tests/test_audit.py -x -q   # Single file
 ```
 

--- a/scripts/devcontainer-smoke.sh
+++ b/scripts/devcontainer-smoke.sh
@@ -7,7 +7,7 @@
 #
 # Tiers (per ralplan-consensus-devcontainer-build-mise-chezmoi-resync §5):
 #   Tier 1 — Tools+hk:      mise ls; which clang++ python uv hk; hk run pre-commit --all
-#   Tier 2 — Python+mounts: uv pytest 171/171; stat ~/.ssh ~/.claude /workspaces/${ws}
+#   Tier 2 — Python+mounts: uv pytest 179/179; stat ~/.ssh ~/.claude /workspaces/${ws}
 #   Tier 3 — Sanitizers+lifecycle: clang++ asan+ubsan; mise-user volume owner; github ssh
 #
 # Tier 4 (CLion remote toolchain) is manual and out of scope here.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -19,11 +19,12 @@ Docker image smoke outputs.
 | `test_config.py` | pytest | Pydantic `DotfilesConfig` and container-path constants |
 | `test_ghcr.py` | pytest | GHCR prerequisite validation and token scope parsing |
 | `test_image_smoke.py` | pytest | Smoke-test script generation and `_parse_human_size` |
+| `test_container.py` | pytest | `verify-container-latest` gate (`dotfiles_setup.container`) — running/bind-mount/smoke freshness checks |
 | `test_shell_integration.py` | pytest | Tool reachability in login shells (mise, chezmoi, uv, pixi, claude, gemini, codex) |
 | `infra/foundation.bats` | Bats | Bash-level foundation checks (shell script integration) |
 | `infra/runtimes.bats` | Bats | Runtime installation checks (bash) |
 
-Total: **171 pytest tests** (pytest runs all `test_*.py` files) plus Bats
+Total: **179 pytest tests** (pytest runs all `test_*.py` files) plus Bats
 scenarios under `infra/`.
 
 ## Running tests


### PR DESCRIPTION
## Summary

Clear-prep doc sync after #149 (`verify-container-latest` gate, +7 tests) and #150 (#148 fix, +1 test). The pytest suite is now **179**.

- Count `171 → 179` across `AGENTS.md`, `README.md`, `python/AGENTS.md`, `tests/AGENTS.md`, `.claude/skills/devcontainer-workflow/SKILL.md`, and the `devcontainer-smoke.sh` tier-2 comment (`171/171 → 179/179`).
- Added `test_container.py` to the `tests/AGENTS.md` file table.

Docs-only · `mise run lint` rc=0 · AGENTS.md 200 lines / 11278 chars (within limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development and testing guidance to reflect the current test suite size.
  * Clarified that the project now reports 179 tests in local and CI-related instructions.
* **Bug Fixes**
  * Aligned smoke-check expectations with the updated test count so validation steps match the latest results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->