### PR TITLE
feat(smoke): assert exact (tool, backend, version) set vs mise-system.toml (#143)

### DIFF
--- a/.claude/skills/devcontainer-workflow/SKILL.md
+++ b/.claude/skills/devcontainer-workflow/SKILL.md
@@ -38,7 +38,7 @@ scripts/devcontainer-smoke.sh --include-up   # also runs `devcontainer up` first
 Tiers:
 
 - **Tier 1** — `mise ls`, `which clang++ python uv hk`, `hk run pre-commit --all`
-- **Tier 2** — `pytest 179/179`, `stat ~/.ssh ~/.claude /workspaces/dotfiles`
+- **Tier 2** — `pytest 187/187`, `stat ~/.ssh ~/.claude /workspaces/dotfiles`
 - **Tier 3** — `clang++ -fsanitize=address,undefined hello.cc && ./hello`
 
 Tier 4 (CLion remote toolchain) is manual.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ the official `@devcontainers/cli` (pinned in `mise.toml`).
 | `.claude/` | Claude-specific agents, skills, rules. Has its own `CLAUDE.md` with OMC orchestration |
 | `home/` | Chezmoi-managed dotfiles — see `home/AGENTS.md` |
 | `python/` | Python package `dotfiles_setup` — see `python/AGENTS.md` |
-| `tests/` | Pytest + Bats test suite (179 pytest tests) — see `tests/AGENTS.md` |
+| `tests/` | Pytest + Bats test suite (187 pytest tests) — see `tests/AGENTS.md` |
 | `scripts/` | Utility scripts (`benchmark-docker.sh`, `devcontainer-smoke.sh`) |
 | `docs/` | Documentation, research findings, design specs |
 
@@ -85,7 +85,7 @@ changes don't take effect.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q               # All 179 tests
+uv run --project python pytest tests/ -x -q               # All 187 tests
 uv run --project python pytest tests/test_audit.py -x -q  # Single file
 hk run pre-commit --all --stash none                      # Lint checks only
 dotfiles-setup verify run                                 # Verification contracts (suites.toml)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ the official `@devcontainers/cli` (pinned in `mise.toml`).
 | `mise.toml` | Tool versions and tasks (hk, pkl, hadolint, shellcheck, actionlint, pinact, python 3.14, uv, agnix) |
 | `mise.lock` | Locked tool versions for reproducible installs |
 | `mise.local.toml` | Gitignored per-clone overrides (e.g., `BASE_IMAGE`). See `mise.local.toml.example` |
-| `hk.pkl` | Project git hook config; imports `hk-common.pkl`; enforces `no_lint_skip`, `no_mcp_registration`, `claude_md_import_stub`, `claude_agents_md_pairs` |
+| `hk.pkl` | Project git hook config; imports `hk-common.pkl`; enforces `no_lint_skip`, `no_mcp_registration`, `require_pipefail`, `claude_md_import_stub`, `claude_agents_md_pairs` |
 | `hk-common.pkl` | Shared step definitions (hygiene, safety, security, typos) reused by `hk.pkl` and `hk-image.pkl` |
 | `hk-image.pkl` | Image-only hook config for devcontainer validation |
 | `docker-bake.hcl` | BuildKit bake config (`dev`, `cpp`, `dev-load`, `cpp-load` targets); `IMAGE_REF` consolidates registry+image |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A highly resilient, declarative dotfiles setup using **Chezmoi**, **Mise**, and 
 ```bash
 mise install                                       # Install all tools
 hk run pre-commit --all                            # Run lint checks (requires HK_PKL_BACKEND=pkl)
-uv run --project python pytest tests/ -x -q      # Run all 179 tests
+uv run --project python pytest tests/ -x -q      # Run all 187 tests
 ```
 
 ### Docker Build

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -37,7 +37,7 @@ Requires **Python 3.14**.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q                # All 179 tests
+uv run --project python pytest tests/ -x -q                # All 187 tests
 uv run --project python pytest tests/test_audit.py -x -q   # Single file
 ```
 

--- a/python/src/dotfiles_setup/image.py
+++ b/python/src/dotfiles_setup/image.py
@@ -12,6 +12,7 @@ import shlex
 import subprocess
 import sys
 import time
+import tomllib
 import zlib
 from typing import TYPE_CHECKING, Any
 
@@ -19,6 +20,7 @@ from dotfiles_setup import _project_root
 from dotfiles_setup.p2996_hash import _extract_bake_variable
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -56,6 +58,100 @@ def resolve_expected_config_sha256() -> str:
     """
     config_path = _project_root() / ".devcontainer" / "mise-system.toml"
     return hashlib.sha256(config_path.read_bytes()).hexdigest()
+
+
+# System mise config inside the image — the Dockerfile COPY target and the
+# ``source.path`` that ``mise ls --json`` attributes system tools to.
+SYSTEM_CONFIG_FILE = "/usr/local/share/mise/config.toml"
+
+
+def _tool_requested_version(spec: str | dict[str, Any]) -> str:
+    """Requested version string from a mise ``[tools]`` entry value.
+
+    Handles both the bare form (``tool = "latest"``) and the table form
+    (``tool = { version = "latest", depends = [...] }``).
+    """
+    if isinstance(spec, str):
+        return spec
+    version = spec.get("version")
+    if not isinstance(version, str):
+        msg = f"mise [tools] entry lacks a string 'version': {spec!r}"
+        raise TypeError(msg)
+    return version
+
+
+def parse_declared_tools(config_text: str) -> dict[str, str]:
+    """Parse ``[tools]`` from a mise-system.toml document.
+
+    Returns ``{tool_key: requested_version}``. Keys preserve the backend prefix
+    verbatim (``conda:llvm``, ``npm:renovate``, bare ``python``) so they line up
+    1:1 with ``mise ls --json`` keys — that is what makes the (tool, backend,
+    version) comparison exact rather than name-only.
+    """
+    data = tomllib.loads(config_text)
+    tools = data.get("tools", {})
+    return {key: _tool_requested_version(spec) for key, spec in tools.items()}
+
+
+def resolve_declared_tools() -> dict[str, str]:
+    """Declared tool set from the repo's ``.devcontainer/mise-system.toml``."""
+    config_path = _project_root() / ".devcontainer" / "mise-system.toml"
+    return parse_declared_tools(config_path.read_text())
+
+
+def installed_tools_from_mise_ls(
+    mise_ls_json: str,
+    config_path: str = SYSTEM_CONFIG_FILE,
+) -> dict[str, str]:
+    """Extract ``{tool_key: requested_version}`` from ``mise ls --json`` output.
+
+    Filters to entries that are (a) sourced from ``config_path`` (the system
+    config, so a user/global overlay's tools don't pollute the comparison) and
+    (b) actually ``installed`` — a declared-but-failed install therefore shows
+    up as a *missing* tool in the diff instead of silently passing.
+    """
+    doc = json.loads(mise_ls_json)
+    result: dict[str, str] = {}
+    for key, entries in doc.items():
+        for entry in entries:
+            source = entry.get("source") or {}
+            if source.get("path") == config_path and entry.get("installed"):
+                result[key] = entry.get("requested_version", "")
+    return result
+
+
+def diff_tool_sets(
+    declared: Mapping[str, str],
+    installed: Mapping[str, str],
+) -> list[str]:
+    """Human-readable diff lines; empty ⇔ exact (tool, backend, version) match.
+
+    Compares against the *requested* version (deterministic, equal to the
+    declared string) rather than the resolved version, because ``latest`` tools
+    drift by design — asserting the resolved version would false-fail on every
+    upstream release.
+    """
+    lines: list[str] = []
+    for key in sorted(set(declared) | set(installed)):
+        want = declared.get(key)
+        have = installed.get(key)
+        if want is None:
+            lines.append(f"+ {key}: installed ({have!r}) but NOT declared")
+        elif have is None:
+            lines.append(f"- {key}: declared ({want!r}) but NOT installed")
+        elif want != have:
+            lines.append(f"~ {key}: declared {want!r} but installed {have!r}")
+    return lines
+
+
+def _format_expected_tool_lines(declared: Mapping[str, str]) -> str:
+    """Tab-separated ``key``/``version`` lines for the injected smoke assertion.
+
+    One line per tool, tab-joined, sorted with Python's default (code-point)
+    order so it matches an in-script ``LC_ALL=C sort`` byte comparison — all
+    tool keys are ASCII.
+    """
+    return "\n".join(sorted(f"{key}\t{ver}" for key, ver in declared.items()))
 
 
 def _is_emulated(target_platform: str) -> bool:
@@ -99,6 +195,7 @@ def build_smoke_script(
     expected_p2996_ref: str,
     *,
     expected_config_sha256: str | None = None,
+    expected_tools: Mapping[str, str] | None = None,
     emulated: bool = False,
 ) -> str:
     """Build the inline smoke test script.
@@ -117,6 +214,13 @@ def build_smoke_script(
     would otherwise pass smoke against old content. An empty/unset value
     leaves the guard dormant (unit-test friendly).
 
+    ``expected_tools`` (#143 — exact tool-set assertion) maps declared tool keys
+    to requested versions (``resolve_declared_tools``). When set, the script
+    asserts the installed set sourced from the system config matches it exactly
+    — catching a tool silently dropped/added or a requested-version drift that
+    the ``(missing)``-count check alone passes green. An empty/unset value
+    leaves the guard dormant (unit-test friendly).
+
     ``emulated`` (gap B — TSan under Rosetta) controls whether the
     ThreadSanitizer binary is RUN after it is compiled. The compile always
     runs (it proves the toolchain); the RUN is skipped under emulation, where
@@ -124,11 +228,15 @@ def build_smoke_script(
     """
     strict = "1" if _SHA_RE.match(expected_p2996_ref) else ""
     tsan_run_skip = "1" if emulated else ""
+    expected_tool_lines = (
+        _format_expected_tool_lines(expected_tools) if expected_tools else ""
+    )
     header = (
         "set -euo pipefail\n"
         f"EXPECTED_P2996_REF={shlex.quote(expected_p2996_ref)}\n"
         f"P2996_REF_STRICT={shlex.quote(strict)}\n"
         f"EXPECTED_CONFIG_SHA256={shlex.quote(expected_config_sha256 or '')}\n"
+        f"EXPECTED_TOOL_REQUESTS={shlex.quote(expected_tool_lines)}\n"
         f"TSAN_RUN_SKIP={shlex.quote(tsan_run_skip)}\n"
     )
     return (
@@ -160,6 +268,29 @@ echo "Missing tools: $missing"
 if [ "$missing" -gt 0 ]; then
   echo "$mise_output" | grep "(missing)"
   exit 1
+fi
+echo "=== exact tool-set assertion (declared vs installed, system config) ==="
+# #143: assert the EXACT (tool, backend, requested-version) set declared in
+# mise-system.toml is what's installed from the system config — not merely that
+# mise reports zero (missing). The declared set is injected as data
+# ($EXPECTED_TOOL_REQUESTS, computed in python: parse_declared_tools); this
+# block only does a mechanical set diff (zero-bash-logic). Comparison is on the
+# requested version (deterministic == declared) not the resolved version, which
+# drifts for `latest` by design. LC_ALL=C sort => byte order matching python's.
+if [ -n "$EXPECTED_TOOL_REQUESTS" ]; then
+  installed_tool_requests=$(mise ls --json | jq -r --arg cfg "$MISE_CFG" '
+    to_entries[] | .key as $k | .value[]
+    | select(.source.path == $cfg and .installed == true)
+    | "\\($k)\\t\\(.requested_version)"' | LC_ALL=C sort -u)
+  if ! diff <(printf '%s\n' "$EXPECTED_TOOL_REQUESTS") \
+            <(printf '%s\n' "$installed_tool_requests"); then
+    echo "FAIL: installed tool set differs from mise-system.toml [tools]" \
+         "('<' declared-not-installed; '>' installed-not-declared/version-drift)"
+    exit 1
+  fi
+  echo "OK: installed tool set matches mise-system.toml [tools]"
+else
+  echo "SKIP: no expected tool set injected (tool-set guard dormant)"
 fi
 echo "=== shell integration ==="
 command -v zsh || { echo "FAIL: zsh not found"; exit 1; }
@@ -307,7 +438,13 @@ def build_smoke_docker_cmd(
     expected_config_sha256: str | None = None,
     emulated: bool | None = None,
 ) -> list[str]:
-    """Build the docker command used for smoke validation."""
+    """Build the docker command used for smoke validation.
+
+    The declared tool set (#143) is always resolved from the repo's
+    ``mise-system.toml`` here — it has no injectable override because, unlike the
+    p2996-ref / config-hash, nothing needs to smoke against a *synthetic* tool
+    set; ``build_smoke_script`` remains the injection seam for unit tests.
+    """
     if expected_p2996_ref is None:
         expected_p2996_ref = resolve_expected_p2996_ref()
     if expected_config_sha256 is None:
@@ -317,6 +454,7 @@ def build_smoke_docker_cmd(
     script = build_smoke_script(
         expected_p2996_ref,
         expected_config_sha256=expected_config_sha256,
+        expected_tools=resolve_declared_tools(),
         emulated=emulated,
     )
     return [
@@ -567,8 +705,43 @@ class ImageCommand:
     candidate_path: Path | None = None
 
 
+def verify_tools_main() -> int:
+    """Assert the installed tool set matches ``.devcontainer/mise-system.toml``.
+
+    Runs ``mise ls --json`` against the ambient mise (inside the devcontainer)
+    and compares to the repo's declared ``[tools]`` — the in-container sibling of
+    the ``build_smoke_script`` assertion (#143), sharing the same parse/compare
+    core so the two smoke paths cannot diverge. Called by
+    ``scripts/devcontainer-smoke.sh`` (keeps the diff logic in python, not bash).
+    """
+    declared = resolve_declared_tools()
+    config_file = os.environ.get("MISE_SYSTEM_CONFIG_FILE", SYSTEM_CONFIG_FILE)
+    result = subprocess.run(
+        ["mise", "ls", "--json"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    installed = installed_tools_from_mise_ls(result.stdout, config_file)
+    diffs = diff_tool_sets(declared, installed)
+    if diffs:
+        sys.stderr.write(
+            "FAIL: installed tool set differs from mise-system.toml [tools]:\n"
+        )
+        for line in diffs:
+            sys.stderr.write(f"  {line}\n")
+        return 1
+    sys.stdout.write(
+        f"OK: installed tool set matches mise-system.toml [tools] "
+        f"({len(declared)} tools)\n"
+    )
+    return 0
+
+
 def main(cmd: ImageCommand) -> int:
     """CLI entry point for image operations."""
+    if cmd.command == "verify-tools":
+        return verify_tools_main()
     if cmd.command == "smoke":
         result = smoke(cmd.image_ref, platform=cmd.platform)
         if result["result"] == "FAIL":

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -158,6 +158,10 @@ def _add_image_subcommands(
         "--output-path",
         help="Optional JSON output path for benchmark metrics",
     )
+    image_sub.add_parser(
+        "verify-tools",
+        help="Assert installed tool set matches mise-system.toml [tools] (#143)",
+    )
     compare_parser = image_sub.add_parser(
         "metrics-compare",
         help="Compare two benchmark JSON files",
@@ -360,6 +364,9 @@ def handle_image(args: argparse.Namespace) -> None:
     Args:
         args: The parsed arguments.
     """
+    if args.image_command == "verify-tools":
+        cmd = ImageCommand("", command="verify-tools")
+        sys.exit(image_main(cmd))
     if args.image_command == "smoke":
         cmd = ImageCommand(args.image_ref, platform=args.platform)
         sys.exit(image_main(cmd))

--- a/scripts/devcontainer-smoke.sh
+++ b/scripts/devcontainer-smoke.sh
@@ -7,7 +7,7 @@
 #
 # Tiers (per ralplan-consensus-devcontainer-build-mise-chezmoi-resync §5):
 #   Tier 1 — Tools+hk:      mise ls; which clang++ python uv hk; hk run pre-commit --all
-#   Tier 2 — Python+mounts: uv pytest 179/179; stat ~/.ssh ~/.claude /workspaces/${ws}
+#   Tier 2 — Python+mounts: uv pytest 187/187; stat ~/.ssh ~/.claude /workspaces/${ws}
 #   Tier 3 — Sanitizers+lifecycle: clang++ asan+ubsan; mise-user volume owner; github ssh
 #
 # Tier 4 (CLion remote toolchain) is manual and out of scope here.
@@ -44,6 +44,12 @@ else
   echo "  SKIP: repo mise-system.toml not found at ${repo_cfg}"
 fi
 mise ls
+# #143: assert the EXACT declared (tool, backend, version) set is installed, not
+# just that mise reports zero (missing). Parse + compare logic lives in python
+# (dotfiles_setup.image.verify_tools_main — zero-bash-logic), sharing the same
+# core as build_smoke_script's injected assertion so the two smoke paths can't
+# diverge (the #148/#150 lockstep lesson).
+uv run --project python dotfiles-setup image verify-tools
 which clang++ python uv hk
 # Use the image-only hk config (installed at /etc/hk/hk.pkl by Dockerfile).
 # The project's ./hk.pkl includes host-only steps (docker_bake_check ->

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -18,13 +18,13 @@ Docker image smoke outputs.
 | `test_bootstrap.py` | pytest | Bootstrap tool availability (`mise`, `chezmoi`, `uv`, `pixi`, python) |
 | `test_config.py` | pytest | Pydantic `DotfilesConfig` and container-path constants |
 | `test_ghcr.py` | pytest | GHCR prerequisite validation and token scope parsing |
-| `test_image_smoke.py` | pytest | Smoke-test script generation and `_parse_human_size` |
+| `test_image_smoke.py` | pytest | Smoke-test script generation, `_parse_human_size`, and the #143 exact tool-set assertion (parse/compare vs mise-system.toml) |
 | `test_container.py` | pytest | `verify-container-latest` gate (`dotfiles_setup.container`) — running/bind-mount/smoke freshness checks |
 | `test_shell_integration.py` | pytest | Tool reachability in login shells (mise, chezmoi, uv, pixi, claude, gemini, codex) |
 | `infra/foundation.bats` | Bats | Bash-level foundation checks (shell script integration) |
 | `infra/runtimes.bats` | Bats | Runtime installation checks (bash) |
 
-Total: **179 pytest tests** (pytest runs all `test_*.py` files) plus Bats
+Total: **187 pytest tests** (pytest runs all `test_*.py` files) plus Bats
 scenarios under `infra/`.
 
 ## Running tests

--- a/tests/test_image_smoke.py
+++ b/tests/test_image_smoke.py
@@ -17,6 +17,10 @@ from dotfiles_setup.image import (
     _sum_manifest_layer_sizes,
     build_smoke_docker_cmd,
     build_smoke_script,
+    diff_tool_sets,
+    installed_tools_from_mise_ls,
+    parse_declared_tools,
+    resolve_declared_tools,
     resolve_expected_config_sha256,
     resolve_expected_p2996_ref,
 )
@@ -296,6 +300,136 @@ def test_smoke_docker_cmd_injects_config_hash() -> None:
     script = cmd[-1]
 
     assert f"EXPECTED_CONFIG_SHA256={resolve_expected_config_sha256()}\n" in script
+
+
+# --- #143: exact tool-set assertion ---
+
+# The in-image system mise config path (mise ls --json source.path).
+_SYS_CFG = "/usr/local/share/mise/config.toml"
+
+# Missing + extra + version-drift = three distinct diff-line classes.
+_EXPECTED_DIFF_CLASSES = 3
+
+# A minimal mise-system.toml covering both [tools] value forms.
+_SAMPLE_MISE_TOML = """\
+[tools]
+python = "latest"
+"conda:llvm" = "latest"
+"npm:@google/gemini-cli" = { version = "latest", depends = ["node"] }
+pinned = "1.2.3"
+
+[settings]
+experimental = true
+"""
+
+
+def _mise_ls_json(entries: dict[str, dict[str, object]]) -> str:
+    """Build a mise ls --json payload from {key: {version,requested,source,installed}}."""
+    doc = {
+        key: [
+            {
+                "version": e.get("version", "9.9.9"),
+                "requested_version": e.get("requested", "latest"),
+                "source": {"type": "mise.toml", "path": e.get("source", _SYS_CFG)},
+                "installed": e.get("installed", True),
+            }
+        ]
+        for key, e in entries.items()
+    }
+    return json.dumps(doc)
+
+
+def test_parse_declared_tools_handles_both_value_forms() -> None:
+    """Bare string and table ({version,...}) [tools] entries both parse."""
+    declared = parse_declared_tools(_SAMPLE_MISE_TOML)
+
+    assert declared == {
+        "python": "latest",
+        "conda:llvm": "latest",
+        "npm:@google/gemini-cli": "latest",
+        "pinned": "1.2.3",
+    }
+
+
+def test_installed_tools_filters_by_source_and_installed() -> None:
+    """Only tools sourced from the system config AND installed are returned."""
+    payload = _mise_ls_json(
+        {
+            "python": {"requested": "latest"},
+            "user-tool": {"source": "/home/x/.config/mise/config.toml"},
+            "half-installed": {"installed": False},
+        }
+    )
+
+    installed = installed_tools_from_mise_ls(payload, _SYS_CFG)
+
+    assert installed == {"python": "latest"}
+
+
+def test_diff_tool_sets_exact_match_is_empty() -> None:
+    """Identical declared/installed maps produce no diff lines."""
+    both = {"python": "latest", "conda:llvm": "latest"}
+
+    assert diff_tool_sets(both, dict(both)) == []
+
+
+def test_diff_tool_sets_reports_missing_extra_and_drift() -> None:
+    """Missing, extra, and version-drift each surface a distinct diff line."""
+    declared = {"python": "latest", "dropped": "latest", "pinned": "1.2.3"}
+    installed = {"python": "latest", "added": "latest", "pinned": "9.9.9"}
+
+    diffs = diff_tool_sets(declared, installed)
+
+    assert any(line.startswith("+ added:") for line in diffs)
+    assert any(line.startswith("- dropped:") for line in diffs)
+    assert any(line.startswith("~ pinned:") for line in diffs)
+    assert len(diffs) == _EXPECTED_DIFF_CLASSES
+
+
+def test_smoke_script_injects_tool_set_assertion() -> None:
+    """#143: declared tools are injected and the jq/diff assertion block present."""
+    script = build_smoke_script(
+        _FAKE_P2996_SHA,
+        expected_tools={"python": "latest", "conda:llvm": "latest"},
+    )
+
+    # Sorted key<TAB>version blob injected as data...
+    assert "EXPECTED_TOOL_REQUESTS=" in script
+    assert "conda:llvm\tlatest" in script
+    assert "python\tlatest" in script
+    # ...and the mechanical set-diff (no logic in bash).
+    assert 'if [ -n "$EXPECTED_TOOL_REQUESTS" ]; then' in script
+    assert "mise ls --json | jq -r" in script
+    assert "select(.source.path == $cfg and .installed == true)" in script
+
+
+def test_smoke_script_tool_set_guard_dormant_without_tools() -> None:
+    """Without an expected set the guard is present but dormant (empty var)."""
+    script = build_smoke_script(_FAKE_P2996_SHA)
+
+    assert "EXPECTED_TOOL_REQUESTS=''\n" in script
+    assert "tool-set guard dormant" in script
+
+
+def test_smoke_docker_cmd_injects_real_declared_tools() -> None:
+    """build_smoke_docker_cmd resolves and injects the repo's real [tools]."""
+    cmd = build_smoke_docker_cmd(
+        "ghcr.io/ray-manaloto/dotfiles-devcontainer:test",
+        expected_p2996_ref=_FAKE_P2996_SHA,
+    )
+    script = cmd[-1]
+
+    # A representative real tool from .devcontainer/mise-system.toml.
+    assert "python\tlatest" in script
+
+
+def test_resolve_declared_tools_reads_repo_config() -> None:
+    """The repo's mise-system.toml parses to a non-empty backend-prefixed set."""
+    declared = resolve_declared_tools()
+
+    assert declared["python"] == "latest"
+    assert "conda:llvm" in declared
+    assert all(isinstance(v, str) for v in declared.values())
 
 
 def test_sum_manifest_layer_sizes_single_manifest() -> None:


### PR DESCRIPTION
## Summary

Closes #143 (Gap E). Both image-smoke paths only checked `mise ls` for a zero `(missing)` count + non-zero total — they never asserted the **exact declared tool set**, so a tool silently dropped/added, or a requested-version drift, passed green.

Complements PR #140's Gap A: **A** proves the image was built from the current config *file* (SHA-256); **E** proves the installed tool *set* matches what that file declares (build-time resolution can differ; a tool can fail to install without failing the build).

## Shared Python core (`dotfiles_setup.image`, unit-tested)

- `parse_declared_tools` / `resolve_declared_tools` — `tomllib` parse of `[tools]`; keys preserve the backend prefix (`conda:llvm`, `npm:renovate`) so they line up 1:1 with `mise ls --json` keys.
- `installed_tools_from_mise_ls` — filters to entries sourced from the **system** config AND `installed` (a failed install shows as *missing*, not a silent pass).
- `diff_tool_sets` — missing / extra / version-drift lines. Compares the **requested** version (deterministic, `== declared`), not the resolved version, which drifts for `latest` by design.

## Two smoke paths, one compare semantics (the #148/#150 lockstep lesson)

- **`build_smoke_script`** (mount-free `docker run`, `dotfiles_setup` unavailable): injects the declared set as data + a mechanical `jq`/`diff` block — the discrimination logic is all in the Python-computed injected data (zero bash logic).
- **`devcontainer-smoke.sh`** (in-container, repo mounted): calls the new `dotfiles-setup image verify-tools` CLI.

## Verification

- **Live against the running devcontainer:** `verify-tools` → `OK … (107 tools)`; injected bash-diff path matches, and a deliberately-dropped tool is caught.
- Local Python gates: ruff / ty / format clean; **pytest 187 passed** (+8); `dotfiles-setup verify run` 71 passed / 0 failed; `require_pipefail` + `agnix` green. Test-count docs synced 179→187.
- (Also carries a one-line #142 follow-up: list `require_pipefail` in AGENTS.md's hk enforced-steps row.)

> Note: hk's *builtin* lint steps (shellcheck/shfmt/etc.) don't execute in the local `mise run lint` in this environment (pre-existing — PR #152 shipped under the same condition); the CI `lint` job runs the full set and is the authoritative gate for the shell change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new image verification check that confirms installed tools match the declared tool set.
  * Added a new `image verify-tools` command for running this check directly.

* **Bug Fixes**
  * Smoke-checks now fail when tool versions or availability differ from expectations, providing stricter validation.

* **Documentation**
  * Updated setup and testing instructions to reflect the current test count and the new verification step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->