### PR TITLE
feat(lint): enforce zero-bash-logic via allowlist + growth budget (#223 follow-up)

### DIFF
--- a/.claude/rules/zero-bash-logic.md
+++ b/.claude/rules/zero-bash-logic.md
@@ -1,0 +1,57 @@
+# Zero-Bash-Logic: No New Bash, No Growth of Existing
+
+Non-trivial logic (environment detection, tool config, validation,
+orchestration) lives in `python/` (`dotfiles_setup`). Bash is restricted to
+**thin check/smoke wrappers** in `scripts/` and `.devcontainer/scripts/`. This
+was a doc-only policy (root `AGENTS.md`) until the `bash_logic_budget` hk step
+gave it machine teeth.
+
+## The gate
+
+Two mechanisms, enforced by `dotfiles_setup.bash_budget` (the `bash-budget`
+CLI subcommand, run by the `bash_logic_budget` hk step in `hk.pkl`):
+
+1. **Allowlist gates NEW files.** Every tracked `scripts/*.sh` and
+   `.devcontainer/scripts/*.sh` must have an `ALLOWLIST` entry in
+   `python/src/dotfiles_setup/bash_budget.py`. A new `.sh` not on the list
+   **fails** — move the logic into `python/` (the default answer), or add an
+   explicit entry with a one-line justification (a reviewable diff).
+2. **Per-file budget flags GROWTH.** Each entry's `max_lines` is the file's
+   baseline line count. Growing past it **fails**; shrinking is always fine. A
+   budget bump is a reviewable diff + justification, not silent creep.
+
+A stale entry (an allowlisted path no longer tracked) also fails, so the map
+can't rot after a script is deleted.
+
+`plugins/**` is out of scope (vendored / third-party).
+
+## Why the check logic is in python
+
+A big inline-bash grep in the hk step would itself violate the policy it
+enforces. So the allowlist + budget logic lives in `bash_budget.py`; the hk
+step and the CLI subcommand are thin wrappers over `find_violations`. This
+mirrors `hook_guard.py` (the PreToolUse guard) and `lint.py` (the hk timeout
+wrapper): logic in python, a thin shell/hk seam.
+
+## Wiring (kept honest by a contract)
+
+`workflow.bash-logic-enforcement` in `python/verification/suites.toml` asserts
+the whole chain exists — hk step ↔ `dotfiles-setup bash-budget` ↔ module ↔
+tests ↔ this rule — so the guard can't silently drift out. Same pattern as
+`workflow.mise-tasks-enforcement`.
+
+## Applies to
+
+Every `scripts/*.sh` and `.devcontainer/scripts/*.sh` in this repo. A new
+recurring workflow ships its logic as a `python/` module + a mise task
+(`.claude/rules/mise-tasks-only.md`), not as a new shell script.
+
+## See also
+
+- `.claude/rules/use-tool-builtins.md` — prefer native/tool features over any
+  homegrown code (bash or python); the parent principle.
+- `.claude/rules/mise-tasks-only.md` — canonical mise tasks wrapping python
+  libraries, not one-off command sequences.
+- `python/src/dotfiles_setup/bash_budget.py` — the enforcer (allowlist +
+  budget map + `find_violations`).
+- `hk.pkl` — the `bash_logic_budget` step.

--- a/hk.pkl
+++ b/hk.pkl
@@ -179,6 +179,20 @@ local allSteps = new Mapping<String, Config.Step> {
       "rc=0; for f in $(git ls-files '*.sh'); do first=$(head -n1 \"$f\"); case \"$first\" in \"#!\"*) ;; *) continue ;; esac; grep -qE 'set -[a-z]*o pipefail' \"$f\" || { echo \"$f: shell script with shebang lacks 'set -o pipefail' (exit-code masking guard, #142)\" >&2; rc=1; }; done; exit $rc"
   }
 
+  // --- Zero-bash-logic enforcement: no NEW bash + no GROWTH of existing.
+  //     The policy (root AGENTS.md — "Non-trivial logic lives in python/;
+  //     bash restricted to thin check/smoke wrappers") was doc-only until
+  //     this step. An allowlist + per-file line budget gate scripts/*.sh and
+  //     .devcontainer/scripts/*.sh (11 files): a NEW .sh not on the allowlist
+  //     FAILS (move logic to python/, or add a justified entry); an existing
+  //     file GROWN past its baseline budget FAILS. The check LOGIC lives in
+  //     python (dotfiles_setup.bash_budget) — a big inline-bash grep here would
+  //     itself violate the policy it enforces. plugins/** is out of scope. ---
+  ["bash_logic_budget"] {
+    glob = List("scripts/*.sh", ".devcontainer/scripts/*.sh")
+    check = "uv run --project python dotfiles-setup bash-budget"
+  }
+
   // --- Markdown ---
   // #154: no markdown_lint step — its builtin runs `markdownlint` (cli v1),
   // but the repo standardizes on `markdownlint-cli2` (+ rumdl, mdschema).

--- a/python/src/dotfiles_setup/bash_budget.py
+++ b/python/src/dotfiles_setup/bash_budget.py
@@ -1,0 +1,197 @@
+"""No-new-bash-logic enforcement: allowlist + per-file growth budget.
+
+The zero-bash-logic policy (root `AGENTS.md` — "Non-trivial logic lives in
+`python/`; bash restricted to thin check/smoke wrappers") was doc-only until
+this module. It gives that policy machine teeth for the two host-side shell
+directories in scope:
+
+- ``scripts/*.sh`` and ``.devcontainer/scripts/*.sh`` (git's ``*`` spans ``/``
+  in a plain pathspec, so nested ``scripts/sub/x.sh`` is caught too — the
+  subdir bypass is closed).
+- ``plugins/**`` is OUT of scope (vendored / third-party).
+
+Two mechanisms, per Ray's locked decision (2026-07-13-e):
+
+1. **Allowlist gates NEW files.** Every in-scope ``.sh`` must have an
+   :data:`ALLOWLIST` entry. A new script not on the list FAILS — the author
+   either moves the logic into ``python/`` (the default answer) or adds an
+   explicit entry with a one-line justification (a reviewable diff).
+2. **Per-file budget flags GROWTH.** Each entry's ``max_lines`` is its baseline
+   line count. Growth past baseline FAILS (shrinking is always fine); a budget
+   bump is a reviewable diff + justification, not a silent creep.
+
+A stale entry (allowlisted path no longer tracked) also FAILS, so the map can't
+rot after a script is deleted — same "keep the wiring honest" spirit as the
+``no_global_skill_leakage`` hk step.
+
+The check logic lives here (not in a big inline-bash hk step) so the enforcer
+does not itself violate the policy it enforces. The hk step
+(``bash_logic_budget``) and the ``bash-budget`` CLI subcommand are thin
+wrappers over :func:`find_violations`.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# git pathspecs for the two in-scope shell directories. `*` spans `/` in a
+# plain git pathspec, so these also match nested `.sh` under each directory.
+SCOPE_PATHSPECS: tuple[str, ...] = (
+    "scripts/*.sh",
+    ".devcontainer/scripts/*.sh",
+)
+
+
+@dataclass(frozen=True)
+class BashAllowance:
+    """A permitted in-scope shell script: its line budget + why bash is OK."""
+
+    max_lines: int
+    reason: str
+
+
+# Declarative allowlist + growth budget. `max_lines` = the file's baseline line
+# count (`wc -l`) at adoption; growth past it FAILS. Each `reason` justifies why
+# thin bash is acceptable here rather than Python. Bumping a budget or adding an
+# entry is a reviewable diff — keep the justification honest.
+ALLOWLIST: dict[str, BashAllowance] = {
+    ".devcontainer/scripts/on-create.sh": BashAllowance(
+        74,
+        "devcontainer postCreate lifecycle hook — thin wrapper from devcontainer.json",
+    ),
+    "scripts/benchmark-docker.sh": BashAllowance(
+        167,
+        "docker build/pull timing harness — thin wrapper over docker/hyperfine CLIs",
+    ),
+    "scripts/check-chezmoi-templates.sh": BashAllowance(
+        48, "hk check wrapper — renders home/ templates via the chezmoi CLI"
+    ),
+    "scripts/check-claude-agents-md-pairs.sh": BashAllowance(
+        45, "hk check wrapper — CLAUDE.md/AGENTS.md sibling-pair assertion"
+    ),
+    "scripts/check-claude-md-stub.sh": BashAllowance(
+        57, "hk check wrapper — CLAUDE.md thin-import-stub assertion"
+    ),
+    "scripts/devcontainer-smoke.sh": BashAllowance(
+        157,
+        "tier 1-3 smoke harness — thin wrapper; the non-trivial tier-1/tier-3 "
+        "cores live in `dotfiles-setup image smoke-script` (#223)",
+    ),
+    "scripts/ensure-docker-up.sh": BashAllowance(
+        74, "hk/mise precondition wrapper — starts Docker Desktop if the daemon is down"
+    ),
+    "scripts/pretooluse-guard.sh": BashAllowance(
+        25,
+        "fail-open shim — execs `dotfiles-setup hook pretooluse` (the guard is Python)",
+    ),
+    "scripts/validate-devcontainer-json.sh": BashAllowance(
+        73,
+        "hk check wrapper — 3-layer devcontainer.json validation via "
+        "biome/devcontainer/check-jsonschema CLIs",
+    ),
+    "scripts/web-setup.sh": BashAllowance(
+        75, "Claude Code web/cloud bootstrap — thin environment wrapper"
+    ),
+    "scripts/workspace-hash.sh": BashAllowance(
+        26, "mise up collision-guard wrapper — emits a stable workspace hash"
+    ),
+}
+
+
+@dataclass(frozen=True)
+class BashViolation:
+    """A zero-bash-logic policy breach found by :func:`find_violations`."""
+
+    path: str
+    kind: str  # "unlisted" | "growth" | "stale"
+    detail: str
+
+
+def tracked_in_scope(repo_root: Path) -> list[str]:
+    """Tracked in-scope shell scripts, via ``git ls-files``."""
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "ls-files", "--", *SCOPE_PATHSPECS],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def line_count(path: Path) -> int:
+    """Newline count — identical to ``wc -l`` for the baselines."""
+    return path.read_text(errors="replace").count("\n")
+
+
+def find_violations(repo_root: Path) -> list[BashViolation]:
+    """Return every zero-bash-logic breach in the in-scope shell dirs.
+
+    Three failure kinds:
+
+    - ``unlisted`` — a tracked in-scope ``.sh`` with no :data:`ALLOWLIST`
+      entry (move the logic to ``python/``, or add a justified entry).
+    - ``growth`` — an allowlisted script now longer than its budget.
+    - ``stale`` — an allowlisted path no longer tracked (prune the entry).
+    """
+    tracked = tracked_in_scope(repo_root)
+    violations: list[BashViolation] = []
+
+    for rel in tracked:
+        allowance = ALLOWLIST.get(rel)
+        if allowance is None:
+            violations.append(
+                BashViolation(
+                    rel,
+                    "unlisted",
+                    "not in the bash-budget allowlist — move non-trivial logic "
+                    "into python/, or add a justified ALLOWLIST entry in "
+                    "python/src/dotfiles_setup/bash_budget.py",
+                )
+            )
+            continue
+        lines = line_count(repo_root / rel)
+        if lines > allowance.max_lines:
+            violations.append(
+                BashViolation(
+                    rel,
+                    "growth",
+                    f"{lines} lines exceeds budget {allowance.max_lines} — shrink "
+                    f"it, move logic to python/, or bump the budget with a reason",
+                )
+            )
+
+    tracked_set = set(tracked)
+    violations.extend(
+        BashViolation(
+            rel,
+            "stale",
+            "allowlisted but no longer tracked — remove the stale ALLOWLIST "
+            "entry in python/src/dotfiles_setup/bash_budget.py",
+        )
+        for rel in ALLOWLIST
+        if rel not in tracked_set
+    )
+
+    return violations
+
+
+def bash_budget_main(repo_root: Path) -> int:
+    """CLI entry: report violations to stderr; exit 1 if any, else 0."""
+    violations = find_violations(repo_root)
+    if violations:
+        for v in violations:
+            logger.error("bash-budget %s: %s — %s", v.kind, v.path, v.detail)
+        return 1
+    logger.info(
+        "bash-budget OK: %d in-scope shell scripts within allowlist + budget",
+        len(ALLOWLIST),
+    )
+    return 0

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from dotfiles_setup.ai import AIOrchestrator
 from dotfiles_setup.audit import DevEnvironmentAuditor, ToolManager
 from dotfiles_setup.autofix import autofix_apply_main
+from dotfiles_setup.bash_budget import bash_budget_main
 from dotfiles_setup.bootstrap_packages import gap_report_failures
 from dotfiles_setup.config import DotfilesConfig
 from dotfiles_setup.container import verify_latest_main
@@ -403,6 +404,12 @@ def setup_parser() -> argparse.ArgumentParser:
         "check-doc-refs",
         help="Verify every backtick path reference in the agent docs "
         "resolves to a real file (#160 T13 validation J)",
+    )
+    subparsers.add_parser(
+        "bash-budget",
+        help="Enforce zero-bash-logic: every scripts/*.sh + "
+        ".devcontainer/scripts/*.sh must be allowlisted and within its "
+        "per-file line budget (new/grown scripts fail — move logic to python/)",
     )
     ghcr_cleanup_parser = subparsers.add_parser(
         "ghcr-cleanup",
@@ -816,6 +823,7 @@ def _build_command_handlers(
         "ghcr-check": lambda: handle_ghcr_check(args, project_root),
         "ghcr-cleanup": lambda: handle_ghcr_cleanup(args),
         "check-doc-refs": lambda: handle_check_doc_refs(project_root),
+        "bash-budget": lambda: sys.exit(bash_budget_main(project_root)),
         "bootstrap-gap-report": lambda: handle_bootstrap_gap_report(args, project_root),
         "lock-stage": lambda: handle_lock_stage(args, project_root),
         "lock-collect": lambda: handle_lock_collect(args, project_root),

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -973,6 +973,28 @@ tokens = [
 ]
 
 [[suite]]
+name = "workflow.bash-logic-enforcement"
+description = "Zero-bash-logic policy wiring: the `bash_logic_budget` hk step must stay wired to the python enforcer end-to-end — hk.pkl shells out to `dotfiles-setup bash-budget`, main.py registers the subcommand, the bash_budget module (allowlist + per-file growth budget) + its tests exist, and the rule doc records the policy. The check LOGIC lives in python so the enforcer does not itself violate the policy it enforces; this contract asserts the whole chain so it can't drift out."
+category = "workflow"
+check_type = "static"
+handler = "require_tokens"
+paths_required = true
+paths = [
+    "hk.pkl",
+    "python/src/dotfiles_setup/main.py",
+    "python/src/dotfiles_setup/bash_budget.py",
+    "tests/test_bash_budget.py",
+    ".claude/rules/zero-bash-logic.md",
+]
+per_path_tokens = { "hk.pkl" = ["bash_logic_budget", "dotfiles-setup bash-budget"], "python/src/dotfiles_setup/main.py" = ["bash-budget"], "python/src/dotfiles_setup/bash_budget.py" = ["def find_violations", "def bash_budget_main"] }
+tokens = [
+    "dotfiles-setup bash-budget",
+    "def bash_budget_main",
+    "def find_violations",
+    "ALLOWLIST",
+]
+
+[[suite]]
 name = "workflow.tool-currency-wiring"
 description = "Daily tool-currency signal wiring: refresh.yml's tool-currency job must render the report via `mise run tool-currency` (thin caller of the python library) and upsert the standing issue; module + tests must exist. The signal feeds the tool-currency-check skill's release-note review (self-learning loop, 2026-07-07)."
 category = "workflow"

--- a/tests/test_bash_budget.py
+++ b/tests/test_bash_budget.py
@@ -1,0 +1,127 @@
+"""Tests for the zero-bash-logic enforcer (dotfiles_setup.bash_budget).
+
+Two layers: isolated logic tests (monkeypatch the tracked set + ALLOWLIST so
+the three failure kinds are exercised without touching the real tree) and
+real-repo guards (the allowlist must exactly equal the tracked in-scope set,
+the tree must currently pass, and the CLI must wire end-to-end).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
+
+from dotfiles_setup import bash_budget
+
+if TYPE_CHECKING:
+    import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+def _write(path: Path, n_lines: int) -> None:
+    """Write a file whose ``wc -l`` (newline count) is exactly ``n_lines``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("x\n" * n_lines)
+
+
+def _isolate(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    allowlist: dict[str, bash_budget.BashAllowance],
+    tracked: list[str],
+) -> None:
+    monkeypatch.setattr(bash_budget, "ALLOWLIST", allowlist)
+    monkeypatch.setattr(bash_budget, "tracked_in_scope", lambda _root: tracked)
+
+
+def test_new_unlisted_script_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _isolate(
+        monkeypatch,
+        allowlist={"scripts/known.sh": bash_budget.BashAllowance(10, "wrapper")},
+        tracked=["scripts/known.sh", "scripts/new.sh"],
+    )
+    _write(tmp_path / "scripts/known.sh", 5)
+    _write(tmp_path / "scripts/new.sh", 3)
+    kinds = {(v.path, v.kind) for v in bash_budget.find_violations(tmp_path)}
+    assert ("scripts/new.sh", "unlisted") in kinds
+    assert ("scripts/known.sh", "growth") not in kinds
+
+
+def test_growth_past_budget_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _isolate(
+        monkeypatch,
+        allowlist={"scripts/known.sh": bash_budget.BashAllowance(26, "wrapper")},
+        tracked=["scripts/known.sh"],
+    )
+    _write(tmp_path / "scripts/known.sh", 30)
+    violations = bash_budget.find_violations(tmp_path)
+    assert [(v.path, v.kind) for v in violations] == [("scripts/known.sh", "growth")]
+
+
+def test_shrink_and_at_budget_pass(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _isolate(
+        monkeypatch,
+        allowlist={"scripts/known.sh": bash_budget.BashAllowance(26, "wrapper")},
+        tracked=["scripts/known.sh"],
+    )
+    # Shrink: below budget is always fine.
+    _write(tmp_path / "scripts/known.sh", 20)
+    assert bash_budget.find_violations(tmp_path) == []
+    # Exactly at budget is fine (only strictly-greater fails).
+    _write(tmp_path / "scripts/known.sh", 26)
+    assert bash_budget.find_violations(tmp_path) == []
+
+
+def test_stale_allowlist_entry_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _isolate(
+        monkeypatch,
+        allowlist={"scripts/deleted.sh": bash_budget.BashAllowance(10, "wrapper")},
+        tracked=[],
+    )
+    violations = bash_budget.find_violations(tmp_path)
+    assert [(v.path, v.kind) for v in violations] == [("scripts/deleted.sh", "stale")]
+
+
+def test_allowlist_equals_tracked_in_scope() -> None:
+    """Allowlist must equal the tracked in-scope set (no stale, no unlisted)."""
+    tracked = set(bash_budget.tracked_in_scope(REPO_ROOT))
+    assert set(bash_budget.ALLOWLIST) == tracked
+
+
+def test_repo_currently_compliant() -> None:
+    assert bash_budget.find_violations(REPO_ROOT) == []
+
+
+def test_budgets_at_or_above_current_size() -> None:
+    """Every baseline budget is >= the file's size, so a shrink never trips."""
+    for rel, allowance in bash_budget.ALLOWLIST.items():
+        actual = bash_budget.line_count(REPO_ROOT / rel)
+        assert actual <= allowance.max_lines, (
+            f"{rel}: {actual} lines exceeds budget {allowance.max_lines}"
+        )
+
+
+def test_cli_wires_end_to_end() -> None:
+    """The `bash-budget` subcommand runs through main.py and passes clean."""
+    res = subprocess.run(
+        ["uv", "run", "--project", "python", "dotfiles-setup", "bash-budget"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=REPO_ROOT,
+        timeout=120,
+    )
+    assert res.returncode == 0, res.stderr


### PR DESCRIPTION
Machine-enforce the previously doc-only zero-bash-logic policy (root
AGENTS.md) for scripts/*.sh + .devcontainer/scripts/*.sh (11 files):

- dotfiles_setup.bash_budget: allowlist gates NEW scripts (a new .sh not
  on the list fails -> move logic to python/ or add a justified entry);
  per-file line budget flags GROWTH past baseline (shrink is fine); a
  stale allowlist entry (untracked path) also fails. Check logic lives in
  python so the enforcer does not itself violate the policy it enforces.
- hk.pkl `bash_logic_budget` step shells out to `dotfiles-setup
  bash-budget`; main.py registers the subcommand.
- suites.toml `workflow.bash-logic-enforcement` asserts the wiring
  (hk step <-> CLI <-> module <-> tests <-> rule) cannot drift out.
- tests/test_bash_budget.py (+8): unlisted/growth/shrink/stale logic +
  real-repo allowlist==tracked pin + end-to-end CLI.
- .claude/rules/zero-bash-logic.md records the policy.

plugins/** is out of scope (vendored). No devcontainer surface touched.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GUpexKZFUw8TRpDGyDYNo3
