### PR TITLE
feat(sync): mise run sync — converge devcontainer onto latest CI image + verify

### DIFF
--- a/.claude/skills/devcontainer-sync/SKILL.md
+++ b/.claude/skills/devcontainer-sync/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: devcontainer-sync
+description: Converge the local devcontainer onto the latest CI-built image and verify it, via `mise run sync`. Use after a merge to main (promote retags :dev), when unsure whether the local container/base is current, or to pre-validate a PR image with --tag pr-NNN. Also carries the wiring audit checklist for the sync workflow itself.
+user-invocable: true
+---
+
+# Devcontainer Sync
+
+`mise run sync` is the one entrypoint for "make my devcontainer run the
+newest image `ci.yml` published and prove everything works". Logic lives
+in `python/src/dotfiles_setup/sync.py` (zero-bash-logic); the mise task
+is a thin caller of `dotfiles-setup docker sync`.
+
+## When to run
+
+- After a PR merges to `main` (the `promote` job retagged registry `:dev`).
+- After any `ci.yml` run that published new image bytes.
+- When unsure whether the local container or its base is current.
+- Pre-merge validation of a PR image: `mise run sync -- --tag pr-NNN`.
+
+## Commands
+
+```bash
+mise run sync                     # observe → converge → smoke-verify
+mise run sync -- --check          # dry-run staleness report (rc 1 if stale)
+mise run sync -- --full           # verify-local chain (R1/R2/R3, persistence, secrets)
+mise run sync -- --tag pr-169     # sync/validate against a PR image
+mise run sync -- --force          # rebuild even when digests match
+mise run sync -- --wait           # await an in-flight ci.yml run first
+```
+
+## What it does (action matrix)
+
+Staleness = the **local docker tag's** digest differs from the registry
+manifest digest (`docker buildx imagetools inspect`, no pull). Comparing
+the local *tag* matters: after PR #169's promote, registry `:dev` moved
+while the local `:dev` tag silently kept the pre-merge digest.
+
+| stale? | container | action |
+|---|---|---|
+| yes (or `--force`) | any | buildkit tag refresh + `dev-rebuild` |
+| no | running | verify only (digest fast-path) |
+| no | stopped/absent | `mise run up` |
+
+Then the verification gate: default = `verify_latest` (bind-mount
+currency + smoke tiers 1-3, incl. tier-1 image-identity base-currency);
+`--full` = the whole `mise run verify-local` chain.
+
+## Interpreting failures
+
+| Output | Meaning | Next step |
+|---|---|---|
+| `registry: UNREACHABLE` warning | Network/auth to ghcr.io failed; staleness unknown | Check `docker login ghcr.io` state, DNS (`dscacheutil -q host -a name ghcr.io`); sync continues against the local tag only — do NOT treat a green run as base-currency evidence |
+| `NOTE ci.yml run … in progress` | The target image may be superseded shortly | Fine to continue for a devloop; rerun sync (or use `--wait`) after the run completes |
+| `FAIL converge: buildkit tag refresh failed` | `docker buildx build --pull` could not fetch the manifest | Registry auth/manifest issue; never fall back to classic `docker pull` (wedges on the ~38GB image) |
+| `FAIL converge: dev-rebuild rc=…` | Lifecycle rebuild failed | Read the streamed devcontainer-cli output; `getaddrinfo ENOTFOUND ghcr.io` = transient DNS, retry once per `.claude/rules/persistence-gate-retry.md` |
+| `FAIL smoke-tiers-1-3 … stale base?` | Tier-1 image identity: in-image config hash ≠ repo `mise-system.toml` | The registry image predates your branch's `mise-system.toml` — wait for CI to publish, then rerun sync |
+| `WARN rebuilding: in-container sessions will be killed` | Expected on stale+running | Workspace bind-mount and home volume persist; running shells die by design |
+| rc 1 from `--check` | Stale — a real sync would rebuild | Run `mise run sync` when ready for the rebuild |
+
+Evidence discipline: trust the printed `PASS`/`FAIL` lines and the task's
+exit code read from a file/API — never a piped tail
+(`.claude/rules/verify-before-advancing.md`).
+
+## Wiring audit (meta-validation)
+
+Machine-enforced by the `workflow.sync-wiring` contract in
+`python/verification/suites.toml` (`dotfiles-setup verify run`). When
+auditing by hand, confirm:
+
+1. `mise.toml` has `[tasks.sync]` delegating to `dotfiles-setup docker sync`
+   (zero-bash-logic: no orchestration in the task body).
+2. `python/src/dotfiles_setup/sync.py` exists and `main.py` wires the
+   `docker sync` subparser (`--tag/--force/--check/--full/--wait`).
+3. `tests/test_sync.py` passes:
+   `uv run --project python pytest tests/test_sync.py -x -q`.
+4. Staleness compares the LOCAL TAG digest to the registry digest
+   (`local_digest` matches the repo of the ref, not bake-stage aliases).
+5. No classic `docker pull` anywhere in the sync path (buildkit only).
+6. Long operations stream (never captured into a pipe); quick probes are
+   timeout-bounded.
+
+## See also
+
+- `.claude/skills/devcontainer-workflow/SKILL.md` — up/down/smoke basics.
+- `.claude/rules/verify-before-advancing.md` — when a synced container is
+  a valid validation environment.
+- `.claude/rules/persistence-gate-retry.md` — transient-DNS retry heuristic.

--- a/.config/mise/mise.lock
+++ b/.config/mise/mise.lock
@@ -568,6 +568,7 @@ url = "https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-linux-aar
 url_api = "https://api.github.com/repos/tamasfe/taplo/releases/assets/257322597"
 
 [tools.taplo."platforms.linux-x64"]
+checksum = "blake3:4871fab0e60275a1eb46e7190726e144f56c9a9527f59b0d1da5a042baead8e2"
 url = "https://github.com/tamasfe/taplo/releases/download/0.10.0/taplo-linux-x86_64.gz"
 url_api = "https://api.github.com/repos/tamasfe/taplo/releases/assets/257322600"
 

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -188,9 +188,9 @@ cache. Empty input exports nothing → the `docker-bake.hcl` pin wins
 - For Docker warning triage, see the `ci-warning-investigator` skill.
 - **`gh run list` returns multiple workflows.** A branch has both a `CI`
   and an `autofix.ci` run per push; filter `--workflow CI` to disambiguate.
-- **Manual autofix recipe** (`autofix-ci/action` can't push back,
-  `500 ... not installed`): `gh run download RUN_ID`, base64-decode
-  `additions[].contents` from `autofix.json`, apply, commit, push (#94).
+- **autofix commit-back live** (app installed 2026-07-07, probe #171):
+  fix-computing runs FAIL BY DESIGN (`✅ Autofix task started.`); the app
+  pushes the fix commit → fresh runs. If uninstalled: #94 recipe.
 - **Re-run a failed job** — `gh run rerun RUN_ID --failed` refires only the
   failed jobs against the same commit (re-verify a fix without a fresh push;
   validated `ee079c5`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ caller) → lint → contract-preflight → `changes` → reusable `build-publis
 mise install                                 # Install all tools
 mise run lint                                # Run lint checks (hk under a hard timeout)
 mise run up / down                           # Bring up / tear down devcontainer (.devcontainer/AGENTS.md)
+mise run sync                                # Converge devcontainer onto latest CI image + verify (-- --check/--full)
 mise run verify-container-latest             # Gate: container on latest branch code + base (hard)
 uv run --project python pytest tests/ -x -q  # Run tests (see python/AGENTS.md)
 dotfiles-setup verify run                    # Run structured verification contracts
@@ -55,7 +56,7 @@ the official `@devcontainers/cli` (pinned in `mise.toml`).
 | `.claude/` | Claude-specific agents, skills, rules. Has its own `CLAUDE.md` with OMC orchestration |
 | `home/` | Chezmoi-managed dotfile templates (its AGENTS.md was removed in #80) |
 | `python/` | Python package `dotfiles_setup` — see `python/AGENTS.md` |
-| `tests/` | Pytest + Bats test suite (224 pytest tests) — see `tests/AGENTS.md` |
+| `tests/` | Pytest + Bats test suite (251 pytest tests) — see `tests/AGENTS.md` |
 | `scripts/` | Utility scripts (`benchmark-docker.sh`, `devcontainer-smoke.sh`) |
 | `docs/` | Documentation, research findings, design specs |
 
@@ -85,7 +86,7 @@ content-hashed since hk 1.47 — no manual cache clearing after edits.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q               # All 224 tests
+uv run --project python pytest tests/ -x -q               # All 251 tests
 uv run --project python pytest tests/test_audit.py -x -q  # Single file
 hk run pre-commit --all --stash none                      # Lint checks only
 dotfiles-setup verify run                                 # Verification contracts (suites.toml)

--- a/hk.pkl
+++ b/hk.pkl
@@ -73,8 +73,8 @@ local allSteps = new Mapping<String, Config.Step> {
   // attaches python/pyproject.toml's [tool.ty] config (probe-verified:
   // without it, cwd=repo-root discovery found NO ty config at all).
   ["py_ty"] {
-    glob = List("python/src/**/*.py", "tests/**/*.py")
-    check = "uv run --project python ty check --project python python/src tests"
+    glob = List("python/src/**/*.py", "tests/**/*.py", "plugins/**/*.py")
+    check = "uv run --project python ty check --project python python/src tests plugins"
   }
 
   // --- Zero inline lint suppressions (enforces zero-skip policy) ---

--- a/mise.lock
+++ b/mise.lock
@@ -482,6 +482,11 @@ checksum = "sha256:5519f7ca12e5c143a609f0d28a0a77b97413a8dce31c2681f1a41c24519a8
 url = "https://github.com/rtk-ai/rtk/releases/download/v0.43.0/rtk-aarch64-unknown-linux-gnu.tar.gz"
 url_api = "https://api.github.com/repos/rtk-ai/rtk/releases/assets/460115891"
 
+[tools.rtk."platforms.linux-arm64-musl"]
+checksum = "sha256:5519f7ca12e5c143a609f0d28a0a77b97413a8dce31c2681f1a41c24519a8731"
+url = "https://github.com/rtk-ai/rtk/releases/download/v0.43.0/rtk-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/rtk-ai/rtk/releases/assets/460115891"
+
 [tools.rtk."platforms.linux-x64"]
 checksum = "sha256:ff8a1e7766496e175291a85aeca1dc97c9ff6df33e51e5893d1fbc78fea2a609"
 url = "https://github.com/rtk-ai/rtk/releases/download/v0.43.0/rtk-x86_64-unknown-linux-musl.tar.gz"

--- a/mise.toml
+++ b/mise.toml
@@ -383,6 +383,19 @@ echo 'OK: home-volume seed survivors + canary present'
 echo "OK: $PRE_COUNT tools persisted identically across stop/up (mise-system.toml baseline: $EXPECTED_MIN)"
 '''
 
+[tasks.sync]
+description = "Converge the devcontainer onto the latest CI image + verify (digest fast-path)"
+# Thin caller per zero-bash-logic; the orchestration (registry-vs-local-tag
+# digest compare, container state matrix, in-flight ci.yml awareness,
+# buildkit tag refresh, tiered verification) lives in
+# python/src/dotfiles_setup/sync.py. Extra flags pass through:
+#   mise run sync -- --check          # dry-run staleness report (rc 1 if stale)
+#   mise run sync -- --full           # verify-local chain instead of smoke gate
+#   mise run sync -- --tag pr-169     # pre-merge validation against a PR image
+#   mise run sync -- --force          # rebuild even when current
+#   mise run sync -- --wait           # await an in-flight ci.yml run first
+run = 'uv run --project python dotfiles-setup docker sync'
+
 [tasks.verify-container-latest]
 description = "Gate: running devcontainer is on the latest branch code + current base + smoke"
 # Enforces verify-before-advancing's devcontainer row: the running container

--- a/plugins/dotfiles-build-optimizer/scripts/gha_run_triage.py
+++ b/plugins/dotfiles-build-optimizer/scripts/gha_run_triage.py
@@ -11,10 +11,24 @@ from pathlib import Path
 from typing import Any
 
 
-def run_json(cmd: list[str]) -> list[dict[str, Any]] | dict[str, Any]:
-    """Run *cmd* and return its stdout parsed as JSON."""
+def run_json_list(cmd: list[str]) -> list[dict[str, Any]]:
+    """Run *cmd* and return its stdout parsed as a JSON array of objects."""
     result = subprocess.run(cmd, check=True, capture_output=True, text=True)
-    return json.loads(result.stdout)
+    data = json.loads(result.stdout)
+    if not isinstance(data, list):
+        msg = f"expected a JSON array from {cmd[0]}, got {type(data).__name__}"
+        raise TypeError(msg)
+    return data
+
+
+def run_json_dict(cmd: list[str]) -> dict[str, Any]:
+    """Run *cmd* and return its stdout parsed as a JSON object."""
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    data = json.loads(result.stdout)
+    if not isinstance(data, dict):
+        msg = f"expected a JSON object from {cmd[0]}, got {type(data).__name__}"
+        raise TypeError(msg)
+    return data
 
 
 def run_text(cmd: list[str]) -> str:
@@ -31,7 +45,7 @@ def parse_run_id(value: str) -> str:
 
 def latest_failed_run() -> str:
     """Return the id of the most recent failed workflow run."""
-    runs = run_json(
+    runs = run_json_list(
         [
             "gh",
             "run",
@@ -84,7 +98,7 @@ def likely_owners(error_signatures: list[str]) -> list[str]:
 
 def build_report(run_id: str) -> dict[str, Any]:
     """Build a triage report dict for the given run id."""
-    run = run_json(
+    run = run_json_dict(
         [
             "gh",
             "run",

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -37,7 +37,7 @@ Requires **Python 3.14**.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q                # All 224 tests
+uv run --project python pytest tests/ -x -q                # All 251 tests
 uv run --project python pytest tests/test_audit.py -x -q   # Single file
 ```
 

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -35,6 +35,7 @@ from dotfiles_setup.p2996_hash import (
     compute_repo_p2996_hash,
 )
 from dotfiles_setup.p2996_refresh import refresh as refresh_p2996_ref
+from dotfiles_setup.sync import SyncOptions, sync_main
 from dotfiles_setup.verify import main as verify_main
 
 if TYPE_CHECKING:
@@ -88,6 +89,39 @@ def _add_docker_subcommands(
         "--no-smoke",
         action="store_true",
         help="Skip the in-container smoke run (fast container/bind-mount check only)",
+    )
+    sync_parser = docker_subparsers.add_parser(
+        "sync",
+        help="Converge the devcontainer onto the latest CI-built image "
+        "(digest fast-path, handles up/stopped/absent) and verify",
+    )
+    sync_parser.add_argument(
+        "--tag",
+        default="dev",
+        help="Registry tag to sync to (default: dev; e.g. pr-169 for "
+        "pre-merge validation)",
+    )
+    sync_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Rebuild even when the local tag matches the registry digest",
+    )
+    sync_parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Dry-run: report staleness only (rc 1 if stale), change nothing",
+    )
+    sync_parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Verify with the whole verify-local chain (R1/R2/R3 + "
+        "persistence + secrets) instead of the default smoke gate",
+    )
+    sync_parser.add_argument(
+        "--wait",
+        action="store_true",
+        help="If a ci.yml run is in flight on the target branch, watch it "
+        "to completion before syncing",
     )
 
 
@@ -347,6 +381,19 @@ def handle_docker(
         docker_manager.initialize_host()
     elif args.docker_command == "verify-latest":
         sys.exit(verify_latest_main(project_root, run_smoke=not args.no_smoke))
+    elif args.docker_command == "sync":
+        sys.exit(
+            sync_main(
+                project_root,
+                SyncOptions(
+                    tag=args.tag,
+                    force=args.force,
+                    check_only=args.check,
+                    full=args.full,
+                    wait=args.wait,
+                ),
+            )
+        )
 
 
 def handle_audit(config: DotfilesConfig | None = None) -> None:

--- a/python/src/dotfiles_setup/sync.py
+++ b/python/src/dotfiles_setup/sync.py
@@ -1,0 +1,421 @@
+"""Devcontainer sync: converge onto the latest CI-built image, then verify.
+
+``dotfiles-setup docker sync`` (wrapped by ``mise run sync``) is the one
+entrypoint for "make my devcontainer run the newest image ci.yml published
+and prove everything works". It handles every starting state:
+
+- **container running / stopped / absent** — detected via the
+  ``devcontainer.local_folder`` label; the action matrix below converges
+  each state onto a running, verified container.
+- **local tag stale vs registry** — the registry manifest digest
+  (``docker buildx imagetools inspect``, no pull) is compared against the
+  digest the *local tag* points at. Comparing the local **tag** matters:
+  after PR #169 merged, the registry ``:dev`` moved while the local
+  ``:dev`` tag silently kept pointing at the pre-merge image — a naive
+  "is some current image present" check would have missed it.
+- **in-flight CI** — if a ``ci.yml`` run is in progress on the target
+  branch, the image about to be synced may be superseded shortly; sync
+  reports it and continues (``--wait`` watches the run to completion
+  first, cross-checking the API conclusion per
+  ``.claude/rules/gh-cli-watch.md``).
+
+Action matrix (``decide_action``):
+
+======  =========  ===========================================
+stale?  container  action
+======  =========  ===========================================
+yes*    any        refresh local tag (buildkit) + dev-rebuild
+no      running    verify only (digest fast-path)
+no      stopped    up (reuse container)
+no      absent     up (create container)
+======  =========  ===========================================
+
+``*`` ``--force`` behaves like stale.
+
+When stale, the local tag is refreshed EXPLICITLY via
+``docker buildx build --pull`` before ``dev-rebuild`` — the overlay's
+``FROM ${BASE_IMAGE}`` resolves against the local image store, so
+trusting ``devcontainer up --build-no-cache`` to re-fetch a stale tag
+would rebuild on old bytes. Classic ``docker pull`` is never used (it
+wedges on the ~38GB image; see ``feedback_mise_local_toml_replaces_task``).
+
+Verification is tiered: the default gate is
+:func:`dotfiles_setup.container.verify_latest` (bind-mount currency +
+smoke tiers 1-3, incl. the tier-1 image-identity base-currency check);
+``--full`` runs the whole ``mise run verify-local`` chain (R1/R2/R3 +
+persistence + secrets).
+
+Logic lives here (Python), not in the mise task, per the repo's
+zero-bash-logic policy; ``mise run sync`` is a thin caller. Lifecycle
+invocations delegate to ``mise run up`` / ``mise run dev-rebuild`` so the
+task bodies stay the single source of truth for env (BASE_IMAGE,
+DOCKER_DEFAULT_PLATFORM, workspace hash, ssh known-hosts cleanup).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+from typing import TYPE_CHECKING, Literal
+
+from dotfiles_setup.container import verify_latest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_LOCAL_FOLDER_LABEL = "devcontainer.local_folder"
+_PLATFORM = "linux/amd64/v2"
+_CI_WORKFLOW = "ci.yml"
+
+# Quick network probes (registry manifest inspect, gh API) — bounded so a
+# dead link surfaces instead of blocking.
+_PROBE_TIMEOUT_S = 120.0
+
+ContainerState = Literal["running", "stopped", "absent"]
+Action = Literal["rebuild", "up", "verify-only"]
+
+_PR_TAG_RE = re.compile(r"^pr-(\d+)$")
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class SyncOptions:
+    """CLI-facing knobs for one sync invocation."""
+
+    tag: str = "dev"
+    base_repo: str = "ghcr.io/ray-manaloto/dotfiles-devcontainer"
+    force: bool = False
+    check_only: bool = False
+    full: bool = False
+    wait: bool = False
+
+    @property
+    def image_ref(self) -> str:
+        """Full registry reference the sync converges onto."""
+        return f"{self.base_repo}:{self.tag}"
+
+
+@dataclasses.dataclass(frozen=True)
+class SyncStatus:
+    """The observed world state sync decides from."""
+
+    image_ref: str
+    registry_digest: str | None
+    local_digest: str | None
+    container_state: ContainerState
+
+    @property
+    def stale(self) -> bool:
+        """True when the local tag does not point at the registry manifest.
+
+        A missing local tag (never pulled) counts as stale — converging
+        requires a pull either way. An unreachable registry (``None``)
+        does NOT count as stale: sync must not tear down a working
+        container on a network blip.
+        """
+        if self.registry_digest is None:
+            return False
+        return self.local_digest != self.registry_digest
+
+
+def _run(
+    cmd: list[str], *, timeout: float | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd, capture_output=True, text=True, check=False, timeout=timeout
+    )
+
+
+def _stream(
+    cmd: list[str],
+    *,
+    env: dict[str, str] | None = None,
+    cwd: Path | None = None,
+) -> int:
+    """Run a long operation streaming to the terminal (never wait blind)."""
+    return subprocess.run(cmd, check=False, env=env, cwd=cwd).returncode
+
+
+def registry_digest(image_ref: str) -> str | None:
+    """Manifest digest the registry serves for ``image_ref`` (no pull)."""
+    res = _run(
+        [
+            "docker",
+            "buildx",
+            "imagetools",
+            "inspect",
+            image_ref,
+            "--format",
+            "{{json .Manifest.Digest}}",
+        ],
+        timeout=_PROBE_TIMEOUT_S,
+    )
+    if res.returncode != 0:
+        logger.warning(
+            "registry inspect failed for %s: %s", image_ref, res.stderr.strip()
+        )
+        return None
+    return json.loads(res.stdout.strip())
+
+
+def local_digest(image_ref: str) -> str | None:
+    """Digest the LOCAL tag ``image_ref`` points at, or None if absent."""
+    res = _run(
+        ["docker", "image", "inspect", image_ref, "--format", "{{json .RepoDigests}}"]
+    )
+    if res.returncode != 0:
+        return None
+    repo = image_ref.rsplit(":", 1)[0]
+    for entry in json.loads(res.stdout.strip()):
+        entry_repo, _, digest = entry.partition("@")
+        if entry_repo == repo:
+            return digest
+    return None
+
+
+def container_state(workspace: Path) -> ContainerState:
+    """Devcontainer state for this workspace: running, stopped, or absent."""
+    res = _run(
+        [
+            "docker",
+            "ps",
+            "-a",
+            "--filter",
+            f"label={_LOCAL_FOLDER_LABEL}={workspace}",
+            "--format",
+            "{{.State}}",
+        ]
+    )
+    states = res.stdout.strip().splitlines()
+    if not states:
+        return "absent"
+    return "running" if "running" in states else "stopped"
+
+
+def tag_branch(tag: str) -> str | None:
+    """CI branch whose ci.yml publishes ``tag`` (None = not CI-tracked).
+
+    ``dev`` is promoted from main; ``pr-NNN`` is built from that PR's
+    head branch (resolved via gh). Anything else (bare shas, hash
+    markers) is immutable — no in-flight run can supersede it.
+    """
+    if tag == "dev":
+        return "main"
+    match = _PR_TAG_RE.match(tag)
+    if match is None:
+        return None
+    res = _run(
+        ["gh", "pr", "view", match.group(1), "--json", "headRefName"],
+        timeout=_PROBE_TIMEOUT_S,
+    )
+    if res.returncode != 0:
+        logger.warning("gh pr view %s failed: %s", match.group(1), res.stderr.strip())
+        return None
+    branch: str = json.loads(res.stdout)["headRefName"]
+    return branch
+
+
+def inflight_ci_runs(branch: str) -> list[dict[str, str]]:
+    """Unfinished ci.yml runs on ``branch`` (may supersede the target image)."""
+    res = _run(
+        [
+            "gh",
+            "run",
+            "list",
+            "--workflow",
+            _CI_WORKFLOW,
+            "--branch",
+            branch,
+            "--limit",
+            "10",
+            "--json",
+            "databaseId,status,displayTitle,url",
+        ],
+        timeout=_PROBE_TIMEOUT_S,
+    )
+    if res.returncode != 0:
+        logger.warning("gh run list failed: %s", res.stderr.strip())
+        return []
+    runs: list[dict[str, str]] = json.loads(res.stdout)
+    return [r for r in runs if r["status"] != "completed"]
+
+
+def wait_for_run(run_id: str) -> bool:
+    """Watch a run to completion; conclusion cross-checked via the API.
+
+    ``gh run watch --exit-status`` alone is untrustworthy (has reported 0
+    prematurely — see ``feedback_gh_run_watch``); the API ``conclusion``
+    field is the evidence.
+    """
+    _stream(["gh", "run", "watch", run_id, "--exit-status"])
+    res = _run(
+        ["gh", "run", "view", run_id, "--json", "conclusion", "--jq", ".conclusion"],
+        timeout=_PROBE_TIMEOUT_S,
+    )
+    conclusion = res.stdout.strip()
+    logger.info("run %s conclusion: %s", run_id, conclusion)
+    return conclusion == "success"
+
+
+def refresh_local_tag(image_ref: str) -> bool:
+    """Re-anchor the local tag onto the registry's current manifest.
+
+    Buildkit ``--pull`` on a trivial ``FROM`` forces registry resolution
+    and loads the result into the docker store under the same tag; layers
+    already present locally are reused, so a promote-only retag (new
+    manifest pointer, same bytes) costs seconds, not a 38GB pull.
+    """
+    proc = subprocess.run(
+        [
+            "docker",
+            "buildx",
+            "build",
+            "--pull",
+            "--platform",
+            _PLATFORM,
+            "--output",
+            "type=docker",
+            "-t",
+            image_ref,
+            "-",
+        ],
+        input=f"FROM {image_ref}\n",
+        text=True,
+        check=False,
+    )
+    return proc.returncode == 0
+
+
+def decide_action(status: SyncStatus, *, force: bool) -> Action:
+    """Pure decision matrix — see the module docstring table."""
+    if force or status.stale:
+        return "rebuild"
+    if status.container_state != "running":
+        return "up"
+    return "verify-only"
+
+
+def observe(workspace: Path, image_ref: str) -> SyncStatus:
+    """Collect the world state the decision matrix needs."""
+    return SyncStatus(
+        image_ref=image_ref,
+        registry_digest=registry_digest(image_ref),
+        local_digest=local_digest(image_ref),
+        container_state=container_state(workspace),
+    )
+
+
+def _mise_env(image_ref: str) -> dict[str, str]:
+    """Env for lifecycle mise tasks: BASE_IMAGE override for non-:dev tags."""
+    env = os.environ.copy()
+    env["BASE_IMAGE"] = image_ref
+    return env
+
+
+def _report_inflight(tag: str, *, wait: bool) -> None:
+    """Report (or await) unfinished ci.yml runs that may supersede ``tag``."""
+    branch = tag_branch(tag)
+    if branch is None:
+        return
+    runs = inflight_ci_runs(branch)
+    if not runs:
+        return
+    for run in runs:
+        sys.stdout.write(
+            f"NOTE  ci.yml run {run['databaseId']} is {run['status']} on "
+            f"{branch} — the {tag} image may be superseded shortly "
+            f"({run['url']})\n"
+        )
+    if wait:
+        newest = runs[0]
+        sys.stdout.write(f"==> --wait: watching run {newest['databaseId']}\n")
+        if not wait_for_run(str(newest["databaseId"])):
+            sys.stdout.write(
+                "FAIL  awaited ci.yml run did not conclude success — not "
+                "syncing to an image from a failed pipeline\n"
+            )
+            raise SystemExit(1)
+
+
+def _converge(workspace: Path, status: SyncStatus, action: Action) -> tuple[bool, str]:
+    """Execute the decided action; returns (ok, detail)."""
+    if action == "verify-only":
+        return True, "local tag current + container running (digest fast-path)"
+    if action == "rebuild":
+        if status.container_state == "running":
+            sys.stdout.write(
+                "WARN  rebuilding: in-container sessions will be killed "
+                "(workspace bind-mount and home volume persist)\n"
+            )
+        if status.stale and not refresh_local_tag(status.image_ref):
+            return False, f"buildkit tag refresh failed for {status.image_ref}"
+        rc = _stream(
+            ["mise", "run", "dev-rebuild"],
+            env=_mise_env(status.image_ref),
+            cwd=workspace,
+        )
+        return rc == 0, f"dev-rebuild rc={rc}"
+    rc = _stream(["mise", "run", "up"], env=_mise_env(status.image_ref), cwd=workspace)
+    return rc == 0, f"up rc={rc}"
+
+
+def _verify(workspace: Path, *, full: bool) -> bool:
+    """Run the post-converge gate: smoke by default, verify-local on --full."""
+    if full:
+        rc = _stream(["mise", "run", "verify-local"], cwd=workspace)
+        sys.stdout.write(f"{'PASS' if rc == 0 else 'FAIL'}  verify-local rc={rc}\n")
+        return rc == 0
+    checks = verify_latest(workspace, run_smoke=True)
+    for check in checks:
+        marker = "PASS" if check.ok else "FAIL"
+        sys.stdout.write(f"{marker}  {check.name}: {check.detail}\n")
+    return all(c.ok for c in checks)
+
+
+def sync_main(workspace: Path, options: SyncOptions | None = None) -> int:
+    """CLI entry: observe → (report CI) → converge → verify. 0 = verified."""
+    opts = options if options is not None else SyncOptions()
+    image_ref = opts.image_ref
+    _report_inflight(opts.tag, wait=opts.wait)
+
+    status = observe(workspace, image_ref)
+    sys.stdout.write(
+        f"==> {image_ref}\n"
+        f"    registry: {status.registry_digest or 'UNREACHABLE'}\n"
+        f"    local:    {status.local_digest or 'ABSENT'}\n"
+        f"    container: {status.container_state}"
+        f"{'  [STALE]' if status.stale else ''}\n"
+    )
+    if status.registry_digest is None:
+        sys.stdout.write(
+            "WARN  registry unreachable — staleness unknown; proceeding "
+            "against the local tag only\n"
+        )
+
+    if opts.check_only:
+        sys.stdout.write(
+            f"check: {'STALE — sync would rebuild' if status.stale else 'current'}\n"
+        )
+        return 1 if status.stale else 0
+
+    action = decide_action(status, force=opts.force)
+    sys.stdout.write(f"==> action: {action}\n")
+    ok, detail = _converge(workspace, status, action)
+    sys.stdout.write(f"{'PASS' if ok else 'FAIL'}  converge: {detail}\n")
+    if not ok:
+        return 1
+
+    if not _verify(workspace, full=opts.full):
+        sys.stdout.write(
+            "\nsync: verification failed — the container is NOT a valid "
+            "environment (see .claude/rules/verify-before-advancing.md)\n"
+        )
+        return 1
+    sys.stdout.write(f"\nsync: OK — container verified on {image_ref}\n")
+    return 0

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -908,3 +908,23 @@ category = "policy"
 check_type = "policy"
 handler = "policy_doc"
 reference = "CLAUDE.md"
+
+[[suite]]
+name = "workflow.sync-wiring"
+description = "Devcontainer sync workflow wiring: `mise run sync` must stay a thin caller of the python library CLI (`dotfiles-setup docker sync`, zero-bash-logic), the sync module + its tests must exist, and the devcontainer-sync skill must document the entrypoint. Catches drift where the task body grows logic or the skill/CLI/task triple falls out of sync."
+category = "workflow"
+check_type = "static"
+handler = "require_tokens"
+paths = [
+    "mise.toml",
+    "python/src/dotfiles_setup/sync.py",
+    "tests/test_sync.py",
+    ".claude/skills/devcontainer-sync/SKILL.md",
+]
+tokens = [
+    "[tasks.sync]",
+    "dotfiles-setup docker sync",
+    "def sync_main",
+    "def decide_action",
+    "mise run sync",
+]

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -20,11 +20,12 @@ Docker image smoke outputs.
 | `test_ghcr.py` | pytest | GHCR prerequisite validation and token scope parsing |
 | `test_image_smoke.py` | pytest | Smoke-test script generation, `_parse_human_size`, and the #143 exact tool-set assertion (parse/compare vs mise-system.toml) |
 | `test_container.py` | pytest | `verify-container-latest` gate (`dotfiles_setup.container`) — running/bind-mount/smoke freshness checks |
+| `test_sync.py` | pytest | `mise run sync` workflow (`dotfiles_setup.sync`) — staleness detection, action matrix, CI awareness, check/full/wait modes |
 | `test_shell_integration.py` | pytest | Tool reachability in login shells (mise, chezmoi, uv, pixi, claude, gemini, codex) |
 | `infra/foundation.bats` | Bats | Bash-level foundation checks (shell script integration) |
 | `infra/runtimes.bats` | Bats | Runtime installation checks (bash) |
 
-Total: **224 pytest tests** (pytest runs all `test_*.py` files) plus Bats
+Total: **251 pytest tests** (pytest runs all `test_*.py` files) plus Bats
 scenarios under `infra/`.
 
 ## Running tests

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,0 +1,256 @@
+"""Tests for the devcontainer sync workflow (dotfiles_setup.sync)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
+
+import pytest
+from dotfiles_setup import sync
+from dotfiles_setup.container import Check
+
+_WORKSPACE = Path("/workspaces-host/dotfiles")
+_REPO = "ghcr.io/ray-manaloto/dotfiles-devcontainer"
+_REF = f"{_REPO}:dev"
+_DIGEST_NEW = "sha256:" + "ce" * 32
+_DIGEST_OLD = "sha256:" + "e5" * 32
+
+
+def _cp(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=""
+    )
+
+
+def _status(
+    *,
+    registry: str | None = _DIGEST_NEW,
+    local: str | None = _DIGEST_NEW,
+    state: sync.ContainerState = "running",
+) -> sync.SyncStatus:
+    return sync.SyncStatus(
+        image_ref=_REF,
+        registry_digest=registry,
+        local_digest=local,
+        container_state=state,
+    )
+
+
+# ---------------------------------------------------------------- staleness
+
+
+def test_matching_digests_not_stale() -> None:
+    assert not _status().stale
+
+
+def test_diverged_local_tag_is_stale() -> None:
+    # The PR #169 promote case: registry :dev moved (retag), the local
+    # :dev tag silently kept the pre-merge digest.
+    assert _status(local=_DIGEST_OLD).stale
+
+
+def test_absent_local_tag_is_stale() -> None:
+    assert _status(local=None).stale
+
+
+def test_unreachable_registry_is_not_stale() -> None:
+    # A network blip must never tear down a working container.
+    assert not _status(registry=None, local=_DIGEST_OLD).stale
+
+
+# ------------------------------------------------------------ action matrix
+
+
+def test_stale_rebuilds_regardless_of_state() -> None:
+    for state in ("running", "stopped", "absent"):
+        status = _status(local=_DIGEST_OLD, state=state)
+        assert sync.decide_action(status, force=False) == "rebuild"
+
+
+def test_force_rebuilds_even_when_current() -> None:
+    assert sync.decide_action(_status(), force=True) == "rebuild"
+
+
+def test_current_and_running_is_fast_path() -> None:
+    assert sync.decide_action(_status(), force=False) == "verify-only"
+
+
+def test_current_but_not_running_brings_up() -> None:
+    assert sync.decide_action(_status(state="stopped"), force=False) == "up"
+    assert sync.decide_action(_status(state="absent"), force=False) == "up"
+
+
+# ------------------------------------------------------------- observation
+
+
+def test_local_digest_matches_repo_not_stage_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # RepoDigests can carry bake-stage aliases (dotfiles-devcontainer-base@…);
+    # only the entry whose repo matches the ref counts.
+    payload = [
+        f"dotfiles-devcontainer-base@{_DIGEST_OLD}",
+        f"{_REPO}@{_DIGEST_NEW}",
+    ]
+    monkeypatch.setattr(sync, "_run", lambda *_a, **_k: _cp(json.dumps(payload) + "\n"))
+    assert sync.local_digest(_REF) == _DIGEST_NEW
+
+
+def test_local_digest_absent_tag(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sync, "_run", lambda *_a, **_k: _cp("", returncode=1))
+    assert sync.local_digest(_REF) is None
+
+
+def test_registry_digest_parses_json_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sync, "_run", lambda *_a, **_k: _cp(f'"{_DIGEST_NEW}"\n'))
+    assert sync.registry_digest(_REF) == _DIGEST_NEW
+
+
+def test_registry_digest_unreachable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sync, "_run", lambda *_a, **_k: _cp("", returncode=1))
+    assert sync.registry_digest(_REF) is None
+
+
+def test_container_state_running(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sync, "_run", lambda *_a, **_k: _cp("running\n"))
+    assert sync.container_state(_WORKSPACE) == "running"
+
+
+def test_container_state_stopped(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sync, "_run", lambda *_a, **_k: _cp("exited\n"))
+    assert sync.container_state(_WORKSPACE) == "stopped"
+
+
+def test_container_state_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sync, "_run", lambda *_a, **_k: _cp(""))
+    assert sync.container_state(_WORKSPACE) == "absent"
+
+
+# ---------------------------------------------------------- CI awareness
+
+
+def test_tag_branch_dev_is_main() -> None:
+    assert sync.tag_branch("dev") == "main"
+
+
+def test_tag_branch_pr_resolves_head_ref(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        sync,
+        "_run",
+        lambda *_a, **_k: _cp(json.dumps({"headRefName": "feat/x"})),
+    )
+    assert sync.tag_branch("pr-169") == "feat/x"
+
+
+def test_tag_branch_immutable_tags_untracked() -> None:
+    assert sync.tag_branch("6a5c92c") is None
+    assert sync.tag_branch("dev-3919d689ab92461b") is None
+
+
+def test_inflight_filters_completed(monkeypatch: pytest.MonkeyPatch) -> None:
+    runs = [
+        {"databaseId": 1, "status": "completed", "displayTitle": "a", "url": "u1"},
+        {"databaseId": 2, "status": "in_progress", "displayTitle": "b", "url": "u2"},
+        {"databaseId": 3, "status": "queued", "displayTitle": "c", "url": "u3"},
+    ]
+    monkeypatch.setattr(sync, "_run", lambda *_a, **_k: _cp(json.dumps(runs)))
+    assert [r["databaseId"] for r in sync.inflight_ci_runs("main")] == [2, 3]
+
+
+# ------------------------------------------------------------ end-to-end
+
+
+def test_sync_fast_path_skips_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Current digest + running container → verify only, no mise lifecycle."""
+    streamed: list[list[str]] = []
+    monkeypatch.setattr(sync, "observe", lambda *_a: _status())
+    monkeypatch.setattr(sync, "_report_inflight", lambda *_a, **_k: None)
+    monkeypatch.setattr(sync, "_stream", lambda cmd, **_k: streamed.append(cmd) or 0)
+    monkeypatch.setattr(sync, "verify_latest", lambda *_a, **_k: [])
+    assert sync.sync_main(_WORKSPACE) == 0
+    assert streamed == []
+
+
+def test_sync_stale_refreshes_tag_then_rebuilds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    monkeypatch.setattr(sync, "observe", lambda *_a: _status(local=_DIGEST_OLD))
+    monkeypatch.setattr(sync, "_report_inflight", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        sync, "refresh_local_tag", lambda _ref: events.append("refresh") or True
+    )
+    monkeypatch.setattr(
+        sync, "_stream", lambda cmd, **_k: events.append(" ".join(cmd[:3])) or 0
+    )
+    monkeypatch.setattr(sync, "verify_latest", lambda *_a, **_k: [])
+    assert sync.sync_main(_WORKSPACE) == 0
+    assert events == ["refresh", "mise run dev-rebuild"]
+
+
+def test_sync_check_mode_reports_without_converging(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sync, "observe", lambda *_a: _status(local=_DIGEST_OLD))
+    monkeypatch.setattr(sync, "_report_inflight", lambda *_a, **_k: None)
+
+    def _boom(*_a: object, **_k: object) -> int:
+        msg = "check mode must not run lifecycle commands"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(sync, "_stream", _boom)
+    monkeypatch.setattr(sync, "refresh_local_tag", _boom)
+    assert sync.sync_main(_WORKSPACE, sync.SyncOptions(check_only=True)) == 1
+
+
+def test_sync_check_mode_current_rc0(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sync, "observe", lambda *_a: _status())
+    monkeypatch.setattr(sync, "_report_inflight", lambda *_a, **_k: None)
+    assert sync.sync_main(_WORKSPACE, sync.SyncOptions(check_only=True)) == 0
+
+
+def test_sync_verify_failure_returns_1(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sync, "observe", lambda *_a: _status())
+    monkeypatch.setattr(sync, "_report_inflight", lambda *_a, **_k: None)
+    monkeypatch.setattr(
+        sync,
+        "verify_latest",
+        lambda *_a, **_k: [Check("smoke-tiers-1-3", ok=False, detail="boom")],
+    )
+    assert sync.sync_main(_WORKSPACE) == 1
+
+
+def test_sync_full_runs_verify_local(monkeypatch: pytest.MonkeyPatch) -> None:
+    streamed: list[list[str]] = []
+    monkeypatch.setattr(sync, "observe", lambda *_a: _status())
+    monkeypatch.setattr(sync, "_report_inflight", lambda *_a, **_k: None)
+    monkeypatch.setattr(sync, "_stream", lambda cmd, **_k: streamed.append(cmd) or 0)
+    assert sync.sync_main(_WORKSPACE, sync.SyncOptions(full=True)) == 0
+    assert ["mise", "run", "verify-local"] in streamed
+
+
+def test_sync_failed_awaited_run_aborts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--wait on a run that concludes non-success must abort the sync."""
+    monkeypatch.setattr(sync, "tag_branch", lambda _t: "main")
+    monkeypatch.setattr(
+        sync,
+        "inflight_ci_runs",
+        lambda _b: [
+            {
+                "databaseId": 42,
+                "status": "in_progress",
+                "displayTitle": "x",
+                "url": "u",
+            }
+        ],
+    )
+    monkeypatch.setattr(sync, "wait_for_run", lambda _id: False)
+    with pytest.raises(SystemExit) as excinfo:
+        sync.sync_main(_WORKSPACE, sync.SyncOptions(wait=True))
+    assert excinfo.value.code == 1


### PR DESCRIPTION
## Summary

One entrypoint — `mise run sync` — for "pull the newest image `ci.yml` published and prove everything works", handling the devcontainer being **up, stopped, or absent**. Requested by Ray post-#169: automate via the python library + a skill to verify/validate the workflow, always with a mise task wrapper.

- **`python/src/dotfiles_setup/sync.py`** (existing library, zero new codebases): registry-vs-**local-tag** digest compare via `docker buildx imagetools inspect` (no pull), container state matrix, in-flight `ci.yml` reporting (`--wait` to watch first), buildkit-only tag refresh, tiered verification (default: `verify_latest` smoke gate; `--full`: whole `verify-local` chain). Flags: `--tag pr-NNN` / `--force` / `--check` / `--wait`.
- **`mise [tasks.sync]`**: thin caller (zero-bash-logic); lifecycle stays delegated to `mise run up` / `dev-rebuild`.
- **Skill `.claude/skills/devcontainer-sync/`**: runbook with failure-mode table + wiring audit checklist.
- **`workflow.sync-wiring` contract** (suites.toml, runs in CI contract-preflight) keeps the task/CLI/skill/tests quadruple from drifting.
- **26 new tests** (`tests/test_sync.py`); suite now **251** (docs synced from stale 224).

### Why local-TAG digest comparison

After #169's `promote` retagged registry `:dev`, the **local** `:dev` tag silently kept the pre-merge digest — a `FROM :dev` overlay rebuild would have used old bytes. Sync therefore compares what the local tag points at against the registry manifest, and when stale explicitly re-anchors it with `docker buildx build --pull` (classic `docker pull` is never used — it wedges on the ~38GB image).

### Strict-analysis gap closed (first commit)

The hk `py_ty` step only checked `python/src tests` — `plugins/` was never type-checked. Adding it surfaced **10 real ty errors** in `gha_run_triage.py` (`list | dict` union return misused at every call site). Fixed via `run_json_list`/`run_json_dict` isinstance narrowing — zero suppressions. `plugins/**` is now permanently under the same ty gate.

## Test plan

- [x] `mise run lint` rc=0
- [x] `uv run --project python pytest tests/ -q` — 251 passed
- [x] `dotfiles-setup verify run` — 83 passed, 0 failed (incl. new `workflow.sync-wiring`)
- [x] `mise run lint-docs` — 0 errors
- [x] Live E2E: `mise run sync -- --check` → `current`, rc=0; full `mise run sync` → digest fast-path + smoke tiers 1-3, rc=0

### Known retire candidate (out of scope)

`DevContainerManager.build()` in `docker.py` still uses classic `docker pull` — flagged for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AbMJtYjtLb9poxXBNm3NWy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `mise run sync` / `docker sync` workflow to bring the devcontainer up to date with the latest CI image and verify it afterward.
  * Added support for flags like `--check`, `--full`, `--tag`, `--force`, and `--wait`.

* **Bug Fixes**
  * Improved handling of image freshness, container state, and in-flight CI runs so sync decisions are more reliable.

* **Tests**
  * Added coverage for sync decision logic, verification paths, and CI-aware behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->