### PR TITLE
chore(renovate): official over custom — drop 8 dead/redundant managers, keep 3

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,17 +3,15 @@
   "extends": [
     "github>jdx/renovate-config"
   ],
-  "mise": {
-    "enabled": true
-  },
   "packageRules": [
     {
       "matchPackageNames": ["bats-core"],
       "groupName": "bats-core"
     },
     {
+      "description": "Digest-pin the devcontainer base image + features (the jdx preset extends docker:pinDigests; this re-enables it for the devcontainer manager).",
       "matchManagers": ["devcontainer"],
-      "pinDigests": false
+      "pinDigests": true
     },
     {
       "matchUpdateTypes": ["minor", "patch", "digest"],
@@ -26,72 +24,8 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["(^|/)mise\\.toml$"],
-      "matchStrings": [
-        "(?<packageName>[\\w-]+)\\s*=\\s*\"(?<currentValue>[^\"]+)\""
-      ],
-      "datasourceTemplate": "asdf-registry"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": ["(^|/)config\\.toml\\.tmpl$"],
-      "matchStrings": [
-        "\"npm:(?<depName>[^\"]+)\"\\s*=\\s*\"(?<currentValue>[^\"]+)\""
-      ],
-      "datasourceTemplate": "npm"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": ["(^|/)config\\.toml\\.tmpl$"],
-      "matchStrings": [
-        "\"pipx:(?<depName>[^\"]+)\"\\s*=\\s*\"(?<currentValue>[^\"]+)\""
-      ],
-      "datasourceTemplate": "pypi"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": ["(^|/)config\\.toml\\.tmpl$"],
-      "matchStrings": [
-        "\"pipx:(?<depName>[^\"]+)\"\\s*=\\s*\\{[^}]*version\\s*=\\s*\"(?<currentValue>[^\"]+)\""
-      ],
-      "datasourceTemplate": "pypi"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": ["(^|/)config\\.toml\\.tmpl$"],
-      "matchStrings": [
-        "\"github:(?<depName>[^\"]+)\"\\s*=\\s*\"(?<currentValue>[^\"]+)\""
-      ],
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": ["(^|/)config\\.toml\\.tmpl$"],
-      "matchStrings": [
-        "\"conda:(?<depName>[^\"]+)\"\\s*=\\s*\"(?<currentValue>[^\"]+)\""
-      ],
-      "datasourceTemplate": "conda"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": ["docker-bake\\.hcl$", "\\.devcontainer/devcontainer\\.json$"],
-      "matchStrings": [
-        "\"(?<depName>[\\w.-]+/[\\w.-]+):(?<currentValue>[\\w.-]+)\""
-      ],
-      "datasourceTemplate": "docker"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": ["\\.devcontainer/Dockerfile$", "docker-bake\\.hcl$", "\\.devcontainer/devcontainer\\.json$"],
-      "matchStrings": [
-        "MISE_VERSION[\"=: ]+v?(?<currentValue>[\\d.]+)"
-      ],
-      "depNameTemplate": "jdx/mise",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": ["hk\\.pkl$"],
+      "description": "hk pkl schema pin (amends + import package:// URLs) — kept in lockstep with hk releases across hk.pkl, hk-common.pkl, hk-image.pkl. No native/preset manager covers a pkl amends URL.",
+      "managerFilePatterns": ["/(^|/)hk(-common|-image)?\\.pkl$/"],
       "matchStrings": [
         "download/v(?<currentValue>[\\d.]+)/hk@"
       ],
@@ -100,7 +34,8 @@
     },
     {
       "customType": "regex",
-      "fileMatch": ["(^|/)\\.chezmoiversion$"],
+      "description": "chezmoi minimum-version file. No native/preset manager covers .chezmoiversion.",
+      "managerFilePatterns": ["/(^|/)\\.chezmoiversion$/"],
       "matchStrings": [
         "v?(?<currentValue>[\\d.]+)"
       ],
@@ -109,7 +44,8 @@
     },
     {
       "customType": "regex",
-      "fileMatch": ["docker-bake\\.hcl$", "\\.devcontainer/Dockerfile$"],
+      "description": "clang-p2996 pinned git SHA (tagless p2996 branch HEAD). git-refs datasource; no preset handles a git digest.",
+      "managerFilePatterns": ["/docker-bake\\.hcl$/", "/\\.devcontainer/Dockerfile$/"],
       "matchStrings": [
         "CLANG_P2996_REF[\"= ]+(?<currentDigest>[a-f0-9]{40})"
       ],
@@ -119,7 +55,7 @@
       "datasourceTemplate": "git-refs"
     }
   ],
-  "enabledManagers": ["npm", "cargo", "go", "pipx", "mise", "dockerfile", "docker-compose", "devcontainer", "github-actions", "custom.regex"],
+  "enabledManagers": ["npm", "cargo", "mise", "dockerfile", "docker-compose", "devcontainer", "github-actions", "custom.regex"],
   "vulnerabilityAlerts": {
     "enabled": true
   }


### PR DESCRIPTION
First slice of the build-input observability program (epic #160). Prefer
Renovate's native managers + the extended `github>jdx/renovate-config` preset over
hand-rolled config (research-first / native-first).

## Changes
- **DELETE 8 dead/redundant `customManagers`:**
  - `asdf-registry` on `mise.toml` → the native `mise` manager covers `[tools]`.
  - all **5** `config.toml.tmpl` managers (npm / pipx ×2 / github / conda) → the file
    has no `[tools]`, so they matched nothing.
  - the `docker` manager → native `dockerfile` + `devcontainer` managers cover the
    real images (the bake refs never matched anyway).
  - `MISE_VERSION` → dead; mise is installed unpinned via `mise.run`.
- **KEEP the 3 with no native/preset coverage:** hk pkl `amends` (widened
  `managerFilePatterns` to cover `hk.pkl` + `hk-common.pkl` + `hk-image.pkl` — closes
  the schema-pin drift gap), `.chezmoiversion`, `CLANG_P2996_REF` (git-refs).
- **Fix a pre-existing bug** the validator surfaced: `enabledManagers` listed invalid
  `go` / `pipx` managers (Go uses `gomod`; pipx tools are handled by the mise manager).
- Migrate deprecated `fileMatch` → `managerFilePatterns`; flip `devcontainer`
  `pinDigests` → true; drop redundant `mise:enabled` (on by default via `config:recommended`).

Net: `renovate.json` **+9 / −73**.

## Validation
- `renovate-config-validator --strict` → rc=0
- `mise run lint` → rc=0
- `dotfiles-setup verify run` → 71 passed / 0 failed (incl. `ci.regex-managers-enabled`,
  `ci.renovate-extends-jdx-preset`)

Follow-up (epic #160): wire `renovate-config-validator` as an hk step + add it to
`mise.toml [tools]` so this validation also runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFxwz3diWb5iNjKtUnae2Q


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update settings for container-based and custom dependency checks.
  * Clarified which files are included in several update rules, making dependency detection more consistent.
  * Removed support for two update managers, so those dependency types will no longer be processed automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->