### PR TITLE
docs(renovate): drop the GITHUB_MCP_PAT "MCP-scoped" fiction

### DIFF
--- a/python/src/dotfiles_setup/renovate_dryrun.py
+++ b/python/src/dotfiles_setup/renovate_dryrun.py
@@ -91,7 +91,6 @@ _RENOVATE_TIMEOUT_S = 900.0
 # run is labelled INCOMPLETE rather than reported as a total.
 #
 # Order: the explicit renovate names first, then the conventional env tokens.
-# GITHUB_MCP_PAT is deliberately absent — it is scoped to the MCP server.
 _TOKEN_ENV_VARS = (
     "GITHUB_COM_TOKEN",
     "RENOVATE_GITHUB_COM_TOKEN",

--- a/tests/test_renovate_dryrun.py
+++ b/tests/test_renovate_dryrun.py
@@ -241,9 +241,29 @@ def test_token_resolution_falls_back_to_conventional_env() -> None:
     )
 
 
-def test_token_resolution_ignores_the_mcp_pat() -> None:
-    # GITHUB_MCP_PAT is scoped to the MCP server; it is not ours to spend here.
-    assert renovate_dryrun.resolve_github_token({"GITHUB_MCP_PAT": "ghp_mcp"}) is None
+def test_token_resolution_reads_only_the_names_it_declares() -> None:
+    """An unrecognised env name is not a token source — no special cases.
+
+    This replaced `test_token_resolution_ignores_the_mcp_pat`, which asserted
+    the same mechanism but justified it as a security boundary: "GITHUB_MCP_PAT
+    is scoped to the MCP server; it is not ours to spend here." That was false.
+    Measured 2026-07-16: GITHUB_MCP_PAT held the SAME classic PAT as
+    GITHUB_TOKEN (identical sha256), which `_TOKEN_ENV_VARS` already accepts —
+    so the "boundary" excluded a credential renovate was handed anyway, and
+    `resolve_github_token` never reached it (GITHUB_TOKEN resolves first, and
+    fnox exports both at login). The old test only passed because its fixture
+    set GITHUB_MCP_PAT *alone*, an env that never occurs.
+
+    The honest rule is the general one below: only declared names are read.
+    Do NOT re-add GITHUB_MCP_PAT to `_TOKEN_ENV_VARS` — if that Doppler secret
+    is ever narrowed to a read-only PAT, accepting it would silently undercount
+    (8 pending vs 33 — see the module comment).
+    """
+    assert renovate_dryrun.resolve_github_token({"GITHUB_MCP_PAT": "ghp_x"}) is None
+    assert renovate_dryrun.resolve_github_token({"SOME_OTHER_PAT": "ghp_y"}) is None
+    # Control arm: a DECLARED name in the same shape IS read, so the assertions
+    # above are about the name and not about the resolver returning None always.
+    assert renovate_dryrun.resolve_github_token({"GITHUB_TOKEN": "ghp_z"}) == "ghp_z"
 
 
 def test_token_resolution_treats_empty_as_absent() -> None:


### PR DESCRIPTION
The comment claimed a security boundary that does not exist:

    # GITHUB_MCP_PAT is deliberately absent — it is scoped to the MCP server.

Measured 2026-07-16 on the real environment: GITHUB_MCP_PAT holds the SAME
classic PAT as GITHUB_TOKEN (identical sha256), and GITHUB_TOKEN is already
in `_TOKEN_ENV_VARS`. So the "boundary" excluded a credential renovate is
handed anyway, one line further down the same tuple. `resolve_github_token`
never even reaches it — GITHUB_TOKEN resolves first, and fnox exports all
four github vars at login, so the exclusion is unreachable in practice.

The old test passed only because its fixture set GITHUB_MCP_PAT *alone* — an
env that never occurs on this machine. A check that can only pass in a state
that cannot happen is not a check.

The underlying intent was real: ~/.config/fnox/config.toml declares FOUR
separate doppler secrets (GITHUB_TOKEN / GITHUB_API_TOKEN / MISE_GITHUB_TOKEN
/ GITHUB_MCP_PAT), so the architecture does mean to separate them. The values
drifted to one full-scope PAT (repo, workflow, write:packages). That is a
doppler data issue, not a code one, and is Ray's call — not fixed here. No
MCP server consumes GITHUB_MCP_PAT today either (.mcp.json ships exa,
context7, memory, filesystem — no github server).

BEHAVIOR UNCHANGED. `_TOKEN_ENV_VARS` is untouched: GITHUB_MCP_PAT stays
absent, which is correct for a reason that is true — it is simply not a name
we read. Deliberately NOT added to the tuple: it is redundant today, and
would become actively wrong the moment that doppler secret is narrowed to a
read-only PAT (renovate would then silently undercount, 8 pending vs 33 —
the exact trap the module comment above it documents). The replacement test
pins that general rule with a control arm, and records why the old
justification was false so nobody restores it.

Local gates: ruff/ty clean, lint rc=0, 735 passed, contracts 93/0 failed.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S1KTdigKumBP1WvH3G6gGC
