### PR TITLE
fix(guard): name the recall the masking trades, instead of claiming none

### DIFF
--- a/.claude/rules/mise-tasks-only.md
+++ b/.claude/rules/mise-tasks-only.md
@@ -127,11 +127,18 @@ command). Rule patterns are untouched, so recall is preserved by
 construction. Measured: the `blocked` bucket went **3 → 1**, keeping the
 one denial that was always correct.
 
-Still fail-open BY DESIGN (unchanged — this is a redirect guard, not a
-sandbox): `$(…)` substitution, `sh -c`, base64, aliases. If a deny ever
-does look wrong, the workaround remains: write the script with the Write
-tool and run `python3 <file>` — and after ANY deny, re-check that the
-command's intended side effects actually happened.
+Still fail-open BY DESIGN (this is a redirect guard, not a sandbox):
+`$(…)` substitution, `sh -c`/`eval`, base64, aliases. Masking narrows
+that class slightly and on purpose — `eval "echo x; gh pr create"` was
+denied before (the quoted `;` anchored `_CMD`) and is allowed now. That
+was an accident, not coverage: bare `eval "gh pr create"` was always
+allowed, so the class was never guarded, only its separator-bearing
+variant. Giving that up IS the precision-over-recall trade, with evasion
+measured at 0.
+
+If a deny ever does look wrong, the workaround remains: write the script
+with the Write tool and run `python3 <file>` — and after ANY deny,
+re-check that the command's intended side effects actually happened.
 
 **Evasion was never the defect — false positives were** (issue #265, now
 closed). The audit's `blocked` bucket measured it: 2 of the 3 denials ever

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ the official `@devcontainers/cli` (pinned in `mise.toml`).
 | `.claude/` | Claude-specific agents, skills, rules. Has its own `CLAUDE.md` with OMC orchestration |
 | `home/` | Chezmoi-managed dotfile templates (its AGENTS.md was removed in #80) |
 | `python/` | Python package `dotfiles_setup` — see `python/AGENTS.md` |
-| `tests/` | Pytest + Bats test suite (561 pytest tests) — see `tests/AGENTS.md` |
+| `tests/` | Pytest + Bats test suite (562 pytest tests) — see `tests/AGENTS.md` |
 | `scripts/` | Utility scripts (`benchmark-docker.sh`, `devcontainer-smoke.sh`) |
 | `docs/` | Documentation, research findings, design specs |
 
@@ -86,7 +86,7 @@ content-hashed since hk 1.47 — no manual cache clearing after edits.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q               # All 561 tests
+uv run --project python pytest tests/ -x -q               # All 562 tests
 uv run --project python pytest tests/test_audit.py -x -q  # Single file
 mise run lint                                             # Lint checks only (hk under a hard timeout)
 dotfiles-setup verify run                                 # Verification contracts (suites.toml)

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -39,7 +39,7 @@ Requires **Python 3.14**.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q                # All 561 tests
+uv run --project python pytest tests/ -x -q                # All 562 tests
 uv run --project python pytest tests/test_audit.py -x -q   # Single file
 ```
 

--- a/python/src/dotfiles_setup/hook_guard.py
+++ b/python/src/dotfiles_setup/hook_guard.py
@@ -255,9 +255,17 @@ _RULES: tuple[Rule, ...] = (
 # the canonical alternation idiom (Friedl's "unrolling the loop"), not a novel
 # parser.
 #
-# This is a redirect guard, not a sandbox: `$(…)` substitution, `sh -c`, and
-# base64 stay fail-open exactly as before — unchanged by this fix, not newly
-# opened by it.
+# This is a redirect guard, not a sandbox: `$(…)` substitution, `sh -c`/`eval`,
+# base64 and aliases are fail-open BY DESIGN. Masking narrows that class
+# slightly and DELIBERATELY (measured against the pre-fix guard, not assumed):
+# `eval "echo x; gh pr create"` was denied before, because the quoted `;`
+# anchored `_CMD`, and is allowed now. That catch was an ACCIDENT, not a
+# capability — `eval "gh pr create"` was always allowed, so the class was never
+# actually covered; only its separator-bearing variant was, which is not a
+# property anyone could have relied on. Losing it is the trade this fix exists
+# to make: evasion has measured 0 for the guard's lifetime while false
+# positives were 2 of its 3 denials. Pinned by
+# tests/test_hook_guard.py::test_masking_trades_the_incidental_eval_catch.
 
 # Exactly `_CMD`'s separator class: neutering these and nothing else is what
 # makes the rules quoting-aware without touching a rule.

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -963,7 +963,7 @@ paths = [
     "tests/test_hook_guard.py",
     ".claude/rules/mise-tasks-only.md",
 ]
-per_path_tokens = { ".claude/settings.json" = ["scripts/pretooluse-guard.sh"], "scripts/pretooluse-guard.sh" = ["dotfiles-setup hook pretooluse"], "python/src/dotfiles_setup/hook_guard.py" = ["def _inert_masked", "_inert_masked(command)"], "tests/test_hook_guard.py" = ["def test_separators_inside_inert_spans_do_not_anchor", "def test_real_npx_denial_was_a_true_positive", "def test_inert_span_redaction_never_costs_a_true_positive"] }
+per_path_tokens = { ".claude/settings.json" = ["scripts/pretooluse-guard.sh"], "scripts/pretooluse-guard.sh" = ["dotfiles-setup hook pretooluse"], "python/src/dotfiles_setup/hook_guard.py" = ["def _inert_masked", "_inert_masked(command)"], "tests/test_hook_guard.py" = ["def test_separators_inside_inert_spans_do_not_anchor", "def test_real_npx_denial_was_a_true_positive", "def test_inert_span_redaction_never_costs_a_true_positive", "def test_masking_trades_the_incidental_eval_catch"] }
 tokens = [
     "dotfiles-setup hook pretooluse",
     "def pretooluse_main",

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -35,7 +35,7 @@ Docker image smoke outputs.
 | `infra/foundation.bats` | Bats | Bash-level foundation checks (shell script integration) |
 | `infra/runtimes.bats` | Bats | Runtime installation checks (bash) |
 
-Total: **561 pytest tests** run by default (`pytest tests/` collects all
+Total: **562 pytest tests** run by default (`pytest tests/` collects all
 `test_*.py` files) plus **4 gated `image_exec`** exec tests (deselected by
 default; run via `mise run smoke-exec`) and Bats scenarios under `infra/`.
 

--- a/tests/test_hook_guard.py
+++ b/tests/test_hook_guard.py
@@ -254,6 +254,30 @@ def test_real_npx_denial_was_a_true_positive() -> None:
     assert "mise-installed binary" in reason
 
 
+def test_masking_trades_the_incidental_eval_catch() -> None:
+    """The `eval`/`sh -c` class loses an ACCIDENTAL catch. Deliberate, measured.
+
+    Before #265, `eval "echo x; gh pr create"` was denied — not because the
+    guard understood `eval`, but because the quoted `;` anchored `_CMD`. Masking
+    removes that, and the third assertion is why it costs nothing real: the bare
+    `eval "gh pr create"` was ALREADY allowed, so the class was never covered —
+    only its separator-bearing variant was, which no one could have relied on.
+
+    The module has always declared `sh -c`/`eval`/`$(…)`/base64 fail-open (a
+    redirect guard, not a sandbox), evasion has measured 0 across the guard's
+    lifetime while false positives were 2 of its 3 denials, and the direction
+    set for this fix was precision over recall. So this is the trade working as
+    intended — pinned here so it stays a decision. If these are ever re-denied,
+    it should be because someone chose to guard `eval` properly, not by
+    accident.
+    """
+    assert hook_guard.decide('eval "echo x; gh pr create"') is None
+    assert hook_guard.decide('bash -c "cd /x && gh pr merge 42"') is None
+    # Never covered even BEFORE the fix — the proof the catch above was
+    # incidental rather than a capability this change gave up.
+    assert hook_guard.decide('eval "gh pr create"') is None
+
+
 @pytest.mark.parametrize(
     ("command", "redirect_hint"),
     [


### PR DESCRIPTION
The previous commit's comment said `sh -c`/`eval`/`$(…)` stay fail-open
"exactly as before — unchanged by this fix". Measured against the pre-fix
guard, that overclaims. Two shapes really do change verdict:

    eval "echo x; gh pr create"        DENY -> ALLOW
    bash -c "cd /x && gh pr merge 42"  DENY -> ALLOW

The trade is correct, and the reason is the third probe result: bare
`eval "gh pr create"` was ALREADY allowed before. So the guard never had
designed `eval` coverage — it only caught the variant that happened to
carry a separator inside the quotes, which is not a property anyone could
have relied on. This removes an accident, not a capability, and that is
exactly the precision-over-recall trade the fix exists to make: evasion
has measured 0 across the guard's lifetime while false positives were 2
of its 3 denials.

Every real invocation, cd-prefixed compound and quoted image ref is
unchanged (DENY -> DENY), verified against origin/main's guard side by
side rather than assumed.

A comment that hides a trade is worse than the trade. So: say it in the
module, say it in the rule doc, and pin it with a test — if these are
ever re-denied it should be because someone chose to guard `eval`
properly, not by accident. Contract pins the test alongside the other
three.

Suite 561 -> 562. lint-docs rc=0 · verify 89 passed/0 failed · ruff clean.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PTsixP4QFhxLdnqJpJdvhr
