### PR TITLE
feat/renovate status tooling

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -407,6 +407,14 @@ description = "Markdown report of tools with upstream movement + release-notes l
 # tool-currency-check skill's release-note review.
 run = 'uv run --project python dotfiles-setup tool-currency'
 
+[tasks.renovate-status]
+description = "Report Mend-hosted Renovate install + privileges + open update PRs"
+# Thin caller (zero-bash-logic); logic in
+# python/src/dotfiles_setup/renovate.py. Read-only — replaces ad-hoc
+# gh/git polling for Renovate status (skill -> mise task -> python).
+# Pass --json for machine-readable output.
+run = 'uv run --project python dotfiles-setup renovate-status'
+
 [tasks.ship]
 description = "Gate matrix → push → open/update PR → watch checks to verified green"
 # Thin caller per zero-bash-logic; orchestration in

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -38,6 +38,7 @@ from dotfiles_setup.p2996_hash import (
 )
 from dotfiles_setup.p2996_refresh import refresh as refresh_p2996_ref
 from dotfiles_setup.pr import land_main, ship_main
+from dotfiles_setup.renovate import renovate_status_main
 from dotfiles_setup.sync import SyncOptions, sync_main
 from dotfiles_setup.tool_currency import tool_currency_main
 from dotfiles_setup.verify import main as verify_main
@@ -426,6 +427,16 @@ def setup_parser() -> argparse.ArgumentParser:
         "links (daily refresh.yml signal; feeds the tool-currency-check skill)",
     )
 
+    # renovate-status command
+    renovate_parser = subparsers.add_parser(
+        "renovate-status",
+        help="Report Mend-hosted Renovate app install + privileges + open "
+        "update PRs (read-only; replaces ad-hoc gh/git polling)",
+    )
+    renovate_parser.add_argument(
+        "--json", action="store_true", help="Emit the raw status as JSON"
+    )
+
     # version command
     subparsers.add_parser("version", help="Show the version of the library")
 
@@ -734,6 +745,9 @@ def _build_command_handlers(
         "docker": lambda: handle_docker(args, project_root, config=config),
         "pr": lambda: handle_pr(args, project_root),
         "tool-currency": lambda: sys.exit(tool_currency_main()),
+        "renovate-status": lambda: sys.exit(
+            renovate_status_main(json_output=args.json)
+        ),
         "autofix-apply": lambda: sys.exit(
             autofix_apply_main(args.run_id, project_root)
         ),

--- a/python/src/dotfiles_setup/renovate.py
+++ b/python/src/dotfiles_setup/renovate.py
@@ -1,0 +1,217 @@
+"""Renovate (Mend hosted) status signal.
+
+``dotfiles-setup renovate-status`` (wrapped by ``mise run renovate-status``)
+reports the health of the Mend-hosted Renovate app on this repo in one
+auditable, read-only command — replacing ad-hoc ``gh``/``git`` polling
+(skill -> mise task -> this module), per ``.claude/rules/mise-tasks-only.md``.
+
+It answers three questions:
+
+1. Is the ``renovate`` GitHub App (app id 2740 — Mend's hosted Renovate,
+   NOT a separate "Mend" app) installed on the repo's org with the
+   privileges Renovate needs?
+2. What update PRs are currently open (the live queue)?
+3. What did Renovate recently merge (automerge activity)?
+
+The scan cadence itself is Mend-side (this tool only observes GitHub
+state); see the ``renovate.json`` ``schedule`` config and docs.mend.io
+for run frequency.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+
+# Mend's hosted Renovate GitHub App. The "renovate" app IS "the Mend app"
+# for dependency PRs; there is no separate Mend app to install for this.
+_RENOVATE_APP_SLUG = "renovate"
+RENOVATE_APP_ID = 2740
+
+# The permissions Renovate must hold to open/merge PRs, manage branches,
+# post the Dependency Dashboard issue, and set check statuses.
+REQUIRED_PERMISSIONS: dict[str, str] = {
+    "contents": "write",
+    "pull_requests": "write",
+    "issues": "write",
+    "checks": "write",
+    "statuses": "write",
+}
+
+_GH_TIMEOUT_S = 60.0
+
+
+@dataclass
+class RenovateStatus:
+    """A snapshot of Renovate's install + queue state from GitHub."""
+
+    repo: str
+    owner: str
+    installed: bool
+    app_id: int | None = None
+    repository_selection: str | None = None
+    missing_permissions: list[str] = field(default_factory=list)
+    open_prs: list[dict[str, str]] = field(default_factory=list)
+    merged_prs: list[dict[str, str]] = field(default_factory=list)
+
+    @property
+    def healthy(self) -> bool:
+        """True when the app is installed AND fully privileged."""
+        return self.installed and not self.missing_permissions
+
+
+def _gh(args: list[str]) -> str:
+    """Run a ``gh`` command and return stdout (empty string on failure)."""
+    result = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=_GH_TIMEOUT_S,
+    )
+    if result.returncode != 0:
+        return ""
+    return result.stdout
+
+
+def _repo_slug() -> str:
+    """Return ``owner/repo`` for the current repo via ``gh``."""
+    out = _gh(["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"])
+    return out.strip()
+
+
+def _installation(owner: str) -> dict[str, object] | None:
+    """Return the Renovate app installation record for ``owner``, or None."""
+    out = _gh(
+        [
+            "api",
+            f"/orgs/{owner}/installations",
+            "--jq",
+            f'.installations[]? | select(.app_slug=="{_RENOVATE_APP_SLUG}")',
+        ]
+    ).strip()
+    if not out:
+        return None
+    try:
+        record = json.loads(out)
+    except json.JSONDecodeError:
+        return None
+    return record if isinstance(record, dict) else None
+
+
+def permission_gaps(install: dict[str, object]) -> list[str]:
+    """Return required permissions the installation does not satisfy."""
+    perms = install.get("permissions")
+    if not isinstance(perms, dict):
+        perms = {}
+    return [
+        f"{name}={want}"
+        for name, want in REQUIRED_PERMISSIONS.items()
+        if perms.get(name) != want
+    ]
+
+
+def _pr_rows(state: str, limit: int) -> list[dict[str, str]]:
+    """Return Renovate-authored PRs in ``state`` as {number,title} rows."""
+    out = _gh(
+        [
+            "pr",
+            "list",
+            "--state",
+            state,
+            "--author",
+            "app/renovate",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title",
+        ]
+    ).strip()
+    if not out:
+        return []
+    try:
+        rows = json.loads(out)
+    except json.JSONDecodeError:
+        return []
+    return [
+        {"number": str(row.get("number", "?")), "title": str(row.get("title", ""))}
+        for row in rows
+        if isinstance(row, dict)
+    ]
+
+
+def collect_status() -> RenovateStatus:
+    """Gather the full Renovate status snapshot from GitHub."""
+    slug = _repo_slug()
+    owner = slug.split("/", 1)[0] if "/" in slug else ""
+    install = _installation(owner) if owner else None
+    if install is None:
+        return RenovateStatus(repo=slug, owner=owner, installed=False)
+    app_id = install.get("app_id")
+    selection = install.get("repository_selection")
+    return RenovateStatus(
+        repo=slug,
+        owner=owner,
+        installed=True,
+        app_id=app_id if isinstance(app_id, int) else None,
+        repository_selection=selection if isinstance(selection, str) else None,
+        missing_permissions=permission_gaps(install),
+        open_prs=_pr_rows("open", 50),
+        merged_prs=_pr_rows("merged", 10),
+    )
+
+
+def render_report(status: RenovateStatus) -> str:
+    """Render the status snapshot as a readable report."""
+    repo = status.repo or "(unknown repo)"
+    lines: list[str] = [f"Renovate status — {repo}", ""]
+
+    if not status.installed:
+        lines.append(
+            f"✗ App NOT installed: the '{_RENOVATE_APP_SLUG}' app "
+            f"(id {RENOVATE_APP_ID}) is not on org '{status.owner}'."
+        )
+        lines.append("  Install: https://github.com/apps/renovate")
+        return "\n".join(lines)
+
+    if status.app_id == RENOVATE_APP_ID:
+        lines.append(
+            f"✓ App installed: {_RENOVATE_APP_SLUG} (app id {status.app_id} — "
+            f"verified Mend-hosted Renovate; no separate Mend app needed)"
+        )
+    else:
+        lines.append(
+            f"⚠ App '{_RENOVATE_APP_SLUG}' installed but app id is "
+            f"{status.app_id}, not the expected {RENOVATE_APP_ID} "
+            f"(Mend Renovate) — verify this is the right app."
+        )
+    lines.append(f"  repository_selection: {status.repository_selection}")
+    if status.missing_permissions:
+        lines.append(f"  ✗ MISSING privileges: {', '.join(status.missing_permissions)}")
+    else:
+        req = ", ".join(f"{k}={v}" for k, v in REQUIRED_PERMISSIONS.items())
+        lines.append(f"  ✓ privileges present: {req}")
+
+    lines.append("")
+    lines.append(f"Open update PRs ({len(status.open_prs)}):")
+    lines.extend(f"  #{pr['number']} {pr['title']}" for pr in status.open_prs)
+    lines.append("")
+    lines.append(f"Recently merged ({len(status.merged_prs)}):")
+    lines.extend(f"  #{pr['number']} {pr['title']}" for pr in status.merged_prs)
+    return "\n".join(lines)
+
+
+def renovate_status_main(*, json_output: bool = False) -> int:
+    """Entry point for ``dotfiles-setup renovate-status``.
+
+    Exit non-zero only when the app is absent or under-privileged, so the
+    command doubles as a gate the way ``lint``/``verify`` do.
+    """
+    status = collect_status()
+    if json_output:
+        sys.stdout.write(json.dumps(asdict(status), indent=2) + "\n")
+    else:
+        sys.stdout.write(render_report(status) + "\n")
+    return 0 if status.healthy else 1

--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>jdx/renovate-config",
-    "schedule:daily"
+    "github>jdx/renovate-config"
   ],
   "minimumReleaseAge": null,
+  "prConcurrentLimit": 20,
+  "prHourlyLimit": 0,
   "packageRules": [
     {
       "matchPackageNames": ["bats-core"],

--- a/tests/test_renovate.py
+++ b/tests/test_renovate.py
@@ -1,0 +1,87 @@
+"""Tests for the Renovate status signal (dotfiles_setup.renovate)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
+
+from dotfiles_setup import renovate
+from dotfiles_setup.renovate import RenovateStatus
+
+
+def test_missing_permissions_all_present() -> None:
+    granted = {
+        "contents": "write",
+        "pull_requests": "write",
+        "issues": "write",
+        "checks": "write",
+        "statuses": "write",
+        "metadata": "read",
+    }
+    assert renovate.permission_gaps({"permissions": granted}) == []
+
+
+def test_missing_permissions_flags_gaps() -> None:
+    # pull_requests granted read-only, issues absent entirely.
+    granted = {"contents": "write", "pull_requests": "read", "checks": "write"}
+    missing = renovate.permission_gaps({"permissions": granted})
+    assert "pull_requests=write" in missing
+    assert "issues=write" in missing
+    assert "statuses=write" in missing
+    assert "contents=write" not in missing
+
+
+def test_missing_permissions_no_permissions_key() -> None:
+    # A malformed record with no permissions is fully missing, not a crash.
+    assert renovate.permission_gaps({}) == [
+        f"{name}={want}" for name, want in renovate.REQUIRED_PERMISSIONS.items()
+    ]
+
+
+def test_status_healthy_requires_install_and_full_privileges() -> None:
+    assert RenovateStatus(repo="o/r", owner="o", installed=False).healthy is False
+    assert (
+        RenovateStatus(
+            repo="o/r", owner="o", installed=True, missing_permissions=["issues=write"]
+        ).healthy
+        is False
+    )
+    assert RenovateStatus(repo="o/r", owner="o", installed=True).healthy is True
+
+
+def test_render_report_not_installed_points_to_install_url() -> None:
+    report = renovate.render_report(
+        RenovateStatus(
+            repo="ray-manaloto/dotfiles", owner="ray-manaloto", installed=False
+        )
+    )
+    assert "NOT installed" in report
+    assert "github.com/apps/renovate" in report
+
+
+def test_render_report_verifies_mend_app_id() -> None:
+    report = renovate.render_report(
+        RenovateStatus(
+            repo="o/r",
+            owner="o",
+            installed=True,
+            app_id=renovate.RENOVATE_APP_ID,
+            repository_selection="all",
+            open_prs=[{"number": "190", "title": "update mise"}],
+            merged_prs=[{"number": "191", "title": "update lefthook"}],
+        )
+    )
+    assert "verified Mend-hosted Renovate" in report
+    assert "Open update PRs (1)" in report
+    assert "#190 update mise" in report
+    assert "Recently merged (1)" in report
+
+
+def test_render_report_warns_on_unexpected_app_id() -> None:
+    report = renovate.render_report(
+        RenovateStatus(repo="o/r", owner="o", installed=True, app_id=9999)
+    )
+    assert "not the expected" in report
+    assert str(renovate.RENOVATE_APP_ID) in report


### PR DESCRIPTION
- **feat(renovate): renovate-status mise task + module (skill→task→python)**
- **chore(renovate): 4-hourly hosted cadence — drop schedule:daily, raise PR limits**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `renovate-status` command and task to show Renovate installation health, required privileges, and update PR activity.
  * Added `--json` output for machine-readable status reports.

* **Bug Fixes**
  * Improved reporting when Renovate is not installed or lacks required permissions.
  * Status checks now handle incomplete or malformed permission data without failing.

* **Chores**
  * Updated Renovate configuration to adjust PR throughput limits and remove the daily schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->