### PR TITLE
fix(hk): order ruff_format with `exclusive`, not `depends` (#268)

### DIFF
--- a/.claude/rules/long-running-command-hangs.md
+++ b/.claude/rules/long-running-command-hangs.md
@@ -72,17 +72,32 @@ unbounded wait + pipe-masked exit code.
    after editing hk.pkl" guidance is retired — the cache is
    content-hashed since hk 1.47; see `ci-local-parity.md` rule 5.)
 
-6. **A hanging lint is usually YOUR ruff error, not flaky tooling
-   (issue #268).** A real ruff violation does not fail the gate — it
-   **wedges hk for the full 600s**, and the error is never printed.
-   The `ruff` step has `fix=true`, so a failed check phase makes hk
-   seek a WRITE lock to run the fix (`failed to get write locks …
-   src/file_rw_locks.rs:85:30`) while `ruff_format` sits at `waiting
-   for ruff`. Proven causal 2026-07-14: same tree with 3 ruff errors →
-   wedged at 39/47 steps, 0% CPU, no children; ruff clean → `rc=0`, 47
-   steps. **So: when lint hangs, run `uv run --project python ruff
-   check` DIRECTLY first** — it prints in seconds what hk hides for ten
-   minutes. Fix, then re-run `mise run lint`.
+6. **The ruff-error wedge is FIXED (#268) — and its published diagnosis
+   was wrong.** A ruff violation now fails `mise run lint` with `rc=1`
+   and a `✗ ruff` summary. Root cause was **`depends` + `fail_fast =
+   false`**, not ruff: hk never releases a dependent whose dependency
+   FAILED, so `ruff_format` (which we had given `depends = List("ruff")`)
+   sat at `waiting for ruff` forever. Fixed by ordering with `exclusive
+   = true` instead; `hk.pkl`'s `no_hk_depends` step now blocks `depends`
+   from coming back. Reproduced on hk 1.50.0 AND 1.51.0 — **not** fixed
+   by a bump.
+
+   **Two red herrings this rule itself repeated for two days, both worth
+   remembering:**
+   - *"The `ruff` step has `fix=true`."* It does not. `fix` on a builtin
+     Step is a **command string**; the boolean lives on the **hook**
+     (`hk.pkl` `["pre-commit"] { fix = true }`). Same key name, two
+     meanings, opposite levels.
+   - *"`failed to get write locks …` is the wedge."* It is a **DEBUG-level,
+     non-fatal** retry line from whole-repo hygiene steps contending over
+     the first file alphabetically; it appears on runs that finish fine.
+     The wedge is one line lower: `waiting for <dep>`. **A scary log line
+     adjacent to a hang is not the hang** — confirm a suspect by removing
+     it and re-probing, which is what finally isolated `depends`.
+
+   The durable habit survives: **when lint hangs, run `uv run --project
+   python ruff check` DIRECTLY** — seconds, and it never lies about your
+   own code.
 
 7. **Find the wedged step by name.** Grep the lint output for a
    `❯ <step>` with no matching `✔ <step>` — that names it directly,

--- a/hk.pkl
+++ b/hk.pkl
@@ -55,9 +55,27 @@ local allSteps = new Mapping<String, Config.Step> {
   ["ruff"] = (Builtins.ruff) {
     prefix = "uv run --project python"
   }
+  // #268: ordering is `exclusive`, NOT `depends`. `depends` deadlocks hk
+  // whenever `ruff` FAILS: hk never releases the dependent, so the run wedges
+  // at `ruff_format: waiting for ruff` until the lint wrapper's 600s timeout
+  // kills it with rc=124. The diagnostics DO stream (#268 says otherwise —
+  // measured, they scroll past), but the run never reaches its `✗ ruff` summary
+  // or exits, so the gate reports a TIMEOUT, indistinguishable from tool flake.
+  // hk's docs define depends as steps that must "finish"; a failed step HAS
+  // finished, so this is an upstream bug (repro'd on 1.50.0 AND 1.51.0 — a
+  // bump is not the fix).
+  // hk's own python-project.pkl example pairs `depends` with hk's DEFAULT
+  // `fail_fast = true`, which aborts the run before the dependent can hang;
+  // our deliberate `fail_fast = false` (zero-skip: report ALL issues) removes
+  // that accidental cover. Dropping the ordering outright is NOT an option —
+  // probe-verified that `ruff check --fix` then landing after `ruff format`
+  // leaves the file unformatted, failing autofix.yml's post-fix verify.
+  // `exclusive` orders it as a barrier instead: probe-verified rc=1 + printed
+  // errors on a failing tree (check AND fix mode), and one-run convergence on
+  // an autofixable tree. Not yet reported upstream (see #268).
   ["ruff_format"] = (Builtins.ruff_format) {
     prefix = "uv run --project python"
-    depends = List("ruff")
+    exclusive = true
   }
   ["python_check_ast"] = (Builtins.python_check_ast) {
     glob = List("python/src/**/*.py", "tests/**/*.py", "plugins/**/*.py")
@@ -332,6 +350,35 @@ local allSteps = new Mapping<String, Config.Step> {
     glob = List("hk.pkl", "hk-common.pkl", "hk-image.pkl", ".config/mise/conf.d/shared.toml")
     check =
       "set -- $(grep -ohE 'hk@[0-9]+\\.[0-9]+\\.[0-9]+' hk.pkl hk-common.pkl hk-image.pkl | sort -u); pin=$(grep -E '^hk = ' .config/mise/conf.d/shared.toml | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+'); [ $# -eq 1 ] && [ \"$1\" = \"hk@${pin}\" ] || { echo \"hk pin drift: pkl URLs [$*] vs shared.toml pin ${pin} — bump all four together\" >&2; exit 1; }"
+  }
+
+  // --- `depends` is a DEADLOCK LANDMINE under `fail_fast = false` (#268) ---
+  //     hk never releases a dependent whose dependency FAILED: the run wedges
+  //     at `<step>: waiting for <dep>` forever, and `mise run lint` reports a
+  //     600s TIMEOUT (rc=124) rather than the error you needed. hk's own docs
+  //     define depends as steps that must "finish" — a failed step HAS
+  //     finished — so this is an upstream bug, reproduced on BOTH 1.50.0 and
+  //     1.51.0 (a version bump does NOT fix it). hk's default `fail_fast =
+  //     true` aborts the run before a dependent can hang, which is why hk's
+  //     own python-project.pkl example ships `depends` safely; hk.pkl:22 and
+  //     hk-image.pkl:21 both set `fail_fast = false` deliberately (zero-skip:
+  //     report ALL issues), removing that accidental cover. So for THIS repo
+  //     the two keys are mutually exclusive, and `depends` loses.
+  //     Use `exclusive = true` for ordering instead — probe-verified to keep
+  //     ruff-before-ruff_format while exiting rc=1 on a failing tree.
+  //     Anchored to `^<space>depends =` so the prose above (which names the
+  //     key repeatedly) cannot trip it — a forbid-token must be anchored, or
+  //     the doc explaining the ban becomes the thing that fails the gate.
+  //     Retire this step ONLY when upstream releases a dependent on a failed
+  //     dependency and a control-armed probe confirms it. ---
+  //     `test -f` first: bare `! grep …` would PASS on a deleted file (grep
+  //     exits 2 on error and `!` flips that to 0) — the silent-false-negative
+  //     class #299 closed. Same `if grep -nE … >&2` idiom as
+  //     no_grep_q_under_pipefail, and pipefail-safe (no pipe, no `grep -q`).
+  ["no_hk_depends"] {
+    glob = List("hk.pkl", "hk-common.pkl", "hk-image.pkl")
+    check =
+      "for f in hk.pkl hk-common.pkl hk-image.pkl; do test -f \"$f\" || { echo \"no_hk_depends: $f is missing — the check cannot answer, so it fails loud (#299)\" >&2; exit 1; }; done; if grep -nE '^[[:space:]]*depends[[:space:]]*=' hk.pkl hk-common.pkl hk-image.pkl >&2; then echo \"hk config uses 'depends' — it DEADLOCKS under fail_fast=false when the dependency FAILS: the run wedges at 'waiting for <dep>' until mise run lint's 600s timeout (#268). Use 'exclusive = true' to order a step instead.\" >&2; exit 1; fi"
   }
 
   // --- No MCP registration (enforces feedback_no_mcp_registration.md) ---


### PR DESCRIPTION
A real ruff violation wedged `mise run lint` for the full 600s instead of
failing with the error. Root cause is NOT ruff and NOT the write-lock path
#268 hypothesised: it is **`depends` + `fail_fast = false`**.

hk never releases a dependent whose dependency FAILED. `ruff_format` carried
our `depends = List("ruff")` override (the builtin has none), so a failing
`ruff` parked it at `waiting for ruff` forever — every tokio worker idle, a
lost wakeup. The wrapper's timeout then killed it with rc=124, i.e. the gate
reported a TIMEOUT, indistinguishable from tool flake.

hk's docs define depends as steps that must "finish"; a failed step HAS
finished, so this is an upstream bug — reproduced on 1.50.0 AND 1.51.0, so a
bump is not the fix (drafted for upstream in #304). hk's own
python-project.pkl ships `depends` safely only because it pairs it with hk's
DEFAULT `fail_fast = true`, which aborts before the dependent can hang; our
deliberate `fail_fast = false` (zero-skip: report ALL issues) removes that
accidental cover.

Dropping the ordering outright is NOT an option — probe-verified that ruff's
F401 fix then lands AFTER `ruff format`, leaving the file unformatted
(`ruff format --diff` rc=1), which would fail autofix.yml's post-fix verify.
`exclusive = true` keeps Astral's check-before-format order without the
failed-dependency wait.

Measured matrix (minimal 2-step/1-file repro, both arms armed):

| ruff_format key | mode | tree | result |
|---|---|---|---|
| depends | check | unfixable err | WEDGE |
| depends | fix | unfixable err | WEDGE (= #268) |
| none | fix | autofixable | rc=0 but NOT converged (regression) |
| exclusive | check | unfixable err | rc=1 + errors |
| exclusive | fix | unfixable err | rc=1 + errors |
| exclusive | fix | autofixable | rc=0, converges in ONE run |

Adds the `no_hk_depends` step: under `fail_fast = false` (hk.pkl:22 AND
hk-image.pkl:21) ANY `depends` is the same landmine, so this generalises
beyond ruff. Anchored to `^<space>depends =` so the prose explaining the ban
cannot trip it, and `test -f`-guarded because a bare `! grep` PASSES on a
deleted file (grep exits 2, `!` flips it to 0) — the silent-false-negative
class #299 closed. Control-armed both ways: passes today, fails when
`depends = List("ruff")` is realistically re-added (hk.pkl:78).

Also corrects `long-running-command-hangs.md` rule 6, which asserted two
things this disproves: that the `ruff` step has `fix=true` (it does not — on a
builtin Step `fix` is a COMMAND; the boolean is the HOOK's), and that
`failed to get write locks` is the wedge (it is DEBUG-level and non-fatal —
counted 52 of them in a run that PASSED rc=0/49 steps).

Gates: lint rc=0 (49 steps, 0 fail), pytest 735 passed, contracts 93 passed /
0 failed, hk validate ok, md-budget rc=0, agnix rc=0.

Acceptance (#268): violation → rc=1 with ruff output ✅ | no 600s hang ✅ |
clean tree passes (rc=0, 49 steps) ✅

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected lint troubleshooting guidance to reflect current failure behavior.
  * Clarified that lint failures now exit promptly with an error status and summary.
  * Added explanations for misleading log messages and updated recommended troubleshooting steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->