### PR TITLE
fix(ci): skip pre-push too — #274 named the wrong hook and lock-refresh still failed

### DIFF
--- a/.github/workflows/gcc-sha-repair.yml
+++ b/.github/workflows/gcc-sha-repair.yml
@@ -32,13 +32,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      # This job commits (below), and `mise install` fires mise.toml's postinstall
-      # (`hk install --mise`) which wires .git/hooks/pre-commit on the runner —
-      # hk would then run every step, incl. ones needing `gh auth` / `claude` on
-      # PATH. Latent today only because `install_args: "python uv"` omits hk, so
-      # the postinstall fails (warn-only) and the hook is never written; widening
-      # install_args would arm it. Same fix as refresh.yml, which this bit for real.
-      HK_SKIP_HOOKS: pre-commit
+      # This job commits AND pushes (below), and `mise install` fires mise.toml's
+      # postinstall (`hk install --mise`) which wires commit-msg + pre-commit +
+      # pre-push on the runner — hk would then run every step, incl. pre-push's
+      # ghcr_publish_prereqs / test, which need `gh auth` and `claude` on PATH.
+      # Latent today only because `install_args: "python uv"` omits hk, so the
+      # postinstall fails (warn-only) and no hook is written; widening install_args
+      # would arm it. Same fix as refresh.yml, which this bit for real.
+      HK_SKIP_HOOKS: pre-commit,pre-push
     steps:
       - name: Mint GitHub App token
         # App-token push fires the PR's `pull_request` CI on its own (unlike

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -55,14 +55,15 @@ jobs:
       # Disk-only debug-level logs for diagnosing lock-regen failures.
       MISE_LOG_FILE: /tmp/mise.log
       MISE_LOG_FILE_LEVEL: debug
-      # `mise install` fires mise.toml's postinstall (`hk install --mise`),
-      # which wires .git/hooks/pre-commit ON THE RUNNER. create-pull-request
-      # then commits into it, so hk runs every step — including ghcr_publish_prereqs
-      # (needs `gh auth`) and test (needs `claude` on PATH). Neither exists here,
-      # so the PR step failed whenever a lock actually drifted. Green until
-      # 2026-07-14 only because no drift meant no commit meant no hook.
-      # CI runs its own lint job; a commit-time hook here is pure accident.
-      HK_SKIP_HOOKS: pre-commit
+      # `mise install` fires mise.toml's postinstall (`hk install --mise`), which
+      # wires commit-msg + pre-commit + pre-push ON THE RUNNER. create-pull-request
+      # both commits AND pushes, so hk runs every step — including pre-push's
+      # ghcr_publish_prereqs (needs `gh auth`) and test (needs `claude` on PATH).
+      # Neither exists here, so the PR step failed whenever a lock actually drifted.
+      # Green until 2026-07-14 only because no drift meant no commit/push, no hook.
+      # pre-push is the one that bites (hk.pkl:438-446); pre-commit is listed because
+      # it is equally accidental. CI runs its own lint job.
+      HK_SKIP_HOOKS: pre-commit,pre-push
     steps:
       - name: Mint GitHub App token
         # App-token PR push fires `pull_request` CI on its own (unlike


### PR DESCRIPTION
#274 set HK_SKIP_HOOKS=pre-commit. The dispatched proof-run then failed anyway,
and said exactly why:

  hk WARN  pre-commit: skipping hook due to HK_SKIP_HOOK    <- the skip worked
  ❯ ghcr_publish_prereqs → Traceback                        <- but this still ran

`hk install` wires THREE hooks — commit-msg, pre-commit, pre-push — and
create-pull-request pushes as well as commits. The two failing steps are
pre-push's: hk.pkl:438 ["pre-push"] -> :440 ghcr_publish_prereqs, :444 test.
#274 cited those very line numbers while calling them pre-commit steps; the
evidence never said which hook, that was assumed.

Probed with a control arm, against a real remote with origin/HEAD established
(a bare remote has none, and hk's pre-push errors out resolving it — which
silently made a first attempt at this probe pass for the wrong reason):

  A  no skip                      -> pre-push FIRED    (probe discriminates)
  B  HK_SKIP_HOOKS=pre-commit     -> pre-push FIRED    (confirms #274's gap)
  C  HK_SKIP_HOOKS=pre-commit,\
     pre-push                     -> skipped           (comma-separated works)

Arm A is the point: without it, arm C's pass proves nothing.

Gates: lint rc=0 (47 steps) · pytest 618 passed · verify 90 passed/0 failed ·
pin-actions rc=0 · actionlint rc=0.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X9TKq5UxojSFBCgXdVzfJe
