### PR TITLE
docs: sync hk-builtins-audit + workflows base-hash (#154 cascade clear-prep)

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -45,6 +45,10 @@ behavior unchanged):
    (`docker manifest inspect`). Hit: <30s. Miss: build the `base` bake
    target (devcontainer-base = apt + mise install + cargo), push it.
    p2996-prep + build pull it instead of rebuilding the mise layer.
+   base-hash covers the bytes of every base-section COPY input —
+   `mise-system.toml` (#140) + `hk-common.pkl`/`hk-image.pkl` (#156). Since
+   p2996-hash includes base-hash, ANY edit to those busts BOTH tiers → a cold
+   ~2h rebuild (batch in-image config changes).
 4. **p2996-prep** — `dotfiles-setup p2996-hash` → probe `:p2996-<hash16>`.
    Hit: <30s. Miss: build the `p2996-cache` bake target (scratch
    `p2996-export` with just `/opt/clang-p2996`, ~500 MB), push to GHCR.

--- a/docs/hk-builtins-audit.md
+++ b/docs/hk-builtins-audit.md
@@ -1,5 +1,17 @@
 # hk Builtins Audit
 
+> **STATUS (2026-07-02): superseded as an "active steps" reference by #154–#158.**
+> This is a point-in-time 2026-04-05 audit. At the time, hk builtins were
+> declared as bare `["name"] {}` blocks that hk **silently no-op'd** — so the
+> table below reflects *intended* steps, not steps that actually ran. #154
+> (PR #155) rewired them via `= Builtins.name` so they run for real, and
+> curated the set: **dropped** `jq`, `taplo_format`, `yamlfmt`, `pkl_format`,
+> `shfmt` (opinionated formatters), `hclfmt` (not in mise registry), `zizmor`
+> (`check=null` no-op), `markdown_lint`/`rumdl` (redundant), `no_commit_to_branch`
+> (fails CI detached-HEAD), `pinact`/`pinact_update` (GitHub API rate-limit).
+> The current authoritative set is `hk.pkl` + `hk-common.pkl` + `hk-image.pkl`.
+> See memory `feedback_hk_builtins_need_assignment`.
+
 - **Last checked:** 2026-04-05
 - **hk version:** v1.40.0
 - **Project:** dotfiles (ray-manaloto/dotfiles)


### PR DESCRIPTION
Doc-sync after the #154 hk-builtins cascade (#155–#158):

- **`docs/hk-builtins-audit.md`** — status banner: the 2026-04-05 audit reflects *intended* steps that were actually silent no-ops (bare `["name"] {}`). #154 rewired them via `= Builtins.name` and curated the set (dropped formatters/no-ops/CI-incompatible steps). Points to the current authoritative pkl configs.
- **`.github/workflows/AGENTS.md`** — base-hash now covers `hk-common.pkl` + `hk-image.pkl` bytes (#156); base-hash feeds p2996-hash, so in-image config edits force a cold ~2h rebuild.

`mise run lint` rc=0. Docs-only; build-publish skips (not a build-path input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified CI pipeline stage notes for base-prep, including what is covered by base-hash and when edits trigger a full rebuild.
  * Added a status update to the builtins audit, marking it as superseded and pointing to the current authoritative builtins set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->