### PR TITLE
fix(pr): ship waits for ci-gate aggregator before declaring a build PR green

### DIFF
--- a/python/src/dotfiles_setup/pr.py
+++ b/python/src/dotfiles_setup/pr.py
@@ -13,7 +13,10 @@ Design notes (deep-research verified, 2026-07-07 —
 - **Check verification reads the ``--json`` buckets**, never a watch
   command's exit code alone (``gh run watch --exit-status`` has reported
   0 prematurely; see ``.claude/rules/gh-cli-watch.md``). A PR is green
-  iff every check bucket is ``pass`` or ``skipping``.
+  iff every check bucket is ``pass`` or ``skipping``. ship also waits for
+  the ``ci-gate`` aggregator (:data:`_AGGREGATE_CHECK`) to register before
+  ``--watch``, so a build PR is not declared green on an early check wave
+  before build-publish's matrix jobs register (#181).
 - **The merge is delegated to GitHub's requirements engine** with the
   head SHA pinned: ``gh pr merge --squash --match-head-commit <sha>``
   returns 409 if the branch moved after we verified it — closing the
@@ -113,6 +116,13 @@ _DOCS_PATTERNS = (
 )
 
 _GREEN_BUCKETS = frozenset({"pass", "skipping"})
+
+# The always-run aggregator job (ci.yml) that `needs` every other job and is
+# branch-protection-required on every PR. ship waits for THIS to register
+# before `gh pr checks --watch`, so --watch cannot exit on an early all-green
+# wave before the build-publish matrix jobs (base-prep/build/smoke-test)
+# register — the premature-green ship gap found landing #181.
+_AGGREGATE_CHECK = "ci-gate"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -257,9 +267,43 @@ def _await_checks_registered(pr_number: int, *, attempts: int = 40) -> bool:
     return False
 
 
+def _await_aggregate_registered(pr_number: int, *, attempts: int = 40) -> bool:
+    """Poll until the ``ci-gate`` aggregator check is registered.
+
+    build-publish's matrix jobs (base-prep/build/smoke-test) register in
+    WAVES after ``changes`` decides build=true, so waiting for *any* check
+    (``_await_checks_registered``) let ``gh pr checks --watch`` exit on an
+    early all-green wave before the build jobs appeared — ship declared #181
+    green prematurely. :data:`_AGGREGATE_CHECK` ``needs`` every job, so once
+    it is present the subsequent ``--watch`` cannot terminate until the whole
+    chain (including the late-registering build jobs) is terminal.
+    """
+    for _ in range(attempts):
+        res = _run(
+            ["gh", "pr", "checks", str(pr_number), "--json", "name"],
+            timeout=_PROBE_TIMEOUT_S,
+        )
+        if res.returncode == 0 and any(
+            c.get("name") == _AGGREGATE_CHECK for c in json.loads(res.stdout or "[]")
+        ):
+            return True
+        time.sleep(15)
+    sys.stdout.write(
+        f"FAIL  pr-checks: aggregator {_AGGREGATE_CHECK!r} never registered on "
+        f"PR #{pr_number} within {attempts * 15}s\n"
+    )
+    return False
+
+
 def watch_pr_checks(pr_number: int) -> bool:
-    """Await registration, watch to terminal state, verify via JSON buckets."""
+    """Await registration, watch to terminal state, verify via JSON buckets.
+
+    Waits for the ``ci-gate`` aggregator to register before ``--watch`` so a
+    build PR is not declared green on an early check wave (#181 gap).
+    """
     if not _await_checks_registered(pr_number):
+        return False
+    if not _await_aggregate_registered(pr_number):
         return False
     _stream(["gh", "pr", "checks", str(pr_number), "--watch", "--fail-fast"])
     ok, detail = pr_checks_green(pr_number)

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -215,21 +215,30 @@ def test_land_surface_pr_validates_full_tier(
 
 
 def test_watch_awaits_check_registration(monkeypatch: pytest.MonkeyPatch) -> None:
-    """'no checks reported' right after PR-create is pending, not failure."""
+    """Registration + ci-gate waits both precede --watch; then buckets verify."""
     calls: list[str] = []
     responses = iter(
         [
             _cp("", returncode=1),  # registration window: gh errors
             _cp("[]"),  # registered but empty list — still pending
-            _cp(json.dumps([{"name": "lint", "bucket": "pending"}])),  # registered
-            _cp(json.dumps([{"name": "lint", "bucket": "pass"}])),  # final verify
+            _cp(json.dumps([{"name": "lint", "bucket": "pending"}])),  # >=1 check
+            _cp(json.dumps([{"name": "lint"}])),  # ci-gate not present yet
+            _cp(json.dumps([{"name": "lint"}, {"name": "ci-gate"}])),  # ci-gate here
+            _cp(  # final bucket verify
+                json.dumps(
+                    [
+                        {"name": "lint", "bucket": "pass"},
+                        {"name": "ci-gate", "bucket": "pass"},
+                    ]
+                )
+            ),
         ]
     )
     monkeypatch.setattr(pr, "_run", lambda *_a, **_k: next(responses))
     monkeypatch.setattr(pr, "_stream", lambda cmd, **_k: calls.append(cmd[0]) or 0)
     monkeypatch.setattr(pr.time, "sleep", lambda _s: None)
     assert pr.watch_pr_checks(9) is True
-    assert calls == ["gh"]  # the --watch ran exactly once, after registration
+    assert calls == ["gh"]  # --watch ran exactly once, after BOTH waits
 
 
 def test_watch_fails_when_checks_never_register(
@@ -240,6 +249,29 @@ def test_watch_fails_when_checks_never_register(
 
     def _boom(*_a: object, **_k: object) -> int:
         msg = "must not watch before checks register"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(pr, "_stream", _boom)
+    assert pr.watch_pr_checks(9) is False
+
+
+def test_watch_fails_when_aggregate_never_registers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#181: >=1 check exists but ci-gate never appears — not green, no watch.
+
+    The premature-green gap: without the ci-gate wait, --watch could exit on
+    an early all-green wave (here `lint`) before the build jobs registered.
+    """
+    monkeypatch.setattr(
+        pr,
+        "_run",
+        lambda *_a, **_k: _cp(json.dumps([{"name": "lint", "bucket": "pass"}])),
+    )
+    monkeypatch.setattr(pr.time, "sleep", lambda _s: None)
+
+    def _boom(*_a: object, **_k: object) -> int:
+        msg = "must not watch before ci-gate registers"
         raise AssertionError(msg)
 
     monkeypatch.setattr(pr, "_stream", _boom)


### PR DESCRIPTION
The third ship/land gap surfaced landing #181: ship declared the PR green
PREMATURELY. build-publish's matrix jobs (base-prep/build/smoke-test)
register in WAVES after `changes` decides build=true, so
`gh pr checks --watch --fail-fast` exited on an early all-green wave
(lint/contract-preflight/changes) before the build jobs registered, and
`pr_checks_green` then sampled only those. Landing was still safe (branch
protection blocks a merge until ci-gate passes), but ship's "green" was
not trustworthy for a build PR.

Fix: `watch_pr_checks` now waits for the `ci-gate` aggregator to REGISTER
(`_await_aggregate_registered`) before `--watch`. ci-gate is the always-run
job that `needs` every other job and is branch-protection-required on every
PR, so once it is present --watch cannot terminate until the whole chain —
including the late-registering build jobs — is terminal.

Self-validating: this PR touches python/**, so its own PR CI runs the build
chain, and its ship uses the fixed watch (working tree) — it will wait for
ci-gate rather than exiting on the lint wave.

Gates: lint rc=0; pytest 361 passed; verify 86 passed 0 failed; ty clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PKHuUnvDFFQk9Tyo7R9tGF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PR check monitoring so the final watch step only starts after the required aggregate status is registered.
  * Prevents false “all green” detection when individual checks pass before the full set of checks is available.
  * If the aggregate status never appears, the process now stops early with a clear failure instead of waiting indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->