### PR TITLE
fix(lint): make `mise run lint` run read-only `hk run check --all` (local == CI)

### DIFF
--- a/.claude/rules/long-running-command-hangs.md
+++ b/.claude/rules/long-running-command-hangs.md
@@ -16,12 +16,14 @@ unbounded wait + pipe-masked exit code.
 
 ## Rules
 
-1. **Use `mise run lint`, not raw `hk run pre-commit`.** `mise run lint`
-   wraps hk in an out-of-process hard timeout (hk has none of its own —
-   verified against hk 1.46 and the live v1.48 docs: no `--timeout` flag,
-   no `timeout` step key, no `HK_*` timeout env var). On expiry it kills
-   hk's whole process group and prints the tail of the debug log. Default
-   600s; override with `--timeout <secs>` or
+1. **Use `mise run lint`, not raw `hk run check`/`hk run pre-commit`.**
+   `mise run lint` runs the **read-only** `hk run check --all` (identical
+   to CI — local == CI, no silent source rewriting; the fix path is
+   `mise run fmt` → `hk fix`) wrapped in an out-of-process hard timeout
+   (hk has none of its own — verified against hk 1.46 and the live v1.48
+   docs: no `--timeout` flag, no `timeout` step key, no `HK_*` timeout env
+   var). On expiry it kills hk's whole process group and prints the tail
+   of the debug log. Default 600s; override with `--timeout <secs>` or
    `DOTFILES_LINT_TIMEOUT=<secs> mise run lint`. Source:
    `python/src/dotfiles_setup/lint.py`.
 

--- a/.claude/rules/mise-tasks-only.md
+++ b/.claude/rules/mise-tasks-only.md
@@ -9,7 +9,7 @@ task (wrapping the python library, zero-bash-logic) in the same change.
 
 | Instead of | Use |
 |---|---|
-| `hk run pre-commit --all` | `mise run lint` (hard timeout + log-tail diagnostics) |
+| `hk run check --all` / `hk run pre-commit --all` | `mise run lint` (read-only ≡ CI, hard timeout + log-tail diagnostics); `mise run fmt` to apply fixes |
 | bare `pytest` | `mise run test`, or `uv run --project python pytest <target>` (doc-level only: the permission engine unwraps runners, so a hook rule would also deny the canonical uv form) |
 | `devcontainer up` / `devcontainer build` | `mise run up` / `mise run dev-rebuild` (env + workspace-hash guard) |
 | `docker pull …dotfiles-devcontainer…` | `mise run sync` (buildkit, digest-aware, verifying; classic pull wedges on ~38GB) |

--- a/.claude/skills/ci-warning-investigator/SKILL.md
+++ b/.claude/skills/ci-warning-investigator/SKILL.md
@@ -61,7 +61,7 @@ gh search issues "warning message" --repo <tool-org>/<tool-repo> --limit 5
 
 1. Apply the fix in the appropriate config file
 2. Verify locally: rebuild and confirm warning is gone
-3. Run `hk run pre-commit --all --stash none` to validate
+3. Run `mise run lint` to validate (`mise run fmt` to auto-fix)
 4. Commit with message explaining the warning and fix
 
 ### 4b. If Unfixable: Document

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ mise run lint-docs                                        # Validate agent docum
 
 Structured verification via `python/verification/suites.toml` runs as CI
 `contract-preflight`. The `dotfiles-setup verify run` gate is **distinct
-from** `hk run pre-commit --all` — some contracts (e.g.,
+from** `hk run check --all` — some contracts (e.g.,
 `build.no-stderr-suppression`) only run through the verify CLI. Run both
 locally before pushing Dockerfile changes.
 
@@ -156,10 +156,10 @@ Before advancing to the next task or claiming done, EVERY applicable check must 
 - **uv for Python**: `uv run --project python` for all Python commands.
   **Never `uv run --directory python`** — the latter changes cwd and
   breaks relative test paths.
-- **hk for hooks**: `mise run lint` for the lint gate (guard redirects
-  raw hk); `hk fix` for auto-formatting. Always `git add` BEFORE hk —
-  `fix=true` + `--stash none` can strand unstaged edits when new files
-  are present.
+- **hk for hooks**: `mise run lint` for the read-only lint gate (≡ CI;
+  guard redirects raw hk); `mise run fmt` to auto-fix. Always `git add`
+  BEFORE `mise run fmt` — `fix=true` can strand unstaged edits when new
+  files are present.
 
 ### Devcontainer success criteria (durable, do NOT silently drop)
 Gated by `mise run verify-local`. Sessions touching `.devcontainer/` or `mise.toml [tasks.up]` MUST preserve all three. Mechanism: `.devcontainer/AGENTS.md`. Research: `.omc/research/research-20260407-ssh-devcontainer/report.md`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A highly resilient, declarative dotfiles setup using **Chezmoi**, **Mise**, and 
 
 ```bash
 mise install                                       # Install all tools
-hk run pre-commit --all                            # Run lint checks (requires HK_PKL_BACKEND=pkl)
+mise run lint                                      # Run lint checks (read-only ≡ CI; `mise run fmt` auto-fixes)
 uv run --project python pytest tests/ -x -q      # Run all 190 tests
 ```
 

--- a/mise.toml
+++ b/mise.toml
@@ -130,7 +130,7 @@ timeout = "700s"
 # tail of the debug log instead of wedging for hours (see the 7h hang in
 # .claude/rules/long-running-command-hangs.md). Default 600s; override
 # with `--timeout <secs>` or `DOTFILES_LINT_TIMEOUT=<secs> mise run lint`.
-description = "Run hk pre-commit --all --stash none under a hard timeout (default 600s) so a hung lint self-aborts"
+description = "Run hk check --all (read-only, ≡ CI) under a hard timeout (default 600s) so a hung lint self-aborts; fix path is `mise run fmt`"
 run = "uv run --project python dotfiles-setup lint"
 
 [tasks.check]

--- a/python/src/dotfiles_setup/hook_guard.py
+++ b/python/src/dotfiles_setup/hook_guard.py
@@ -119,11 +119,11 @@ _RULES: tuple[Rule, ...] = (
         _V1,
     ),
     Rule(
-        "hk run pre-commit",
-        re.compile(_CMD + r"hk\s+run\s+pre-commit\b"),
-        "Use `mise run lint` — it wraps hk in a hard timeout (hk has none) "
-        "with log-tail diagnostics. See "
-        ".claude/rules/long-running-command-hangs.md.",
+        "hk run pre-commit/check",
+        re.compile(_CMD + r"hk\s+run\s+(?:pre-commit|check)\b"),
+        "Use `mise run lint` (read-only gate, ≡ CI) — it wraps hk in a hard "
+        "timeout (hk has none) with log-tail diagnostics. To apply fixes use "
+        "`mise run fmt`. See .claude/rules/long-running-command-hangs.md.",
         _V1,
     ),
     Rule(

--- a/python/src/dotfiles_setup/lint.py
+++ b/python/src/dotfiles_setup/lint.py
@@ -1,4 +1,10 @@
-"""Run hk pre-commit under a hard timeout so a hung lint self-aborts.
+"""Run the hk lint gate under a hard timeout so a hung lint self-aborts.
+
+The gate is `hk run check --all` — the **read-only** hook, identical to what
+CI runs (`ci.yml`), so `mise run lint` and CI check the same thing. It does
+NOT auto-fix: a violation fails loud with `rc=1` instead of being silently
+rewritten (the fix path is `mise run fmt` → `hk fix`). `check`, `pre-commit`,
+and `fix` share the same `...allSteps` in `hk.pkl`, so coverage is identical.
 
 hk has **no native timeout** — verified against hk 1.46 (installed) and
 the live v1.48 docs: `hk run` exposes only `--jobs`/`--fail-fast`,
@@ -35,7 +41,9 @@ TIMEOUT_ENV_VAR = "DOTFILES_LINT_TIMEOUT"
 TIMEOUT_EXIT_CODE = 124  # GNU coreutils `timeout` convention
 KILL_GRACE_SECONDS = 10
 LOG_TAIL_LINES = 40
-HK_COMMAND = ("hk", "run", "pre-commit", "--all", "--stash", "none")
+# Read-only gate (no --stash: check never fixes, so it has nothing to stash).
+# Matches CI's `hk run check --all` so local == CI. Fix path is `mise run fmt`.
+HK_COMMAND = ("hk", "run", "check", "--all")
 DEFAULT_LOG_FILE = Path.home() / ".local" / "state" / "dotfiles" / "hk-lint.log"
 
 

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -527,11 +527,11 @@ def setup_parser() -> argparse.ArgumentParser:
     # install command
     subparsers.add_parser("install", help="Execute toolchain installation")
 
-    # lint command — hk pre-commit under a hard timeout so hangs self-abort
+    # lint command — hk check (read-only, ≡ CI) under a hard timeout
     lint_parser = subparsers.add_parser(
         "lint",
-        help="Run hk pre-commit under a hard timeout (default 600s) so a "
-        "hung lint self-aborts instead of wedging",
+        help="Run hk check --all (read-only, ≡ CI) under a hard timeout "
+        "(default 600s) so a hung lint self-aborts instead of wedging",
     )
     lint_parser.add_argument(
         "--timeout",

--- a/tests/test_hook_guard.py
+++ b/tests/test_hook_guard.py
@@ -23,6 +23,7 @@ from dotfiles_setup import hook_guard
         ("chezmoi apply", "devcontainer"),
         ("chezmoi update -v", "devcontainer"),
         ("hk run pre-commit --all --stash none", "mise run lint"),
+        ("hk run check --all", "mise run lint"),
         ("devcontainer up --workspace-folder .", "mise run up"),
         ("devcontainer build --workspace-folder .", "mise run dev-rebuild"),
         (


### PR DESCRIPTION
`mise run lint` ran the FIX-mode `hk run pre-commit --all --stash none`, so
locally it silently rewrote source and returned rc=0 whenever a violation was
autofixable — while CI runs the read-only `hk run check --all`. Local was more
permissive than CI, backwards, and the rewrites were invisible.

Point the timeout wrapper at `hk run check --all` instead. `check`, `pre-commit`
and `fix` all spread the same `...allSteps` in hk.pkl, so coverage is identical;
only the fix/stash behavior differs. A violation now fails loud (rc=1, `✗ ruff`)
instead of being rewritten. The fix path is `mise run fmt` → `hk fix`, which
already exists.

Also:
- Guard (`hook_guard`) now redirects raw `hk run check` too (same wedge risk),
  and its message names `mise run fmt` for fixes; test added.
- Docs synced: lint.py docstring, mise `[tasks.lint]` desc, CLI help,
  long-running-command-hangs rule 1, mise-tasks-only map, AGENTS.md, README
  (also drops the retired HK_PKL_BACKEND), ci-warning-investigator skill.

Control-armed: clean tree → rc=0; an autofixable F401 → rc=1 AND the file is
left unmodified (proving read-only, no silent rewrite).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016pejfQDqHy9GeN9EspGUX1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated linting guidance to use `mise run lint`, matching CI’s read-only checks.
  * Added `mise run fmt` as the recommended automatic formatting workflow.
  * Added bounded lint execution with timeout handling and diagnostic output.

* **Bug Fixes**
  * Prevented direct lint and pre-commit commands from bypassing the standardized workflow.
  * Updated command guidance and validation checks to consistently use the CI-aligned lint mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->