### PR TITLE
test(shell): PR #86 review followups — gpg-agent guard test, drop dead is_devcontainer, drop circular pixi test (#87 #88 #89)

### DIFF
--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -20,10 +20,17 @@
        v6 refactor (plan home-volume-consolidation-draft.md):
        `is_ephemeral` removed. It conflated two concerns: "don't template
        tool-managed dirs" and "don't run chezmoi on the Mac host." Replaced
-       by `is_darwin` / `is_devcontainer` which name the host vs container
-       discriminator directly. Tool-managed dirs (.cargo, .rustup,
-       .config/gcloud) are now unconditionally skipped in .chezmoiignore
-       regardless of environment. */ -}}
+       by `is_darwin`, the host discriminator. Tool-managed dirs (.cargo,
+       .rustup, .config/gcloud) are now unconditionally skipped in
+       .chezmoiignore regardless of environment.
+
+       #88: the sibling `is_devcontainer` data var was removed here. It was
+       dead (no consumer) and misleadingly named — its predicate was just
+       `eq .chezmoi.os "linux"`, and the mise-overlay gate in .chezmoiignore
+       keys on the built-in `chezmoi.os` fact directly, so no linux-side
+       data var is needed. Keeping a misnamed "am I in a devcontainer" var
+       invited a future consumer to wire it up wrongly (a real /.dockerenv
+       probe would break the image build, where /.dockerenv is absent). */ -}}
 {{- $isDevComputer := false -}}
 {{- $isPersonal := false -}}
 
@@ -40,7 +47,6 @@
     is_dev_computer = {{ $isDevComputer }}
     is_personal = {{ $isPersonal }}
     is_darwin = {{ eq .chezmoi.os "darwin" }}
-    is_devcontainer = {{ eq .chezmoi.os "linux" }}
     is_ci = {{ $isCI }}
     remote = {{ $remote }}
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -51,15 +51,6 @@ def test_uv_version() -> None:
     assert "uv" in result.stdout.lower()
 
 
-def test_pixi_version() -> None:
-    """Verify that pixi is functional."""
-    result = subprocess.run(
-        ["pixi", "--version"], capture_output=True, text=True, check=False
-    )
-    assert result.returncode == 0
-    assert "pixi" in result.stdout.lower()
-
-
 def test_python_version() -> None:
     """Verify that python is functional."""
     result = subprocess.run(

--- a/tests/test_shell_integration.py
+++ b/tests/test_shell_integration.py
@@ -1,9 +1,137 @@
 """Tests for shell integration and tool reachability in login shells."""
 
+import re
+import shutil
 import subprocess
+import tempfile
 from pathlib import Path
 
 import pytest
+
+_REPO_ROOT = Path(__file__).parent.parent
+
+# The gpg-agent SSH-override guard is duplicated in the bash and zsh
+# rc templates. It must fire ONLY when gpg-agent has ssh-support enabled;
+# a wrong predicate silently rebinds SSH_AUTH_SOCK and breaks every SSH
+# workflow (1Password, macOS Keychain, Docker Desktop's magic socket).
+# Regression test for issue #87 (S1 from the PR #86 review).
+_SHELL_RC_TEMPLATES = ["dot_bashrc.tmpl", "dot_zshrc.tmpl"]
+
+# Capture the literal shell block from the template: from the guard's
+# opening `if command -v gpgconf` to the first column-0 `fi` (the inner
+# `  fi` is indented, so `^fi$` cannot match it). The surrounding
+# chezmoi `{{if not .remote}}` conditionals sit OUTSIDE this block, so
+# the captured text is pure shell.
+_GPG_GUARD_RE = re.compile(
+    r"^(if command -v gpgconf\b.*?^fi)$", re.MULTILINE | re.DOTALL
+)
+
+
+def _extract_gpg_guard(template_name: str) -> str:
+    text = (_REPO_ROOT / "home" / template_name).read_text()
+    match = _GPG_GUARD_RE.search(text)
+    assert match is not None, f"gpg-agent guard block not found in {template_name}"
+    return match.group(1)
+
+
+# Sentinel socket path the gpgconf shim reports for agent-ssh-socket.
+# Not under /tmp (so no hardcoded-temp lint) and never created on disk —
+# the guard only reads it as a string to assign to SSH_AUTH_SOCK.
+_AGENT_SOCK_BASENAME = "fake-gpg-agent-ssh.sock"
+
+
+def _run_guard(
+    guard: str, *, gpgconf_present: bool, ssh_support_enabled: bool, orig_sock: str
+) -> str:
+    """Run the extracted guard under a hermetic PATH and return SSH_AUTH_SOCK.
+
+    PATH is restricted to a temp dir holding only a `grep` symlink (the
+    guard's one external dependency) and, optionally, a `gpgconf` shim —
+    so `command -v gpgconf` resolves deterministically regardless of
+    whether the host actually has gpgconf installed.
+    """
+    bash = shutil.which("bash")
+    grep = shutil.which("grep")
+    assert bash, "bash is required to run this test"
+    assert grep, "grep is required to run this test"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        bin_dir = Path(tmp) / "bin"
+        bin_dir.mkdir()
+        (bin_dir / "grep").symlink_to(grep)
+        agent_sock = str(Path(tmp) / _AGENT_SOCK_BASENAME)
+
+        if gpgconf_present:
+            # Absolute-path shebang so the shim runs under the restricted
+            # PATH (an `/usr/bin/env bash` shebang would fail to find bash).
+            value = "1" if ssh_support_enabled else "0"
+            shim = bin_dir / "gpgconf"
+            shim.write_text(
+                "#!/bin/sh\n"
+                'if [ "$1" = "--list-options" ]; then\n'
+                f'  echo "enable-ssh-support:0:{value}"\n'
+                'elif [ "$1" = "--list-dirs" ]; then\n'
+                f'  echo "{agent_sock}"\n'
+                "fi\n"
+            )
+            # Owner-only exec — the test process is the only caller.
+            shim.chmod(0o700)
+
+        script = f'{guard}\nprintf "%s" "$SSH_AUTH_SOCK"'
+        env = {"PATH": str(bin_dir), "SSH_AUTH_SOCK": orig_sock}
+        result = subprocess.run(
+            [bash, "-c", script],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, f"guard errored: {result.stderr}"
+        return result.stdout
+
+
+@pytest.mark.parametrize("template_name", _SHELL_RC_TEMPLATES)
+def test_gpg_guard_no_clobber_when_gpgconf_absent(template_name: str) -> None:
+    """Gpgconf absent → SSH_AUTH_SOCK MUST be untouched."""
+    guard = _extract_gpg_guard(template_name)
+    orig = "/original/agent.sock"
+    out = _run_guard(
+        guard, gpgconf_present=False, ssh_support_enabled=False, orig_sock=orig
+    )
+    assert out == orig, (
+        f"{template_name}: guard clobbered SSH_AUTH_SOCK with gpgconf absent"
+    )
+
+
+@pytest.mark.parametrize("template_name", _SHELL_RC_TEMPLATES)
+def test_gpg_guard_no_clobber_when_ssh_support_disabled(template_name: str) -> None:
+    """Gpgconf present but ssh-support disabled → SSH_AUTH_SOCK untouched.
+
+    This is the exact regression the guard's predicate exists to prevent
+    (an earlier session burned hours on a silent override here).
+    """
+    guard = _extract_gpg_guard(template_name)
+    orig = "/original/agent.sock"
+    out = _run_guard(
+        guard, gpgconf_present=True, ssh_support_enabled=False, orig_sock=orig
+    )
+    assert out == orig, (
+        f"{template_name}: guard clobbered SSH_AUTH_SOCK despite ssh-support disabled"
+    )
+
+
+@pytest.mark.parametrize("template_name", _SHELL_RC_TEMPLATES)
+def test_gpg_guard_overrides_when_ssh_support_enabled(template_name: str) -> None:
+    """Gpgconf present AND ssh-support enabled → override fires (positive case)."""
+    guard = _extract_gpg_guard(template_name)
+    orig = "/original/agent.sock"
+    out = _run_guard(
+        guard, gpgconf_present=True, ssh_support_enabled=True, orig_sock=orig
+    )
+    assert out != orig, f"{template_name}: override did not fire (got {out!r})"
+    assert out.endswith(_AGENT_SOCK_BASENAME), (
+        f"{template_name}: SSH_AUTH_SOCK not set to gpg-agent socket (got {out!r})"
+    )
 
 
 # We parametrize with the tools we expect to be in the PATH


### PR DESCRIPTION
Three followups from the PR #86 review, all small and thematically
identical (test/config hygiene):

- #87: add a gpg-agent SSH-override regression test. The guard in
  dot_bashrc.tmpl / dot_zshrc.tmpl must fire ONLY when gpg-agent has
  ssh-support enabled; a wrong predicate silently rebinds
  SSH_AUTH_SOCK and breaks every SSH workflow (an earlier session
  burned hours on exactly this). The test extracts the literal shell
  block from each template and runs it hermetically under a PATH
  holding only a gpgconf shim + a grep symlink, so `command -v
  gpgconf` resolves deterministically regardless of the host. Three
  scenarios × both templates (bash+zsh) catch the "guard duplicated in
  two files, one regresses" failure mode.

- #88: remove the dead `is_devcontainer` data var. Its premise in the
  issue ("`.chezmoiignore` uses it to gate the overlay") is stale — the
  gate keys on the built-in `chezmoi.os` fact directly, so the var has
  zero consumers. It was also misleadingly named (predicate was just
  `eq .chezmoi.os "linux"`), inviting a future consumer to wire it up
  wrongly (a real /.dockerenv probe would break the image build, where
  /.dockerenv is absent). Removing dead+misnamed data beats renaming it.

- #89: drop the circular `test_pixi_version`. The pin `pixi = "0.66.0"`
  was added in #86 solely to make it pass; it guards the pin, not pixi.
  Coverage is triplicated by test_tool_installed[pixi] and both
  test_shell_integration pixi cases.

Gates: mise run lint (exit 0), pytest 366 passed, verify 86 passed/0 failed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Da2WyJfN4oD6zD9KCDF5W2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell startup behavior so SSH agent settings are handled more reliably in login shells.
  * Updated host/environment detection so the configuration matches the current machine type more accurately.
  * Removed an outdated environment variable from the generated setup, reducing confusion across machines.
* **Tests**
  * Added coverage for version checks and shell-session behavior to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->