### PR TITLE
feat(scanner): add command-audit — mine transcripts for one-off Bash culprits

### DIFF
--- a/.claude/rules/mise-tasks-only.md
+++ b/.claude/rules/mise-tasks-only.md
@@ -45,8 +45,18 @@ single-test `pytest path::test` via uv) are NOT wrapped and stay direct.
 3. **This rule + skills** — `pr-workflow` and `devcontainer-sync` skills
    name the canonical tasks; markdown alone is "relying on the LLM", so
    it is never the only layer.
-4. **Contracts** — `workflow.mise-tasks-enforcement` (the deny guard) and
-   `workflow.hook-selfcheck-wiring` (the selfcheck gate) in suites.toml
+4. **Self-learning loop (`mise run command-audit`)** —
+   `python/src/dotfiles_setup/command_audit.py` scans this project's recent
+   Claude Code transcript JSONL (native capture — no logging hook) and flags
+   mutating one-off Bash commands the guard does NOT yet cover, so the layers
+   above get refined over time. It is the *inverse* of Claude Code's
+   `fewer-permission-prompts` skill (same transcript mine + command+subcommand
+   grouping, opposite verdict). Review the report, then add a `mise run` task
+   (+ a `hook_guard._RULES` redirect for a known-bad shape) for the top
+   culprits. Ongoing, not one-shot.
+5. **Contracts** — `workflow.mise-tasks-enforcement` (the deny guard),
+   `workflow.hook-selfcheck-wiring` (the selfcheck gate), and
+   `workflow.command-audit-wiring` (the self-learning loop) in suites.toml
    assert the whole chain exists (settings.json → wrapper → CLI → module →
    tests), so nothing silently drifts out.
 
@@ -62,9 +72,10 @@ belong in settings.json permission deny rules, not the hook.
 > and the LLM-behavior evidence ranks a hard gate (zero decay) far above
 > per-turn reminders (which decay, cost instruction budget, and sit in the
 > lowest-trust context tier). See
-> `.omc/research/research-20260714-hook-enforcement/report.md`. A separate
-> self-learning loop (telemetry review + a scanner that flags one-off-command
-> culprits to refine these layers) is the improvement path — not more hooks.
+> `.omc/research/research-20260714-hook-enforcement/report.md`. The improvement
+> path is the self-learning loop (`mise run command-audit`, layer 4 above) that
+> mines native transcripts for one-off-command culprits to refine these layers
+> — not more per-turn hooks.
 
 ## Known limitation: prose content in compound commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ the official `@devcontainers/cli` (pinned in `mise.toml`).
 | `.claude/` | Claude-specific agents, skills, rules. Has its own `CLAUDE.md` with OMC orchestration |
 | `home/` | Chezmoi-managed dotfile templates (its AGENTS.md was removed in #80) |
 | `python/` | Python package `dotfiles_setup` — see `python/AGENTS.md` |
-| `tests/` | Pytest + Bats test suite (475 pytest tests) — see `tests/AGENTS.md` |
+| `tests/` | Pytest + Bats test suite (505 pytest tests) — see `tests/AGENTS.md` |
 | `scripts/` | Utility scripts (`benchmark-docker.sh`, `devcontainer-smoke.sh`) |
 | `docs/` | Documentation, research findings, design specs |
 
@@ -86,7 +86,7 @@ content-hashed since hk 1.47 — no manual cache clearing after edits.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q               # All 475 tests
+uv run --project python pytest tests/ -x -q               # All 505 tests
 uv run --project python pytest tests/test_audit.py -x -q  # Single file
 mise run lint                                             # Lint checks only (hk under a hard timeout)
 dotfiles-setup verify run                                 # Verification contracts (suites.toml)

--- a/mise.toml
+++ b/mise.toml
@@ -413,6 +413,16 @@ description = "Markdown report of tools with upstream movement + release-notes l
 # tool-currency-check skill's release-note review.
 run = 'uv run --project python dotfiles-setup tool-currency'
 
+[tasks.command-audit]
+description = "Scan recent Claude Code transcripts for one-off Bash culprits to package as mise tasks"
+# Thin caller (zero-bash-logic); logic in
+# python/src/dotfiles_setup/command_audit.py. The self-learning half of the
+# mise-tasks-only loop: mines native transcript JSONL (no capture hook), flags
+# mutating hand-run commands the PreToolUse guard does not yet cover. Review
+# the report to refine rules/hooks/docs. Pass flags through: mise run
+# command-audit -- --limit 20
+run = 'uv run --project python dotfiles-setup command-audit'
+
 [tasks.renovate-status]
 description = "Report Mend-hosted Renovate install + privileges + open update PRs"
 # Thin caller (zero-bash-logic); logic in

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -39,7 +39,7 @@ Requires **Python 3.14**.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q                # All 475 tests
+uv run --project python pytest tests/ -x -q                # All 505 tests
 uv run --project python pytest tests/test_audit.py -x -q   # Single file
 ```
 

--- a/python/src/dotfiles_setup/command_audit.py
+++ b/python/src/dotfiles_setup/command_audit.py
@@ -1,0 +1,423 @@
+"""Command-audit scanner: mine Claude Code transcripts for one-off Bash culprits.
+
+The self-learning half of the mise-tasks-only enforcement loop. The PreToolUse
+guard (:mod:`dotfiles_setup.hook_guard`) DENIES a fixed set of one-off command
+shapes; this scanner finds the shapes it does NOT yet cover — mutating,
+hand-run commands that should become mise tasks — so the rules/hooks/docs can
+be refined over time. It is the *inverse* of Claude Code's official
+``fewer-permission-prompts`` skill (which mines the same transcripts to
+allow-list read-only commands); same input + grouping, opposite verdict.
+
+Capture is 100% native — no logging hook, no OTel collector. Every Bash call is
+already recorded verbatim in the session transcript JSONL
+(``$CLAUDE_CONFIG_DIR/projects/<encoded-cwd>/<session>.jsonl``, default
+``~/.claude``): an ``type:"assistant"`` line whose ``message.content`` holds a
+``{type:"tool_use", name:"Bash", input:{command:"…"}}`` block. That schema is
+community-reverse-engineered, not an officially versioned contract, so every
+field access here is defensive (a malformed line is skipped, never fatal).
+
+Classification (first match wins):
+
+- ``denied`` — :func:`hook_guard.decide` returns a reason. A KNOWN one-off that
+  still ran ⇒ the guard was bypassed or the command predates the rule. Highest
+  signal.
+- ``mise`` — already goes through a mise task / the ``dotfiles_setup`` CLI /
+  canonical pytest. Good; no action.
+- ``diagnostic`` — a read-only/allowlisted shape (ls, cat, git status, docker
+  ps, …) that legitimately stays direct.
+- ``one_off`` — everything else: a mutating hand-run command with no mise task.
+  The refine-loop candidates. Over-inclusion is fine — a human reviews.
+
+``dotfiles-setup command-audit`` (→ ``mise run command-audit``) renders a
+frequency-ranked markdown report grouped by command+subcommand.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from dotfiles_setup import hook_guard
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+# Most-recent sessions to scan by default (mirrors fewer-permission-prompts' cap).
+DEFAULT_SESSION_LIMIT = 50
+
+# A command already routed through a mise task / the dotfiles_setup CLI / the
+# canonical pytest form (the mise tasks themselves wrap these — stay direct).
+_MISE_BACKED = re.compile(
+    r"^\s*(?:env\s+)?(?:\w+=\S*\s+)*"
+    r"(?:mise\s|uv\s+run\s+--project\s+python\s+(?:dotfiles-setup|pytest)\b)"
+)
+
+# Read-only command heads that legitimately stay direct (mise-tasks-only.md:
+# "diagnostic/read-only commands are NOT wrapped"). Bare heads are read-only.
+_DIAGNOSTIC_HEADS = frozenset(
+    {
+        "ls",
+        "cat",
+        "bat",
+        "echo",
+        "printf",
+        "pwd",
+        "cd",
+        "head",
+        "tail",
+        "wc",
+        "grep",
+        "rg",
+        "fd",
+        "find",
+        "which",
+        "type",
+        "file",
+        "stat",
+        "tree",
+        "jq",
+        "yq",
+        "sort",
+        "uniq",
+        "cut",
+        "awk",
+        "sed",
+        "diff",
+        "test",
+        "true",
+        "env",
+        "date",
+        "whoami",
+        "uname",
+        "hostname",
+        "df",
+        "du",
+        "ps",
+        "top",
+        "read",
+        "column",
+        "tr",
+        "basename",
+        "dirname",
+        "realpath",
+        "readlink",
+    }
+)
+
+# Sub-command allowlists for multi-verb tools: only these are read-only.
+_READ_SUBCOMMANDS: dict[str, frozenset[str]] = {
+    "git": frozenset(
+        {
+            "status",
+            "log",
+            "diff",
+            "show",
+            "branch",
+            "rev-parse",
+            "ls-files",
+            "blame",
+            "describe",
+            "remote",
+            "config",
+            "tag",
+            "shortlog",
+            "reflog",
+            "cat-file",
+            "grep",
+            "for-each-ref",
+            "merge-base",
+            "rev-list",
+            "name-rev",
+        }
+    ),
+    "docker": frozenset(
+        {
+            "ps",
+            "images",
+            "logs",
+            "inspect",
+            "info",
+            "version",
+            "context",
+            "history",
+            "image",
+            "system",
+            "top",
+            "port",
+            "stats",
+            "manifest",
+        }
+    ),
+    "gh": frozenset({"pr", "run", "issue", "api", "repo", "release", "workflow"}),
+    "mise": frozenset({}),  # handled by _MISE_BACKED, never reaches here
+    "uv": frozenset({}),
+    "kubectl": frozenset({"get", "describe", "logs", "top", "version"}),
+    "cargo": frozenset({"tree", "metadata"}),
+}
+
+# `gh <x> …` is read-only only for these value shapes (view/checks/list/--json).
+_GH_READ_MARKERS = re.compile(r"\b(view|checks|list|status|--json)\b")
+
+
+@dataclass(frozen=True)
+class BashCommand:
+    """One Bash invocation recovered from a transcript."""
+
+    command: str
+    session: str
+    timestamp: str
+
+
+def transcripts_base(
+    env: dict[str, str] | None = None, home: Path | None = None
+) -> Path:
+    """The Claude Code projects dir (env-aware; never hardcoded)."""
+    env = env if env is not None else dict(os.environ)
+    home = home if home is not None else Path.home()
+    config_dir = env.get("CLAUDE_CONFIG_DIR")
+    base = Path(config_dir) if config_dir else home / ".claude"
+    return base / "projects"
+
+
+def encode_cwd(cwd: Path) -> str:
+    """Claude Code's project-dir encoding of an absolute path (``/``,``.`` → ``-``)."""
+    return re.sub(r"[/.]", "-", str(cwd))
+
+
+def project_transcripts(base: Path, cwd: Path, *, limit: int) -> list[Path]:
+    """The ``limit`` most-recent transcript files for ``cwd`` (newest first)."""
+    project_dir = base / encode_cwd(cwd)
+    if not project_dir.is_dir():
+        return []
+    files = [p for p in project_dir.glob("*.jsonl") if p.is_file()]
+    files.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return files[:limit]
+
+
+def _bash_blocks(content: object) -> Iterator[str]:
+    """Yield Bash ``input.command`` strings from an assistant line's content."""
+    if not isinstance(content, list):
+        return
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "tool_use" and block.get("name") == "Bash":
+            command = block.get("input", {})
+            if isinstance(command, dict):
+                cmd = command.get("command")
+                if isinstance(cmd, str) and cmd.strip():
+                    yield cmd
+
+
+def iter_bash_commands(paths: Iterable[Path]) -> Iterator[BashCommand]:
+    """Every Bash command across the transcripts, parsed defensively."""
+    for path in paths:
+        try:
+            lines = path.read_text(errors="replace").splitlines()
+        except OSError:
+            continue
+        for line in lines:
+            if not line.strip():
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(obj, dict) or obj.get("type") != "assistant":
+                continue
+            message = obj.get("message")
+            content = message.get("content") if isinstance(message, dict) else None
+            session = str(obj.get("sessionId", ""))
+            timestamp = str(obj.get("timestamp", ""))
+            for cmd in _bash_blocks(content):
+                yield BashCommand(cmd, session=session, timestamp=timestamp)
+
+
+# A leading `cd <path> &&|;|newline` prefix hides the operative command from
+# first-token classification/grouping (the same chained-command shape the
+# research flagged as guard-evasion). Strip it (repeatedly) so `cd repo &&
+# git commit` classifies as `git commit`, not as a `cd` diagnostic.
+_CD_PREFIX = re.compile(r"^\s*cd\s+\S+\s*(?:&&|;|\n)\s*")
+
+
+def _operative(command: str) -> str:
+    """The command with any leading ``cd <path> &&|;`` prefix(es) stripped."""
+    prev = None
+    cur = command
+    while cur != prev:
+        prev = cur
+        cur = _CD_PREFIX.sub("", cur, count=1)
+    return cur or command
+
+
+def is_mise_backed(command: str) -> bool:
+    """True when ``command`` already runs via mise / the dotfiles_setup CLI."""
+    return bool(_MISE_BACKED.match(_operative(command)))
+
+
+def _head_and_sub(command: str) -> tuple[str, str]:
+    """The command head and its first sub-token, past ``cd`` + ``env VAR=x``."""
+    tokens = _operative(command).split()
+    i = 0
+    while i < len(tokens) and (tokens[i] == "env" or "=" in tokens[i]):
+        i += 1
+    head = tokens[i] if i < len(tokens) else ""
+    sub = tokens[i + 1] if i + 1 < len(tokens) else ""
+    return head, sub
+
+
+def is_diagnostic(command: str) -> bool:
+    """True for read-only/allowlisted shapes that legitimately stay direct."""
+    head, sub = _head_and_sub(command)
+    if head in _DIAGNOSTIC_HEADS:
+        return True
+    reads = _READ_SUBCOMMANDS.get(head)
+    if reads is None:
+        return False
+    if head == "gh":
+        # gh is read-only only in its view/checks/list/--json shapes.
+        return bool(_GH_READ_MARKERS.search(command))
+    return sub in reads
+
+
+def classify(command: str) -> str:
+    """One of ``denied`` / ``mise`` / ``diagnostic`` / ``one_off`` (first match)."""
+    if hook_guard.decide(command) is not None:
+        return "denied"
+    if is_mise_backed(command):
+        return "mise"
+    if is_diagnostic(command):
+        return "diagnostic"
+    return "one_off"
+
+
+def group_key(command: str) -> str:
+    """A normalized ``head sub`` grouping key (mirrors fewer-permission-prompts)."""
+    head, sub = _head_and_sub(command)
+    return f"{head} {sub}".strip() if head else "(empty)"
+
+
+@dataclass(frozen=True)
+class AuditResult:
+    """The classified + grouped outcome of a scan."""
+
+    counts: dict[str, int]
+    denied_groups: list[tuple[str, int, str]]
+    one_off_groups: list[tuple[str, int, str]]
+    sessions: int
+    total: int
+
+
+def audit(commands: Iterable[BashCommand], *, sessions: int) -> AuditResult:
+    """Classify + frequency-rank the commands into an :class:`AuditResult`."""
+    counts: Counter[str] = Counter()
+    group_counts: dict[str, Counter[str]] = {"denied": Counter(), "one_off": Counter()}
+    examples: dict[str, dict[str, str]] = {"denied": {}, "one_off": {}}
+    total = 0
+    for bc in commands:
+        total += 1
+        kind = classify(bc.command)
+        counts[kind] += 1
+        if kind in group_counts:
+            key = group_key(bc.command)
+            group_counts[kind][key] += 1
+            examples[kind].setdefault(key, bc.command)
+
+    def ranked(kind: str) -> list[tuple[str, int, str]]:
+        return [
+            (key, n, examples[kind][key]) for key, n in group_counts[kind].most_common()
+        ]
+
+    return AuditResult(
+        counts=dict(counts),
+        denied_groups=ranked("denied"),
+        one_off_groups=ranked("one_off"),
+        sessions=sessions,
+        total=total,
+    )
+
+
+def _truncate(text: str, width: int = 80) -> str:
+    text = text.replace("\n", " ").strip()
+    return text if len(text) <= width else text[: width - 1] + "…"
+
+
+def render_report(result: AuditResult) -> str:
+    """A frequency-ranked markdown report for human review of the refine loop."""
+    c = result.counts
+    n_one_off = c.get("one_off", 0)
+    n_denied = c.get("denied", 0)
+    n_mise = c.get("mise", 0)
+    n_diag = c.get("diagnostic", 0)
+    lines = [
+        "# Command audit — one-off Bash culprits",
+        "",
+        f"Scanned **{result.sessions}** recent session(s), "
+        f"**{result.total}** Bash command(s).",
+        "",
+        "| class | count | meaning |",
+        "|---|---:|---|",
+        f"| one_off | {n_one_off} | mutating hand-run — package as a mise task |",
+        f"| denied | {n_denied} | already-denied shape that ran (bypass / pre-rule) |",
+        f"| mise | {n_mise} | already via a mise task / dotfiles_setup CLI |",
+        f"| diagnostic | {n_diag} | read-only, legitimately direct |",
+        "",
+    ]
+    if result.denied_groups:
+        lines += [
+            "## ⚠️ Denied-but-ran (investigate — guard bypass or pre-rule history)",
+            "",
+            "| count | shape | example |",
+            "|---:|---|---|",
+            *(
+                f"| {n} | `{key}` | `{_truncate(ex)}` |"
+                for key, n, ex in result.denied_groups
+            ),
+            "",
+        ]
+    lines += [
+        "## One-off culprits (candidates for a mise task + python function)",
+        "",
+    ]
+    if result.one_off_groups:
+        lines += [
+            "| count | shape | example |",
+            "|---:|---|---|",
+            *(
+                f"| {n} | `{key}` | `{_truncate(ex)}` |"
+                for key, n, ex in result.one_off_groups
+            ),
+        ]
+    else:
+        lines.append("_None — no un-wrapped one-off commands found._")
+    lines += [
+        "",
+        "Refine loop: for a high-frequency one-off shape, add a `mise run <task>` "
+        "wrapping a `dotfiles_setup` function (zero-bash-logic), and if it's a "
+        "known bad shape, add a `hook_guard._RULES` redirect. See "
+        ".claude/rules/mise-tasks-only.md.",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def command_audit_main(
+    project_root: Path, *, limit: int = DEFAULT_SESSION_LIMIT
+) -> int:
+    """Scan this project's recent transcripts; print the markdown report."""
+    base = transcripts_base()
+    transcripts = project_transcripts(base, project_root, limit=limit)
+    if not transcripts:
+        sys.stdout.write(
+            f"command-audit: no transcripts for {project_root} under {base} "
+            "(set CLAUDE_CONFIG_DIR if your Claude config lives elsewhere)\n"
+        )
+        return 0
+    result = audit(iter_bash_commands(transcripts), sessions=len(transcripts))
+    sys.stdout.write(render_report(result))
+    return 0

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -16,6 +16,7 @@ from dotfiles_setup.audit import DevEnvironmentAuditor, ToolManager
 from dotfiles_setup.autofix import autofix_apply_main
 from dotfiles_setup.bash_budget import bash_budget_main
 from dotfiles_setup.bootstrap_packages import gap_report_failures
+from dotfiles_setup.command_audit import DEFAULT_SESSION_LIMIT, command_audit_main
 from dotfiles_setup.config import DotfilesConfig
 from dotfiles_setup.container import verify_latest_main
 from dotfiles_setup.doc_refs import find_unresolved_refs
@@ -522,6 +523,18 @@ def setup_parser() -> argparse.ArgumentParser:
         "links (daily refresh.yml signal; feeds the tool-currency-check skill)",
     )
 
+    command_audit_parser = subparsers.add_parser(
+        "command-audit",
+        help="Scan recent Claude Code transcripts for one-off Bash commands "
+        "that should be mise tasks (self-learning mise-tasks-only loop)",
+    )
+    command_audit_parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_SESSION_LIMIT,
+        help=f"Most-recent sessions to scan (default {DEFAULT_SESSION_LIMIT})",
+    )
+
     # renovate-status command
     renovate_parser = subparsers.add_parser(
         "renovate-status",
@@ -871,6 +884,9 @@ def _build_command_handlers(
         "docker": lambda: handle_docker(args, project_root, config=config),
         "pr": lambda: handle_pr(args, project_root),
         "tool-currency": lambda: sys.exit(tool_currency_main()),
+        "command-audit": lambda: sys.exit(
+            command_audit_main(project_root, limit=args.limit)
+        ),
         "renovate-status": lambda: sys.exit(
             renovate_status_main(json_output=args.json)
         ),

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -1034,3 +1034,24 @@ tokens = [
     "mise run tool-currency",
     "Tool currency report (daily)",
 ]
+
+[[suite]]
+name = "workflow.command-audit-wiring"
+description = "Command-audit self-learning loop wiring: `mise run command-audit` must stay a thin caller of the python library (`dotfiles-setup command-audit`, zero-bash-logic), the command_audit module (transcript scan + classifier) + its tests must exist, and the rule doc must name the loop. The scanner is the inverse of fewer-permission-prompts — it flags one-off Bash commands the PreToolUse guard does not yet cover, so the enforcement layers can be refined over time. Asserts the chain so the loop can't silently drift out."
+category = "workflow"
+check_type = "static"
+handler = "require_tokens"
+paths_required = true
+paths = [
+    "mise.toml",
+    "python/src/dotfiles_setup/command_audit.py",
+    "python/src/dotfiles_setup/main.py",
+    "tests/test_command_audit.py",
+    ".claude/rules/mise-tasks-only.md",
+]
+per_path_tokens = { "mise.toml" = ["[tasks.command-audit]", "dotfiles-setup command-audit"], "python/src/dotfiles_setup/command_audit.py" = ["def command_audit_main", "def classify", "def iter_bash_commands"], "python/src/dotfiles_setup/main.py" = ["command-audit"], ".claude/rules/mise-tasks-only.md" = ["mise run command-audit"] }
+tokens = [
+    "dotfiles-setup command-audit",
+    "def command_audit_main",
+    "def classify",
+]

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -25,6 +25,7 @@ Docker image smoke outputs.
 | `test_pr.py` | pytest | `mise run ship`/`land` workflow (`dotfiles_setup.pr`) — surface detection, gate matrix, bucket verification, pinned merge |
 | `test_hook_guard.py` | pytest | PreToolUse mise-tasks-only guard (`dotfiles_setup.hook_guard`) — deny/redirect rules, false-positive guards, JSON contract |
 | `test_hook_selfcheck.py` | pytest | Host-side hook self-check (`dotfiles_setup.hook_selfcheck`, the ship/land `hook-selfcheck` gate) — settings.json wiring + Bash-matcher assertions, and an end-to-end real-repo pass driving the wired PreToolUse guard |
+| `test_command_audit.py` | pytest | Command-audit transcript scanner (`dotfiles_setup.command_audit`, the self-learning mise-tasks loop) — env-aware transcript discovery, defensive JSONL parse, one-off/denied/mise/diagnostic classifier (cd-prefix unwrap), grouping, report rendering |
 | `test_tool_currency.py` | pytest | Daily tool-currency signal (`dotfiles_setup.tool_currency`) — release-link backends, report rendering |
 | `test_renovate.py` | pytest | Renovate status signal (`dotfiles_setup.renovate`) — app-id/privilege check, report rendering |
 | `test_autofix.py` | pytest | autofix.ci artifact applier (`dotfiles_setup.autofix`) — additions, traversal/shape/deletion refusal |
@@ -34,7 +35,7 @@ Docker image smoke outputs.
 | `infra/foundation.bats` | Bats | Bash-level foundation checks (shell script integration) |
 | `infra/runtimes.bats` | Bats | Runtime installation checks (bash) |
 
-Total: **475 pytest tests** run by default (`pytest tests/` collects all
+Total: **505 pytest tests** run by default (`pytest tests/` collects all
 `test_*.py` files) plus **4 gated `image_exec`** exec tests (deselected by
 default; run via `mise run smoke-exec`) and Bats scenarios under `infra/`.
 

--- a/tests/test_command_audit.py
+++ b/tests/test_command_audit.py
@@ -1,0 +1,231 @@
+"""Tests for the command-audit transcript scanner (dotfiles_setup.command_audit).
+
+Covers transcript discovery (env-aware, never hardcoded), defensive JSONL
+parsing, the one-off/denied/mise/diagnostic classifier (incl. cd-prefix
+compound unwrapping), grouping, and report rendering.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
+
+import pytest
+from dotfiles_setup import command_audit as ca
+
+# --------------------------------------------------------- discovery / encoding
+
+
+def test_transcripts_base_uses_config_dir_env() -> None:
+    base = ca.transcripts_base({"CLAUDE_CONFIG_DIR": "/x/cfg"}, Path("/home/u"))
+    assert base == Path("/x/cfg/projects")
+
+
+def test_transcripts_base_defaults_to_home_claude() -> None:
+    base = ca.transcripts_base({}, Path("/home/u"))
+    assert base == Path("/home/u/.claude/projects")
+
+
+def test_encode_cwd_replaces_slashes_and_dots() -> None:
+    assert ca.encode_cwd(Path("/Users/x/dev/dot.files")) == "-Users-x-dev-dot-files"
+
+
+def test_project_transcripts_missing_dir_is_empty(tmp_path: Path) -> None:
+    assert ca.project_transcripts(tmp_path, Path("/no/such/cwd"), limit=5) == []
+
+
+def test_project_transcripts_limit_and_recency(tmp_path: Path) -> None:
+    cwd = Path("/repo")
+    proj = tmp_path / ca.encode_cwd(cwd)
+    proj.mkdir()
+    for i in range(4):
+        f = proj / f"s{i}.jsonl"
+        f.write_text("{}\n")
+    # Make s3 the newest, s0 the oldest via mtime.
+    for i in range(4):
+        ts = 1_000 + i * 10
+        os.utime(proj / f"s{i}.jsonl", (ts, ts))
+    got = ca.project_transcripts(tmp_path, cwd, limit=2)
+    assert [p.name for p in got] == ["s3.jsonl", "s2.jsonl"]
+
+
+# ------------------------------------------------------------ defensive parsing
+
+
+def _assistant_bash(cmd: str) -> str:
+    return json.dumps(
+        {
+            "type": "assistant",
+            "sessionId": "sess1",
+            "timestamp": "2026-07-14T00:00:00Z",
+            "message": {
+                "content": [
+                    {"type": "tool_use", "name": "Bash", "input": {"command": cmd}}
+                ]
+            },
+        }
+    )
+
+
+def test_iter_bash_commands_extracts_and_skips_defensively(tmp_path: Path) -> None:
+    f = tmp_path / "t.jsonl"
+    f.write_text(
+        "\n".join(
+            [
+                "not json at all",  # malformed -> skipped
+                json.dumps(
+                    {"type": "user", "message": {"content": "hi"}}
+                ),  # not assistant
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {"content": [{"type": "text", "text": "x"}]},
+                    }
+                ),  # not a Bash tool_use
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "content": [
+                                {"type": "tool_use", "name": "Read", "input": {}}
+                            ]
+                        },
+                    }
+                ),  # non-Bash tool
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "content": [
+                                {"type": "tool_use", "name": "Bash", "input": {}}
+                            ]
+                        },
+                    }
+                ),  # Bash but no command
+                _assistant_bash("ls -la"),  # the only real one
+                "",  # blank -> skipped
+            ]
+        )
+    )
+    cmds = list(ca.iter_bash_commands([f]))
+    assert [c.command for c in cmds] == ["ls -la"]
+    assert cmds[0].session == "sess1"
+
+
+def test_iter_bash_commands_unreadable_file_skipped(tmp_path: Path) -> None:
+    assert list(ca.iter_bash_commands([tmp_path / "does-not-exist.jsonl"])) == []
+
+
+# ------------------------------------------------------------- classification
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "mise run lint",
+        "uv run --project python dotfiles-setup verify run",
+        "uv run --project python pytest tests/",
+        "cd /repo && mise run ship",
+    ],
+)
+def test_is_mise_backed(command: str) -> None:
+    assert ca.is_mise_backed(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "ls -la",
+        "cat x",
+        "git status",
+        "git log --oneline",
+        "docker ps",
+        "gh pr view 1 --json state",
+        "cd /repo && cat x",
+        "grep foo bar",
+    ],
+)
+def test_diagnostic_reads(command: str) -> None:
+    assert ca.is_diagnostic(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git commit -m x",
+        "docker run --rm ubuntu",
+        "gh pr merge 1",
+        "chmod +x f",
+        "cd /repo && git commit -m y",
+        "docker exec c ls",
+    ],
+)
+def test_not_diagnostic_mutations(command: str) -> None:
+    assert not ca.is_diagnostic(command)
+
+
+def test_classify_precedence() -> None:
+    # denied (guard rule) wins even inside a cd compound
+    assert ca.classify("cd /repo && gh pr create --fill") == "denied"
+    assert ca.classify("mise run lint") == "mise"
+    assert ca.classify("git status") == "diagnostic"
+    assert ca.classify("git commit -m x") == "one_off"
+    assert ca.classify("docker run --rm ubuntu bash -c 'x'") == "one_off"
+
+
+def test_group_key_uses_operative_head_sub() -> None:
+    # group_key exercises _operative: single + repeated cd-prefix, bare cd, plain.
+    assert ca.group_key("cd /repo && docker exec c ls") == "docker exec"
+    assert ca.group_key("cd /a && cd /b && ls -la") == "ls -la"
+    assert ca.group_key("git commit -m 'x'") == "git commit"
+    assert ca.group_key("cd /repo") == "cd /repo"
+
+
+# -------------------------------------------------------------- audit + report
+
+
+def _cmds(*commands: str) -> list[ca.BashCommand]:
+    return [ca.BashCommand(c, session="s", timestamp="t") for c in commands]
+
+
+def test_audit_counts_and_ranks() -> None:
+    result = ca.audit(
+        _cmds(
+            "git commit -m a",
+            "git commit -m b",  # one_off, grouped
+            "docker run --rm x",  # one_off
+            "ls",  # diagnostic
+            "mise run lint",  # mise
+            "gh pr create",  # denied
+        ),
+        sessions=2,
+    )
+    assert result.total == 6
+    assert result.sessions == 2
+    assert result.counts["one_off"] == 3
+    assert result.counts["diagnostic"] == 1
+    assert result.counts["mise"] == 1
+    assert result.counts["denied"] == 1
+    # "git commit" is the top one-off group with count 2
+    assert result.one_off_groups[0][0] == "git commit"
+    assert result.one_off_groups[0][1] == 2
+
+
+def test_render_report_has_sections_and_counts() -> None:
+    result = ca.audit(_cmds("git commit -m x", "gh pr create"), sessions=1)
+    report = ca.render_report(result)
+    assert "# Command audit" in report
+    assert "One-off culprits" in report
+    assert "Denied-but-ran" in report
+    assert "`git commit`" in report
+    assert "mise-tasks-only.md" in report
+
+
+def test_render_report_no_one_offs() -> None:
+    result = ca.audit(_cmds("ls", "git status"), sessions=1)
+    report = ca.render_report(result)
+    assert "_None — no un-wrapped one-off commands found._" in report


### PR DESCRIPTION
`dotfiles-setup command-audit` (→ `mise run command-audit`) scans this project's
recent Claude Code transcript JSONL and flags mutating one-off Bash commands the
PreToolUse guard does not yet cover, so the rules/hooks/docs get refined over
time. It is the self-learning half of the mise-tasks-only loop — the inverse of
Claude Code's official `fewer-permission-prompts` skill: same transcript mine +
command+subcommand grouping, opposite verdict.

Research-backed (.omc/research/research-20260714-hook-enforcement): capture is
100% native — transcripts already record every Bash `input.command`, so the
scanner is the only custom part (the policy classifier), satisfying the
use-tool-builtins gate. Transcript location is env-discovered (CLAUDE_CONFIG_DIR
/ ~/.claude/projects), and the unofficial JSONL schema is parsed defensively (a
malformed line is skipped, never fatal).

Classification (first match wins): `denied` (reuses hook_guard.decide — a denied
shape that still ran ⇒ guard bypass / pre-rule history), `mise`, `diagnostic`
(read-only allowlist), `one_off` (mutating hand-run — the refine candidates). A
compound `cd <path> && <cmd>` is unwrapped to the operative command so it
classifies and groups correctly (the chained-command shape the research flagged).

- command_audit.py: discovery, defensive parse, classifier, grouping, markdown report.
- mise.toml [tasks.command-audit] + `command-audit` CLI subcommand (--limit).
- workflow.command-audit-wiring contract asserts the chain (task → CLI → module → tests → rule).
- tests/test_command_audit.py (+30 → 505); docs: mise-tasks-only.md layer 4 + count.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012YXey1ZVNGhxReBp8JzAzZ
