### PR TITLE
feat(pr): native GitHub auto-merge replaces the CI-wait; research-first rule

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,6 +11,7 @@ Coordinate specialized agents, tools, and skills so work is completed accurately
 - Prefer evidence over assumptions: verify outcomes before final claims.
 - Choose the lightest-weight path that preserves quality.
 - Consult official docs before implementing with SDKs/frameworks/APIs.
+- Research existing tools/native features/services BEFORE writing any custom code (hard gate — `.claude/rules/use-tool-builtins.md`); homegrown code is the last resort and needs written justification.
 </operating_principles>
 
 <delegation_rules>

--- a/.claude/rules/use-tool-builtins.md
+++ b/.claude/rules/use-tool-builtins.md
@@ -1,4 +1,48 @@
-# Use Tool Built-ins Before Inventing
+# Research Existing Tools/Services Before Building Custom
+
+**Before writing ANY custom code, script, or config to accomplish a capability,
+you MUST first research whether an existing tool, service, native feature, or
+canonical pattern already provides it — and prefer that.** This covers tool
+built-in *facts* (below) AND, more broadly, any capability you are about to
+hand-roll: a CLI already ships the command (`gh`, `mise`, `docker`, `chezmoi`),
+a platform already has the feature (GitHub auto-merge / merge queue / webhooks /
+`workflow_run`), an established service or library already solves it, or the
+tool's docs show a canonical pattern. Homegrown code is the LAST resort, not the
+first reach.
+
+This is a **standing rule** — it is written here so it never needs to be
+repeated per-task. If you find yourself about to write a loop, a poller, a
+parser, a detector, or a wrapper, STOP and research first.
+
+## The hard gate (do this before writing custom code)
+
+1. **Name the capability** you need in one sentence ("wait for CI to finish then
+   merge", "detect the OS", "monitor a workflow run").
+2. **Research existing solutions FIRST** (walk `research-doc-sources.md`): the
+   relevant CLI's manual/`--help`, the platform's feature docs + changelog, CLI
+   extensions, established services, and libraries. Assume the native mechanism
+   exists until you've confirmed it doesn't.
+3. **Prefer the existing mechanism.** Custom code is justified ONLY when no
+   existing tool/service fits, AND you record *why* in the code comment or PR
+   body (which options you evaluated and why each was insufficient). Without
+   that written justification, the default answer is "delete the custom code,
+   use the existing tool."
+4. **A known-flaky native tool is not license to hand-roll a replacement** —
+   first check for a newer version, the documented robust usage, an extension,
+   or an adjacent native feature (e.g. auto-merge instead of watch-then-merge)
+   that sidesteps the flaw. Reinvention is the last resort even then.
+
+### Worked failure (2026-07-11)
+
+Asked to fix a ship/land CI-wait that used a fixed timeout, the agent hand-rolled
+a custom `await_pr_checks_terminal()` polling loop — WITHOUT first researching
+that GitHub offers **native auto-merge** (`gh pr merge --auto`), **merge queue**,
+`gh run watch`, `workflow_run` triggers, and webhooks, several of which eliminate
+the polling entirely. The maintainer had to send the agent back to research. This
+rule is strengthened so that never recurs: research existing tools/services
+first, every time, unprompted.
+
+## Tool built-in facts (the original case)
 
 Before designing custom detection logic, custom data variables, custom env-var
 parsing, or custom helper scripts to discriminate environments / machines /

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -15,9 +15,9 @@ These tasks ARE the canonical workflow — do not hand-roll
 ## Commands
 
 ```bash
-mise run ship                      # gates → push → PR open/update → watch checks
+mise run ship                      # gates → push → PR open/update → enable native auto-merge, return
 mise run ship -- --title "..."     # override the PR title (default: gh --fill)
-mise run land -- <PR#>             # verify green → pinned squash-merge → main CI → local sync
+mise run land -- <PR#>             # (after it auto-merges) confirm merged → main CI → local verify
 ```
 
 ## What ship does
@@ -33,33 +33,43 @@ mise run land -- <PR#>             # verify green → pinned squash-merge → ma
    `.devcontainer/**`, `docker-bake.hcl`, smoke/workspace scripts,
    `container.py`/`sync.py`/`image.py`/`docker.py`/`pr.py`,
    `python/verification/*`).
-   The full-sync gate's smoke tier-1 base-currency (config-hash AND
-   tool-set) validates against the **merge-base** for a branch that
-   changed an image build input — the local base can't be built from the
-   branch (its base is built by that branch's own PR CI), so branch-config
-   validation defers to CI. Without this, an image-input bump deadlocks the
-   gate (#179/#180).
-3. Push, open (or reuse) the PR, wait for the **`ci-gate` aggregator to
-   register** (it `needs` every job), then `gh pr checks --watch
-   --fail-fast`, then **verify via `--json` buckets** — green means every
-   check `pass`/`skipping`. The ci-gate wait stops a build PR being called
-   green on an early check wave before build-publish's matrix jobs register
-   (#181); a watch exit code alone is never trusted.
+   **Base-image input changes DEFER the container gate to CI**
+   (`BASE_INPUT_PATTERNS` — the mise-system/runtime toml+lock, `shared.toml`,
+   the shared `hk` pkl fragments, `Dockerfile`, `docker-bake.hcl`): the new base is
+   built ONLY by the PR's own CI, so the local `:dev` base can't validate it
+   (a chezmoi/gcc bump can even make the stale base's `onCreate` fail). ship
+   runs lint/pytest/verify locally, skips the impossible local convergence,
+   and gates on CI's base-build + smoke instead. Non-base surface changes
+   (`sync.py`/`pr.py`/`container.py`, smoke script, `devcontainer.json`)
+   still run the full local sync gate.
+3. Push, open (or reuse) the PR, **enable GitHub-native auto-merge, and
+   return** — `gh pr merge --auto --squash --match-head-commit HEAD`
+   (`enable_auto_merge`). GitHub then merges the PR **server-side** the
+   instant the required `ci-gate` check goes green — no client poll, no
+   timeout, tolerant of multi-hour base builds (a fixed-timeout or
+   hand-rolled watch was the wrong shape). `--match-head-commit` pins the
+   gated SHA and GitHub auto-disables auto-merge on new pushes, closing the
+   verify-then-merge race. A short bounded retry covers the transient
+   March-2026 422 enable regression. ship prints the `mise run land`
+   follow-up for post-merge Mac validation.
 
 ## What land does
 
-1. Verifies the PR is OPEN and every check bucket is green (API, not
-   watch exit codes).
-2. **Pinned merge**: `gh pr merge --squash --delete-branch
-   --match-head-commit VERIFIED_SHA` — GitHub refuses if the branch
-   moved after verification (closes the verify-then-merge race).
-3. Watches the main `ci.yml` run for the merge commit; conclusion must
-   be `success` via `gh run view --json conclusion`.
-4. Fast-forwards local main, then **local validation on this Mac**:
-   `sync` (digest fast-path); full `verify-local` tier automatically
-   when the PR touched the devcontainer surface.
+land is the **post-merge validation** step (ship's auto-merge does the merge):
 
-Invoking `land` IS the merge approval — nothing auto-merges without it.
+1. Confirms the PR is **MERGED** + main-based. If still OPEN, auto-merge is
+   pending `ci-gate` — land says so and exits (re-run once it has merged).
+2. Verifies the main `ci.yml` run for the merge commit concluded `success`
+   (`gh run view --json conclusion`), path-aware per `CI_PUSH_PATHS` (#178).
+3. Fast-forwards local main, then **local validation on this Mac**:
+   `sync` (digest fast-path); full `verify-local` tier automatically when
+   the PR touched the devcontainer surface — the arm64 R1/R2/R3 checks that
+   can't run in CI. `land` is idempotent (safe to re-run); the `--resume`
+   flag is accepted for compatibility but has no separate effect.
+
+The **merge approval is enabling auto-merge at ship** (`main` requires only
+`ci-gate`, no review); GitHub merges when green. `--match-head-commit`
+scopes it to the SHA the local gates validated.
 
 ## Failure modes
 
@@ -68,8 +78,9 @@ Invoking `land` IS the merge approval — nothing auto-merges without it.
 | `ship: refusing to ship from main` | On main/detached HEAD | Create a feature branch first |
 | `ship: working tree not clean` | Uncommitted changes | Commit (or stash) so gates validate the shipped tree |
 | `FAIL gate <name>` | A local gate failed | That failure IS the task (zero-skip); fix, rerun ship |
-| `pr-checks: <name>=fail` | CI check failed after watch | Triage the run; autofix "✅ Autofix task started" failures mean the bot pushed a fix commit — re-watch |
-| `land: merge refused` | Head moved since verification / protection unmet | Re-run land (it re-verifies) |
+| `ship: could not enable auto-merge` | The 422 regression outlasted the bounded retry, or "Allow auto-merge"/`ci-gate` isn't configured | Check the repo's auto-merge setting + branch protection; re-run `ship` (it reuses the PR) |
+| `land: PR #N is OPEN, not yet MERGED` | Auto-merge is still pending `ci-gate` (CI running) | Wait for GitHub to merge it, then re-run `land` for the post-merge Mac validation |
+| CI check failed (PR never auto-merges) | A required check went red, so auto-merge never fires | Triage the run; autofix "✅ Autofix task started" means the bot pushed a fix → new checks run → auto-merges when green |
 | land failed AFTER the merge (CI watch / sync) | Merged-but-unvalidated PR | `mise run land -- <PR#> --resume` replays the idempotent post-merge steps |
 | `land: no main ci.yml run appeared` | A merge that SHOULD trigger a run didn't register (~10 min) | Check Actions; land only expects a run when the diff matches `CI_PUSH_PATHS` (ci.yml on.push.paths) — a merge matching none passes without one (#179) |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,9 +126,9 @@ locally before pushing Dockerfile changes.
   clear low-risk tasks. See `.claude/rules/clarify-before-acting.md`.
 - **Local validation first**: Run `mise run lint`, `pytest`, AND
   `dotfiles-setup verify run` locally before pushing.
-- **Use tool built-ins**: Prefer documented built-in facts (e.g.
-  `chezmoi.os`) over homegrown detection logic. See
-  `.claude/rules/use-tool-builtins.md`.
+- **Research existing tools/services before custom code (HARD GATE)**: prefer an
+  existing tool / native feature / CLI / service (`gh` auto-merge, `chezmoi.os`)
+  over ANY homegrown code (last resort + justification). See `.claude/rules/use-tool-builtins.md`.
 - **Chezmoi is devcontainer-only on this Mac**: `chezmoi apply`/`update`
   blocked on host (enforced by `.claude/settings.json` deny rules); read-only ok.
 - **Notepad enforcement**: Agents write findings to notepad during work, not at session end. See `.claude/rules/notepad-enforcement.md`.

--- a/python/src/dotfiles_setup/pr.py
+++ b/python/src/dotfiles_setup/pr.py
@@ -10,17 +10,21 @@ verify-before-advancing rule as code instead of discipline.
 Design notes (deep-research verified, 2026-07-07 —
 ``.omc/research/research-20260707-gha-shipland-enforcement/report.md``):
 
-- **Check verification reads the ``--json`` buckets**, never a watch
-  command's exit code alone (``gh run watch --exit-status`` has reported
-  0 prematurely; see ``.claude/rules/gh-cli-watch.md``). A PR is green
-  iff every check bucket is ``pass`` or ``skipping``. ship also waits for
-  the ``ci-gate`` aggregator (:data:`_AGGREGATE_CHECK`) to register before
-  ``--watch``, so a build PR is not declared green on an early check wave
-  before build-publish's matrix jobs register (#181).
-- **The merge is delegated to GitHub's requirements engine** with the
-  head SHA pinned: ``gh pr merge --squash --match-head-commit <sha>``
-  returns 409 if the branch moved after we verified it — closing the
-  verify-then-merge race.
+- **The CI wait is GitHub's, not ours — native auto-merge, no polling.**
+  A base-image build can take hours, so a client-side watch (fixed timeout
+  OR hand-rolled poll) is the wrong shape. ship enables **GitHub-native
+  auto-merge** (``gh pr merge --auto --squash --match-head-commit <sha>``,
+  :func:`enable_auto_merge`) and returns; GitHub merges the PR server-side
+  the instant the branch-protection-required ``ci-gate`` check goes green.
+  No client process stays alive, no ``gh run watch``/``--watch`` (both have
+  exited/reported prematurely; see ``.claude/rules/gh-cli-watch.md``).
+  ``--match-head-commit`` scopes the enable to the gated SHA and GitHub
+  auto-disables auto-merge on new pushes, closing the verify-then-merge
+  race. **land** is the post-merge step (confirm merged → main-CI concluded
+  → ff main → local ``verify-local``), run after the PR has auto-merged.
+- **Green is read from the ``--json`` buckets**, never a watch exit code:
+  a PR/run is green iff every check bucket is ``pass``/``skipping`` and the
+  API ``conclusion`` is ``success``.
 - **Hard path-aware gate (no *operator* override)**: when the diff
   touches the devcontainer/image/validation surface
   (:data:`SURFACE_PATTERNS`) but NOT a base-image build input, ship
@@ -150,13 +154,6 @@ _DOCS_PATTERNS = (
 )
 
 _GREEN_BUCKETS = frozenset({"pass", "skipping"})
-
-# The always-run aggregator job (ci.yml) that `needs` every other job and is
-# branch-protection-required on every PR. ship waits for THIS to register
-# before `gh pr checks --watch`, so --watch cannot exit on an early all-green
-# wave before the build-publish matrix jobs (base-prep/build/smoke-test)
-# register — the premature-green ship gap found landing #181.
-_AGGREGATE_CHECK = "ci-gate"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -315,48 +312,57 @@ def _await_checks_registered(pr_number: int, *, attempts: int = 40) -> bool:
     return False
 
 
-def _await_aggregate_registered(pr_number: int, *, attempts: int = 40) -> bool:
-    """Poll until the ``ci-gate`` aggregator check is registered.
+# Absolute backstop for the terminal-state poll. A cold base+p2996 build is
+# ~2.5h (memory: feedback_ci_build_duration_baseline); 4h leaves margin. This
+# is a genuinely-stuck guard, NOT a "typical build takes this long" estimate —
+# the poll returns as soon as CI reaches terminal, however long that is.
+# GitHub's March-2026 auto-merge regression can 422 the *enable* call until
+# requirements are near-met (community #190610). A short bounded retry
+# (seconds-to-minutes, NOT an hours-long poll) rides it out; if GitHub only
+# accepts once ci-gate is green, auto-merge degrades to an immediate merge —
+# still correct, still poll-free. Verify on the first real auto-merge PR.
+_AUTOMERGE_ENABLE_ATTEMPTS = 5
+_AUTOMERGE_ENABLE_BACKOFF_S = 20
 
-    build-publish's matrix jobs (base-prep/build/smoke-test) register in
-    WAVES after ``changes`` decides build=true, so waiting for *any* check
-    (``_await_checks_registered``) let ``gh pr checks --watch`` exit on an
-    early all-green wave before the build jobs appeared — ship declared #181
-    green prematurely. :data:`_AGGREGATE_CHECK` ``needs`` every job, so once
-    it is present the subsequent ``--watch`` cannot terminate until the whole
-    chain (including the late-registering build jobs) is terminal.
+
+def enable_auto_merge(workspace: Path, pr_number: int, head: str) -> bool:
+    """Enable GitHub-native auto-merge (squash), pinned to the verified head.
+
+    GitHub then merges the PR server-side the instant the required ``ci-gate``
+    check goes green — no client poll, no timeout, tolerant of multi-hour base
+    builds. ``--match-head-commit`` scopes the enable to the SHA ship gated (and
+    GitHub auto-disables auto-merge if new commits are pushed), closing the
+    verify-then-merge race. Runs as a subprocess, so it is not a hand-rolled
+    watch — GitHub owns the wait.
     """
-    for _ in range(attempts):
-        res = _run(
-            ["gh", "pr", "checks", str(pr_number), "--json", "name"],
-            timeout=_PROBE_TIMEOUT_S,
-        )
-        if res.returncode == 0 and any(
-            c.get("name") == _AGGREGATE_CHECK for c in json.loads(res.stdout or "[]")
-        ):
+    cmd = [
+        "gh",
+        "pr",
+        "merge",
+        str(pr_number),
+        "--auto",
+        "--squash",
+        "--delete-branch",
+        "--match-head-commit",
+        head,
+    ]
+    res = _run(cmd, timeout=_PROBE_TIMEOUT_S, cwd=workspace)
+    for attempt in range(1, _AUTOMERGE_ENABLE_ATTEMPTS):
+        if res.returncode == 0:
             return True
-        time.sleep(15)
+        sys.stdout.write(
+            f"==> auto-merge enable attempt {attempt} failed "
+            f"({res.stderr.strip()[:80]}); retrying (transient 422)…\n"
+        )
+        time.sleep(_AUTOMERGE_ENABLE_BACKOFF_S)
+        res = _run(cmd, timeout=_PROBE_TIMEOUT_S, cwd=workspace)
+    if res.returncode == 0:
+        return True
     sys.stdout.write(
-        f"FAIL  pr-checks: aggregator {_AGGREGATE_CHECK!r} never registered on "
-        f"PR #{pr_number} within {attempts * 15}s\n"
+        f"FAIL  ship: could not enable auto-merge on PR #{pr_number}: "
+        f"{res.stderr.strip()}\n"
     )
     return False
-
-
-def watch_pr_checks(pr_number: int) -> bool:
-    """Await registration, watch to terminal state, verify via JSON buckets.
-
-    Waits for the ``ci-gate`` aggregator to register before ``--watch`` so a
-    build PR is not declared green on an early check wave (#181 gap).
-    """
-    if not _await_checks_registered(pr_number):
-        return False
-    if not _await_aggregate_registered(pr_number):
-        return False
-    _stream(["gh", "pr", "checks", str(pr_number), "--watch", "--fail-fast"])
-    ok, detail = pr_checks_green(pr_number)
-    sys.stdout.write(f"{'PASS' if ok else 'FAIL'}  pr-checks: {detail}\n")
-    return ok
 
 
 def _current_branch(workspace: Path) -> str:
@@ -422,11 +428,15 @@ def _open_or_update_pr(workspace: Path, title: str | None) -> int | None:
 
 
 def ship_main(workspace: Path, *, title: str | None = None) -> int:
-    """Gates → push → PR → watched checks. Requires committed work on a branch.
+    """Gates → push → open PR → enable native auto-merge → return.
 
-    Commit creation stays with the operator/agent (messages need human
-    judgment); ship refuses a dirty tree so nothing half-staged leaks
-    past the gates (`clean-git-state` rule).
+    Requires committed work on a branch. Commit creation stays with the
+    operator/agent (messages need human judgment); ship refuses a dirty tree
+    so nothing half-staged leaks past the gates (`clean-git-state` rule).
+    The CI wait is GitHub's, not ours: ship enables auto-merge and returns;
+    GitHub merges when the required ``ci-gate`` check goes green (no client
+    poll, no timeout — a base build can take hours). land is the post-merge
+    Mac-validation step. See :func:`enable_auto_merge`.
     """
     preflight = _ship_preflight(workspace)
     if preflight is None:
@@ -456,9 +466,30 @@ def ship_main(workspace: Path, *, title: str | None = None) -> int:
         return 1
 
     number = _open_or_update_pr(workspace, title)
-    if number is None or not watch_pr_checks(number):
+    if number is None:
         return 1
-    sys.stdout.write(f"\nship: OK — PR #{number} green and ready for land\n")
+    head = _run(
+        ["git", "-C", str(workspace), "rev-parse", "HEAD"], timeout=_PROBE_TIMEOUT_S
+    ).stdout.strip()
+    # Confirm CI kicked off (auto-merge waits for ci-gate regardless, but if CI
+    # never triggers the PR would never merge — surface that early).
+    if _await_checks_registered(number):
+        sys.stdout.write(f"==> CI started on PR #{number}\n")
+    else:
+        sys.stdout.write(
+            f"WARN  ship: no CI checks registered yet on PR #{number} — auto-merge "
+            "waits for ci-gate; if CI never triggers, the PR won't merge\n"
+        )
+    # Native auto-merge is the wait: GitHub merges when ci-gate is green. No
+    # client poll, no timeout — the wrong-shape fixed-timeout watch is gone.
+    if not enable_auto_merge(workspace, number, head):
+        return 1
+    sys.stdout.write(
+        f"\nship: OK — PR #{number} open, local gates green, AUTO-MERGE enabled.\n"
+        f"GitHub merges it the instant ci-gate goes green (no poll; a base build "
+        f"can take hours). After it merges, run `mise run land -- {number}` for "
+        "the post-merge Mac validation (or `mise run sync` on next bring-up).\n"
+    )
     return 0
 
 
@@ -549,115 +580,59 @@ def _pr_changed_paths(pr_number: int) -> list[str]:
     return [line for line in res.stdout.splitlines() if line]
 
 
-def _land_preflight(pr_number: int) -> tuple[str, bool] | None:
-    """PR open + base main + checks verified green; None on fail."""
+def _land_post_merge(pr_number: int) -> bool | None:
+    """Confirm the PR auto-merged + the main ci.yml run concluded; surface flag.
+
+    ship enables native auto-merge, so by the time land runs GitHub should have
+    already squash-merged the PR (when ci-gate went green). land does NOT merge
+    — it validates the merged result. Returns the surface flag (which local
+    validation tier to run), or None on fail. A still-OPEN PR means auto-merge
+    is pending ci-gate; land says so and exits (re-run once it has merged).
+    """
     view = _run(
-        [
-            "gh",
-            "pr",
-            "view",
-            str(pr_number),
-            "--json",
-            "state,headRefOid,baseRefName",
-        ],
+        ["gh", "pr", "view", str(pr_number), "--json", "state,baseRefName"],
         timeout=_PROBE_TIMEOUT_S,
     )
     if view.returncode != 0:
         sys.stdout.write(f"FAIL  land: gh pr view failed: {view.stderr.strip()}\n")
         return None
     info = json.loads(view.stdout)
-    if info["state"] != "OPEN":
-        sys.stdout.write(f"FAIL  land: PR #{pr_number} is {info['state']}\n")
-        return None
     if info.get("baseRefName") != "main":
-        # Review finding [11]: land's post-merge main-CI watch and local
-        # main fast-forward only make sense for main-based PRs.
+        # Post-merge main-CI watch + local main fast-forward assume a main PR.
         sys.stdout.write(
             f"FAIL  land: PR #{pr_number} targets {info.get('baseRefName')!r}, "
-            "not main — land only lands main-based PRs\n"
+            "not main — land only validates main-based PRs\n"
         )
         return None
-    ok, detail = pr_checks_green(pr_number)
-    sys.stdout.write(f"{'PASS' if ok else 'FAIL'}  pr-checks: {detail}\n")
-    if not ok:
-        return None
-    surface = touches_surface(_pr_changed_paths(pr_number))
-    return info["headRefOid"], surface
-
-
-def _merge_and_watch_main(workspace: Path, pr_number: int, head: str) -> bool:
-    """Pinned squash-merge, then the main ci.yml run must conclude success.
-
-    Known-accepted race (review finding [7]): main can advance between
-    check-verification and this merge; --match-head-commit pins only the
-    PR head. Accepted because the post-merge main-CI watch below re-runs
-    the full gate chain on the ACTUAL merge commit and land fails loud if
-    it does not conclude success — the race window cannot produce a
-    silently-broken main.
-    """
-    merge = [
-        "gh",
-        "pr",
-        "merge",
-        str(pr_number),
-        "--squash",
-        "--delete-branch",
-        "--match-head-commit",
-        head,
-    ]
-    if _stream(merge, cwd=workspace) != 0:
+    if info["state"] != "MERGED":
         sys.stdout.write(
-            "FAIL  land: merge refused (head moved since verification, or "
-            "branch protection unmet) — re-verify and rerun\n"
+            f"land: PR #{pr_number} is {info['state']}, not yet MERGED — ship "
+            "enabled auto-merge; GitHub merges when ci-gate is green. Re-run land "
+            "once it has merged (land is the post-merge Mac validation now).\n"
         )
-        return False
+        return None
     merge_oid = _merge_commit_oid(pr_number)
-    if not merge_oid:
-        sys.stdout.write("FAIL  land: could not resolve the merge commit oid\n")
-        return False
-    expect_run = expects_main_run(_pr_changed_paths(pr_number))
-    return _main_run_conclusion(merge_oid, expect_run=expect_run)
-
-
-def _land_merge_phase(workspace: Path, pr_number: int, *, resume: bool) -> bool | None:
-    """Merge (or resume-verify) phase; returns surface flag or None on fail."""
-    if resume:
-        state = _run(
-            ["gh", "pr", "view", str(pr_number), "--json", "state"],
-            timeout=_PROBE_TIMEOUT_S,
-        )
-        if state.returncode != 0 or json.loads(state.stdout)["state"] != "MERGED":
-            sys.stdout.write(
-                f"FAIL  land --resume: PR #{pr_number} is not MERGED — use a "
-                "plain land\n"
-            )
-            return None
-        merge_oid = _merge_commit_oid(pr_number)
-        pr_paths = _pr_changed_paths(pr_number)
-        if not merge_oid or not _main_run_conclusion(
-            merge_oid, expect_run=expects_main_run(pr_paths)
-        ):
-            return None
-        return touches_surface(pr_paths)
-    preflight = _land_preflight(pr_number)
-    if preflight is None:
+    pr_paths = _pr_changed_paths(pr_number)
+    if not merge_oid or not _main_run_conclusion(
+        merge_oid, expect_run=expects_main_run(pr_paths)
+    ):
         return None
-    head, surface = preflight
-    if not _merge_and_watch_main(workspace, pr_number, head):
-        return None
-    return surface
+    return touches_surface(pr_paths)
 
 
 def land_main(workspace: Path, pr_number: int, *, resume: bool = False) -> int:
-    """Verify green → pinned squash-merge → main-CI watch → local validation.
+    """Post-merge validation for an auto-merged PR.
 
-    ``resume=True`` (review finding [6]): re-enter after a failure that
-    happened AFTER the merge (main-CI watch, fast-forward, local
-    validation) — skips the merge for an already-MERGED PR and replays
-    the idempotent post-merge steps, so a merged-but-unvalidated PR never
-    strands.
+    ship enables native auto-merge, so GitHub merges the PR when ci-gate is
+    green. land is the post-merge step: confirm the PR MERGED, verify the main
+    ci.yml run concluded success, fast-forward local main, and run the
+    Mac-local ``verify-local`` (arm64 R1/R2/R3 + persistence) that can't run in
+    CI. Run it once the PR has merged; it is idempotent (safe to re-run). The
+    ``resume`` flag is accepted for compatibility — land is always the
+    idempotent post-merge replay now, so it has no separate effect.
     """
-    surface = _land_merge_phase(workspace, pr_number, resume=resume)
+    _ = resume  # land is always the idempotent post-merge replay now
+    surface = _land_post_merge(pr_number)
     if surface is None:
         return 1
 

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -214,55 +214,123 @@ def test_ship_gate_failure_stops_before_push(
 # ------------------------------------------------------------------- land
 
 
-def test_land_aborts_on_non_green_checks(monkeypatch: pytest.MonkeyPatch) -> None:
-    view = {"state": "OPEN", "headRefOid": "a" * 40, "baseRefName": "main"}
-    monkeypatch.setattr(pr, "_run", lambda *_a, **_k: _cp(json.dumps(view)))
-    monkeypatch.setattr(pr, "pr_checks_green", lambda _n: (False, "lint=fail"))
-
-    def _boom(*_a: object, **_k: object) -> int:
-        msg = "must not merge with non-green checks"
-        raise AssertionError(msg)
-
-    monkeypatch.setattr(pr, "_stream", _boom)
-    assert pr.land_main(_WORKSPACE, 7) == 1
-
-
-def test_land_aborts_on_closed_pr(monkeypatch: pytest.MonkeyPatch) -> None:
-    view = {"state": "MERGED", "headRefOid": "a" * 40, "baseRefName": "main"}
-    monkeypatch.setattr(pr, "_run", lambda *_a, **_k: _cp(json.dumps(view)))
-    assert pr.land_main(_WORKSPACE, 7) == 1
-
-
-def test_land_merge_pins_verified_head(monkeypatch: pytest.MonkeyPatch) -> None:
+def testenable_auto_merge_builds_pinned_squash_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     head = "b" * 40
-    view = {"state": "OPEN", "headRefOid": head, "baseRefName": "main"}
-    streamed: list[list[str]] = []
+    seen: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_k: object) -> subprocess.CompletedProcess[str]:
+        seen.append(cmd)
+        return _cp()
+
+    monkeypatch.setattr(pr, "_run", fake_run)
+    assert pr.enable_auto_merge(_WORKSPACE, 7, head) is True
+    cmd = seen[-1]
+    assert cmd[:3] == ["gh", "pr", "merge"]
+    assert "--auto" in cmd
+    assert "--squash" in cmd
+    assert "--match-head-commit" in cmd
+    assert head in cmd
+
+
+def testenable_auto_merge_retries_transient_422(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses = iter([_cp("422 Failed enabling auto-merge", returncode=1), _cp()])
+    monkeypatch.setattr(pr, "_run", lambda *_a, **_k: next(responses))
+    monkeypatch.setattr(pr.time, "sleep", lambda _s: None)
+    assert pr.enable_auto_merge(_WORKSPACE, 7, "a" * 40) is True
+
+
+def testenable_auto_merge_fails_after_all_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pr, "_run", lambda *_a, **_k: _cp("422", returncode=1))
+    monkeypatch.setattr(pr.time, "sleep", lambda _s: None)
+    assert pr.enable_auto_merge(_WORKSPACE, 7, "a" * 40) is False
+
+
+def test_ship_enables_auto_merge_and_returns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ship opens the PR, enables native auto-merge (pinned to HEAD), returns 0.
+
+    GitHub owns the wait — ship never watches the build.
+    """
+    enabled: dict[str, object] = {}
+    monkeypatch.setattr(pr, "_current_branch", lambda _w: "feat/x")
+    monkeypatch.setattr(pr, "_working_tree_clean", lambda _w: True)
+    monkeypatch.setattr(pr, "changed_paths_vs_main", lambda _w: ["README.md"])
+    monkeypatch.setattr(pr, "run_gates", lambda *_a: True)
+    monkeypatch.setattr(pr, "_stream", lambda *_a, **_k: 0)  # git push
+    monkeypatch.setattr(pr, "_open_or_update_pr", lambda *_a, **_k: 42)
+    monkeypatch.setattr(pr, "_await_checks_registered", lambda _n: True)
+    monkeypatch.setattr(pr, "_run", lambda *_a, **_k: _cp("abc123\n"))  # rev-parse
+
+    def fake_enable(_w: Path, n: int, head: str) -> bool:
+        enabled["pr"] = n
+        enabled["head"] = head
+        return True
+
+    monkeypatch.setattr(pr, "enable_auto_merge", fake_enable)
+    assert pr.ship_main(_WORKSPACE) == 0
+    assert enabled["pr"] == 42
+    assert enabled["head"] == "abc123"
+
+
+def test_ship_fails_if_auto_merge_enable_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(pr, "_current_branch", lambda _w: "feat/x")
+    monkeypatch.setattr(pr, "_working_tree_clean", lambda _w: True)
+    monkeypatch.setattr(pr, "changed_paths_vs_main", lambda _w: ["README.md"])
+    monkeypatch.setattr(pr, "run_gates", lambda *_a: True)
+    monkeypatch.setattr(pr, "_stream", lambda *_a, **_k: 0)
+    monkeypatch.setattr(pr, "_open_or_update_pr", lambda *_a, **_k: 42)
+    monkeypatch.setattr(pr, "_await_checks_registered", lambda _n: True)
+    monkeypatch.setattr(pr, "_run", lambda *_a, **_k: _cp("abc123\n"))
+    monkeypatch.setattr(pr, "enable_auto_merge", lambda *_a: False)
+    assert pr.ship_main(_WORKSPACE) == 1
+
+
+def test_land_requires_merged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A still-OPEN PR means auto-merge is pending ci-gate — land exits 1."""
+    view = {"state": "OPEN", "baseRefName": "main"}
+    monkeypatch.setattr(pr, "_run", lambda *_a, **_k: _cp(json.dumps(view)))
+    assert pr.land_main(_WORKSPACE, 7) == 1
+
+
+def test_land_refuses_non_main_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Land only validates main-based PRs."""
+    view = {"state": "MERGED", "baseRefName": "develop"}
+    monkeypatch.setattr(pr, "_run", lambda *_a, **_k: _cp(json.dumps(view)))
+    assert pr.land_main(_WORKSPACE, 7) == 1
+
+
+def test_land_merged_validates_and_syncs(monkeypatch: pytest.MonkeyPatch) -> None:
+    view = {"state": "MERGED", "baseRefName": "main"}
     monkeypatch.setattr(pr, "_run", lambda *_a, **_k: _cp(json.dumps(view)))
     monkeypatch.setattr(pr, "_pr_changed_paths", lambda _n: ["a.py"])
-    monkeypatch.setattr(pr, "pr_checks_green", lambda _n: (True, "ok"))
-    monkeypatch.setattr(pr, "_stream", lambda cmd, **_k: streamed.append(cmd) or 0)
     monkeypatch.setattr(pr, "_merge_commit_oid", lambda _n: "c" * 40)
     monkeypatch.setattr(pr, "_main_run_conclusion", lambda _o, **_k: True)
+    monkeypatch.setattr(pr, "_stream", lambda *_a, **_k: 0)
     monkeypatch.setattr(pr, "sync_main", lambda *_a, **_k: 0)
     assert pr.land_main(_WORKSPACE, 7) == 0
-    merge_cmd = next(c for c in streamed if c[:3] == ["gh", "pr", "merge"])
-    assert "--match-head-commit" in merge_cmd
-    assert head in merge_cmd
 
 
 def test_land_surface_pr_validates_full_tier(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    view = {"state": "OPEN", "headRefOid": "d" * 40, "baseRefName": "main"}
+    view = {"state": "MERGED", "baseRefName": "main"}
     seen: dict[str, bool] = {}
     monkeypatch.setattr(pr, "_run", lambda *_a, **_k: _cp(json.dumps(view)))
     monkeypatch.setattr(
         pr, "_pr_changed_paths", lambda _n: [".devcontainer/Dockerfile"]
     )
-    monkeypatch.setattr(pr, "pr_checks_green", lambda _n: (True, "ok"))
-    monkeypatch.setattr(pr, "_stream", lambda *_a, **_k: 0)
     monkeypatch.setattr(pr, "_merge_commit_oid", lambda _n: "e" * 40)
     monkeypatch.setattr(pr, "_main_run_conclusion", lambda _o, **_k: True)
+    monkeypatch.setattr(pr, "_stream", lambda *_a, **_k: 0)
 
     def fake_sync(_w: Path, options: SyncOptions) -> int:
         seen["full"] = options.full
@@ -273,89 +341,10 @@ def test_land_surface_pr_validates_full_tier(
     assert seen["full"] is True
 
 
-def test_watch_awaits_check_registration(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Registration + ci-gate waits both precede --watch; then buckets verify."""
-    calls: list[str] = []
-    responses = iter(
-        [
-            _cp("", returncode=1),  # registration window: gh errors
-            _cp("[]"),  # registered but empty list — still pending
-            _cp(json.dumps([{"name": "lint", "bucket": "pending"}])),  # >=1 check
-            _cp(json.dumps([{"name": "lint"}])),  # ci-gate not present yet
-            _cp(json.dumps([{"name": "lint"}, {"name": "ci-gate"}])),  # ci-gate here
-            _cp(  # final bucket verify
-                json.dumps(
-                    [
-                        {"name": "lint", "bucket": "pass"},
-                        {"name": "ci-gate", "bucket": "pass"},
-                    ]
-                )
-            ),
-        ]
-    )
-    monkeypatch.setattr(pr, "_run", lambda *_a, **_k: next(responses))
-    monkeypatch.setattr(pr, "_stream", lambda cmd, **_k: calls.append(cmd[0]) or 0)
-    monkeypatch.setattr(pr.time, "sleep", lambda _s: None)
-    assert pr.watch_pr_checks(9) is True
-    assert calls == ["gh"]  # --watch ran exactly once, after BOTH waits
-
-
-def test_watch_fails_when_checks_never_register(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(pr, "_run", lambda *_a, **_k: _cp("", returncode=1))
-    monkeypatch.setattr(pr.time, "sleep", lambda _s: None)
-
-    def _boom(*_a: object, **_k: object) -> int:
-        msg = "must not watch before checks register"
-        raise AssertionError(msg)
-
-    monkeypatch.setattr(pr, "_stream", _boom)
-    assert pr.watch_pr_checks(9) is False
-
-
-def test_watch_fails_when_aggregate_never_registers(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """#181: >=1 check exists but ci-gate never appears — not green, no watch.
-
-    The premature-green gap: without the ci-gate wait, --watch could exit on
-    an early all-green wave (here `lint`) before the build jobs registered.
-    """
-    monkeypatch.setattr(
-        pr,
-        "_run",
-        lambda *_a, **_k: _cp(json.dumps([{"name": "lint", "bucket": "pass"}])),
-    )
-    monkeypatch.setattr(pr.time, "sleep", lambda _s: None)
-
-    def _boom(*_a: object, **_k: object) -> int:
-        msg = "must not watch before ci-gate registers"
-        raise AssertionError(msg)
-
-    monkeypatch.setattr(pr, "_stream", _boom)
-    assert pr.watch_pr_checks(9) is False
-
-
-def test_land_refuses_non_main_base(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Review finding [11]: land only lands main-based PRs."""
-    view = {"state": "OPEN", "headRefOid": "a" * 40, "baseRefName": "develop"}
+def test_land_resume_is_accepted_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resume is accepted for compat — land is always the post-merge replay."""
+    view = {"state": "MERGED", "baseRefName": "main"}
     monkeypatch.setattr(pr, "_run", lambda *_a, **_k: _cp(json.dumps(view)))
-    assert pr.land_main(_WORKSPACE, 7) == 1
-
-
-def test_land_resume_requires_merged(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Review finding [6]: --resume only replays post-merge steps."""
-    monkeypatch.setattr(
-        pr, "_run", lambda *_a, **_k: _cp(json.dumps({"state": "OPEN"}))
-    )
-    assert pr.land_main(_WORKSPACE, 7, resume=True) == 1
-
-
-def test_land_resume_replays_post_merge(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        pr, "_run", lambda *_a, **_k: _cp(json.dumps({"state": "MERGED"}))
-    )
     monkeypatch.setattr(pr, "_pr_changed_paths", lambda _n: ["a.py"])
     monkeypatch.setattr(pr, "_merge_commit_oid", lambda _n: "c" * 40)
     monkeypatch.setattr(pr, "_main_run_conclusion", lambda _o, **_k: True)
@@ -452,7 +441,7 @@ def test_land_passes_when_no_main_run_expected(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """#178: a merge whose paths match no ci.yml push path needs no run."""
-    view = {"state": "OPEN", "headRefOid": "b" * 40, "baseRefName": "main"}
+    view = {"state": "MERGED", "baseRefName": "main"}
     monkeypatch.setattr(pr, "_run", _land_run_dispatch(view))
     monkeypatch.setattr(
         pr, "_pr_changed_paths", lambda _n: ["mise.toml", ".agnix.toml"]
@@ -467,7 +456,7 @@ def test_land_fails_when_expected_main_run_absent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A ci.yml-push-path merge with no main run is a real failure."""
-    view = {"state": "OPEN", "headRefOid": "b" * 40, "baseRefName": "main"}
+    view = {"state": "MERGED", "baseRefName": "main"}
     monkeypatch.setattr(pr, "_run", _land_run_dispatch(view))
     monkeypatch.setattr(
         pr, "_pr_changed_paths", lambda _n: [".config/mise/conf.d/shared.toml"]
@@ -482,7 +471,7 @@ def test_land_watches_main_run_when_one_unexpectedly_appears(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Grace poll: a run appearing despite no expectation is still verified."""
-    view = {"state": "OPEN", "headRefOid": "b" * 40, "baseRefName": "main"}
+    view = {"state": "MERGED", "baseRefName": "main"}
     monkeypatch.setattr(pr, "_run", _land_run_dispatch(view, run_id="999"))
     monkeypatch.setattr(pr, "_pr_changed_paths", lambda _n: ["docs/x.md"])
     monkeypatch.setattr(pr, "_stream", lambda *_a, **_k: 0)


### PR DESCRIPTION
Replaces the hand-rolled CI-wait (a fixed-timeout watch, then a custom
await_pr_checks_terminal poll) with GitHub-native auto-merge — no client poll,
no timeout, tolerant of multi-hour base builds. The repo is already configured
for it (allow_auto_merge=true, main requires only ci-gate, no review).

ship: gates → push → open PR → `gh pr merge --auto --squash --match-head-commit
HEAD` (enable_auto_merge, bounded retry for the March-2026 422 enable
regression) → return. GitHub merges server-side the instant ci-gate goes green.
land: repurposed to post-merge validation — confirm MERGED → main-CI concluded
→ ff main → local verify-local (the arm64 R1/R2/R3 checks CI can't run). A
still-OPEN PR means auto-merge is pending; land says so and exits. --resume is
an accepted no-op alias now (land is always the idempotent post-merge replay).

Removed: await_pr_checks_terminal, _await_aggregate_registered, _land_preflight,
_merge_and_watch_main, _land_merge_phase, _AGGREGATE_CHECK. `--match-head-commit`
moves to ship's auto-merge (still closes the verify-then-merge race; GitHub also
auto-disables auto-merge on new pushes).

Also hardens the "research existing tools/services before building custom code"
rule (use-tool-builtins.md — hard gate + this exact custom-poll misstep as the
worked example; AGENTS.md policy; OMC .claude/CLAUDE.md principle), so it is
enforced without repetition. This custom poll is the failure it prevents:
native auto-merge / `gh pr checks --watch` existed and were never researched.

Tests: enable_auto_merge (pinned cmd, 422 retry, exhaustion), ship enables +
returns / fails-if-enable-fails, land requires-merged / non-main-base / merged
-validates / surface-full-tier / resume-alias; 390 pass. pr-workflow skill +
module docs updated to the auto-merge model. ship-land-wiring contract green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LsKvnhfBu4Nsovbpw3TXgp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Workflow Improvements**
  - Shipping a pull request now enables GitHub’s native auto-merge after checks are registered.
  - Landing validates that the pull request merged successfully, confirms the main-branch CI result, and synchronizes local changes.
  - Landing supports safe, repeatable post-merge validation.

- **Guidance**
  - Added a requirement to research existing tools, services, and native features before creating custom solutions.

- **Reliability**
  - Added retry handling for temporary auto-merge failures and expanded validation coverage for shipping and landing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->