### PR TITLE
feat(verify): close the silent-false-negative class + correct three stale facts (#299)

### DIFF
--- a/.claude/rules/long-running-command-hangs.md
+++ b/.claude/rules/long-running-command-hangs.md
@@ -27,7 +27,25 @@ unbounded wait + pipe-masked exit code.
 
 2. **For any command expected to exceed ~30s, never wait blind.** Either
    bound it with a timeout, or run it in the background and monitor its
-   debug log. For a `mise run lint` run the log is
+   debug log. **EXCEPTION — Mac-side container ops: background-and-idle gets
+   them REAPED.** `mise run ship`/`land`, `verify-local`, `sync`, and image
+   pulls are killed if the turn goes idle waiting on them, so "background it"
+   — the default advice above — is precisely wrong here and cost a killed
+   20-minute image pull (2026-07-16). Measured both ways: a foreground 10-min
+   bound also killed a `ship` mid-`shellcheck` (rc=143). What works is
+   **in-turn polling** — background the command, then keep the turn engaged
+   reading its log until it finishes:
+
+   ```bash
+   deadline=$((SECONDS+540))
+   while [ $SECONDS -lt $deadline ]; do grep -q RC "$LOG" && break; sleep 15; done
+   ```
+
+   **Backgrounding stays correct for CI/remote waits** (`gh pr checks --watch`,
+   `gh run watch`) — those run on GitHub's infrastructure, not this Mac, and
+   nothing local reaps them. The hazard is specifically local, long, Mac-side
+   work. See `feedback_long_mac_ops_keep_turn_engaged`, which this rule used to
+   contradict outright. For a `mise run lint` run the log is
    **`~/.local/state/dotfiles/hk-lint.log`** — the per-run `HK_LOG_FILE`
    the wrapper sets (`lint.py` `DEFAULT_LOG_FILE`). Read THAT one:
    `~/.local/state/hk/hk.log` is a *different* file written by other hk

--- a/.claude/rules/probes-need-a-control-arm.md
+++ b/.claude/rules/probes-need-a-control-arm.md
@@ -32,6 +32,34 @@ The **inverse** bites too. `cmd | grep -q PAT` under `set -o pipefail` returns
 only fail. That broke the #289 base build; see `no_grep_q_under_pipefail` in
 `hk.pkl`.
 
+## Cross-check: when two probes disagree, one of them is broken
+
+The cheapest bug detector available is a **second probe of the same fact by a
+different route**. It needs no fixture and no reasoning: if two probes of one
+fact disagree, you have found a defect *for free* — and it is in a probe far
+more often than in the world. Reach for this the moment a result surprises you,
+before you write up the surprise.
+
+The value is that it names *which* answer to distrust. A lone probe returning
+"MISSING" is indistinguishable from a probe that cannot see; a second route
+returning "PRESENT" proves the first one is blind. Three instances, all
+2026-07-16, all cheap to cross-check and expensive to believe:
+
+| the probe said | the disagreeing route | what was actually broken |
+|---|---|---|
+| pin `curl=8.18.0-1ubuntu2` FAILS to install | same pin in a **clean base container** → installs fine | the **devcontainer was dirty** — it already had a newer curl, and apt refuses to downgrade. The pin was correct; the environment lied. |
+| CI job SKIPPED ⇒ "unaffected by this change" | reading the job's `if:` condition | a SKIPPED job **never asked the question**. "Never ran" is not "ran and found nothing". |
+| every package reports MISSING | running the same command without the outer quoting | the **inner shell ate the variable** — a nested-quote format string expanded to empty, so every lookup compared against `""`. |
+
+A fourth, from the session that wrote this section: a contract was probed by
+renaming `def changes_apt_pin_inputs` → `def changes_apt_pin_inputs_REMOVED`
+to prove the contract would catch its removal. The contract passed, which
+looked like a contract defect — but the renamed symbol **still contains the
+original as a substring**, and the check is a substring match. The probe was
+the bug. Renaming to a genuinely different symbol made it fail correctly.
+(See `feedback_forbid_tokens_substring_fragile` — substring matching turns a
+"removal" probe into a no-op.)
+
 ## Rules
 
 1. **Arm the negative.** Before reporting "X does not exist", run the same probe
@@ -49,6 +77,9 @@ only fail. That broke the #289 base build; see `no_grep_q_under_pipefail` in
 5. **Say which arm you ran.** When reporting a probe result, state the control:
    "bogus-dist → 404 while resolute-22 → 200, so the probe discriminates." A
    result without its control is an opinion.
+6. **Cross-check a surprise before you report it.** A second route to the same
+   fact costs seconds and settles which side is broken. Disagreement is a
+   finding, not noise — and the finding is usually your probe.
 
 ## Applies to
 

--- a/.claude/rules/verify-before-advancing.md
+++ b/.claude/rules/verify-before-advancing.md
@@ -118,6 +118,25 @@ confirming the delegate's checks actually passed).
 > and gets applied to files its real owner never governed. Cite a figure only
 > where you can name the vendor; when code and a doc disagree, re-read the
 > source before making either match the other. See [[md-size-budgets]].
+>
+> **The other half is SCOPE: a fact needs the CONDITION that makes it true, not
+> just its source.** Provenance alone is not enough. Each fact below is genuine
+> and correctly sourced, and each was still wrong where it was used — because it
+> travelled without its "true when". This is *harder* to catch than invention:
+> the citation checks out, so the claim survives review.
+>
+> | fact | true when | was applied to | what it cost |
+> |---|---|---|---|
+> | 12,000-char limit | Windsurf / agnix AGM-003 | all Claude markdown | a gate enforcing a limit its real owner never set |
+> | renovate "extracts NOTHING" under an unsupported node | some older renovate | 43.265.1, which extracts fine | a hunt for a data-loss bug that does not exist |
+> | 2–2.5h cold build | the p2996 cache **misses** | any `mise-system.toml` touch | a ~4x over-warning; measured ~37 min |
+>
+> A stated condition is also what makes a fact **falsifiable later**: "2.5h when
+> p2996 misses" tells the next reader what to check, while a bare "2.5h" can only
+> be believed or doubted. So when you carry a number, carry its condition — and
+> when you meet one, ask "what has to be true for this to hold, and is it true
+> HERE?" (Deliberately folded into this blockquote rather than given its own
+> eager rule: one idea, one place.)
 
 ## See also
 

--- a/mise.toml
+++ b/mise.toml
@@ -498,11 +498,14 @@ description = "Report the updates Renovate would raise, from this working tree (
 # renovate.json byte-identical to what hosted Renovate reads.
 #
 # tools.node pins THIS TASK to node 24 (#251). Renovate 43.x declares
-# `engines.node ^24.11.0`; under our node 26 the binary exits rc=1 with
-# "Unsupported node environment detected" and extracts NOTHING — which reads
-# like "no deps found", not like an env error. `depends` cannot fix this (it is
-# install ORDER only); `tasks.*.tools` is mise's documented per-task version
-# override ("a tool with a different version... only used for that task").
+# `engines.node ^24.11.0`; under our node 26 the binary logs "Unsupported node
+# environment detected" and exits rc=1. CORRECTED in #299: it still extracts
+# and resolves NORMALLY — the pin buys a clean exit code, not report
+# correctness. (The former "extracts NOTHING" note was true of some older
+# renovate, not of 43.265.1, and cost a hunt for a data-loss bug that does not
+# exist.) `depends` cannot fix this (it is install ORDER only); `tasks.*.tools`
+# is mise's documented per-task version override ("a tool with a different
+# version... only used for that task").
 # Probed 2026-07-15: default task -> v26.5.0, tools.node="24" task -> v24.x.
 # Renovate's own mise manager reads `tasks.*.tools`, so this pin stays current.
 #

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -54,6 +54,20 @@ pre-commit --all` — some contracts (e.g., `build.no-stderr-suppression`)
 only run through the verify CLI. Run both locally before pushing
 Dockerfile changes.
 
+Two engine defaults bind every contract you write (#299):
+
+- **`paths_required` defaults to `true`** — a declared path that no longer
+  exists FAILS the suite, for every handler, enforced in `run_suite` before
+  dispatch. Opt out with an explicit `paths_required = false`. Without this,
+  *partial* path loss is silent: handlers resolve paths through
+  `_resolve_paths`, which drops what is gone, so a suite naming two files
+  keeps passing on the strength of the one that survives.
+- **Bare `tokens` is a UNION** (combined text): a token in ANY listed file
+  satisfies the contract for all of them. Use **`per_path_tokens`** to state
+  which file must carry which token — otherwise a contract has no opinion
+  about the files it names (`build.path-includes-mise-shims` named a file that
+  stopped wiring PATH and stayed green ~3.5 months).
+
 Contracts use handler types like `policy_doc` (references a doc file)
 and `regex_forbid` (pattern-based rejection). Note: static contract
 substring matches false-positive on prefixed ENV vars (e.g.,

--- a/python/src/dotfiles_setup/pr.py
+++ b/python/src/dotfiles_setup/pr.py
@@ -141,6 +141,22 @@ CI_PUSH_PATHS: tuple[str, ...] = (
     ".config/mise/conf.d/shared.toml",
 )
 
+# The inputs to the `verify-apt-pins` probe (apt_pins.MISE_SYSTEM_TOML +
+# apt_pins.DOCKERFILE). BOTH are probe inputs, not just the pin declarations:
+# the Dockerfile carries `ARG BASE_IMAGE` and the LLVM signing key — what the
+# pins get resolved AGAINST — so a base bump can invalidate every pin without
+# touching a pin line.
+#
+# Both are also BASE_INPUT_PATTERNS, i.e. exactly the changes for which ship
+# DEFERS container validation to CI. That is why this gate earns its place:
+# it is the ~60s local probe standing in for the deferred container gate, and
+# an unresolvable pin otherwise surfaces only after a ~37min CI base build
+# (.claude/rules/local-devcontainer-first.md).
+_APT_PIN_PATTERNS = (
+    ".devcontainer/mise-system.toml",
+    ".devcontainer/Dockerfile",
+)
+
 # Conditional gates from verify-before-advancing's check matrix.
 _GHA_PATTERNS = (".github/*", ".github/**/*")
 _DOCS_PATTERNS = (
@@ -210,6 +226,15 @@ def changes_base_image_inputs(paths: list[str]) -> bool:
     return any(_matches_any(p, BASE_INPUT_PATTERNS) for p in paths)
 
 
+def changes_apt_pin_inputs(paths: list[str]) -> bool:
+    """True when the diff changes an input to the apt-pin resolvability probe.
+
+    Either the `[bootstrap.packages]` declarations themselves or the base
+    image / signing key they resolve against (:data:`_APT_PIN_PATTERNS`).
+    """
+    return any(_matches_any(p, _APT_PIN_PATTERNS) for p in paths)
+
+
 def expects_main_run(paths: list[str]) -> bool:
     """True when merging these paths triggers a main ci.yml run.
 
@@ -237,7 +262,8 @@ def gate_matrix(paths: list[str]) -> list[Gate]:
     Always: lint, pytest, verify contracts, hook-selfcheck (the wired
     host-side hooks, end-to-end). Conditional per
     verify-before-advancing: pin-actions on .github changes, lint-docs on
-    agent-doc changes. The full-sync hard gate runs LAST (most expensive)
+    agent-doc changes, verify-apt-pins on apt-pin inputs
+    (:func:`changes_apt_pin_inputs`). The full-sync hard gate runs LAST (most expensive)
     when the devcontainer/image/validation surface changed — EXCEPT when a
     base-image build input changed (:func:`changes_base_image_inputs`), for
     which the local base cannot validate the branch and container validation
@@ -266,6 +292,13 @@ def gate_matrix(paths: list[str]) -> list[Gate]:
         gates.append(Gate("pin-actions", ("mise", "run", "pin-actions")))
     if any(_matches_any(p, _DOCS_PATTERNS) for p in paths):
         gates.append(Gate("lint-docs", ("mise", "run", "lint-docs")))
+    # ~60s in a throwaway base container, and deliberately NOT conditioned on
+    # changes_base_image_inputs: these paths ARE base inputs, so the container
+    # gate below is skipped for them and this probe is the only local check
+    # that a pin still resolves. Local-first (#288/#299) — it exists precisely
+    # to fail in 60s instead of after a ~37min CI base build.
+    if changes_apt_pin_inputs(paths):
+        gates.append(Gate("verify-apt-pins", ("mise", "run", "verify-apt-pins")))
     if touches_surface(paths) and not changes_base_image_inputs(paths):
         gates.append(Gate("sync-full", ("mise", "run", "sync", "--", "--full")))
     return gates

--- a/python/src/dotfiles_setup/renovate_dryrun.py
+++ b/python/src/dotfiles_setup/renovate_dryrun.py
@@ -41,6 +41,16 @@ The local platform also returns ``persistRepoData: true``, which is the only
 thing suppressing the repository worker's ``deleteLocalFile('.')`` — under
 ``platform=local`` the "localDir" IS this working tree. Do not set
 ``persistRepoData: false``.
+
+A fourth fact, corrected in #299: ``mise.toml`` pins this task to node 24
+because renovate 43.x declares ``engines.node ^24.11.0``. Under node 26 the
+binary **extracts and resolves normally** and then exits non-zero on the
+logged engine error — it does NOT lose data. The pin buys a clean exit code,
+not correctness of the report. The earlier "extracts NOTHING" rationale was a
+true statement about *some older renovate* applied outside the condition that
+made it true; measured against 43.265.1 it is false, and it sent a reader
+hunting a data-loss bug that does not exist. A fact needs its condition, not
+just its source (``.claude/rules/verify-before-advancing.md``).
 """
 
 from __future__ import annotations
@@ -50,7 +60,7 @@ import os
 import subprocess
 import sys
 import tempfile
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 # Renovate resolves `force` AFTER repo config (renovate.json + presets), so it
@@ -110,6 +120,32 @@ class PendingUpdate:
 
 
 @dataclass
+class GroupStats:
+    """Dep tallies for one manager, or one datasource.
+
+    Exists so the report can answer "did my regex extract?" — the question
+    #251 documented and #288 had to answer by bypassing the task and running
+    the binary by hand. A pending-updates list alone cannot: a custom manager
+    that matched zero files and a custom manager whose deps are all current
+    both render as silence.
+    """
+
+    name: str
+    deps: int
+    updates: int
+    skipped: int
+
+    def render(self) -> str:
+        """Render as one aligned report row."""
+        skipped = f", {self.skipped} skipped" if self.skipped else ""
+        dep = "dep " if self.deps == 1 else "deps"
+        return (
+            f"  {self.name:<14} {self.deps:>3} {dep}, "
+            f"{self.updates:>2} pending{skipped}"
+        )
+
+
+@dataclass
 class DryRunResult:
     """The outcome of one local Renovate dry-run."""
 
@@ -119,6 +155,11 @@ class DryRunResult:
     # False when no github.com token was available, i.e. every github-datasource
     # dep was skipped and `updates` is a FLOOR rather than a total.
     complete: bool = True
+    # What each manager/datasource actually extracted. Renovate's native report
+    # carries `manager`, `datasource` and `skipReason` per dep; these were
+    # discarded at the parse seam until #299.
+    managers: list[GroupStats] = field(default_factory=list)
+    datasources: list[GroupStats] = field(default_factory=list)
 
 
 def resolve_github_token(env: dict[str, str] | None = None) -> str | None:
@@ -163,17 +204,56 @@ def run_renovate(report_path: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _tally(
+    counts: dict[str, list[int]], key: str, *, updates: int, skipped: int
+) -> None:
+    """Accumulate one dep into the [deps, updates, skipped] row for `key`."""
+    row = counts.setdefault(key, [0, 0, 0])
+    row[0] += 1
+    row[1] += updates
+    row[2] += skipped
+
+
+def _stats(counts: dict[str, list[int]]) -> list[GroupStats]:
+    """Render the tally rows as GroupStats, busiest first then alphabetical."""
+    return [
+        GroupStats(name=name, deps=row[0], updates=row[1], skipped=row[2])
+        for name, row in sorted(counts.items(), key=lambda kv: (-kv[1][0], kv[0]))
+    ]
+
+
 def parse_report(raw: str, *, complete: bool = True) -> DryRunResult:
-    """Extract the pending updates from renovate's native JSON report."""
+    """Extract the pending updates and extraction tallies from renovate's report.
+
+    The per-manager/per-datasource tallies are the answer to "did it look?" —
+    a manager absent from `managers` matched nothing, which is a different
+    fact from "matched, and everything is current" (deps > 0, updates == 0).
+    Renovate reports both identically in its pending list, which is why #288
+    could not use this task and hand-ran the binary instead (#299).
+    """
     report = json.loads(raw)
     repo = report.get("repositories", {}).get("local", {})
     updates: list[PendingUpdate] = []
+    by_manager: dict[str, list[int]] = {}
+    by_datasource: dict[str, list[int]] = {}
     total = 0
     for manager, files in (repo.get("packageFiles") or {}).items():
         for entry in files:
             package_file = entry.get("packageFile", "?")
             for dep in entry.get("deps", []):
                 total += 1
+                pending = dep.get("updates") or []
+                # A skipReason means renovate declined to look this dep up --
+                # NOT that it is current. Counting it as either would restate
+                # the very confusion this report exists to remove.
+                skipped = 1 if dep.get("skipReason") else 0
+                _tally(by_manager, manager, updates=len(pending), skipped=skipped)
+                _tally(
+                    by_datasource,
+                    dep.get("datasource", "?"),
+                    updates=len(pending),
+                    skipped=skipped,
+                )
                 updates.extend(
                     PendingUpdate(
                         manager=manager,
@@ -182,7 +262,7 @@ def parse_report(raw: str, *, complete: bool = True) -> DryRunResult:
                         current_value=dep.get("currentValue", "?"),
                         new_value=upd.get("newValue", "?"),
                     )
-                    for upd in dep.get("updates") or []
+                    for upd in pending
                 )
     problems = [
         str(p.get("msg", p))
@@ -190,7 +270,12 @@ def parse_report(raw: str, *, complete: bool = True) -> DryRunResult:
         if isinstance(p, dict)
     ]
     return DryRunResult(
-        total_deps=total, updates=updates, problems=problems, complete=complete
+        total_deps=total,
+        updates=updates,
+        problems=problems,
+        complete=complete,
+        managers=_stats(by_manager),
+        datasources=_stats(by_datasource),
     )
 
 
@@ -224,6 +309,17 @@ def render_report(result: DryRunResult) -> str:
             f"Scanned {result.total_deps} deps; "
             f"at least {len(result.updates)} would be updated."
         )
+    # Print the extraction tallies BEFORE the pending list: "which managers
+    # matched, and how much" is the question you cannot answer from the
+    # pending list, and a manager missing from this block extracted nothing.
+    if result.managers:
+        lines.append("")
+        lines.append("Extracted by manager (absent == matched no files):")
+        lines.extend(g.render() for g in result.managers)
+    if result.datasources:
+        lines.append("")
+        lines.append("Looked up by datasource:")
+        lines.extend(g.render() for g in result.datasources)
     if result.updates:
         lines.append("")
         lines.extend(u.render() for u in result.updates)
@@ -262,8 +358,19 @@ def renovate_dryrun_main(*, json_output: bool = False, check: bool = False) -> i
         proc = run_renovate(report_path)
         if proc.returncode != 0 or not report_path.is_file():
             sys.stderr.write(proc.stderr or proc.stdout)
+            # These two failures read identically until you say which is which,
+            # and the difference decides where to look next: a report ON DISK
+            # means extraction worked and the exit code is the complaint (an
+            # unsupported node does exactly this), while no report means the
+            # run died before writing one. Sending a reader to hunt for a file
+            # that is sitting on disk is the bug this message had (#299).
             sys.stderr.write(
-                f"\nrenovate exited {proc.returncode} and produced no report.\n"
+                f"\nrenovate exited {proc.returncode} but DID write its report "
+                f"({report_path}) — extraction ran; the exit code is the "
+                f"complaint. Re-read the errors above.\n"
+                if report_path.is_file()
+                else f"\nrenovate exited {proc.returncode} and produced no "
+                f"report at {report_path}.\n"
             )
             return 1
         result = parse_report(

--- a/python/src/dotfiles_setup/verify.py
+++ b/python/src/dotfiles_setup/verify.py
@@ -34,12 +34,31 @@ def load_manifest(path: Path) -> list[dict[str, Any]]:
     return suites
 
 
+def _missing_paths(entry: dict[str, Any]) -> list[str]:
+    """Return the entry's declared paths that do not exist on disk."""
+    root = _project_root()
+    return [raw for raw in entry.get("paths", []) if not (root / raw).exists()]
+
+
 def run_suite(
     entry: dict[str, Any],
     *,
     handlers: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Execute a single verification suite entry.
+
+    A declared path that no longer exists FAILS the suite unless the entry
+    opts out with ``paths_required = false``. This is enforced here — before
+    dispatch — rather than inside any one handler, because *partial* path loss
+    is invisible from inside: every handler resolves its paths through
+    :func:`_resolve_paths`, which silently drops what is gone, so a suite
+    naming two files keeps passing on the strength of the one that survives.
+    Proven both arms on 2026-07-16 (delete one of two -> still PASSED; delete
+    both -> correctly failed, so the probe discriminated). Spec #299.
+
+    Default-strict rather than opt-in: at the time of the change **0 of 97**
+    suites declared a missing path, so it was a no-op then and a gate since —
+    and a suite written later is protected without its author remembering.
 
     Args:
         entry: Suite entry dictionary with name and handler keys.
@@ -58,6 +77,17 @@ def run_suite(
             "status": "failed",
             "reason": f"Handler '{handler_name}' not found",
         }
+
+    if entry.get("paths_required", True):
+        missing = _missing_paths(entry)
+        if missing:
+            description = entry.get("description", "")
+            reason = f"required path(s) missing: {', '.join(missing)}"
+            return {
+                "name": name,
+                "status": "failed",
+                "reason": f"{description}: {reason}" if description else reason,
+            }
 
     try:
         result: dict[str, Any] = all_handlers[handler_name](entry)
@@ -357,14 +387,8 @@ def _handle_forbid_tokens(entry: dict[str, Any]) -> dict[str, Any]:
 
 def _handle_require_tokens(entry: dict[str, Any]) -> dict[str, Any]:
     description = entry.get("description", "")
-    # Review finding [21]: a listed path that no longer exists must FAIL,
-    # not silently shrink the combined text — otherwise deleting a wired
-    # test file (or the module itself) passes every "must exist" contract.
-    if entry.get("paths_required", False):
-        root = _project_root()
-        missing = [raw for raw in entry.get("paths", []) if not (root / raw).exists()]
-        if missing:
-            fail(f"{description}: required path(s) missing: {', '.join(missing)}")
+    # Review finding [21] (a listed path that no longer exists must FAIL) is
+    # enforced for EVERY handler in run_suite, default-strict — see spec #299.
     # Review findings [19]/[22]: per-path token requirements — combined-text
     # semantics let a token in ANY listed file satisfy the contract, so
     # "wired in settings.json" could be satisfied by the rule doc alone.

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -197,11 +197,12 @@ tokens = ['npm_config_update_notifier = "false"']
 
 [[suite]]
 name = "build.path-includes-mise-shims"
-description = "Overlay/runtime paths must include the default per-user mise shims path"
+description = "Overlay/runtime paths must include the default per-user mise shims path. PER-PATH by deliberate choice (#299): this contract named three files under combined-text `tokens`, where a token in ANY listed file satisfies it for all. Commit fc8af71 (#34, 2026-04-05) removed devcontainer.json's remoteEnv PATH entry — a file this contract names — inside a multi-topic refactor that never mentioned it, and the union kept the contract GREEN for ~3.5 months. The overlay ENV PATH is the load-bearing site (mise's own docs: shims are the mechanism for non-interactive contexts, and `mise activate` REMOVES the shims dir from PATH in login shells, so `_.path` cannot bootstrap shims), so it is bound explicitly below. `paths` stays as declared: the scope is visible, nothing is deleted, and a prior review's rejection of DELETING these paths is not re-litigated here."
 category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/Dockerfile.host-user", ".devcontainer/devcontainer.json", "home/.chezmoi.toml.tmpl"]
+per_path_tokens = { ".devcontainer/Dockerfile.host-user" = [".local/share/mise/shims"] }
 tokens = [".local/share/mise/shims"]
 
 [[suite]]
@@ -401,6 +402,14 @@ category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/Dockerfile", ".devcontainer/mise-system.lock"]
+# Bound per-path (#299): under combined-text `tokens` the lock's conda table
+# could satisfy the Dockerfile's `--locked` requirement and vice versa, so the
+# contract had no opinion about either file individually.
+per_path_tokens = { ".devcontainer/Dockerfile" = [
+  "mise install --system --locked",
+], ".devcontainer/mise-system.lock" = [
+  "[conda-packages.linux-x64",
+] }
 tokens = [
   "mise install --system --locked",
   "[conda-packages.linux-x64",
@@ -916,6 +925,19 @@ paths = [
     "tests/test_sync.py",
     ".claude/skills/devcontainer-sync/SKILL.md",
 ]
+# Bound per-path (#299). Under combined-text `tokens` the skill doc's own
+# quoting of `[tasks.sync]` satisfied the contract, so mise.toml could lose the
+# task entirely and stay green — the documentation of a thing standing in for
+# the thing. test_sync.py is existence-only (paths_required).
+per_path_tokens = { "mise.toml" = [
+    "[tasks.sync]",
+    "dotfiles-setup docker sync",
+], "python/src/dotfiles_setup/sync.py" = [
+    "def sync_main",
+    "def decide_action",
+], ".claude/skills/devcontainer-sync/SKILL.md" = [
+    "mise run sync",
+] }
 tokens = [
     "[tasks.sync]",
     "dotfiles-setup docker sync",
@@ -937,6 +959,23 @@ paths = [
     "tests/test_pr.py",
     ".claude/skills/pr-workflow/SKILL.md",
 ]
+# Bound per-path (#299). Under combined-text `tokens` the skill doc's quoting
+# of `[tasks.ship]` / `--match-head-commit` satisfied the contract for every
+# file, so mise.toml could lose a task and pr.py could lose the head-SHA pin
+# while the suite stayed green. test_pr.py is existence-only (paths_required).
+per_path_tokens = { "mise.toml" = [
+    "[tasks.ship]",
+    "[tasks.land]",
+    "dotfiles-setup pr ship",
+    "dotfiles-setup pr land",
+], "python/src/dotfiles_setup/pr.py" = [
+    "def ship_main",
+    "def land_main",
+    "--match-head-commit",
+], ".claude/skills/pr-workflow/SKILL.md" = [
+    "mise run ship",
+    "mise run land",
+] }
 tokens = [
     "[tasks.ship]",
     "[tasks.land]",
@@ -1049,6 +1088,19 @@ paths = [
     "tests/test_tool_currency.py",
     ".github/workflows/refresh.yml",
 ]
+# Bound per-path (#299). Under combined-text `tokens` the module's own
+# docstring mention of `mise run tool-currency` satisfied the contract, so
+# refresh.yml could stop invoking the task and the suite would not notice —
+# the job wiring is the whole point. test_tool_currency.py is existence-only.
+per_path_tokens = { "mise.toml" = [
+    "[tasks.tool-currency]",
+    "dotfiles-setup tool-currency",
+], "python/src/dotfiles_setup/tool_currency.py" = [
+    "def tool_currency_main",
+], ".github/workflows/refresh.yml" = [
+    "mise run tool-currency",
+    "Tool currency report (daily)",
+] }
 tokens = [
     "[tasks.tool-currency]",
     "dotfiles-setup tool-currency",
@@ -1106,7 +1158,7 @@ tokens = [
 
 [[suite]]
 name = "workflow.apt-pins-enforcement"
-description = "#288 local-first apt-pin gate wiring: `mise run verify-apt-pins` must stay wired to the python probe end-to-end — the mise task shells out to `dotfiles-setup apt-pins`, main.py registers the subcommand, the apt_pins module (pin parsing + the generated apt --simulate script) + its tests exist, and the rule doc records the policy. The probe runs apt's real SOLVER in a throwaway base container because an index lookup cannot see a co-versioned-dependency conflict (a pinned version can be present in the index and still uninstallable); this contract asserts the whole chain so it can't drift out. Same shape as workflow.bash-logic-enforcement."
+description = "#288 local-first apt-pin gate wiring: `mise run verify-apt-pins` must stay wired to the python probe end-to-end — the mise task shells out to `dotfiles-setup apt-pins`, main.py registers the subcommand, the apt_pins module (pin parsing + the generated apt --simulate script) + its tests exist, and the rule doc records the policy. The probe runs apt's real SOLVER in a throwaway base container because an index lookup cannot see a co-versioned-dependency conflict (a pinned version can be present in the index and still uninstallable); this contract asserts the whole chain so it can't drift out. Same shape as workflow.bash-logic-enforcement. EXTENDED in #299: the gate is also wired into ship (`pr.gate_matrix` -> `changes_apt_pin_inputs`), because a probe that runs only when a human remembers is the 'relying on the LLM' layer mise-tasks-only.md says is never sufficient alone — it ran on #288 only because someone remembered."
 category = "workflow"
 check_type = "static"
 handler = "require_tokens"
@@ -1115,10 +1167,12 @@ paths = [
     "mise.toml",
     "python/src/dotfiles_setup/main.py",
     "python/src/dotfiles_setup/apt_pins.py",
+    "python/src/dotfiles_setup/pr.py",
     "tests/test_apt_pins.py",
+    "tests/test_pr.py",
     ".claude/rules/local-devcontainer-first.md",
 ]
-per_path_tokens = { "mise.toml" = ["tasks.verify-apt-pins", "dotfiles-setup apt-pins"], "python/src/dotfiles_setup/main.py" = ["apt-pins"], "python/src/dotfiles_setup/apt_pins.py" = ["def pinned_apt_packages", "def probe_script", "def apt_pins_main"], ".claude/rules/local-devcontainer-first.md" = ["mise run verify-apt-pins"] }
+per_path_tokens = { "mise.toml" = ["tasks.verify-apt-pins", "dotfiles-setup apt-pins"], "python/src/dotfiles_setup/main.py" = ["apt-pins"], "python/src/dotfiles_setup/apt_pins.py" = ["def pinned_apt_packages", "def probe_script", "def apt_pins_main"], "python/src/dotfiles_setup/pr.py" = ["_APT_PIN_PATTERNS", "def changes_apt_pin_inputs", "verify-apt-pins"], "tests/test_pr.py" = ["verify-apt-pins"], ".claude/rules/local-devcontainer-first.md" = ["mise run verify-apt-pins"] }
 tokens = [
     "dotfiles-setup apt-pins",
     "def apt_pins_main",

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -91,6 +91,43 @@ def test_gate_matrix_docs_adds_lint_docs() -> None:
     assert "lint-docs" in names
 
 
+def test_gate_matrix_bootstrap_packages_add_apt_pin_gate() -> None:
+    # The pin declarations, and the Dockerfile the pins resolve AGAINST (its
+    # ARG BASE_IMAGE / signing key) — a base bump can invalidate every pin
+    # without touching a pin line, so both are probe inputs (#299).
+    names = [g.name for g in pr.gate_matrix([".devcontainer/mise-system.toml"])]
+    assert "verify-apt-pins" in names
+    names = [g.name for g in pr.gate_matrix([".devcontainer/Dockerfile"])]
+    assert "verify-apt-pins" in names
+
+
+def test_gate_matrix_unrelated_surface_omits_apt_pin_gate() -> None:
+    # Control arm: the gate costs a ~60s container probe, so an unrelated
+    # change must not pay it. Without this, the test above is satisfied by a
+    # gate matrix that runs verify-apt-pins unconditionally.
+    names = [g.name for g in pr.gate_matrix(["README.md"])]
+    assert "verify-apt-pins" not in names
+    names = [g.name for g in pr.gate_matrix([".github/workflows/ci.yml"])]
+    assert "verify-apt-pins" not in names
+
+
+def test_gate_matrix_apt_pin_gate_survives_the_base_input_deferral() -> None:
+    """The pin gate must fire even though its paths ARE base inputs.
+
+    Base-input changes make ship defer container validation to CI, so the
+    sync-full gate is deliberately absent here. That deferral is exactly why
+    the pin probe earns its place: it is the only local check left that a pin
+    still resolves, and it fails in ~60s instead of after a ~37min CI base
+    build. A future refactor that folds this gate under the same
+    `not changes_base_image_inputs(...)` condition as sync-full would silently
+    disable it for every change that can break a pin.
+    """
+    names = [g.name for g in pr.gate_matrix([".devcontainer/mise-system.toml"])]
+    assert pr.changes_base_image_inputs([".devcontainer/mise-system.toml"])
+    assert "sync-full" not in names
+    assert "verify-apt-pins" in names
+
+
 def test_gate_matrix_non_base_surface_adds_full_sync_last() -> None:
     # A surface change that does NOT rebuild the base (validation tooling /
     # overlay) still runs the local container gate last.

--- a/tests/test_renovate_dryrun.py
+++ b/tests/test_renovate_dryrun.py
@@ -93,6 +93,86 @@ def test_parse_report_empty_repo() -> None:
     assert result.updates == []
 
 
+def test_parse_report_tallies_deps_per_manager() -> None:
+    # Independent source of truth: the fixture declares one dep under `regex`
+    # and one under `mise`. The tally must reproduce that split, not the
+    # flattened total the parser already reports.
+    result = renovate_dryrun.parse_report(json.dumps(_REPORT))
+    tallies = {g.name: g for g in result.managers}
+    assert tallies["regex"].deps == 1
+    assert tallies["mise"].deps == 1
+
+
+def test_parse_report_distinguishes_extracted_from_pending() -> None:
+    """A manager that matched but is CURRENT must not read as absent.
+
+    This is the whole point (#251/#288): "my regex extracted 1 dep and it is
+    up to date" and "my regex matched nothing" are the same silence in a
+    pending-updates list, and telling them apart is why #288 had to bypass
+    the task and hand-run the binary.
+    """
+    result = renovate_dryrun.parse_report(json.dumps(_REPORT))
+    regex = next(g for g in result.managers if g.name == "regex")
+    assert regex.deps == 1, "regex DID extract"
+    assert regex.updates == 0, "and its dep is current"
+    # Control arm: a manager that matched nothing is absent entirely, which is
+    # a different report from the one above.
+    assert not [g for g in result.managers if g.name == "npm"]
+
+
+def test_parse_report_tallies_deps_per_datasource() -> None:
+    result = renovate_dryrun.parse_report(json.dumps(_REPORT))
+    tallies = {g.name: g.deps for g in result.datasources}
+    assert tallies == {"deb": 1, "npm": 1}
+
+
+def test_parse_report_counts_a_skipped_dep_as_neither_pending_nor_current() -> None:
+    """A skipReason means renovate declined to look — not that it is current.
+
+    Counting a skipped dep as current is the "never looked" masquerading as
+    "nothing to do" trap this reporting exists to close.
+    """
+    skipped = {
+        "repositories": {
+            "local": {
+                "packageFiles": {
+                    "regex": [
+                        {
+                            "packageFile": ".devcontainer/mise-system.toml",
+                            "deps": [
+                                {
+                                    "depName": "gcc-latest",
+                                    "currentValue": "17.0.0",
+                                    "datasource": "deb",
+                                    "skipReason": "unsupported-datasource",
+                                    "updates": [],
+                                }
+                            ],
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    result = renovate_dryrun.parse_report(json.dumps(skipped))
+    regex = next(g for g in result.managers if g.name == "regex")
+    assert regex.skipped == 1
+    assert regex.updates == 0
+    # Control arm: the clean fixture's deps carry no skipReason, so a parser
+    # that marked everything skipped would fail here.
+    clean = renovate_dryrun.parse_report(json.dumps(_REPORT))
+    assert all(g.skipped == 0 for g in clean.managers)
+
+
+def test_render_report_surfaces_what_each_manager_extracted() -> None:
+    result = renovate_dryrun.parse_report(json.dumps(_REPORT))
+    out = renovate_dryrun.render_report(result)
+    assert "Extracted by manager" in out
+    assert "regex" in out
+    assert "Looked up by datasource" in out
+    assert "deb" in out
+
+
 def test_exit_code_bare_run_is_always_zero() -> None:
     result = renovate_dryrun.parse_report(json.dumps(_REPORT))
     assert result.updates, "fixture must carry drift for this test to mean anything"

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,0 +1,158 @@
+"""Tests for the verification engine (dotfiles_setup.verify).
+
+Scoped to the behaviour spec #299 changed — path strictness and token binding
+— NOT a retrofit of every handler; untested handlers this PR does not touch
+are not its debt (spec, Out of Scope).
+
+Every check here pins its FAIL direction next to its pass. That is the whole
+subject: the bug being fixed was a contract that *passed* when the thing it
+guarded had vanished, so a test that only ever asserts PASSED would reproduce
+the defect rather than catch it (`.claude/rules/probes-need-a-control-arm.md`).
+
+The suite entries are literal dicts and the handler map is injected, so these
+tests need no fixture files on disk. Paths that must exist resolve against the
+real project root; paths that must NOT exist are named under a directory that
+has never existed in this repo.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
+
+from dotfiles_setup import verify
+
+# A real, tracked file — the independent source of truth for "this path
+# exists" is the repo itself, not something the engine computes.
+_REAL = "mise.toml"
+_ALSO_REAL = "python/verification/suites.toml"
+
+# Never existed in this repo; the engine must treat it as missing.
+_GONE = "no/such/dir/ABCD1234.toml"
+
+# A handler that always passes. It makes the runner's own precondition the
+# only thing under test: any failure below came from run_suite, not a handler.
+_ALWAYS_PASS = {"nop": lambda _entry: {"status": "passed"}}
+
+
+def _entry(**over: object) -> dict[str, object]:
+    base: dict[str, object] = {"name": "t.suite", "handler": "nop"}
+    return base | over
+
+
+def test_paths_required_defaults_to_strict() -> None:
+    """A missing path fails with no `paths_required` key present at all.
+
+    This is the default that spec #299 inverted: 82 of 97 suites named no
+    `paths_required`, so the engine's default IS their behaviour.
+    """
+    result = verify.run_suite(_entry(paths=[_GONE]), handlers=_ALWAYS_PASS)
+    assert result["status"] == "failed"
+    assert _GONE in result["reason"]
+
+
+def test_existing_paths_pass_under_the_strict_default() -> None:
+    """Control arm: strict-by-default must not fail a suite that is fine.
+
+    Without this, `test_paths_required_defaults_to_strict` is satisfied by an
+    engine that fails everything.
+    """
+    result = verify.run_suite(_entry(paths=[_REAL, _ALSO_REAL]), handlers=_ALWAYS_PASS)
+    assert result["status"] == "passed"
+
+
+def test_explicit_false_opts_out_of_strictness() -> None:
+    """`paths_required = false` is the visible, reviewable opt-out."""
+    result = verify.run_suite(
+        _entry(paths=[_GONE], paths_required=False), handlers=_ALWAYS_PASS
+    )
+    assert result["status"] == "passed"
+
+
+def test_partial_path_loss_fails() -> None:
+    """THE regression. One of two declared paths gone must FAIL.
+
+    Proven on 2026-07-16 against the pre-#299 engine: deleting one of two
+    declared files left the contract PASSED, because every handler resolves
+    paths through `_resolve_paths`, which silently drops what is gone. The
+    surviving file carried the contract, and a guarded file could be renamed
+    or deleted without any contract noticing (`fc8af71` did exactly this and
+    went unnoticed for ~3.5 months).
+    """
+    result = verify.run_suite(_entry(paths=[_REAL, _GONE]), handlers=_ALWAYS_PASS)
+    assert result["status"] == "failed"
+    assert _GONE in result["reason"]
+    # The surviving file is not the complaint — only the missing one is.
+    assert _REAL not in result["reason"]
+
+
+def test_all_paths_gone_fails() -> None:
+    """Total path loss fails too — strictness is not partial-only.
+
+    Note precisely whose behaviour this is. `require_tokens` already rejected
+    a fully-empty path list pre-#299 via its own "no target files found"
+    check, so *for that one handler* total loss was always caught. This test
+    runs the always-pass handler, so it pins the ENGINE — which pre-#299 had
+    no such check, and where the guarantee now holds for every handler
+    regardless of what the handler itself does. (Verified by reintroducing the
+    old default: this test fails against it.)
+    """
+    result = verify.run_suite(_entry(paths=[_GONE]), handlers=_ALWAYS_PASS)
+    assert result["status"] == "failed"
+
+
+def test_strictness_is_enforced_before_the_handler_runs() -> None:
+    """The precondition belongs to the runner, not to any one handler.
+
+    Pre-#299 only `require_tokens` honoured `paths_required`, so a
+    `regex_forbid` or `forbid_tokens` suite could lose a guarded file
+    silently. A handler that would blow up if reached proves the check is
+    upstream of dispatch — and therefore covers every handler at once.
+    """
+
+    def _explode(_entry: dict[str, object]) -> dict[str, object]:
+        msg = "handler must never be reached when a required path is missing"
+        raise AssertionError(msg)
+
+    result = verify.run_suite(_entry(paths=[_GONE]), handlers={"nop": _explode})
+    assert result["status"] == "failed"
+    assert "missing" in result["reason"]
+
+
+def test_per_path_tokens_binds_a_token_to_its_file() -> None:
+    """A token bound to a file that does not carry it must FAIL.
+
+    `mise.toml` does not contain `def sync_main` — sync.py does. Binding is
+    what gives a contract an opinion about each file it names.
+    """
+    result = verify.run_suite(
+        _entry(
+            handler="require_tokens",
+            paths=[_REAL],
+            per_path_tokens={_REAL: ["def sync_main"]},
+        )
+    )
+    assert result["status"] == "failed"
+    assert "def sync_main" in result["reason"]
+
+
+def test_bare_tokens_are_a_union_across_paths() -> None:
+    """Control arm documenting WHY `per_path_tokens` exists.
+
+    The identical token+paths pair from the test above passes under bare
+    `tokens`, because combined-text semantics let ANY listed file satisfy the
+    contract for all of them. Same inputs, opposite verdict: that difference
+    is the silent-false-negative class spec #299 closes. If this ever starts
+    failing, `require_tokens`'s union semantics changed and the four converted
+    wiring suites need re-reading, not this test "fixing".
+    """
+    result = verify.run_suite(
+        _entry(
+            handler="require_tokens",
+            paths=[_REAL, "python/src/dotfiles_setup/sync.py"],
+            tokens=["def sync_main"],
+        )
+    )
+    assert result["status"] == "passed"


### PR DESCRIPTION
Spec #299. Every item here is a check that could not fail: a contract whose
guarded file had vanished, a union satisfied by any file, a dry-run reporting
zero because it never looked. The fixes move the DEFAULT toward failing
loudly rather than adding advice someone must remember.

Contract engine (verify.py)
- `paths_required` moves to the `run_suite` seam and defaults to TRUE, so a
  declared path that no longer exists fails the suite for EVERY handler,
  before dispatch. Previously only `require_tokens` honoured it, opt-in, and
  82 of 97 suites therefore had no protection at all.
- Partial path loss was the live bug: handlers resolve paths through
  `_resolve_paths`, which silently drops what is gone, so a suite naming two
  files kept passing on the strength of the one that survived. Proven both
  arms 2026-07-16 (delete one of two -> PASSED; delete both -> failed).
- Measured safe: 0 of 97 suites declare a missing path, re-verified this
  session with a control arm. A no-op today, a gate tomorrow.

Contract declarations (suites.toml)
- 5 suites bound with `per_path_tokens`. Bare `tokens` is combined-text: a
  token in ANY listed file satisfies the contract for all of them. The
  token->file matrix showed this is worse than the spec states —
  `[tasks.sync]` and `[tasks.ship]` live in both mise.toml AND the skill
  docs, so mise.toml could lose a task entirely and stay green, satisfied by
  the documentation of the thing that no longer exists.
- `build.path-includes-mise-shims` binds to the overlay Dockerfile and KEEPS
  its `paths` visible. This is deliberately not the change a 2026-07-07
  review rejected 2-to-1 (that proposal deleted paths); this states per-path
  what each path must carry, which is the mechanism the same review shipped
  as findings [19]/[22]. Its description records the fc8af71 regression it
  missed for ~3.5 months, so nobody restores the union later.

Dry-run reporting (renovate_dryrun.py)
- Report per-manager/per-datasource dep counts + skipped tallies, so "my
  regex extracted 1 dep and it is current" stops reading identically to "my
  regex matched nothing" — the distinction #288 had to bypass the task and
  hand-run the binary to get.
- A skipReason means renovate declined to look, not that the dep is current.
- The failure message no longer says "produced no report" when the report is
  on disk; a non-zero exit WITH a report means extraction ran.

Ship gating (pr.py)
- Wire `verify-apt-pins` to fire on the pin declarations AND the Dockerfile
  the pins resolve against (ARG BASE_IMAGE / signing key — a base bump can
  invalidate every pin without touching a pin line). Deliberately not gated
  behind `changes_base_image_inputs`: those paths ARE base inputs, so the
  container gate is skipped for them and this ~60s probe is the only local
  check left. It ran on #288 only because a human remembered, which
  mise-tasks-only.md calls the layer that is never sufficient alone.

Stale facts corrected at source (a fact needs its CONDITION, not just its
source — each below is genuine, sourced, and was still wrong where used)
- renovate does NOT "extract NOTHING" under an unsupported node; it extracts
  and resolves normally, then exits non-zero. True of some older renovate,
  false of 43.265.1 — it cost a hunt for a data-loss bug that does not exist.
- verify-before-advancing.md: the misattribution blockquote gains the SCOPE
  half + the 3-instance table (12000 / node-26 / 2.5h).
- probes-need-a-control-arm.md: the cross-check technique (two probes
  disagree => one is broken) + 3 instances (dirty env, SKIPPED job read as
  unaffected, nested-quote expansion).
- long-running-command-hangs.md rule 2 gains the Mac-op reaping exception;
  it previously contradicted feedback_long_mac_ops_keep_turn_engaged
  outright, and following it cost a killed 20-minute pull.

Tests
- NEW tests/test_verify.py (8): the engine had zero tests. Armed by
  reintroducing the old default — 4 of 8 correctly fail against it.
- test_pr.py (+3): both arms of the pin gate, plus one pinning that the gate
  survives the base-input deferral.
- test_renovate_dryrun.py (+5): per-manager tallies, extracted-vs-pending,
  and a skipped dep counted as neither.

Local gates: ruff/ty clean, lint rc=0, 734 passed, contracts 93/0 failed,
lint-docs rc=0, md-budget rc=0.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S1KTdigKumBP1WvH3G6gGC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Renovate dry-run reports now show dependency extraction totals by manager and data source, including pending and skipped updates.
  - Pull request verification now checks apt-pin resolvability when related system or container configuration changes.
- **Bug Fixes**
  - Verification now detects missing required paths before running checks, improving failure reporting.
  - Token checks now support file-specific requirements for more accurate validation.
- **Documentation**
  - Updated guidance for long-running commands, cross-checking unexpected results, verification scope, and Renovate configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->