### PR TITLE
chore(phase0): renovate-validator hk step + stale-doc/footgun fixes + tool-currency rule (#160)

### DIFF
--- a/.claude/agents/dockerfile-reviewer.md
+++ b/.claude/agents/dockerfile-reviewer.md
@@ -18,7 +18,7 @@ This project uses a multi-stage Dockerfile with BuildKit features:
 ## docker-bake.hcl Patterns
 
 - **Variable naming**: HCL variables can be overridden by same-named environment variables. Never use generic names like `REGISTRY` that CI workflows might set. Current convention: `DEFAULT_REGISTRY`, `IMAGE_REF`.
-- **Tag separation**: Push-safe targets (`dev`, `cpp`) have only registry-prefixed tags. Local-load targets (`dev-load`, `cpp-load`) add short local tags for convenience.
+- **Tag separation**: The registry target (`dev`) pushes with CI-managed tags (SHA/latest/PR, from `docker-metadata-action`). The local-load variant (`dev-load`) inherits `dev` but outputs `type=docker` to load the image locally.
 - **Cache refs**: Must use `${IMAGE_REF}:buildcache` pattern, matching the push destination org.
 - **Attestations**: All targets must include `type=provenance,mode=min` and `type=sbom`.
 

--- a/.claude/rules/tool-currency-and-native-first.md
+++ b/.claude/rules/tool-currency-and-native-first.md
@@ -1,0 +1,103 @@
+# Tool Currency & Native-First: Research Release Notes Before Building or Keeping Custom Code
+
+Before you **build** new custom tooling around a managed tool — or **keep**
+existing custom tooling that a tool might now do natively — first research that
+tool's **release notes / CHANGELOG and latest documentation**. Prefer the
+native/framework mechanism. When a native feature supersedes custom code,
+**retire the custom code in the same change** and update every doc that
+describes it.
+
+This is the currency-over-time sibling of `use-tool-builtins.md`: that rule says
+*prefer the built-in over inventing one now*; this rule says *keep checking,
+because the built-in you needed may have shipped since you last looked — and the
+custom code you wrote last year may now be dead weight.*
+
+## Why this rule exists
+
+The managed tools in this repo (mise, hk, Renovate, uv, docker, chezmoi) move
+fast, and their **docs lag their code** — the merged CHANGELOG/PRs are often the
+only truthful source. Stated twice by Ray (2026-07-04), and verified repeatedly
+in the devcontainer build-input program:
+
+- **mise's rattler `conda:` backend** now writes per-platform `sha256` +
+  transitive deps to `mise.lock` (graduated v2026.5.0, confirmed on 2026.7.0).
+  This **retires** the custom `mise-system-resolved.json` snapshot +
+  `mise_snapshot.py` + the manual capture task — a hand-rolled workaround the
+  tool now does natively and more strongly. The docs "backend-support table"
+  still listed conda as unsupported; only the CHANGELOG told the truth.
+- **`minimum_release_age` / `lockfile` / `lockfile_platforms`** are native — no
+  custom cooldown or platform-scoping machinery needed.
+- **Renovate's native `mise` manager + the `github>jdx/renovate-config` preset**
+  made **8 of 11** hand-rolled `customManagers` redundant (PR #161).
+- **`get_env()` vs the Tera `env.VAR` variable** (mise 2026.7.0): the
+  *documented* function was insufficient for a mise.local.toml `[env]` override;
+  only empirically probing both revealed which one the task actually needed. The
+  native mechanism is the default answer, but *verify which native mechanism*.
+
+The failure mode this prevents: shipping (or preserving) homegrown machinery for
+a problem the tool already solves — paying maintenance cost forever, and often
+getting a *weaker* result (version-only vs sha256-verified) than the native path.
+
+## Rules
+
+1. **Before writing custom tooling around a managed tool, research its release
+   notes first.** Walk the `research-doc-sources.md` chain (cache → `llms.txt` →
+   `.md` → ctx7) for the tool's CHANGELOG and the relevant docs page. Assume the
+   docs may be stale; cross-check against the merged CHANGELOG/PRs. If the
+   feature you were about to hand-write already exists, use it.
+
+2. **Periodically re-check pinned-vs-latest for existing custom code.** For each
+   piece of custom tooling wrapping a managed tool, ask "does the tool now do
+   this natively?" Run the [[tool-currency-check]] skill (`mise outdated` +
+   pkl/pin-vs-latest-release diff + release-note scan) to produce a retire/bump
+   report.
+
+3. **Prefer native / framework over custom; when a native feature supersedes
+   custom code, RETIRE the custom code.** Don't leave a superseded snapshot,
+   script, or manager lingering "just in case" — dead custom code rots and
+   misleads. Delete it in the same change that adopts the native path.
+
+4. **Verify *which* native mechanism empirically.** A tool often exposes several
+   near-synonyms (e.g. `get_env()` vs `env.VAR`, `MISE_IGNORED_CONFIG_PATHS` vs
+   `MISE_OVERRIDE_CONFIG_FILENAMES`). Probe the real behavior before committing —
+   the documented-sounding one is not always the one that meets the requirement.
+
+5. **Sync the describing docs/skills in the SAME change.** Retiring a snapshot,
+   decoupling a cache tier, bumping a pinned version, or swapping custom→native
+   goes stale in `P2996-CACHE.md`, the `AGENTS.md` files, isolation wikis, and
+   skill files. Update them in the same commit — respecting
+   `claude_md_size_limit` / `claude_agents_md_pairs` / `claude_md_import_stub`.
+
+6. **Justify any custom code that survives the check, in writing.** If a native
+   feature exists but is genuinely insufficient (rule 4's `get_env()` case),
+   record *why* in the code comment or commit body. Without that justification,
+   the default answer is "use the native path, delete the custom code."
+
+## Applies to
+
+All managed tools in this repo: mise, hk, Renovate, uv/ruff/ty, docker/bake,
+chezmoi, pinact, agnix, and future additions. Especially the custom machinery in
+`python/src/dotfiles_setup/` (content-hash, snapshots, refresh) and the
+`renovate.json` customManagers — the two largest reservoirs of "does the tool do
+this natively now?" surface area.
+
+## Machine enforcement
+
+Partially machine-backed, not fully automatable (judgment is required):
+
+- **hk cross-file version-parity** (planned check-H): asserts `hk@<ver>` is
+  identical across `hk.pkl` / `hk-common.pkl` / `hk-image.pkl` and matches the
+  `mise.toml` binary pin — catches pin drift that this rule would otherwise
+  catch by hand.
+- **Renovate PRs carry the CHANGELOG** — bump review IS release-note review.
+- **agnix** structurally validates this rule file + the skill.
+
+## See also
+
+- `use-tool-builtins.md` — the point-in-time sibling: prefer built-ins over
+  inventing custom logic now.
+- `research-doc-sources.md` — the doc-fetch preference chain (cache-first) this
+  rule's research step walks.
+- `.claude/skills/tool-currency-check/SKILL.md` — the operational workflow.
+- Memory: `feedback_research_release_notes_native_first`,
+  `feedback_use_tool_builtins`, `feedback_content_hash_must_cover_copy_inputs`.

--- a/.claude/skills/tool-currency-check/SKILL.md
+++ b/.claude/skills/tool-currency-check/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: tool-currency-check
+description: "Use when auditing whether the repo's pinned tools are current AND whether any hand-rolled custom code is now superseded by a native tool feature. Produces a retire/bump report from mise outdated + pkl/pin-vs-latest diff + a cache-first release-note scan."
+user-invocable: true
+type: learned-skill
+extracted-from: session 2026-07-04 (devcontainer build-input program, epic #160)
+applicability: any repo managing tools via mise + hk + Renovate
+---
+
+# Skill: Tool Currency Check
+
+Operationalizes `.claude/rules/tool-currency-and-native-first.md`: find
+out-of-date pins AND custom code a tool now does natively, in one pass.
+
+## When to use
+
+- Starting a "get on latest tool versions" / "stop reinventing" task.
+- Before writing new custom tooling around a managed tool (confirm it's not
+  already native).
+- Periodically, to catch custom code that a tool's newer release has superseded
+  (the `mise_snapshot.py` → `mise.lock` class of finding).
+
+## Procedure
+
+1. **Version drift — `mise outdated`.** Lists pinned-vs-latest for every
+   `mise.toml` / `mise-system.toml` tool:
+
+   ```bash
+   mise outdated            # host/project tools (root mise.toml)
+   ```
+
+   Note which are intentionally held back (comments in `mise.toml`, e.g. `rtk`
+   pinned for a lockfile bug) — those are decisions, not drift.
+
+2. **Cross-file pin parity.** Some versions are pinned in more than one place
+   and must move together. The load-bearing one is **hk**, pinned in the pkl
+   `amends`/`import` URLs of all three pkl files AND in `mise.toml`:
+
+   ```bash
+   grep -rhoE 'hk@[0-9]+\.[0-9]+\.[0-9]+' hk.pkl hk-common.pkl hk-image.pkl | sort -u
+   grep -E '^hk = ' mise.toml
+   ```
+
+   All must be identical. A mismatch is drift (the current 1.44.2-pkl /
+   1.46-mise gap is a real example). Compare against the latest release via
+   `mise outdated hk`.
+
+3. **Custom-code inventory — "does the tool do this natively now?"** For each
+   piece of hand-rolled machinery, re-check the tool's current capability:
+
+   | Custom code | Tool feature to re-check |
+   |---|---|
+   | `python/.../p2996_hash.py` content-hash | mise SBOM / `mise bom` / any toolchain-fingerprint (none as of 2026-07) |
+   | `mise-system-resolved.json` + `mise_snapshot.py` | `mise lock` conda `sha256` (rattler — NOW native, retire the snapshot) |
+   | `refresh.yml` `p2996-refresh` | Renovate `git-refs` datasource |
+   | `renovate.json` customManagers | native mise/dockerfile/devcontainer managers + jdx preset |
+
+4. **Release-note scan (cache-first).** For each outdated / custom-wrapped tool,
+   read the CHANGELOG via the `research-doc-sources.md` chain — **do not** guess
+   from the docs, which lag the code:
+
+   ```bash
+   # step 0: local cache
+   grep -rHi <feature> docs/research/mintlify-cache/jdx/<tool>/
+   # step 1/2: remote, only on cache miss
+   curl -s https://raw.githubusercontent.com/jdx/<tool>/main/docs/... .md
+   ```
+
+   Look specifically for features that would let us **delete** custom code.
+
+5. **Emit a retire/bump report.** One table:
+
+   ```
+   | tool/code | pinned | latest | native-now? | action        |
+   |-----------|--------|--------|-------------|---------------|
+   | hk        | 1.44.2 | 1.49.0 | n/a         | bump (3 pkl + mise + lock) |
+   | mise-snapshot.json | — | — | mise.lock conda sha256 | RETIRE |
+   ```
+
+   Actions: `bump`, `retire` (custom→native), `hold` (with reason), `keep`
+   (custom still justified — record why per rule 6).
+
+## Guardrails
+
+- **In-image config edits cascade.** Bumping a pin in `mise-system.toml` /
+  `hk-image.pkl` / `hk-common.pkl` busts the base content-hash → cold rebuild.
+  Batch those (Phase 1), don't drip them.
+- **Retire in the same change** that adopts the native path, and sync the docs
+  that describe the retired code (`P2996-CACHE.md`, the `AGENTS.md` files) — rule
+  5.
+- **Renovate already owns routine bumps.** This skill is for the judgment layer
+  (custom→native retirement, cross-file parity) Renovate can't do, not for
+  re-doing what a Renovate PR already proposes.
+
+## Related
+
+- `.claude/rules/tool-currency-and-native-first.md` — the rule this implements.
+- `.claude/rules/use-tool-builtins.md` — prefer built-ins over inventing.
+- `.claude/rules/research-doc-sources.md` — the cache-first doc chain step 4 walks.
+- Memory: `feedback_research_release_notes_native_first`,
+  `feedback_content_hash_must_cover_copy_inputs`.

--- a/.claude/skills/tool-currency-check/SKILL.md
+++ b/.claude/skills/tool-currency-check/SKILL.md
@@ -70,7 +70,7 @@ out-of-date pins AND custom code a tool now does natively, in one pass.
 
 5. **Emit a retire/bump report.** One table:
 
-   ```
+   ```text
    | tool/code | pinned | latest | native-now? | action        |
    |-----------|--------|--------|-------------|---------------|
    | hk        | 1.44.2 | 1.49.0 | n/a         | bump (3 pkl + mise + lock) |

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -13,11 +13,11 @@ post-failure reporting.
 | File | Purpose |
 |------|---------|
 | `ci.yml` | Thin caller (Phase B, #118): lint → contract-preflight → `changes` (path-gate) → `build-publish` (the reusable build chain, gated on `changes.build` + push-to-main exemption); OR lint → promote (push to main) |
-| `build-publish.yml` | Reusable (`on: workflow_call`) build chain: base-prep → p2996-prep → dev-prep → build → smoke-test (smoke+Dive) → dev-tag. dev-prep/dev-tag are the third content-hash tier (#122). Inputs `{tag_strategy, publish, target, ref, p2996_ref, platform*}` (`p2996_ref` active Phase D #120; `*platform` reserved); outputs `{image_ref, digest}`. `github` context = caller's event, so sha/pr tags resolve identically |
+| `build-publish.yml` | Reusable (`on: workflow_call`) build chain: base-prep → p2996-prep → dev-prep → build → smoke-test → dev-tag (dev-prep/dev-tag = 3rd content-hash tier, #122). Inputs `{tag_strategy, publish, target, ref, p2996_ref, platform*}` (`p2996_ref` #120; `*` reserved); outputs `{image_ref, digest}`. Caller's `github` context → sha/pr tags resolve identically |
 | `ci-failure-report.yml` | Post-failure diagnostics / issue filing |
 | `image-analysis.yml` | Async (`workflow_run` on CI success): benchmark metrics + Trivy CVE scan, off the PR critical path |
-| `refresh.yml` | Daily cron (00:00): two independent jobs — `snapshot-refresh` (refresh `mise-system-resolved.json` on conda-forge drift, **auto-merges**) and `p2996-refresh` (bump `CLANG_P2996_REF` to latest `bloomberg/clang-p2996` HEAD, **review-required**, #100). Each mints a GitHub App token (Phase C, #119) so its PR fires CI on its own; both open a PR via `open-refresh-pr`. See **GitHub App** below. |
-| `dispatch-build.yml` | Thin `repository_dispatch` caller (Phase D, #120, type `build-p2996`): calls `build-publish.yml` with `client_payload.{p2996_ref,ref?}` + `tag_strategy: dispatch` for an on-demand exact-upstream-SHA build. Never moves `:dev`/`:latest`; warms `:p2996-<hash>`/`:dev-<hash>`. See **Phase D** below. |
+| `refresh.yml` | Daily cron (00:00), two independent jobs: `snapshot-refresh` (refresh `mise-system-resolved.json` on conda-forge drift, **auto-merges**) and `p2996-refresh` (bump `CLANG_P2996_REF` to `bloomberg/clang-p2996` HEAD, **review-required**, #100). Each mints an App token (#119) so its PR fires CI on its own; both PR via `open-refresh-pr`. See **GitHub App** below. |
+| `dispatch-build.yml` | Thin `repository_dispatch` caller (Phase D, #120, type `build-p2996`): calls `build-publish.yml` with `client_payload.{p2996_ref,ref?}` + `tag_strategy: dispatch` for on-demand exact-upstream-SHA builds. Never moves `:dev`/`:latest`; warms `:p2996-<hash>`/`:dev-<hash>`. See **Phase D** below. |
 
 ## Composite actions (`.github/actions/`)
 
@@ -25,8 +25,8 @@ Self-documented in each `action.yml`: `setup-mise` (wraps `jdx/mise-action`
 + `install_args`, all 8 mise jobs) and `open-refresh-pr` (App-token create-PR
 + optional squash auto-merge, both `refresh.yml` jobs). **Local-composite
 checkout gotcha:** `./.github/actions/*` resolves from `$GITHUB_WORKSPACE`
-(empty until checkout), so jobs run `actions/checkout` FIRST, then the
-composite. **Composites can't read `secrets`** — the App token is minted in
+(empty until checkout), so jobs `actions/checkout` FIRST, then the composite.
+**Composites can't read `secrets`** — the App token is minted in
 `refresh.yml`, passed in.
 
 ## Pipeline stages
@@ -38,17 +38,17 @@ behavior unchanged):
 1. **lint** — mise install, hk pre-commit, agnix agent-doc validation
    (`agnix .`; `.agnix.toml` `severity = "Warning"` = non-blocking),
    `mise doctor --json`, `mise.lock` upload + cache. agnix uses the
-   `github:agent-sh/agnix` backend (not `npm:agnix` — see `mise.toml`).
+   `github:agent-sh/agnix` backend (not `npm:agnix`).
 2. **contract-preflight** — Python 3.14 + uv; runs `dotfiles-setup
    verify run` over `python/verification/suites.toml`.
 3. **base-prep** — `dotfiles-setup base-hash` → probe `:base-<hash16>`
    (`docker manifest inspect`). Hit: <30s. Miss: build the `base` bake
-   target (devcontainer-base = apt + mise install + cargo), push it.
+   target (devcontainer-base = apt + mise install + cargo), push it;
    p2996-prep + build pull it instead of rebuilding the mise layer.
-   base-hash covers the bytes of every base-section COPY input —
-   `mise-system.toml` (#140) + `hk-common.pkl`/`hk-image.pkl` (#156). Since
-   p2996-hash includes base-hash, ANY edit to those busts BOTH tiers → a cold
-   ~2h rebuild (batch in-image config changes).
+   base-hash covers the BYTES of every base-section COPY input —
+   `mise-system.toml` (#140), `hk-common.pkl`/`hk-image.pkl` (#156). Since
+   p2996-hash folds base-hash, ANY edit busts BOTH tiers → a cold ~2h
+   rebuild (batch in-image config edits).
 4. **p2996-prep** — `dotfiles-setup p2996-hash` → probe `:p2996-<hash16>`.
    Hit: <30s. Miss: build the `p2996-cache` bake target (scratch
    `p2996-export` with just `/opt/clang-p2996`, ~500 MB), push to GHCR.
@@ -61,7 +61,7 @@ behavior unchanged):
 7. **smoke-test** — pulls `:sha-<github.sha>`, runs the PR-blocking gates
    `image smoke` + Dive (`.dive-ci`); benchmark + Trivy are async in
    `image-analysis.yml`. On success **dev-tag** stamps the `:dev-<hash>`
-   validated marker — the smoked image is what's retagged `:dev`/`:latest`.
+   validated marker — the smoked image is retagged `:dev`/`:latest`.
 
 Push-to-main path (after a PR merge):
 
@@ -86,7 +86,7 @@ Push-to-main path (after a PR merge):
   group by `${{ github.workflow }}-${{ github.head_ref || github.ref }}`; a
   new commit cancels the older in-flight run. **main is exempt**
   (`cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`) so its
-  push-path `promote` retag is never interrupted mid-flight.
+  `promote` retag is never interrupted mid-flight.
 - **Python 3.14 + uv via the `setup-mise` composite** for contract-preflight
   and smoke-test (`install_args: python uv`). lint caches mise data on `mise.lock`.
 - **build job** passes GitHub token via BuildKit **secret mount**
@@ -101,13 +101,12 @@ Push-to-main path (after a PR merge):
 - **Three-tier content-hash probe cache** (#122): `:base-`/`:p2996-`/`:dev-<hash>`,
   each `docker manifest inspect`-probed (`dotfiles-setup {base,p2996,dev}-hash`)
   before its build. `:dev-<hash>` (= base+p2996 hashes + whole Dockerfile + dev
-  target) is tagged only AFTER smoke passes (validated marker), so a PR hit
-  skips build+smoke (retag to `:sha`/`:pr-NNN`). Nightly skips the dev probe
-  and always rebuilds (catches rolling-tool drift the hash can't see).
-- **P2996 cache inputs.** Key = `CLANG_P2996_REF`, `BASE_IMAGE`,
-  `PLATFORM`, Dockerfile, bake, `mise-system-resolved.json`,
-  `mise-system.toml`. Bust: `mise run capture-mise-system-resolved`
-  (`.devcontainer/P2996-CACHE.md`).
+  target) is tagged only AFTER smoke passes, so a PR hit skips build+smoke
+  (retag to `:sha`/`:pr-NNN`). Nightly skips the dev probe and always rebuilds
+  (catches rolling-tool drift the hash can't see).
+- **P2996 cache inputs.** Key = `CLANG_P2996_REF`, `BASE_IMAGE`, `PLATFORM`,
+  Dockerfile, bake, `mise-system-resolved.json`, `mise-system.toml`. Bust:
+  `mise run capture-mise-system-resolved` (`.devcontainer/P2996-CACHE.md`).
 - **`uv run --project python`**, not `--directory` — `--directory`
   changes cwd and breaks relative test paths.
 - **Use `--watch`, never sleep-poll** (`gh pr checks <n> --watch`); the
@@ -115,19 +114,19 @@ Push-to-main path (after a PR merge):
   `--json conclusion`. Authority: `.claude/rules/gh-cli-watch.md`.
 - **No `type=gha` cache on `base`/`p2996-cache` targets** — registry tag +
   `Probe cache` IS the durable cache; `mode=max` gha export exceeds the 1h
-  Azure SAS TTL → `403` on cold runs. `dev` keeps gha cache (small).
+  Azure SAS TTL → `403` on cold runs. `dev` keeps gha cache.
 - **Trivy lives in `image-analysis.yml` (async), not smoke-test.**
-  `scanners: vuln` + `timeout: 15m`, warn-only (default scanners timeout
-  at 5min on the multi-GB image); CVE-only scope (issue #92).
+  `scanners: vuln` + `timeout: 15m`, warn-only (defaults timeout at 5min on
+  the multi-GB image); CVE-only (#92).
 - **`wagoodman/dive` action is broken upstream** (v0.13.1 `ARG
-  DOCKER_CLI_VERSION` empty → 404s on `docker-.tgz`). Install the binary
-  release tarball in a `run:` step; never `uses: wagoodman/dive@<sha>`.
+  DOCKER_CLI_VERSION` empty → 404s on `docker-.tgz`). Install the release
+  tarball in a `run:` step; never `uses: wagoodman/dive@<sha>`.
 
 ## Cron schedules (`schedule:`)
 
 GHA `schedule.cron` honors a sibling `timezone:` field (IANA zone), e.g.
-`timezone: "America/Chicago"` — NOT UTC-only (a stale claim). Two staggered
-daily crons, **distinct, complementary** roles:
+`timezone: "America/Chicago"` — NOT UTC-only. Two staggered daily crons,
+**distinct, complementary** roles:
 
 | Time | Workflow | Role |
 |------|----------|------|
@@ -140,15 +139,14 @@ nightly publishes. Do NOT collapse onto one cron (issue #116).
 ## GitHub App — refresh auto-merge (Phase C, #119)
 
 `refresh.yml` mints an App token (`actions/create-github-app-token`) so its
-PR fires `pull_request` CI on its own — GITHUB_TOKEN PRs don't. **One-time
+PR fires `pull_request` CI on its own (GITHUB_TOKEN PRs don't). **One-time
 repo-admin setup:** (1) create a GitHub App with **contents: write +
-pull-requests: write**, install it here, add secrets `REFRESH_APP_ID` (the
-**numeric App ID**, not Client ID `Iv…`) + `REFRESH_APP_PRIVATE_KEY`;
-(2) enable **Allow auto-merge**; (3) branch protection on `main` requiring
-the **`ci-gate`** check — else `--auto` lands before smoke. Policy:
-snapshot auto-merges (squash) once smoke passes; p2996 is review-required.
-`ci-gate` (always-run: passes when upstream succeed/skip) lets non-build
-PRs merge without admin.
+pull-requests: write**, install it, add secrets `REFRESH_APP_ID` (**numeric
+App ID**, not Client ID `Iv…`) + `REFRESH_APP_PRIVATE_KEY`; (2) enable
+**Allow auto-merge**; (3) branch protection on `main` requiring **`ci-gate`**
+— else `--auto` lands before smoke. Policy: snapshot auto-merges (squash)
+once smoke passes; p2996 is review-required. `ci-gate` (always-run: passes
+when upstream succeed/skip) lets non-build PRs merge without admin.
 
 ## Phase D — on-demand p2996 build (#120)
 
@@ -161,20 +159,20 @@ gh api repos/ray-manaloto/dotfiles/dispatches -f event_type=build-p2996 \
 ```
 
 `p2996_ref` flows into build-publish.yml's **Resolve p2996 ref override**
-steps (p2996-prep, dev-prep, dev-tag): they export `CLANG_P2996_REF` so
-BOTH `dotfiles-setup {p2996,dev}-hash` AND docker bake's native variable
-override resolve the same SHA — the cache tag tracks the override, never
-poisoning the pinned cache. Empty input exports nothing → the
-`docker-bake.hcl` pin wins (byte-identical build). `tag_strategy: dispatch`
-emits `:sha` only; merge the `p2996-refresh` PR to make a bump permanent.
+steps (p2996-prep, dev-prep, dev-tag): they export `CLANG_P2996_REF` so BOTH
+`dotfiles-setup {p2996,dev}-hash` AND docker bake's native variable resolve
+the same SHA — the cache tag tracks the override, never poisoning the pinned
+cache. Empty input exports nothing → the `docker-bake.hcl` pin wins
+(byte-identical). `tag_strategy: dispatch` emits `:sha` only; merge the
+`p2996-refresh` PR to make a bump permanent.
 
 ## Dependabot (`.github/dependabot.yml`)
 
 - **`interval: "cron"` enforces a 24h minimum.** The schema accepts
   `interval: "cron"` + `cronjob: "<expr>"` + `timezone: "<tz>"`, but
-  `dependabot-api.githubapp.com` rejects sub-daily (min allowed 24h). Use
+  `dependabot-api.githubapp.com` rejects sub-daily (min 24h). Use
   `0 0 * * *` or longer, never `0 * * * *`. Validated as a check named
-  `.github/dependabot.yml` on every PR touching the file. (PR #86.)
+  `.github/dependabot.yml` on every PR touching the file. (#86.)
 
 ## Debugging CI failures
 
@@ -189,11 +187,11 @@ emits `:sha` only; merge the `p2996-refresh` PR to make a bump permanent.
 - For Docker warning triage, see the `ci-warning-investigator` skill.
 - **`gh run list` returns multiple workflows.** A branch has both a `CI`
   and an `autofix.ci` run per push; filter `--workflow CI` to disambiguate.
-- **Manual autofix-fix recipe** (`autofix-ci/action` can't push back,
+- **Manual autofix recipe** (`autofix-ci/action` can't push back,
   `500 ... not installed`): `gh run download RUN_ID`, base64-decode
-  `additions[].contents` from `autofix.json`, apply, commit, push (PR #94).
+  `additions[].contents` from `autofix.json`, apply, commit, push (#94).
 - **Re-run a failed job** — `gh run rerun RUN_ID --failed` refires only the
-  failed jobs against the same commit (verify a config fix without a fresh
-  push; validated on the autofix.ci app install, `ee079c5`).
+  failed jobs against the same commit (re-verify a fix without a fresh push;
+  validated `ee079c5`).
 
 <!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ the official `@devcontainers/cli` (pinned in `mise.toml`).
 | `hk.pkl` | Project git hook config; imports `hk-common.pkl`; enforces `no_lint_skip`, `no_mcp_registration`, `require_pipefail`, `claude_md_import_stub`, `claude_agents_md_pairs` |
 | `hk-common.pkl` | Shared step definitions (hygiene, safety, security, typos) reused by `hk.pkl` and `hk-image.pkl` |
 | `hk-image.pkl` | Image-only hook config for devcontainer validation |
-| `docker-bake.hcl` | BuildKit bake config (`dev`, `cpp`, `dev-load`, `cpp-load` targets); `IMAGE_REF` consolidates registry+image |
+| `docker-bake.hcl` | BuildKit bake config (`dev`, `dev-load` build targets + `base`/`p2996-cache` CI stages); `IMAGE_REF` consolidates registry+image |
 | `renovate.json` | Renovate dependency update config |
 | `AGENTS.md` | Agent-agnostic project instructions (this file) |
 | `CLAUDE.md` | Thin `@AGENTS.md` import stub for Claude Code |

--- a/hk.pkl
+++ b/hk.pkl
@@ -197,6 +197,28 @@ hooks {
         glob = List("**/mise.toml")
       }
 
+      // --- Renovate config validation ---
+      //     `renovate-config-validator` (from npm:renovate in mise.toml) is the
+      //     official schema + migration validator. `--strict` fails on any
+      //     warning/error OR a needed config migration (e.g. a deprecated
+      //     `regex` manager name that must become `custom.regex`). `--no-global`
+      //     validates renovate.json AS A REPO CONFIG — without it the validator
+      //     treats a named file as GLOBAL self-hosted config and applies the
+      //     wrong schema. Network-safe: the validator does NOT fetch remote
+      //     `extends` presets (verified: a nonexistent preset still passes, run
+      //     is ~0.25s), so unlike pinact there's no GitHub rate-limit risk.
+      //
+      //     NOTE: this is COMPLEMENTARY to — not a replacement for — the
+      //     `ci.regex-managers-enabled` and `ci.renovate-extends-jdx-preset`
+      //     contracts in suites.toml. Empirically the validator passes when
+      //     `custom.regex` is dropped from enabledManagers (the 3 customManagers
+      //     silently go dead) AND when the jdx preset is removed; those two
+      //     repo-specific semantics are guarded only by the suites.toml tokens.
+      ["renovate_config_validate"] {
+        glob = List("renovate.json")
+        check = "renovate-config-validator --strict --no-global renovate.json"
+      }
+
       // --- Agent documentation ---
       ["agnix"] {
         check = "agnix ."

--- a/mise.local.toml.example
+++ b/mise.local.toml.example
@@ -1,18 +1,28 @@
 # mise.local.toml.example — per-clone override surface for the devcontainer tasks.
 #
-# Copy to mise.local.toml (gitignored) and edit. mise merges *.local.toml
-# on top of mise.toml, so any key here shadows the matching key in mise.toml.
+# Copy to mise.local.toml (gitignored) and edit. Override via a top-level
+# `[env]` block: mise MERGES `[env]` across configs (more-specific wins), and
+# the devcontainer tasks read these vars as templated defaults
+# (`{{ env.VAR | default(value='...') }}`), so a value set here overrides the
+# task default WITHOUT touching the task body.
 #
-# Primary overrides:
+# WARNING: do NOT override by redefining a task (`[tasks.up]`,
+# `[tasks.dev-rebuild]`, …). A `[tasks.<name>]` block in mise.local.toml
+# REPLACES the whole task — it strips the task's `run` body, so `mise run up`
+# silently becomes a no-op. mise task tables do NOT deep-merge (verified on
+# mise 2026.7.0). Use `[env]` only. See feedback_mise_local_toml_replaces_task.
+#
+# Overridable vars (consumed by the up / dev-rebuild / verify-* tasks):
 #
 #   - DEVCONTAINER_SSH_PORT — host-side port for the inbound ssh shell
-#     (Requirement R1). Default 4444. Bump on port collision; volume
-#     names do NOT include the port (C10/C11/C12) so you won't lose
-#     mise-user/cargo-user/rustup-user installs when recovering.
-#   - BASE_IMAGE — pin to a specific SHA tag for reproducible rebuilds.
+#     (Requirement R1). Default 4444. Bump on port collision; volume names do
+#     NOT include the port (C10/C11/C12), so you keep your home volume when
+#     recovering.
+#   - BASE_IMAGE — pin to a specific tag/SHA for reproducible rebuilds.
+#     Default ghcr.io/ray-manaloto/dotfiles-devcontainer:dev.
 #
 # DO NOT check in mise.local.toml; it is gitignored by design.
 
-[tasks.up]
-env = { DEVCONTAINER_SSH_PORT = "4444" }
-# env = { DEVCONTAINER_SSH_PORT = "4444", BASE_IMAGE = "ghcr.io/ray-manaloto/dotfiles-devcontainer:<sha>" }
+[env]
+DEVCONTAINER_SSH_PORT = "4444"
+# BASE_IMAGE = "ghcr.io/ray-manaloto/dotfiles-devcontainer:<sha>"

--- a/mise.lock
+++ b/mise.lock
@@ -721,6 +721,10 @@ backend = "npm:oh-my-claude-sisyphus"
 version = "0.13.1"
 backend = "npm:portless"
 
+[[tools."npm:renovate"]]
+version = "43.251.3"
+backend = "npm:renovate"
+
 [[tools."npm:skills"]]
 version = "1.5.9"
 backend = "npm:skills"

--- a/mise.toml
+++ b/mise.toml
@@ -169,7 +169,20 @@ description = "Bring the devcontainer up via the official @devcontainers/cli (Ma
 # pull` here — it bypasses the devcontainer-cli lifecycle (no
 # initializeCommand etc.) and recreates the silent-failure surface
 # from PR #86. To force-refresh, use `mise run dev-rebuild`.
-env = { BASE_IMAGE = "ghcr.io/ray-manaloto/dotfiles-devcontainer:dev", DOCKER_DEFAULT_PLATFORM = "linux/amd64/v2", DEVCONTAINER_SSH_PORT = "4444", DOPPLER_PROJECT = "dotfiles", DOPPLER_CONFIG = "dev" }
+#
+# BASE_IMAGE + DEVCONTAINER_SSH_PORT are templated `{{ env.VAR |
+# default(value='...') }}` so a per-clone gitignored mise.local.toml
+# `[env]` (or a shell env var) overrides them WITHOUT redefining the
+# task. A bare `[tasks.up]` in mise.local.toml REPLACES the whole task and
+# strips this `run` body (see mise.local.toml.example and
+# feedback_mise_local_toml_replaces_task) — templating is how the
+# documented override actually works. The Tera `env.VAR` variable (NOT the
+# documented `get_env()` function) is required: `get_env()` reads only the
+# ambient process env and is blind to mise's own merged `[env]` layer, so
+# it would silently ignore a mise.local.toml `[env]` override. The default
+# keeps these TASK-scoped (no global leak of BASE_IMAGE / the amd64
+# platform into unrelated subprocesses) unless the user opts in.
+env = { BASE_IMAGE = "{{ env.BASE_IMAGE | default(value='ghcr.io/ray-manaloto/dotfiles-devcontainer:dev') }}", DOCKER_DEFAULT_PLATFORM = "linux/amd64/v2", DEVCONTAINER_SSH_PORT = "{{ env.DEVCONTAINER_SSH_PORT | default(value='4444') }}", DOPPLER_PROJECT = "dotfiles", DOPPLER_CONFIG = "dev" }
 run = '''
 set -euo pipefail
 # v6 collision guard: compute an 8-char hash of $PWD so sibling clones
@@ -194,7 +207,8 @@ description = "Force a full rebuild + re-pull of :dev (lifecycle hooks fire)"
 # layer if the registry has a new digest), and `--build-no-cache` rebuilds
 # the host-user overlay without cached layers. Lifecycle hooks
 # (initializeCommand → onCreateCommand → postCreateCommand) all fire.
-env = { BASE_IMAGE = "ghcr.io/ray-manaloto/dotfiles-devcontainer:dev", DOCKER_DEFAULT_PLATFORM = "linux/amd64/v2", DEVCONTAINER_SSH_PORT = "4444", DOPPLER_PROJECT = "dotfiles", DOPPLER_CONFIG = "dev" }
+# BASE_IMAGE + DEVCONTAINER_SSH_PORT templated for per-clone override — see the up task.
+env = { BASE_IMAGE = "{{ env.BASE_IMAGE | default(value='ghcr.io/ray-manaloto/dotfiles-devcontainer:dev') }}", DOCKER_DEFAULT_PLATFORM = "linux/amd64/v2", DEVCONTAINER_SSH_PORT = "{{ env.DEVCONTAINER_SSH_PORT | default(value='4444') }}", DOPPLER_PROJECT = "dotfiles", DOPPLER_CONFIG = "dev" }
 run = '''
 set -euo pipefail
 DEVCONTAINER_WORKSPACE_HASH="$(scripts/workspace-hash.sh)"
@@ -209,7 +223,7 @@ description = "Spot-check cookbook paths in :dev (cargo/rustup cookbook layout +
 # NOT root mise.toml. Root mise.toml tools (hk, pkl, the 5 markdown
 # linters, etc.) live on the HOST, not in the image. Keep assertions here
 # scoped to what mise-system.toml actually provides.
-env = { BASE_IMAGE = "ghcr.io/ray-manaloto/dotfiles-devcontainer:dev", DOCKER_DEFAULT_PLATFORM = "linux/amd64/v2" }
+env = { BASE_IMAGE = "{{ env.BASE_IMAGE | default(value='ghcr.io/ray-manaloto/dotfiles-devcontainer:dev') }}", DOCKER_DEFAULT_PLATFORM = "linux/amd64/v2" }
 run = '''
 docker run --rm "$BASE_IMAGE" bash -lc '
   set -euo pipefail
@@ -421,7 +435,7 @@ description = "R1: ssh ${USER}@localhost -p ${DEVCONTAINER_SSH_PORT} succeeds fr
 # container. StrictHostKeyChecking=accept-new + UserKnownHostsFile=/dev/
 # null so we don't pollute the host's known_hosts with the container's
 # ephemeral host keys.
-env = { DEVCONTAINER_SSH_PORT = "4444" }
+env = { DEVCONTAINER_SSH_PORT = "{{ env.DEVCONTAINER_SSH_PORT | default(value='4444') }}" }
 run = '''
 set -euo pipefail
 port="${DEVCONTAINER_SSH_PORT}"

--- a/mise.toml
+++ b/mise.toml
@@ -30,6 +30,7 @@ lima = "2.1.2"
 "npm:agents-lint" = "0.5.0"
 "pipx:mcp2cli" = "3.2.0"
 "pipx:check-jsonschema" = "0.37.2"
+"npm:renovate" = "43.251.3"         # provides `renovate-config-validator` for the hk `renovate_config_validate` step (CI-local parity). The validator bin ships ONLY inside the full renovate package (~354M); no validator-only package exists. Pin == latest.
 biome = "2.4.16"
 # Markdown + Claude-docs linters. Installed now; hk.pkl integration is
 # scheduled for post-devcontainer-work review (see GH issue tracking


### PR DESCRIPTION
## Epic #160 Phase 0 — no-cold-rebuild housekeeping bundle

Five focused commits, all host-only (zero image inputs touched → no base rebuild). Every commit gate-verified locally: `mise run lint` rc=0, `pytest` 190 passed, `dotfiles-setup verify run` 71 passed / 0 failed.

### Commits
1. **`ci(renovate)`** — wire `renovate-config-validator` as an hk step (`renovate_config_validate`) + add `npm:renovate` to `mise.toml` for CI-local parity. Runs `--strict --no-global renovate.json` (validates as a *repo* config, not global self-hosted). Network-safe (no preset fetch). **Kept** `ci.regex-managers-enabled` + `ci.renovate-extends-jdx-preset` contracts — empirically the validator does NOT supersede them (it passes when `custom.regex` is dropped from `enabledManagers` or the jdx preset is removed), so they guard complementary semantics.
2. **`docs(bake)`** — fix stale `cpp`/`cpp-load` bake-target references (real targets are `dev`/`dev-load` + `base`/`p2996-cache`) in `AGENTS.md` and `dockerfile-reviewer.md`.
3. **`fix(mise)`** — make `BASE_IMAGE` + `DEVCONTAINER_SSH_PORT` overridable per-clone via `mise.local.toml` `[env]`. They were hardcoded in task-inline env, which is un-overridable: a `[tasks.up]` block in `mise.local.toml` *replaces* the whole task (strips `run` → `mise run up` becomes a no-op). Fixed by templating `{{ env.VAR | default(value='...') }}` (the Tera `env` var, not `get_env()` — the latter is blind to mise's merged `[env]` layer). Rewrote `mise.local.toml.example` to use `[env]`. Verified in-repo: default→4444, shell→5555, `mise.local.toml`→6666.
4. **`docs(rules)`** — add `tool-currency-and-native-first.md` rule + `tool-currency-check` skill, codifying the "research release notes first / native-first / retire superseded custom code" directive.
5. **`docs(ci)`** — trim `.github/workflows/AGENTS.md` under agnix's 12000-char limit (was 12269; a pre-existing warning surfaced during validation), preserving every fact/issue-ref.

### Deferred to Phase 1 (cold rebuild)
- **`mise-system.toml:39` editorconfig comment** — stale (editorconfig-checker is dead in-image; hk-image.pkl runs gitleaks but not editorconfig), but *any* `mise-system.toml` edit busts the base content-hash. Carries an add-step-vs-remove-tool decision.
- **"p2996-hash folds base-hash" docs** — currently *accurate*; only becomes false after the Phase-1 p2996 decouple.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new pinned development tool version.
  * Improved local override handling so environment values can be customized without redefining tasks.

* **Documentation**
  * Clarified guidance for Docker image tagging and local image loading.
  * Expanded setup notes for CI workflows and developer task configuration.
  * Added new guidance on checking tool updates before keeping custom behavior.

* **Chores**
  * Updated several internal reference documents to match the latest workflow and tool conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->