### PR TITLE
fix(hash): cover hk-common.pkl + hk-image.pkl in base content-hash (#154 follow-up)

### DIFF
--- a/.claude/skills/devcontainer-workflow/SKILL.md
+++ b/.claude/skills/devcontainer-workflow/SKILL.md
@@ -38,7 +38,7 @@ scripts/devcontainer-smoke.sh --include-up   # also runs `devcontainer up` first
 Tiers:
 
 - **Tier 1** — `mise ls`, `which clang++ python uv hk`, `hk run pre-commit --all`
-- **Tier 2** — `pytest 187/187`, `stat ~/.ssh ~/.claude /workspaces/dotfiles`
+- **Tier 2** — `pytest 190/190`, `stat ~/.ssh ~/.claude /workspaces/dotfiles`
 - **Tier 3** — `clang++ -fsanitize=address,undefined hello.cc && ./hello`
 
 Tier 4 (CLion remote toolchain) is manual.

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -81,7 +81,9 @@ jobs:
   # ============================================================
   base-prep:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Cold base rebuild (apt + mise install + cargo crates + conda solve) runs
+    # ~20-30 min; conda solve time varies, so keep generous headroom.
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: write
@@ -179,7 +181,12 @@ jobs:
   p2996-prep:
     needs: [base-prep]
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Cold clang-p2996 build is a multi-hour from-source compile (~2h+). The
+    # earlier 60 was far too low and CANCELLED cold rebuilds (regression from
+    # #154's timeout-minutes addition; only warm cache-hits — seconds — masked
+    # it). Cache HITS still finish in seconds; this ceiling only bounds a cold
+    # build. See docs/research/.../P2996-CACHE.md + feedback_ci_build_duration.
+    timeout-minutes: 240
     permissions:
       contents: read
       packages: write # explicit; do not rely on workflow-level inheritance
@@ -303,7 +310,7 @@ jobs:
     needs: [base-prep, p2996-prep]
     if: inputs.tag_strategy == 'pr'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write
@@ -427,7 +434,9 @@ jobs:
       && (needs.dev-prep.result == 'skipped'
           || (needs.dev-prep.result == 'success' && needs.dev-prep.outputs.hit != 'true'))
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Cold dev assembly (pull p2996 cache + final COPY/overlay + bake) can run
+    # longer than a warm build; keep headroom for a cold path.
+    timeout-minutes: 120
     permissions:
       contents: read
       packages: write
@@ -533,7 +542,7 @@ jobs:
   smoke-test:
     needs: [build]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ the official `@devcontainers/cli` (pinned in `mise.toml`).
 | `.claude/` | Claude-specific agents, skills, rules. Has its own `CLAUDE.md` with OMC orchestration |
 | `home/` | Chezmoi-managed dotfiles — see `home/AGENTS.md` |
 | `python/` | Python package `dotfiles_setup` — see `python/AGENTS.md` |
-| `tests/` | Pytest + Bats test suite (187 pytest tests) — see `tests/AGENTS.md` |
+| `tests/` | Pytest + Bats test suite (190 pytest tests) — see `tests/AGENTS.md` |
 | `scripts/` | Utility scripts (`benchmark-docker.sh`, `devcontainer-smoke.sh`) |
 | `docs/` | Documentation, research findings, design specs |
 
@@ -85,7 +85,7 @@ changes don't take effect.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q               # All 187 tests
+uv run --project python pytest tests/ -x -q               # All 190 tests
 uv run --project python pytest tests/test_audit.py -x -q  # Single file
 hk run pre-commit --all --stash none                      # Lint checks only
 dotfiles-setup verify run                                 # Verification contracts (suites.toml)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A highly resilient, declarative dotfiles setup using **Chezmoi**, **Mise**, and 
 ```bash
 mise install                                       # Install all tools
 hk run pre-commit --all                            # Run lint checks (requires HK_PKL_BACKEND=pkl)
-uv run --project python pytest tests/ -x -q      # Run all 187 tests
+uv run --project python pytest tests/ -x -q      # Run all 190 tests
 ```
 
 ### Docker Build

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -37,7 +37,7 @@ Requires **Python 3.14**.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q                # All 187 tests
+uv run --project python pytest tests/ -x -q                # All 190 tests
 uv run --project python pytest tests/test_audit.py -x -q   # Single file
 ```
 

--- a/python/src/dotfiles_setup/p2996_hash.py
+++ b/python/src/dotfiles_setup/p2996_hash.py
@@ -35,7 +35,10 @@ if TYPE_CHECKING:
 
 HASH_LENGTH = 16
 # v2: split single-hash into base+p2996. v3: base-hash covers mise-system.toml.
-SCHEMA_VERSION = 3
+# v4: base-hash covers hk-common.pkl + hk-image.pkl (Dockerfile base-section
+# COPY inputs — their bytes were unhashed, so #154's /etc/hk config change did
+# not bust the cache and CI skipped the rebuild).
+SCHEMA_VERSION = 4
 RECORD_SEPARATOR = "\x1f"  # ASCII unit separator — never appears in inputs
 SHA256_HEX_LEN = 64
 
@@ -57,6 +60,7 @@ class BaseHashInputs:
     base_section_digest: str
     snapshot_digest: str
     mise_system_config_digest: str
+    hk_config_digest: str
 
     def __post_init__(self) -> None:
         """Reject empty literals + non-64-hex digests."""
@@ -69,6 +73,7 @@ class BaseHashInputs:
             "base_section_digest",
             "snapshot_digest",
             "mise_system_config_digest",
+            "hk_config_digest",
         ):
             value = getattr(self, field_name)
             _validate_hex_digest(value, f"BaseHashInputs.{field_name}")
@@ -107,11 +112,13 @@ class P2996HashInputs:
 class DevHashInputs:
     """Inputs feeding the top-tier `:dev-<hash>` validated-image cache.
 
-    The final `devcontainer` Dockerfile stage COPYs nothing from the
-    repo build context — only `/opt/clang-p2996` from the (already
-    hashed) p2996 cache and a rolling `gcc-latest.deb` URL. So, given
-    fixed `base_hash` + `p2996_hash`, the dev image content is a pure
-    function of the Dockerfile instructions and the `dev` bake target.
+    The final `devcontainer` Dockerfile stage COPYs only `/opt/clang-p2996`
+    from the (already hashed) p2996 cache and a rolling `gcc-latest.deb`
+    URL — the repo-context COPYs (mise-system.toml, hk-common.pkl,
+    hk-image.pkl) all live in the base section and are hashed into
+    `base_hash`. So, given fixed `base_hash` + `p2996_hash`, the dev image
+    content is a pure function of the Dockerfile instructions and the
+    `dev` bake target.
 
     `dockerfile_digest` covers the WHOLE Dockerfile (not a sentinel
     slice): under-hashing here is the cardinal sin — a probe hit skips
@@ -257,12 +264,23 @@ def gather_base_inputs(repo_root: Path) -> BaseHashInputs:
     # [env]/[tasks] edits (which don't move the resolved snapshot) still bust
     # the cache and trigger a rebuild. See PR #140.
     mise_system_config_path = repo_root / ".devcontainer" / "mise-system.toml"
+    # The base section also COPYs hk-common.pkl + hk-image.pkl verbatim to
+    # /etc/hk/ (the in-image hk config the devcontainer smoke uses). Same gap as
+    # mise-system.toml: base_section_digest captures the COPY *instruction*, not
+    # the file bytes, so an edit to either pkl (e.g. #154's builtin wiring) did
+    # not bust the cache and CI skipped the rebuild. Hash both files' bytes.
+    hk_common_path = repo_root / "hk-common.pkl"
+    hk_image_path = repo_root / "hk-image.pkl"
+    hk_config_digest = _sha256_hex(
+        _file_digest(hk_common_path) + _file_digest(hk_image_path)
+    )
     return BaseHashInputs(
         base_image=_extract_bake_variable(bake_text, "BASE_IMAGE"),
         platform=_extract_bake_variable(bake_text, "PLATFORM"),
         base_section_digest=_sha256_hex(base_section),
         snapshot_digest=_file_digest(snapshot_path),
         mise_system_config_digest=_file_digest(mise_system_config_path),
+        hk_config_digest=hk_config_digest,
     )
 
 
@@ -277,6 +295,7 @@ def compute_base_hash(inputs: BaseHashInputs) -> str:
             f"base_section={inputs.base_section_digest}",
             f"snapshot={inputs.snapshot_digest}",
             f"mise_system_config={inputs.mise_system_config_digest}",
+            f"hk_config={inputs.hk_config_digest}",
         ],
     )
     return _sha256_hex(canonical)[:HASH_LENGTH]

--- a/scripts/devcontainer-smoke.sh
+++ b/scripts/devcontainer-smoke.sh
@@ -7,7 +7,7 @@
 #
 # Tiers (per ralplan-consensus-devcontainer-build-mise-chezmoi-resync §5):
 #   Tier 1 — Tools+hk:      mise ls; which clang++ python uv hk; hk run pre-commit --all
-#   Tier 2 — Python+mounts: uv pytest 187/187; stat ~/.ssh ~/.claude /workspaces/${ws}
+#   Tier 2 — Python+mounts: uv pytest 190/190; stat ~/.ssh ~/.claude /workspaces/${ws}
 #   Tier 3 — Sanitizers+lifecycle: clang++ asan+ubsan; mise-user volume owner; github ssh
 #
 # Tier 4 (CLion remote toolchain) is manual and out of scope here.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -24,7 +24,7 @@ Docker image smoke outputs.
 | `infra/foundation.bats` | Bats | Bash-level foundation checks (shell script integration) |
 | `infra/runtimes.bats` | Bats | Runtime installation checks (bash) |
 
-Total: **187 pytest tests** (pytest runs all `test_*.py` files) plus Bats
+Total: **190 pytest tests** (pytest runs all `test_*.py` files) plus Bats
 scenarios under `infra/`.
 
 ## Running tests

--- a/tests/test_p2996_hash.py
+++ b/tests/test_p2996_hash.py
@@ -47,6 +47,7 @@ def _stub_base_inputs(**overrides: str) -> BaseHashInputs:
         "base_section_digest": "a" * 64,
         "snapshot_digest": "c" * 64,
         "mise_system_config_digest": "f" * 64,
+        "hk_config_digest": "b" * 64,
     }
     base.update(overrides)
     return BaseHashInputs(**base)
@@ -116,6 +117,10 @@ def _seed_repo(tmp_path: Path) -> Path:
     (devcontainer / "mise-system.toml").write_text(
         '[tools]\n"conda:cmake" = "latest"\n\n[settings]\nexperimental = true\n',
     )
+    # hk-common.pkl + hk-image.pkl are base-section COPY inputs hashed into the
+    # base hash (they land at /etc/hk/ in the image).
+    (tmp_path / "hk-common.pkl").write_text("hygiene = new {}\n")
+    (tmp_path / "hk-image.pkl").write_text('amends "Config.pkl"\n')
     return tmp_path
 
 
@@ -171,6 +176,33 @@ def test_repo_base_hash_changes_when_mise_system_toml_edited(tmp_path: Path) -> 
     toml.write_text(
         toml.read_text().replace("experimental = true", "asdf_compat = true")
     )
+    after = compute_repo_base_hash(tmp_path)
+    assert before != after
+
+
+def test_base_hash_changes_when_hk_config_digest_changes() -> None:
+    # The base section COPYs hk-common.pkl + hk-image.pkl to /etc/hk/; their
+    # bytes must bust the base hash (previously unhashed — #154's builtin wiring
+    # edit did not trigger a rebuild, leaving a stale in-image hk config).
+    base = _stub_base_inputs()
+    bumped = _stub_base_inputs(hk_config_digest="d" * 64)
+    assert compute_base_hash(base) != compute_base_hash(bumped)
+
+
+def test_repo_base_hash_changes_when_hk_image_pkl_edited(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    before = compute_repo_base_hash(tmp_path)
+    hk_image = tmp_path / "hk-image.pkl"
+    hk_image.write_text(hk_image.read_text() + '\nimport "Builtins.pkl"\n')
+    after = compute_repo_base_hash(tmp_path)
+    assert before != after
+
+
+def test_repo_base_hash_changes_when_hk_common_pkl_edited(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    before = compute_repo_base_hash(tmp_path)
+    hk_common = tmp_path / "hk-common.pkl"
+    hk_common.write_text(hk_common.read_text() + "\nsafety = new {}\n")
     after = compute_repo_base_hash(tmp_path)
     assert before != after
 
@@ -602,6 +634,7 @@ def test_dev_hash_kind_namespacing_differs_from_base_and_p2996() -> None:
             base_section_digest="a" * 64,
             snapshot_digest="a" * 64,
             mise_system_config_digest="a" * 64,
+            hk_config_digest="a" * 64,
         )
     )
     dev = compute_dev_hash(_stub_dev_inputs())


### PR DESCRIPTION
## Summary

Follow-up to #154. Both `hk-common.pkl` and `hk-image.pkl` are `COPY` inputs in the Dockerfile **base section** (→ `/etc/hk/`, the in-image hk config the devcontainer smoke uses), but their **bytes were unhashed** — `base_section_digest` captured only the `COPY` *instruction* text.

So #154's builtin-wiring edit to those files changed **no** content hash: CI's `build-publish` computed the same base/p2996/dev hashes → cache hit → **skipped the rebuild**, and the published `:dev` kept the stale pre-#154 `/etc/hk/` config. Verified on the running container: its `/etc/hk/hk.pkl` had **0** `Builtins.` refs vs the repo's 2 — i.e. the old bare-builtin (no-op) config.

Same gap class as `mise-system.toml`, fixed in PR #140 (`feedback_content_hash_must_cover_copy_inputs`).

## Changes

- `p2996_hash.py`: add `hk_config_digest` (sha256 of both pkl files' bytes) to `BaseHashInputs` + `compute_base_hash`; `SCHEMA_VERSION` 3→4.
- Fix the stale `DevHashInputs` docstring — it claimed the final stage "COPYs nothing from the build context", which is false (the base section COPYs `mise-system.toml` + both pkls).
- +3 tests (unit digest-sensitivity + repo-level per pkl); seed the test repo with the pkl files. **pytest 187→190**; test-count docs synced.

## Effect

Merging changes the base-hash → CI sees a cache **miss** → rebuilds `:dev` with the current `/etc/hk/` config (a one-time **cold base rebuild**, ~2.5h — expected and correct). After that lands, `mise run dev-rebuild` + `mise run verify-container-latest` deploy + verify the container on the fresh image.

## Verification

- Pre-commit hook ran the full builtin suite → all ✔.
- `mise run lint` rc=0 · pytest **190** · `dotfiles-setup verify run` 71/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved build cache invalidation so changes to the Dockerfile cache inputs (including hk pickle files) properly refresh base and downstream tiers, reducing the chance of stale layers.
- **Documentation**
  - Updated setup/testing guides to reflect the current pytest suite size (187 → 190) and kept smoke-check expectations in sync.
- **Chores**
  - Increased CI job timeouts to reduce cancellations on cold cache misses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->