### PR TITLE
docs(devcontainer): note the mise run smoke-exec containerized exec gate

### DIFF
--- a/.claude/skills/devcontainer-workflow/SKILL.md
+++ b/.claude/skills/devcontainer-workflow/SKILL.md
@@ -43,6 +43,13 @@ Tiers:
 
 Tier 4 (CLion remote toolchain) is manual.
 
+`mise run smoke-exec` is a complementary **containerized real-toolchain
+exec gate** (`tests/test_image_smoke_exec.py`, marked `image_exec`): it runs
+the python-generated tier-1/tier-3 smoke cores against the local `:dev`
+image and asserts both the happy path and a tampered FAIL. It's deselected
+from the default `mise run test` (root `pytest.ini`) and needs Docker + a
+current `:dev` (`mise run sync`).
+
 ## Hard rules (DO NOT VIOLATE)
 
 1. **Never grow `Dockerfile.host-user` beyond 89 lines.** Add capabilities via


### PR DESCRIPTION
Document the new `mise run smoke-exec` gate (added in #241) alongside the
tier 1-3 smoke checks: it runs the python-generated tier-1/tier-3 smoke
cores against the local `:dev` image (real toolchain), is `image_exec`-
marked / deselected from the default suite, and needs Docker + a current
`:dev`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018C1D95uaEZtHbbMGvo25CX
