### PR TITLE
fix(image): #222 PR-C follow-up — expose apt LLVM via mise _.path, not profile.d

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -198,23 +198,20 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     printf 'graph{a--b--c--a}' | neato -Tsvg -o /dev/null && \
     dot -V 2>&1 | grep -q 'version 15'
 
-# LLVM-22 C++ toolchain PATH + build-time smoke (#222 PR-C).
+# LLVM-22 C++ toolchain build-time smoke (#222 PR-C).
 # The apt llvm/clang/lld/lldb/clang-tools packages (declared in mise-system.toml
 # [bootstrap.packages], installed by `mise bootstrap packages apply` above) put
 # their UNVERSIONED binaries under /usr/lib/llvm-22/bin (clang, clang++, clangd,
 # clang-tidy, clang-format, lld, ld.lld, lldb, llvm-*) — /usr/bin holds only the
-# `-22`-suffixed names. A single /etc/profile.d entry prepends that dir so the
-# toolchain is on PATH under its plain names for every login/mise-activated shell,
-# exactly as the retired conda shims exposed it (smoke runs `bash -lc`). The
-# escaped \$PATH stays literal in the written file (not build-time expanded;
-# double-quoted so hadolint SC2016 doesn't misread it). The compile smoke is the
-# loud build-time self-check: it proves clang++ is really v22, that the
-# asan+ubsan sanitizer runtimes (libclang-rt-22-dev) link AND the binary runs, and
-# that clangd/clang-tidy/lld/lldb/llvm-config are present (capability parity with
-# the removed conda tools). TSan is not RUN here (build-as-root ASLR layout; the
-# tier-3 smoke covers it on real amd64).
-RUN printf "export PATH=\"/usr/lib/llvm-22/bin:\$PATH\"\n" > /etc/profile.d/llvm-toolchain.sh && \
-    /usr/lib/llvm-22/bin/clang++ --version | grep -q 'version 22' && \
+# `-22`-suffixed names. That dir is put on PATH via mise's `_.path` in
+# mise-system.toml [env] (NOT /etc/profile.d: the chezmoi ~/.profile runs `mise
+# activate`, which resets PATH and would drop a profile.d addition). This RUN is
+# purely the loud build-time self-check (full paths, no PATH dependency): it proves
+# clang++ is really v22, that the asan+ubsan sanitizer runtimes (libclang-rt-22-dev)
+# link AND the binary runs, and that clangd/clang-tidy/lld/lldb/llvm-config are
+# present (capability parity with the removed conda tools). TSan is not RUN here
+# (build-as-root ASLR layout; the tier-3 smoke covers it on real amd64).
+RUN /usr/lib/llvm-22/bin/clang++ --version | grep -q 'version 22' && \
     printf '#include <cstdio>\nint main(){printf("ok\\n");return 0;}\n' > /tmp/llvmcheck.cpp && \
     /usr/lib/llvm-22/bin/clang++ -fsanitize=address,undefined /tmp/llvmcheck.cpp -o /tmp/llvmcheck && \
     /tmp/llvmcheck | grep -q '^ok$' && \

--- a/.devcontainer/mise-system.toml
+++ b/.devcontainer/mise-system.toml
@@ -193,6 +193,17 @@ missing_tools = "always"
 show_env = true
 
 [env]
+# Expose the apt LLVM-22 toolchain (#222 PR-C) on PATH via mise's native path
+# directive — NOT /etc/profile.d. mise manages PATH through activation (this is
+# how every base tool is exposed), and the chezmoi-rendered ~/.profile runs
+# `mise activate`, which resets PATH and would discard a profile.d addition. The
+# old conda clang++ survived only because it was a mise shim in a dir mise's PATH
+# includes; `_.path` restores that exact exposure for the apt binaries. mise puts
+# this FIRST in the activated PATH, so the unversioned clang/clang++/clangd/
+# clang-tidy/clang-format/lld/lldb/llvm-* win over /opt/clang-p2996 (the general
+# toolchain, matching the pre-#222 behavior). Covers login + non-login +
+# CI dev-image smoke (all mise-activated). See the base-stage smoke in the Dockerfile.
+_.path = ["/usr/lib/llvm-22/bin"]
 # Build toolchain
 CC = "gcc"
 CXX = "g++"


### PR DESCRIPTION
PR #246 moved the LLVM toolchain to apt but exposed /usr/lib/llvm-22/bin via
/etc/profile.d/llvm-toolchain.sh. That works in CI (the dev-image smoke has no
chezmoi overlay) but is DROPPED in the devcontainer: the chezmoi-rendered
~/.profile runs `mise activate`, which resets PATH and discards the profile.d
addition. Result: clang++/clangd/clang-tidy/lld/lldb are not on the devcontainer
login-shell PATH — verify-local's tier-1 smoke (`which clang++ …`) fails. The old
conda clang++ survived only because it was a mise shim in a dir mise's PATH keeps.

Fix: expose the dir the same way mise exposes every base tool — `_.path =
["/usr/lib/llvm-22/bin"]` in mise-system.toml [env]. mise places it FIRST in the
activated PATH, so the unversioned clang/clang++/clangd/clang-tidy/clang-format/
lld/lldb/llvm-* win over /opt/clang-p2996 (general toolchain, matching pre-#222
behavior) and resolve in login, non-login, and CI dev-image contexts alike. The
Dockerfile's profile.d write is removed; its RUN is now purely the build-time
compile smoke (full paths, no PATH dependency).

Proven live in the running devcontainer: injecting _.path resolved all 7 tools in
the login shell and passed tier-1 (only the identity-hash check tripped, from the
hand-edit — clears on rebuild). base-hash busts (warm rebuild); p2996-hash
UNCHANGED c83d61e4 (warm). Gates: lint rc=0, pytest 445, verify 87/0.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018C1D95uaEZtHbbMGvo25CX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LLVM-22 tools are now available automatically in mise-activated shells.
  * The system LLVM toolchain takes precedence, ensuring consistent access to tools such as Clang and Clangd.

* **Bug Fixes**
  * Improved toolchain path handling across development environments.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->