### PR TITLE
feat(hooks): run command-audit every session (SessionEnd) + pin the cd-prefix guard denials

### DIFF
--- a/.claude/rules/mise-tasks-only.md
+++ b/.claude/rules/mise-tasks-only.md
@@ -53,7 +53,15 @@ single-test `pytest path::test` via uv) are NOT wrapped and stay direct.
    `fewer-permission-prompts` skill (same transcript mine + command+subcommand
    grouping, opposite verdict). Review the report, then add a `mise run` task
    (+ a `hook_guard._RULES` redirect for a known-bad shape) for the top
-   culprits. Ongoing, not one-shot.
+   culprits. Ongoing, not one-shot — a **`SessionEnd` hook** in
+   `.claude/settings.json` runs it once per session (`-- --output
+   .omc/command-audit.md`), so the report is always waiting rather than
+   remember-to-run. `SessionEnd` and not `Stop`: it fires once per session at
+   termination and *cannot block*, while `Stop` fires every turn and can block
+   (exit 2 continues the turn) — a transcript scan belongs on neither the
+   per-turn path nor a blocking one. It is also **local-only by nature** (it
+   reads `~/.claude` transcripts), so it is a hook and never a GHA job — a CI
+   runner has no transcripts. The report stays out of git via `.gitignore`.
 5. **Contracts** — `workflow.mise-tasks-enforcement` (the deny guard),
    `workflow.hook-selfcheck-wiring` (the selfcheck gate), and
    `workflow.command-audit-wiring` (the self-learning loop) in suites.toml

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,6 +29,17 @@
           }
         ]
       }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "mise run command-audit -- --output .omc/command-audit.md",
+            "timeout": 120
+          }
+        ]
+      }
     ]
   },
   "enabledPlugins": {

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,11 @@ mise.*.local.toml
 # the tree and tripped `mise run ship`'s clean-tree gate (forcing stash dances).
 # Durable findings live in GH issues + `.omc/research/`, not here.
 .omc/notepad.md
+# Regenerated every session by the SessionEnd command-audit hook (settings.json)
+# and derived from LOCAL ~/.claude transcripts, so it is per-clone by nature —
+# same clean-tree rationale as the notepad above. `.omc/*` is only excluded via
+# this clone's .git/info/exclude, which a fresh clone does not get.
+.omc/command-audit.md
 .omx/
 
 # Codex CLI temporary state

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ the official `@devcontainers/cli` (pinned in `mise.toml`).
 | `.claude/` | Claude-specific agents, skills, rules. Has its own `CLAUDE.md` with OMC orchestration |
 | `home/` | Chezmoi-managed dotfile templates (its AGENTS.md was removed in #80) |
 | `python/` | Python package `dotfiles_setup` — see `python/AGENTS.md` |
-| `tests/` | Pytest + Bats test suite (505 pytest tests) — see `tests/AGENTS.md` |
+| `tests/` | Pytest + Bats test suite (522 pytest tests) — see `tests/AGENTS.md` |
 | `scripts/` | Utility scripts (`benchmark-docker.sh`, `devcontainer-smoke.sh`) |
 | `docs/` | Documentation, research findings, design specs |
 
@@ -86,7 +86,7 @@ content-hashed since hk 1.47 — no manual cache clearing after edits.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q               # All 505 tests
+uv run --project python pytest tests/ -x -q               # All 522 tests
 uv run --project python pytest tests/test_audit.py -x -q  # Single file
 mise run lint                                             # Lint checks only (hk under a hard timeout)
 dotfiles-setup verify run                                 # Verification contracts (suites.toml)

--- a/mise.toml
+++ b/mise.toml
@@ -421,6 +421,8 @@ description = "Scan recent Claude Code transcripts for one-off Bash culprits to 
 # mutating hand-run commands the PreToolUse guard does not yet cover. Review
 # the report to refine rules/hooks/docs. Pass flags through: mise run
 # command-audit -- --limit 20
+# Also run automatically by the SessionEnd hook in .claude/settings.json
+# (`-- --output .omc/command-audit.md`) — run it by hand for an ad-hoc report.
 run = 'uv run --project python dotfiles-setup command-audit'
 
 [tasks.renovate-status]

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -39,7 +39,7 @@ Requires **Python 3.14**.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q                # All 505 tests
+uv run --project python pytest tests/ -x -q                # All 522 tests
 uv run --project python pytest tests/test_audit.py -x -q   # Single file
 ```
 

--- a/python/src/dotfiles_setup/command_audit.py
+++ b/python/src/dotfiles_setup/command_audit.py
@@ -30,6 +30,15 @@ Classification (first match wins):
 
 ``dotfiles-setup command-audit`` (→ ``mise run command-audit``) renders a
 frequency-ranked markdown report grouped by command+subcommand.
+
+The loop is RECURRING, not remember-to-run: a ``SessionEnd`` hook in
+``.claude/settings.json`` refreshes ``.omc/command-audit.md`` via ``--output``
+once per session. SessionEnd (not ``Stop``) is the right event — it fires once
+per session at termination and *cannot block*, whereas ``Stop`` fires every
+turn and can block (exit 2 continues the conversation), which would put a
+transcript scan on the per-turn path and risk a stop-loop. The scan is local by
+nature (it reads ``~/.claude`` transcripts), so this is a local hook and never
+a CI job — a GHA runner has no transcripts to read.
 """
 
 from __future__ import annotations
@@ -406,10 +415,34 @@ def render_report(result: AuditResult) -> str:
     return "\n".join(lines) + "\n"
 
 
+def write_report(text: str, project_root: Path, output: Path) -> Path:
+    """Write ``text`` to ``output`` (relative paths resolve against the repo).
+
+    Python owns the path resolution + parent creation so the SessionEnd hook
+    stays a pure invocation with no shell redirect (zero-bash-logic), and so
+    the destination does not depend on the hook's cwd.
+    """
+    dest = output if output.is_absolute() else project_root / output
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(text)
+    return dest
+
+
 def command_audit_main(
-    project_root: Path, *, limit: int = DEFAULT_SESSION_LIMIT
+    project_root: Path,
+    *,
+    limit: int = DEFAULT_SESSION_LIMIT,
+    output: Path | None = None,
 ) -> int:
-    """Scan this project's recent transcripts; print the markdown report."""
+    """Scan this project's recent transcripts; report to stdout or ``output``.
+
+    ``--output`` is what the SessionEnd hook (``.claude/settings.json``) uses to
+    refresh ``.omc/command-audit.md`` once per session, making the refine loop
+    recurring instead of remember-to-run. The no-transcripts branch deliberately
+    leaves any existing report untouched rather than clobbering it with a
+    notice — and it cannot fire from the hook anyway, since a SessionEnd
+    implies this project has a transcript.
+    """
     base = transcripts_base()
     transcripts = project_transcripts(base, project_root, limit=limit)
     if not transcripts:
@@ -419,5 +452,14 @@ def command_audit_main(
         )
         return 0
     result = audit(iter_bash_commands(transcripts), sessions=len(transcripts))
-    sys.stdout.write(render_report(result))
+    text = render_report(result)
+    if output is None:
+        sys.stdout.write(text)
+        return 0
+    dest = write_report(text, project_root, output)
+    sys.stdout.write(
+        f"command-audit: wrote {dest} "
+        f"({result.counts.get('one_off', 0)} one-off, "
+        f"{result.counts.get('denied', 0)} denied-but-ran)\n"
+    )
     return 0

--- a/python/src/dotfiles_setup/hook_guard.py
+++ b/python/src/dotfiles_setup/hook_guard.py
@@ -143,6 +143,18 @@ _RULES: tuple[tuple[re.Pattern[str], str], ...] = (
 # meant to redirect. A rule here would deny the documented command.
 # Bare-pytest guidance stays doc-level (python/AGENTS.md, mise-tasks-only).
 
+# NO `cd`-prefix unwrap, deliberately (probe-observed 2026-07-14): the
+# "chained-command evasion" the enforcement research predicted for
+# `cd /x && gh pr create` does not exist here. Every `cd` prefix ends in
+# `&&`/`;`/newline BY CONSTRUCTION, `_CMD`'s `[;&|\n]` class re-anchors on
+# that separator, and `re.search` retries at every offset — so the rule
+# already matches the operative command. Mirroring `command_audit._operative`
+# into `decide()` would be dead code: that module needs the unwrap because it
+# reads token[0] after `.split()` (a genuinely positional read); a regex
+# search is not positional. tests/test_hook_guard.py pins the cd-prefixed
+# denials so a future narrowing of `_CMD` fails loudly rather than silently
+# opening the bypass.
+
 
 def decide(command: str) -> str | None:
     """Redirect reason when ``command`` should be denied, else None."""

--- a/python/src/dotfiles_setup/hook_selfcheck.py
+++ b/python/src/dotfiles_setup/hook_selfcheck.py
@@ -6,8 +6,9 @@ never drives the actual path the harness uses: ``.claude/settings.json`` ->
 hook pretooluse``. This module closes that gap. It:
 
 - asserts ``.claude/settings.json`` wires the project hooks
-  (:data:`_SETTINGS_WIRING`): the PreToolUse deny guard (scoped to ``Bash``) and
-  the SessionStart web-setup bootstrap;
+  (:data:`_SETTINGS_WIRING`): the PreToolUse deny guard (scoped to ``Bash``),
+  the SessionStart web-setup bootstrap, and the SessionEnd command-audit
+  refresh;
 - drives the REAL PreToolUse wrapper end-to-end — a denied command must DENY,
   an allowed one must stay silent;
 - ``bash -n`` syntax-checks the wired hook scripts (a parse error in
@@ -53,9 +54,17 @@ _HOOK_SCRIPTS = (_PRETOOLUSE_WRAPPER, _WEB_SETUP)
 # wired command(s), required matcher or None). Keeps the project hooks from
 # silently drifting out of .claude/settings.json (the wiring the end-to-end
 # check then exercises). PreToolUse must stay scoped to Bash.
+#
+# SessionEnd runs the command-audit refine loop once per session (the recurring
+# half of mise-tasks-only enforcement). A matcher would SCOPE it to particular
+# end reasons (clear/logout/resume/...) — it must fire on all of them, hence
+# None. Deliberately NOT a `Stop` hook: Stop fires every turn and can block,
+# which would put a transcript scan on the per-turn path.
+_SESSION_END_REPORT = ".omc/command-audit.md"
 _SETTINGS_WIRING: tuple[tuple[str, tuple[str, ...], str | None], ...] = (
     ("PreToolUse", (_PRETOOLUSE_WRAPPER,), "Bash"),
     ("SessionStart", (_WEB_SETUP, "CLAUDE_CODE_REMOTE"), None),
+    ("SessionEnd", ("mise run command-audit", _SESSION_END_REPORT), None),
 )
 
 

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -534,6 +534,14 @@ def setup_parser() -> argparse.ArgumentParser:
         default=DEFAULT_SESSION_LIMIT,
         help=f"Most-recent sessions to scan (default {DEFAULT_SESSION_LIMIT})",
     )
+    command_audit_parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Write the report here instead of stdout (relative paths resolve "
+        "against the repo root). Used by the SessionEnd hook to refresh "
+        ".omc/command-audit.md once per session",
+    )
 
     # renovate-status command
     renovate_parser = subparsers.add_parser(
@@ -885,7 +893,7 @@ def _build_command_handlers(
         "pr": lambda: handle_pr(args, project_root),
         "tool-currency": lambda: sys.exit(tool_currency_main()),
         "command-audit": lambda: sys.exit(
-            command_audit_main(project_root, limit=args.limit)
+            command_audit_main(project_root, limit=args.limit, output=args.output)
         ),
         "renovate-status": lambda: sys.exit(
             renovate_status_main(json_output=args.json)

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -1037,7 +1037,7 @@ tokens = [
 
 [[suite]]
 name = "workflow.command-audit-wiring"
-description = "Command-audit self-learning loop wiring: `mise run command-audit` must stay a thin caller of the python library (`dotfiles-setup command-audit`, zero-bash-logic), the command_audit module (transcript scan + classifier) + its tests must exist, and the rule doc must name the loop. The scanner is the inverse of fewer-permission-prompts — it flags one-off Bash commands the PreToolUse guard does not yet cover, so the enforcement layers can be refined over time. Asserts the chain so the loop can't silently drift out."
+description = "Command-audit self-learning loop wiring: `mise run command-audit` must stay a thin caller of the python library (`dotfiles-setup command-audit`, zero-bash-logic), the command_audit module (transcript scan + classifier) + its tests must exist, and the rule doc must name the loop. The scanner is the inverse of fewer-permission-prompts — it flags one-off Bash commands the PreToolUse guard does not yet cover, so the enforcement layers can be refined over time. The loop is RECURRING: a SessionEnd hook in .claude/settings.json refreshes .omc/command-audit.md via --output once per session (SessionEnd fires once per session and cannot block — unlike Stop, which fires per-turn and can block), hook_selfcheck asserts that wiring, and .gitignore keeps the report local. Asserts the chain so the loop can't silently drift out."
 category = "workflow"
 check_type = "static"
 handler = "require_tokens"
@@ -1046,10 +1046,13 @@ paths = [
     "mise.toml",
     "python/src/dotfiles_setup/command_audit.py",
     "python/src/dotfiles_setup/main.py",
+    "python/src/dotfiles_setup/hook_selfcheck.py",
+    ".claude/settings.json",
+    ".gitignore",
     "tests/test_command_audit.py",
     ".claude/rules/mise-tasks-only.md",
 ]
-per_path_tokens = { "mise.toml" = ["[tasks.command-audit]", "dotfiles-setup command-audit"], "python/src/dotfiles_setup/command_audit.py" = ["def command_audit_main", "def classify", "def iter_bash_commands"], "python/src/dotfiles_setup/main.py" = ["command-audit"], ".claude/rules/mise-tasks-only.md" = ["mise run command-audit"] }
+per_path_tokens = { "mise.toml" = ["[tasks.command-audit]", "dotfiles-setup command-audit"], "python/src/dotfiles_setup/command_audit.py" = ["def command_audit_main", "def classify", "def iter_bash_commands", "def write_report"], "python/src/dotfiles_setup/main.py" = ["command-audit", "--output"], "python/src/dotfiles_setup/hook_selfcheck.py" = ["SessionEnd", "_SESSION_END_REPORT"], ".claude/settings.json" = ["SessionEnd", "mise run command-audit -- --output .omc/command-audit.md"], ".gitignore" = [".omc/command-audit.md"], "tests/test_command_audit.py" = ["def test_main_output_writes_file_instead_of_stdout"], ".claude/rules/mise-tasks-only.md" = ["mise run command-audit", "SessionEnd"] }
 tokens = [
     "dotfiles-setup command-audit",
     "def command_audit_main",

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -23,9 +23,9 @@ Docker image smoke outputs.
 | `test_container.py` | pytest | `verify-container-latest` gate (`dotfiles_setup.container`) — running/bind-mount/smoke freshness checks |
 | `test_sync.py` | pytest | `mise run sync` workflow (`dotfiles_setup.sync`) — staleness detection, action matrix, CI awareness, check/full/wait modes |
 | `test_pr.py` | pytest | `mise run ship`/`land` workflow (`dotfiles_setup.pr`) — surface detection, gate matrix, bucket verification, pinned merge |
-| `test_hook_guard.py` | pytest | PreToolUse mise-tasks-only guard (`dotfiles_setup.hook_guard`) — deny/redirect rules, false-positive guards, JSON contract |
-| `test_hook_selfcheck.py` | pytest | Host-side hook self-check (`dotfiles_setup.hook_selfcheck`, the ship/land `hook-selfcheck` gate) — settings.json wiring + Bash-matcher assertions, and an end-to-end real-repo pass driving the wired PreToolUse guard |
-| `test_command_audit.py` | pytest | Command-audit transcript scanner (`dotfiles_setup.command_audit`, the self-learning mise-tasks loop) — env-aware transcript discovery, defensive JSONL parse, one-off/denied/mise/diagnostic classifier (cd-prefix unwrap), grouping, report rendering |
+| `test_hook_guard.py` | pytest | PreToolUse mise-tasks-only guard (`dotfiles_setup.hook_guard`) — deny/redirect rules, false-positive guards, JSON contract, and the cd-prefixed compound denials (pinned: they pass with NO cd-unwrap in `decide()`, since `_CMD` re-anchors on the `&&`/`;`/newline every prefix ends in — probe 2026-07-14 refuting the predicted "chained-command evasion") |
+| `test_hook_selfcheck.py` | pytest | Host-side hook self-check (`dotfiles_setup.hook_selfcheck`, the ship/land `hook-selfcheck` gate) — settings.json wiring + Bash-matcher assertions incl. the SessionEnd command-audit hook, and an end-to-end real-repo pass driving the wired PreToolUse guard |
+| `test_command_audit.py` | pytest | Command-audit transcript scanner (`dotfiles_setup.command_audit`, the self-learning mise-tasks loop) — env-aware transcript discovery, defensive JSONL parse, one-off/denied/mise/diagnostic classifier (cd-prefix unwrap), grouping, report rendering, and the `--output` path the SessionEnd hook uses (repo-anchored resolve, no-clobber on a transcript miss, real-CLI flag pin) |
 | `test_tool_currency.py` | pytest | Daily tool-currency signal (`dotfiles_setup.tool_currency`) — release-link backends, report rendering |
 | `test_renovate.py` | pytest | Renovate status signal (`dotfiles_setup.renovate`) — app-id/privilege check, report rendering |
 | `test_autofix.py` | pytest | autofix.ci artifact applier (`dotfiles_setup.autofix`) — additions, traversal/shape/deletion refusal |
@@ -35,7 +35,7 @@ Docker image smoke outputs.
 | `infra/foundation.bats` | Bats | Bash-level foundation checks (shell script integration) |
 | `infra/runtimes.bats` | Bats | Runtime installation checks (bash) |
 
-Total: **505 pytest tests** run by default (`pytest tests/` collects all
+Total: **522 pytest tests** run by default (`pytest tests/` collects all
 `test_*.py` files) plus **4 gated `image_exec`** exec tests (deselected by
 default; run via `mise run smoke-exec`) and Bats scenarios under `infra/`.
 

--- a/tests/test_command_audit.py
+++ b/tests/test_command_audit.py
@@ -2,13 +2,15 @@
 
 Covers transcript discovery (env-aware, never hardcoded), defensive JSONL
 parsing, the one-off/denied/mise/diagnostic classifier (incl. cd-prefix
-compound unwrapping), grouping, and report rendering.
+compound unwrapping), grouping, report rendering, and the ``--output`` path the
+SessionEnd hook uses to refresh the report once per session.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -229,3 +231,98 @@ def test_render_report_no_one_offs() -> None:
     result = ca.audit(_cmds("ls", "git status"), sessions=1)
     report = ca.render_report(result)
     assert "_None — no un-wrapped one-off commands found._" in report
+
+
+# ------------------------------------------- --output (the SessionEnd hook path)
+
+
+def _seed_transcript(tmp_path: Path, project: Path, *commands: str) -> Path:
+    """A CLAUDE_CONFIG_DIR holding one transcript for ``project``."""
+    cfg = tmp_path / "cfg"
+    proj = cfg / "projects" / ca.encode_cwd(project)
+    proj.mkdir(parents=True)
+    (proj / "s.jsonl").write_text("\n".join(_assistant_bash(c) for c in commands))
+    return cfg
+
+
+def test_write_report_resolves_relative_to_project_root(tmp_path: Path) -> None:
+    """Relative output is repo-anchored (the hook must not depend on cwd)."""
+    dest = ca.write_report("body", tmp_path, Path(".omc/command-audit.md"))
+    assert dest == tmp_path / ".omc" / "command-audit.md"
+    assert dest.read_text() == "body"  # parent created on demand
+
+
+def test_write_report_honors_absolute_path(tmp_path: Path) -> None:
+    target = tmp_path / "out" / "r.md"
+    assert ca.write_report("body", tmp_path / "unused", target) == target
+    assert target.read_text() == "body"
+
+
+def test_main_output_writes_file_instead_of_stdout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    project = tmp_path / "repo"
+    project.mkdir()
+    monkeypatch.setenv(
+        "CLAUDE_CONFIG_DIR",
+        str(_seed_transcript(tmp_path, project, "git commit -m x", "ls")),
+    )
+    assert ca.command_audit_main(project, output=Path(".omc/command-audit.md")) == 0
+    report = (project / ".omc" / "command-audit.md").read_text()
+    assert "# Command audit" in report
+    assert "`git commit`" in report
+    out = capsys.readouterr().out
+    assert "wrote" in out
+    assert "# Command audit" not in out  # the body went to the file, not stdout
+
+
+def test_main_without_output_prints_report(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    project = tmp_path / "repo"
+    project.mkdir()
+    monkeypatch.setenv(
+        "CLAUDE_CONFIG_DIR", str(_seed_transcript(tmp_path, project, "git commit -m x"))
+    )
+    assert ca.command_audit_main(project) == 0
+    assert "# Command audit" in capsys.readouterr().out
+
+
+def test_main_no_transcripts_leaves_existing_report_intact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A miss must not clobber a good report with an empty/notice file."""
+    project = tmp_path / "repo"
+    (project / ".omc").mkdir(parents=True)
+    stale = project / ".omc" / "command-audit.md"
+    stale.write_text("previous report")
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "empty"))
+    assert ca.command_audit_main(project, output=Path(".omc/command-audit.md")) == 0
+    assert stale.read_text() == "previous report"
+    assert "no transcripts" in capsys.readouterr().out
+
+
+def test_cli_accepts_the_session_end_output_flag() -> None:
+    """The flag the SessionEnd hook passes must exist on the REAL CLI.
+
+    The wiring check asserts settings.json names `--output`; this asserts
+    argparse actually accepts it, so the hook cannot fail only at runtime.
+    """
+    res = subprocess.run(
+        [
+            "uv",
+            "run",
+            "--project",
+            "python",
+            "dotfiles-setup",
+            "command-audit",
+            "--help",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=Path(__file__).parent.parent,
+        timeout=120,
+    )
+    assert res.returncode == 0
+    assert "--output" in res.stdout

--- a/tests/test_hook_guard.py
+++ b/tests/test_hook_guard.py
@@ -121,6 +121,36 @@ def test_bypass_routes_denied(command: str) -> None:
     assert hook_guard.decide(command) is not None
 
 
+@pytest.mark.parametrize(
+    ("command", "redirect_hint"),
+    [
+        ("cd /x && gh pr create --fill", "mise run ship"),
+        ("cd /x && gh pr merge 42 --squash", "mise run land"),
+        # No space around the separator, and `;`/newline variants.
+        ("cd /x&&gh pr create --fill", "mise run ship"),
+        ("cd /x ; gh pr merge 42 --squash", "mise run land"),
+        ("cd /x\ngh run watch 123 --exit-status", "gh run view"),
+        # Stacked prefixes, a `~` path, a subshell, and an interposed command.
+        ("cd /a && cd /b && hk run pre-commit --all", "mise run lint"),
+        ("cd ~/dev && devcontainer up --workspace-folder .", "mise run up"),
+        ("(cd /x && gh pr create --fill)", "mise run ship"),
+        ("cd /x && echo starting && gh pr create --fill", "mise run ship"),
+    ],
+)
+def test_cd_prefixed_one_offs_denied(command: str, redirect_hint: str) -> None:
+    """A leading `cd <path> &&` must never hide the operative command.
+
+    These pass WITHOUT a cd-unwrap in `decide()` (probe 2026-07-14, refuting
+    the research report's predicted "chained-command evasion"): the `cd` prefix
+    always ends in a separator `_CMD` re-anchors on. Pinned so a future
+    narrowing of `_CMD`'s separator class fails here instead of silently
+    opening the bypass. See the "NO `cd`-prefix unwrap" note in hook_guard.py.
+    """
+    reason = hook_guard.decide(command)
+    assert reason is not None
+    assert redirect_hint in reason
+
+
 def test_pull_rule_does_not_span_separators() -> None:
     # [16]: an unrelated pull followed by a mention must not be denied.
     cmd = "docker pull ubuntu:24.04 && echo dotfiles-devcontainer"

--- a/tests/test_hook_selfcheck.py
+++ b/tests/test_hook_selfcheck.py
@@ -54,6 +54,9 @@ def _full_settings() -> dict:
                     "bash scripts/web-setup.sh; fi",
                 )
             ],
+            "SessionEnd": [
+                _hook(None, "mise run command-audit -- --output .omc/command-audit.md")
+            ],
         }
     }
 
@@ -83,6 +86,22 @@ def test_wrong_command_fails(tmp_path: Path) -> None:
     settings["hooks"]["SessionStart"] = [_hook("startup|resume", "bash other.sh")]
     failures = _wiring(tmp_path, settings)
     assert any("SessionStart" in f for f in failures)
+
+
+def test_missing_session_end_fails(tmp_path: Path) -> None:
+    """The recurring command-audit loop must stay wired (SessionEnd hook)."""
+    settings = _full_settings()
+    del settings["hooks"]["SessionEnd"]
+    failures = _wiring(tmp_path, settings)
+    assert any("SessionEnd" in f for f in failures)
+
+
+def test_session_end_without_output_path_fails(tmp_path: Path) -> None:
+    """A SessionEnd that drops `--output` would print to a debug log, not the report."""
+    settings = _full_settings()
+    settings["hooks"]["SessionEnd"] = [_hook(None, "mise run command-audit")]
+    failures = _wiring(tmp_path, settings)
+    assert any("SessionEnd" in f and "command-audit.md" in f for f in failures)
 
 
 def test_unreadable_settings_fails(tmp_path: Path) -> None:


### PR DESCRIPTION
The two hook-enforcement follow-ups from session 2026-07-14-d. One shipped as
code; the other shipped as evidence that no code was needed.

1. Guard cd-prefix unwrap — NOT NEEDED (probe-refuted, no code change)

The handoff and the research report both called `cd /x && <one-off>` a live
"chained-command evasion" gap and prescribed mirroring
`command_audit._operative` into the guard. A 9-case probe refutes it: every
cd-prefixed form is ALREADY denied today (`&&`, no-space `cd /x&&`, `;`,
newline, stacked `cd /a && cd /b &&`, `~` path, subshell, interposed command).

Every `cd` prefix ends in `&&`/`;`/newline BY CONSTRUCTION, `_CMD`'s `[;&|\n]`
class re-anchors on that separator, and `re.search` retries at every offset — so
the rule already matches the operative command. An unwrap in `decide()` would be
dead code. `command_audit` genuinely needs its unwrap because it reads token[0]
after `.split()` (a positional read); a regex search is not positional. The
claim came from prior art written against first-token-splitting guards; it does
not describe ours.

Ray's call: pin the behavior, add no unwrap.
- `test_cd_prefixed_one_offs_denied` — 9 cases, so a future narrowing of `_CMD`'s
  separator class fails loudly instead of silently opening the predicted gap.
- A "NO `cd`-prefix unwrap, deliberately" note in hook_guard.py, matching the
  existing "NO pytest rule, deliberately" idiom for recording probed negatives.
- The report's bullet is annotated REFUTED in place (local/gitignored).

2. Recurring command-audit via a SessionEnd hook

Layer 4 of mise-tasks-only was remember-to-run; now the report is always waiting.

- `.claude/settings.json`: SessionEnd hook running
  `mise run command-audit -- --output .omc/command-audit.md`.
  SessionEnd and NOT Stop (confirmed against code.claude.com/docs/en/hooks):
  SessionEnd fires once per session at termination and CANNOT block; Stop fires
  every turn and CAN block (exit 2 continues the turn), which would put a
  transcript scan on the per-turn path with stop-loop risk. No matcher, so it
  fires on every end reason. Not a GHA job: the scan reads LOCAL ~/.claude
  transcripts, which a runner does not have.
- `command_audit.write_report()` + `--output`: python owns path resolution
  (repo-anchored, so the hook does not depend on cwd) and parent creation, which
  keeps the hook a pure invocation with no shell redirect (zero-bash-logic). A
  transcript miss leaves an existing report intact rather than clobbering it.
- No wrapper script, deliberately: `pretooluse-guard.sh` exists to fail OPEN
  because a denied PreToolUse call would brick every Bash call. SessionEnd cannot
  block — worst case is a one-line notice — so a wrapper would buy nothing and
  would owe bash_budget an allowlist entry.
- `hook_selfcheck._SETTINGS_WIRING` + `workflow.command-audit-wiring` now assert
  the hook, the `--output` flag on the real CLI, and the gitignore entry, so the
  recurring half cannot silently drift out.
- `.gitignore`: `.omc/command-audit.md` — regenerated every session from local
  transcripts. `.omc/*` was only excluded via a per-clone `.git/info/exclude`,
  which a fresh clone does not get; without this the report would dirty the tree
  and trip ship's clean-tree gate (the same rationale as `.omc/notepad.md`).

Docs: mise-tasks-only.md layer 4, tests/AGENTS.md rows, test count 505 -> 522.
Gates: lint rc=0 - lint-docs clean - pytest 522 (+17) - verify 89/0 failed -
hook-selfcheck OK.

Claude-Session: https://claude.ai/code/session_01PTsixP4QFhxLdnqJpJdvhr

Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Command-audit reports can now be saved to a specified file.
  - Reports refresh automatically at the end of each session and remain local to the current checkout.
- **Bug Fixes**
  - Improved command protection for one-off commands embedded in chained shell expressions.
  - Existing reports are preserved when no transcript data is available.
- **Documentation**
  - Updated workflow and testing documentation to reflect the recurring audit process and expanded test suite.
- **Tests**
  - Added coverage for report generation, hook configuration, CLI output, and chained-command handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->