### PR TITLE
feat/llvm apt expansion

### DIFF
--- a/.devcontainer/mise-system.toml
+++ b/.devcontainer/mise-system.toml
@@ -132,15 +132,123 @@ cargo-binstall = "latest"
 # ld.lld, lldb, llvm-*) live under /usr/lib/llvm-22/bin, added to PATH by the
 # base-stage RUN in the Dockerfile. libclang-rt-22-dev supplies the sanitizer
 # runtimes (asan/ubsan/tsan/fuzzer) the tier-3 smoke exercises via `clang++`.
-"apt:clang-22" = "latest"
-"apt:clang-tools-22" = "latest"
-"apt:clang-tidy-22" = "latest"
-"apt:clangd-22" = "latest"
-"apt:clang-format-22" = "latest"
-"apt:lld-22" = "latest"
-"apt:lldb-22" = "latest"
-"apt:llvm-22" = "latest"
-"apt:libclang-rt-22-dev" = "latest"
+#
+# The set below is the COMPLETE llvm-toolchain-22 suite and is DERIVED, not
+# hand-typed — every list written from memory has been wrong (#251 proposed
+# `apt:mlir-22`, which does not exist; OpenMP is `libomp-22-dev`, matching no
+# substring of "openmp"). Regenerate with:
+#
+#     mise run apt-repo -- --llvm-version 22 --toml
+#
+# (`--llvm-version` takes 21 | 22 | dev; dev is the UNNUMBERED apt.llvm.org
+# suite — `llvm-toolchain-resolute-23` is a 404.) The task reads the repo's
+# Packages index via python-debian; see python/src/dotfiles_setup/apt_repo.py.
+#
+# Deliberately NOT passing `--exclude-runtime`: that flag drops `Section: libs`
+# on the assumption they always arrive via Depends:. True for 9 of the 10 it
+# drops — and FALSE for libclc-22, which is the payload (124 OpenCL .bc libs)
+# and which nothing depends on, because libclc inverts the usual arrow
+# (`libclc-22` Depends: `libclc-22-dev`, not the reverse). A heuristic that
+# silently drops payload must not generate this file. Declaring a package that
+# would arrive via Depends: anyway is merely explicit — and it makes the
+# Dockerfile's `status --json --missing` gate actually verify it is present.
+#
+# Covers every component apt.llvm.org advertises: LLVM, Clang, compiler-rt,
+# polly, LLDB, LLD, libFuzzer, libc++, libc++abi, openmp, libclc, libunwind,
+# MLIR, BOLT, flang, libc (libllvmlibc-22-dev), wasm.
+#
+# python3-clang-22 — installed, and DELIBERATELY not on the default python
+# (Ray, 2026-07-15). It lands in /usr/lib/python3/dist-packages/, which only
+# /usr/bin/python3 sees; the default `python3` here is the mise shim. That is
+# the intended arrangement, not a defect:
+#
+#   * Debian's is the ONLY version-matched source. PyPI `clang` stops at
+#     21.1.7 and `libclang` at 18.1.1 — both mismatch our libclang 22.1.2, and
+#     cindex.py raises LibclangError when a binding's function is absent.
+#     `libclang` also bundles its own .so, duplicating a lib we ship (#222).
+#   * The module is pure-python ctypes (0 .so), so nothing is broken — it
+#     imports, creates an Index and parses real C under /usr/bin/python3.
+#     Reach it there; set LIBCLANG_LIBRARY_FILE=/usr/lib/llvm-22/lib/
+#     libclang-22.so.1 (cindex.py reads that env var natively).
+#
+# DO NOT "fix" this with PYTHONPATH=/usr/lib/python3/dist-packages. PYTHONPATH
+# lands at sys.path[1] while site-packages is [5], so dist-packages WINS:
+# probed 2026-07-15, a venv pinning pyyaml==6.0.2 silently got Debian's 6.0.3.
+# That trades every project's pinned deps for one import.
+#
+# These are Ubuntu 26.04 resolute/universe names at 22.1.2. apt.llvm.org
+# publishes the same names at a 22.1.8 daily snapshot (#251 open decision).
+"apt:bolt-22"                   = "latest"
+"apt:clang-22"                  = "latest"
+"apt:clang-format-22"           = "latest"
+"apt:clang-tidy-22"             = "latest"
+"apt:clang-tools-22"            = "latest"
+"apt:clangd-22"                 = "latest"
+"apt:flang-22"                  = "latest"
+"apt:libbolt-22-dev"            = "latest"
+"apt:libc++-22-dev"             = "latest"
+"apt:libc++-22-dev-wasm32"      = "latest"
+"apt:libc++1"                   = "latest"
+"apt:libc++abi-22-dev"          = "latest"
+"apt:libc++abi-22-dev-wasm32"   = "latest"
+"apt:libc++abi1"                = "latest"
+"apt:libclang-22-dev"           = "latest"
+"apt:libclang-common-22-dev"    = "latest"
+"apt:libclang-cpp22"            = "latest"
+"apt:libclang-cpp22-dev"        = "latest"
+"apt:libclang-rt-22-dev"        = "latest"
+"apt:libclang-rt-22-dev-wasm32" = "latest"
+"apt:libclang-rt-22-dev-wasm64" = "latest"
+"apt:libclang1-22"              = "latest"
+"apt:libclc-22"                 = "latest"
+"apt:libclc-22-dev"             = "latest"
+"apt:libflang-22-dev"           = "latest"
+"apt:libfuzzer-22-dev"          = "latest"
+"apt:liblld-22"                 = "latest"
+"apt:liblld-22-dev"             = "latest"
+"apt:liblldb-22"                = "latest"
+"apt:liblldb-22-dev"            = "latest"
+"apt:libllvm-22-ocaml-dev"      = "latest"
+"apt:libllvm22"                 = "latest"
+"apt:libllvmlibc-22-dev"        = "latest"
+"apt:libmlir-22"                = "latest"
+"apt:libmlir-22-dev"            = "latest"
+"apt:liboffload-22"             = "latest"
+"apt:liboffload-22-dev"         = "latest"
+"apt:libomp-22-dev"             = "latest"
+"apt:libomp5"                   = "latest"
+"apt:libpolly-22-dev"           = "latest"
+"apt:libunwind-22-dev"          = "latest"
+"apt:lld-22"                    = "latest"
+"apt:lldb-22"                   = "latest"
+"apt:llvm-22"                   = "latest"
+"apt:llvm-22-dev"               = "latest"
+"apt:llvm-22-linker-tools"      = "latest"
+"apt:llvm-22-runtime"           = "latest"
+"apt:llvm-22-tools"             = "latest"
+"apt:llvm-libunwind1"           = "latest"
+"apt:mlir-22-tools"             = "latest"
+"apt:python3-clang-22"          = "latest"
+"apt:python3-lldb-22"           = "latest"
+
+# NOT installed — listed so the set is visibly complete and a reader sees
+# these were considered and rejected, not missed.
+#
+# docs/examples: pure image weight; #222 just took :dev 25.8 GB -> 17.5 GB.
+# "apt:clang-22-doc"              = "latest"
+# "apt:clang-22-examples"         = "latest"
+# "apt:libomp-22-doc"             = "latest"
+# "apt:llvm-22-doc"               = "latest"
+# "apt:llvm-22-examples"          = "latest"
+#
+# libclang-rt-22-dev-win: UN-INSTALLABLE alongside libclang-rt-22-dev, which
+# supplies the asan/ubsan/tsan/fuzzer runtimes tier-3 smoke exercises. Both
+# ship /usr/lib/llvm-22/lib/clang/22/lib/windows/libclang_rt.builtins-aarch64.a
+# and Ubuntu declares no Conflicts/Replaces, so dpkg aborts the WHOLE apt
+# transaction — one bad package takes all 30 with it. Upstream packaging bug;
+# probed in-container 2026-07-15, fails identically when installed alone. We
+# do not target Windows, so this is no loss.
+# "apt:libclang-rt-22-dev-win"    = "latest"
 
 [settings]
 arch = "x86_64"

--- a/.devcontainer/mise-system.toml
+++ b/.devcontainer/mise-system.toml
@@ -157,6 +157,32 @@ cargo-binstall = "latest"
 # polly, LLDB, LLD, libFuzzer, libc++, libc++abi, openmp, libclc, libunwind,
 # MLIR, BOLT, flang, libc (libllvmlibc-22-dev), wasm.
 #
+# TWO PYTHONS COEXIST HERE, AND THAT IS CORRECT (Ray, 2026-07-15):
+#
+#   * mise's python (~113 MB, pinned in conf.d/shared.toml) is THE default —
+#     `python3` resolves to /usr/local/share/mise/installs/python/<ver>. It is a
+#     python-build-standalone build: Astral's project, the same artifact
+#     `uv python install` fetches, which is why `uv python list --only-installed`
+#     reports it as cpython-<ver>-linux-x86_64-gnu. mise downloads it directly
+#     (it does NOT shell out to uv); uv's role here is venvs, via
+#     `python.uv_venv_auto = "source"` below.
+#   * Ubuntu's /usr/bin/python3 (~23 MB) is NOT removable: it is a hard Depends:
+#     of the LLVM set above. `apt-get -s remove python3` would also remove
+#     clang-format-22, clang-tidy-22, clang-tools-22, lldb-22, llvm-22-dev,
+#     llvm-22-tools, liblldb-22-dev, libllvm-22-ocaml-dev, python3-clang-22 and
+#     python3-lldb-22. Removing the 23 MB removes the toolchain.
+#
+# This is NOT the conda-LLVM duplication #222 PR-C fixed. That was ONE 186 MB
+# libLLVM.so copied EIGHT times (~6.9 GB of pure redundancy). This is two
+# interpreters with distinct jobs — the pinned dev python, and the one
+# clang-format-22 links against — costing 23 MB against a 17.5 GB image (0.13%).
+# Neither mise nor uv can install python "as the system binary" anyway: both
+# ship relocatable python-build-standalone into a managed prefix by design
+# (mise docs: "not a system-wide installation"; `uv python dir` likewise), with
+# no dist-packages layout, so replacing /usr/bin/python3 would break every
+# apt-installed python module. Tier-1 smoke asserts the DEFAULT python3 is
+# mise's and matches this pin (dotfiles_setup.image._TIER1_PYTHON_DEFAULT).
+#
 # python3-clang-22 — installed, and DELIBERATELY not on the default python
 # (Ray, 2026-07-15). It lands in /usr/lib/python3/dist-packages/, which only
 # /usr/bin/python3 sees; the default `python3` here is the mise shim. That is

--- a/python/src/dotfiles_setup/image.py
+++ b/python/src/dotfiles_setup/image.py
@@ -306,7 +306,48 @@ fi
 # (:func:`build_tier1_script`, emitted by ``image smoke-script --tier 1``) so
 # the two paths cannot diverge (#223). Only the injected DATA differs by caller
 # (HEAD hashes/tools for CI; merge-base for the devcontainer).
-_TIER1_CORE_BODY = _TIER1_MISE_PATHS + _TIER1_IDENTITY_BLOCK + _TIER1_MISE_LS_TOOLSET
+# #251: the default `python3` must BE mise's declared interpreter, not the
+# distro's. The image ships two 3.14s — mise's (python-build-standalone, pinned
+# in the shared fragment) and Ubuntu's /usr/bin/python3 — and NOTHING else
+# pins which one bare `python3` resolves to: the tool-set diff proves only that
+# mise *knows about* python; `which python` proves only that a path exists
+# (protective solely because Debian ships no bare `python`); and tier-2's
+# `uv run --project python pytest` resolves the project venv's interpreter,
+# which uv provisions, so it stays green through a shim regression. Asserts
+# both halves — resolution (sys.executable under mise's installs, which is what
+# separates 3.14.6 from the distro's 3.14.4 at the same minor) and the exact
+# declared version. Dormant when the var is unset, like the guards above.
+_TIER1_PYTHON_DEFAULT = """\
+if [ -n "$EXPECTED_PYTHON_VERSION" ]; then
+  command -v python3 >/dev/null \
+    || { echo "FAIL: python3 not on PATH"; exit 1; }
+  py_exe=$(python3 -c 'import sys; print(sys.executable)')
+  case "$py_exe" in
+    "$MISE_DIR"/installs/python/*) ;;
+    *)
+      echo "FAIL: default python3 is $py_exe, not a mise install under" \
+           "$MISE_DIR/installs/python — the distro python has taken the PATH"
+      exit 1
+      ;;
+  esac
+  py_ver=$(python3 -c 'import platform; print(platform.python_version())')
+  if [ "$py_ver" != "$EXPECTED_PYTHON_VERSION" ]; then
+    echo "FAIL: default python3 is $py_ver, declared $EXPECTED_PYTHON_VERSION"
+    exit 1
+  fi
+  echo "OK: default python3 is mise's $py_ver ($py_exe)"
+else
+  echo "SKIP: no expected python version injected (python guard dormant)"
+fi
+"""
+
+
+_TIER1_CORE_BODY = (
+    _TIER1_MISE_PATHS
+    + _TIER1_IDENTITY_BLOCK
+    + _TIER1_MISE_LS_TOOLSET
+    + _TIER1_PYTHON_DEFAULT
+)
 
 
 # The tier-3 COMPILER substrate: sanitizer compile checks + reflection compiler
@@ -411,6 +452,7 @@ rm -f /tmp/refl-func.cpp /tmp/refl-gcc /tmp/refl-clang
 def _tier1_var_lines(
     expected_identity: Mapping[str, str] | None,
     expected_tools: Mapping[str, str] | None,
+    expected_python: str | None = None,
 ) -> str:
     """Injected-data header lines the tier-1 core reads ($EXPECTED_*)."""
     identity_blob = (
@@ -420,6 +462,7 @@ def _tier1_var_lines(
     return (
         f"EXPECTED_IDENTITY={shlex.quote(identity_blob)}\n"
         f"EXPECTED_TOOL_REQUESTS={shlex.quote(tool_lines)}\n"
+        f"EXPECTED_PYTHON_VERSION={shlex.quote(expected_python or '')}\n"
     )
 
 
@@ -466,6 +509,7 @@ def build_tier1_script(
     *,
     expected_identity: Mapping[str, str] | None = None,
     expected_tools: Mapping[str, str] | None = None,
+    expected_python: str | None = None,
 ) -> str:
     """Standalone tier-1 core smoke script: image identity + exact tool-set.
 
@@ -478,7 +522,7 @@ def build_tier1_script(
     """
     return (
         "set -euo pipefail\n"
-        + _tier1_var_lines(expected_identity, expected_tools)
+        + _tier1_var_lines(expected_identity, expected_tools, expected_python)
         + _TIER1_CORE_BODY
     )
 
@@ -1527,9 +1571,15 @@ def smoke_script_main(tier: int | None) -> int:
     """
     root = _project_root()
     if tier == _SMOKE_SCRIPT_TIER1:
+        # The python pin comes from the SAME merge-base tool set the diff uses
+        # (#140 Gap A base-currency), never a second resolution — a branch that
+        # bumps python is validated by its own CI-built base, not against a
+        # local base that predates the bump.
+        base_tools = resolve_declared_tools_at_base(root)
         script = build_tier1_script(
             expected_identity=resolve_expected_identity_at_base(),
-            expected_tools=resolve_declared_tools_at_base(root),
+            expected_tools=base_tools,
+            expected_python=base_tools.get("python"),
         )
     elif tier == _SMOKE_SCRIPT_TIER3:
         script = build_tier3_script(

--- a/tests/test_image_smoke.py
+++ b/tests/test_image_smoke.py
@@ -16,6 +16,7 @@ import json
 import pytest
 from dotfiles_setup.image import (
     _TIER1_IDENTITY_BLOCK,
+    _TIER1_PYTHON_DEFAULT,
     _TIER3_COMPILER_BODY,
     IDENTITY_IMAGE_PATHS,
     AnalysisTarget,
@@ -1308,3 +1309,81 @@ def test_resolve_analysis_ref_main_fail_exits_nonzero_no_stdout(
     # No GITHUB_OUTPUT lines on failure (stdout is redirected to $GITHUB_OUTPUT).
     assert out.out == ""
     assert "FAIL" in out.err
+
+
+def _run_python_block(
+    mise_dir: Path, py_exe: str, py_ver: str, want_ver: str
+) -> subprocess.CompletedProcess:
+    """Run just the tier-1 python block against a fake `python3` via bash.
+
+    A stub `python3` on PATH reports `py_exe`/`py_ver`, so the block's two
+    assertions (resolution under $MISE_DIR/installs/python, exact version) can
+    be driven in both directions without a real interpreter.
+    """
+    bin_dir = mise_dir / "stub-bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    stub = bin_dir / "python3"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        f'case "$*" in *sys.executable*) echo {shlex.quote(py_exe)} ;; '
+        f"*python_version*) echo {shlex.quote(py_ver)} ;; esac\n"
+    )
+    stub.chmod(0o755)
+    harness = (
+        "set -euo pipefail\n"
+        f"MISE_DIR={shlex.quote(str(mise_dir))}\n"
+        f"PATH={shlex.quote(str(bin_dir))}:$PATH\n"
+        f"EXPECTED_PYTHON_VERSION={shlex.quote(want_ver)}\n" + _TIER1_PYTHON_DEFAULT
+    )
+    return subprocess.run(
+        ["bash", "-c", harness], capture_output=True, text=True, check=False
+    )
+
+
+def test_tier1_python_block_passes_for_mise_python(tmp_path: Path) -> None:
+    """The happy path: python3 under mise's installs at the declared version."""
+    exe = f"{tmp_path}/installs/python/3.14.6/bin/python3"
+    r = _run_python_block(tmp_path, exe, "3.14.6", "3.14.6")
+    assert r.returncode == 0, r.stderr
+    assert "OK: default python3 is mise's 3.14.6" in r.stdout
+
+
+def test_tier1_python_block_fails_on_distro_python(tmp_path: Path) -> None:
+    """FAIL arm: the distro python taking the PATH is caught.
+
+    This is the regression the block exists for — the image ships Ubuntu's
+    /usr/bin/python3 as a hard Depends: of clang-format-22/lldb-22, so a shim
+    or PATH break silently hands `python3` to a DIFFERENT interpreter. Without
+    this arm the block would be a probe that can only pass.
+    """
+    r = _run_python_block(tmp_path, "/usr/bin/python3", "3.14.4", "3.14.6")
+    assert r.returncode == 1
+    assert "not a mise install" in r.stdout
+
+
+def test_tier1_python_block_fails_on_version_drift(tmp_path: Path) -> None:
+    """FAIL arm: right location, wrong version — the pin is enforced too."""
+    exe = f"{tmp_path}/installs/python/3.14.4/bin/python3"
+    r = _run_python_block(tmp_path, exe, "3.14.4", "3.14.6")
+    assert r.returncode == 1
+    assert "declared 3.14.6" in r.stdout
+
+
+def test_tier1_python_block_dormant_when_unset(tmp_path: Path) -> None:
+    """An unpopulated call is a no-op SKIP, never a false green."""
+    r = _run_python_block(tmp_path, "/usr/bin/python3", "3.14.4", "")
+    assert r.returncode == 0
+    assert "SKIP" in r.stdout
+
+
+def test_build_tier1_script_injects_python_version() -> None:
+    """`build_tier1_script` threads the declared version into the script."""
+    s = build_tier1_script(expected_python="3.14.6")
+    assert "EXPECTED_PYTHON_VERSION=3.14.6" in s
+    assert "not a mise install under" in s
+
+
+def test_build_tier1_script_python_guard_dormant_without_data() -> None:
+    """No python version => the guard is emitted but inert."""
+    s = build_tier1_script()
+    assert "EXPECTED_PYTHON_VERSION=''" in s


### PR DESCRIPTION
- **feat(image): declare the full LLVM-22 apt suite (#251 Part A)**
- **feat(image): gate that the default python3 IS mise's declared interpreter**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Devcontainers now include a complete LLVM/Clang 22 toolchain for broader development and debugging support.
  - Added automatic verification that the configured Python version is the default `python3` interpreter in supported environments.

- **Bug Fixes**
  - Improved detection of incorrect or mismatched Python installations during environment validation.

- **Documentation**
  - Added guidance explaining the LLVM package selection, Python environment behavior, and intentionally excluded platform-specific tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->