### PR TITLE
ci: set init.defaultBranch via GIT_CONFIG_* in every workflow (#21)

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -20,6 +20,15 @@ env:
   HK_LOG_FILE_LEVEL: debug
   MISE_LOG_FILE: /tmp/mise.log
   MISE_LOG_FILE_LEVEL: debug
+  # Silence git's "Using 'master' as the name for the initial branch" hint
+  # that actions/checkout's `git init` emits (#21). git reads GIT_CONFIG_COUNT/
+  # KEY/VALUE directly, so this needs no `git config` step and applies to every
+  # git invocation in the workflow. It MUST be repeated per workflow file: env
+  # does NOT cross workflow_call, and it must be set before checkout runs.
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
+
 # Match ci.yml: group per source branch and cancel superseded autofix runs.
 concurrency:
   group: autofix-${{ github.head_ref || github.ref }}

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -67,6 +67,15 @@ env:
   HK_LOG_FILE_LEVEL: debug
   MISE_LOG_FILE: /tmp/mise.log
   MISE_LOG_FILE_LEVEL: debug
+  # Silence git's "Using 'master' as the name for the initial branch" hint
+  # that actions/checkout's `git init` emits (#21). git reads GIT_CONFIG_COUNT/
+  # KEY/VALUE directly, so this needs no `git config` step and applies to every
+  # git invocation in the workflow. It MUST be repeated per workflow file: env
+  # does NOT cross workflow_call, and it must be set before checkout runs.
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
+
 permissions:
   contents: read
   packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,15 @@ env:
   HK_LOG_FILE_LEVEL: debug
   MISE_LOG_FILE: /tmp/mise.log
   MISE_LOG_FILE_LEVEL: debug
+  # Silence git's "Using 'master' as the name for the initial branch" hint
+  # that actions/checkout's `git init` emits (#21). git reads GIT_CONFIG_COUNT/
+  # KEY/VALUE directly, so this needs no `git config` step and applies to every
+  # git invocation in the workflow. It MUST be repeated per workflow file: env
+  # does NOT cross workflow_call, and it must be set before checkout runs.
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
+
 permissions:
   contents: read
   packages: write

--- a/.github/workflows/gcc-sha-repair.yml
+++ b/.github/workflows/gcc-sha-repair.yml
@@ -24,6 +24,17 @@ on:
       - ".devcontainer/Dockerfile"
 permissions:
   contents: read # the App token carries contents:write for the push
+
+env:
+  # Silence git's "Using 'master' as the name for the initial branch" hint
+  # that actions/checkout's `git init` emits (#21). git reads GIT_CONFIG_COUNT/
+  # KEY/VALUE directly, so this needs no `git config` step and applies to every
+  # git invocation in the workflow. It MUST be repeated per workflow file: env
+  # does NOT cross workflow_call, and it must be set before checkout runs.
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
+
 concurrency:
   group: gcc-sha-repair-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -30,6 +30,17 @@ on:
         type: string
 permissions:
   contents: read
+
+env:
+  # Silence git's "Using 'master' as the name for the initial branch" hint
+  # that actions/checkout's `git init` emits (#21). git reads GIT_CONFIG_COUNT/
+  # KEY/VALUE directly, so this needs no `git config` step and applies to every
+  # git invocation in the workflow. It MUST be repeated per workflow file: env
+  # does NOT cross workflow_call, and it must be set before checkout runs.
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/image-analysis.yml
+++ b/.github/workflows/image-analysis.yml
@@ -35,6 +35,15 @@ concurrency:
 env:
   CONTAINER_REGISTRY: ghcr.io
   IMAGE_NAME: ray-manaloto/dotfiles-devcontainer
+  # Silence git's "Using 'master' as the name for the initial branch" hint
+  # that actions/checkout's `git init` emits (#21). git reads GIT_CONFIG_COUNT/
+  # KEY/VALUE directly, so this needs no `git config` step and applies to every
+  # git invocation in the workflow. It MUST be repeated per workflow file: env
+  # does NOT cross workflow_call, and it must be set before checkout runs.
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
+
 jobs:
   analyze:
     # Only for successful CI runs whose event built a fresh image. push-to-main

--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -42,6 +42,17 @@ on:
 permissions:
   contents: write
   pull-requests: write
+
+env:
+  # Silence git's "Using 'master' as the name for the initial branch" hint
+  # that actions/checkout's `git init` emits (#21). git reads GIT_CONFIG_COUNT/
+  # KEY/VALUE directly, so this needs no `git config` step and applies to every
+  # git invocation in the workflow. It MUST be repeated per workflow file: env
+  # does NOT cross workflow_call, and it must be set before checkout runs.
+  GIT_CONFIG_COUNT: "1"
+  GIT_CONFIG_KEY_0: init.defaultBranch
+  GIT_CONFIG_VALUE_0: main
+
 jobs:
   lock-refresh:
     runs-on: ubuntu-latest

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -1125,3 +1125,22 @@ tokens = [
     "def pinned_apt_packages",
     "--simulate",
 ]
+
+[[suite]]
+name = "ci.git-default-branch-env"
+description = "#21: every workflow must set init.defaultBranch via GIT_CONFIG_* env, so actions/checkout's `git init` stops emitting the `Using 'master' as the name for the initial branch` hint. It MUST be per-file: env does NOT cross workflow_call (build-publish.yml is a reusable workflow, and its own env block already says so), which is why PR #21's ci.yml-only fix would have covered 3 of the 6 hint-emitting jobs. per_path_tokens, NOT tokens: plain tokens use combined-text semantics (findings [19]/[22]), so one workflow carrying the env would satisfy the contract for all seven. paths_required fails loudly on a rename. KNOWN GAP: this is an explicit list, so a NEWLY ADDED workflow is not covered — today every workflow runs actions/checkout, so the list and 'workflows that need it' are the same set; if that stops being true, this needs a dynamic check (see bash_budget's tracked-set comparison)."
+category = "ci"
+check_type = "static"
+handler = "require_tokens"
+paths_required = true
+paths = [
+    ".github/workflows/autofix.yml",
+    ".github/workflows/build-publish.yml",
+    ".github/workflows/ci.yml",
+    ".github/workflows/gcc-sha-repair.yml",
+    ".github/workflows/ghcr-cleanup.yml",
+    ".github/workflows/image-analysis.yml",
+    ".github/workflows/refresh.yml",
+]
+per_path_tokens = { ".github/workflows/autofix.yml" = ["GIT_CONFIG_KEY_0: init.defaultBranch"], ".github/workflows/build-publish.yml" = ["GIT_CONFIG_KEY_0: init.defaultBranch"], ".github/workflows/ci.yml" = ["GIT_CONFIG_KEY_0: init.defaultBranch"], ".github/workflows/gcc-sha-repair.yml" = ["GIT_CONFIG_KEY_0: init.defaultBranch"], ".github/workflows/ghcr-cleanup.yml" = ["GIT_CONFIG_KEY_0: init.defaultBranch"], ".github/workflows/image-analysis.yml" = ["GIT_CONFIG_KEY_0: init.defaultBranch"], ".github/workflows/refresh.yml" = ["GIT_CONFIG_KEY_0: init.defaultBranch"] }
+tokens = ["GIT_CONFIG_KEY_0: init.defaultBranch"]


### PR DESCRIPTION
actions/checkout's `git init` emits `hint: Using 'master' as the name for the
initial branch` on every run. Silence it at the source: git reads
GIT_CONFIG_COUNT/KEY_0/VALUE_0 directly, so a workflow-level env needs no
`git config` step and covers every git invocation in the workflow.

Closes the last live item from the stale draft PR #21 (2026-04-01,
CONFLICTING). Its other asks already landed via other work: the Dockerfile sed
fix and its `build.manpage-restore-sed-syntax` guard are both on main verbatim,
and `conda:graphviz` was removed by #222 PR-A (graphviz is now a pinned GitLab
.deb), which moots the `build.no-conda-graphviz` guard it also proposed.

PR #21's fix was incomplete: it patched ci.yml only. env does NOT cross
workflow_call — build-publish.yml's own env block already says so — so its
version would have covered 3 of the 6 hint-emitting jobs, leaving base-prep,
dev-prep and p2996-prep noisy. Measured against a run where build-publish
actually executed; the run I checked first had it SKIPPED, where the absence of
those jobs reads as "not affected" rather than "never asked"
(probes-need-a-control-arm). All 7 workflows run actions/checkout, so all 7 get
the env.

The `ci.git-default-branch-env` contract uses per_path_tokens, NOT tokens: plain
tokens are combined-text (findings [19]/[22]), so one workflow carrying the env
would satisfy the contract for all seven. Control-armed: stripping the env from
refresh.yml alone FAILS the contract — the exact case a tokens-only version
would have passed. Its known gap is recorded in the description: the path list
is explicit, so a newly added workflow is not covered; today "all workflows" and
"workflows that checkout" are the same set.

Verified: actionlint rc=0, all 7 parse with GIT_CONFIG at top level, pin-actions
rc=0, lint rc=0, pytest 709 passed, verify run 92 passed 0 failed.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S1KTdigKumBP1WvH3G6gGC
