### PR TITLE
fix(ghcr): honor OAuth scope hierarchy so admin:org satisfies read:org

### DIFF
--- a/python/src/dotfiles_setup/ghcr.py
+++ b/python/src/dotfiles_setup/ghcr.py
@@ -61,6 +61,40 @@ def _parse_scopes(auth_output: str) -> set[str]:
     return {scope.strip() for scope in raw_scopes.split(",") if scope.strip()}
 
 
+# GitHub OAuth scope hierarchy: a broader scope implicitly grants the narrower
+# ones, so `gh auth status` prints only the broad scope actually granted (e.g. a
+# token with `admin:org` never lists `read:org`). A flat set-difference against
+# the required scopes therefore false-positives on an OVER-privileged token —
+# which blocked every push from an admin-scoped token (#268 follow-up). We
+# expand the granted set to its implied closure before checking.
+# Ref: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps
+_SCOPE_IMPLICATIONS: dict[str, tuple[str, ...]] = {
+    "admin:org": ("write:org", "read:org"),
+    "write:org": ("read:org",),
+    "write:packages": ("read:packages",),
+    "repo": ("repo:status", "repo_deployment", "public_repo"),
+}
+
+
+def _expand_scopes(granted: set[str]) -> set[str]:
+    """Return granted scopes plus every narrower scope they imply.
+
+    Iterates to a fixed point so a chain (admin:org -> write:org -> read:org)
+    resolves fully regardless of how the implication map is flattened.
+    """
+    expanded = set(granted)
+    changed = True
+    while changed:
+        changed = False
+        for parent, children in _SCOPE_IMPLICATIONS.items():
+            if parent in expanded:
+                new_children = set(children) - expanded
+                if new_children:
+                    expanded |= new_children
+                    changed = True
+    return expanded
+
+
 def _require_workflow_permissions(ci_workflow_path: Path) -> None:
     """Ensure the CI workflow explicitly requests package write access."""
     if not ci_workflow_path.exists():
@@ -91,7 +125,9 @@ def validate_ghcr_prereqs(
         message = (auth_result.stderr or auth_result.stdout).strip()
         raise GhcrCheckError(message or "gh auth status failed")
 
-    scopes = _parse_scopes(f"{auth_result.stdout}\n{auth_result.stderr}")
+    scopes = _expand_scopes(
+        _parse_scopes(f"{auth_result.stdout}\n{auth_result.stderr}"),
+    )
     required_scopes = {"repo", "read:org", "workflow", "write:packages"}
     missing_scopes = sorted(required_scopes - scopes)
     if missing_scopes:

--- a/tests/test_ghcr.py
+++ b/tests/test_ghcr.py
@@ -11,7 +11,12 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
 
-from dotfiles_setup.ghcr import GhcrCheckError, _parse_scopes, validate_ghcr_prereqs
+from dotfiles_setup.ghcr import (
+    GhcrCheckError,
+    _expand_scopes,
+    _parse_scopes,
+    validate_ghcr_prereqs,
+)
 
 
 def test_parse_scopes_extracts_all_scopes() -> None:
@@ -20,6 +25,23 @@ def test_parse_scopes_extracts_all_scopes() -> None:
     scopes = _parse_scopes(text)
 
     assert scopes == {"repo", "read:org", "workflow", "write:packages"}
+
+
+def test_expand_scopes_admin_org_implies_read_org() -> None:
+    """admin:org grants read:org transitively (via write:org)."""
+    expanded = _expand_scopes({"admin:org"})
+
+    assert {"write:org", "read:org"} <= expanded
+
+
+def test_expand_scopes_write_packages_implies_read_packages() -> None:
+    """write:packages grants read:packages."""
+    assert "read:packages" in _expand_scopes({"write:packages"})
+
+
+def test_expand_scopes_leaves_unrelated_scopes_untouched() -> None:
+    """A scope with no implications (control arm) is not expanded."""
+    assert _expand_scopes({"workflow"}) == {"workflow"}
 
 
 def test_validate_ghcr_prereqs_requires_packages_write_scope(


### PR DESCRIPTION
The ghcr-prereq check did a flat set-difference of granted vs required
scopes, but GitHub's OAuth scopes are hierarchical: a broader scope
implicitly grants the narrower ones, and `gh auth status` prints ONLY the
broad scope actually held (a token with `admin:org` never lists
`read:org`). So an OVER-privileged token read as under-privileged and the
check raised "missing required scopes: read:org" — blocking every push
from an admin-scoped token.

Fix: expand the granted set to its implied closure (`admin:org` →
`write:org` → `read:org`; `write:packages` → `read:packages`; `repo` →
its repo:* children) before the difference. Required set unchanged.

Control-armed both ways: `admin:org` now satisfies `read:org`, while a
scope with no implications (`workflow`) is left untouched and the
existing "missing write:packages" negative test still fails as before.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016pejfQDqHy9GeN9EspGUX1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub authentication scope validation by recognizing permissions implicitly included within broader granted scopes.
  * Prevented false warnings when required package or organization permissions are already covered by broader access.

* **Tests**
  * Added coverage for direct and transitive scope expansion.
  * Verified that unrelated permissions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->