### PR TITLE
feat(hk): enforce set -o pipefail in shell scripts (#142)

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -150,6 +150,20 @@ hooks {
         check_first = true
       }
 
+      // --- Exit-code-masking guard (#142): every shell script with a
+      //     shebang MUST declare `set -o pipefail` so a failing stage in
+      //     a `cmd | filter` pipeline surfaces instead of being masked by
+      //     the last stage's exit 0. Iterates all tracked `*.sh` (not just
+      //     the staged glob match) so a script anywhere in the tree cannot
+      //     regress — same whole-tree idiom as `claude_md_size_limit`.
+      //     Matches all short-flag forms (`set -o`, `set -euo`, ...) via
+      //     `set -[a-z]*o pipefail`. See .claude/rules/verify-before-advancing.md
+      //     (evidence discipline) and feedback_pipe_kills_exit_code.
+      ["require_pipefail"] {
+        glob = List("**/*.sh")
+        check = "rc=0; for f in $(git ls-files '*.sh'); do first=$(head -n1 \"$f\"); case \"$first\" in \"#!\"*) ;; *) continue ;; esac; grep -qE 'set -[a-z]*o pipefail' \"$f\" || { echo \"$f: shell script with shebang lacks 'set -o pipefail' (exit-code masking guard, #142)\" >&2; rc=1; }; done; exit $rc"
+      }
+
       // --- Markdown ---
       ["markdown_lint"] {
         types = List("markdown")


### PR DESCRIPTION
## Summary

Closes #142. Adds a `require_pipefail` pre-commit guard: every tracked shell script with a shebang must declare `set -o pipefail`, so a failing stage in a `cmd | filter` pipeline surfaces instead of being masked by the last stage's exit `0`.

This machine-enforces the exit-code-masking discipline that `.claude/rules/verify-before-advancing.md` and the `feedback_pipe_kills_exit_code` memory already codify at the process level — turning a PROCESS invariant into a durable guard, matching the repo's `no_lint_skip` / `no_mcp_registration` idiom.

## Audit result (the named #142 surfaces are already clean)

`scripts/`, `mise.toml`, `python/src/dotfiles_setup/`, and (bonus) `.github/workflows/` were all already compliant:

- **All 10 tracked `*.sh`** declare `set -o pipefail`. `git ls-files` surfaced `.devcontainer/scripts/on-create.sh`, which an `fd` sweep missed (fd skips hidden dirs) — the guard's own whole-tree iteration catches this class.
- **Every multi-line `mise.toml` task body** starts `set -euo pipefail`; single-line tasks have no pipelines to mask.
- **Every Python subprocess** is `check=True` (raises) or `check=False` with an explicit `if result.returncode != 0` guard; embedded smoke scripts emit `set -euo pipefail` (`image.py` `build_smoke_script`, line 128).
- No `(cmd; echo RC=$?)` subshells, no `RC=$?` after pipes, no piped result-gates (pipes present are value-captures like `$(… | head -1)`).

So this PR ships the **regression guard**, not a fix.

## Implementation

- Iterates all tracked `*.sh` (not just the staged glob match) — same whole-tree idiom as `claude_md_size_limit` — so a non-compliant script anywhere in the tree cannot land.
- Matches all short-flag forms (`set -o`, `set -euo`, `set -eo`, …) via `set -[a-z]*o pipefail`.

## Verification

- `hk validate` — valid.
- **Negative test:** a deliberately pipefail-less `#!`-script → guard fails with `rc=1` and a clear message.
- **Positive:** current tree passes; `require_pipefail` ran and passed in the full `mise run lint` (`rc=0`).
- `pytest` — 179 passed. `dotfiles-setup verify run` — 71 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)