### PR TITLE
feat(docs): adopt the mattpocock tracker config + label vocabulary, hand-placed

### DIFF
--- a/.agnix.toml
+++ b/.agnix.toml
@@ -40,7 +40,13 @@ max_files_to_validate = 10000
 #    "## Project Context" header, and are at the 200-line claude_md_size_limit.
 #  - PE-001: "critical keyword in the 40-60% lost-in-middle zone" is a prompt
 #    heuristic that misfires on reference docs.
-paths = ["**/AGENTS.md", "**/CLAUDE.md", "AGENTS.md", "CLAUDE.md"]
+# CONTEXT.md joins them (2026-07-15): it is the domain glossary the mattpocock
+# engineering skills read, and the same XP-003 rationale applies verbatim — its
+# `.claude/rules/*.md` references are the POINT (that is where this repo's ADRs
+# live; see docs/adr/README.md). Rewording them to satisfy a portability check
+# would delete the fact the section exists to state. Scoped to the exact filename
+# so a stray hard-coded path in new code still flags.
+paths = ["**/AGENTS.md", "**/CLAUDE.md", "AGENTS.md", "CLAUDE.md", "CONTEXT.md"]
 disabled_rules = ["XP-003", "AGM-004", "AGM-006", "PE-001"]
 
 [[overrides]]

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -59,6 +59,31 @@ Kill switches: `DISABLE_OMC`, `OMC_SKIP_HOOKS` (comma-separated).
 State: `.omc/state/`, `.omc/state/sessions/{sessionId}/`, `.omc/notepad.md`, `.omc/project-memory.json`, `.omc/plans/`, `.omc/research/`, `.omc/logs/`
 </worktree_paths>
 
+## Agent skills
+
+Config for the `mattpocock-skills` engineering flow. Lives here, because the root `CLAUDE.md` is
+byte-exactly `@AGENTS.md` (`claude_md_import_stub`) and `AGENTS.md` is at 200/200 lines.
+
+**These files are hand-placed, and stay that way.** `/setup-matt-pocock-skills` generates the same
+config but writes it to the root `CLAUDE.md` and `docs/agents/*.md` — paths our gates reject (the
+stub check, and agnix's `**/agents/*.md` frontmatter rule). Reach for the files below instead; they
+are its output, already adapted.
+
+### Issue tracker
+
+GitHub Issues on `ray-manaloto/dotfiles`, via `gh`. See `docs/issue-tracker.md`.
+**`gh pr create`/`merge` are guard-denied — use `mise run ship` / `mise run land`.**
+
+### Triage labels
+
+The five canonical roles, adopted verbatim (no remapping). See `docs/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` (glossary) + `docs/adr/`. See `docs/domain.md`.
+**Our ADRs are `.claude/rules/*.md`** — each carries its own "Why this rule exists"; `docs/adr/`
+holds only domain-shaped decisions.
+
 ## Setup
 
 Say "setup omc" or run `/oh-my-claudecode:omc-setup`.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -56,7 +56,7 @@
     "pyright-lsp@claude-plugins-official": false,
     "pyright@claude-code-lsps": false,
     "explanatory-output-style@claude-plugins-official": true,
-    "plugin-dev@claude-plugins-official": true,
+    "plugin-dev@claude-plugins-official": false,
     "hookify@claude-plugins-official": true,
     "learning-output-style@claude-plugins-official": true,
     "gopls-lsp@claude-plugins-official": false,

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -192,8 +192,11 @@ jobs:
             gh issue edit "$number" --repo "$REPO" --body-file /tmp/tool-currency.md
             echo "Updated issue #$number"
           else
+            # needs-triage puts bot-filed issues into the /triage flow rather than
+            # leaving them unlabelled (docs/triage-labels.md). Safe to add: this
+            # issue is deduped by EXACT TITLE above, never by label.
             gh issue create --repo "$REPO" --title "$title" \
-              --body-file /tmp/tool-currency.md --label dependencies
+              --body-file /tmp/tool-currency.md --label dependencies,needs-triage
           fi
       - name: Upload report artifact
         if: always()

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,72 @@
+# CONTEXT — domain glossary
+
+The vocabulary this repo actually uses. Read by `/mattpocock-skills:domain-modeling`,
+`improve-codebase-architecture`, `tdd`, and `diagnosing-bugs` (all "if it exists" — absence is not
+an error).
+
+**Scope:** single-context. There is no `CONTEXT-MAP.md`; this repo is one context.
+
+**This is a glossary, not an architecture doc.** Architecture lives in `CLAUDE.md` → `AGENTS.md`
+and the per-directory `AGENTS.md` files. Decisions-with-rationale live in `.claude/rules/*.md`.
+Use the term below when naming things; don't drift to synonyms.
+
+## The two build types
+
+| Term | Means |
+|---|---|
+| **Build Type 1 / local linting** | hk + mise on the Mac host. `mise run lint` is the gate. |
+| **Build Type 2 / the image** | The devcontainer image, built **in CI only**, published to `ghcr.io/ray-manaloto/dotfiles-devcontainer`. Never built locally. |
+
+## Image tiers — three, each independently content-hashed
+
+| Term | Means |
+|---|---|
+| **base** | apt + `mise install` + cargo. Tag `:base-<hash16>`. Inputs: every base-section `COPY` source, **by bytes** (`mise-system.toml`, `hk-common.pkl`, `hk-image.pkl`). |
+| **p2996** | The Clang-P2996 compiler install prefix, exported out-of-tree. Tag `:p2996-<hash16>`. Keyed on `CLANG_P2996_REF` + builder image + platform — **decoupled** from base-hash since #160 T11, so a base edit doesn't cold-rebuild the compiler. |
+| **dev** | The published image. Tag `:dev-<hash16>` is stamped **only after smoke passes**; `:dev`/`:latest` are retags of a smoked image. |
+| **content-hash probe** | The cache. `dotfiles-setup {base,p2996,dev}-hash` → `docker manifest inspect` the tag. Hit ⇒ skip the build. |
+| **promote** | The push-to-main path: `docker buildx imagetools create` retags the merged PR's `:pr-NNN` to `:dev`/`:latest`. **Manifest-only, ~30s, no rebuild.** |
+
+## The R invariants — the devcontainer's reason to exist
+
+Durable; never silently dropped. Gated by `mise run verify-local`.
+
+| Term | Means |
+|---|---|
+| **R1 inbound** | `ssh ${USER}@localhost -p 4444` opens a shell, no password. |
+| **R2 outbound** | `ssh -T git@github.com` **inside** the container authenticates — via Docker Desktop's `/run/host-services/ssh-auth.sock`. |
+| **R3 amd64** | The container reports `x86_64`/`amd64`. The Mac is arm64; the image is not. |
+
+## Workflow vocabulary
+
+| Term | Means |
+|---|---|
+| **ship** | `mise run ship` — gates, then open the PR, then watch checks to bucket-verified green. **Never** `gh pr create` (guard-denied). |
+| **land** | `mise run land -- <PR#>` — post-merge validation on the Mac. |
+| **the guard** | The PreToolUse hook (`hook_guard.py`) that DENIES one-off commands with a canonical `mise run` equivalent. Deterministic; applies even in bypassPermissions. |
+| **surface** | A diff path matching `SURFACE_PATTERNS` (`pr.py`) — forces ship's hard `sync-full` gate (~25 min). |
+| **sync** | `mise run sync` — converge the local container onto the CI-built `:dev`. |
+| **the gate matrix** | `mise run lint` + pytest + `dotfiles-setup verify run`, plus conditional rows (`pin-actions`, `lint-docs`, `verify-local`). See `.claude/rules/verify-before-advancing.md`. |
+
+## Enforcement vocabulary
+
+| Term | Means |
+|---|---|
+| **contract** | An entry in `python/verification/suites.toml`, run by `dotfiles-setup verify run`. Asserts a wiring chain exists (hk step ↔ CLI ↔ module ↔ tests ↔ rule) so it can't silently drift out. |
+| **zero-skip** | No warning/error is ever dismissed. A suppression needs explicit approval. |
+| **zero-bash-logic** | Non-trivial logic lives in `python/`; bash is thin check/smoke wrappers only. Enforced by `bash_budget.py` (allowlist + per-file line budget). |
+| **the stub** | Root `CLAUDE.md` — byte-exactly `@AGENTS.md\n`. Enforced by `claude_md_import_stub`. `.claude/**` is exempt. |
+| **bypass / blocked / pre_rule** | `mise run command-audit` classes. Only **bypass** (matched a live rule AND ran) is an alarm. Measured: **0 bypasses, ever.** |
+
+## Terms we deliberately do NOT use
+
+- **"ADR"** as a separate artifact — `.claude/rules/*.md` already are ADRs; each has a *"Why this
+  rule exists"* section citing the incident that produced it. See `docs/adr/README.md`.
+- **"dotfiles" as the product** — the product is the **AMD64 devcontainer**; the dotfiles are how it
+  gets configured.
+
+## See also
+
+- `docs/domain.md` — how skills should consume this file.
+- `CLAUDE.md` → `AGENTS.md` — architecture, tasks, policies.
+- `.claude/rules/` — the decisions, with rationale.

--- a/docs/adr/0001-hk-hooks-do-not-run-in-ci.md
+++ b/docs/adr/0001-hk-hooks-do-not-run-in-ci.md
@@ -1,0 +1,78 @@
+# ADR-0001 — hk git hooks must not run in CI
+
+**Status:** accepted · **Date:** 2026-07-15 · **PRs:** #274 (wrong), #275 (correct)
+
+## Context
+
+`mise.toml`'s `[hooks] postinstall = "mise reshim && hk install --mise"` runs on **every**
+`mise install` — including on GitHub Actions runners. `hk install` writes three git hooks:
+`commit-msg`, `pre-commit`, `pre-push`.
+
+Any CI job that then commits or pushes fires them. `refresh.yml`'s lock-refresh job does both (via
+`peter-evans/create-pull-request`), so hk ran its full step set on the runner, including two steps
+that **cannot** pass there:
+
+- `ghcr_publish_prereqs` (`hk.pkl:440`) → `GhcrCheckError: You are not logged into any GitHub hosts`
+- `test` (`hk.pkl:444`) → `test_tool_reachable_in_login_shell[claude]`: `claude` is not on a
+  runner's login-shell PATH
+
+**Consequence:** the daily lockfile refresh failed 2026-07-14 and 2026-07-15, and **no lock-refresh
+PR had ever opened** in the workflow's lifetime (`gh pr list --label lockfile` → `[]`).
+
+**Why it hid for six days:** the failing step is conditional — *"Open PR **if any lock drifted**"*.
+No drift ⇒ no commit ⇒ no hook ⇒ green. The bug only fires when the workflow has real work to do.
+`gcc-sha-repair.yml` is exposed identically but stayed latent for two independent reasons: it exits
+early when there's nothing to repair, and its `install_args: "python uv"` omits hk, so the
+postinstall fails (warn-only) and no hook is written.
+
+## Decision
+
+**Skip the hooks; don't satisfy them.** `HK_SKIP_HOOKS: pre-commit,pre-push` at job level in every
+workflow that commits or pushes (`refresh.yml`, `gcc-sha-repair.yml`).
+
+CI runs its own lint job (`ci.yml`). A commit-time hook on a runner is an accident of tool
+installation, not a gate anyone designed. Skipping it removes nothing that CI doesn't already do.
+
+`skip_hooks` is hk's **native** mechanism (`HK_SKIP_HOOKS` / `hk.skipHook`: *"Hook names to skip
+entirely. Values from all sources are unioned together."*), so this needs no custom code —
+`use-tool-builtins.md`. hk has **no CI self-detection** (grepped the docs cache and all 100 releases
+v0.7.0→v1.51.0: zero hits), so the skip must be explicit.
+
+## Alternatives rejected
+
+| Option | Why not |
+|---|---|
+| **Gate the postinstall** so `hk install` skips CI | Attacks the root cause, but `postinstall` also runs `mise reshim`, which CI genuinely needs (added for a real pipx shim bug — `mise.toml:64-65`), and mise documents no env-conditional postinstall ⇒ shell logic in `mise.toml`, against `zero-bash-logic.md`. |
+| **hk `profiles`** — mark the two steps as local-only | Elegant, and `profiles` is a feature we don't use. But it changes step semantics everywhere, risking `ci-local-parity.md`. |
+| **Make the two steps pass on a runner** | Biggest change, and wrong: a full pytest run has no business inside a lockfile-bump commit hook. |
+
+## Consequences
+
+- Any **new** workflow that commits or pushes must set `HK_SKIP_HOOKS` too. There is no global
+  guard — the two known cases are fixed by name.
+- Correctness now depends on remembering. A contract asserting "every workflow that commits sets
+  `HK_SKIP_HOOKS`" would give this teeth; not written yet.
+- `commit-msg` is deliberately **not** skipped: `check_conventional_commit` passes on the bots'
+  messages and is cheap. Add it if that changes.
+
+## The lesson worth keeping
+
+**#274 set `HK_SKIP_HOOKS: pre-commit` and was merged with every gate green** — lint, 618 tests,
+contracts, ship's five gates, `land`'s full container validation. **It was still broken.** The
+failing steps are `pre-push`'s (`hk.pkl:438`), and `create-pull-request` pushes as well as commits.
+#274 cited `hk.pkl:440`/`:444` while calling them pre-commit steps; the evidence never said which
+hook.
+
+Nothing we run could have caught it, because the interesting path is conditional and no gate
+exercises it. **Only dispatching the workflow at real drift proved it** — which then also proved
+#275:
+
+```
+hk WARN  pre-commit: skipping hook due to HK_SKIP_HOOK
+hk WARN  pre-push:   skipping hook due to HK_SKIP_HOOK
+→ PR #276 — the first lock-refresh PR that has ever existed
+```
+
+Corollary, learned the same hour: the first re-probe of the fix **passed for the wrong reason** —
+its control arm showed the hook never fired at all (hk errors resolving `origin/HEAD` against a bare
+remote). A probe without a control arm is not evidence.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,33 @@
+# ADRs — mostly not here
+
+The mattpocock engineering skills look for `docs/adr/`. This file exists so they find a real answer
+instead of an empty directory.
+
+## The ADRs are `.claude/rules/*.md`
+
+This repo filled the ADR role before those skills arrived. Every file in `.claude/rules/` is a
+decision record: the decision, a **"Why this rule exists"** section naming the incident that forced
+it, what it applies to, and a "See also" graph. That is an ADR in everything but filename.
+
+Duplicating them here would create a second decision store to keep in sync — and several rules are
+**machine-enforced** (hk steps, the PreToolUse guard, `python/verification/suites.toml` contracts),
+so the rule file is the one that has teeth. A copy under `docs/adr/` would be the copy that rots.
+
+**So: read `.claude/rules/` for decisions.** `CONTEXT.md` is the glossary; `docs/domain.md` explains
+the consumption order.
+
+## What DOES belong here
+
+Decisions that are **domain-shaped rather than agent-behaviour-shaped** — a choice about the
+devcontainer/image/CI domain that isn't a rule for how an agent should work, and therefore has no
+natural home in `.claude/rules/`.
+
+Expect this directory to stay small. Two decisions live here today:
+
+| ADR | Decision |
+|---|---|
+| [`0001-hk-hooks-do-not-run-in-ci.md`](0001-hk-hooks-do-not-run-in-ci.md) | CI installs git hooks as a side effect of installing tools; they must be skipped, not satisfied |
+
+## Numbering
+
+`NNNN-kebab-title.md`, zero-padded, monotonic. Never renumber — a stale link is worse than a gap.

--- a/docs/domain.md
+++ b/docs/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the mattpocock engineering skills should consume this repo's domain documentation.
+Adapted from the `setup-matt-pocock-skills` seed.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root — the glossary.
+- **`docs/adr/`** — but read `docs/adr/README.md` first: **this repo's ADRs live in
+  `.claude/rules/*.md`**, not here. See below.
+- There is **no `CONTEXT-MAP.md`** — this is a single-context repo (no monorepo signals: no
+  `package.json`, no `pnpm-workspace.yaml`, no `packages/*/src`).
+
+If a file doesn't exist, **proceed silently.** Don't flag its absence or suggest creating it.
+
+## ⚠️ Our ADRs are `.claude/rules/*.md`
+
+The seed template assumes `docs/adr/NNNN-*.md`. This repo already had that role filled before the
+skills arrived: **each file in `.claude/rules/` is an ADR** — a decision plus a *"Why this rule
+exists"* section citing the incident that produced it, plus a "See also" graph.
+
+So when a skill says *"read ADRs that touch the area you're about to work in"*, read
+**`.claude/rules/`**. `docs/adr/` holds only decisions that are genuinely domain-shaped rather than
+agent-behaviour-shaped; it is expected to stay small.
+
+Worked examples of rules-as-ADRs:
+
+| Decision | Rule file | The incident |
+|---|---|---|
+| Bound every long-running command | `long-running-command-hangs.md` | a 7-hour hk hang at 0% CPU, 2026-06-29 |
+| Prefer native tool features over custom code | `use-tool-builtins.md` | ~20 lines of custom chezmoi container-detection that `chezmoi.os` already did |
+| Canonical mise tasks over one-off commands | `mise-tasks-only.md` | the whole ship/land guard programme |
+| Never trust a piped tail's exit code | *(memory)* `feedback_pipe_kills_exit_code` | a killed hk run reporting exit 0 |
+
+## Use the glossary's vocabulary
+
+When output names a domain concept (an issue title, a refactor proposal, a hypothesis, a test name),
+use the term as defined in `CONTEXT.md`. Don't drift to synonyms it avoids.
+
+If a concept isn't in the glossary, that's a signal — either you're inventing language the project
+doesn't use (reconsider), or there's a real gap (note it).
+
+## Flag ADR conflicts
+
+If output contradicts an existing rule, surface it rather than silently overriding:
+
+> _Contradicts `.claude/rules/zero-bash-logic.md` — but worth reopening because…_
+
+This matters more here than in a typical repo: several rules are **machine-enforced** (hk steps,
+the PreToolUse guard, verification contracts). Contradicting one doesn't just disagree with a
+document — it fails a gate.

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -1,0 +1,110 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues on
+[`ray-manaloto/dotfiles`](https://github.com/ray-manaloto/dotfiles). Use the `gh` CLI for all
+operations — it infers the repo from `git remote -v` when run inside a clone.
+
+Adapted from the `setup-matt-pocock-skills` seed template. Consumed by
+`/mattpocock-skills:wayfinder`, `to-spec`, `to-tickets`, `triage`, and `code-review`.
+
+> **Why this file is not at `docs/agents/issue-tracker.md`** (the path those skills' `setup` step
+> writes): `agnix` treats any `**/agents/*.md` as an agent definition needing YAML frontmatter, so
+> that path fails `mise run lint-docs` (`error: Agent file must have YAML frontmatter`, rc=1).
+> Probed both ways — this path is clean. Nothing depends on the location: only `setup` itself and
+> `code-review:13` mention `docs/agents/` at all, and `wayfinder:25` degrades gracefully
+> (*"If no tracker has been provided, default to the local-markdown tracker"*). **Do not run
+> `/setup-matt-pocock-skills`** — it also edits the root `CLAUDE.md`, which the
+> `claude_md_import_stub` hk step rejects (that file must be byte-exactly `@AGENTS.md\n`).
+
+## ⚠️ Repo-specific: PR creation is guard-denied
+
+**`gh pr create` is DENIED by this repo's PreToolUse guard** (`hook_guard.py`, rule `"gh pr create"`).
+Any skill step that reaches for it will be blocked — and a deny cancels the whole compound command.
+
+| Instead of | Use |
+|---|---|
+| `gh pr create` | **`mise run ship`** — runs the path-aware gate matrix *before* the PR opens, then watches checks to bucket-verified green |
+| `gh pr merge` | **`mise run land -- <PR#>`** |
+
+`gh issue *` commands are **not** guarded — everything below is safe to run as written.
+See `.claude/rules/mise-tasks-only.md`.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with `--label` / `--state` filters.
+- **Comment**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo starts treating external PRs as
+feature requests; `/triage` reads this flag.)_ This is a solo infra repo — PRs here are our own work
+and `mise run ship`/`land` already gate them.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with
+`gh pr view 42`, falling back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body.
+  `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues
+  endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put
+  `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>`
+  (`research`/`prototype`/`grilling`/`task`). Once claimed, assign to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies**. Add an edge with
+  `gh api --method POST repos/ray-manaloto/dotfiles/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`,
+  where `<blocker-db-id>` is the blocker's numeric **database id**
+  (`gh api repos/ray-manaloto/dotfiles/issues/<n> --jq .id` — **not** the `#number` or `node_id`).
+  GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only). Where dependencies
+  aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A
+  ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the
+  map's sub-issues / task list), drop any with an open blocker
+  (`issue_dependencies_summary.blocked_by > 0`) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a
+  context pointer to the map's Decisions-so-far.
+
+### Prerequisites — all verified live on 2026-07-15
+
+`/wayfinder` needs three things from GitHub. All were probed against this repo, not assumed:
+
+| Prerequisite | Probe | Result |
+|---|---|---|
+| `wayfinder:*` labels | `gh label list` | **created** — `map`, `research`, `prototype`, `grilling`, `task` |
+| **Sub-issues** (child tickets) | `gh api repos/ray-manaloto/dotfiles/issues/254/sub_issues` | `[]` — endpoint live, feature enabled ⇒ use the sub-issue path, not the task-list fallback |
+| **Issue dependencies** (blocking) | `gh api …/issues/254 --jq .issue_dependencies_summary` | `{"blocked_by":0,"blocking":0,"total_blocked_by":0,"total_blocking":0}` — available ⇒ use native dependencies, not the `Blocked by:` body fallback |
+
+So both documented fallbacks (task-list children, `Blocked by:` lines) are **unnecessary here** — the
+native mechanisms work. They are retained above only because the upstream template carries them.
+
+**The db-id gotcha is real** — worked example on this repo:
+`gh api repos/ray-manaloto/dotfiles/issues/254 --jq .id` → `4886228692`, whereas its `node_id` is
+`I_kwDORuOFLM8AAAABIs3u1A` and its number is `254`. The dependencies endpoint wants **`4886228692`**.
+
+## How this relates to the existing epics practice
+
+This repo already runs multi-session efforts as GitHub issue epics — **#160** (build-input program),
+**#222** (image-waste program), **#254** (follow-ups). Those are checklists of *work to do*.
+Wayfinder's map is an index of *decisions made*, with the unknown written down explicitly (its "Not
+yet specified" section). Different axis; they can coexist. Nothing here retires the epics practice.
+
+## See also
+
+- `docs/triage-labels.md` — the label vocabulary `/triage` reads.
+- `.claude/rules/mise-tasks-only.md` — why `gh pr create`/`merge` are denied.
+- `.claude/skills/pr-workflow/SKILL.md` — `mise run ship` / `land`.

--- a/docs/triage-labels.md
+++ b/docs/triage-labels.md
@@ -1,0 +1,50 @@
+# Triage Labels
+
+The mattpocock engineering skills speak in terms of five canonical triage roles. This file maps
+those roles to the actual label strings on
+[`ray-manaloto/dotfiles`](https://github.com/ray-manaloto/dotfiles). Read by
+`/mattpocock-skills:triage`.
+
+**The mapping is the identity.** We adopted the canonical vocabulary verbatim rather than
+translating it, so there is no remapping layer to keep in sync.
+
+| Canonical role | Our label | Meaning | Status |
+|---|---|---|---|
+| `needs-triage` | `needs-triage` | Not yet assessed | created 2026-07-15 |
+| `needs-info` | `needs-info` | Blocked pending information | created 2026-07-15 |
+| `ready-for-agent` | `ready-for-agent` | Fully specified; an agent can take it unattended | created 2026-07-15 |
+| `ready-for-human` | `ready-for-human` | Needs human judgement | created 2026-07-15 |
+| `wontfix` | `wontfix` | Will not be actioned | pre-existing (GitHub default) |
+
+When a skill mentions a role ("apply the AFK-ready triage label"), use the label string above.
+
+## These are STATE labels — orthogonal to our type labels
+
+They answer *where is this in the flow*. The repo's existing vocabulary answers *what kind of thing
+is this*, and is unaffected:
+
+| Type label | Live usage (last 60 issues) |
+|---|---|
+| `enhancement` | 23 |
+| `bug` | 8 |
+| `dependencies` | 5 (bot PRs) |
+| `lockfile` | refresh.yml's lock-refresh PRs |
+| *(unlabelled)* | 25 |
+
+**Both axes coexist on one issue** — `enhancement` + `ready-for-agent` is the normal shape, not a
+conflict. Nothing here changes how `enhancement`/`bug`/`dependencies` are used.
+
+## Honest note on adoption
+
+These labels exist but are **not yet in use** — no issue carries one today. `/triage` is
+`disable-model-invocation: true`, so only a human typing `/mattpocock-skills:triage` drives it. This
+file records the vocabulary so the skill works when reached for; it does not assert a practice we
+have.
+
+The one wiring in place: `refresh.yml`'s tool-currency issue is labelled `needs-triage` on creation,
+so bot-filed issues enter the flow rather than sitting unlabelled (25 of the last 60 issues have no
+label at all).
+
+## See also
+
+- `docs/issue-tracker.md` — the tracker config these skills read.


### PR DESCRIPTION
Configures this repo for the mattpocock-skills engineering flow WITHOUT running
/setup-matt-pocock-skills, which cannot run here: it is disable-model-invocation
(so no agent can drive it), and its two write targets both trip our gates.
Probed, not assumed:

  docs/agents/issue-tracker.md -> agnix: "Agent file must have YAML frontmatter"
                                  rc=1  (**/agents/*.md == an agent definition)
  docs/issue-tracker.md        -> "No issues found"  rc=0
  root CLAUDE.md + its block   -> "not a thin @AGENTS.md import stub"  rc=1
                                  (check-claude-md-stub.sh:45 wants @AGENTS.md\n)

So the substance is taken and the paths are ours. This costs nothing: only
setup itself and code-review:13 reference docs/agents/ at all — wayfinder,
to-spec, to-tickets and triage never hardcode it, and wayfinder:25 degrades
("If no tracker has been provided, default to the local-markdown tracker").

The pointer block goes in .claude/CLAUDE.md — exempt from the stub check
(check-claude-md-stub.sh:55 filters ^\.claude/) with room (89/200 lines).
AGENTS.md has zero line headroom (200/200) and is untouched.

/wayfinder's prerequisites verified live, not assumed:
  wayfinder:{map,research,prototype,grilling,task}  created
  sub-issues     GET .../issues/254/sub_issues -> []            (enabled)
  dependencies   .issue_dependencies_summary   -> {"blocked_by":0,...}  (available)
=> both documented fallbacks (task-list children, "Blocked by:" lines) are
   unnecessary here. The db-id gotcha is worked through on a real issue.

Labels adopted verbatim, no remapping layer: the 5 canonical roles are STATE
labels, orthogonal to our TYPE labels (enhancement 23 / bug 8 / dependencies 5
of the last 60). Both axes coexist on one issue. wontfix already existed.

CONTEXT.md is a real glossary, not a scaffold — an empty one would be the
"no-op" failure mode writing-great-skills names. docs/adr/ says plainly that
our ADRs ARE .claude/rules/*.md (each already carries "Why this rule exists"),
and seeds ADR-0001 with today's real decision rather than sitting empty.

refresh.yml's tool-currency issue now gets needs-triage, so bot-filed issues
enter the flow (25 of the last 60 issues carry no label at all). Safe: that
issue is deduped by EXACT TITLE, never by label.

.agnix.toml: CONTEXT.md joins the existing XP-003 override (Ray-approved) —
same rationale as AGENTS.md/CLAUDE.md, since its `.claude/rules/*.md` refs are
the point. Scoped to the exact filename. The sibling negation warning was FIXED
rather than suppressed (prompt the positive) — agnix independently flagging the
same failure mode writing-great-skills names.

.claude/settings.json: plugin-dev disabled — ~2,349 tok/session reclaimed, the
most expensive plugin installed; authoring-only per Ray.

Gates: lint rc=0 · pytest 618 passed · verify 90/0 failed · lint-docs rc=0
(0 warnings) · pin-actions rc=0.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X9TKq5UxojSFBCgXdVzfJe
