### PR TITLE
docs(clear-prep): mandate ambiguity-resolution + no-context-lost check; sync tests doc

### DIFF
--- a/.claude/skills/clear-prep/SKILL.md
+++ b/.claude/skills/clear-prep/SKILL.md
@@ -16,6 +16,26 @@ your guess.
 Work top-to-bottom. Do not skip the validation gate. Keep the final resume
 prompt short — durable detail lives in memory + the handoff, not the prompt.
 
+## 0. Resolve next-task ambiguity FIRST — mandatory (Ray, 2026-07-08)
+
+**Before writing the handoff, drive the next-task scope to zero ambiguity by
+asking the user clarifying questions** (`AskUserQuestion`), and keep asking
+across rounds until nothing material is unresolved. The handoff's "Next task"
+section is only as good as this step — a vague next-task line makes the whole
+`/clear` lossy. This is a hard requirement, not a courtesy: if the next task
+admits multiple interpretations, scope forks, an undecided B-vs-C, or an
+unstated end-goal, you MUST surface each and get the user's answer, then encode
+the answers verbatim in the handoff. Skipping this because the task "seems
+clear" is the failure mode this step exists to prevent.
+
+**Then double-check nothing will be lost by `/clear`** (see step 3c + the
+final checklist): every findings-bearing agent/research report is on disk,
+every decision + open question is in the handoff, and the resume prompt +
+memory + handoff together reconstruct the full working context. Verify by
+asking: "if I `/clear` right now and only have MEMORY.md + the handoff + the
+research artifacts, can the next session continue with no gaps?" If the answer
+is no, fix it before emitting the resume prompt.
+
 ## 1. Snapshot the working state
 
 Gather, don't guess:
@@ -181,6 +201,8 @@ resumes from the handoff."*
 
 ## Checklist (all true before you're done)
 
+- [ ] **Next-task ambiguity driven to zero via clarifying questions (step 0, mandatory); answers encoded in the handoff.**
+- [ ] **No-context-lost self-check passed: MEMORY.md + handoff + research artifacts alone reconstruct the full working context.**
 - [ ] Working state snapshotted; open PR/CI state known.
 - [ ] Background tasks/agents + scheduled wakeups inventoried; stale ones cancelled or noted.
 - [ ] Every doc affected by this session's changes updated; cross-refs grep-clean.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -24,12 +24,13 @@ Docker image smoke outputs.
 | `test_pr.py` | pytest | `mise run ship`/`land` workflow (`dotfiles_setup.pr`) — surface detection, gate matrix, bucket verification, pinned merge |
 | `test_hook_guard.py` | pytest | PreToolUse mise-tasks-only guard (`dotfiles_setup.hook_guard`) — deny/redirect rules, false-positive guards, JSON contract |
 | `test_tool_currency.py` | pytest | Daily tool-currency signal (`dotfiles_setup.tool_currency`) — release-link backends, report rendering |
+| `test_renovate.py` | pytest | Renovate status signal (`dotfiles_setup.renovate`) — app-id/privilege check, report rendering |
 | `test_autofix.py` | pytest | autofix.ci artifact applier (`dotfiles_setup.autofix`) — additions, traversal/shape/deletion refusal |
 | `test_shell_integration.py` | pytest | Tool reachability in login shells (mise, chezmoi, uv, pixi, claude, gemini, codex) |
 | `infra/foundation.bats` | Bats | Bash-level foundation checks (shell script integration) |
 | `infra/runtimes.bats` | Bats | Runtime installation checks (bash) |
 
-Total: **316 pytest tests** (pytest runs all `test_*.py` files) plus Bats
+Total: **373 pytest tests** (pytest runs all `test_*.py` files) plus Bats
 scenarios under `infra/`.
 
 ## Running tests


### PR DESCRIPTION
- .claude/skills/clear-prep/SKILL.md: add mandatory Step 0 — drive next-task
  scope to zero ambiguity via clarifying questions BEFORE writing the handoff,
  then a no-context-lost self-check (MEMORY + handoff + research artifacts must
  reconstruct the full context). Ray-requested 2026-07-08.
- tests/AGENTS.md: add test_renovate.py row; fix stale test count (316→373).

Gate: mise run lint rc=0 (agnix 0/0, size-limit ✔).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Da2WyJfN4oD6zD9KCDF5W2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the handoff workflow with an upfront ambiguity-check step before restarting work.
  - Added a self-check to ensure a restart can be reconstructed from saved notes and research materials alone.

- **Chores**
  - Updated test documentation to reflect the larger repository test suite and current coverage totals.
  - Added recently covered test files to the documented key files list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->