### PR TITLE
feat(hooks): add hook-selfcheck ship/land gate validating the PreToolUse guard end-to-end

### DIFF
--- a/.claude/rules/mise-tasks-only.md
+++ b/.claude/rules/mise-tasks-only.md
@@ -28,23 +28,43 @@ single-test `pytest path::test` via uv) are NOT wrapped and stay direct.
 
 ## Enforcement layers (deep-research verified, 2026-07-07)
 
-1. **PreToolUse hook** — `.claude/settings.json` wires every Bash call
-   through `dotfiles-setup hook pretooluse`
+1. **PreToolUse hook (hard deny)** — `.claude/settings.json` wires every
+   Bash call through `dotfiles-setup hook pretooluse`
    (`python/src/dotfiles_setup/hook_guard.py`): a matched one-off command
    is DENIED with the redirect reason fed back (JSON
    `permissionDecision: "deny"`; deterministic, applies even in
    bypassPermissions mode). The rules are tested in
    `tests/test_hook_guard.py`.
-2. **This rule + skills** — `pr-workflow` and `devcontainer-sync` skills
+2. **ship/land `hook-selfcheck` gate** — `mise run ship` / `land` run
+   `dotfiles-setup hook selfcheck`
+   (`python/src/dotfiles_setup/hook_selfcheck.py`) as an always-run gate: it
+   drives the WIRED PreToolUse guard end-to-end (settings.json wiring +
+   `Bash` matcher, the real wrapper, `bash -n` on the scripts), so a hook
+   regression fails a PR like lint/pytest. Tested in
+   `tests/test_hook_selfcheck.py`.
+3. **This rule + skills** — `pr-workflow` and `devcontainer-sync` skills
    name the canonical tasks; markdown alone is "relying on the LLM", so
    it is never the only layer.
-3. **Contract** — `workflow.mise-tasks-enforcement` in suites.toml
-   asserts the hook wiring exists (settings.json → CLI → module → tests),
-   so the guard can't silently drift out.
+4. **Contracts** — `workflow.mise-tasks-enforcement` (the deny guard) and
+   `workflow.hook-selfcheck-wiring` (the selfcheck gate) in suites.toml
+   assert the whole chain exists (settings.json → wrapper → CLI → module →
+   tests), so nothing silently drifts out.
 
-The hook fails OPEN on its own errors (a crashed guard must not brick
-every Bash call); hard one-off bans that must never fail open belong in
-settings.json permission deny rules, not the hook.
+The hook fails OPEN on its own errors (a crashed guard must not brick every
+Bash call — the wrapper exits 0 when the Python>=3.14 interpreter is absent,
+e.g. a cold Claude-web session). Hard one-off bans that must never fail open
+belong in settings.json permission deny rules, not the hook.
+
+> **Enforcement design note (2026-07-14, research-backed):** we deliberately
+> do NOT re-inject a "use mise tasks" reminder every turn (UserPromptSubmit)
+> or nudge after every command (PostToolUse). Anthropic's guidance routes
+> static conventions to CLAUDE.md and enforcement to the PreToolUse hook,
+> and the LLM-behavior evidence ranks a hard gate (zero decay) far above
+> per-turn reminders (which decay, cost instruction budget, and sit in the
+> lowest-trust context tier). See
+> `.omc/research/research-20260714-hook-enforcement/report.md`. A separate
+> self-learning loop (telemetry review + a scanner that flags one-off-command
+> culprits to refine these layers) is the improvement path — not more hooks.
 
 ## Known limitation: prose content in compound commands
 

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -26,7 +26,9 @@ mise run land -- <PR#>             # (after it auto-merges) confirm merged → m
    first — the gates must validate exactly what ships).
 2. **Path-aware gate matrix, cheap-first** (from
    `.claude/rules/verify-before-advancing.md`): `mise run lint` →
-   pytest → `dotfiles-setup verify run`; + `pin-actions` when `.github/**`
+   pytest → `dotfiles-setup verify run` → `hook-selfcheck` (always-run:
+   drives the wired host-side hooks end-to-end — see
+   `.claude/rules/mise-tasks-only.md`); + `pin-actions` when `.github/**`
    changed; + `lint-docs` when agent docs changed; + **`mise run sync --
    --full` (hard gate, no override)** when the diff touches the
    devcontainer/image/validation surface (`SURFACE_PATTERNS` in pr.py:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ the official `@devcontainers/cli` (pinned in `mise.toml`).
 | `.claude/` | Claude-specific agents, skills, rules. Has its own `CLAUDE.md` with OMC orchestration |
 | `home/` | Chezmoi-managed dotfile templates (its AGENTS.md was removed in #80) |
 | `python/` | Python package `dotfiles_setup` — see `python/AGENTS.md` |
-| `tests/` | Pytest + Bats test suite (466 pytest tests) — see `tests/AGENTS.md` |
+| `tests/` | Pytest + Bats test suite (475 pytest tests) — see `tests/AGENTS.md` |
 | `scripts/` | Utility scripts (`benchmark-docker.sh`, `devcontainer-smoke.sh`) |
 | `docs/` | Documentation, research findings, design specs |
 
@@ -86,7 +86,7 @@ content-hashed since hk 1.47 — no manual cache clearing after edits.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q               # All 466 tests
+uv run --project python pytest tests/ -x -q               # All 475 tests
 uv run --project python pytest tests/test_audit.py -x -q  # Single file
 mise run lint                                             # Lint checks only (hk under a hard timeout)
 dotfiles-setup verify run                                 # Verification contracts (suites.toml)

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -39,7 +39,7 @@ Requires **Python 3.14**.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q                # All 466 tests
+uv run --project python pytest tests/ -x -q                # All 475 tests
 uv run --project python pytest tests/test_audit.py -x -q   # Single file
 ```
 

--- a/python/src/dotfiles_setup/hook_selfcheck.py
+++ b/python/src/dotfiles_setup/hook_selfcheck.py
@@ -1,0 +1,211 @@
+"""Host-side hook self-check: exercise the WIRED hook entrypoints end-to-end.
+
+``tests/test_hook_guard.py`` calls :func:`hook_guard.decide` *in process* — it
+never drives the actual path the harness uses: ``.claude/settings.json`` ->
+``scripts/pretooluse-guard.sh`` (the fail-open wrapper) -> ``dotfiles-setup
+hook pretooluse``. This module closes that gap. It:
+
+- asserts ``.claude/settings.json`` wires the project hooks
+  (:data:`_SETTINGS_WIRING`): the PreToolUse deny guard (scoped to ``Bash``) and
+  the SessionStart web-setup bootstrap;
+- drives the REAL PreToolUse wrapper end-to-end — a denied command must DENY,
+  an allowed one must stay silent;
+- ``bash -n`` syntax-checks the wired hook scripts (a parse error in
+  ``web-setup.sh`` would brick a cold Claude-web session before the first Bash
+  tool call).
+
+``dotfiles-setup hook selfcheck`` runs it, and ``mise run ship`` / ``mise run
+land`` gate on it (an always-run core gate, like lint/pytest/verify) so a hook
+regression is caught automatically.
+
+Each ``check_*`` helper returns a list of failure strings (empty == pass) so
+the checks are unit-testable without capturing stdout;
+:func:`hook_selfcheck_main` runs them all, prints a PASS/FAIL line per check,
+and returns 0 iff every check passed.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+from dotfiles_setup import hook_guard
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_PROBE_TIMEOUT_S = 60.0
+
+# A representative denied command (has a canonical mise task) and an allowed
+# one (a plain diagnostic). Driven through the REAL wrapper end-to-end; the
+# full rule battery lives in tests/test_hook_guard.py.
+_DENIED_SAMPLE = "gh pr create --fill"
+_DENIED_HINT = "mise run ship"
+_ALLOWED_SAMPLE = "git status --porcelain"
+
+_PRETOOLUSE_WRAPPER = "scripts/pretooluse-guard.sh"
+_WEB_SETUP = "scripts/web-setup.sh"
+_HOOK_SCRIPTS = (_PRETOOLUSE_WRAPPER, _WEB_SETUP)
+
+# Each settings.json hook event -> (command substrings that MUST appear in its
+# wired command(s), required matcher or None). Keeps the project hooks from
+# silently drifting out of .claude/settings.json (the wiring the end-to-end
+# check then exercises). PreToolUse must stay scoped to Bash.
+_SETTINGS_WIRING: tuple[tuple[str, tuple[str, ...], str | None], ...] = (
+    ("PreToolUse", (_PRETOOLUSE_WRAPPER,), "Bash"),
+    ("SessionStart", (_WEB_SETUP, "CLAUDE_CODE_REMOTE"), None),
+)
+
+
+def _run(
+    cmd: list[str], *, stdin: str | None = None, cwd: Path | None = None
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(
+            cmd,
+            input=stdin,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_PROBE_TIMEOUT_S,
+            cwd=cwd,
+        )
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(cmd, 124, "", "probe timed out")
+    except OSError as exc:
+        return subprocess.CompletedProcess(cmd, 127, "", str(exc))
+
+
+def _hook_payload(command: str) -> str:
+    """The PreToolUse stdin JSON the harness sends the hook."""
+    return json.dumps({"tool_name": "Bash", "tool_input": {"command": command}})
+
+
+def _event_entries(settings: dict, event: str) -> list[tuple[str, str]]:
+    """(matcher, command) pairs wired for a settings.json hook event."""
+    entries: list[tuple[str, str]] = []
+    for entry in settings.get("hooks", {}).get(event, []):
+        matcher = entry.get("matcher", "")
+        matcher = matcher if isinstance(matcher, str) else ""
+        entries.extend(
+            (matcher, cmd)
+            for hook in entry.get("hooks", [])
+            if isinstance((cmd := hook.get("command")), str)
+        )
+    return entries
+
+
+def check_settings_wiring(settings_path: Path) -> list[str]:
+    """Every project hook must be wired to its wrapper (with the right matcher)."""
+    failures: list[str] = []
+    try:
+        settings = json.loads(settings_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        return [f"could not read {settings_path}: {exc}"]
+    for event, required, matcher in _SETTINGS_WIRING:
+        entries = _event_entries(settings, event)
+        if not entries:
+            failures.append(f"settings.json has no {event} hook wired")
+            continue
+        joined = "\n".join(cmd for _, cmd in entries)
+        failures.extend(
+            f"settings.json {event} hook is missing {token!r}"
+            for token in required
+            if token not in joined
+        )
+        if matcher is not None and not any(matcher in m for m, _ in entries):
+            failures.append(
+                f"settings.json {event} hook must be scoped with matcher "
+                f"{matcher!r} (tool events fire on every tool otherwise)"
+            )
+    return failures
+
+
+def check_pretooluse_endtoend(project_root: Path) -> list[str]:
+    """Drive the REAL PreToolUse wrapper end-to-end (deny + allow).
+
+    A denied command must deny, an allowed one must stay silent. Exercises
+    settings.json's wired entrypoint (wrapper -> uv -> ``dotfiles-setup hook
+    pretooluse`` -> :func:`hook_guard.decide`), not just ``decide`` alone.
+    """
+    failures: list[str] = []
+    wrapper = str(project_root / _PRETOOLUSE_WRAPPER)
+
+    denied = _run(
+        ["bash", wrapper], stdin=_hook_payload(_DENIED_SAMPLE), cwd=project_root
+    )
+    if denied.returncode != 0:
+        failures.append(
+            f"pretooluse wrapper exited {denied.returncode} on a denied command "
+            f"(must exit 0 and emit the decision as JSON): {denied.stderr.strip()}"
+        )
+    elif '"permissionDecision": "deny"' not in denied.stdout:
+        failures.append(
+            f"pretooluse wrapper did not DENY {_DENIED_SAMPLE!r} — the wired "
+            f"guard path is broken. stdout={denied.stdout.strip()!r}"
+        )
+    elif _DENIED_HINT not in denied.stdout:
+        failures.append(
+            f"pretooluse deny for {_DENIED_SAMPLE!r} lost its redirect hint "
+            f"({_DENIED_HINT!r})"
+        )
+
+    allowed = _run(
+        ["bash", wrapper], stdin=_hook_payload(_ALLOWED_SAMPLE), cwd=project_root
+    )
+    if allowed.returncode != 0:
+        failures.append(
+            f"pretooluse wrapper exited {allowed.returncode} on an allowed "
+            f"command: {allowed.stderr.strip()}"
+        )
+    elif allowed.stdout.strip():
+        failures.append(
+            f"pretooluse wrapper was not silent on the allowed command "
+            f"{_ALLOWED_SAMPLE!r}: {allowed.stdout.strip()!r}"
+        )
+    return failures
+
+
+def check_guard_decisions() -> list[str]:
+    """In-process smoke of :func:`hook_guard.decide` (belt-and-braces)."""
+    failures: list[str] = []
+    if hook_guard.decide(_DENIED_SAMPLE) is None:
+        failures.append(f"decide() no longer denies {_DENIED_SAMPLE!r}")
+    if hook_guard.decide(_ALLOWED_SAMPLE) is not None:
+        failures.append(f"decide() wrongly denies the diagnostic {_ALLOWED_SAMPLE!r}")
+    return failures
+
+
+def check_script_syntax(project_root: Path) -> list[str]:
+    """``bash -n`` every wired hook script — a parse error would brick a hook."""
+    failures: list[str] = []
+    for rel in _HOOK_SCRIPTS:
+        res = _run(["bash", "-n", str(project_root / rel)])
+        if res.returncode != 0:
+            failures.append(f"{rel} failed `bash -n`: {res.stderr.strip()}")
+    return failures
+
+
+def hook_selfcheck_main(project_root: Path) -> int:
+    """Run every host-side hook check; print PASS/FAIL per check; 0 iff clean."""
+    settings_path = project_root / ".claude" / "settings.json"
+    checks = (
+        ("settings-wiring", lambda: check_settings_wiring(settings_path)),
+        ("script-syntax", lambda: check_script_syntax(project_root)),
+        ("guard-decisions", check_guard_decisions),
+        ("pretooluse-endtoend", lambda: check_pretooluse_endtoend(project_root)),
+    )
+    ok = True
+    for name, run in checks:
+        failures = run()
+        if failures:
+            ok = False
+            for failure in failures:
+                sys.stdout.write(f"FAIL  hook-selfcheck[{name}]: {failure}\n")
+        else:
+            sys.stdout.write(f"PASS  hook-selfcheck[{name}]\n")
+    if ok:
+        sys.stdout.write("hook-selfcheck: OK — all wired host-side hooks pass\n")
+    return 0 if ok else 1

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -24,6 +24,7 @@ from dotfiles_setup.gcc_sha import gcc_sha_main
 from dotfiles_setup.ghcr import validate_ghcr_prereqs
 from dotfiles_setup.ghcr_cleanup import plan_cleanup
 from dotfiles_setup.hook_guard import pretooluse_main
+from dotfiles_setup.hook_selfcheck import hook_selfcheck_main
 from dotfiles_setup.image import ImageCommand
 from dotfiles_setup.image import main as image_main
 from dotfiles_setup.lint import (
@@ -319,6 +320,31 @@ def _add_pr_subcommands(
     )
 
 
+def _add_hook_subcommands(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    """Register the Claude Code hook entrypoints (wired in settings.json).
+
+    Args:
+        subparsers: The parent subparsers action to attach hook commands to.
+    """
+    hook_parser = subparsers.add_parser(
+        "hook",
+        help="Claude Code hook entrypoints (wired in .claude/settings.json)",
+    )
+    hook_sub = hook_parser.add_subparsers(dest="hook_command", help="Hook events")
+    hook_sub.add_parser(
+        "pretooluse",
+        help="PreToolUse Bash guard: deny-with-redirect for one-off commands "
+        "that have a canonical mise task (mise-tasks-only policy)",
+    )
+    hook_sub.add_parser(
+        "selfcheck",
+        help="Exercise the WIRED host-side hooks end-to-end (ship/land gate) — "
+        "settings.json wiring, the real wrappers, and `bash -n` on the scripts",
+    )
+
+
 def setup_parser() -> argparse.ArgumentParser:
     """Configure the argument parser."""
     parser = argparse.ArgumentParser(description="Reproducible Dotfiles Orchestrator")
@@ -481,16 +507,7 @@ def setup_parser() -> argparse.ArgumentParser:
         help="GHCR container package name",
     )
 
-    hook_parser = subparsers.add_parser(
-        "hook",
-        help="Claude Code hook entrypoints (wired in .claude/settings.json)",
-    )
-    hook_sub = hook_parser.add_subparsers(dest="hook_command", help="Hook events")
-    hook_sub.add_parser(
-        "pretooluse",
-        help="PreToolUse Bash guard: deny-with-redirect for one-off commands "
-        "that have a canonical mise task (mise-tasks-only policy)",
-    )
+    _add_hook_subcommands(subparsers)
 
     autofix_parser = subparsers.add_parser(
         "autofix-apply",
@@ -572,6 +589,19 @@ def handle_pr(args: argparse.Namespace, project_root: Path) -> None:
         sys.exit(ship_main(project_root, title=args.title))
     elif args.pr_command == "land":
         sys.exit(land_main(project_root, args.number, resume=args.resume))
+
+
+def handle_hook(args: argparse.Namespace, project_root: Path) -> None:
+    """Dispatch a Claude Code hook subcommand (wired in .claude/settings.json).
+
+    Each hook main returns a process exit code; ``selfcheck`` is the ship/land
+    gate. Unknown/absent subcommand is a no-op (never bricks a hook).
+    """
+    command = getattr(args, "hook_command", None)
+    if command == "pretooluse":
+        sys.exit(pretooluse_main())
+    elif command == "selfcheck":
+        sys.exit(hook_selfcheck_main(project_root))
 
 
 def handle_audit(config: DotfilesConfig | None = None) -> None:
@@ -847,11 +877,7 @@ def _build_command_handlers(
         "autofix-apply": lambda: sys.exit(
             autofix_apply_main(args.run_id, project_root)
         ),
-        "hook": lambda: (
-            sys.exit(pretooluse_main())
-            if getattr(args, "hook_command", None) == "pretooluse"
-            else None
-        ),
+        "hook": lambda: handle_hook(args, project_root),
         "version": _version,
         "install": lambda: handle_install(project_root),
         "verify": lambda: handle_verify(args),

--- a/python/src/dotfiles_setup/pr.py
+++ b/python/src/dotfiles_setup/pr.py
@@ -234,7 +234,8 @@ def changed_paths_vs_main(workspace: Path) -> list[str]:
 def gate_matrix(paths: list[str]) -> list[Gate]:
     """The ordered, path-aware gate list for ship — cheap gates first.
 
-    Always: lint, pytest, verify contracts. Conditional per
+    Always: lint, pytest, verify contracts, hook-selfcheck (the wired
+    host-side hooks, end-to-end). Conditional per
     verify-before-advancing: pin-actions on .github changes, lint-docs on
     agent-doc changes. The full-sync hard gate runs LAST (most expensive)
     when the devcontainer/image/validation surface changed — EXCEPT when a
@@ -251,6 +252,14 @@ def gate_matrix(paths: list[str]) -> list[Gate]:
         Gate(
             "verify-contracts",
             ("uv", "run", "--project", "python", "dotfiles-setup", "verify", "run"),
+        ),
+        # Host-side hook validation: drives the WIRED PreToolUse guard + the
+        # advisory UserPromptSubmit/PostToolUse hooks end-to-end (settings.json
+        # wiring, the real wrappers, `bash -n`), so a hook regression is caught
+        # like any other gate. Always-run and cheap — see hook_selfcheck.py.
+        Gate(
+            "hook-selfcheck",
+            ("uv", "run", "--project", "python", "dotfiles-setup", "hook", "selfcheck"),
         ),
     ]
     if any(_matches_any(p, _GHA_PATTERNS) for p in paths):

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -973,6 +973,26 @@ tokens = [
 ]
 
 [[suite]]
+name = "workflow.hook-selfcheck-wiring"
+description = "Host-side hook self-check gate wiring: ship/land must gate on `hook-selfcheck` (an always-run gate that drives the WIRED PreToolUse guard end-to-end — settings.json wiring + Bash matcher, the real wrapper, `bash -n`), the hook_selfcheck module + its tests must exist, and main.py must register the `selfcheck` subcommand. Asserts the chain so the gate that validates the enforcement guard can't itself silently drift out."
+category = "workflow"
+check_type = "static"
+handler = "require_tokens"
+paths_required = true
+paths = [
+    "python/src/dotfiles_setup/hook_selfcheck.py",
+    "python/src/dotfiles_setup/main.py",
+    "python/src/dotfiles_setup/pr.py",
+    "tests/test_hook_selfcheck.py",
+    ".claude/rules/mise-tasks-only.md",
+]
+per_path_tokens = { "python/src/dotfiles_setup/hook_selfcheck.py" = ["def hook_selfcheck_main", "def check_settings_wiring", "def check_pretooluse_endtoend"], "python/src/dotfiles_setup/main.py" = ["selfcheck"], "python/src/dotfiles_setup/pr.py" = ["hook-selfcheck"] }
+tokens = [
+    "dotfiles-setup hook selfcheck",
+    "def hook_selfcheck_main",
+]
+
+[[suite]]
 name = "workflow.bash-logic-enforcement"
 description = "Zero-bash-logic policy wiring: the `bash_logic_budget` hk step must stay wired to the python enforcer end-to-end — hk.pkl shells out to `dotfiles-setup bash-budget`, main.py registers the subcommand, the bash_budget module (allowlist + per-file growth budget) + its tests exist, and the rule doc records the policy. The check LOGIC lives in python so the enforcer does not itself violate the policy it enforces; this contract asserts the whole chain so it can't drift out."
 category = "workflow"

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -24,6 +24,7 @@ Docker image smoke outputs.
 | `test_sync.py` | pytest | `mise run sync` workflow (`dotfiles_setup.sync`) — staleness detection, action matrix, CI awareness, check/full/wait modes |
 | `test_pr.py` | pytest | `mise run ship`/`land` workflow (`dotfiles_setup.pr`) — surface detection, gate matrix, bucket verification, pinned merge |
 | `test_hook_guard.py` | pytest | PreToolUse mise-tasks-only guard (`dotfiles_setup.hook_guard`) — deny/redirect rules, false-positive guards, JSON contract |
+| `test_hook_selfcheck.py` | pytest | Host-side hook self-check (`dotfiles_setup.hook_selfcheck`, the ship/land `hook-selfcheck` gate) — settings.json wiring + Bash-matcher assertions, and an end-to-end real-repo pass driving the wired PreToolUse guard |
 | `test_tool_currency.py` | pytest | Daily tool-currency signal (`dotfiles_setup.tool_currency`) — release-link backends, report rendering |
 | `test_renovate.py` | pytest | Renovate status signal (`dotfiles_setup.renovate`) — app-id/privilege check, report rendering |
 | `test_autofix.py` | pytest | autofix.ci artifact applier (`dotfiles_setup.autofix`) — additions, traversal/shape/deletion refusal |
@@ -33,7 +34,7 @@ Docker image smoke outputs.
 | `infra/foundation.bats` | Bats | Bash-level foundation checks (shell script integration) |
 | `infra/runtimes.bats` | Bats | Runtime installation checks (bash) |
 
-Total: **466 pytest tests** run by default (`pytest tests/` collects all
+Total: **475 pytest tests** run by default (`pytest tests/` collects all
 `test_*.py` files) plus **4 gated `image_exec`** exec tests (deselected by
 default; run via `mise run smoke-exec`) and Bats scenarios under `infra/`.
 

--- a/tests/test_hook_selfcheck.py
+++ b/tests/test_hook_selfcheck.py
@@ -1,0 +1,95 @@
+"""Tests for the host-side hook self-check (dotfiles_setup.hook_selfcheck).
+
+The self-check drives the WIRED hook entrypoints end-to-end; it is the
+ship/land ``hook-selfcheck`` gate. Unit tests cover the pure helpers (wiring
+parse, JSON extraction, in-process decide smoke); one integration test runs
+the whole thing against the real repo so a wiring/wrapper regression fails
+the gate.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
+
+from dotfiles_setup import hook_selfcheck
+
+_REPO = Path(__file__).parent.parent
+_REAL_SETTINGS = _REPO / ".claude" / "settings.json"
+
+
+def test_real_settings_wiring_passes() -> None:
+    assert hook_selfcheck.check_settings_wiring(_REAL_SETTINGS) == []
+
+
+def test_guard_decisions_smoke_passes() -> None:
+    assert hook_selfcheck.check_guard_decisions() == []
+
+
+def _wiring(tmp_path: Path, settings: dict) -> list[str]:
+    path = tmp_path / "settings.json"
+    path.write_text(json.dumps(settings))
+    return hook_selfcheck.check_settings_wiring(path)
+
+
+def _hook(matcher: str | None, command: str) -> dict:
+    entry: dict[str, object] = {"hooks": [{"type": "command", "command": command}]}
+    if matcher is not None:
+        entry["matcher"] = matcher
+    return entry
+
+
+def _full_settings() -> dict:
+    """A minimally-complete, passing settings shape for tampering in tests."""
+    return {
+        "hooks": {
+            "PreToolUse": [_hook("Bash", "bash scripts/pretooluse-guard.sh")],
+            "SessionStart": [
+                _hook(
+                    "startup|resume",
+                    'if [ "$CLAUDE_CODE_REMOTE" = "true" ]; then '
+                    "bash scripts/web-setup.sh; fi",
+                )
+            ],
+        }
+    }
+
+
+def test_synthetic_full_settings_passes(tmp_path: Path) -> None:
+    assert _wiring(tmp_path, _full_settings()) == []
+
+
+def test_missing_event_fails(tmp_path: Path) -> None:
+    settings = _full_settings()
+    del settings["hooks"]["PreToolUse"]
+    failures = _wiring(tmp_path, settings)
+    assert any("PreToolUse" in f for f in failures)
+
+
+def test_missing_matcher_fails(tmp_path: Path) -> None:
+    settings = _full_settings()
+    # Strip the Bash matcher off PreToolUse — a tool event without a matcher
+    # fires on every tool, which the check must reject.
+    settings["hooks"]["PreToolUse"] = [_hook(None, "bash scripts/pretooluse-guard.sh")]
+    failures = _wiring(tmp_path, settings)
+    assert any("PreToolUse" in f and "matcher" in f for f in failures)
+
+
+def test_wrong_command_fails(tmp_path: Path) -> None:
+    settings = _full_settings()
+    settings["hooks"]["SessionStart"] = [_hook("startup|resume", "bash other.sh")]
+    failures = _wiring(tmp_path, settings)
+    assert any("SessionStart" in f for f in failures)
+
+
+def test_unreadable_settings_fails(tmp_path: Path) -> None:
+    failures = hook_selfcheck.check_settings_wiring(tmp_path / "nope.json")
+    assert len(failures) == 1
+
+
+def test_selfcheck_main_passes_on_real_repo() -> None:
+    """End-to-end: drives the real wrappers; the ship/land gate itself."""
+    assert hook_selfcheck.hook_selfcheck_main(_REPO) == 0

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -58,9 +58,25 @@ def test_non_surface_paths_not_detected(path: str) -> None:
 
 def test_gate_matrix_always_has_core_gates() -> None:
     names = [g.name for g in pr.gate_matrix(["README.md"])]
-    assert names[:3] == ["lint", "pytest", "verify-contracts"]
+    assert names[:4] == ["lint", "pytest", "verify-contracts", "hook-selfcheck"]
     assert "sync-full" not in names
     assert "pin-actions" not in names
+
+
+def test_hook_selfcheck_is_an_unconditional_gate() -> None:
+    # The host-side hook validation runs on EVERY ship, like lint/pytest —
+    # a hook regression can arrive from any diff, not just a hook-file change.
+    for paths in (["README.md"], [".github/workflows/ci.yml"], ["python/x.py"]):
+        gate = next(g for g in pr.gate_matrix(paths) if g.name == "hook-selfcheck")
+        assert gate.cmd == (
+            "uv",
+            "run",
+            "--project",
+            "python",
+            "dotfiles-setup",
+            "hook",
+            "selfcheck",
+        )
 
 
 def test_gate_matrix_gha_adds_pin_actions() -> None:


### PR DESCRIPTION
Adds `dotfiles-setup hook selfcheck` — an always-run ship/land gate that drives
the WIRED PreToolUse deny guard end-to-end (settings.json wiring + Bash matcher,
the real scripts/pretooluse-guard.sh wrapper, and `bash -n` on the hook scripts),
so a hook regression fails a PR like lint/pytest. The unit tests only exercised
hook_guard.decide() in-process; this closes the gap by driving the actual harness
path (.claude/settings.json -> wrapper -> uv -> dotfiles-setup hook pretooluse).

Also records the research-backed enforcement design decision in mise-tasks-only.md:
per Anthropic's guidance (static conventions -> CLAUDE.md; enforcement -> the
PreToolUse hook) and the LLM-behavior literature (a hard gate has zero decay;
per-turn reminders decay, cost instruction budget, and sit in the lowest-trust
context tier), we deliberately do NOT re-inject a directive every turn or nudge
after every command. Ongoing improvement is a transcript-fed scanner (next piece),
not more per-turn hooks. Full cited research:
.omc/research/research-20260714-hook-enforcement/report.md.

- hook_selfcheck.py: settings-wiring + Bash-matcher assertions, PreToolUse
  end-to-end (deny + allow), `bash -n` syntax checks; `hook selfcheck` CLI.
- pr.py: hook-selfcheck added as an always-run core gate in the matrix.
- suites.toml: workflow.hook-selfcheck-wiring contract asserts the gate chain.
- tests: test_hook_selfcheck.py (+9); test_pr.py asserts the unconditional gate.
- docs: mise-tasks-only.md enforcement layers, pr-workflow SKILL.md, count 466->475.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012YXey1ZVNGhxReBp8JzAzZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an automated self-check that validates hook configuration, exercises allowed and denied commands, and reports clear pass/fail results.
  - Added the self-check as a required step in the standard ship and land validation flow.

- **Documentation**
  - Updated workflow guidance to describe the expanded enforcement checks and current test-suite size.

- **Tests**
  - Added coverage for hook wiring, command decisions, configuration failures, and unconditional release-gate execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->