### PR TITLE
fix(ci): #248 #249 #250 — Renovate hk-bump + gcc-latest auto-sha + agnix --strict

### DIFF
--- a/.agnix.toml
+++ b/.agnix.toml
@@ -43,6 +43,21 @@ max_files_to_validate = 10000
 paths = ["**/AGENTS.md", "**/CLAUDE.md", "AGENTS.md", "CLAUDE.md"]
 disabled_rules = ["XP-003", "AGM-004", "AGM-006", "PE-001"]
 
+[[overrides]]
+# CC-HK-025 is a VERIFIED upstream agnix bug (source-confirmed at 0.37.5, the
+# latest release; see .omc/research/research-20260714-agnix/report.md). It
+# tests the RAW matcher string (e.g. "startup|resume") against the SessionStart
+# enum {startup,resume,clear,compact} WITHOUT splitting on '|'/',' — but the
+# official Claude Code hooks docs (code.claude.com/docs/en/hooks) parse a
+# matcher containing only [A-Za-z0-9_ -,|] as a LIST of exact values split on
+# '|'/','. So our `startup|resume` correctly fires on both; agnix is wrong.
+# Version-pinning (VER-001) does NOT fix it (the enum is a compile-time const).
+# Scoped to settings.json so a genuinely-bad matcher elsewhere still flags.
+# Sibling precedent upstream fixed: agent-sh/agnix#1052 (CC-SK-008 whitespace
+# split). Remove this override once an equivalent CC-HK-025 fix ships upstream.
+paths = [".claude/settings.json", "**/settings.json"]
+disabled_rules = ["CC-HK-025"]
+
 [rules]
 skills = true
 hooks = true

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,7 +24,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"${CLAUDE_CODE_REMOTE:-}\" = \"true\" ] && bash scripts/web-setup.sh || true",
+            "command": "if [ \"${CLAUDE_CODE_REMOTE:-}\" = \"true\" ]; then bash scripts/web-setup.sh; fi",
             "timeout": 600
           }
         ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -422,9 +422,11 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG GCC_LATEST_DEB=gcc-latest_17.0.0-20260705git88752b86ff1a.deb
 # Validation D (#160 T13): kayari publishes NO checksum or signature (all
 # 404), so this locally-computed pin is the .deb's only integrity handle.
-# Deliberately NOT Renovate-managed: a GCC_LATEST_DEB bump fails this check
-# until a human recomputes the hash (`curl -fLO <url> && sha256sum <deb>`)
-# — supply-chain friction by design, the one place custom shell is justified.
+# NOT Renovate-managed (Renovate can't compute a sha): a GCC_LATEST_DEB bump
+# leaves this stale, but the gcc-sha-repair workflow (#249) recomputes it from
+# the newly-pinned .deb and commits the fix to the Renovate branch — the pin
+# stays byte-exact without the old human-recompute friction. To repair by hand:
+# `uv run --project python dotfiles-setup gcc-sha` (or `--check` to dry-run).
 ARG GCC_LATEST_DEB_SHA256=2503ddace30a46c732b5a764f0d3a7cbae35666f4cc064d34485e0c10652f93a
 # #222 PR-A (dev-hash only): the kayari .deb ships UNSTRIPPED backend
 # executables — cc1plus 518M, cc1 480M, lto1 463M, lto-dump 463M each carry

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -12,11 +12,12 @@ post-failure reporting.
 
 | File | Purpose |
 |------|---------|
-| `ci.yml` | Thin caller (Phase B, #118): lint → contract-preflight → `changes` (path-gate) → `build-publish` (the reusable build chain, gated on `changes.build` + push-to-main exemption); OR lint → promote (push to main) |
-| `build-publish.yml` | Reusable (`on: workflow_call`) build chain: base-prep → p2996-prep → dev-prep → build → smoke-test → dev-tag (dev-prep/dev-tag = 3rd content-hash tier, #122). Inputs `{tag_strategy, publish, target, ref, p2996_ref, platform*}` (#120; `*` reserved); outputs `{image_ref, digest}`. Caller's `github` context → sha/pr tags resolve identically |
-| `image-analysis.yml` | Async (`workflow_run` on CI success): benchmark metrics + Trivy CVE scan, off the PR critical path. Analyzes `:pr-NNN` — resolved from the head sha via `commits/<sha>/pulls` (NOT `workflow_run.pull_requests[]`, empty), #231; a PR run with no resolvable PR **fails loud** (red, non-gating). Resolver: `image resolve-analysis-ref` |
-| `refresh.yml` | Daily cron (00:00), one `lock-refresh` job (#160 T8): regenerates all four lockfiles via the `lock-refresh` composite (pinned image mise, linux-x64), PRs via `open-refresh-pr` (App token #119), **auto-merges**. `CLANG_P2996_REF` bumps: Renovate git-refs. |
+| `ci.yml` | Thin caller (Phase B, #118): lint → contract-preflight → `changes` (path-gate) → `build-publish` (gated on `changes.build` + push-to-main exemption); OR lint → promote (push to main) |
+| `build-publish.yml` | Reusable (`on: workflow_call`) build chain: base-prep → p2996-prep → dev-prep → build → smoke-test → dev-tag (dev-prep/dev-tag = 3rd content-hash tier, #122). Inputs `{tag_strategy, publish, target, ref, p2996_ref, platform*}` (#120); outputs `{image_ref, digest}`. |
+| `image-analysis.yml` | Async (`workflow_run` on CI success): benchmark metrics + Trivy CVE scan, off the PR critical path. Analyzes `:pr-NNN` resolved from the head sha via `commits/<sha>/pulls` (#231); a PR run with no resolvable PR **fails loud** (non-gating). Resolver: `image resolve-analysis-ref` |
+| `refresh.yml` | Daily cron (00:00), `lock-refresh` job (#160 T8): regenerates all four lockfiles (pinned image mise, linux-x64), PRs via `open-refresh-pr` (App token #119), **auto-merges**. `CLANG_P2996_REF`: Renovate git-refs. |
 | `ghcr-cleanup.yml` | Weekly hash-family retention plan (#160 T12.5); dry-run ALWAYS — delete only via dispatch `delete=true` after plan review. Planner: `dotfiles_setup.ghcr_cleanup` |
+| `gcc-sha-repair.yml` | `push: renovate/**` + Dockerfile change → `dotfiles-setup gcc-sha` recomputes `GCC_LATEST_DEB_SHA256` (kayari has no checksum) + commits via App token → greens the gcc bump (#249). |
 
 ## Composite actions (`.github/actions/`)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,11 @@ jobs:
           echo "## mise doctor" >> "$GITHUB_STEP_SUMMARY"
           mise doctor -J | jq '.' >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
       - name: Validate agent documentation
-        run: agnix .
+        # --strict: warnings are errors (agnix exits 0 on warnings otherwise,
+        # so they were invisible — #250). Kept CI/local-parity with the hk
+        # `agnix` step and `mise run lint-docs`. Known false positives are
+        # scoped out in .agnix.toml, so a NEW warning fails loud here.
+        run: agnix . --strict
       - name: Upload mise lockfile
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/gcc-sha-repair.yml
+++ b/.github/workflows/gcc-sha-repair.yml
@@ -1,0 +1,75 @@
+name: gcc-sha repair
+# When Renovate bumps the dated GCC_LATEST_DEB filename in the Dockerfile, the
+# GCC_LATEST_DEB_SHA256 pin goes stale — kayari.org publishes no checksum, so
+# the sha is deliberately Renovate-unmanaged (Dockerfile ARG comment) and
+# `sha256sum -c` fails the image build "by design" until a human recomputes it
+# (#249). This job recomputes the sha from the newly-pinned .deb and commits it
+# back to the Renovate branch, so the bump goes green automatically.
+#
+# Push (not pull_request) trigger: this only acts on our OWN renovate/** branch
+# pushes — no PR-head checkout with a write token. It commits with a GitHub App
+# token (like refresh.yml) so the corrected commit RE-FIRES the PR's
+# `pull_request` CI (a secrets.GITHUB_TOKEN push does not — GitHub's recursion
+# guard). Idempotent + self-terminating: the App-token push re-fires THIS
+# workflow, which recomputes, finds the sha already correct, and pushes nothing.
+#
+# The download+hash+rewrite logic lives in `dotfiles-setup gcc-sha`
+# (python/src/dotfiles_setup/gcc_sha.py) per the zero-bash-logic rule; this
+# workflow is a thin trigger + commit seam.
+on:
+  push:
+    branches:
+      - "renovate/**"
+    paths:
+      - ".devcontainer/Dockerfile"
+permissions:
+  contents: read # the App token carries contents:write for the push
+concurrency:
+  group: gcc-sha-repair-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  repair:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Mint GitHub App token
+        # App-token push fires the PR's `pull_request` CI on its own (unlike
+        # secrets.GITHUB_TOKEN). Reuses the refresh.yml App; REFRESH_APP_ID is
+        # the NUMERIC App ID (signs the JWT `iss`). See workflows/AGENTS.md.
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.REFRESH_APP_ID }}
+          private-key: ${{ secrets.REFRESH_APP_PRIVATE_KEY }}
+          permission-contents: write
+      - name: Checkout the pushed branch
+        # persist-credentials: false — the App token is used ONLY in the push
+        # step below (via a tokenized remote), never persisted to .git/config
+        # (zizmor artipacked). Default GITHUB_TOKEN suffices to check out.
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Install mise (python + uv)
+        uses: ./.github/actions/setup-mise
+        with:
+          install_args: "python uv"
+      - name: Recompute + repair gcc-latest sha
+        # Downloads the pinned .deb, recomputes sha256, rewrites the ARG only on
+        # drift (a 404 = the dated .deb aged out of kayari's rolling window,
+        # which fails loud here — the bump is invalid).
+        run: uv run --project python dotfiles-setup gcc-sha
+      - name: Commit + push if the sha drifted
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- .devcontainer/Dockerfile; then
+            echo "gcc-latest sha already correct — nothing to repair."
+            exit 0
+          fi
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
+          git add .devcontainer/Dockerfile
+          git commit -m "chore(image): repair GCC_LATEST_DEB_SHA256 for bumped gcc-latest .deb (#249)"
+          git push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${GITHUB_REF_NAME}"

--- a/hk.pkl
+++ b/hk.pkl
@@ -271,8 +271,20 @@ local allSteps = new Mapping<String, Config.Step> {
 
   // --- Agent documentation ---
   ["agnix"] {
-    check = "agnix ."
-    glob = List("CLAUDE.md", "AGENTS.md", ".claude/**/*.md", ".agnix.toml")
+    // --strict: warnings-as-errors so agnix warnings surface + FAIL locally
+    // (agnix exits 0 on warnings-only, so they were invisible — #250). Parity
+    // with ci.yml + `mise run lint-docs`. Known false positives (CC-HK-025)
+    // are scoped out in .agnix.toml. settings.json is in the glob so a hook
+    // config change triggers agnix locally (it was .md-only, missing the file
+    // agnix actually flagged).
+    check = "agnix . --strict"
+    glob = List(
+      "CLAUDE.md",
+      "AGENTS.md",
+      ".claude/**/*.md",
+      ".claude/settings.json",
+      ".agnix.toml",
+    )
   }
 
   // --- Doc path-reference existence (#160 T13, validation J): every

--- a/mise.toml
+++ b/mise.toml
@@ -668,7 +668,8 @@ run = "pinact run --verify"
 
 [tasks.lint-docs]
 description = "Validate agent documentation"
-run = "agnix ."
+# --strict: warnings-as-errors (#250) — parity with ci.yml + the hk agnix step.
+run = "agnix . --strict"
 
 [tasks.lock]
 description = "Regenerate mise.lock"

--- a/python/src/dotfiles_setup/gcc_sha.py
+++ b/python/src/dotfiles_setup/gcc_sha.py
@@ -1,0 +1,239 @@
+"""Auto-repair `GCC_LATEST_DEB_SHA256` to match the pinned gcc-latest .deb.
+
+kayari.org (jwakely's gcc-latest server) publishes **no checksum or
+signature**, so the sha256 in `.devcontainer/Dockerfile` is a
+LOCALLY-computed integrity pin. Renovate bumps the dated `GCC_LATEST_DEB`
+filename via the `custom.gcc-latest` datasource but cannot compute the sha
+of the new .deb, so a bump leaves `GCC_LATEST_DEB_SHA256` stale ->
+`sha256sum -c` fails at build time (the "red by design" friction, issue
+#249). This module recomputes the sha from the pinned filename and
+rewrites the ARG **only when it drifted**, so the `gcc-sha-repair`
+workflow can green a Renovate gcc bump automatically.
+
+The sha stays **pinned** in the Dockerfile (reproducible, hermetic): this
+recomputes it from the same immutable dated URL the build fetches, giving
+byte-level drift detection between repair-time and build-time. It is NOT a
+trust anchor (kayari serves no signature) — the dated filename is the
+reproducibility handle, the sha the tamper/corruption check.
+
+Mirrors `p2996_refresh.py`: read the pin, resolve upstream via an
+injectable seam, rewrite only on change with a strict `subn` count so a
+renamed/removed ARG fails loud instead of silently no-op'ing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Must match the download URL in `.devcontainer/Dockerfile` (the RUN that
+# fetches "${KAYARI_BASE_URL}${GCC_LATEST_DEB}").
+KAYARI_BASE_URL = "https://kayari.org/gcc-latest/"
+SHA256_HEX_LEN = 64
+_DOWNLOAD_CHUNK = 1 << 20  # 1 MiB — stream a ~480 MB .deb without buffering it.
+# No hard total timeout: the .deb is ~480 MB, so a slow-but-progressing link
+# must be allowed to finish. Fail fast on a dead connection, and abort only a
+# genuinely STALLED transfer (below _MIN_BYTES_PER_SEC for _STALL_SECONDS).
+_CONNECT_TIMEOUT_SECONDS = 30
+_STALL_SECONDS = 120
+_MIN_BYTES_PER_SEC = 1024
+
+# `ARG GCC_LATEST_DEB=gcc-latest_17.0.0-20260705git88752b86ff1a.deb`
+_DEB_PATTERN = re.compile(
+    r"^ARG GCC_LATEST_DEB=(?P<deb>gcc-latest_[0-9A-Za-z._-]+\.deb)\s*$",
+    re.MULTILINE,
+)
+# `ARG GCC_LATEST_DEB_SHA256=<64 lowercase-hex>` — split so `subn` rewrites
+# only the digest, preserving the ARG prefix.
+_SHA_PATTERN = re.compile(
+    r"(ARG GCC_LATEST_DEB_SHA256=)(?P<sha>[0-9a-f]{" + str(SHA256_HEX_LEN) + r"})",
+)
+
+
+@dataclass(frozen=True)
+class RepairResult:
+    """Outcome of a gcc-sha repair attempt."""
+
+    changed: bool
+    deb: str
+    old_sha: str
+    new_sha: str
+
+    def as_json(self) -> str:
+        """Render the result as a one-line JSON object."""
+        return json.dumps(asdict(self))
+
+
+def _validate_sha(value: str, source: str) -> str:
+    """Return `value` if it is a 64-char lowercase-hex sha256.
+
+    Raises:
+        ValueError: when `value` is not a well-formed sha256 digest.
+    """
+    if len(value) != SHA256_HEX_LEN or not all(c in "0123456789abcdef" for c in value):
+        msg = (
+            f"{source} must be a {SHA256_HEX_LEN}-char lowercase-hex sha256; "
+            f"got {value!r}"
+        )
+        raise ValueError(msg)
+    return value
+
+
+def parse_pins(dockerfile_text: str) -> tuple[str, str]:
+    """Return `(deb_filename, pinned_sha)` from the Dockerfile text.
+
+    Raises:
+        ValueError: when either ARG is missing (so a repair can never run
+            against a renamed/removed pin).
+    """
+    deb_match = _DEB_PATTERN.search(dockerfile_text)
+    if deb_match is None:
+        msg = "no `ARG GCC_LATEST_DEB=gcc-latest_*.deb` found in Dockerfile"
+        raise ValueError(msg)
+    sha_match = _SHA_PATTERN.search(dockerfile_text)
+    if sha_match is None:
+        msg = "no `ARG GCC_LATEST_DEB_SHA256=<64-hex>` found in Dockerfile"
+        raise ValueError(msg)
+    return deb_match.group("deb"), sha_match.group("sha")
+
+
+def _default_fetcher(url: str) -> str:
+    """Stream `url` via curl and return its sha256 hexdigest.
+
+    Downloads with `curl -fsSL` (the same fetcher the Dockerfile uses; `-f`
+    makes an HTTP 404 a non-zero exit) and hashes the byte stream in Python
+    without buffering the ~480 MB body. Subprocess is this repo's blessed
+    fetch mechanism (see `p2996_refresh`'s git ls-remote); no HTTP client
+    dependency is introduced.
+
+    Raises:
+        RuntimeError: when curl exits non-zero — a 404 means the pinned
+            dated .deb has aged out of kayari's rolling window, a real,
+            loud failure the caller must surface, not paper over.
+    """
+    digest = hashlib.sha256()
+    curl_cmd = [
+        "curl",
+        "-fsSL",
+        "--connect-timeout",
+        str(_CONNECT_TIMEOUT_SECONDS),
+        "--speed-limit",
+        str(_MIN_BYTES_PER_SEC),
+        "--speed-time",
+        str(_STALL_SECONDS),
+        url,
+    ]
+    with subprocess.Popen(
+        curl_cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    ) as proc:
+        # Bind to a local so the type checker narrows away the `| None`
+        # (stdout=PIPE guarantees a pipe; this branch is unreachable).
+        stdout = proc.stdout
+        if stdout is None:
+            msg = "curl subprocess produced no stdout pipe"
+            raise RuntimeError(msg)
+        for chunk in iter(lambda: stdout.read(_DOWNLOAD_CHUNK), b""):
+            digest.update(chunk)
+        _, stderr = proc.communicate()
+    if proc.returncode != 0:
+        msg = (
+            f"curl failed (rc={proc.returncode}) fetching {url}: "
+            f"{stderr.decode(errors='replace').strip()}"
+        )
+        raise RuntimeError(msg)
+    return digest.hexdigest()
+
+
+def compute_sha(
+    deb: str,
+    fetcher: Callable[[str], str] | None = None,
+    *,
+    base_url: str = KAYARI_BASE_URL,
+) -> str:
+    """Download `deb` from `base_url` and return its validated sha256.
+
+    `fetcher` is a test seam: a callable `(url) -> sha256_hexdigest`.
+    """
+    fetch = fetcher or _default_fetcher
+    url = f"{base_url}{deb}"
+    logger.info("Fetching gcc-latest .deb to compute sha256: %s", url)
+    return _validate_sha(fetch(url), f"computed sha256 of {deb}")
+
+
+def replace_sha(dockerfile_text: str, new_sha: str) -> str:
+    """Return `dockerfile_text` with `GCC_LATEST_DEB_SHA256` set to `new_sha`.
+
+    Raises:
+        ValueError: when the ARG is missing (so a silent no-op rewrite can
+            never mask a renamed/removed pin).
+    """
+    new_text, count = _SHA_PATTERN.subn(rf"\g<1>{new_sha}", dockerfile_text)
+    if count != 1:
+        msg = (
+            "expected exactly one GCC_LATEST_DEB_SHA256 ARG in Dockerfile, "
+            f"found {count}"
+        )
+        raise ValueError(msg)
+    return new_text
+
+
+def repair(
+    repo_root: Path,
+    *,
+    fetcher: Callable[[str], str] | None = None,
+    write: bool = True,
+) -> RepairResult:
+    """Recompute the gcc-latest sha and rewrite the ARG if it drifted.
+
+    Writes `.devcontainer/Dockerfile` only when the sha changed (so an
+    already-correct pin leaves the file byte-identical — no spurious
+    commit). With `write=False` this is a pure check: it still downloads
+    and compares, but never mutates the file.
+    """
+    dockerfile_path = repo_root / ".devcontainer" / "Dockerfile"
+    dockerfile_text = dockerfile_path.read_text()
+    deb, old_sha = parse_pins(dockerfile_text)
+    new_sha = compute_sha(deb, fetcher)
+    if new_sha == old_sha:
+        logger.info("GCC_LATEST_DEB_SHA256 already matches %s (%s)", deb, new_sha)
+        return RepairResult(changed=False, deb=deb, old_sha=old_sha, new_sha=new_sha)
+    if write:
+        dockerfile_path.write_text(replace_sha(dockerfile_text, new_sha))
+        logger.info("Repaired GCC_LATEST_DEB_SHA256: %s -> %s", old_sha, new_sha)
+    else:
+        logger.warning(
+            "GCC_LATEST_DEB_SHA256 drift for %s: pinned %s, actual %s",
+            deb,
+            old_sha,
+            new_sha,
+        )
+    return RepairResult(changed=True, deb=deb, old_sha=old_sha, new_sha=new_sha)
+
+
+def gcc_sha_main(repo_root: Path, *, check: bool = False) -> int:
+    """CLI entry: `repair` writes on drift; `--check` reports without writing.
+
+    Returns 0 when the pin already matches (or was repaired). In `--check`
+    mode returns 1 on drift so a caller can gate on it; the emitted JSON
+    line carries `changed`/`old_sha`/`new_sha` for the workflow to consume.
+    """
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    result = repair(repo_root, write=not check)
+    sys.stdout.write(result.as_json() + "\n")
+    if check and result.changed:
+        return 1
+    return 0

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -20,6 +20,7 @@ from dotfiles_setup.config import DotfilesConfig
 from dotfiles_setup.container import verify_latest_main
 from dotfiles_setup.doc_refs import find_unresolved_refs
 from dotfiles_setup.docker import DevContainerManager
+from dotfiles_setup.gcc_sha import gcc_sha_main
 from dotfiles_setup.ghcr import validate_ghcr_prereqs
 from dotfiles_setup.ghcr_cleanup import plan_cleanup
 from dotfiles_setup.hook_guard import pretooluse_main
@@ -422,6 +423,18 @@ def setup_parser() -> argparse.ArgumentParser:
         "check-doc-refs",
         help="Verify every backtick path reference in the agent docs "
         "resolves to a real file (#160 T13 validation J)",
+    )
+    gcc_sha_parser = subparsers.add_parser(
+        "gcc-sha",
+        help="Recompute GCC_LATEST_DEB_SHA256 from the pinned gcc-latest "
+        ".deb and rewrite it on drift (kayari publishes no checksum; the "
+        "gcc-sha-repair workflow greens a Renovate gcc bump, #249)",
+    )
+    gcc_sha_parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Report drift without writing; exit 1 if the pinned sha is "
+        "stale (still downloads the .deb to compare)",
     )
     subparsers.add_parser(
         "bash-budget",
@@ -846,6 +859,7 @@ def _build_command_handlers(
         "ghcr-check": lambda: handle_ghcr_check(args, project_root),
         "ghcr-cleanup": lambda: handle_ghcr_cleanup(args),
         "check-doc-refs": lambda: handle_check_doc_refs(project_root),
+        "gcc-sha": lambda: sys.exit(gcc_sha_main(project_root, check=args.check)),
         "bash-budget": lambda: sys.exit(bash_budget_main(project_root)),
         "bootstrap-gap-report": lambda: handle_bootstrap_gap_report(args, project_root),
         "lock-stage": lambda: handle_lock_stage(args, project_root),

--- a/renovate.json
+++ b/renovate.json
@@ -35,10 +35,11 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "hk pkl schema pin (amends + import package:// URLs) — kept in lockstep with hk releases across hk.pkl, hk-common.pkl, hk-image.pkl. No native/preset manager covers a pkl amends URL.",
+      "description": "hk pkl schema pin (amends + import package:// URLs) — kept in lockstep with hk releases across hk.pkl, hk-common.pkl, hk-image.pkl. No native/preset manager covers a pkl amends URL. The version appears TWICE per URL (release tag `download/v<X>/` AND package `hk@<X>`); both matchStrings are required so a bump rewrites both — a single-occurrence match produces the 404 URL `v<new>/hk@<old>.zip` (fixed #248).",
       "managerFilePatterns": ["/(^|/)hk(-common|-image)?\\.pkl$/"],
       "matchStrings": [
-        "download/v(?<currentValue>[\\d.]+)/hk@"
+        "download/v(?<currentValue>[\\d.]+)/hk@",
+        "hk@(?<currentValue>[\\d.]+)"
       ],
       "depNameTemplate": "jdx/hk",
       "datasourceTemplate": "github-releases"
@@ -67,7 +68,7 @@
     },
     {
       "customType": "regex",
-      "description": "gcc-latest.deb dated URL pin. Upstream (kayari) publishes NO checksum/signature — the immutable dated filename is the reproducibility handle. Bumped via the custom.gcc-latest HTML datasource on the jwakely index; no native/preset manager covers a rolling .deb URL.",
+      "description": "gcc-latest.deb dated URL pin. Upstream (kayari) publishes NO checksum/signature — the immutable dated filename is the reproducibility handle. Bumped via the custom.gcc-latest HTML datasource on the jwakely index; no native/preset manager covers a rolling .deb URL. The companion GCC_LATEST_DEB_SHA256 is NOT managed here (Renovate can't hash an artifact); the gcc-sha-repair.yml workflow recomputes + commits it on this bump (#249).",
       "managerFilePatterns": ["/\\.devcontainer/Dockerfile$/"],
       "matchStrings": [
         "ARG GCC_LATEST_DEB=gcc-latest_(?<currentValue>[0-9.]+-\\d+git[0-9a-f]+)\\.deb"

--- a/tests/test_gcc_sha.py
+++ b/tests/test_gcc_sha.py
@@ -1,0 +1,176 @@
+"""Tests for `dotfiles_setup.gcc_sha`."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+from dotfiles_setup import gcc_sha
+from dotfiles_setup.gcc_sha import (
+    SHA256_HEX_LEN,
+    RepairResult,
+    compute_sha,
+    gcc_sha_main,
+    parse_pins,
+    repair,
+    replace_sha,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+DEB = "gcc-latest_17.0.0-20260705git88752b86ff1a.deb"
+OLD_SHA = "a" * SHA256_HEX_LEN
+NEW_SHA = "b" * SHA256_HEX_LEN
+
+
+def _seed_dockerfile(tmp_path: Path, *, deb: str = DEB, sha: str = OLD_SHA) -> Path:
+    """Write a .devcontainer/Dockerfile with the gcc-latest ARGs."""
+    devcontainer = tmp_path / ".devcontainer"
+    devcontainer.mkdir(parents=True, exist_ok=True)
+    (devcontainer / "Dockerfile").write_text(
+        "FROM ubuntu:26.04 AS devcontainer\n"
+        "# renovate: datasource=custom.gcc-latest depName=gcc-latest\n"
+        f"ARG GCC_LATEST_DEB={deb}\n"
+        f"ARG GCC_LATEST_DEB_SHA256={sha}\n"
+        'RUN curl -fLOSs "https://kayari.org/gcc-latest/${GCC_LATEST_DEB}"\n',
+    )
+    return tmp_path
+
+
+# ──────────────────────────────────────────────────────────────────────
+# parse_pins
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_parse_pins_extracts_deb_and_sha(tmp_path: Path) -> None:
+    root = _seed_dockerfile(tmp_path)
+    deb, sha = parse_pins((root / ".devcontainer" / "Dockerfile").read_text())
+    assert deb == DEB
+    assert sha == OLD_SHA
+
+
+def test_parse_pins_raises_when_deb_missing() -> None:
+    text = f"ARG GCC_LATEST_DEB_SHA256={OLD_SHA}\n"
+    with pytest.raises(ValueError, match="GCC_LATEST_DEB="):
+        parse_pins(text)
+
+
+def test_parse_pins_raises_when_sha_missing() -> None:
+    text = f"ARG GCC_LATEST_DEB={DEB}\n"
+    with pytest.raises(ValueError, match="GCC_LATEST_DEB_SHA256"):
+        parse_pins(text)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# replace_sha
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_replace_sha_rewrites_only_the_digest() -> None:
+    text = f"ARG GCC_LATEST_DEB={DEB}\nARG GCC_LATEST_DEB_SHA256={OLD_SHA}\n"
+    out = replace_sha(text, NEW_SHA)
+    assert f"ARG GCC_LATEST_DEB_SHA256={NEW_SHA}" in out
+    assert OLD_SHA not in out
+    # The filename ARG is untouched.
+    assert f"ARG GCC_LATEST_DEB={DEB}" in out
+
+
+def test_replace_sha_raises_when_arg_missing() -> None:
+    with pytest.raises(ValueError, match="expected exactly one"):
+        replace_sha("FROM ubuntu:26.04\n", NEW_SHA)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# compute_sha
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_compute_sha_uses_fetcher_and_returns_digest() -> None:
+    seen: list[str] = []
+
+    def fetcher(url: str) -> str:
+        seen.append(url)
+        return NEW_SHA
+
+    result = compute_sha(DEB, fetcher)
+    assert result == NEW_SHA
+    assert seen == [f"https://kayari.org/gcc-latest/{DEB}"]
+
+
+def test_compute_sha_rejects_malformed_digest() -> None:
+    with pytest.raises(ValueError, match="lowercase-hex sha256"):
+        compute_sha(DEB, lambda _url: "not-a-sha")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# repair
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_repair_no_change_leaves_file_byte_identical(tmp_path: Path) -> None:
+    root = _seed_dockerfile(tmp_path)
+    before = (root / ".devcontainer" / "Dockerfile").read_text()
+    result = repair(root, fetcher=lambda _url: OLD_SHA)
+    assert result.changed is False
+    assert result.old_sha == OLD_SHA
+    assert result.new_sha == OLD_SHA
+    assert (root / ".devcontainer" / "Dockerfile").read_text() == before
+
+
+def test_repair_rewrites_on_drift(tmp_path: Path) -> None:
+    root = _seed_dockerfile(tmp_path)
+    result = repair(root, fetcher=lambda _url: NEW_SHA)
+    assert result.changed is True
+    assert result.old_sha == OLD_SHA
+    assert result.new_sha == NEW_SHA
+    assert (
+        f"ARG GCC_LATEST_DEB_SHA256={NEW_SHA}"
+        in (root / ".devcontainer" / "Dockerfile").read_text()
+    )
+
+
+def test_repair_check_mode_detects_drift_without_writing(tmp_path: Path) -> None:
+    root = _seed_dockerfile(tmp_path)
+    before = (root / ".devcontainer" / "Dockerfile").read_text()
+    result = repair(root, fetcher=lambda _url: NEW_SHA, write=False)
+    assert result.changed is True
+    assert (root / ".devcontainer" / "Dockerfile").read_text() == before
+
+
+# ──────────────────────────────────────────────────────────────────────
+# RepairResult / gcc_sha_main
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_repair_result_as_json_shape() -> None:
+    result = RepairResult(changed=True, deb=DEB, old_sha=OLD_SHA, new_sha=NEW_SHA)
+    payload = json.loads(result.as_json())
+    assert payload == {
+        "changed": True,
+        "deb": DEB,
+        "old_sha": OLD_SHA,
+        "new_sha": NEW_SHA,
+    }
+
+
+def test_gcc_sha_main_check_returns_1_on_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _seed_dockerfile(tmp_path)
+    monkeypatch.setattr(gcc_sha, "_default_fetcher", lambda _url: NEW_SHA)
+    rc = gcc_sha_main(root, check=True)
+    assert rc == 1
+    # check mode never mutates.
+    assert OLD_SHA in (root / ".devcontainer" / "Dockerfile").read_text()
+
+
+def test_gcc_sha_main_repair_returns_0_and_writes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _seed_dockerfile(tmp_path)
+    monkeypatch.setattr(gcc_sha, "_default_fetcher", lambda _url: NEW_SHA)
+    rc = gcc_sha_main(root, check=False)
+    assert rc == 0
+    assert NEW_SHA in (root / ".devcontainer" / "Dockerfile").read_text()


### PR DESCRIPTION
Post-PR-C P0 CI-breakage batch (all three locally validated: mise run lint
rc=0, 458 pytest, verify 87/0).

#248 — renovate.json hk customManager matched only `download/v<X>/hk@`, so a
bump rewrote the release tag but not the `hk@<X>` package suffix, producing the
404 URL `v<new>/hk@<old>.zip` that broke pkl load. Added a 2nd matchString
`hk@(?<currentValue>[\d.]+)` so both halves bump together.

#249 — gcc-latest sha auto-repair (Option A). kayari publishes no checksum, so
GCC_LATEST_DEB_SHA256 is Renovate-unmanaged and a bump left it stale -> build
red by design. New dotfiles_setup.gcc_sha (curl-stream into hashlib, no new dep,
injectable fetcher seam; mirrors p2996_refresh) + `dotfiles-setup gcc-sha
[--check]` + 13 tests; gcc-sha-repair.yml recomputes + commits the sha on a
`push: renovate/**` Dockerfile change via the refresh App token, greening the
bump. E2E-verified against the real 480 MB deb (sha matches pin, changed=false).

#250 — agnix warnings now surface + FAIL locally (they exited 0 before, so were
invisible). CC-HK-009 (`|| true`) fixed via if/fi (stops masking real web-setup
failures). CC-HK-025 is a source-verified upstream agnix bug at 0.37.5 (the
matcher list `startup|resume` is never split on `|`/`,`) -> scoped [[overrides]]
disabling it for **/settings.json; upstream filing tracked as #255 (P3). Wired
`--strict` into ci.yml + hk.pkl + `mise run lint-docs` + added settings.json to
the hk agnix glob.

Closes #248
Closes #249
Closes #250

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012YXey1ZVNGhxReBp8JzAzZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic repair of GCC package integrity hashes when pinned artifacts change.
  - Added a `gcc-sha` command with check-only support.
  - Added automation to detect and commit updated hashes on Renovate branches.

- **Bug Fixes**
  - Improved package version matching so related references update consistently.
  - Session startup setup now runs only in remote environments.

- **Quality Improvements**
  - Documentation validation now treats warnings as errors.
  - Added coverage for hash parsing, validation, repair, and check modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->