### PR TITLE
docs(skills): sync pr-workflow + devcontainer-sync to merge-base tier-1 + ci-gate wait

### DIFF
--- a/.claude/skills/devcontainer-sync/SKILL.md
+++ b/.claude/skills/devcontainer-sync/SKILL.md
@@ -54,7 +54,7 @@ currency + smoke tiers 1-3, incl. tier-1 image-identity base-currency);
 | `NOTE ci.yml run … in progress` | The target image may be superseded shortly | Fine to continue for a devloop; rerun sync (or use `--wait`) after the run completes |
 | `FAIL converge: buildkit tag refresh failed` | `docker buildx build --pull` could not fetch the manifest | Registry auth/manifest issue; never fall back to classic `docker pull` (wedges on the ~38GB image) |
 | `FAIL converge: dev-rebuild rc=…` | Lifecycle rebuild failed | Read the streamed devcontainer-cli output; `getaddrinfo ENOTFOUND ghcr.io` = transient DNS, retry once per `.claude/rules/persistence-gate-retry.md` |
-| `FAIL smoke-tiers-1-3 … stale base?` | Tier-1 image identity: in-image config hash ≠ repo `mise-system.toml` | The registry image predates your branch's `mise-system.toml` — wait for CI to publish, then rerun sync |
+| `FAIL smoke-tiers-1-3 … stale base?` | Tier-1 image identity: in-image config hash / tool-set ≠ the **merge-base** config (base-currency, not branch HEAD — `dotfiles-setup image identity-expected` / `resolve_declared_tools_at_base`) | The registry base predates what's integrated on `main` — wait for CI to publish `:dev`, then rerun sync. A branch's own image-input bump does NOT trip this (merge-base baseline); PR CI validates that image |
 | `WARN rebuilding: in-container sessions will be killed` | Expected on stale+running | Workspace bind-mount and home volume persist; running shells die by design |
 | rc 1 from `--check` | Stale — a real sync would rebuild | Run `mise run sync` when ready for the rebuild |
 | rc 2 from `--check` | UNKNOWN — registry unreachable, currency could not be verified | Fix ghcr auth/DNS; never treat as current |

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -33,9 +33,18 @@ mise run land -- <PR#>             # verify green → pinned squash-merge → ma
    `.devcontainer/**`, `docker-bake.hcl`, smoke/workspace scripts,
    `container.py`/`sync.py`/`image.py`/`docker.py`/`pr.py`,
    `python/verification/*`).
-3. Push, open (or reuse) the PR, `gh pr checks --watch --fail-fast`,
-   then **verify via `--json` buckets** — green means every check
-   `pass`/`skipping`; a watch exit code alone is never trusted.
+   The full-sync gate's smoke tier-1 base-currency (config-hash AND
+   tool-set) validates against the **merge-base** for a branch that
+   changed an image build input — the local base can't be built from the
+   branch (its base is built by that branch's own PR CI), so branch-config
+   validation defers to CI. Without this, an image-input bump deadlocks the
+   gate (#179/#180).
+3. Push, open (or reuse) the PR, wait for the **`ci-gate` aggregator to
+   register** (it `needs` every job), then `gh pr checks --watch
+   --fail-fast`, then **verify via `--json` buckets** — green means every
+   check `pass`/`skipping`. The ci-gate wait stops a build PR being called
+   green on an early check wave before build-publish's matrix jobs register
+   (#181); a watch exit code alone is never trusted.
 
 ## What land does
 
@@ -62,7 +71,7 @@ Invoking `land` IS the merge approval — nothing auto-merges without it.
 | `pr-checks: <name>=fail` | CI check failed after watch | Triage the run; autofix "✅ Autofix task started" failures mean the bot pushed a fix commit — re-watch |
 | `land: merge refused` | Head moved since verification / protection unmet | Re-run land (it re-verifies) |
 | land failed AFTER the merge (CI watch / sync) | Merged-but-unvalidated PR | `mise run land -- <PR#> --resume` replays the idempotent post-merge steps |
-| `land: no main ci.yml run appeared` | Merge-commit run never registered (~10 min) | Check Actions; run land's remaining steps manually via `mise run sync` after main is green |
+| `land: no main ci.yml run appeared` | A merge that SHOULD trigger a run didn't register (~10 min) | Check Actions; land only expects a run when the diff matches `CI_PUSH_PATHS` (ci.yml on.push.paths) — a merge matching none passes without one (#179) |
 
 ## Wiring audit (meta-validation)
 


### PR DESCRIPTION
Reflect the ship/land behavior shipped this session (#179/#180/#182):
- pr-workflow: full-sync gate's tier-1 base-currency (config-hash AND
  tool-set) validates against the merge-base for image-input-bump
  branches; ship waits for the ci-gate aggregator to register before
  --watch (no premature-green on a build PR); land's "no main run"
  failure mode is now path-aware (CI_PUSH_PATHS).
- devcontainer-sync: the tier-1 "stale base" row now describes the
  merge-base baseline (identity-expected / resolve_declared_tools_at_base)
  — a branch's own image-input bump does not trip it; PR CI validates
  that image.

Gate: mise run lint-docs rc=0 (agnix, 0 errors).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PKHuUnvDFFQk9Tyo7R9tGF
