### PR TITLE
docs: sync pytest count to 413 + note #223 tier-3 smoke coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ the official `@devcontainers/cli` (pinned in `mise.toml`).
 | `.claude/` | Claude-specific agents, skills, rules. Has its own `CLAUDE.md` with OMC orchestration |
 | `home/` | Chezmoi-managed dotfile templates (its AGENTS.md was removed in #80) |
 | `python/` | Python package `dotfiles_setup` — see `python/AGENTS.md` |
-| `tests/` | Pytest + Bats test suite (406 pytest tests) — see `tests/AGENTS.md` |
+| `tests/` | Pytest + Bats test suite (413 pytest tests) — see `tests/AGENTS.md` |
 | `scripts/` | Utility scripts (`benchmark-docker.sh`, `devcontainer-smoke.sh`) |
 | `docs/` | Documentation, research findings, design specs |
 
@@ -86,7 +86,7 @@ content-hashed since hk 1.47 — no manual cache clearing after edits.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q               # All 406 tests
+uv run --project python pytest tests/ -x -q               # All 413 tests
 uv run --project python pytest tests/test_audit.py -x -q  # Single file
 mise run lint                                             # Lint checks only (hk under a hard timeout)
 dotfiles-setup verify run                                 # Verification contracts (suites.toml)

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -37,7 +37,7 @@ Requires **Python 3.14**.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q                # All 406 tests
+uv run --project python pytest tests/ -x -q                # All 413 tests
 uv run --project python pytest tests/test_audit.py -x -q   # Single file
 ```
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -18,7 +18,7 @@ Docker image smoke outputs.
 | `test_bootstrap.py` | pytest | Bootstrap tool availability (`mise`, `chezmoi`, `uv`, `pixi`, python) |
 | `test_config.py` | pytest | Pydantic `DotfilesConfig` and container-path constants |
 | `test_ghcr.py` | pytest | GHCR prerequisite validation and token scope parsing |
-| `test_image_smoke.py` | pytest | Smoke-test script generation, `_parse_human_size`, the #143 exact tool-set assertion, and the #223 shared tier-1 core (`build_tier1_script`, HEAD-vs-merge-base identity resolvers, a real bash EXECUTION test that the identity loop gates on a wrong hash) |
+| `test_image_smoke.py` | pytest | Smoke-test script generation, `_parse_human_size`, the #143 exact tool-set assertion, and the #223 shared cores — tier-1 (`build_tier1_script`, HEAD-vs-merge-base identity resolvers, a real bash EXECUTION test that the identity loop gates on a wrong hash) and tier-3 (`build_tier3_script` sanitizer+reflection substrate, `resolve_expected_p2996_ref_at_base` merge-base ref-pin, TSan-skip/ref-strict injection, golden byte-parity with `build_smoke_script`) |
 | `test_container.py` | pytest | `verify-container-latest` gate (`dotfiles_setup.container`) — running/bind-mount/smoke freshness checks |
 | `test_sync.py` | pytest | `mise run sync` workflow (`dotfiles_setup.sync`) — staleness detection, action matrix, CI awareness, check/full/wait modes |
 | `test_pr.py` | pytest | `mise run ship`/`land` workflow (`dotfiles_setup.pr`) — surface detection, gate matrix, bucket verification, pinned merge |
@@ -30,7 +30,7 @@ Docker image smoke outputs.
 | `infra/foundation.bats` | Bats | Bash-level foundation checks (shell script integration) |
 | `infra/runtimes.bats` | Bats | Runtime installation checks (bash) |
 
-Total: **406 pytest tests** (pytest runs all `test_*.py` files) plus Bats
+Total: **413 pytest tests** (pytest runs all `test_*.py` files) plus Bats
 scenarios under `infra/`.
 
 ## Running tests


### PR DESCRIPTION
PR #234 (tier-3 smoke-unify) added 7 tests (406→413). Update the
count in root/python/tests AGENTS.md, and extend the
test_image_smoke.py row to name the tier-3 coverage (build_tier3_script
sanitizer+reflection substrate, resolve_expected_p2996_ref_at_base
merge-base ref-pin, TSan-skip/ref-strict injection, golden byte-parity).

Docs-only — in-place count swaps (root AGENTS.md stays at its 200-line
ceiling, chars unchanged); build-publish/promote skip, no land needed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GUpexKZFUw8TRpDGyDYNo3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing guidance to reflect the current total of 413 pytest tests.
  * Revised repository and Python testing instructions to show the updated test count.
  * Expanded test documentation to cover additional image smoke-test scenarios, including sanitizer and reflection checks, merge-base and reference-pin behavior, and injection-related coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->