### PR TITLE
docs(rules): a hanging lint is usually your own ruff error (#268)

### DIFF
--- a/.claude/rules/long-running-command-hangs.md
+++ b/.claude/rules/long-running-command-hangs.md
@@ -27,8 +27,12 @@ unbounded wait + pipe-masked exit code.
 
 2. **For any command expected to exceed ~30s, never wait blind.** Either
    bound it with a timeout, or run it in the background and monitor its
-   debug log: hk → `~/.local/state/hk/hk.log` (or the per-run
-   `HK_LOG_FILE` that `mise run lint` sets), mise →
+   debug log. For a `mise run lint` run the log is
+   **`~/.local/state/dotfiles/hk-lint.log`** — the per-run `HK_LOG_FILE`
+   the wrapper sets (`lint.py` `DEFAULT_LOG_FILE`). Read THAT one:
+   `~/.local/state/hk/hk.log` is a *different* file written by other hk
+   entrypoints (e.g. the pre-push hook) and is typically stale, which
+   makes a live hang look idle (misread 2026-07-14). mise →
    `~/.local/state/mise/mise.log` (`MISE_LOG_FILE`, debug level set in
    `mise.toml [env]`). Use a count-diff monitor loop, not a fixed sleep.
 
@@ -49,6 +53,22 @@ unbounded wait + pipe-masked exit code.
    `~/.local/state/hk/`. (The old "clear ~/Library/Caches/hk/configs/
    after editing hk.pkl" guidance is retired — the cache is
    content-hashed since hk 1.47; see `ci-local-parity.md` rule 5.)
+
+6. **A hanging lint is usually YOUR ruff error, not flaky tooling
+   (issue #268).** A real ruff violation does not fail the gate — it
+   **wedges hk for the full 600s**, and the error is never printed.
+   The `ruff` step has `fix=true`, so a failed check phase makes hk
+   seek a WRITE lock to run the fix (`failed to get write locks …
+   src/file_rw_locks.rs:85:30`) while `ruff_format` sits at `waiting
+   for ruff`. Proven causal 2026-07-14: same tree with 3 ruff errors →
+   wedged at 39/47 steps, 0% CPU, no children; ruff clean → `rc=0`, 47
+   steps. **So: when lint hangs, run `uv run --project python ruff
+   check` DIRECTLY first** — it prints in seconds what hk hides for ten
+   minutes. Fix, then re-run `mise run lint`.
+
+7. **Find the wedged step by name.** Grep the lint output for a
+   `❯ <step>` with no matching `✔ <step>` — that names it directly,
+   without reading the whole debug log.
 
 ## Applies to
 

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -81,7 +81,7 @@ scopes it to the SHA the local gates validated.
 | `ship: working tree not clean` | Uncommitted changes | Commit (or stash) so gates validate the shipped tree |
 | `FAIL gate <name>` | A local gate failed | That failure IS the task (zero-skip); fix, rerun ship |
 | `ship: could not enable auto-merge` | The 422 regression outlasted the bounded retry, or "Allow auto-merge"/`ci-gate` isn't configured | Check the repo's auto-merge setting + branch protection; re-run `ship` (it reuses the PR) |
-| `land: PR #N is OPEN, not yet MERGED` | Auto-merge is still pending `ci-gate` (CI running) | Wait for GitHub to merge it, then re-run `land` for the post-merge Mac validation |
+| `land: PR #N is OPEN, not yet MERGED` | Auto-merge is still pending `ci-gate` (CI running). **Expected right after ship — not a failure**, though `land` does exit non-zero | Wait for the merge, then re-run `land` for the post-merge Mac validation. `land` has no `--wait` and `gh pr checks --watch` is guard-denied, so poll the blessed one-shot read, keeping the turn engaged: `until [ "$(gh pr view <N> --json state --jq .state)" = MERGED ]; do sleep 60; done` |
 | CI check failed (PR never auto-merges) | A required check went red, so auto-merge never fires | Triage the run; autofix "✅ Autofix task started" means the bot pushed a fix → new checks run → auto-merges when green |
 | land failed AFTER the merge (CI watch / sync) | Merged-but-unvalidated PR | `mise run land -- <PR#> --resume` replays the idempotent post-merge steps |
 | `land: no main ci.yml run appeared` | A merge that SHOULD trigger a run didn't register (~10 min) | Check Actions; land only expects a run when the diff matches `CI_PUSH_PATHS` (ci.yml on.push.paths) — a merge matching none passes without one (#179) |


### PR DESCRIPTION
Session 2026-07-14-f lost ~10 minutes to a lint that hung at 0% CPU with no
children. The cause was not flaky tooling: ruff had found 3 real violations,
and hk wedged on its own failure path rather than printing them.

`ruff` has fix=true, so a failed check phase makes hk seek a WRITE lock to run
the fix (`failed to get write locks … src/file_rw_locks.rs:85:30`) while
`ruff_format` sits at `waiting for ruff`. Neither yields. Proven causal: same
tree with the violations fixed → rc=0, 47 steps.

The natural inference from a hanging lint is "the tooling is flaky" — exactly
the wrong lesson, and one that defeats zero-skip, since you cannot resolve an
error the gate hides for ten minutes. So long-running-command-hangs.md gains:

- rule 6: when lint hangs, run `ruff check` DIRECTLY first. It prints in
  seconds what hk hides for 600s. Full evidence in #268.
- rule 7: find the wedged step by name — grep for a `❯ <step>` with no
  matching `✔ <step>`. (Used to catch the typo in this very commit.)
- rule 2 sharpened: the log to read for a `mise run lint` run is
  ~/.local/state/dotfiles/hk-lint.log, NOT ~/.local/state/hk/hk.log — a
  different file written by other hk entrypoints, typically stale, which makes
  a live hang look idle. Misread once this session.

Also pr-workflow: the `land: PR #N is OPEN, not yet MERGED` row said "wait for
GitHub to merge it" without saying how. `land` has no --wait and
`gh pr checks --watch` is guard-denied, so the row now carries the blessed
one-shot poll. Hit for real on #267.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PTsixP4QFhxLdnqJpJdvhr
