### PR TITLE
docs(tests): sync pytest count to 406 + note #223 tier-1 smoke coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ the official `@devcontainers/cli` (pinned in `mise.toml`).
 | `.claude/` | Claude-specific agents, skills, rules. Has its own `CLAUDE.md` with OMC orchestration |
 | `home/` | Chezmoi-managed dotfile templates (its AGENTS.md was removed in #80) |
 | `python/` | Python package `dotfiles_setup` — see `python/AGENTS.md` |
-| `tests/` | Pytest + Bats test suite (316 pytest tests) — see `tests/AGENTS.md` |
+| `tests/` | Pytest + Bats test suite (406 pytest tests) — see `tests/AGENTS.md` |
 | `scripts/` | Utility scripts (`benchmark-docker.sh`, `devcontainer-smoke.sh`) |
 | `docs/` | Documentation, research findings, design specs |
 
@@ -86,7 +86,7 @@ content-hashed since hk 1.47 — no manual cache clearing after edits.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q               # All 316 tests
+uv run --project python pytest tests/ -x -q               # All 406 tests
 uv run --project python pytest tests/test_audit.py -x -q  # Single file
 mise run lint                                             # Lint checks only (hk under a hard timeout)
 dotfiles-setup verify run                                 # Verification contracts (suites.toml)

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -37,7 +37,7 @@ Requires **Python 3.14**.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q                # All 316 tests
+uv run --project python pytest tests/ -x -q                # All 406 tests
 uv run --project python pytest tests/test_audit.py -x -q   # Single file
 ```
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -18,7 +18,7 @@ Docker image smoke outputs.
 | `test_bootstrap.py` | pytest | Bootstrap tool availability (`mise`, `chezmoi`, `uv`, `pixi`, python) |
 | `test_config.py` | pytest | Pydantic `DotfilesConfig` and container-path constants |
 | `test_ghcr.py` | pytest | GHCR prerequisite validation and token scope parsing |
-| `test_image_smoke.py` | pytest | Smoke-test script generation, `_parse_human_size`, and the #143 exact tool-set assertion (parse/compare vs mise-system.toml) |
+| `test_image_smoke.py` | pytest | Smoke-test script generation, `_parse_human_size`, the #143 exact tool-set assertion, and the #223 shared tier-1 core (`build_tier1_script`, HEAD-vs-merge-base identity resolvers, a real bash EXECUTION test that the identity loop gates on a wrong hash) |
 | `test_container.py` | pytest | `verify-container-latest` gate (`dotfiles_setup.container`) — running/bind-mount/smoke freshness checks |
 | `test_sync.py` | pytest | `mise run sync` workflow (`dotfiles_setup.sync`) — staleness detection, action matrix, CI awareness, check/full/wait modes |
 | `test_pr.py` | pytest | `mise run ship`/`land` workflow (`dotfiles_setup.pr`) — surface detection, gate matrix, bucket verification, pinned merge |
@@ -30,7 +30,7 @@ Docker image smoke outputs.
 | `infra/foundation.bats` | Bats | Bash-level foundation checks (shell script integration) |
 | `infra/runtimes.bats` | Bats | Runtime installation checks (bash) |
 
-Total: **373 pytest tests** (pytest runs all `test_*.py` files) plus Bats
+Total: **406 pytest tests** (pytest runs all `test_*.py` files) plus Bats
 scenarios under `infra/`.
 
 ## Running tests


### PR DESCRIPTION
Test-count drift after #223 (PR #232) added the tier-1 smoke-unify tests:
- root AGENTS.md + python/AGENTS.md: 316 -> 406
- tests/AGENTS.md: 373 -> 406 and the test_image_smoke.py row now names the
  #223 shared tier-1 core coverage (build_tier1_script, HEAD-vs-merge-base
  identity resolvers, the bash execution test that the identity loop gates on
  a wrong hash).

Docs-only; build-publish/promote skip.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GUpexKZFUw8TRpDGyDYNo3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project testing documentation to reflect the expanded suite of 406 pytest tests.
  * Added details on additional image smoke-test coverage, including script generation, human-readable size parsing, tool-set validation, and shared execution-gating scenarios.
  * No application behavior or testing instructions were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->