### PR TITLE
refactor(image): #222 PR-B — export only the clang-p2996 install prefix (~6 GB off)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -218,9 +218,12 @@ WORKDIR /workspaces
 # from the parameterized ${BUILDER_IMAGE} and installs its own compile
 # toolchain via apt, so mise/hk/base-config edits never invalidate the
 # ~2h compiler build (p2996-hash no longer folds base-hash). Only the
-# install prefix (/opt/clang-p2996) ships — via the scratch
-# p2996-export stage (~500 MB), pushed to GHCR as :p2996-<hash16> and
-# re-consumed as a digest-pinned named build context on warm paths.
+# install prefix (/opt/clang-p2996) ships — via the scratch p2996-export
+# stage (~2.8 GB uncompressed / ~0.7 GB compressed: bin + libTooling static
+# libs + headers), pushed to GHCR as :p2996-<hash16> and re-consumed as a
+# digest-pinned named build context on warm paths. The source checkout +
+# build tree stay under /build (builder-only), excluded from the export
+# since #222 PR-B.
 FROM ${BUILDER_IMAGE} AS clang-builder-cold
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -255,20 +258,32 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       libzstd-dev \
       swig
 
-WORKDIR /opt/clang-p2996
+# Out-of-tree build (#222 PR-B): the source checkout (+ .git) and the CMake
+# build tree live under /build/clang-p2996 (builder-only, NEVER shipped);
+# ONLY the install prefix /opt/clang-p2996 is COPYd into p2996-export below.
+# Before this, `git init .` + build + install all happened IN /opt/clang-p2996,
+# so `COPY /opt/clang-p2996` grabbed the whole ~8.5 GB tree (source ~2.3 GB +
+# build/ ~3.4 GB + .git ~0.25 GB) instead of the ~2.8 GB install prefix — a
+# capability-preserving ~6 GB of pure packaging waste. The bloomberg/clang-p2996
+# commit is still embedded in `clang --version` at build time (.git is present
+# during the compile here, just excluded from the export), so the smoke ref-pin
+# check (image.py) is unaffected.
+WORKDIR /build/clang-p2996
 
 RUN git init . && \
     git remote add origin "${CLANG_P2996_REPO}" && \
     git fetch --depth 1 origin "${CLANG_P2996_REF}" && \
     git checkout FETCH_HEAD
 
-WORKDIR /opt/clang-p2996/build
+WORKDIR /build/clang-p2996/build
 
 # cmake and ninja come from the builder's own apt toolchain (#160 T11).
 # Build only X86 target to minimize compile time and binary size.
 # ccache mount persists across builds — on SHA change, ~80% of objects
 # are reusable, cutting rebuild time significantly vs cold cache.
 # See issue #82 for further caching optimization (sccache, separate scope).
+# `../llvm` resolves to /build/clang-p2996/llvm; install goes to the separate
+# prefix /opt/clang-p2996 (the only thing exported).
 RUN --mount=type=cache,target=/root/.cache/ccache,sharing=locked \
     cmake -G Ninja ../llvm \
       -DCMAKE_BUILD_TYPE=Release \
@@ -302,7 +317,9 @@ RUN printf '#include <meta>\nint main(){return 0;}\n' >/tmp/refl.cpp && \
       -fsyntax-only && \
     rm -f /tmp/refl.cpp
 
-# ── p2996-export: tiny scratch-based image holding just the install prefix.
+# ── p2996-export: scratch-based image holding ONLY the install prefix
+# (~2.8 GB uncompressed). The out-of-tree build above keeps source + build/ +
+# .git under /build, so this COPY genuinely grabs just the prefix (#222 PR-B).
 # This is what gets pushed to GHCR as :p2996-<hash16> for cross-build reuse.
 FROM scratch AS p2996-export
 COPY --from=clang-builder-cold /opt/clang-p2996 /opt/clang-p2996

--- a/.devcontainer/P2996-CACHE.md
+++ b/.devcontainer/P2996-CACHE.md
@@ -14,8 +14,11 @@ image keyed on a content-hash of the build inputs.
    edits never rebuild the compiler. Performs the `git fetch` + `cmake`
    + `ninja install` to `/opt/clang-p2996` + the reflection smoke test.
 2. **`p2996-export`** — `FROM scratch` + `COPY --from=clang-builder-cold
-   /opt/clang-p2996 /opt/clang-p2996`. ~500 MB image holding just the
-   install prefix; small enough to push/pull as a cache image.
+   /opt/clang-p2996 /opt/clang-p2996`. **~2.8 GB uncompressed / ~0.7 GB
+   compressed** — the install prefix only (bin + libTooling static libs +
+   headers). Since #222 PR-B the compiler is built out-of-tree under
+   `/build/clang-p2996`, so source + build/ + `.git` (~6 GB) are NOT in the
+   export (previously the whole ~8.5 GB tree shipped by mistake).
 
 The final `devcontainer` stage does `COPY --from=p2996-export`: on the
 cold path that builds the local stages; on warm CI paths bake-action
@@ -118,7 +121,9 @@ the Dockerfile pins — cross-version lock formats are not interchangeable
 ## Why scratch + named contexts
 
 The cache image is `FROM scratch` (instead of inheriting from the
-builder) to keep it small — 500 MB vs multi-GB with the toolchain.
+builder) to keep it small — ~2.8 GB (install prefix only, out-of-tree
+build since #222 PR-B) vs ~8.5 GB if source + build/ + `.git` were
+included, and far more if it inherited the builder's apt toolchain.
 Since #160 T11 there is NO indirection stage: on warm paths CI injects
 the cache image as a digest-pinned `p2996-export` named build context
 that overrides the local stage of the same name; cold paths just build

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -50,7 +50,9 @@ behavior unchanged):
    base tier; the compiler cache stays warm.
 4. **p2996-prep** — `dotfiles-setup p2996-hash` → probe `:p2996-<hash16>`.
    Hit: <30s. Miss: build the `p2996-cache` bake target (scratch
-   `p2996-export` with just `/opt/clang-p2996`, ~500 MB), push to GHCR.
+   `p2996-export` with just `/opt/clang-p2996`, ~2.8 GB uncompressed /
+   ~0.7 GB compressed — install prefix only, out-of-tree since #222 PR-B),
+   push to GHCR.
 5. **dev-prep** (#122, PR builds only) — `dotfiles-setup dev-hash` → probe
    `:dev-<hash16>`. Hit: retag the validated image to `:sha`/`:pr-NNN`,
    skip build+smoke. Miss: fall through. Nightly skips this (always builds).


### PR DESCRIPTION
The p2996-export stage COPYd the ENTIRE /opt/clang-p2996 directory, which was
the source checkout + CMake build tree + .git — not just the install prefix.
Root cause: the builder did `git init .` and built in-tree under
/opt/clang-p2996 with `-DCMAKE_INSTALL_PREFIX=/opt/clang-p2996`, so source,
build/, and install all shared one dir the COPY grabbed whole.

du-probe of the live image (docs/research/runs/research-20260713-222-p2-restructure):
  install prefix (bin 2.0G + lib 689M incl. 387M .a + include 87M) = ~2.78 GB  KEEP
  build/ 3.4G (duplicate binaries/libs) + source ~2.3G + .git 0.25G = ~5.95 GB  WASTE

Fix: out-of-tree build. Clone + build under /build/clang-p2996 (builder-only,
never shipped); keep `-DCMAKE_INSTALL_PREFIX=/opt/clang-p2996` so `ninja install`
writes only the prefix, and `COPY /opt/clang-p2996` grabs only that. Result:
~5.95 GB uncompressed / ~1.6 GB compressed off the layer, with EVERY compiler,
libTooling static lib, and dev header retained (capability-first, #222 reframe).

The bloomberg/clang-p2996 commit is still embedded in `clang --version` at build
time (.git present during compile, excluded only from the export), so the
smoke ref-pin check (image.py) is unaffected. Reflection smoke + libTooling use
only the install prefix, which is retained verbatim.

Busts p2996-hash → CI cold-recompiles (~2 h) + reflection smoke gates the cut.
No runtime code reads the source/build/.git (verified: all refs are bin/lib/
include). Contract build.p2996-cache-dockerfile-stages unchanged (COPY line
identical). Also refreshes the stale "~500 MB" export size in P2996-CACHE.md +
workflows/AGENTS.md to the true ~2.8 GB uncompressed / ~0.7 GB compressed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018C1D95uaEZtHbbMGvo25CX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated P2996 build and cache documentation to clarify that exported artifacts contain only the installable toolchain.
  * Documented revised cache size estimates: approximately 2.8 GB uncompressed and 0.7 GB compressed.
  * Updated CI workflow guidance to reflect the revised cache output size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->