### PR TITLE
fix(pr): merge-base tier-1 identity + path-aware main-run expectation

### DIFF
--- a/.claude/rules/verify-before-advancing.md
+++ b/.claude/rules/verify-before-advancing.md
@@ -57,7 +57,11 @@ and a green result against it is a false positive.
   files it runs are the host working tree at branch HEAD (not a snapshot);
 - **base is current** — `scripts/devcontainer-smoke.sh` tier-1 image
   identity (PR #140 "Gap A") compares the in-image `config.toml` hash to
-  the repo `mise-system.toml` and **hard-fails a stale base**. Refresh with
+  the expected build input and **hard-fails a stale base**. On a branch
+  that CHANGES an image build input, "expected" is the merge-base blob
+  (`dotfiles-setup image identity-expected`) — the new base is built by
+  that PR's own CI, so branch-config identity is validated there, not
+  locally. Refresh with
   `mise run dev-rebuild` (pulls the registry `:dev`; on a slow link this is
   a long buildkit pull — never classic `docker pull`, which wedges on the
   ~38GB image, see `feedback_mise_local_toml_replaces_task`);

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -77,10 +77,13 @@ Push-to-main path (after a PR merge):
 - **Build chain is path-gated.** A `changes` job (dorny/paths-filter,
   `list-files: json`) matches image/test inputs (`.devcontainer/**`,
   `docker-bake.hcl`, `hk-common.pkl`, `hk-image.pkl`, `python/**`,
-  `.dive-ci`, `ci.yml`); `decide` drops markdown-only matches
+  `.dive-ci`, `ci.yml`, `.config/mise/conf.d/shared.toml`); `decide`
+  drops markdown-only matches
   via `jq` (`!**/*.md` can't — `**/*.md` skips dot-dirs). So docs, root-mise,
   hk.pkl, home PRs run lint+contract-preflight only; schedule +
-  workflow_dispatch always build.
+  workflow_dispatch always build. `shared.toml` is on both the push-paths
+  and this build filter — it is a Dockerfile COPY input (gap found
+  landing #178).
 - **Concurrency cancels superseded runs per branch.** `ci.yml`/`autofix.yml`
   group by `${{ github.workflow }}-${{ github.head_ref || github.ref }}`; a
   new commit cancels the older in-flight run. **main is exempt**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ on:
       - "hk-image.pkl"
       - "hk-common.pkl"
       - "renovate.json"
+      # Image build input: COPYd to /usr/local/share/mise/conf.d/ by the
+      # Dockerfile and covered by the base content-hash — a merge touching
+      # only this file must still run promote (gap found landing #178).
+      - ".config/mise/conf.d/shared.toml"
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -231,6 +235,7 @@ jobs:
               - 'python/**'
               - '.dive-ci'
               - '.github/workflows/ci.yml'
+              - '.config/mise/conf.d/shared.toml'
       - name: Decide whether the build chain runs
         id: decide
         env:

--- a/python/src/dotfiles_setup/image.py
+++ b/python/src/dotfiles_setup/image.py
@@ -20,7 +20,7 @@ from dotfiles_setup import _project_root
 from dotfiles_setup.p2996_hash import _extract_bake_variable
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Callable, Mapping
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -773,6 +773,53 @@ class ImageCommand:
     output_path: Path | None = None
     baseline_path: Path | None = None
     candidate_path: Path | None = None
+    identity_path: str | None = None
+
+
+def identity_expected_hash(repo_root: Path, rel_path: str) -> str:
+    """Expected sha256 for the in-image copy of an image build input.
+
+    A branch that CHANGES an image build input can never have a local base
+    built from it — the new base is built by that branch's own PR CI — so
+    smoke tier-1 identity validates base currency against the MERGE-BASE
+    blob ("is the base current w.r.t. what is already integrated on main")
+    and defers branch-config identity to the PR CI build+smoke. On main,
+    merge-base == HEAD, so this is byte-identical to the committed file.
+
+    Falls back to the worktree bytes when the merge-base or blob cannot be
+    resolved (checkout without origin/main, path not yet tracked).
+    """
+    merge_base = subprocess.run(
+        ["git", "-C", str(repo_root), "merge-base", "HEAD", "origin/main"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if merge_base.returncode == 0:
+        blob = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "show",
+                f"{merge_base.stdout.strip()}:{rel_path}",
+            ],
+            capture_output=True,
+            check=False,
+        )
+        if blob.returncode == 0:
+            return hashlib.sha256(blob.stdout).hexdigest()
+    return hashlib.sha256((repo_root / rel_path).read_bytes()).hexdigest()
+
+
+def identity_expected_main(rel_path: str) -> int:
+    """CLI: print the tier-1 expected hash for ``rel_path`` (see above).
+
+    Called by ``scripts/devcontainer-smoke.sh`` so the merge-base decision
+    lives in python, not bash (zero-bash-logic).
+    """
+    sys.stdout.write(identity_expected_hash(_project_root(), rel_path) + "\n")
+    return 0
 
 
 def verify_tools_main() -> int:
@@ -811,42 +858,62 @@ def verify_tools_main() -> int:
     return 0
 
 
+def _handle_verify_tools(_cmd: ImageCommand) -> int:
+    return verify_tools_main()
+
+
+def _handle_identity_expected(cmd: ImageCommand) -> int:
+    if cmd.identity_path is None:
+        sys.stderr.write("identity-expected requires a path\n")
+        return 2
+    return identity_expected_main(cmd.identity_path)
+
+
+def _handle_smoke(cmd: ImageCommand) -> int:
+    result = smoke(cmd.image_ref, platform=cmd.platform)
+    if result["result"] == "FAIL":
+        sys.stderr.write(f"FAIL: {cmd.image_ref}\n")
+        sys.stderr.write(result.get("stderr", ""))
+        return 1
+    sys.stderr.write(f"PASS: {cmd.image_ref}\n")
+    return 0
+
+
+def _handle_size_report(cmd: ImageCommand) -> int:
+    payload = size_report(cmd.image_ref, platform=cmd.platform)
+    sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    return 0
+
+
+def _handle_benchmark(cmd: ImageCommand) -> int:
+    payload = benchmark(
+        cmd.image_ref, platform=cmd.platform, output_path=cmd.output_path
+    )
+    sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    return 0
+
+
+def _handle_metrics_compare(cmd: ImageCommand) -> int:
+    if cmd.baseline_path is None or cmd.candidate_path is None:
+        msg = "baseline_path and candidate_path are required"
+        raise ValueError(msg)
+    payload = metrics_compare(cmd.baseline_path, cmd.candidate_path)
+    sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    return 0
+
+
 def main(cmd: ImageCommand) -> int:
-    """CLI entry point for image operations."""
-    if cmd.command == "verify-tools":
-        return verify_tools_main()
-    if cmd.command == "smoke":
-        result = smoke(cmd.image_ref, platform=cmd.platform)
-        if result["result"] == "FAIL":
-            sys.stderr.write(f"FAIL: {cmd.image_ref}\n")
-            sys.stderr.write(result.get("stderr", ""))
-            return 1
-        sys.stderr.write(f"PASS: {cmd.image_ref}\n")
-        return 0
-    if cmd.command == "size-report":
-        payload = size_report(cmd.image_ref, platform=cmd.platform)
-        sys.stdout.write(
-            json.dumps(payload, indent=2, sort_keys=True) + "\n",
-        )
-        return 0
-    if cmd.command == "benchmark":
-        payload = benchmark(
-            cmd.image_ref,
-            platform=cmd.platform,
-            output_path=cmd.output_path,
-        )
-        sys.stdout.write(
-            json.dumps(payload, indent=2, sort_keys=True) + "\n",
-        )
-        return 0
-    if cmd.command == "metrics-compare":
-        if cmd.baseline_path is None or cmd.candidate_path is None:
-            msg = "baseline_path and candidate_path are required"
-            raise ValueError(msg)
-        payload = metrics_compare(cmd.baseline_path, cmd.candidate_path)
-        sys.stdout.write(
-            json.dumps(payload, indent=2, sort_keys=True) + "\n",
-        )
-        return 0
-    msg = f"Unsupported command: {cmd.command}"
-    raise ValueError(msg)
+    """CLI entry point for image operations (command → handler dispatch)."""
+    handlers: dict[str, Callable[[ImageCommand], int]] = {
+        "verify-tools": _handle_verify_tools,
+        "identity-expected": _handle_identity_expected,
+        "smoke": _handle_smoke,
+        "size-report": _handle_size_report,
+        "benchmark": _handle_benchmark,
+        "metrics-compare": _handle_metrics_compare,
+    }
+    handler = handlers.get(cmd.command)
+    if handler is None:
+        msg = f"Unsupported command: {cmd.command}"
+        raise ValueError(msg)
+    return handler(cmd)

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -199,6 +199,16 @@ def _add_image_subcommands(
         "verify-tools",
         help="Assert installed tool set matches mise-system.toml [tools] (#143)",
     )
+    identity_parser = image_sub.add_parser(
+        "identity-expected",
+        help="Print the smoke tier-1 expected sha256 for an image build input "
+        "(merge-base blob when the branch changed it; worktree otherwise)",
+    )
+    identity_parser.add_argument(
+        "path",
+        help="Repo-relative path of the image build input (e.g. "
+        ".devcontainer/mise-system.toml)",
+    )
     compare_parser = image_sub.add_parser(
         "metrics-compare",
         help="Compare two benchmark JSON files",
@@ -531,6 +541,9 @@ def handle_image(args: argparse.Namespace) -> None:
     """
     if args.image_command == "verify-tools":
         cmd = ImageCommand("", command="verify-tools")
+        sys.exit(image_main(cmd))
+    if args.image_command == "identity-expected":
+        cmd = ImageCommand("", command="identity-expected", identity_path=args.path)
         sys.exit(image_main(cmd))
     if args.image_command == "smoke":
         cmd = ImageCommand(args.image_ref, platform=args.platform)

--- a/python/src/dotfiles_setup/pr.py
+++ b/python/src/dotfiles_setup/pr.py
@@ -23,7 +23,14 @@ Design notes (deep-research verified, 2026-07-07 —
   (:data:`SURFACE_PATTERNS`), ship requires a full local
   ``mise run sync -- --full`` (verify-local chain) BEFORE the PR opens,
   and land re-runs it after the merge. Zero-skip: there is no flag to
-  bypass this.
+  bypass this. For branches that CHANGE an image build input, smoke
+  tier-1 identity validates against the merge-base blob (the local base
+  can never be built from the branch's config — that base is built by
+  the branch's own PR CI); see ``image.identity_expected_hash``.
+- **Main-CI expectation is path-aware** (:data:`CI_PUSH_PATHS`): ci.yml's
+  push trigger is path-filtered, so a merge whose diff matches no push
+  path legitimately produces NO main run — land passes that outcome
+  instead of false-failing (#178).
 - Gate order is cheap-first: lint → pytest → verify → conditional
   (pin-actions / lint-docs) → full sync last.
 
@@ -71,6 +78,26 @@ SURFACE_PATTERNS: tuple[str, ...] = (
     "hk-image.pkl",
     ".config/mise/conf.d/*",
     "mise.toml",
+)
+
+# ci.yml's on.push.paths, mirrored: a merge to main whose diff matches NONE
+# of these produces NO main ci.yml run — that is the expected outcome, not a
+# failure (found landing #178: a mise.toml-only merge false-failed land).
+# tests/test_pr.py asserts this constant stays in lockstep with ci.yml.
+CI_PUSH_PATHS: tuple[str, ...] = (
+    ".devcontainer/*",
+    ".devcontainer/**/*",
+    "docker-bake.hcl",
+    "home/*",
+    "home/**/*",
+    "python/*",
+    "python/**/*",
+    ".github/workflows/ci.yml",
+    "hk.pkl",
+    "hk-image.pkl",
+    "hk-common.pkl",
+    "renovate.json",
+    ".config/mise/conf.d/shared.toml",
 )
 
 # Conditional gates from verify-before-advancing's check matrix.
@@ -129,6 +156,16 @@ def _matches_any(path: str, patterns: tuple[str, ...]) -> bool:
 def touches_surface(paths: list[str]) -> bool:
     """True when the diff touches the devcontainer/image/validation surface."""
     return any(_matches_any(p, SURFACE_PATTERNS) for p in paths)
+
+
+def expects_main_run(paths: list[str]) -> bool:
+    """True when merging these paths triggers a main ci.yml run.
+
+    Mirrors ci.yml's ``on.push.paths`` (:data:`CI_PUSH_PATHS`). A merge
+    matching none produces no main run, so land treats that absence as
+    success rather than a false failure (#178).
+    """
+    return any(_matches_any(p, CI_PUSH_PATHS) for p in paths)
 
 
 def changed_paths_vs_main(workspace: Path) -> list[str]:
@@ -333,8 +370,14 @@ def _merge_commit_oid(pr_number: int) -> str | None:
     return commit.get("oid")
 
 
-def _main_run_conclusion(merge_oid: str) -> bool:
-    """Watch the main ci.yml run for the merge commit; verify via the API."""
+def _main_run_conclusion(merge_oid: str, *, expect_run: bool = True) -> bool:
+    """Watch the main ci.yml run for the merge commit; verify via the API.
+
+    ``expect_run=False`` (merge diff matches no ci.yml push path): a short
+    grace poll still runs — if a run DOES appear (constant drifted vs
+    ci.yml) it is watched normally — but no run within the grace window is
+    the expected outcome and passes.
+    """
     run_id = ""
     sys.stdout.write("==> waiting for main ci.yml run on the merge commit\n")
     find = [
@@ -354,12 +397,21 @@ def _main_run_conclusion(merge_oid: str) -> bool:
         "--jq",
         ".[0].databaseId // empty",
     ]
-    for _ in range(40):  # ~10 min at 15s; the run registers within seconds
+    # ~10 min at 15s when a run is expected (it registers within seconds);
+    # a short grace poll otherwise, in case CI_PUSH_PATHS drifted vs ci.yml.
+    attempts = 40 if expect_run else 4
+    for _ in range(attempts):
         run_id = _run(find, timeout=_PROBE_TIMEOUT_S).stdout.strip()
         if run_id:
             break
         time.sleep(15)
     if not run_id:
+        if not expect_run:
+            sys.stdout.write(
+                "PASS  main run: none expected — the merge diff matches no "
+                "ci.yml push path (PR-level CI validated the merge)\n"
+            )
+            return True
         sys.stdout.write("FAIL  land: no main ci.yml run appeared for the merge\n")
         return False
     _stream(["gh", "run", "watch", run_id, "--exit-status"])
@@ -460,7 +512,8 @@ def _merge_and_watch_main(workspace: Path, pr_number: int, head: str) -> bool:
     if not merge_oid:
         sys.stdout.write("FAIL  land: could not resolve the merge commit oid\n")
         return False
-    return _main_run_conclusion(merge_oid)
+    expect_run = expects_main_run(_pr_changed_paths(pr_number))
+    return _main_run_conclusion(merge_oid, expect_run=expect_run)
 
 
 def _land_merge_phase(workspace: Path, pr_number: int, *, resume: bool) -> bool | None:
@@ -477,9 +530,12 @@ def _land_merge_phase(workspace: Path, pr_number: int, *, resume: bool) -> bool 
             )
             return None
         merge_oid = _merge_commit_oid(pr_number)
-        if not merge_oid or not _main_run_conclusion(merge_oid):
+        pr_paths = _pr_changed_paths(pr_number)
+        if not merge_oid or not _main_run_conclusion(
+            merge_oid, expect_run=expects_main_run(pr_paths)
+        ):
             return None
-        return touches_surface(_pr_changed_paths(pr_number))
+        return touches_surface(pr_paths)
     preflight = _land_preflight(pr_number)
     if preflight is None:
         return None

--- a/scripts/devcontainer-smoke.sh
+++ b/scripts/devcontainer-smoke.sh
@@ -30,13 +30,19 @@ echo "[tier1] image identity — mise-system config hash"
 # runtime (Dockerfile.host-user + devcontainer.json) to the USER config dir
 # /home/<user>/.config/mise, a chezmoi-rendered file in the persistent home
 # volume — a different file that false-fails this check on a current base.
+# Expected hashes come from `dotfiles-setup image identity-expected` (not a
+# raw sha256sum of the worktree file): a branch that CHANGES an image build
+# input can never have a local base built from it — the new base is built by
+# that PR's own CI — so the expected hash is the MERGE-BASE blob for
+# branch-modified inputs and the worktree file otherwise (identical on main).
+# Branch-config identity is validated by the PR CI build+smoke instead.
 sys_cfg="${MISE_SYSTEM_CONFIG_FILE:-/usr/local/share/mise/config.toml}"
 repo_cfg="${WORKSPACE_FOLDER}/.devcontainer/mise-system.toml"
 if [ -f "$repo_cfg" ]; then
-  expected_cfg_hash="$(sha256sum "$repo_cfg" | cut -d' ' -f1)"
+  expected_cfg_hash="$(cd "${WORKSPACE_FOLDER}" && uv run --project python dotfiles-setup image identity-expected .devcontainer/mise-system.toml)"
   actual_cfg_hash="$(sha256sum "$sys_cfg" | cut -d' ' -f1)"
   if [ "$actual_cfg_hash" != "$expected_cfg_hash" ]; then
-    echo "  FAIL: in-image mise config ${actual_cfg_hash} != repo mise-system.toml ${expected_cfg_hash} (stale/cached image — rebuild)" >&2
+    echo "  FAIL: in-image mise config ${actual_cfg_hash} != expected mise-system.toml ${expected_cfg_hash} (stale/cached image — rebuild)" >&2
     exit 1
   fi
   echo "  OK: image built from current mise-system.toml (${actual_cfg_hash})"
@@ -45,17 +51,18 @@ if [ -f "$repo_cfg" ]; then
   # too, and a base stale w.r.t. either passed this gate. Compare all
   # in-image config tiers that have a repo-side source of truth.
   for pair in \
-    "/usr/local/share/mise/conf.d/shared.toml:${WORKSPACE_FOLDER}/.config/mise/conf.d/shared.toml" \
-    "/usr/local/share/mise/config.runtime.toml:${WORKSPACE_FOLDER}/.devcontainer/mise-runtime.toml"; do
-    img_file="${pair%%:*}"; src_file="${pair##*:}"
+    "/usr/local/share/mise/conf.d/shared.toml:.config/mise/conf.d/shared.toml" \
+    "/usr/local/share/mise/config.runtime.toml:.devcontainer/mise-runtime.toml"; do
+    img_file="${pair%%:*}"; src_rel="${pair##*:}"
+    src_file="${WORKSPACE_FOLDER}/${src_rel}"
     if [ -f "$src_file" ] && [ -f "$img_file" ]; then
-      want="$(sha256sum "$src_file" | cut -d' ' -f1)"
+      want="$(cd "${WORKSPACE_FOLDER}" && uv run --project python dotfiles-setup image identity-expected "$src_rel")"
       got="$(sha256sum "$img_file" | cut -d' ' -f1)"
       if [ "$got" != "$want" ]; then
-        echo "  FAIL: in-image $(basename "$img_file") ${got} != repo $(basename "$src_file") ${want} (stale/cached image — rebuild)" >&2
+        echo "  FAIL: in-image $(basename "$img_file") ${got} != expected $(basename "$src_rel") ${want} (stale/cached image — rebuild)" >&2
         exit 1
       fi
-      echo "  OK: image built from current $(basename "$src_file") (${got})"
+      echo "  OK: image built from current $(basename "$src_rel") (${got})"
     fi
   done
 else

--- a/tests/test_image_smoke.py
+++ b/tests/test_image_smoke.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
+import subprocess
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -19,6 +21,7 @@ from dotfiles_setup.image import (
     build_smoke_docker_cmd,
     build_smoke_script,
     diff_tool_sets,
+    identity_expected_hash,
     installed_tools_from_mise_ls,
     parse_declared_tools,
     resolve_declared_tools,
@@ -507,3 +510,74 @@ def test_sum_manifest_layer_sizes_single_manifest() -> None:
     assert (
         _sum_manifest_layer_sizes(raw, "ghcr.io/owner/repo:tag") == _LAYERS_TOTAL_BYTES
     )
+
+
+# --------------------------------------- tier-1 identity (merge-base aware)
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+        },
+    )
+
+
+def _identity_fixture_repo(tmp_path: Path) -> Path:
+    """A repo where origin/main pins config.toml at its ORIGINAL content."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    (repo / "config.toml").write_text("original\n")
+    (repo / "other.toml").write_text("untouched\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base")
+    _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+    return repo
+
+
+def test_identity_expected_unchanged_file_uses_worktree(tmp_path: Path) -> None:
+    repo = _identity_fixture_repo(tmp_path)
+    expected = hashlib.sha256(b"untouched\n").hexdigest()
+    assert identity_expected_hash(repo, "other.toml") == expected
+
+
+def test_identity_expected_branch_change_uses_merge_base(tmp_path: Path) -> None:
+    """A branch that changes an image input expects the MERGE-BASE blob.
+
+    The local base can never be built from the branch's config (that base
+    is built by the branch's own PR CI), so tier-1 identity must expect
+    the integrated content — the exact ship-gate deadlock of the #178
+    follow-up (jq CVE bump PR).
+    """
+    repo = _identity_fixture_repo(tmp_path)
+    _git(repo, "checkout", "-b", "bump")
+    (repo / "config.toml").write_text("bumped\n")
+    _git(repo, "commit", "-am", "bump config")
+    expected = hashlib.sha256(b"original\n").hexdigest()
+    assert identity_expected_hash(repo, "config.toml") == expected
+
+
+def test_identity_expected_on_main_equals_worktree(tmp_path: Path) -> None:
+    """On main (merge-base == HEAD) the expectation is the committed file."""
+    repo = _identity_fixture_repo(tmp_path)
+    expected = hashlib.sha256(b"original\n").hexdigest()
+    assert identity_expected_hash(repo, "config.toml") == expected
+
+
+def test_identity_expected_falls_back_without_origin_main(tmp_path: Path) -> None:
+    repo = tmp_path / "bare-checkout"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    (repo / "config.toml").write_text("only-local\n")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "no origin")
+    expected = hashlib.sha256(b"only-local\n").hexdigest()
+    assert identity_expected_hash(repo, "config.toml") == expected

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -183,7 +183,7 @@ def test_land_merge_pins_verified_head(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(pr, "pr_checks_green", lambda _n: (True, "ok"))
     monkeypatch.setattr(pr, "_stream", lambda cmd, **_k: streamed.append(cmd) or 0)
     monkeypatch.setattr(pr, "_merge_commit_oid", lambda _n: "c" * 40)
-    monkeypatch.setattr(pr, "_main_run_conclusion", lambda _o: True)
+    monkeypatch.setattr(pr, "_main_run_conclusion", lambda _o, **_k: True)
     monkeypatch.setattr(pr, "sync_main", lambda *_a, **_k: 0)
     assert pr.land_main(_WORKSPACE, 7) == 0
     merge_cmd = next(c for c in streamed if c[:3] == ["gh", "pr", "merge"])
@@ -203,7 +203,7 @@ def test_land_surface_pr_validates_full_tier(
     monkeypatch.setattr(pr, "pr_checks_green", lambda _n: (True, "ok"))
     monkeypatch.setattr(pr, "_stream", lambda *_a, **_k: 0)
     monkeypatch.setattr(pr, "_merge_commit_oid", lambda _n: "e" * 40)
-    monkeypatch.setattr(pr, "_main_run_conclusion", lambda _o: True)
+    monkeypatch.setattr(pr, "_main_run_conclusion", lambda _o, **_k: True)
 
     def fake_sync(_w: Path, options: SyncOptions) -> int:
         seen["full"] = options.full
@@ -267,7 +267,7 @@ def test_land_resume_replays_post_merge(monkeypatch: pytest.MonkeyPatch) -> None
     )
     monkeypatch.setattr(pr, "_pr_changed_paths", lambda _n: ["a.py"])
     monkeypatch.setattr(pr, "_merge_commit_oid", lambda _n: "c" * 40)
-    monkeypatch.setattr(pr, "_main_run_conclusion", lambda _o: True)
+    monkeypatch.setattr(pr, "_main_run_conclusion", lambda _o, **_k: True)
     monkeypatch.setattr(pr, "_stream", lambda *_a, **_k: 0)
     monkeypatch.setattr(pr, "sync_main", lambda *_a, **_k: 0)
     assert pr.land_main(_WORKSPACE, 7, resume=True) == 0
@@ -280,3 +280,121 @@ def test_land_resume_replays_post_merge(monkeypatch: pytest.MonkeyPatch) -> None
 def test_surface_covers_image_copy_inputs(path: str) -> None:
     """Review finding [5]: image COPY inputs + task definitions are surface."""
     assert pr.touches_surface([path])
+
+
+# ------------------------------------------- main-CI expectation (post #178)
+
+
+def _ci_yml_push_paths() -> list[str]:
+    """The on.push.paths entries as written in ci.yml (comments skipped)."""
+    text = (
+        Path(__file__).parent.parent / ".github" / "workflows" / "ci.yml"
+    ).read_text()
+    block = text.split("push:", 1)[1].split("paths:", 1)[1]
+    entries: list[str] = []
+    for line in block.splitlines()[1:]:
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        if not stripped.startswith("- "):
+            break
+        entries.append(stripped[2:].strip('"'))
+    return entries
+
+
+def _fnmatch_patterns_for(yaml_path: str) -> tuple[str, ...]:
+    """The fnmatch mirror of one ci.yml glob (``x/**`` needs two patterns)."""
+    if yaml_path.endswith("/**"):
+        base = yaml_path.removesuffix("/**")
+        return (f"{base}/*", f"{base}/**/*")
+    return (yaml_path,)
+
+
+def test_ci_push_paths_mirror_ci_yml() -> None:
+    """CI_PUSH_PATHS must stay in lockstep with ci.yml on.push.paths.
+
+    Land's "no main run expected" outcome (#178) is only correct while the
+    mirrored constant matches the workflow — this test fails on drift in
+    either direction.
+    """
+    entries = _ci_yml_push_paths()
+    assert entries, "failed to parse ci.yml on.push.paths"
+    expected: set[str] = set()
+    for entry in entries:
+        expected.update(_fnmatch_patterns_for(entry))
+    assert set(pr.CI_PUSH_PATHS) == expected
+
+
+@pytest.mark.parametrize(
+    ("paths", "expected"),
+    [
+        (["mise.toml", "mise.lock", ".agnix.toml"], False),  # the #178 shape
+        ([".config/mise/conf.d/shared.toml"], True),
+        (["python/src/dotfiles_setup/pr.py"], True),
+        (["home/dot_zshrc"], True),
+        ([".devcontainer/mise-system.lock"], True),
+        ([".claude/rules/do-not.md", "AGENTS.md"], False),
+    ],
+)
+def test_expects_main_run(paths: list[str], *, expected: bool) -> None:
+    assert pr.expects_main_run(paths) is expected
+
+
+def _land_run_dispatch(view: dict[str, str], *, run_id: str = "") -> object:
+    """Fake ``pr._run`` dispatching by gh subcommand for land_main flows."""
+
+    def fake(cmd: list[str], **_k: object) -> subprocess.CompletedProcess[str]:
+        if "run" in cmd and "list" in cmd:
+            return _cp(f"{run_id}\n" if run_id else "")
+        if "conclusion" in cmd:
+            return _cp("success\n")
+        if "mergeCommit" in cmd:
+            return _cp(json.dumps({"mergeCommit": {"oid": "c" * 40}}))
+        if "checks" in cmd:
+            return _cp(json.dumps([{"name": "lint", "bucket": "pass"}]))
+        return _cp(json.dumps(view))
+
+    return fake
+
+
+def test_land_passes_when_no_main_run_expected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#178: a merge whose paths match no ci.yml push path needs no run."""
+    view = {"state": "OPEN", "headRefOid": "b" * 40, "baseRefName": "main"}
+    monkeypatch.setattr(pr, "_run", _land_run_dispatch(view))
+    monkeypatch.setattr(
+        pr, "_pr_changed_paths", lambda _n: ["mise.toml", ".agnix.toml"]
+    )
+    monkeypatch.setattr(pr, "_stream", lambda *_a, **_k: 0)
+    monkeypatch.setattr(pr, "sync_main", lambda *_a, **_k: 0)
+    monkeypatch.setattr(pr.time, "sleep", lambda _s: None)
+    assert pr.land_main(_WORKSPACE, 7) == 0
+
+
+def test_land_fails_when_expected_main_run_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ci.yml-push-path merge with no main run is a real failure."""
+    view = {"state": "OPEN", "headRefOid": "b" * 40, "baseRefName": "main"}
+    monkeypatch.setattr(pr, "_run", _land_run_dispatch(view))
+    monkeypatch.setattr(
+        pr, "_pr_changed_paths", lambda _n: [".config/mise/conf.d/shared.toml"]
+    )
+    monkeypatch.setattr(pr, "_stream", lambda *_a, **_k: 0)
+    monkeypatch.setattr(pr, "sync_main", lambda *_a, **_k: 0)
+    monkeypatch.setattr(pr.time, "sleep", lambda _s: None)
+    assert pr.land_main(_WORKSPACE, 7) == 1
+
+
+def test_land_watches_main_run_when_one_unexpectedly_appears(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Grace poll: a run appearing despite no expectation is still verified."""
+    view = {"state": "OPEN", "headRefOid": "b" * 40, "baseRefName": "main"}
+    monkeypatch.setattr(pr, "_run", _land_run_dispatch(view, run_id="999"))
+    monkeypatch.setattr(pr, "_pr_changed_paths", lambda _n: ["docs/x.md"])
+    monkeypatch.setattr(pr, "_stream", lambda *_a, **_k: 0)
+    monkeypatch.setattr(pr, "sync_main", lambda *_a, **_k: 0)
+    monkeypatch.setattr(pr.time, "sleep", lambda _s: None)
+    assert pr.land_main(_WORKSPACE, 7) == 0


### PR DESCRIPTION
Two ship/land gaps found landing #178, both blocking the jq-CVE
shared.toml bump that follows this PR.

1. Merge-base tier-1 identity (unblocks image-input-bump PRs).
   A branch that CHANGES an image build input (mise-system.toml /
   shared.toml / mise-runtime.toml) can never have a local base built
   from it — the new base is built by that branch's own PR CI — so
   ship's hard `sync --full` gate deadlocked: smoke tier-1 compared the
   in-image config to the branch's bumped config and always failed
   "stale base". Now `dotfiles-setup image identity-expected <path>`
   returns the MERGE-BASE blob hash for branch-modified inputs (the
   base IS current w.r.t. what's integrated on main) and the worktree
   hash otherwise (identical on main). Branch-config identity is
   validated by the PR CI build+smoke, where it belongs. The smoke
   script calls the CLI instead of a raw sha256sum (zero-bash-logic).

2. Path-aware main-run expectation (fixes land false-failure).
   ci.yml's push trigger is path-filtered, so a merge whose diff
   matches no push path produces NO main run — but land treated the
   absence as failure ("no main ci.yml run appeared", the #178 exit
   rc=1 on the mise.toml-only merge). `CI_PUSH_PATHS` mirrors
   on.push.paths (lockstep-tested vs ci.yml), `expects_main_run(paths)`
   drives a grace poll: a run that does appear is watched normally; a
   legitimately-absent one passes.

Also: add `.config/mise/conf.d/shared.toml` to ci.yml's on.push.paths
AND the `changes` build filter — it is a Dockerfile COPY input but was
in neither, so a shared.toml-only merge would skip promote and a
shared.toml-only PR would skip the build chain. (The lockstep test
requires this be in the same change as CI_PUSH_PATHS.)

Refactor: `image.main()` command dispatch → handler dict (was 8 return
branches, PLR0911). Tests drive the public `land_main` /
`expects_main_run` (codebase convention: no private-member access).

Gates: lint rc=0; pytest 357 passed; verify 86 passed 0 failed;
pin-actions rc=0; lint-docs rc=0; ty clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PKHuUnvDFFQk9Tyo7R9tGF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command to report the expected identity hash for image/config inputs.
  * Improved CLI handling for image-related commands.

* **Bug Fixes**
  * CI and container checks now detect stale cached images more reliably.
  * PR land/ship flows now better account for whether a main CI run should be expected.

* **Chores**
  * Updated workflow and contributor-facing docs to reflect the new path-gating behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->