### PR TITLE
fix(audit): make the bypass alarm mean something — 0 real bypasses, ever

### DIFF
--- a/.claude/rules/mise-tasks-only.md
+++ b/.claude/rules/mise-tasks-only.md
@@ -53,7 +53,9 @@ single-test `pytest path::test` via uv) are NOT wrapped and stay direct.
    `fewer-permission-prompts` skill (same transcript mine + command+subcommand
    grouping, opposite verdict). Review the report, then add a `mise run` task
    (+ a `hook_guard._RULES` redirect for a known-bad shape) for the top
-   culprits. Ongoing, not one-shot — a **`SessionEnd` hook** in
+   culprits. A rule-matching command is only an alarm (`bypass`) when it ran
+   AFTER its rule's `since` date AND actually executed — see "Reading the
+   report" below. Ongoing, not one-shot — a **`SessionEnd` hook** in
    `.claude/settings.json` runs it once per session (`-- --output
    .omc/command-audit.md`), so the report is always waiting rather than
    remember-to-run. `SessionEnd` and not `Stop`: it fires once per session at
@@ -85,6 +87,27 @@ belong in settings.json permission deny rules, not the hook.
 > mines native transcripts for one-off-command culprits to refine these layers
 > — not more per-turn hooks.
 
+## Reading the command-audit report
+
+Only **`bypass`** is an alarm: a command that matched a rule ALREADY LIVE
+(`timestamp > rule.since`) and that really executed. The other rule-matching
+classes are not:
+
+- **`blocked`** — the guard denied it; it never ran. The guard working. Audit
+  these for FALSE POSITIVES (see the known limitation below), not for evasion.
+- **`pre_rule`** — it predates the rule that matches it. History.
+- **`one_off`** — the refine-loop candidates, but known-noisy (#266): its top
+  shapes are currently sanctioned work (plain git, ad-hoc scripts, the
+  prescribed wait-loops). Read it with that discount until #266 lands.
+
+Both distinctions are load-bearing, because a bare "matched a rule" verdict is
+almost pure noise. Measured over 3,615 real commands (2026-07-14): **155**
+matched a rule — **147** predated it, **3** were denials, and **0** were
+bypasses. Nothing has ever evaded the guard. The transcript is what forces the
+second axis: it records the Bash `tool_use` block whether or not the command
+ran (a PreToolUse deny lands *after* the model emits it), so a denial and a
+bypass are byte-identical until you pair the attempt to its result.
+
 ## Known limitation: prose content in compound commands
 
 The guard matches the raw Bash string, so heredoc/quoted CONTENT that
@@ -95,11 +118,20 @@ compound command, silently skipping its other parts (observed twice,
 `python3 <file>`; after ANY deny, re-check that the command's intended
 side effects actually happened.
 
+**This — not evasion — is the guard's live defect** (issue #265). The audit's
+`blocked` bucket measures it: 2 of the 3 denials ever recorded were false
+positives, both from a `|` INSIDE a quoted regex (`grep -iE
+"…|devcontainer up|…"`) reading as a shell separator.
+
 ## Extending
 
 New redirect = new `_RULES` entry in `hook_guard.py` + a test + a row in
-the table above, same change. Keep patterns narrow: a redirect that
-misfires on legitimate diagnostics erodes trust in the guard.
+the table above, same change. Give it a `since` date (the day it lands on
+main) — the audit needs it to tell a real bypass from pre-rule history, and a
+rule missing one classifies every match as history forever, darkening the
+alarm. `since` dates the RULE, not its wording: never bump it on a reword.
+Keep patterns narrow: a redirect that misfires on legitimate diagnostics
+erodes trust in the guard.
 
 ## See also
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ the official `@devcontainers/cli` (pinned in `mise.toml`).
 | `.claude/` | Claude-specific agents, skills, rules. Has its own `CLAUDE.md` with OMC orchestration |
 | `home/` | Chezmoi-managed dotfile templates (its AGENTS.md was removed in #80) |
 | `python/` | Python package `dotfiles_setup` — see `python/AGENTS.md` |
-| `tests/` | Pytest + Bats test suite (522 pytest tests) — see `tests/AGENTS.md` |
+| `tests/` | Pytest + Bats test suite (545 pytest tests) — see `tests/AGENTS.md` |
 | `scripts/` | Utility scripts (`benchmark-docker.sh`, `devcontainer-smoke.sh`) |
 | `docs/` | Documentation, research findings, design specs |
 
@@ -86,7 +86,7 @@ content-hashed since hk 1.47 — no manual cache clearing after edits.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q               # All 522 tests
+uv run --project python pytest tests/ -x -q               # All 545 tests
 uv run --project python pytest tests/test_audit.py -x -q  # Single file
 mise run lint                                             # Lint checks only (hk under a hard timeout)
 dotfiles-setup verify run                                 # Verification contracts (suites.toml)

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -39,7 +39,7 @@ Requires **Python 3.14**.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q                # All 522 tests
+uv run --project python pytest tests/ -x -q                # All 545 tests
 uv run --project python pytest tests/test_audit.py -x -q   # Single file
 ```
 

--- a/python/src/dotfiles_setup/command_audit.py
+++ b/python/src/dotfiles_setup/command_audit.py
@@ -12,15 +12,30 @@ Capture is 100% native — no logging hook, no OTel collector. Every Bash call i
 already recorded verbatim in the session transcript JSONL
 (``$CLAUDE_CONFIG_DIR/projects/<encoded-cwd>/<session>.jsonl``, default
 ``~/.claude``): an ``type:"assistant"`` line whose ``message.content`` holds a
-``{type:"tool_use", name:"Bash", input:{command:"…"}}`` block. That schema is
+``{type:"tool_use", name:"Bash", input:{command:"…"}}`` block, answered by a
+later ``type:"user"`` line carrying the matching ``tool_result``. That schema is
 community-reverse-engineered, not an officially versioned contract, so every
 field access here is defensive (a malformed line is skipped, never fatal).
 
-Classification (first match wins):
+A transcript records ATTEMPTS, not executions: the ``tool_use`` block is
+written whether or not the command ran, because a PreToolUse deny lands *after*
+the model emits it. So an attempt is paired to its result (see
+:func:`_executed_ids`) to tell "the guard blocked this" from "this evaded the
+guard" — two outcomes that are otherwise byte-identical in the transcript.
 
-- ``denied`` — :func:`hook_guard.decide` returns a reason. A KNOWN one-off that
-  still ran ⇒ the guard was bypassed or the command predates the rule. Highest
-  signal.
+Classification (first match wins). The three rule-matching classes exist
+because a bare "matched a deny rule" verdict is almost pure noise — measured
+over 3,615 real calls on 2026-07-14: 155 matched a rule, 147 predated it, 3 were
+denials, and **0** were bypasses:
+
+- ``bypass`` — matched a rule that ALREADY EXISTED (``timestamp > rule.since``)
+  *and* actually executed. A real evasion. The only alarm worth raising.
+- ``blocked`` — matched a live rule and did NOT run: the guard working. Audit
+  these for FALSE POSITIVES — the guard is quoting-blind, so a denied literal
+  inside a quoted string (``grep -iE "…|devcontainer up|…"``) is denied, which
+  cancels the whole compound command. That, not evasion, is the live defect.
+- ``pre_rule`` — matched a rule that post-dates it: history from before the
+  guard existed. No action; NOT a one-off (it has a mise task today).
 - ``mise`` — already goes through a mise task / the ``dotfiles_setup`` CLI /
   canonical pytest. Good; no action.
 - ``diagnostic`` — a read-only/allowlisted shape (ls, cat, git status, docker
@@ -176,11 +191,18 @@ _GH_READ_MARKERS = re.compile(r"\b(view|checks|list|status|--json)\b")
 
 @dataclass(frozen=True)
 class BashCommand:
-    """One Bash invocation recovered from a transcript."""
+    """One Bash invocation recovered from a transcript.
+
+    ``executed`` says the command really RAN, as opposed to being refused by
+    the permission layer before execution. It has no default on purpose: the
+    field decides whether a rule-matching command reads as a guard bypass or as
+    the guard working, so every construction site must state it outright.
+    """
 
     command: str
     session: str
     timestamp: str
+    executed: bool
 
 
 def transcripts_base(
@@ -209,8 +231,8 @@ def project_transcripts(base: Path, cwd: Path, *, limit: int) -> list[Path]:
     return files[:limit]
 
 
-def _bash_blocks(content: object) -> Iterator[str]:
-    """Yield Bash ``input.command`` strings from an assistant line's content."""
+def _bash_blocks(content: object) -> Iterator[tuple[str, str]]:
+    """Yield ``(tool_use_id, command)`` for Bash calls in one line's content."""
     if not isinstance(content, list):
         return
     for block in content:
@@ -221,31 +243,90 @@ def _bash_blocks(content: object) -> Iterator[str]:
             if isinstance(command, dict):
                 cmd = command.get("command")
                 if isinstance(cmd, str) and cmd.strip():
-                    yield cmd
+                    yield str(block.get("id", "")), cmd
+
+
+def _json_lines(path: Path) -> list[dict[str, object]]:
+    """Every well-formed JSON object line in ``path`` (bad lines skipped)."""
+    try:
+        raw = path.read_text(errors="replace")
+    except OSError:
+        return []
+    objs: list[dict[str, object]] = []
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            objs.append(obj)
+    return objs
+
+
+def _content_blocks(obj: dict[str, object]) -> object:
+    """The ``message.content`` of a transcript line, if it has one."""
+    message = obj.get("message")
+    return message.get("content") if isinstance(message, dict) else None
+
+
+def _executed_ids(objs: Iterable[dict[str, object]]) -> set[str]:
+    """The ``tool_use`` ids whose result proves the command actually ran.
+
+    A Bash result line carries ``toolUseResult``: a **dict** with a ``stdout``
+    key when the command executed, or a bare **str** (``"Error: <reason>"``)
+    when the permission layer refused it first. Probed against 3,618 real
+    results (2026-07-14): ``stdout`` is present in every executed variant —
+    plain, ``backgroundTaskId``, ``gitOperation``, ``persistedOutputPath``,
+    ``returnCodeInterpretation`` — and the 80 refusals are the only non-dicts,
+    so the dict-with-stdout test is a structural signal, not a string match on
+    the reason. Each line holds exactly one ``tool_result`` block (6,822/6,822
+    probed), so the line-level ``toolUseResult`` maps to it unambiguously.
+
+    An id absent from the returned set is treated as NOT executed — a result
+    can be missing for the final in-flight call of a session. That direction is
+    deliberate: proof-of-execution is required to cry bypass, so an unknown
+    outcome stays quiet rather than inventing an alarm.
+    """
+    ids: set[str] = set()
+    for obj in objs:
+        result = obj.get("toolUseResult")
+        if not (isinstance(result, dict) and "stdout" in result):
+            continue
+        content = _content_blocks(obj)
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "tool_result":
+                uid = block.get("tool_use_id")
+                if isinstance(uid, str):
+                    ids.add(uid)
+    return ids
 
 
 def iter_bash_commands(paths: Iterable[Path]) -> Iterator[BashCommand]:
-    """Every Bash command across the transcripts, parsed defensively."""
+    """Every Bash command across the transcripts, parsed defensively.
+
+    Two passes per file: results can only be paired to attempts once the whole
+    file is read (the ``tool_result`` always lands on a later line than its
+    ``tool_use``). The file is read into memory either way.
+    """
     for path in paths:
-        try:
-            lines = path.read_text(errors="replace").splitlines()
-        except OSError:
-            continue
-        for line in lines:
-            if not line.strip():
+        objs = _json_lines(path)
+        executed = _executed_ids(objs)
+        for obj in objs:
+            if obj.get("type") != "assistant":
                 continue
-            try:
-                obj = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if not isinstance(obj, dict) or obj.get("type") != "assistant":
-                continue
-            message = obj.get("message")
-            content = message.get("content") if isinstance(message, dict) else None
             session = str(obj.get("sessionId", ""))
             timestamp = str(obj.get("timestamp", ""))
-            for cmd in _bash_blocks(content):
-                yield BashCommand(cmd, session=session, timestamp=timestamp)
+            for uid, cmd in _bash_blocks(_content_blocks(obj)):
+                yield BashCommand(
+                    cmd,
+                    session=session,
+                    timestamp=timestamp,
+                    executed=uid in executed,
+                )
 
 
 # A leading `cd <path> &&|;|newline` prefix hides the operative command from
@@ -295,13 +376,27 @@ def is_diagnostic(command: str) -> bool:
     return sub in reads
 
 
-def classify(command: str) -> str:
-    """One of ``denied`` / ``mise`` / ``diagnostic`` / ``one_off`` (first match)."""
-    if hook_guard.decide(command) is not None:
-        return "denied"
-    if is_mise_backed(command):
+def classify(bc: BashCommand) -> str:
+    """The class of one command: see the module docstring (first match wins).
+
+    A command matching a rule that post-dates it is ``pre_rule`` and stops
+    there — it is NOT a one-off, because it has a canonical mise task today;
+    telling the reader to "package it as a mise task" would be wrong.
+
+    The cutoff compares dates, and a command from the rule's own landing DAY
+    counts as pre-rule: the rule may have merged later that day, and a false
+    bypass alarm costs more than a missed same-day one. Every later day is
+    exact. An empty/short timestamp likewise reads as pre-rule — no alarm
+    without evidence.
+    """
+    rule = hook_guard.match(bc.command)
+    if rule is not None:
+        if bc.timestamp[:10] <= rule.since:
+            return "pre_rule"
+        return "bypass" if bc.executed else "blocked"
+    if is_mise_backed(bc.command):
         return "mise"
-    if is_diagnostic(command):
+    if is_diagnostic(bc.command):
         return "diagnostic"
     return "one_off"
 
@@ -312,29 +407,46 @@ def group_key(command: str) -> str:
     return f"{head} {sub}".strip() if head else "(empty)"
 
 
+def _group_name(bc: BashCommand, kind: str) -> str:
+    """The group a command reports under: rule name for denials, else shape."""
+    if kind == "blocked":
+        rule = hook_guard.match(bc.command)
+        if rule is not None:
+            return rule.name
+    return group_key(bc.command)
+
+
 @dataclass(frozen=True)
 class AuditResult:
     """The classified + grouped outcome of a scan."""
 
     counts: dict[str, int]
-    denied_groups: list[tuple[str, int, str]]
+    bypass_groups: list[tuple[str, int, str]]
+    blocked_groups: list[tuple[str, int, str]]
     one_off_groups: list[tuple[str, int, str]]
     sessions: int
     total: int
 
 
+# Grouped classes, and how each one names a group. Guard denials group by the
+# RULE that fired, not by command shape: a false-positive denial's head names
+# nothing useful (`ps aux | grep -iE "…|devcontainer up|…"` heads as `echo`),
+# whereas the rule identity is exactly what the reader must audit.
+_GROUPED = ("bypass", "blocked", "one_off")
+
+
 def audit(commands: Iterable[BashCommand], *, sessions: int) -> AuditResult:
     """Classify + frequency-rank the commands into an :class:`AuditResult`."""
     counts: Counter[str] = Counter()
-    group_counts: dict[str, Counter[str]] = {"denied": Counter(), "one_off": Counter()}
-    examples: dict[str, dict[str, str]] = {"denied": {}, "one_off": {}}
+    group_counts: dict[str, Counter[str]] = {k: Counter() for k in _GROUPED}
+    examples: dict[str, dict[str, str]] = {k: {} for k in _GROUPED}
     total = 0
     for bc in commands:
         total += 1
-        kind = classify(bc.command)
+        kind = classify(bc)
         counts[kind] += 1
         if kind in group_counts:
-            key = group_key(bc.command)
+            key = _group_name(bc, kind)
             group_counts[kind][key] += 1
             examples[kind].setdefault(key, bc.command)
 
@@ -345,7 +457,8 @@ def audit(commands: Iterable[BashCommand], *, sessions: int) -> AuditResult:
 
     return AuditResult(
         counts=dict(counts),
-        denied_groups=ranked("denied"),
+        bypass_groups=ranked("bypass"),
+        blocked_groups=ranked("blocked"),
         one_off_groups=ranked("one_off"),
         sessions=sessions,
         total=total,
@@ -357,13 +470,19 @@ def _truncate(text: str, width: int = 80) -> str:
     return text if len(text) <= width else text[: width - 1] + "…"
 
 
+def _table(groups: list[tuple[str, int, str]], label: str) -> list[str]:
+    """A ranked ``count | <label> | example`` markdown table."""
+    return [
+        f"| count | {label} | example |",
+        "|---:|---|---|",
+        *(f"| {n} | `{key}` | `{_truncate(ex)}` |" for key, n, ex in groups),
+        "",
+    ]
+
+
 def render_report(result: AuditResult) -> str:
     """A frequency-ranked markdown report for human review of the refine loop."""
     c = result.counts
-    n_one_off = c.get("one_off", 0)
-    n_denied = c.get("denied", 0)
-    n_mise = c.get("mise", 0)
-    n_diag = c.get("diagnostic", 0)
     lines = [
         "# Command audit — one-off Bash culprits",
         "",
@@ -372,44 +491,52 @@ def render_report(result: AuditResult) -> str:
         "",
         "| class | count | meaning |",
         "|---|---:|---|",
-        f"| one_off | {n_one_off} | mutating hand-run — package as a mise task |",
-        f"| denied | {n_denied} | already-denied shape that ran (bypass / pre-rule) |",
-        f"| mise | {n_mise} | already via a mise task / dotfiles_setup CLI |",
-        f"| diagnostic | {n_diag} | read-only, legitimately direct |",
+        f"| bypass | {c.get('bypass', 0)} | ran DESPITE a live guard rule — "
+        "a real evasion, investigate |",
+        f"| blocked | {c.get('blocked', 0)} | guard denied it (working) — "
+        "audit for false positives |",
+        f"| pre_rule | {c.get('pre_rule', 0)} | matched a rule that post-dates "
+        "it — history, no action |",
+        f"| one_off | {c.get('one_off', 0)} | mutating hand-run — package as a "
+        "mise task |",
+        f"| mise | {c.get('mise', 0)} | already via a mise task / dotfiles_setup CLI |",
+        f"| diagnostic | {c.get('diagnostic', 0)} | read-only, legitimately direct |",
+        "",
+        "## 🚨 Bypasses (ran despite a live guard rule)",
         "",
     ]
-    if result.denied_groups:
+    if result.bypass_groups:
+        lines += _table(result.bypass_groups, "shape")
+    else:
         lines += [
-            "## ⚠️ Denied-but-ran (investigate — guard bypass or pre-rule history)",
+            "_None — nothing has evaded the guard since its rule landed._",
             "",
-            "| count | shape | example |",
-            "|---:|---|---|",
-            *(
-                f"| {n} | `{key}` | `{_truncate(ex)}` |"
-                for key, n, ex in result.denied_groups
-            ),
+        ]
+    if result.blocked_groups:
+        lines += [
+            "## Guard denials (the guard working — audit for false positives)",
             "",
+            "A denial is only correct if the command really was the shape the "
+            "rule names. The guard is quoting-blind: a denied literal inside a "
+            'quoted string (`grep -iE "…|devcontainer up|…"`) is denied too, '
+            "and that cancels the WHOLE compound command. Grouped by the rule "
+            "that fired.",
+            "",
+            *_table(result.blocked_groups, "rule"),
         ]
     lines += [
         "## One-off culprits (candidates for a mise task + python function)",
         "",
     ]
     if result.one_off_groups:
-        lines += [
-            "| count | shape | example |",
-            "|---:|---|---|",
-            *(
-                f"| {n} | `{key}` | `{_truncate(ex)}` |"
-                for key, n, ex in result.one_off_groups
-            ),
-        ]
+        lines += _table(result.one_off_groups, "shape")
     else:
-        lines.append("_None — no un-wrapped one-off commands found._")
+        lines += ["_None — no un-wrapped one-off commands found._", ""]
     lines += [
-        "",
         "Refine loop: for a high-frequency one-off shape, add a `mise run <task>` "
         "wrapping a `dotfiles_setup` function (zero-bash-logic), and if it's a "
-        "known bad shape, add a `hook_guard._RULES` redirect. See "
+        "known bad shape, add a `hook_guard._RULES` redirect — with a `since` "
+        "date, or its first scan reports as history. See "
         ".claude/rules/mise-tasks-only.md.",
     ]
     return "\n".join(lines) + "\n"
@@ -460,6 +587,7 @@ def command_audit_main(
     sys.stdout.write(
         f"command-audit: wrote {dest} "
         f"({result.counts.get('one_off', 0)} one-off, "
-        f"{result.counts.get('denied', 0)} denied-but-ran)\n"
+        f"{result.counts.get('bypass', 0)} bypass, "
+        f"{result.counts.get('blocked', 0)} guard-denied)\n"
     )
     return 0

--- a/python/src/dotfiles_setup/hook_guard.py
+++ b/python/src/dotfiles_setup/hook_guard.py
@@ -29,10 +29,43 @@ import json
 import os
 import re
 import sys
+from dataclasses import dataclass
 
-# (pattern, reason). First match wins. Patterns run against the whole
-# Bash command string; they are deliberately narrow — a redirect that
-# misfires on legitimate diagnostics erodes trust in the guard.
+
+@dataclass(frozen=True)
+class Rule:
+    """One deny rule: what it matches, why, and when it started denying.
+
+    ``since`` is the ISO date (UTC) the rule LANDED ON MAIN — the date from
+    which a matching command that actually RAN is a genuine bypass. It exists
+    for :mod:`dotfiles_setup.command_audit`, which scans transcripts reaching
+    back long before the guard did: with no per-rule cutoff, every historical
+    ``gh pr create`` (2026-07-01, when no guard existed) reads as an evasion.
+    Measured 2026-07-14: 147 of 155 rule-matching commands predated their rule
+    — a 95% false-alarm rate that buries any real signal.
+
+    Set ``since`` when a rule is ADDED and never touch it again: it dates the
+    RULE, not the wording. Rewording a reason must not reset the cutoff, or
+    real bypasses go dark. (Deriving these from ``git log -S`` was rejected:
+    non-deterministic, slow, needs git at scan time, and a reword would reset
+    the date — the very failure this field is pinned against. A test asserts
+    every rule carries a valid one.)
+
+    ``name`` is a short shape label. The audit report groups guard denials by
+    rule identity, because grouping them by command head is meaningless — a
+    prose false-positive like ``ps aux | grep -iE "…|devcontainer up|…"``
+    groups under ``echo``, naming nothing.
+    """
+
+    name: str
+    pattern: re.Pattern[str]
+    reason: str
+    since: str
+
+
+# First match wins. Patterns run against the whole Bash command string;
+# they are deliberately narrow — a redirect that misfires on legitimate
+# diagnostics erodes trust in the guard.
 #
 # _CMD anchors every rule to command position (start of string or right
 # after a shell separator) so quoted/prose mentions — `echo 'gh pr
@@ -47,62 +80,91 @@ import sys
 # denied a review agent quoting the merge rule). Deliberately fail-open
 # beyond this (sh -c, base64, aliases): this is a redirect guard, not a
 # sandbox — hard bans live in settings.json permissions deny.
+#
+# Anchoring does NOT make the guard quoting-aware, and that gap is the only
+# defect the audit has ever measured (#265): the separator class cannot see
+# that a `|` INSIDE a quoted string is not a shell separator, so
+# `grep -iE "…|devcontainer up|…"` denies. 2 of the 3 denials this guard has
+# ever issued were this shape; 0 commands have ever evaded it. Any narrowing
+# here should trade recall for precision — never the reverse.
 _WRAPPER = (
     r"(?:(?:env\s+)?(?:\w+=\S*\s+)*"
     r"(?:exec\s+|nohup\s+|time\s+|timeout\s+\S+\s+|xargs\s+)?)*"
 )
 _CMD = r"(?:^|[;&|\n]\s*)" + _WRAPPER
-_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
-    (
+# The eight original rules landed together in #174 (90d699e, 2026-07-07);
+# #176 re-anchored them the same day, so the cutoff is unchanged.
+_V1 = "2026-07-07"
+# The three workflow-observation rules landed in #260 (7eae108, 2026-07-14).
+_V2 = "2026-07-14"
+
+_RULES: tuple[Rule, ...] = (
+    Rule(
+        "npx",
         re.compile(_CMD + r"npx\s"),
         "Do not use npx. Use the mise-installed binary directly (e.g. "
         "`agnix`, not `npx agnix`) — all tools are pinned in mise.toml. "
         "See .claude/rules/ci-local-parity.md.",
+        _V1,
     ),
-    (
+    Rule(
+        "chezmoi apply/update",
         re.compile(_CMD + r"chezmoi\s+(apply|update)\b"),
         "chezmoi apply/update is blocked on the Mac host — it may only run "
         "inside the devcontainer (chezmoi.os == 'linux' renders the "
         "container-only overlay). Read-only chezmoi commands are fine. See "
         ".claude/rules/use-tool-builtins.md.",
+        _V1,
     ),
-    (
+    Rule(
+        "hk run pre-commit",
         re.compile(_CMD + r"hk\s+run\s+pre-commit\b"),
         "Use `mise run lint` — it wraps hk in a hard timeout (hk has none) "
         "with log-tail diagnostics. See "
         ".claude/rules/long-running-command-hangs.md.",
+        _V1,
     ),
-    (
+    Rule(
+        "devcontainer up",
         re.compile(_CMD + r"devcontainer\s+up\b"),
         "Use `mise run up` (or `mise run dev-rebuild` to force-refresh) — "
         "the task carries BASE_IMAGE/platform/ssh-port env and the "
         "workspace-hash collision guard a raw `devcontainer up` misses.",
+        _V1,
     ),
-    (
+    Rule(
+        "devcontainer build",
         re.compile(_CMD + r"devcontainer\s+build\b"),
         "Use `mise run dev-rebuild` — the overlay build needs the task's "
         "env (BASE_IMAGE, DOCKER_DEFAULT_PLATFORM) to be reproducible.",
+        _V1,
     ),
-    (
+    Rule(
+        "docker pull (devcontainer image)",
         re.compile(
             _CMD + r"docker\s+(?:image\s+)?pull\b[^;&|\n]*dotfiles-devcontainer"
         ),
         "Never classic-pull the devcontainer image (it wedges on the ~38GB "
         "blob). Use `mise run sync` — buildkit-based, digest-aware, and it "
         "verifies the result.",
+        _V1,
     ),
-    (
+    Rule(
+        "gh pr create",
         re.compile(_CMD + r"gh\s+pr\s+create\b"),
         "Use `mise run ship` — it runs the path-aware gate matrix (incl. "
         "the hard full-sync gate on devcontainer-surface diffs) before the "
         "PR opens, then watches checks to bucket-verified green. See "
         ".claude/skills/pr-workflow/SKILL.md.",
+        _V1,
     ),
-    (
+    Rule(
+        "gh pr merge",
         re.compile(_CMD + r"gh\s+pr\s+merge\b"),
         "Use `mise run land -- <PR#>` — it verifies check buckets, pins the "
         "merge to the verified head SHA, watches main CI, and validates "
         "locally. See .claude/skills/pr-workflow/SKILL.md.",
+        _V1,
     ),
     # `nohup`/manual detachment of a mise task orphans it from the harness
     # (no completion notification, hand-rolled log-polling on top). _CMD's
@@ -110,7 +172,8 @@ _RULES: tuple[tuple[re.Pattern[str], str], ...] = (
     # (otherwise canonical/allowed) slips through when detached — hence a
     # dedicated rule that anchors `nohup` at command position and requires a
     # `mise run` later in the same segment.
-    (
+    Rule(
+        "nohup mise run",
         re.compile(
             r"(?:^|[;&|\n]\s*)(?:env\s+)?(?:\w+=\S*\s+)*nohup\s+[^;&|\n]*"
             r"mise\s+run\b"
@@ -119,20 +182,25 @@ _RULES: tuple[tuple[re.Pattern[str], str], ...] = (
         "background mechanism so it stays tracked and reports one clean "
         "completion — no orphaned process, no hand-rolled log monitor. See "
         ".claude/rules/mise-tasks-only.md.",
+        _V2,
     ),
-    (
+    Rule(
+        "gh run watch",
         re.compile(_CMD + r"gh\s+run\s+watch\b"),
         "Do not hand-roll `gh run watch` (it reports prematurely — see "
         ".claude/rules/gh-cli-watch.md). `mise run land -- <PR#>` already "
         "watches main CI via --json buckets; for a one-shot check use "
         "`gh run view <id> --json conclusion`.",
+        _V2,
     ),
-    (
+    Rule(
+        "gh pr checks --watch",
         re.compile(_CMD + r"gh\s+pr\s+checks\b[^;&|\n]*--watch\b"),
         "Do not hand-roll `gh pr checks --watch` — `mise run ship` already "
         "watches PR checks to bucket-verified green and `mise run land` "
         "watches main CI. A one-shot `gh pr checks <n> --json` read is fine. "
         "See .claude/rules/mise-tasks-only.md.",
+        _V2,
     ),
 )
 
@@ -156,12 +224,34 @@ _RULES: tuple[tuple[re.Pattern[str], str], ...] = (
 # opening the bypass.
 
 
+def rules() -> tuple[Rule, ...]:
+    """Every deny rule, in match order — the guard's introspection surface.
+
+    The rule table is a contract, not an implementation detail: `since` and
+    `name` are read outside this module (the audit dates bypasses by the first
+    and groups denials by the second), and the invariants that keep those
+    honest — every rule dated, every name unique — are asserted against this.
+    """
+    return _RULES
+
+
+def match(command: str) -> Rule | None:
+    """The first :class:`Rule` matching ``command``, else None.
+
+    Split out of :func:`decide` for :mod:`dotfiles_setup.command_audit`, which
+    needs the matched rule's ``since`` date (and ``name``) — not just its
+    reason — to tell a genuine bypass from pre-rule history.
+    """
+    for rule in _RULES:
+        if rule.pattern.search(command):
+            return rule
+    return None
+
+
 def decide(command: str) -> str | None:
     """Redirect reason when ``command`` should be denied, else None."""
-    for pattern, reason in _RULES:
-        if pattern.search(command):
-            return reason
-    return None
+    rule = match(command)
+    return rule.reason if rule is not None else None
 
 
 def _read_command() -> str:

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -1037,7 +1037,7 @@ tokens = [
 
 [[suite]]
 name = "workflow.command-audit-wiring"
-description = "Command-audit self-learning loop wiring: `mise run command-audit` must stay a thin caller of the python library (`dotfiles-setup command-audit`, zero-bash-logic), the command_audit module (transcript scan + classifier) + its tests must exist, and the rule doc must name the loop. The scanner is the inverse of fewer-permission-prompts — it flags one-off Bash commands the PreToolUse guard does not yet cover, so the enforcement layers can be refined over time. The loop is RECURRING: a SessionEnd hook in .claude/settings.json refreshes .omc/command-audit.md via --output once per session (SessionEnd fires once per session and cannot block — unlike Stop, which fires per-turn and can block), hook_selfcheck asserts that wiring, and .gitignore keeps the report local. Asserts the chain so the loop can't silently drift out."
+description = "Command-audit self-learning loop wiring: `mise run command-audit` must stay a thin caller of the python library (`dotfiles-setup command-audit`, zero-bash-logic), the command_audit module (transcript scan + classifier) + its tests must exist, and the rule doc must name the loop. The scanner is the inverse of fewer-permission-prompts — it flags one-off Bash commands the PreToolUse guard does not yet cover, so the enforcement layers can be refined over time. The loop is RECURRING: a SessionEnd hook in .claude/settings.json refreshes .omc/command-audit.md via --output once per session (SessionEnd fires once per session and cannot block — unlike Stop, which fires per-turn and can block), hook_selfcheck asserts that wiring, and .gitignore keeps the report local. Also pins the two axes that make the alarm mean anything (measured 2026-07-14: of 155 rule-matching commands, 147 predated their rule, 3 were denials, 0 were bypasses): every hook_guard Rule carries a `since` landing date (without it classify() reads every match as history and the bypass alarm goes dark), and _executed_ids pairs each attempt to its result (a transcript records a denied Bash call identically to an executed one, so denial and evasion are indistinguishable without it). Asserts the chain so the loop can't silently drift out."
 category = "workflow"
 check_type = "static"
 handler = "require_tokens"
@@ -1045,14 +1045,16 @@ paths_required = true
 paths = [
     "mise.toml",
     "python/src/dotfiles_setup/command_audit.py",
+    "python/src/dotfiles_setup/hook_guard.py",
     "python/src/dotfiles_setup/main.py",
     "python/src/dotfiles_setup/hook_selfcheck.py",
     ".claude/settings.json",
     ".gitignore",
     "tests/test_command_audit.py",
+    "tests/test_hook_guard.py",
     ".claude/rules/mise-tasks-only.md",
 ]
-per_path_tokens = { "mise.toml" = ["[tasks.command-audit]", "dotfiles-setup command-audit"], "python/src/dotfiles_setup/command_audit.py" = ["def command_audit_main", "def classify", "def iter_bash_commands", "def write_report"], "python/src/dotfiles_setup/main.py" = ["command-audit", "--output"], "python/src/dotfiles_setup/hook_selfcheck.py" = ["SessionEnd", "_SESSION_END_REPORT"], ".claude/settings.json" = ["SessionEnd", "mise run command-audit -- --output .omc/command-audit.md"], ".gitignore" = [".omc/command-audit.md"], "tests/test_command_audit.py" = ["def test_main_output_writes_file_instead_of_stdout"], ".claude/rules/mise-tasks-only.md" = ["mise run command-audit", "SessionEnd"] }
+per_path_tokens = { "mise.toml" = ["[tasks.command-audit]", "dotfiles-setup command-audit"], "python/src/dotfiles_setup/command_audit.py" = ["def command_audit_main", "def classify", "def iter_bash_commands", "def write_report", "def _executed_ids"], "python/src/dotfiles_setup/hook_guard.py" = ["class Rule", "since: str", "def match"], "python/src/dotfiles_setup/main.py" = ["command-audit", "--output"], "python/src/dotfiles_setup/hook_selfcheck.py" = ["SessionEnd", "_SESSION_END_REPORT"], ".claude/settings.json" = ["SessionEnd", "mise run command-audit -- --output .omc/command-audit.md"], ".gitignore" = [".omc/command-audit.md"], "tests/test_command_audit.py" = ["def test_main_output_writes_file_instead_of_stdout", "def test_iter_bash_commands_pairs_results_to_attempts"], "tests/test_hook_guard.py" = ["def test_every_rule_carries_a_usable_since_date"], ".claude/rules/mise-tasks-only.md" = ["mise run command-audit", "SessionEnd", "since"] }
 tokens = [
     "dotfiles-setup command-audit",
     "def command_audit_main",

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -23,9 +23,9 @@ Docker image smoke outputs.
 | `test_container.py` | pytest | `verify-container-latest` gate (`dotfiles_setup.container`) — running/bind-mount/smoke freshness checks |
 | `test_sync.py` | pytest | `mise run sync` workflow (`dotfiles_setup.sync`) — staleness detection, action matrix, CI awareness, check/full/wait modes |
 | `test_pr.py` | pytest | `mise run ship`/`land` workflow (`dotfiles_setup.pr`) — surface detection, gate matrix, bucket verification, pinned merge |
-| `test_hook_guard.py` | pytest | PreToolUse mise-tasks-only guard (`dotfiles_setup.hook_guard`) — deny/redirect rules, false-positive guards, JSON contract, and the cd-prefixed compound denials (pinned: they pass with NO cd-unwrap in `decide()`, since `_CMD` re-anchors on the `&&`/`;`/newline every prefix ends in — probe 2026-07-14 refuting the predicted "chained-command evasion") |
+| `test_hook_guard.py` | pytest | PreToolUse mise-tasks-only guard (`dotfiles_setup.hook_guard`) — deny/redirect rules, false-positive guards, JSON contract, `match()` rule lookup, per-rule `since`/`name` integrity (a rule with a malformed `since` silently classifies every match as history and darkens the audit's bypass alarm), and the cd-prefixed compound denials (pinned: they pass with NO cd-unwrap in `decide()`, since `_CMD` re-anchors on the `&&`/`;`/newline every prefix ends in — probe 2026-07-14 refuting the predicted "chained-command evasion") |
 | `test_hook_selfcheck.py` | pytest | Host-side hook self-check (`dotfiles_setup.hook_selfcheck`, the ship/land `hook-selfcheck` gate) — settings.json wiring + Bash-matcher assertions incl. the SessionEnd command-audit hook, and an end-to-end real-repo pass driving the wired PreToolUse guard |
-| `test_command_audit.py` | pytest | Command-audit transcript scanner (`dotfiles_setup.command_audit`, the self-learning mise-tasks loop) — env-aware transcript discovery, defensive JSONL parse, one-off/denied/mise/diagnostic classifier (cd-prefix unwrap), grouping, report rendering, and the `--output` path the SessionEnd hook uses (repo-anchored resolve, no-clobber on a transcript miss, real-CLI flag pin) |
+| `test_command_audit.py` | pytest | Command-audit transcript scanner (`dotfiles_setup.command_audit`, the self-learning mise-tasks loop) — env-aware transcript discovery, defensive JSONL parse, attempt→result pairing (a denied Bash call is recorded exactly like an executed one; only the `stdout`-bearing `toolUseResult` separates them), the bypass/blocked/pre_rule/mise/diagnostic/one_off classifier (cd-prefix unwrap; era×outcome split — probe 2026-07-14: of 155 rule-matching commands, 147 were pre-rule, 3 denials, **0** bypasses), denials grouped by rule identity not command head, report rendering, and the `--output` path the SessionEnd hook uses (repo-anchored resolve, no-clobber on a transcript miss, real-CLI flag pin) |
 | `test_tool_currency.py` | pytest | Daily tool-currency signal (`dotfiles_setup.tool_currency`) — release-link backends, report rendering |
 | `test_renovate.py` | pytest | Renovate status signal (`dotfiles_setup.renovate`) — app-id/privilege check, report rendering |
 | `test_autofix.py` | pytest | autofix.ci artifact applier (`dotfiles_setup.autofix`) — additions, traversal/shape/deletion refusal |
@@ -35,7 +35,7 @@ Docker image smoke outputs.
 | `infra/foundation.bats` | Bats | Bash-level foundation checks (shell script integration) |
 | `infra/runtimes.bats` | Bats | Runtime installation checks (bash) |
 
-Total: **522 pytest tests** run by default (`pytest tests/` collects all
+Total: **545 pytest tests** run by default (`pytest tests/` collects all
 `test_*.py` files) plus **4 gated `image_exec`** exec tests (deselected by
 default; run via `mise run smoke-exec`) and Bats scenarios under `infra/`.
 

--- a/tests/test_command_audit.py
+++ b/tests/test_command_audit.py
@@ -1,7 +1,9 @@
 """Tests for the command-audit transcript scanner (dotfiles_setup.command_audit).
 
 Covers transcript discovery (env-aware, never hardcoded), defensive JSONL
-parsing, the one-off/denied/mise/diagnostic classifier (incl. cd-prefix
+parsing, attempt-to-result pairing (a denied Bash call is recorded exactly like
+an executed one — only the result tells them apart), the
+bypass/blocked/pre_rule/mise/diagnostic/one_off classifier (incl. cd-prefix
 compound unwrapping), grouping, report rendering, and the ``--output`` path the
 SessionEnd hook uses to refresh the report once per session.
 """
@@ -58,16 +60,47 @@ def test_project_transcripts_limit_and_recency(tmp_path: Path) -> None:
 # ------------------------------------------------------------ defensive parsing
 
 
-def _assistant_bash(cmd: str) -> str:
+# Any date strictly after every rule's `since`, so seeded commands land in the
+# live-rule era (the pre_rule cutoff is exercised separately, by classify).
+_LIVE_TS = "2026-07-20T00:00:00Z"
+
+
+def _assistant_bash(cmd: str, uid: str = "tu1", ts: str = _LIVE_TS) -> str:
     return json.dumps(
         {
             "type": "assistant",
             "sessionId": "sess1",
-            "timestamp": "2026-07-14T00:00:00Z",
+            "timestamp": ts,
             "message": {
                 "content": [
-                    {"type": "tool_use", "name": "Bash", "input": {"command": cmd}}
+                    {
+                        "type": "tool_use",
+                        "id": uid,
+                        "name": "Bash",
+                        "input": {"command": cmd},
+                    }
                 ]
+            },
+        }
+    )
+
+
+def _result(uid: str, *, executed: bool) -> str:
+    """A tool_result line: dict-with-stdout when it ran, bare str when refused.
+
+    Mirrors the real shapes probed 2026-07-14 — a refused call carries the
+    guard's reason as a plain string, an executed one a stdout-bearing dict.
+    """
+    return json.dumps(
+        {
+            "type": "user",
+            "toolUseResult": (
+                {"stdout": "out", "stderr": "", "interrupted": False}
+                if executed
+                else "Error: Use `mise run ship` — …"
+            ),
+            "message": {
+                "content": [{"type": "tool_result", "tool_use_id": uid}],
             },
         }
     )
@@ -116,10 +149,41 @@ def test_iter_bash_commands_extracts_and_skips_defensively(tmp_path: Path) -> No
     cmds = list(ca.iter_bash_commands([f]))
     assert [c.command for c in cmds] == ["ls -la"]
     assert cmds[0].session == "sess1"
+    # No tool_result for it: unproven execution never counts as executed.
+    assert cmds[0].executed is False
 
 
 def test_iter_bash_commands_unreadable_file_skipped(tmp_path: Path) -> None:
     assert list(ca.iter_bash_commands([tmp_path / "does-not-exist.jsonl"])) == []
+
+
+def test_iter_bash_commands_pairs_results_to_attempts(tmp_path: Path) -> None:
+    """The transcript records a denied attempt exactly like an executed one.
+
+    Only the paired tool_result separates them, so this pairing is the whole
+    basis for telling a guard bypass from the guard working.
+    """
+    f = tmp_path / "t.jsonl"
+    f.write_text(
+        "\n".join(
+            [
+                _assistant_bash("ls -la", uid="a"),
+                _assistant_bash("gh pr create --fill", uid="b"),
+                _assistant_bash("git status", uid="c"),
+                # Results arrive on LATER lines, and out of order — the pairing
+                # is by id, never by position.
+                _result("b", executed=False),  # guard refused it
+                _result("a", executed=True),
+                # (no result for "c" — still in flight)
+            ]
+        )
+    )
+    got = {c.command: c.executed for c in ca.iter_bash_commands([f])}
+    assert got == {
+        "ls -la": True,
+        "gh pr create --fill": False,
+        "git status": False,
+    }
 
 
 # ------------------------------------------------------------- classification
@@ -170,13 +234,55 @@ def test_not_diagnostic_mutations(command: str) -> None:
     assert not ca.is_diagnostic(command)
 
 
+def _bc(command: str, *, ts: str = _LIVE_TS, executed: bool = True) -> ca.BashCommand:
+    return ca.BashCommand(command, session="s", timestamp=ts, executed=executed)
+
+
 def test_classify_precedence() -> None:
-    # denied (guard rule) wins even inside a cd compound
-    assert ca.classify("cd /repo && gh pr create --fill") == "denied"
-    assert ca.classify("mise run lint") == "mise"
-    assert ca.classify("git status") == "diagnostic"
-    assert ca.classify("git commit -m x") == "one_off"
-    assert ca.classify("docker run --rm ubuntu bash -c 'x'") == "one_off"
+    # A guard rule wins even inside a cd compound.
+    assert ca.classify(_bc("cd /repo && gh pr create --fill")) == "bypass"
+    assert ca.classify(_bc("mise run lint")) == "mise"
+    assert ca.classify(_bc("git status")) == "diagnostic"
+    assert ca.classify(_bc("git commit -m x")) == "one_off"
+    assert ca.classify(_bc("docker run --rm ubuntu bash -c 'x'")) == "one_off"
+
+
+@pytest.mark.parametrize(
+    ("ts", "executed", "expected"),
+    [
+        # Live rule (gh pr create landed 2026-07-07) + it really ran = evasion.
+        ("2026-07-08T00:00:00Z", True, "bypass"),
+        # Live rule but refused: the guard working, not a bypass.
+        ("2026-07-08T00:00:00Z", False, "blocked"),
+        # Before the rule existed — history, whether or not it ran.
+        ("2026-07-01T00:00:00Z", True, "pre_rule"),
+        ("2026-07-01T00:00:00Z", False, "pre_rule"),
+        # The rule's own landing day counts as pre-rule: it may have merged
+        # later that day, and a false alarm costs more than a missed one.
+        ("2026-07-07T23:59:59Z", True, "pre_rule"),
+        # No timestamp ⇒ no evidence ⇒ no alarm.
+        ("", True, "pre_rule"),
+    ],
+)
+def test_classify_rule_match_splits_by_era_and_outcome(
+    ts: str, expected: str, *, executed: bool
+) -> None:
+    """A bare "matched a rule" verdict was 98% noise; these two axes fix it.
+
+    Measured 2026-07-14 over 3,615 real commands: 155 matched a rule — 147
+    predated it, 3 were denials, 0 were bypasses.
+    """
+    assert ca.classify(_bc("gh pr create --fill", ts=ts, executed=executed)) == expected
+
+
+def test_classify_uses_the_matched_rules_own_since_date() -> None:
+    """Rules landed on different dates, so the cutoff must be per-rule.
+
+    `gh run watch` landed 2026-07-14, a week after `gh pr create` — on
+    2026-07-10 the first is still history while the second is already live.
+    """
+    assert ca.classify(_bc("gh run watch 1", ts="2026-07-10T00:00:00Z")) == "pre_rule"
+    assert ca.classify(_bc("gh pr create", ts="2026-07-10T00:00:00Z")) == "bypass"
 
 
 def test_group_key_uses_operative_head_sub() -> None:
@@ -191,7 +297,7 @@ def test_group_key_uses_operative_head_sub() -> None:
 
 
 def _cmds(*commands: str) -> list[ca.BashCommand]:
-    return [ca.BashCommand(c, session="s", timestamp="t") for c in commands]
+    return [_bc(c) for c in commands]
 
 
 def test_audit_counts_and_ranks() -> None:
@@ -202,7 +308,7 @@ def test_audit_counts_and_ranks() -> None:
             "docker run --rm x",  # one_off
             "ls",  # diagnostic
             "mise run lint",  # mise
-            "gh pr create",  # denied
+            "gh pr create",  # bypass (live rule + executed)
         ),
         sessions=2,
     )
@@ -211,10 +317,30 @@ def test_audit_counts_and_ranks() -> None:
     assert result.counts["one_off"] == 3
     assert result.counts["diagnostic"] == 1
     assert result.counts["mise"] == 1
-    assert result.counts["denied"] == 1
+    assert result.counts["bypass"] == 1
     # "git commit" is the top one-off group with count 2
     assert result.one_off_groups[0][0] == "git commit"
     assert result.one_off_groups[0][1] == 2
+
+
+def test_audit_groups_denials_by_rule_not_command_shape() -> None:
+    """Denials group by the rule that fired — a false positive's head is junk.
+
+    Both commands here are the real prose false positive (probed 2026-07-14):
+    the `|` sitting INSIDE the quoted regex, right before the literal, reads as
+    a shell separator to the guard, so `devcontainer up` matches at "command
+    position". Their command HEAD is `echo`/`ps`, naming nothing; the rule
+    identity is the thing to audit.
+    """
+    result = ca.audit(
+        [
+            _bc('echo hi | grep -E "mise run|devcontainer up"', executed=False),
+            _bc('ps aux | grep -E "land|devcontainer up|cli"', executed=False),
+        ],
+        sessions=1,
+    )
+    assert result.counts["blocked"] == 2
+    assert [(k, n) for k, n, _ex in result.blocked_groups] == [("devcontainer up", 2)]
 
 
 def test_render_report_has_sections_and_counts() -> None:
@@ -222,9 +348,17 @@ def test_render_report_has_sections_and_counts() -> None:
     report = ca.render_report(result)
     assert "# Command audit" in report
     assert "One-off culprits" in report
-    assert "Denied-but-ran" in report
+    assert "Bypasses (ran despite a live guard rule)" in report
     assert "`git commit`" in report
     assert "mise-tasks-only.md" in report
+
+
+def test_render_report_no_bypasses_says_so() -> None:
+    """Zero bypasses is the expected steady state — report it, don't omit it."""
+    report = ca.render_report(ca.audit(_cmds("ls", "git commit -m x"), sessions=1))
+    assert "_None — nothing has evaded the guard since its rule landed._" in report
+    # A clean run must not imply the guard was never exercised.
+    assert "Guard denials" not in report
 
 
 def test_render_report_no_one_offs() -> None:

--- a/tests/test_hook_guard.py
+++ b/tests/test_hook_guard.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -155,6 +157,37 @@ def test_pull_rule_does_not_span_separators() -> None:
     # [16]: an unrelated pull followed by a mention must not be denied.
     cmd = "docker pull ubuntu:24.04 && echo dotfiles-devcontainer"
     assert hook_guard.decide(cmd) is None
+
+
+@pytest.mark.parametrize("rule", hook_guard.rules(), ids=lambda r: r.name)
+def test_every_rule_carries_a_usable_since_date(rule: hook_guard.Rule) -> None:
+    """A rule with no (or a malformed) `since` reports as history forever.
+
+    `command_audit.classify` compares an ISO timestamp prefix against this
+    field, so a wrong shape doesn't crash — it silently classifies every
+    match as `pre_rule` and the bypass alarm goes dark. Pinned here so a rule
+    added without a date fails loudly at authoring time instead.
+    """
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}", rule.since), rule.since
+    # A real date, not just the right shape (e.g. not 2026-13-45).
+    landed = dt.date.fromisoformat(rule.since)
+    assert landed >= dt.date(2026, 7, 7), "no rule predates the guard itself"
+    assert landed <= dt.datetime.now(dt.UTC).date(), "since must not be a future date"
+
+
+def test_rule_names_are_unique_and_nonempty() -> None:
+    """Denials group by rule name in the audit report — collisions merge rows."""
+    names = [r.name for r in hook_guard.rules()]
+    assert all(names)
+    assert len(set(names)) == len(names)
+
+
+def test_match_returns_the_rule_behind_the_reason() -> None:
+    rule = hook_guard.match("gh pr create --fill")
+    assert rule is not None
+    assert rule.name == "gh pr create"
+    assert rule.reason == hook_guard.decide("gh pr create --fill")
+    assert hook_guard.match("git status") is None
 
 
 def test_read_command_real_hook_payload() -> None:


### PR DESCRIPTION
The command-audit report's top bucket ("denied-but-ran — investigate: guard
bypass") listed 174 rows and was 100% noise. Measured over 3,615 real Bash
calls from 50 transcripts:

    | | executed | blocked |
    |---|---:|---:|
    | pre-rule  | 147 | 5 |
    | post-rule |   0 | 3 |

Nothing has ever evaded the guard. The bucket was wrong in two independent
ways, and needs both axes to be right:

1. Pre-rule history (147). The scan reaches back long before the guard
   existed, so every historical one-off matched a rule that did not yet
   exist. Each `_RULES` entry is now a `Rule` dataclass carrying a `since`
   landing date (2026-07-07 for the eight #174 rules, 2026-07-14 for the
   three from #260), and `classify()` only alarms past it. The rule's own
   landing day counts as pre-rule — it may have merged later that day, and
   a false alarm costs more than a missed same-day one. `since` dates the
   RULE, not its wording; a test pins that every rule has a valid one, since
   a missing date silently darkens the alarm forever.

2. The bucket counted ATTEMPTS, not executions. A transcript records the
   Bash tool_use block whether or not the guard denied it — the PreToolUse
   deny lands after the model emits it — so a denial and a bypass were
   byte-identical. `_executed_ids` now pairs each attempt to its result:
   executed calls carry a `stdout`-bearing dict `toolUseResult`, refused
   ones a bare `"Error: …"` string. Probed robust across all 7 executed
   variants (plain, backgroundTaskId, gitOperation, persistedOutputPath,
   returnCodeInterpretation, staleReadFileStateHint, backgroundedByUser);
   every line carries exactly one tool_result block (6822/6822), so the
   line-level toolUseResult pairs unambiguously. No result ⇒ not executed:
   proof is required to cry bypass.

`denied` therefore splits into `bypass` (live rule + it ran — the only
alarm), `blocked` (guard denied it: working as intended) and `pre_rule`
(history). Today: 0 / 3 / 152.

The inversion worth keeping: the enforcement research predicted EVASION as
the risk. Evasion is zero. The guard's only measured defect is the opposite
— FALSE POSITIVE denials, 2 of the 3 it has ever issued, from a `|` inside
a quoted regex reading as a shell separator. That is now surfaced in its own
report bucket (grouped by rule identity — a false positive's command head
names nothing) and filed as #265. Same shape as #264's REFUTED cd-prefix
"evasion".

Deferred deliberately: the one_off bucket has the same disease (1,127 rows
whose top shapes are all sanctioned work) — #266, kept out of this PR to
stay reviewable.

Verified: the SessionEnd hook FIRED for the first time (report mtime tracked
the /clear that ended the prior session), which also settles an open
question — Claude Code does re-read settings.json mid-session.

Suite: 545 tests (+23), 89 contracts. Contract extended to pin both axes.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PTsixP4QFhxLdnqJpJdvhr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Command-audit reports now distinguish bypasses, blocked commands, and commands covered by earlier rules.
  - Reports identify which guard rule blocked a command and accurately track whether attempted commands executed.
  - Added protections for monitoring workflow commands.

- **Documentation**
  - Expanded guidance for interpreting audit reports, handling false positives, and extending enforcement rules.
  - Updated documented test-suite totals to 545 tests.

- **Tests**
  - Added coverage for transcript parsing, execution tracking, rule dates, rule identity, and audit classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->