### PR TITLE
fix(image): complete merge-base tier-1 — tool-set check too (#179 follow-up)

### DIFF
--- a/python/src/dotfiles_setup/image.py
+++ b/python/src/dotfiles_setup/image.py
@@ -776,15 +776,16 @@ class ImageCommand:
     identity_path: str | None = None
 
 
-def identity_expected_hash(repo_root: Path, rel_path: str) -> str:
-    """Expected sha256 for the in-image copy of an image build input.
+def base_currency_blob(repo_root: Path, rel_path: str) -> bytes:
+    """Bytes of an image build input as the CURRENT local base was built from it.
 
     A branch that CHANGES an image build input can never have a local base
     built from it — the new base is built by that branch's own PR CI — so
-    smoke tier-1 identity validates base currency against the MERGE-BASE
-    blob ("is the base current w.r.t. what is already integrated on main")
-    and defers branch-config identity to the PR CI build+smoke. On main,
-    merge-base == HEAD, so this is byte-identical to the committed file.
+    the local smoke tier-1 base-currency checks compare against the
+    MERGE-BASE blob ("is the base current w.r.t. what is already integrated
+    on main") and defer branch-config validation to the PR CI build+smoke.
+    On main, merge-base == HEAD, so this is byte-identical to the committed
+    file.
 
     Falls back to the worktree bytes when the merge-base or blob cannot be
     resolved (checkout without origin/main, path not yet tracked).
@@ -808,8 +809,17 @@ def identity_expected_hash(repo_root: Path, rel_path: str) -> str:
             check=False,
         )
         if blob.returncode == 0:
-            return hashlib.sha256(blob.stdout).hexdigest()
-    return hashlib.sha256((repo_root / rel_path).read_bytes()).hexdigest()
+            return blob.stdout
+    return (repo_root / rel_path).read_bytes()
+
+
+def identity_expected_hash(repo_root: Path, rel_path: str) -> str:
+    """Expected sha256 for the in-image copy of an image build input.
+
+    Base-currency hash: the merge-base blob for a branch-modified input,
+    the committed file otherwise (see :func:`base_currency_blob`).
+    """
+    return hashlib.sha256(base_currency_blob(repo_root, rel_path)).hexdigest()
 
 
 def identity_expected_main(rel_path: str) -> int:
@@ -822,16 +832,44 @@ def identity_expected_main(rel_path: str) -> int:
     return 0
 
 
+def resolve_declared_tools_at_base(repo_root: Path) -> dict[str, str]:
+    """Declared image tools as the CURRENT local base was built from them.
+
+    Merge-base-aware sibling of :func:`resolve_declared_tools` (which reads
+    HEAD and feeds ``build_smoke_script`` — CI builds the image FROM the
+    branch config, so it must compare against HEAD). The local
+    devcontainer's base predates a branch's image-input bump, so
+    ``verify_tools_main`` compares installed tools against the merge-base
+    declaration; branch tool bumps are validated by the PR CI build+smoke.
+    """
+    declared: dict[str, str] = {}
+    for rel_path in (
+        ".devcontainer/mise-system.toml",
+        ".config/mise/conf.d/shared.toml",
+        ".devcontainer/mise-runtime.toml",
+    ):
+        declared.update(
+            parse_declared_tools(base_currency_blob(repo_root, rel_path).decode())
+        )
+    return declared
+
+
 def verify_tools_main() -> int:
-    """Assert the installed tool set matches ``.devcontainer/mise-system.toml``.
+    """Assert the installed tool set matches the base-declared ``[tools]``.
 
     Runs ``mise ls --json`` against the ambient mise (inside the devcontainer)
-    and compares to the repo's declared ``[tools]`` — the in-container sibling of
-    the ``build_smoke_script`` assertion (#143), sharing the same parse/compare
-    core so the two smoke paths cannot diverge. Called by
+    and compares to the MERGE-BASE declared ``[tools]`` — the in-container
+    sibling of the ``build_smoke_script`` assertion (#143), sharing the same
+    parse/compare core so the two smoke paths cannot diverge. Called by
     ``scripts/devcontainer-smoke.sh`` (keeps the diff logic in python, not bash).
+
+    Uses :func:`resolve_declared_tools_at_base`, not
+    :func:`resolve_declared_tools`: the local base predates a branch's
+    image-input bump, so a HEAD comparison would false-fail on the bumped
+    tools (#178 follow-up). Branch tool bumps are validated by the PR CI
+    build+smoke, which builds the image from HEAD.
     """
-    declared = resolve_declared_tools()
+    declared = resolve_declared_tools_at_base(_project_root())
     result = subprocess.run(
         ["mise", "ls", "--json"],
         capture_output=True,
@@ -846,13 +884,14 @@ def verify_tools_main() -> int:
     diffs = diff_tool_sets(declared, installed)
     if diffs:
         sys.stderr.write(
-            "FAIL: installed tool set differs from mise-system.toml [tools]:\n"
+            "FAIL: installed tool set differs from base-declared [tools] "
+            "(merge-base):\n"
         )
         for line in diffs:
             sys.stderr.write(f"  {line}\n")
         return 1
     sys.stdout.write(
-        f"OK: installed tool set matches mise-system.toml [tools] "
+        f"OK: installed tool set matches base-declared [tools] "
         f"({len(declared)} tools)\n"
     )
     return 0

--- a/tests/test_image_smoke.py
+++ b/tests/test_image_smoke.py
@@ -18,6 +18,7 @@ from dotfiles_setup.image import (
     _parse_human_size,
     _repo_without_tag,
     _sum_manifest_layer_sizes,
+    base_currency_blob,
     build_smoke_docker_cmd,
     build_smoke_script,
     diff_tool_sets,
@@ -25,6 +26,7 @@ from dotfiles_setup.image import (
     installed_tools_from_mise_ls,
     parse_declared_tools,
     resolve_declared_tools,
+    resolve_declared_tools_at_base,
     resolve_expected_config_sha256,
     resolve_expected_p2996_ref,
 )
@@ -581,3 +583,56 @@ def test_identity_expected_falls_back_without_origin_main(tmp_path: Path) -> Non
     _git(repo, "commit", "-m", "no origin")
     expected = hashlib.sha256(b"only-local\n").hexdigest()
     assert identity_expected_hash(repo, "config.toml") == expected
+
+
+# --------------------------- tool-set base-currency (merge-base declared)
+
+
+def _tool_config_fixture_repo(tmp_path: Path) -> Path:
+    """A repo whose origin/main pins the three image tool-config tiers."""
+    repo = tmp_path / "toolrepo"
+    (repo / ".devcontainer").mkdir(parents=True)
+    (repo / ".config" / "mise" / "conf.d").mkdir(parents=True)
+    (repo / ".devcontainer" / "mise-system.toml").write_text(
+        '[tools]\npython = "3.14.6"\n'
+    )
+    (repo / ".config" / "mise" / "conf.d" / "shared.toml").write_text(
+        '[tools]\njq = "1.8.1"\n'
+    )
+    (repo / ".devcontainer" / "mise-runtime.toml").write_text(
+        '[tools]\nfd = "10.4.2"\n'
+    )
+    _git(repo, "init", "-b", "main")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base tool configs")
+    _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+    return repo
+
+
+def test_resolve_declared_tools_at_base_uses_merge_base(tmp_path: Path) -> None:
+    """A branch bump reports the MERGE-BASE version, not the branch HEAD.
+
+    The exact deadlock this closes: the local base predates the bump, so a
+    HEAD comparison false-fails verify-tools on the bumped tool (#178).
+    """
+    repo = _tool_config_fixture_repo(tmp_path)
+    _git(repo, "checkout", "-b", "bump")
+    (repo / ".config" / "mise" / "conf.d" / "shared.toml").write_text(
+        '[tools]\njq = "1.8.2"\n'
+    )
+    _git(repo, "commit", "-am", "bump jq")
+    declared = resolve_declared_tools_at_base(repo)
+    assert declared["jq"] == "1.8.1"  # merge-base, not the branch's 1.8.2
+    assert declared["python"] == "3.14.6"
+    assert declared["fd"] == "10.4.2"
+
+
+def test_resolve_declared_tools_at_base_on_main_is_worktree(tmp_path: Path) -> None:
+    repo = _tool_config_fixture_repo(tmp_path)
+    declared = resolve_declared_tools_at_base(repo)
+    assert declared["jq"] == "1.8.1"
+
+
+def test_base_currency_blob_returns_bytes(tmp_path: Path) -> None:
+    repo = _identity_fixture_repo(tmp_path)
+    assert base_currency_blob(repo, "config.toml") == b"original\n"


### PR DESCRIPTION
#179 made smoke tier-1's config-HASH identity merge-base-aware but left
the tier-1 tool-SET assertion (verify_tools_main) comparing the branch's
declared versions against the local base. For an image-input bump the
base predates the bump, so it false-failed:

  FAIL: installed tool set differs ...
    ~ jq: declared '1.8.2' but installed '1.8.1'
    ~ yq: declared '4.53.3' but installed '4.53.2'
    ~ pipx:check-jsonschema: declared '0.37.4' but installed '0.37.2'

— re-deadlocking the jq-CVE shared.toml bump at a later gate stage than
before. This completes the same fix on the other axis.

- Extract `base_currency_blob(repo_root, rel_path)` (merge-base blob or
  worktree fallback) from identity_expected_hash; both tier-1 checks now
  share it.
- Add `resolve_declared_tools_at_base()` — the merge-base-aware sibling
  of `resolve_declared_tools()`. verify_tools_main uses it; the local
  base predates a branch's bump, so it compares installed vs the
  merge-base declaration. Branch tool bumps are validated by the PR CI
  build+smoke (which builds FROM head — `build_smoke_script` keeps using
  the HEAD `resolve_declared_tools()`, unchanged). devcontainer-smoke.sh
  is local-only, so this can't affect CI.

Gates: lint rc=0; pytest 360 passed; verify 86 passed 0 failed; ty clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PKHuUnvDFFQk9Tyo7R9tGF
