### PR TITLE
feat(smoke): validate the apt LLVM-22 toolchain functionally (#294)

### DIFF
--- a/python/src/dotfiles_setup/image.py
+++ b/python/src/dotfiles_setup/image.py
@@ -28,6 +28,47 @@ logger = logging.getLogger(__name__)
 
 _SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 
+# Leading MAJOR.MINOR.PATCH of a Debian apt version, past an optional epoch
+# (``1:22.1.8~++2026...`` -> ``22.1.8``). Anchored: the release is always the
+# first token after the epoch, never inside the ``~++<snapshot>`` suffix.
+_LLVM_VERSION_RE = re.compile(r"(?:\d+:)?(\d+\.\d+\.\d+)")
+
+
+def _parse_apt_llvm_version(config_text: str) -> str:
+    """Extract the LLVM release (``MAJOR.MINOR.PATCH``) from ``apt:clang-22``.
+
+    The whole apt.llvm.org suite shares one version string, so the pinned
+    ``clang-22`` package in ``[bootstrap.packages]`` is the natural anchor for
+    "what LLVM release is this image". Fails loud if the pin is absent or
+    unparsable — a silently-empty version would leave the runtime version
+    guard dormant, reintroducing the false-positive it exists to catch.
+    """
+    data = tomllib.loads(config_text)
+    packages = data.get("bootstrap", {}).get("packages", {})
+    pin = packages.get("apt:clang-22")
+    if not isinstance(pin, str):
+        msg = "mise-system.toml [bootstrap.packages] lacks a string 'apt:clang-22' pin"
+        raise TypeError(msg)
+    match = _LLVM_VERSION_RE.match(pin)
+    if match is None:
+        msg = f"could not parse an LLVM release from apt:clang-22 pin {pin!r}"
+        raise ValueError(msg)
+    return match.group(1)
+
+
+def resolve_expected_llvm_version() -> str:
+    """The apt LLVM release the image is expected to ship (HEAD).
+
+    Reads the committed ``mise-system.toml`` pin — feeds ``build_smoke_script``,
+    since CI builds the image FROM branch HEAD. The merge-base sibling
+    (:func:`resolve_expected_llvm_version_at_base`) feeds the devcontainer smoke,
+    whose local base predates a branch's pin bump.
+    """
+    root = _project_root()
+    return _parse_apt_llvm_version(
+        (root / ".devcontainer" / "mise-system.toml").read_text()
+    )
+
 
 def resolve_expected_p2996_ref() -> str:
     """Resolve the clang-p2996 ref the image is expected to be built from.
@@ -363,7 +404,53 @@ _TIER1_CORE_BODY = (
 # $EXPECTED_P2996_REF / $P2996_REF_STRICT (the pinned clang-p2996 ref). Only the
 # injected DATA differs by caller (HEAD ref for CI; merge-base for the
 # devcontainer, whose local base was built from the merge-base pin).
-_TIER3_COMPILER_BODY = """\
+# #294: the default-clang identity + version gate. Extracted as its own
+# constant (like _TIER1_PYTHON_DEFAULT) so its FAIL direction is control-armable
+# in a unit test with a stubbed clang++ — a version guard verified only on a
+# right answer is a probe that can only pass. The image ships several clang++
+# (apt LLVM-22 at /usr/lib/llvm-22/bin, the clang-p2996 reflection build at
+# /opt/clang-p2996/bin, plus conda's); the sanitizer + openmp + lld probes below
+# all invoke BARE clang++, so pin which one that resolves to (the apt LLVM
+# build) and — when the release is injected — that its --version reports it.
+_TIER3_DEFAULT_CLANG = """\
+echo "=== default clang toolchain identity (#294) ==="
+clang_bin=$(command -v clang++ 2>/dev/null || true)
+[ -n "$clang_bin" ] || { echo "FAIL: clang++ not on PATH"; exit 1; }
+clang_real=$(readlink -f "$clang_bin")
+case "$clang_real" in
+  /usr/lib/llvm-*/*) echo "OK: default clang++ -> $clang_real (apt LLVM)" ;;
+  *)
+    echo "FAIL: default clang++ resolves to $clang_real, not apt /usr/lib/llvm-*"
+    exit 1
+    ;;
+esac
+if [ -n "$EXPECTED_LLVM_VERSION" ]; then
+  clang_ver=$(clang++ --version 2>&1 || true)
+  case "$clang_ver" in
+    *"clang version $EXPECTED_LLVM_VERSION"*)
+      echo "OK: default clang++ is LLVM $EXPECTED_LLVM_VERSION" ;;
+    *)
+      echo "FAIL: default clang++ is not LLVM $EXPECTED_LLVM_VERSION"
+      echo "$clang_ver"
+      exit 1
+      ;;
+  esac
+else
+  echo "SKIP: no expected LLVM version injected (clang version guard dormant)"
+fi
+"""
+
+
+_TIER3_COMPILER_BODY = (
+    _TIER3_DEFAULT_CLANG
+    + """\
+echo "=== clang driver presence (#294: moved from CI-only tail) ==="
+# Presence of the apt LLVM driver entrypoints, in the SHARED substrate so the
+# devcontainer smoke (verify-container-latest) runs it too — not just the CI
+# no-mount smoke where it used to live.
+for tool in clang clang++ clangd clang-tidy clang-format lld lldb; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "FAIL: missing $tool"; exit 1; }
+done
 echo "=== sanitizer compile checks ==="
 cat >/tmp/sanitizer.cpp <<'CPP'
 #include <iostream>
@@ -379,6 +466,32 @@ else
   /tmp/san-tsan >/dev/null
 fi
 clang++ -fsanitize=fuzzer-no-link -c /tmp/sanitizer.cpp -o /tmp/san-fuzz.o
+echo "=== openmp compile+link+run (#294: libomp-22-dev) ==="
+# Proves the OpenMP runtime is actually linkable+runnable, not merely that the
+# libomp package installed. Runs even under emulation (like asan/ubsan): OpenMP
+# threading works under Rosetta/QEMU; only TSan's shadow memory does not.
+cat >/tmp/omp.cpp <<'CPP'
+#include <omp.h>
+#include <cstdio>
+int main() {
+  int n = 0;
+#pragma omp parallel reduction(+ : n)
+  n += 1;
+  std::printf("openmp threads=%d\\n", n);
+  return n >= 1 ? 0 : 1;
+}
+CPP
+clang++ -fopenmp /tmp/omp.cpp -o /tmp/omp \
+  || { echo "FAIL: clang++ -fopenmp link failed (libomp-22-dev missing?)"; exit 1; }
+/tmp/omp >/dev/null || { echo "FAIL: openmp binary did not run"; exit 1; }
+echo "OK: openmp -fopenmp compiles, links, runs"
+echo "=== lld linker (#294: -fuse-ld=lld) ==="
+# lld presence is asserted above; this proves it actually LINKS. Reuses the
+# sanitizer source (still on disk — never removed).
+clang++ -fuse-ld=lld /tmp/sanitizer.cpp -o /tmp/lld-linked \
+  || { echo "FAIL: clang++ -fuse-ld=lld link failed"; exit 1; }
+/tmp/lld-linked >/dev/null || { echo "FAIL: lld-linked binary did not run"; exit 1; }
+echo "OK: lld links (-fuse-ld=lld) + binary runs"
 echo "=== reflection compiler checks ==="
 test -x /opt/gcc-latest/bin/g++ \
   || { echo "FAIL: gcc-latest binary missing"; exit 1; }
@@ -445,8 +558,69 @@ P2996_LIBCXX_DIR=$(dirname "$P2996_LIBCXX_SO")
   /tmp/refl-func.cpp -o /tmp/refl-clang \
   || { echo "FAIL: clang-p2996 reflection link failed"; exit 1; }
 /tmp/refl-clang || { echo "FAIL: clang-p2996 reflection binary did not run"; exit 1; }
-rm -f /tmp/refl-func.cpp /tmp/refl-gcc /tmp/refl-clang
+echo "=== llvm utility version smoke (#294) ==="
+# The core LLVM binaries all embed the release in --version. opt/llc/llvm-cov/
+# llvm-profdata/llvm-symbolizer ship in the `llvm-22` package (verified from the
+# .deb: /usr/lib/llvm-22/bin/*); llvm-bolt in `bolt-22`; mlir-opt in
+# `mlir-22-tools`. Match the bare release substring (format-robust across all
+# banners). `case` glob, never `cmd | grep -q` — the latter SIGPIPEs (141) under
+# pipefail (hk no_grep_q_under_pipefail).
+if [ -n "$EXPECTED_LLVM_VERSION" ]; then
+  for util in opt llc llvm-cov llvm-profdata llvm-symbolizer llvm-bolt mlir-opt; do
+    ubin=$(command -v "$util" 2>/dev/null || true)
+    [ -n "$ubin" ] || { echo "FAIL: $util not on PATH"; exit 1; }
+    uver=$("$ubin" --version 2>&1 || true)
+    case "$uver" in
+      *"$EXPECTED_LLVM_VERSION"*) echo "OK: $util reports $EXPECTED_LLVM_VERSION" ;;
+      *)
+        echo "FAIL: $util --version missing $EXPECTED_LLVM_VERSION"
+        echo "$uver"
+        exit 1
+        ;;
+    esac
+  done
+else
+  echo "SKIP: no expected LLVM version injected (utility version guard dormant)"
+fi
+echo "=== flang fortran compile+run (#294: flang-22) ==="
+# Binary name varies across LLVM releases (flang | flang-new); accept either.
+flang_bin=$(command -v flang 2>/dev/null || command -v flang-new 2>/dev/null || true)
+[ -n "$flang_bin" ] || { echo "FAIL: flang/flang-new not on PATH"; exit 1; }
+if [ -n "$EXPECTED_LLVM_VERSION" ]; then
+  fver=$("$flang_bin" --version 2>&1 || true)
+  case "$fver" in
+    *"$EXPECTED_LLVM_VERSION"*) echo "OK: flang reports $EXPECTED_LLVM_VERSION" ;;
+    *)
+      echo "FAIL: flang --version missing $EXPECTED_LLVM_VERSION"
+      echo "$fver"
+      exit 1
+      ;;
+  esac
+fi
+cat >/tmp/hello.f90 <<'F90'
+program hello
+  implicit none
+  print *, "flang ok"
+end program hello
+F90
+"$flang_bin" /tmp/hello.f90 -o /tmp/flang-hello \
+  || { echo "FAIL: flang compile/link failed"; exit 1; }
+/tmp/flang-hello >/dev/null || { echo "FAIL: flang binary did not run"; exit 1; }
+echo "OK: flang compiles + runs a Fortran program"
+echo "=== libclc bitcode presence (#294: libclc-22) ==="
+# libclc-22 ships its OpenCL *.bc bitcode under /usr/lib/clc (verified from the
+# .deb); the extra roots tolerate a future relocation. The trailing `|| true` is
+# load-bearing: `find` exits NON-ZERO if any start dir is absent, and under
+# `set -e` a bare `var=$(find ...)` would then abort the script BEFORE this
+# check runs (a probe that dies at its own setup — probes-need-a-control-arm).
+clc_bc=$(find /usr/lib/clc /usr/lib/clang /usr/lib/llvm-22 \
+  -name '*.bc' 2>/dev/null | head -n1 || true)
+[ -n "$clc_bc" ] || { echo "FAIL: no libclc bitcode (*.bc) found in image"; exit 1; }
+echo "OK: libclc bitcode present ($clc_bc)"
+rm -f /tmp/refl-func.cpp /tmp/refl-gcc /tmp/refl-clang \
+  /tmp/omp.cpp /tmp/omp /tmp/lld-linked /tmp/hello.f90 /tmp/flang-hello
 """
+)
 
 
 def _tier1_var_lines(
@@ -466,7 +640,12 @@ def _tier1_var_lines(
     )
 
 
-def _tier3_var_lines(expected_p2996_ref: str, *, emulated: bool) -> str:
+def _tier3_var_lines(
+    expected_p2996_ref: str,
+    *,
+    emulated: bool,
+    expected_llvm_version: str | None = None,
+) -> str:
     """Injected-data header lines the tier-3 substrate reads.
 
     ``P2996_REF_STRICT`` is set only for a 40-hex SHA (a non-SHA dispatch
@@ -474,6 +653,9 @@ def _tier3_var_lines(expected_p2996_ref: str, *, emulated: bool) -> str:
     ``TSAN_RUN_SKIP`` gates the ThreadSanitizer RUN — the compile always fires
     (it proves the toolchain), but the RUN is skipped under emulation, where
     TSan's shadow-memory ASLR layout is incompatible with Rosetta/QEMU.
+    ``EXPECTED_LLVM_VERSION`` is the apt LLVM release (#294) the default-clang
+    and utility ``--version`` guards assert; empty leaves those guards dormant
+    (unit-test friendly), like the tier-1 guards.
     """
     strict = "1" if _SHA_RE.match(expected_p2996_ref) else ""
     tsan_run_skip = "1" if emulated else ""
@@ -481,6 +663,7 @@ def _tier3_var_lines(expected_p2996_ref: str, *, emulated: bool) -> str:
         f"EXPECTED_P2996_REF={shlex.quote(expected_p2996_ref)}\n"
         f"P2996_REF_STRICT={shlex.quote(strict)}\n"
         f"TSAN_RUN_SKIP={shlex.quote(tsan_run_skip)}\n"
+        f"EXPECTED_LLVM_VERSION={shlex.quote(expected_llvm_version or '')}\n"
     )
 
 
@@ -488,6 +671,7 @@ def build_tier3_script(
     *,
     expected_p2996_ref: str,
     emulated: bool,
+    expected_llvm_version: str | None = None,
 ) -> str:
     """Standalone tier-3 compiler smoke script: sanitizers + reflection.
 
@@ -497,10 +681,16 @@ def build_tier3_script(
     source of truth for the tier-3 compiler substrate. The mount/SSH-dependent
     tier-3 checks (home-volume, TMPDIR, R2 SSH) stay bash-only and are NOT part
     of this substrate. ``emulated`` skips the TSan RUN (the compile still runs).
+    ``expected_llvm_version`` (#294) drives the apt-suite default-clang + utility
+    ``--version`` guards; unset leaves them dormant.
     """
     return (
         "set -euo pipefail\n"
-        + _tier3_var_lines(expected_p2996_ref, emulated=emulated)
+        + _tier3_var_lines(
+            expected_p2996_ref,
+            emulated=emulated,
+            expected_llvm_version=expected_llvm_version,
+        )
         + _TIER3_COMPILER_BODY
     )
 
@@ -533,6 +723,7 @@ def build_smoke_script(
     expected_identity: Mapping[str, str] | None = None,
     expected_tools: Mapping[str, str] | None = None,
     emulated: bool = False,
+    expected_llvm_version: str | None = None,
 ) -> str:
     """Build the inline CI (no-mount) smoke test script.
 
@@ -566,11 +757,20 @@ def build_smoke_script(
     ThreadSanitizer binary is RUN after it is compiled. The compile always
     runs (it proves the toolchain); the RUN is skipped under emulation, where
     TSan's shadow-memory layout is incompatible with Rosetta/QEMU.
+
+    ``expected_llvm_version`` (#294 — apt LLVM-22 runtime coverage) is the
+    release the default-clang identity gate and the ``opt``/``llvm-bolt``/
+    ``mlir-opt``/``flang`` ``--version`` guards assert. Unset leaves those
+    guards dormant (unit-test friendly).
     """
     header = (
         "set -euo pipefail\n"
         + _tier1_var_lines(expected_identity, expected_tools)
-        + _tier3_var_lines(expected_p2996_ref, emulated=emulated)
+        + _tier3_var_lines(
+            expected_p2996_ref,
+            emulated=emulated,
+            expected_llvm_version=expected_llvm_version,
+        )
     )
     return (
         header
@@ -614,10 +814,6 @@ grep -q 'cargo.binstall = true' "$MISE_CFG" || {
 grep -q 'python.uv_venv_auto = "source"' "$MISE_CFG" || {
   echo "FAIL: python uv venv policy missing"; exit 1;
 }
-echo "=== clang tooling checks ==="
-for tool in clang clang++ clangd clang-tidy clang-format lld lldb; do
-  command -v "$tool" >/dev/null 2>&1 || { echo "FAIL: missing $tool"; exit 1; }
-done
 """
         + _TIER3_COMPILER_BODY
         + """\
@@ -665,6 +861,7 @@ def build_smoke_docker_cmd(
         expected_identity=expected_identity,
         expected_tools=resolve_declared_tools(),
         emulated=emulated,
+        expected_llvm_version=resolve_expected_llvm_version(),
     )
     return [
         "docker",
@@ -1539,6 +1736,20 @@ def resolve_expected_p2996_ref_at_base() -> str:
     return _extract_bake_variable(blob.decode(), "CLANG_P2996_REF")
 
 
+def resolve_expected_llvm_version_at_base() -> str:
+    """The apt LLVM release the CURRENT local base was built from (merge-base).
+
+    Merge-base-aware sibling of :func:`resolve_expected_llvm_version`. The local
+    devcontainer's base predates a branch's ``mise-system.toml`` pin bump (the
+    branch's base is built by its own PR CI, never locally), so the devcontainer
+    tier-3 version guard (injected by :func:`build_tier3_script` / ``smoke-script
+    --tier 3``) must expect the MERGE-BASE pin — reading HEAD would false-FAIL on
+    a branch that bumps the LLVM version. On main, merge-base == HEAD.
+    """
+    blob = base_currency_blob(_project_root(), ".devcontainer/mise-system.toml")
+    return _parse_apt_llvm_version(blob.decode())
+
+
 _SMOKE_SCRIPT_TIER1 = 1
 _SMOKE_SCRIPT_TIER3 = 3
 
@@ -1585,6 +1796,7 @@ def smoke_script_main(tier: int | None) -> int:
         script = build_tier3_script(
             expected_p2996_ref=resolve_expected_p2996_ref_at_base(),
             emulated=True,
+            expected_llvm_version=resolve_expected_llvm_version_at_base(),
         )
     else:
         sys.stderr.write(

--- a/tests/test_image_smoke.py
+++ b/tests/test_image_smoke.py
@@ -18,6 +18,7 @@ from dotfiles_setup.image import (
     _TIER1_IDENTITY_BLOCK,
     _TIER1_PYTHON_DEFAULT,
     _TIER3_COMPILER_BODY,
+    _TIER3_DEFAULT_CLANG,
     IDENTITY_IMAGE_PATHS,
     AnalysisTarget,
     _count_tools_from_mise_ls,
@@ -26,6 +27,7 @@ from dotfiles_setup.image import (
     _format_identity_lines,
     _is_emulated,
     _lookup_pr_number,
+    _parse_apt_llvm_version,
     _parse_build_timing,
     _parse_human_size,
     _repo_without_tag,
@@ -48,6 +50,8 @@ from dotfiles_setup.image import (
     resolve_declared_tools_at_base,
     resolve_expected_identity_at_base,
     resolve_expected_identity_head,
+    resolve_expected_llvm_version,
+    resolve_expected_llvm_version_at_base,
     resolve_expected_p2996_ref,
     resolve_expected_p2996_ref_at_base,
     smoke_script_main,
@@ -60,6 +64,9 @@ _PLAIN_BYTES_VALUE = 512
 # clang-p2996 ref-pin check tests.
 _FAKE_P2996_SHA = "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"
 _NON_SHA_REF = "p2996-branch"
+
+# A fake apt LLVM release for the #294 default-clang + utility version guards.
+_FAKE_LLVM_VERSION = "22.1.8"
 
 # A fake 64-hex SHA-256 for the image-identity (config-hash) tests.
 _FAKE_CONFIG_SHA256 = "0" * 64
@@ -90,19 +97,23 @@ def test_smoke_docker_cmd_no_volume_mount() -> None:
     assert "--volume" not in cmd
 
 
-def test_smoke_script_does_not_require_llvm_symbolizer() -> None:
-    """Verify the smoke script does not check for llvm-symbolizer."""
-    script = build_smoke_script(_FAKE_P2996_SHA)
+def test_smoke_script_probes_standalone_llvm_tools() -> None:
+    """#294: the standalone LLVM tools now ship (llvm-22 .deb) and are probed.
 
-    assert "llvm-symbolizer" not in script
+    Inverts the pre-#294 guardrail (commits 61e0ec3/82e9a22, "validate the
+    shipped toolchain, not an imagined superset"): back then the conda-narrow
+    image did NOT ship llvm-cov/profdata/symbolizer, so requiring them
+    false-FAILed. Since #222/#251 adopted the full apt.llvm.org suite, all
+    three ship in the declared ``llvm-22`` package, so the smoke asserts them —
+    exactly the "update alongside actual toolchain changes" the guardrail
+    sanctioned.
+    """
+    script = build_smoke_script(
+        _FAKE_P2996_SHA, expected_llvm_version=_FAKE_LLVM_VERSION
+    )
 
-
-def test_smoke_script_does_not_require_standalone_llvm_tools() -> None:
-    """Verify the smoke script does not check for standalone LLVM tools."""
-    script = build_smoke_script(_FAKE_P2996_SHA)
-
-    assert "llvm-cov" not in script
-    assert "llvm-profdata" not in script
+    for util in ("llvm-cov", "llvm-profdata", "llvm-symbolizer", "opt", "llc"):
+        assert util in script
 
 
 def test_smoke_script_injects_p2996_ref_and_strict_match() -> None:
@@ -190,6 +201,198 @@ def test_resolve_expected_p2996_ref_reads_bake_pin(
     # The pin is a 40-hex git SHA.
     assert len(ref) == 40
     assert all(c in "0123456789abcdef" for c in ref)
+
+
+# --- #294: apt LLVM version resolution + tier-3 functional probes ---
+
+
+def test_parse_apt_llvm_version_strips_epoch_and_suffix() -> None:
+    """The release is the MAJOR.MINOR.PATCH past the epoch, before the snapshot.
+
+    Independent-literal expectation (not recomputed the parser's way): a real
+    apt.llvm.org pin shape with epoch + `~++<snapshot>` suffix must yield the
+    bare release.
+    """
+    cfg = (
+        "[bootstrap.packages]\n"
+        '"apt:clang-22" = "1:22.1.8~++20260714015917+ca7933e47d3a-1~exp1~x"\n'
+    )
+    assert _parse_apt_llvm_version(cfg) == "22.1.8"
+
+
+def test_parse_apt_llvm_version_rejects_missing_pin() -> None:
+    """A missing apt:clang-22 pin fails loud, never a silent empty version."""
+    with pytest.raises(TypeError):
+        _parse_apt_llvm_version('[bootstrap.packages]\n"apt:curl" = "latest"\n')
+
+
+def test_resolve_expected_llvm_version_is_release_triple() -> None:
+    """HEAD resolver returns a real MAJOR.MINOR.PATCH from mise-system.toml."""
+    ver = resolve_expected_llvm_version()
+    parts = ver.split(".")
+    assert len(parts) == 3
+    assert all(p.isdigit() for p in parts)
+
+
+def test_resolve_expected_llvm_version_at_base_is_release_triple() -> None:
+    """Merge-base resolver returns a real MAJOR.MINOR.PATCH (== HEAD on main)."""
+    ver = resolve_expected_llvm_version_at_base()
+    parts = ver.split(".")
+    assert len(parts) == 3
+    assert all(p.isdigit() for p in parts)
+
+
+def test_tier3_injects_llvm_version_and_guards_dormant_without_it() -> None:
+    """The version var is injected; unset leaves the version guards SKIP-dormant."""
+    with_ver = build_tier3_script(
+        expected_p2996_ref=_FAKE_P2996_SHA,
+        emulated=True,
+        expected_llvm_version=_FAKE_LLVM_VERSION,
+    )
+    assert f"EXPECTED_LLVM_VERSION={_FAKE_LLVM_VERSION}\n" in with_ver
+
+    without_ver = build_tier3_script(expected_p2996_ref=_FAKE_P2996_SHA, emulated=True)
+    assert "EXPECTED_LLVM_VERSION=''\n" in without_ver
+    assert "clang version guard dormant" in without_ver
+
+
+def test_tier3_probes_openmp_lld_flang_libclc() -> None:
+    """The functional probes (#294) are present and RUN, not just compile."""
+    s = build_tier3_script(
+        expected_p2996_ref=_FAKE_P2996_SHA,
+        emulated=True,
+        expected_llvm_version=_FAKE_LLVM_VERSION,
+    )
+    # openmp: compile + RUN (RUN fires even under emulation, like asan/ubsan).
+    assert "clang++ -fopenmp /tmp/omp.cpp -o /tmp/omp" in s
+    assert "\n/tmp/omp >/dev/null" in s
+    # lld: exercised as a linker, not merely present.
+    assert "clang++ -fuse-ld=lld /tmp/sanitizer.cpp -o /tmp/lld-linked" in s
+    # flang: Fortran compile + RUN, with flang|flang-new fallback.
+    assert "command -v flang 2>/dev/null || command -v flang-new" in s
+    assert "\n/tmp/flang-hello >/dev/null" in s
+    # libclc: bitcode presence across candidate roots (location-robust).
+    assert "-name '*.bc'" in s
+    # The `|| true` is load-bearing (regression: container smoke #294) — find
+    # exits non-zero on a missing start dir, and under `set -e` a bare
+    # `clc_bc=$(find ...)` would abort the script BEFORE the presence check,
+    # dying silently instead of reporting. Guard that it never regresses.
+    assert "-name '*.bc' 2>/dev/null | head -n1 || true" in s
+
+
+def test_tier3_utility_version_smoke_covers_the_standalone_llvm_tools() -> None:
+    """#294 (Ray): opt/llc/llvm-cov/profdata/symbolizer/bolt/mlir-opt all probed."""
+    s = build_tier3_script(
+        expected_p2996_ref=_FAKE_P2996_SHA,
+        emulated=True,
+        expected_llvm_version=_FAKE_LLVM_VERSION,
+    )
+    assert (
+        "for util in opt llc llvm-cov llvm-profdata llvm-symbolizer "
+        "llvm-bolt mlir-opt" in s
+    )
+
+
+def test_tier3_driver_presence_is_in_shared_body_not_ci_only() -> None:
+    """#294: the 7-driver PATH loop moved into the SHARED tier-3 substrate.
+
+    Regression guard: it used to live only in ``build_smoke_script``'s CI tail,
+    so ``verify-container-latest`` (which runs ``build_tier3_script``) never saw
+    it. It must now be in the shared body, and the old CI-only header must be
+    gone (no duplication).
+    """
+    tier3 = build_tier3_script(expected_p2996_ref=_FAKE_P2996_SHA, emulated=True)
+    assert "for tool in clang clang++ clangd clang-tidy clang-format lld lldb" in tier3
+    # The pre-#294 CI-only section header is retired.
+    ci = build_smoke_script(_FAKE_P2996_SHA)
+    assert "=== clang tooling checks ===" not in ci
+
+
+def test_build_smoke_docker_cmd_injects_real_llvm_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The CI docker command injects the resolved release (not the dormant '')."""
+    monkeypatch.delenv("CLANG_P2996_REF", raising=False)
+    cmd = build_smoke_docker_cmd("ghcr.io/ray-manaloto/dotfiles-devcontainer:test")
+    script = cmd[-1]
+    assert "EXPECTED_LLVM_VERSION=''" not in script
+    assert f"EXPECTED_LLVM_VERSION={resolve_expected_llvm_version()}" in script
+
+
+def _run_default_clang_block(
+    tmp_path: Path, clang_real: str, clang_ver_line: str, want_ver: str
+) -> subprocess.CompletedProcess:
+    """Run just the #294 default-clang gate against a stubbed clang++ via bash.
+
+    Stubs ``clang++`` (its ``--version`` prints ``clang_ver_line``) and
+    ``readlink`` (echoes ``clang_real``) on PATH, so the gate's resolution +
+    version assertions run in both directions without a real toolchain. Mirrors
+    ``_run_python_block``.
+    """
+    bin_dir = tmp_path / "stub-bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    clang = bin_dir / "clang++"
+    clang.write_text(
+        "#!/usr/bin/env bash\n"
+        f'case "$*" in *--version*) echo {shlex.quote(clang_ver_line)} ;; esac\n'
+    )
+    clang.chmod(0o755)
+    readlink = bin_dir / "readlink"
+    readlink.write_text(f"#!/usr/bin/env bash\necho {shlex.quote(clang_real)}\n")
+    readlink.chmod(0o755)
+    harness = (
+        "set -euo pipefail\n"
+        f"PATH={shlex.quote(str(bin_dir))}:$PATH\n"
+        f"EXPECTED_LLVM_VERSION={shlex.quote(want_ver)}\n" + _TIER3_DEFAULT_CLANG
+    )
+    return subprocess.run(
+        ["bash", "-c", harness], capture_output=True, text=True, check=False
+    )
+
+
+def test_default_clang_block_passes_for_apt_llvm(tmp_path: Path) -> None:
+    """Happy path: clang++ under /usr/lib/llvm-22, --version reports the release."""
+    r = _run_default_clang_block(
+        tmp_path,
+        "/usr/lib/llvm-22/bin/clang",
+        "Ubuntu clang version 22.1.8 (++2026...)",
+        "22.1.8",
+    )
+    assert r.returncode == 0, r.stderr
+    assert "OK: default clang++ is LLVM 22.1.8" in r.stdout
+
+
+def test_default_clang_block_fails_on_wrong_version(tmp_path: Path) -> None:
+    """FAIL arm: right location, wrong release — the version pin is enforced."""
+    r = _run_default_clang_block(
+        tmp_path,
+        "/usr/lib/llvm-22/bin/clang",
+        "Ubuntu clang version 21.1.0 (++2026...)",
+        "22.1.8",
+    )
+    assert r.returncode == 1
+    assert "not LLVM 22.1.8" in r.stdout
+
+
+def test_default_clang_block_fails_on_non_apt_clang(tmp_path: Path) -> None:
+    """FAIL arm: a p2996/conda clang taking bare clang++ is caught."""
+    r = _run_default_clang_block(
+        tmp_path,
+        "/opt/clang-p2996/bin/clang",
+        "clang version 22.1.8",
+        "22.1.8",
+    )
+    assert r.returncode == 1
+    assert "not apt /usr/lib/llvm-*" in r.stdout
+
+
+def test_default_clang_block_dormant_when_version_unset(tmp_path: Path) -> None:
+    """Unset version => the version guard SKIPs (path check still runs)."""
+    r = _run_default_clang_block(
+        tmp_path, "/usr/lib/llvm-22/bin/clang", "clang version 22.1.8", ""
+    )
+    assert r.returncode == 0
+    assert "SKIP" in r.stdout
 
 
 def test_parse_human_size_handles_gigabytes_before_bytes_suffix() -> None:


### PR DESCRIPTION
Part B-lite of #251: the apt.llvm.org LLVM-22 suite (66 [bootstrap.packages]
pins) had strong config-integrity protection (identity-hashed) but almost no
runtime-behavior validation — the exact tool-set diff only covers mise [tools],
and tier-3 exercised only bare clang++ (sanitizers) + the two reflection
toolchains. This adds functional probes to the shared #223 tier-3 substrate, so
BOTH the CI no-mount smoke and the devcontainer smoke (verify-container-latest)
run them from one source of truth:

- Default-clang identity + version gate (extracted as _TIER3_DEFAULT_CLANG,
  control-armed): bare clang++ resolves under /usr/lib/llvm-* and --version
  reports the pinned release. Mirrors the tier-1 default-python3 gate.
- OpenMP -fopenmp compile+link+run; lld exercised as a linker (-fuse-ld=lld);
  flang Fortran compile+run (flang|flang-new); libclc bitcode presence.
- Utility --version smoke for opt, llc, llvm-cov, llvm-profdata, llvm-symbolizer,
  llvm-bolt, mlir-opt. These ship in the declared llvm-22 / bolt-22 /
  mlir-22-tools packages (verified from the .deb), so probing them is the
  "update alongside actual toolchain changes" the 61e0ec3/82e9a22 guardrails
  sanctioned — the two stale does_not_require_* tests are inverted accordingly.
- Moved the 7-driver PATH presence loop out of the CI-only tail into the shared
  substrate so verify-container-latest sees it too.

The expected LLVM release is injected merge-base-aware (resolve_expected_llvm_
version for CI / _at_base for the devcontainer), parsed from the apt:clang-22
pin — the same HEAD-vs-merge-base discipline as CLANG_P2996_REF. Version guards
are dormant when unset (unit-test friendly). Probes use `case` globs, never
`cmd | grep -q` (SIGPIPE under pipefail).

image.py-only: no image build input changes, so no base rebuild.

Closes #294.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012eMxUCfQSkRnpHE6SbcgSr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened compiler smoke checks to verify the expected LLVM-22 version and apt installation.
  - Added validation for OpenMP, lld, flang, libclc, and additional LLVM utilities.
  - Improved detection of incorrect or missing compiler installations.

- **Tests**
  - Expanded smoke-test coverage for LLVM version matching, compiler identity, tool availability, and representative compiler workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->