### PR TITLE
docs(tests): name the two silent false negatives tests/AGENTS.md already had

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -60,6 +60,41 @@ bats tests/infra/
 changes cwd and breaks `Path(__file__).parent.parent` resolution in the
 test fixtures.
 
+## What a good test is here
+
+Tests verify behavior through a **public interface** — an exported function,
+a CLI's rc and output, a generated script's real execution — never through
+implementation details. Code can change entirely; the test shouldn't. The tell
+for an implementation-coupled test is that it breaks under a refactor while
+behavior hasn't changed.
+
+Two anti-patterns have already cost this repo real bugs. Both are **silent
+false negatives**: they surface as a green suite, never as a failure, so only
+a deliberate probe finds them.
+
+- **Tautological** — the assertion recomputes the expected value the way the
+  code does, so it passes by construction and can never disagree with the
+  code. Expected values must come from an **independent source of truth**: a
+  known-good literal, a worked example, the real artifact. The four
+  `test_memory_index.py` bugs above are this shape.
+- **A probe with no control arm** — a check that can only pass is not a check.
+  Pin the FAIL direction next to the pass: tier-1 identity really fails on a
+  wrong hash, tier-3 on a wrong ref, and every `_inert_masked` case is paired
+  with a recall pin. A 2026-07-15 hook probe "passed" while its control proved
+  the hook had never fired at all.
+
+## Mocking
+
+Mock at **system boundaries only** — the network (GHCR, `gh`, release feeds),
+Docker, the clock, the filesystem where `tmp_path` won't do. Never mock our
+own modules, internal collaborators, or anything we control: that couples the
+test to structure and is exactly how the implementation-coupled tell appears.
+
+At a boundary, prefer **injecting** the dependency over constructing it inside
+the function. `gcc_sha`'s injected fetcher and `hook_guard`'s pure `decide()`
+are the pattern already in use here — the seam is a parameter, so the test
+substitutes a value and needs no patching at all.
+
 ## Working in this directory
 
 - **Imports from `python/src/`:** tests add


### PR DESCRIPTION
Lifts the test-quality substance of mattpocock-skills' tdd + mocking skills
into tests/AGENTS.md. The gap was proven by grep, not assumed:

  tautolog|implementation detail|passes by construction
    -> 0 hits across all of .claude/rules/ + every AGENTS.md
  \bmock
    -> 0 hits across .claude/rules/ + tests/AGENTS.md

The doc already carried the evidence without ever naming the class:
tests/AGENTS.md:29 documents four test_memory_index.py bugs an adversarial
probe caught pre-merge and calls them "each a silent false negative" -- which
is precisely the tautological anti-pattern (tdd:29). The bugs were written
down; the shape that produces them was not, so nothing stopped the next one.

Prose, no TypeScript. The upstream mocking.md is entirely TS (a Stripe client,
a fetch SDK) and none of it transfers to a pytest suite, so the dependency-
injection point is anchored to seams already in use here: gcc_sha's injected
fetcher and hook_guard's pure decide(), both of which need no patching because
the seam is a parameter. Naming an existing practice beats importing a foreign
example.

Second anti-pattern is repo-earned rather than lifted -- a probe with no
control arm. On 2026-07-15 an hk-hook probe "passed" while its control proved
the hook had never fired at all: passing by construction, tdd:29 live. The
suite already pins the FAIL direction in three places (tier-1 identity on a
wrong hash, tier-3 on a wrong ref, each _inert_masked case against a recall
pin); this states the rule those pins were following.

Placement note: tests/AGENTS.md:88 carries a "preserved on regeneration"
MANUAL marker implying a generator owns the text above it. Nothing in the repo
regenerates these files (grepped --include=*.py/*.toml/*.pkl -> 0 hits), so the
marker is vestigial scaffolding and the sections sit where they read best,
between "Running tests" and "Working in this directory".

Size (bytes bind, not lines): 123/200 lines, 11153/12000 bytes -- 1862 chars
of the 2709 available.

Gates: lint rc=0 | 618 passed rc=0 | verify 90 passed 0 failed rc=0 |
agnix --strict "No issues found" rc=0.
