### PR TITLE
feat(currency): daily tool-currency signal — release-notes report + standing issue

### DIFF
--- a/.claude/rules/do-not.md
+++ b/.claude/rules/do-not.md
@@ -42,6 +42,7 @@ self-contained block). Each item's context is preserved verbatim.
 
 ## See also
 
+- `mise-tasks-only.md` — canonical mise tasks over one-off commands (hook-enforced)
 - `zero-skip-policy.md` — no warning/error shall be dismissed
 - `verify-before-advancing.md` — every applicable check green before the next task
 - `ci-local-parity.md` — keep local checks in sync with CI

--- a/.claude/skills/tool-currency-check/SKILL.md
+++ b/.claude/skills/tool-currency-check/SKILL.md
@@ -9,6 +9,13 @@ applicability: any repo managing tools via mise + hk + Renovate
 
 # Skill: Tool Currency Check
 
+
+> Daily input signal: refresh.yml's `tool-currency` job upserts the
+> standing issue "Tool currency report (daily)" (rendered by
+> `mise run tool-currency`) whenever upstream moved — start the review
+> there instead of re-deriving the outdated set.
+
+
 Operationalizes `.claude/rules/tool-currency-and-native-first.md`: find
 out-of-date pins AND custom code a tool now does natively, in one pass.
 

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -119,3 +119,58 @@ jobs:
           name: lock-refresh-logs
           path: /tmp/mise.log
           if-no-files-found: ignore
+  # ============================================================
+  # Tool-currency signal (2026-07-07, Ray's self-learning ask): render
+  # `mise outdated --json` into a markdown report with per-tool
+  # release-notes links and upsert it into a standing issue. The
+  # AGENT-grade half (read the release notes, decide adopt/retire,
+  # research newer tools/techniques) happens locally via the
+  # tool-currency-check skill, with this issue as its daily input —
+  # a workflow can produce the signal, not the judgment.
+  # ============================================================
+  tool-currency:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Install mise (all tools)
+        uses: ./.github/actions/setup-mise
+      - name: Render tool-currency report
+        run: mise run tool-currency > /tmp/tool-currency.md
+      - name: Upsert the standing report issue
+        # Only when something moved upstream (the report has table rows).
+        # One standing issue, body replaced daily — history lives in the
+        # issue timeline, not in N stale issues.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if ! grep -q '^| `' /tmp/tool-currency.md; then
+            echo "All tools current — no issue update."
+            exit 0
+          fi
+          title="Tool currency report (daily)"
+          number=$(gh issue list --repo "$REPO" --state open \
+                     --search "in:title \"$title\"" \
+                     --json number --jq '.[0].number // empty')
+          if [ -n "$number" ]; then
+            gh issue edit "$number" --repo "$REPO" --body-file /tmp/tool-currency.md
+            echo "Updated issue #$number"
+          else
+            gh issue create --repo "$REPO" --title "$title" \
+              --body-file /tmp/tool-currency.md --label dependencies
+          fi
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tool-currency-report
+          path: /tmp/tool-currency.md
+          if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ the official `@devcontainers/cli` (pinned in `mise.toml`).
 | `.claude/` | Claude-specific agents, skills, rules. Has its own `CLAUDE.md` with OMC orchestration |
 | `home/` | Chezmoi-managed dotfile templates (its AGENTS.md was removed in #80) |
 | `python/` | Python package `dotfiles_setup` — see `python/AGENTS.md` |
-| `tests/` | Pytest + Bats test suite (307 pytest tests) — see `tests/AGENTS.md` |
+| `tests/` | Pytest + Bats test suite (316 pytest tests) — see `tests/AGENTS.md` |
 | `scripts/` | Utility scripts (`benchmark-docker.sh`, `devcontainer-smoke.sh`) |
 | `docs/` | Documentation, research findings, design specs |
 
@@ -86,7 +86,7 @@ content-hashed since hk 1.47 — no manual cache clearing after edits.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q               # All 307 tests
+uv run --project python pytest tests/ -x -q               # All 316 tests
 uv run --project python pytest tests/test_audit.py -x -q  # Single file
 hk run pre-commit --all --stash none                      # Lint checks only
 dotfiles-setup verify run                                 # Verification contracts (suites.toml)

--- a/mise.toml
+++ b/mise.toml
@@ -383,6 +383,14 @@ echo 'OK: home-volume seed survivors + canary present'
 echo "OK: $PRE_COUNT tools persisted identically across stop/up (mise-system.toml baseline: $EXPECTED_MIN)"
 '''
 
+[tasks.tool-currency]
+description = "Markdown report of tools with upstream movement + release-notes links"
+# Thin caller (zero-bash-logic); logic in
+# python/src/dotfiles_setup/tool_currency.py. Run daily by refresh.yml's
+# tool-currency job (upserts the standing issue); locally it feeds the
+# tool-currency-check skill's release-note review.
+run = 'uv run --project python dotfiles-setup tool-currency'
+
 [tasks.ship]
 description = "Gate matrix → push → open/update PR → watch checks to verified green"
 # Thin caller per zero-bash-logic; orchestration in

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -37,7 +37,7 @@ Requires **Python 3.14**.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q                # All 307 tests
+uv run --project python pytest tests/ -x -q                # All 316 tests
 uv run --project python pytest tests/test_audit.py -x -q   # Single file
 ```
 

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -38,6 +38,7 @@ from dotfiles_setup.p2996_hash import (
 from dotfiles_setup.p2996_refresh import refresh as refresh_p2996_ref
 from dotfiles_setup.pr import land_main, ship_main
 from dotfiles_setup.sync import SyncOptions, sync_main
+from dotfiles_setup.tool_currency import tool_currency_main
 from dotfiles_setup.verify import main as verify_main
 
 if TYPE_CHECKING:
@@ -395,6 +396,12 @@ def setup_parser() -> argparse.ArgumentParser:
         "that have a canonical mise task (mise-tasks-only policy)",
     )
 
+    subparsers.add_parser(
+        "tool-currency",
+        help="Markdown report of tools with upstream movement + release-notes "
+        "links (daily refresh.yml signal; feeds the tool-currency-check skill)",
+    )
+
     # version command
     subparsers.add_parser("version", help="Show the version of the library")
 
@@ -699,6 +706,7 @@ def _build_command_handlers(
         "ai-setup": _ai_setup,
         "docker": lambda: handle_docker(args, project_root, config=config),
         "pr": lambda: handle_pr(args, project_root),
+        "tool-currency": lambda: sys.exit(tool_currency_main()),
         "hook": lambda: (
             sys.exit(pretooluse_main())
             if getattr(args, "hook_command", None) == "pretooluse"

--- a/python/src/dotfiles_setup/tool_currency.py
+++ b/python/src/dotfiles_setup/tool_currency.py
@@ -1,0 +1,93 @@
+"""Daily tool-currency signal: what moved upstream, with release links.
+
+``dotfiles-setup tool-currency`` (wrapped by ``mise run tool-currency``,
+run daily by refresh.yml's ``tool-currency`` job) renders
+``mise outdated --json`` into a markdown report whose rows link straight
+to each tool's release notes. The report feeds the self-learning loop
+Ray asked for (2026-07-07): fast-moving tools (mise/hk/chezmoi/docker/
+uv/ruff/ty/…) get their release notes REVIEWED — by the
+``tool-currency-check`` skill locally — before bumps are adopted, and
+the daily issue the workflow upserts is that skill's standing input.
+
+This module only produces the signal. Judgment (adopt/retire/defer,
+native-feature supersedes custom code) stays with the skill per
+``.claude/rules/tool-currency-and-native-first.md``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+_OUTDATED_TIMEOUT_S = 300.0
+
+_REGISTRY_URL = "https://mise.jdx.dev/registry.html"
+
+
+def release_link(tool_key: str) -> str:
+    """Best-effort release-notes URL for a mise tool key.
+
+    Backend-prefixed keys encode their source; short registry names fall
+    back to the mise registry page (which links each tool's homepage).
+    """
+    backend, _, rest = tool_key.partition(":")
+    if backend in ("github", "aqua", "ubi") and "/" in rest:
+        return f"https://github.com/{rest}/releases"
+    if backend == "npm":
+        return f"https://www.npmjs.com/package/{rest}?activeTab=versions"
+    if backend in ("pipx", "uvx"):
+        return f"https://pypi.org/project/{rest.partition('[')[0]}/#history"
+    if backend == "cargo":
+        return f"https://crates.io/crates/{rest}/versions"
+    return _REGISTRY_URL
+
+
+def render_report(outdated: dict[str, dict[str, str]]) -> str:
+    """Markdown report from the ``mise outdated --json`` mapping."""
+    if not outdated:
+        return "All pinned tools are current — nothing moved upstream.\n"
+    lines = [
+        "# Tool currency report",
+        "",
+        "Review each release-notes link BEFORE adopting a bump — and ask",
+        "whether a new native feature supersedes custom code",
+        "(`.claude/rules/tool-currency-and-native-first.md`; run the",
+        "`tool-currency-check` skill for the full retire/bump pass).",
+        "",
+        "| tool | current | latest | release notes |",
+        "|---|---|---|---|",
+    ]
+    for key in sorted(outdated):
+        info = outdated[key]
+        current = info.get("current") or info.get("requested") or "?"
+        latest = info.get("latest") or info.get("bump") or "?"
+        lines.append(f"| `{key}` | {current} | {latest} | {release_link(key)} |")
+    lines += [
+        "",
+        f"{len(outdated)} tool(s) have upstream movement.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def tool_currency_main() -> int:
+    """CLI entry: print the markdown report; rc 1 only on probe failure.
+
+    An outdated tool is a SIGNAL, not an error — the daily workflow gates
+    issue-upsert on report content, not exit code, so a busy upstream day
+    never turns the cron red.
+    """
+    res = subprocess.run(
+        ["mise", "outdated", "--json"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=_OUTDATED_TIMEOUT_S,
+    )
+    if res.returncode != 0:
+        sys.stderr.write(f"mise outdated failed: {res.stderr.strip()}\n")
+        return 1
+    outdated = json.loads(res.stdout or "{}")
+    sys.stdout.write(render_report(outdated))
+    return 0

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -967,3 +967,23 @@ tokens = [
     "mise run land",
     "mise run ship",
 ]
+
+[[suite]]
+name = "workflow.tool-currency-wiring"
+description = "Daily tool-currency signal wiring: refresh.yml's tool-currency job must render the report via `mise run tool-currency` (thin caller of the python library) and upsert the standing issue; module + tests must exist. The signal feeds the tool-currency-check skill's release-note review (self-learning loop, 2026-07-07)."
+category = "workflow"
+check_type = "static"
+handler = "require_tokens"
+paths = [
+    "mise.toml",
+    "python/src/dotfiles_setup/tool_currency.py",
+    "tests/test_tool_currency.py",
+    ".github/workflows/refresh.yml",
+]
+tokens = [
+    "[tasks.tool-currency]",
+    "dotfiles-setup tool-currency",
+    "def tool_currency_main",
+    "mise run tool-currency",
+    "Tool currency report (daily)",
+]

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -22,11 +22,13 @@ Docker image smoke outputs.
 | `test_container.py` | pytest | `verify-container-latest` gate (`dotfiles_setup.container`) — running/bind-mount/smoke freshness checks |
 | `test_sync.py` | pytest | `mise run sync` workflow (`dotfiles_setup.sync`) — staleness detection, action matrix, CI awareness, check/full/wait modes |
 | `test_pr.py` | pytest | `mise run ship`/`land` workflow (`dotfiles_setup.pr`) — surface detection, gate matrix, bucket verification, pinned merge |
+| `test_hook_guard.py` | pytest | PreToolUse mise-tasks-only guard (`dotfiles_setup.hook_guard`) — deny/redirect rules, false-positive guards, JSON contract |
+| `test_tool_currency.py` | pytest | Daily tool-currency signal (`dotfiles_setup.tool_currency`) — release-link backends, report rendering |
 | `test_shell_integration.py` | pytest | Tool reachability in login shells (mise, chezmoi, uv, pixi, claude, gemini, codex) |
 | `infra/foundation.bats` | Bats | Bash-level foundation checks (shell script integration) |
 | `infra/runtimes.bats` | Bats | Runtime installation checks (bash) |
 
-Total: **307 pytest tests** (pytest runs all `test_*.py` files) plus Bats
+Total: **316 pytest tests** (pytest runs all `test_*.py` files) plus Bats
 scenarios under `infra/`.
 
 ## Running tests

--- a/tests/test_tool_currency.py
+++ b/tests/test_tool_currency.py
@@ -1,0 +1,49 @@
+"""Tests for the daily tool-currency signal (dotfiles_setup.tool_currency)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
+
+import pytest
+from dotfiles_setup import tool_currency
+
+
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        ("github:ast-grep/ast-grep", "https://github.com/ast-grep/ast-grep/releases"),
+        ("aqua:jackchuka/mdschema", "https://github.com/jackchuka/mdschema/releases"),
+        ("npm:@devcontainers/cli", "npmjs.com/package/@devcontainers/cli"),
+        ("pipx:mcp2cli", "pypi.org/project/mcp2cli"),
+        ("cargo:rtk", "crates.io/crates/rtk"),
+        ("hk", "mise.jdx.dev/registry.html"),
+    ],
+)
+def test_release_link_per_backend(key: str, expected: str) -> None:
+    assert expected in tool_currency.release_link(key)
+
+
+def test_render_report_empty_is_all_current() -> None:
+    report = tool_currency.render_report({})
+    assert "current" in report
+    assert "|" not in report
+
+
+def test_render_report_rows_and_links() -> None:
+    outdated = {
+        "hk": {"current": "1.49.0", "latest": "1.50.1"},
+        "github:agent-sh/agnix": {"current": "0.36.2", "latest": "0.37.0"},
+    }
+    report = tool_currency.render_report(outdated)
+    assert "| `hk` | 1.49.0 | 1.50.1 |" in report
+    assert "https://github.com/agent-sh/agnix/releases" in report
+    assert "2 tool(s)" in report
+    assert "tool-currency-check" in report
+
+
+def test_render_report_tolerates_missing_fields() -> None:
+    report = tool_currency.render_report({"x": {}})
+    assert "| `x` | ? | ? |" in report


### PR DESCRIPTION
Second half of Ray's self-learning ask (the Renovate digest pin was
already live from #169 T3 — probe-verified: ubuntu base digest-pinned in
docker-bake.hcl + Dockerfile, Renovate-managed in lockstep):

- python/src/dotfiles_setup/tool_currency.py renders `mise outdated
  --json` into markdown with a per-tool release-notes link
  (github/aqua/ubi → releases page, npm → versions tab, pipx/uvx →
  PyPI history, cargo → crates.io, registry shorthand → mise registry).
- refresh.yml gains a daily `tool-currency` job: renders via
  `mise run tool-currency` and upserts ONE standing issue ('Tool
  currency report (daily)') when upstream moved — history in the issue
  timeline, no stale-issue pile. Outdated tools are a signal, not a red
  cron: issue-upsert gates on report content, not exit code.
- The tool-currency-check skill starts from that issue; judgment
  (adopt/retire per tool-currency-and-native-first) stays agent-side.
- Contract workflow.tool-currency-wiring; 9 tests (suite 316).

Also restores two doc lines lost in #174: the hook deny on a compound
command silently killed its heredoc doc-edits (do-not.md pointer +
tests/AGENTS.md row) — a denied Bash call cancels ALL its parts.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AbMJtYjtLb9poxXBNm3NWy
