### PR TITLE
feat(guard): mise-tasks-only PreToolUse hook — deny one-off workflow commands with a redirect

### DIFF
--- a/.claude/rules/mise-tasks-only.md
+++ b/.claude/rules/mise-tasks-only.md
@@ -1,0 +1,57 @@
+# Mise Tasks Only: No One-Off Commands for Canonical Workflows
+
+Every recurring workflow in this repo has (or gets) a canonical mise
+task. When a task exists, USE IT — never hand-roll the underlying
+command sequence. When you build a new recurring workflow, ship its mise
+task (wrapping the python library, zero-bash-logic) in the same change.
+
+## The canonical task map
+
+| Instead of | Use |
+|---|---|
+| `hk run pre-commit --all` | `mise run lint` (hard timeout + log-tail diagnostics) |
+| bare `pytest` | `mise run test`, or `uv run --project python pytest <target>` (doc-level only: the permission engine unwraps runners, so a hook rule would also deny the canonical uv form) |
+| `devcontainer up` / `devcontainer build` | `mise run up` / `mise run dev-rebuild` (env + workspace-hash guard) |
+| `docker pull …dotfiles-devcontainer…` | `mise run sync` (buildkit, digest-aware, verifying; classic pull wedges on ~38GB) |
+| `gh pr create` (+ push + gates by hand) | `mise run ship` |
+| `gh pr merge` (+ watch + validate by hand) | `mise run land -- <PR#>` |
+| `npx <tool>` | the mise-pinned binary directly |
+| `chezmoi apply/update` on the Mac host | nothing — devcontainer-only |
+
+Diagnostic/read-only commands (`docker ps`, `gh pr view`, `git status`,
+single-test `pytest path::test` via uv) are NOT wrapped and stay direct.
+
+## Enforcement layers (deep-research verified, 2026-07-07)
+
+1. **PreToolUse hook** — `.claude/settings.json` wires every Bash call
+   through `dotfiles-setup hook pretooluse`
+   (`python/src/dotfiles_setup/hook_guard.py`): a matched one-off command
+   is DENIED with the redirect reason fed back (JSON
+   `permissionDecision: "deny"`; deterministic, applies even in
+   bypassPermissions mode). The rules are tested in
+   `tests/test_hook_guard.py`.
+2. **This rule + skills** — `pr-workflow` and `devcontainer-sync` skills
+   name the canonical tasks; markdown alone is "relying on the LLM", so
+   it is never the only layer.
+3. **Contract** — `workflow.mise-tasks-enforcement` in suites.toml
+   asserts the hook wiring exists (settings.json → CLI → module → tests),
+   so the guard can't silently drift out.
+
+The hook fails OPEN on its own errors (a crashed guard must not brick
+every Bash call); hard one-off bans that must never fail open belong in
+settings.json permission deny rules, not the hook.
+
+## Extending
+
+New redirect = new `_RULES` entry in `hook_guard.py` + a test + a row in
+the table above, same change. Keep patterns narrow: a redirect that
+misfires on legitimate diagnostics erodes trust in the guard.
+
+## See also
+
+- `.claude/rules/verify-before-advancing.md` — the gates the ship/land
+  tasks encode.
+- `.claude/rules/long-running-command-hangs.md` — why `mise run lint`.
+- `.omc/research/research-20260707-gha-shipland-enforcement/report.md` —
+  the evidence base (hooks deny; allow-lists live in permissions; hookify
+  is advisory-grade).

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,13 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | jq -re '.command // empty' | grep -qw 'npx'; then echo 'BLOCKED: Do not use npx. Use the mise-installed binary directly (e.g., agnix not npx agnix). All tools should be in mise.toml. See .claude/rules/ci-local-parity.md.' >&2; exit 1; fi",
-            "timeout": 5
-          },
-          {
-            "type": "command",
-            "command": "if echo \"$CLAUDE_TOOL_INPUT\" | jq -re '.command // empty' | grep -qE '\\bchezmoi[[:space:]]+(apply|update)\\b'; then echo 'BLOCKED: chezmoi apply/update on host. Mac integration is not yet started; chezmoi may only run inside the devcontainer (where chezmoi.os == \"linux\" renders the container-only mise overlay correctly). Read-only commands (diff, managed, doctor, source-path, init --apply=false, execute-template) remain allowed for inspection. Remove this guard once Mac integration ships. See .claude/rules/use-tool-builtins.md and memory feedback_devcontainer_only_mise_overlay.md.' >&2; exit 1; fi",
-            "timeout": 5
+            "command": "uv run --project python dotfiles-setup hook pretooluse",
+            "timeout": 20
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ the official `@devcontainers/cli` (pinned in `mise.toml`).
 | `.claude/` | Claude-specific agents, skills, rules. Has its own `CLAUDE.md` with OMC orchestration |
 | `home/` | Chezmoi-managed dotfile templates (its AGENTS.md was removed in #80) |
 | `python/` | Python package `dotfiles_setup` — see `python/AGENTS.md` |
-| `tests/` | Pytest + Bats test suite (278 pytest tests) — see `tests/AGENTS.md` |
+| `tests/` | Pytest + Bats test suite (307 pytest tests) — see `tests/AGENTS.md` |
 | `scripts/` | Utility scripts (`benchmark-docker.sh`, `devcontainer-smoke.sh`) |
 | `docs/` | Documentation, research findings, design specs |
 
@@ -86,7 +86,7 @@ content-hashed since hk 1.47 — no manual cache clearing after edits.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q               # All 278 tests
+uv run --project python pytest tests/ -x -q               # All 307 tests
 uv run --project python pytest tests/test_audit.py -x -q  # Single file
 hk run pre-commit --all --stash none                      # Lint checks only
 dotfiles-setup verify run                                 # Verification contracts (suites.toml)

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -37,7 +37,7 @@ Requires **Python 3.14**.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q                # All 278 tests
+uv run --project python pytest tests/ -x -q                # All 307 tests
 uv run --project python pytest tests/test_audit.py -x -q   # Single file
 ```
 

--- a/python/src/dotfiles_setup/hook_guard.py
+++ b/python/src/dotfiles_setup/hook_guard.py
@@ -1,0 +1,153 @@
+"""PreToolUse Bash guard: canonical mise tasks over one-off commands.
+
+``dotfiles-setup hook pretooluse`` is the single project PreToolUse hook
+(wired in ``.claude/settings.json``). It reads the hook JSON from stdin
+and either allows the Bash call (silent exit 0) or denies it with a
+redirect reason via the documented JSON contract
+(``permissionDecision: "deny"`` — deterministic, applies even in
+bypassPermissions mode).
+
+Why a deny-with-redirect hook and not more: the deep-research pass
+(.omc/research/research-20260707-gha-shipland-enforcement/report.md)
+verified that hooks cannot ALLOW-list (the JSON "approve" path was
+refuted) — allow rules belong to the permission system — and that
+markdown rules alone are "relying on the LLM". So: hard bans and
+redirects live here; hookify remains advisory-grade (fail-open).
+
+Scope (Ray's decision, 2026-07-07): WORKFLOW commands only — commands
+that have a canonical mise task. Read-only/diagnostic commands
+(``docker ps``, ``gh pr view``, granular ``pytest path::test``) pass
+untouched. This module also absorbs the two legacy shell guards (npx,
+chezmoi apply/update) which exited 1 — a NON-blocking code for
+PreToolUse; the intent was clearly to block, so consolidating here
+fixes them.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+# (pattern, reason). First match wins. Patterns run against the whole
+# Bash command string; they are deliberately narrow — a redirect that
+# misfires on legitimate diagnostics erodes trust in the guard.
+#
+# _CMD anchors every rule to command position (start of string or right
+# after a shell separator) so quoted/prose mentions — `echo 'gh pr
+# merge'`, `rg 'npx' docs/`, a commit message DESCRIBING the chezmoi
+# ban — never false-positive. Probe-observed 2026-07-07: the unanchored
+# chezmoi rule denied a commit whose message documented it. Anchoring
+# still catches every real invocation (they sit at command position).
+_CMD = r"(?:^|[;&|(]\s*)"
+_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(_CMD + r"npx\s"),
+        "Do not use npx. Use the mise-installed binary directly (e.g. "
+        "`agnix`, not `npx agnix`) — all tools are pinned in mise.toml. "
+        "See .claude/rules/ci-local-parity.md.",
+    ),
+    (
+        re.compile(_CMD + r"chezmoi\s+(apply|update)\b"),
+        "chezmoi apply/update is blocked on the Mac host — it may only run "
+        "inside the devcontainer (chezmoi.os == 'linux' renders the "
+        "container-only overlay). Read-only chezmoi commands are fine. See "
+        ".claude/rules/use-tool-builtins.md.",
+    ),
+    (
+        re.compile(_CMD + r"hk\s+run\s+pre-commit\b"),
+        "Use `mise run lint` — it wraps hk in a hard timeout (hk has none) "
+        "with log-tail diagnostics. See "
+        ".claude/rules/long-running-command-hangs.md.",
+    ),
+    (
+        re.compile(_CMD + r"devcontainer\s+up\b"),
+        "Use `mise run up` (or `mise run dev-rebuild` to force-refresh) — "
+        "the task carries BASE_IMAGE/platform/ssh-port env and the "
+        "workspace-hash collision guard a raw `devcontainer up` misses.",
+    ),
+    (
+        re.compile(_CMD + r"devcontainer\s+build\b"),
+        "Use `mise run dev-rebuild` — the overlay build needs the task's "
+        "env (BASE_IMAGE, DOCKER_DEFAULT_PLATFORM) to be reproducible.",
+    ),
+    (
+        re.compile(_CMD + r"docker\s+pull\b.*dotfiles-devcontainer"),
+        "Never classic-pull the devcontainer image (it wedges on the ~38GB "
+        "blob). Use `mise run sync` — buildkit-based, digest-aware, and it "
+        "verifies the result.",
+    ),
+    (
+        re.compile(_CMD + r"gh\s+pr\s+create\b"),
+        "Use `mise run ship` — it runs the path-aware gate matrix (incl. "
+        "the hard full-sync gate on devcontainer-surface diffs) before the "
+        "PR opens, then watches checks to bucket-verified green. See "
+        ".claude/skills/pr-workflow/SKILL.md.",
+    ),
+    (
+        re.compile(_CMD + r"gh\s+pr\s+merge\b"),
+        "Use `mise run land -- <PR#>` — it verifies check buckets, pins the "
+        "merge to the verified head SHA, watches main CI, and validates "
+        "locally. See .claude/skills/pr-workflow/SKILL.md.",
+    ),
+)
+
+# NO pytest rule, deliberately (probe-observed 2026-07-07): Claude Code's
+# permission engine UNWRAPS runner commands before invoking hooks — the
+# canonical `uv run --project python pytest tests/` reaches the hook as
+# plain `pytest tests/`, indistinguishable from the bare form the rule
+# meant to redirect. A rule here would deny the documented command.
+# Bare-pytest guidance stays doc-level (python/AGENTS.md, mise-tasks-only).
+
+
+def decide(command: str) -> str | None:
+    """Redirect reason when ``command`` should be denied, else None."""
+    for pattern, reason in _RULES:
+        if pattern.search(command):
+            return reason
+    return None
+
+
+def _read_command() -> str:
+    """Bash command from the hook stdin JSON (env-var fallback)."""
+    raw = sys.stdin.read() if not sys.stdin.isatty() else ""
+    if raw:
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            payload = {}
+        tool_input = payload.get("tool_input", payload)
+        if isinstance(tool_input, dict):
+            return str(tool_input.get("command", ""))
+    legacy = os.environ.get("CLAUDE_TOOL_INPUT", "")
+    if legacy:
+        try:
+            return str(json.loads(legacy).get("command", ""))
+        except json.JSONDecodeError, AttributeError:
+            return ""
+    return ""
+
+
+def pretooluse_main() -> int:
+    """Hook entry: emit a deny decision or allow silently.
+
+    Always exits 0 — the decision travels in the JSON (the documented
+    contract); a crash here would fail OPEN (hook errors do not block),
+    which is the acceptable failure mode for a redirect guard.
+    """
+    reason = decide(_read_command())
+    if reason is not None:
+        sys.stdout.write(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PreToolUse",
+                        "permissionDecision": "deny",
+                        "permissionDecisionReason": reason,
+                    }
+                }
+            )
+            + "\n"
+        )
+    return 0

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -20,6 +20,7 @@ from dotfiles_setup.doc_refs import find_unresolved_refs
 from dotfiles_setup.docker import DevContainerManager
 from dotfiles_setup.ghcr import validate_ghcr_prereqs
 from dotfiles_setup.ghcr_cleanup import plan_cleanup
+from dotfiles_setup.hook_guard import pretooluse_main
 from dotfiles_setup.image import ImageCommand
 from dotfiles_setup.image import main as image_main
 from dotfiles_setup.lint import (
@@ -383,6 +384,17 @@ def setup_parser() -> argparse.ArgumentParser:
         help="GHCR container package name",
     )
 
+    hook_parser = subparsers.add_parser(
+        "hook",
+        help="Claude Code hook entrypoints (wired in .claude/settings.json)",
+    )
+    hook_sub = hook_parser.add_subparsers(dest="hook_command", help="Hook events")
+    hook_sub.add_parser(
+        "pretooluse",
+        help="PreToolUse Bash guard: deny-with-redirect for one-off commands "
+        "that have a canonical mise task (mise-tasks-only policy)",
+    )
+
     # version command
     subparsers.add_parser("version", help="Show the version of the library")
 
@@ -687,6 +699,11 @@ def _build_command_handlers(
         "ai-setup": _ai_setup,
         "docker": lambda: handle_docker(args, project_root, config=config),
         "pr": lambda: handle_pr(args, project_root),
+        "hook": lambda: (
+            sys.exit(pretooluse_main())
+            if getattr(args, "hook_command", None) == "pretooluse"
+            else None
+        ),
         "version": _version,
         "install": lambda: handle_install(project_root),
         "verify": lambda: handle_verify(args),

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -947,3 +947,23 @@ tokens = [
     "mise run ship",
     "mise run land",
 ]
+
+[[suite]]
+name = "workflow.mise-tasks-enforcement"
+description = "mise-tasks-only policy wiring: the PreToolUse Bash guard must stay wired end-to-end — .claude/settings.json invokes `dotfiles-setup hook pretooluse`, the guard module + its tests exist, and the rule doc names the canonical task map. Prevents the guard silently drifting out of the hook chain."
+category = "workflow"
+check_type = "static"
+handler = "require_tokens"
+paths = [
+    ".claude/settings.json",
+    "python/src/dotfiles_setup/hook_guard.py",
+    "tests/test_hook_guard.py",
+    ".claude/rules/mise-tasks-only.md",
+]
+tokens = [
+    "dotfiles-setup hook pretooluse",
+    "def pretooluse_main",
+    "permissionDecision",
+    "mise run land",
+    "mise run ship",
+]

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -26,7 +26,7 @@ Docker image smoke outputs.
 | `infra/foundation.bats` | Bats | Bash-level foundation checks (shell script integration) |
 | `infra/runtimes.bats` | Bats | Runtime installation checks (bash) |
 
-Total: **278 pytest tests** (pytest runs all `test_*.py` files) plus Bats
+Total: **307 pytest tests** (pytest runs all `test_*.py` files) plus Bats
 scenarios under `infra/`.
 
 ## Running tests

--- a/tests/test_hook_guard.py
+++ b/tests/test_hook_guard.py
@@ -1,0 +1,86 @@
+"""Tests for the PreToolUse mise-tasks-only guard (dotfiles_setup.hook_guard)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
+
+import pytest
+from dotfiles_setup import hook_guard
+
+
+@pytest.mark.parametrize(
+    ("command", "redirect_hint"),
+    [
+        ("npx agnix .", "mise-installed binary"),
+        ("cd /tmp && npx cowsay hi", "mise-installed binary"),
+        ("chezmoi apply", "devcontainer"),
+        ("chezmoi update -v", "devcontainer"),
+        ("hk run pre-commit --all --stash none", "mise run lint"),
+        ("devcontainer up --workspace-folder .", "mise run up"),
+        ("devcontainer build --workspace-folder .", "mise run dev-rebuild"),
+        (
+            "docker pull ghcr.io/ray-manaloto/dotfiles-devcontainer:dev",
+            "mise run sync",
+        ),
+        ("gh pr create --fill", "mise run ship"),
+        ("gh pr merge 42 --squash", "mise run land"),
+    ],
+)
+def test_one_off_commands_denied_with_redirect(
+    command: str, redirect_hint: str
+) -> None:
+    reason = hook_guard.decide(command)
+    assert reason is not None
+    assert redirect_hint in reason
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # Diagnostics and reads stay direct.
+        "docker ps --filter label=x",
+        "gh pr view 172 --json state",
+        "gh pr checks 172 --watch",
+        "chezmoi diff",
+        "chezmoi execute-template < a.tmpl",
+        "git status --porcelain",
+        # The canonical forms themselves.
+        "mise run lint",
+        "mise run ship -- --title x",
+        "uv run --project python pytest tests/test_pr.py -x -q",
+        # The unwrapped form the permission engine hands the hook for the
+        # canonical uv pytest command — MUST stay allowed (probe 2026-07-07).
+        "pytest tests/ -x -q",
+        # Substrings that must NOT false-positive.
+        "docker pull ubuntu:24.04",
+        "echo 'gh pr merge is wrapped by land'",
+        "rg 'npx' docs/",
+        "hk validate",
+        # Prose mentions inside a commit message (probe 2026-07-07: the
+        # unanchored chezmoi rule denied its own documenting commit).
+        "git commit -m 'docs: chezmoi apply/update stays devcontainer-only'",
+    ],
+)
+def test_legitimate_commands_allowed(command: str) -> None:
+    assert hook_guard.decide(command) is None
+
+
+def test_pretooluse_emits_deny_json(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(hook_guard, "_read_command", lambda: "gh pr create")
+    assert hook_guard.pretooluse_main() == 0
+    out = capsys.readouterr().out
+    assert '"permissionDecision": "deny"' in out
+    assert "mise run ship" in out
+
+
+def test_pretooluse_silent_on_allowed(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(hook_guard, "_read_command", lambda: "git status")
+    assert hook_guard.pretooluse_main() == 0
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
python/src/dotfiles_setup/hook_guard.py replaces the two legacy shell
guards in .claude/settings.json (which exited 1 — a NON-blocking code
for PreToolUse; the documented block is exit 2 or JSON
permissionDecision deny). One tested python hook now handles npx, the
host chezmoi write-ban, and the workflow-command redirects:
hk run pre-commit → mise run lint · devcontainer up/build → mise run
up/dev-rebuild · docker pull of the devcontainer image → mise run sync ·
gh pr create/merge → mise run ship/land.

Two constraints probe-observed LIVE in-session while building this:
1. The permission engine UNWRAPS runner commands before hooks — the
   canonical uv pytest form reaches the hook as bare pytest, so a pytest
   redirect would deny the documented command. No pytest rule (doc-level
   only) + a regression test pinning the unwrapped form as allowed.
2. Every rule must be command-position anchored: the first unanchored
   host-chezmoi rule denied the very commit whose message documented it.
   Anchored now; prose/quoted mentions never match, real invocations do.

Rule .claude/rules/mise-tasks-only.md (canonical task map + enforcement
split: hook denies/redirects, permissions hard-ban, hookify advisory),
contract workflow.mise-tasks-enforcement, 27 tests (suite 307).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AbMJtYjtLb9poxXBNm3NWy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new safeguard that guides common workflows toward the app’s canonical task commands.
  * Improved handling of hook-based commands so disallowed one-off actions now return clear redirect guidance instead of running directly.

* **Bug Fixes**
  * Expanded coverage so approved diagnostic and read-only commands continue to work normally.

* **Tests**
  * Added end-to-end checks for allowed, denied, and redirect behaviors to keep the workflow rules consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->