### PR TITLE
feat(cicd): image build-metrics — tool-count, CI build-time, step summary (#17)

### DIFF
--- a/.github/workflows/image-analysis.yml
+++ b/.github/workflows/image-analysis.yml
@@ -27,6 +27,7 @@ on: # zizmor: ignore[dangerous-triggers] — deliberate: see comment above
 permissions:
   contents: read
   packages: read
+  actions: read # read the upstream CI run's job timings (build-metrics, #17)
   security-events: write # Trivy SARIF → GitHub code scanning
 concurrency:
   group: image-analysis-${{ github.event.workflow_run.head_sha }}
@@ -119,6 +120,21 @@ jobs:
             --image-ref "$REF" \
             --output-path artifacts/build/devcontainer-metrics.json \
             > /tmp/devcontainer-metrics.stdout.json
+      - name: Render metrics step summary (#17)
+        # Renders size + installed-tool-count + smoke + upstream CI build-time
+        # to the run summary. Visibility-only — never gates. build-time comes
+        # from the source CI run's jobs API (workflow_run.id → actions:read).
+        if: steps.image.outputs.present == 'true'
+        env:
+          METRICS_RUN_ID: ${{ github.event.workflow_run.id }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          uv run --project python dotfiles-setup image metrics-summary \
+            --metrics-path artifacts/build/devcontainer-metrics.json \
+            --run-id "$METRICS_RUN_ID" \
+            --repo "$REPO" \
+            --summary-path "$GITHUB_STEP_SUMMARY"
       - name: Scan image for CVEs (Trivy, warn-only)
         # warn-only (exit-code 0): SARIF surfaces in the Security tab; does not
         # gate. `scanners: vuln` + `timeout: 15m` per the heavy-image notes that

--- a/python/src/dotfiles_setup/image.py
+++ b/python/src/dotfiles_setup/image.py
@@ -14,6 +14,7 @@ import sys
 import time
 import tomllib
 import zlib
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 from dotfiles_setup import _project_root
@@ -723,9 +724,10 @@ def benchmark(
     smoke_finished = time.time()
     report = size_report(image_ref, platform=platform)
     finished = time.time()
+    tool_count = count_installed_tools(image_ref, platform=platform)
 
     payload = {
-        "schema_version": 1,
+        "schema_version": 2,
         "image_ref": image_ref,
         "platform": platform,
         "smoke": smoke_result,
@@ -736,6 +738,7 @@ def benchmark(
         },
         "image_size_bytes": report["image_size_bytes"],
         "compressed_size_bytes": report["compressed_size_bytes"],
+        "tool_count": tool_count,
         "top_layers": report["top_layers"],
         "result": smoke_result["result"].lower(),
     }
@@ -763,6 +766,195 @@ def metrics_compare(baseline_path: Path, candidate_path: Path) -> dict[str, Any]
     }
 
 
+def _count_tools_from_mise_ls(raw: str) -> int:
+    """Count installed tool entries from ``mise ls --json`` output.
+
+    ``mise ls --json`` maps each tool key to a list of its installed version
+    objects, so summing those list lengths counts every installed
+    (tool, version) entry — the JSON-robust equivalent of ``mise ls | wc -l``
+    (one line per tool-version) without depending on the plain-text columns.
+    """
+    data = json.loads(raw)
+    total = 0
+    for versions in data.values():
+        total += len(versions) if isinstance(versions, list) else 1
+    return total
+
+
+def count_installed_tools(image_ref: str, *, platform: str = "linux/amd64/v2") -> int:
+    """Installed tool count inside ``image_ref`` via ``mise ls --json``.
+
+    Runs mise in a login shell (``-lc``) so the image's mise activation and
+    PATH are in effect, mirroring :func:`build_smoke_docker_cmd`.
+    """
+    raw = _run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--platform",
+            platform,
+            "--entrypoint",
+            "/bin/bash",
+            image_ref,
+            "-lc",
+            "mise ls --json",
+        ],
+    ).stdout
+    return _count_tools_from_mise_ls(raw)
+
+
+def _parse_build_timing(jobs_json: str) -> dict[str, Any]:
+    """Reduce a ``/actions/runs/<id>/jobs`` payload to timing metrics.
+
+    Jobs in the reusable build chain run partly in parallel, so the honest
+    "total build time" is wall-clock: the span from the earliest job start to
+    the latest job completion. Per-job durations are kept for a visibility
+    breakdown. Jobs still running (null ``completed_at``) are skipped — this
+    runs after CI has completed, so that is only a defensive guard.
+    """
+    doc = json.loads(jobs_json)
+    per_job: list[dict[str, Any]] = []
+    starts: list[datetime] = []
+    ends: list[datetime] = []
+    for job in doc.get("jobs", []):
+        started = job.get("started_at")
+        completed = job.get("completed_at")
+        if not started or not completed:
+            continue
+        start_dt = datetime.fromisoformat(started)
+        end_dt = datetime.fromisoformat(completed)
+        starts.append(start_dt)
+        ends.append(end_dt)
+        per_job.append(
+            {
+                "name": job.get("name", "?"),
+                "conclusion": job.get("conclusion"),
+                "duration_s": round((end_dt - start_dt).total_seconds(), 3),
+            }
+        )
+    total_wall_s = (
+        round((max(ends) - min(starts)).total_seconds(), 3) if starts else 0.0
+    )
+    return {"total_wall_s": total_wall_s, "jobs": per_job}
+
+
+def fetch_build_timing(run_id: str, repo: str) -> dict[str, Any]:
+    """Fetch upstream CI-run job timings via ``gh api`` (needs actions:read).
+
+    ``run_id`` is the source CI run exposed by the ``workflow_run`` trigger
+    (``github.event.workflow_run.id``); ``repo`` is ``owner/name``. Uses the
+    native jobs endpoint — no build-job instrumentation needed. No
+    ``--paginate``: the object-wrapped list endpoint would emit one JSON doc
+    per page (unparsable), and the build chain has far fewer than 100 jobs.
+    """
+    raw = _run(
+        ["gh", "api", f"repos/{repo}/actions/runs/{run_id}/jobs"],
+    ).stdout
+    return _parse_build_timing(raw)
+
+
+_BYTE_STEP = 1024.0
+
+
+def _format_bytes(num_bytes: int) -> str:
+    value = float(num_bytes)
+    for unit in ("B", "KB", "MB", "GB"):
+        if abs(value) < _BYTE_STEP:
+            return f"{int(value)} {unit}" if unit == "B" else f"{value:.2f} {unit}"
+        value /= _BYTE_STEP
+    return f"{value:.2f} TB"
+
+
+def _format_duration(seconds: float) -> str:
+    total = round(seconds)
+    minutes, secs = divmod(total, 60)
+    hours, minutes = divmod(minutes, 60)
+    if hours:
+        return f"{hours}h {minutes}m {secs}s"
+    if minutes:
+        return f"{minutes}m {secs}s"
+    return f"{secs}s"
+
+
+def render_metrics_summary(
+    payload: Mapping[str, Any], timing: Mapping[str, Any] | None
+) -> str:
+    """Render benchmark ``payload`` (+ optional CI ``timing``) as markdown.
+
+    GitHub-flavored markdown for ``$GITHUB_STEP_SUMMARY``. Pure — no IO.
+    """
+    compressed = _format_bytes(payload.get("compressed_size_bytes", 0))
+    uncompressed = _format_bytes(payload.get("image_size_bytes", 0))
+    lines: list[str] = [
+        "## \U0001f433 Devcontainer image metrics",
+        "",
+        f"**Image:** `{payload.get('image_ref', '?')}`",
+        "",
+        "| Metric | Value |",
+        "| --- | --- |",
+        f"| Compressed size | {compressed} |",
+        f"| Uncompressed size | {uncompressed} |",
+    ]
+    if "tool_count" in payload:
+        lines.append(f"| Installed tools | {payload['tool_count']} |")
+    lines.append(f"| Smoke result | {payload.get('result', '?').upper()} |")
+    if timing is not None:
+        lines.append(
+            f"| CI build time (wall) | {_format_duration(timing['total_wall_s'])} |"
+        )
+    lines.append("")
+
+    top_layers = payload.get("top_layers") or []
+    if top_layers:
+        lines += ["### Largest layers", "", "| Size | Created by |", "| --- | --- |"]
+        lines.extend(
+            f"| {_format_bytes(layer.get('size_bytes', 0))} | "
+            f"`{layer.get('created_by', '').replace('|', '\\|')}` |"
+            for layer in top_layers[:5]
+        )
+        lines.append("")
+
+    jobs = (timing or {}).get("jobs") or []
+    if jobs:
+        lines += [
+            "### CI job timings",
+            "",
+            "| Job | Duration | Conclusion |",
+            "| --- | --- | --- |",
+        ]
+        lines.extend(
+            f"| {job.get('name', '?')} "
+            f"| {_format_duration(job.get('duration_s', 0))} "
+            f"| {job.get('conclusion') or '?'} |"
+            for job in jobs
+        )
+        lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def metrics_summary(
+    metrics_path: Path,
+    *,
+    run_id: str | None = None,
+    repo: str | None = None,
+    summary_path: Path | None = None,
+) -> str:
+    """Read a benchmark JSON, render a step summary, return the markdown.
+
+    Optionally fetches upstream CI timings (when ``run_id``/``repo`` given)
+    and appends the rendered markdown to ``summary_path``.
+    """
+    payload = json.loads(metrics_path.read_text(encoding="utf-8"))
+    timing = fetch_build_timing(run_id, repo) if run_id and repo else None
+    markdown = render_metrics_summary(payload, timing)
+    if summary_path is not None:
+        with summary_path.open("a", encoding="utf-8") as handle:
+            handle.write(markdown)
+    return markdown
+
+
 @dataclasses.dataclass(frozen=True)
 class ImageCommand:
     """Parsed image CLI command parameters."""
@@ -774,6 +966,10 @@ class ImageCommand:
     baseline_path: Path | None = None
     candidate_path: Path | None = None
     identity_path: str | None = None
+    metrics_path: Path | None = None
+    run_id: str | None = None
+    repo: str | None = None
+    summary_path: Path | None = None
 
 
 def base_currency_blob(repo_root: Path, rel_path: str) -> bytes:
@@ -941,6 +1137,20 @@ def _handle_metrics_compare(cmd: ImageCommand) -> int:
     return 0
 
 
+def _handle_metrics_summary(cmd: ImageCommand) -> int:
+    if cmd.metrics_path is None:
+        sys.stderr.write("metrics-summary requires --metrics-path\n")
+        return 2
+    markdown = metrics_summary(
+        cmd.metrics_path,
+        run_id=cmd.run_id,
+        repo=cmd.repo,
+        summary_path=cmd.summary_path,
+    )
+    sys.stdout.write(markdown)
+    return 0
+
+
 def main(cmd: ImageCommand) -> int:
     """CLI entry point for image operations (command → handler dispatch)."""
     handlers: dict[str, Callable[[ImageCommand], int]] = {
@@ -950,6 +1160,7 @@ def main(cmd: ImageCommand) -> int:
         "size-report": _handle_size_report,
         "benchmark": _handle_benchmark,
         "metrics-compare": _handle_metrics_compare,
+        "metrics-summary": _handle_metrics_summary,
     }
     handler = handlers.get(cmd.command)
     if handler is None:

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -220,6 +220,30 @@ def _add_image_subcommands(
         required=True,
         help="Candidate JSON path",
     )
+    summary_parser = image_sub.add_parser(
+        "metrics-summary",
+        help="Render a benchmark JSON (+ optional CI run timings) as a "
+        "GitHub step-summary markdown report (#17)",
+    )
+    summary_parser.add_argument(
+        "--metrics-path",
+        required=True,
+        help="Benchmark JSON produced by `image benchmark`",
+    )
+    summary_parser.add_argument(
+        "--run-id",
+        help="Upstream CI run id (github.event.workflow_run.id) for build-time "
+        "metrics; omit to skip the CI-timing section",
+    )
+    summary_parser.add_argument(
+        "--repo",
+        help="owner/name for the gh jobs API (github.repository)",
+    )
+    summary_parser.add_argument(
+        "--summary-path",
+        help="File to append the rendered markdown to (e.g. $GITHUB_STEP_SUMMARY); "
+        "always also printed to stdout",
+    )
 
 
 def _add_pr_subcommands(
@@ -581,6 +605,16 @@ def handle_image(args: argparse.Namespace) -> None:
             command="metrics-compare",
             baseline_path=Path(args.baseline),
             candidate_path=Path(args.candidate),
+        )
+        sys.exit(image_main(cmd))
+    if args.image_command == "metrics-summary":
+        cmd = ImageCommand(
+            "",
+            command="metrics-summary",
+            metrics_path=Path(args.metrics_path),
+            run_id=args.run_id,
+            repo=args.repo,
+            summary_path=Path(args.summary_path) if args.summary_path else None,
         )
         sys.exit(image_main(cmd))
 

--- a/tests/test_image_smoke.py
+++ b/tests/test_image_smoke.py
@@ -14,7 +14,11 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
 import json
 
 from dotfiles_setup.image import (
+    _count_tools_from_mise_ls,
+    _format_bytes,
+    _format_duration,
     _is_emulated,
+    _parse_build_timing,
     _parse_human_size,
     _repo_without_tag,
     _sum_manifest_layer_sizes,
@@ -24,7 +28,9 @@ from dotfiles_setup.image import (
     diff_tool_sets,
     identity_expected_hash,
     installed_tools_from_mise_ls,
+    metrics_summary,
     parse_declared_tools,
+    render_metrics_summary,
     resolve_declared_tools,
     resolve_declared_tools_at_base,
     resolve_expected_config_sha256,
@@ -636,3 +642,138 @@ def test_resolve_declared_tools_at_base_on_main_is_worktree(tmp_path: Path) -> N
 def test_base_currency_blob_returns_bytes(tmp_path: Path) -> None:
     repo = _identity_fixture_repo(tmp_path)
     assert base_currency_blob(repo, "config.toml") == b"original\n"
+
+
+# --- #17 build-metrics: tool-count, build-time, step-summary ---------------
+
+# Expected tool-entry count for the mise-ls fixture below (jq: 1, python: 2).
+_EXPECTED_TOOL_ENTRIES = 3
+
+# Expected wall-clock seconds for the two-job jobs fixture (12:00:05 → 12:10:05).
+_EXPECTED_WALL_SECONDS = 600.0
+
+# One gibibyte, for the byte-format assertion.
+_ONE_GIB = 1024**3
+
+
+def test_count_tools_from_mise_ls_sums_version_entries() -> None:
+    raw = json.dumps(
+        {
+            "jq": [{"version": "1.8.1", "installed": True}],
+            "python": [
+                {"version": "3.14.0", "installed": True},
+                {"version": "3.13.0", "installed": True},
+            ],
+        }
+    )
+    assert _count_tools_from_mise_ls(raw) == _EXPECTED_TOOL_ENTRIES
+
+
+def test_parse_build_timing_computes_wall_clock_and_per_job() -> None:
+    jobs = json.dumps(
+        {
+            "jobs": [
+                {
+                    "name": "base-prep",
+                    "conclusion": "success",
+                    "started_at": "2026-07-13T12:00:05Z",
+                    "completed_at": "2026-07-13T12:00:25Z",
+                },
+                {
+                    "name": "build",
+                    "conclusion": "success",
+                    "started_at": "2026-07-13T12:00:30Z",
+                    "completed_at": "2026-07-13T12:10:05Z",
+                },
+                {
+                    "name": "still-running",
+                    "conclusion": None,
+                    "started_at": "2026-07-13T12:10:00Z",
+                    "completed_at": None,
+                },
+            ]
+        }
+    )
+    timing = _parse_build_timing(jobs)
+    # Wall clock spans earliest start (12:00:05) to latest completion (12:10:05).
+    assert timing["total_wall_s"] == _EXPECTED_WALL_SECONDS
+    # The still-running job (null completed_at) is skipped.
+    assert [job["name"] for job in timing["jobs"]] == ["base-prep", "build"]
+
+
+def test_parse_build_timing_empty_is_zero() -> None:
+    timing = _parse_build_timing(json.dumps({"jobs": []}))
+    assert timing["total_wall_s"] == 0.0
+    assert timing["jobs"] == []
+
+
+def test_format_bytes_scales_units() -> None:
+    assert _format_bytes(512) == "512 B"
+    assert _format_bytes(_ONE_GIB) == "1.00 GB"
+
+
+def test_format_duration_renders_hms() -> None:
+    assert _format_duration(45) == "45s"
+    assert _format_duration(605) == "10m 5s"
+    assert _format_duration(3661) == "1h 1m 1s"
+
+
+def test_render_metrics_summary_includes_all_sections() -> None:
+    payload = {
+        "image_ref": "ghcr.io/owner/repo:abc1234",
+        "compressed_size_bytes": _ONE_GIB,
+        "image_size_bytes": 2 * _ONE_GIB,
+        "tool_count": 107,
+        "result": "pass",
+        "top_layers": [{"created_by": "RUN mise install", "size_bytes": _ONE_GIB}],
+    }
+    timing = {
+        "total_wall_s": _EXPECTED_WALL_SECONDS,
+        "jobs": [{"name": "build", "conclusion": "success", "duration_s": 300.0}],
+    }
+    markdown = render_metrics_summary(payload, timing)
+    assert "Devcontainer image metrics" in markdown
+    assert "ghcr.io/owner/repo:abc1234" in markdown
+    assert "| Installed tools | 107 |" in markdown
+    assert "| Smoke result | PASS |" in markdown
+    assert "| CI build time (wall) | 10m 0s |" in markdown
+    assert "### Largest layers" in markdown
+    assert "### CI job timings" in markdown
+
+
+def test_render_metrics_summary_without_timing_omits_ci_sections() -> None:
+    payload = {
+        "image_ref": "ghcr.io/owner/repo:abc1234",
+        "compressed_size_bytes": _ONE_GIB,
+        "image_size_bytes": _ONE_GIB,
+        "result": "pass",
+        "top_layers": [],
+    }
+    markdown = render_metrics_summary(payload, None)
+    assert "CI build time" not in markdown
+    assert "### CI job timings" not in markdown
+
+
+def test_metrics_summary_appends_to_summary_path(tmp_path: Path) -> None:
+    metrics = tmp_path / "metrics.json"
+    metrics.write_text(
+        json.dumps(
+            {
+                "image_ref": "ghcr.io/owner/repo:abc1234",
+                "compressed_size_bytes": _ONE_GIB,
+                "image_size_bytes": _ONE_GIB,
+                "tool_count": 42,
+                "result": "pass",
+                "top_layers": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    summary = tmp_path / "summary.md"
+    summary.write_text("pre-existing\n", encoding="utf-8")
+    returned = metrics_summary(metrics, summary_path=summary)
+    written = summary.read_text(encoding="utf-8")
+    # Appends (does not truncate) and returns the same markdown it wrote.
+    assert written.startswith("pre-existing\n")
+    assert "| Installed tools | 42 |" in written
+    assert returned in written


### PR DESCRIPTION
Add the three unmet #17 acceptance-criteria metrics to the async
image-analysis pipeline (visibility-only, never on the PR-critical path):

- tool-count: count_installed_tools() runs `mise ls --json` in the image
  and records the installed (tool, version) entry count in the benchmark
  payload (schema_version 1 -> 2).
- total build-time: fetch_build_timing() reads the upstream CI run's
  /actions/runs/<id>/jobs (native, no build-job instrumentation) and
  computes wall-clock span + per-job durations. Needs the new
  `actions: read` permission on image-analysis.yml (the explicit
  permissions block defaults every unlisted scope to none).
- step summary: new `image metrics-summary` CLI renders size + tools +
  smoke + build-time as markdown to $GITHUB_STEP_SUMMARY.

Out of scope (per decision): no trend/history file, no regression gate —
per-run reporting only.

Pure cores (_count_tools_from_mise_ls, _parse_build_timing,
render_metrics_summary, _format_bytes, _format_duration) are unit-tested
without docker or gh; 9 new tests in test_image_smoke.py.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GUpexKZFUw8TRpDGyDYNo3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added image benchmark reporting for installed tool counts, build size, and duration metrics.
  - Added a `metrics-summary` command to generate readable Markdown reports from benchmark results.
  - Reports can include CI build timing details and append directly to workflow summaries.
- **Improvements**
  - GitHub Actions now displays generated image metrics in the run summary for easier review.
  - Benchmark output now includes expanded metrics for more complete image analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->