### PR TITLE
chore(policy): relax the MCP-registration ban to mcp2cli-first preference

### DIFF
--- a/.claude/rules/do-not.md
+++ b/.claude/rules/do-not.md
@@ -28,17 +28,17 @@ self-contained block). Each item's context is preserved verbatim.
 6. **Do NOT trust `gh run watch --exit-status`.** Verify with
    `gh pr checks <n> --json` or `gh run list --json`.
 
-7. **Do NOT register MCP servers via the native Claude Code CLI
-   subcommand** (the one that adds servers via `mcp`). Registering a
-   server injects every tool's JSON schema into every conversation's
-   system prompt forever. Use `mcp2cli` (process-spawn, no schema
-   injection) instead; machine-enforced by the `no_mcp_registration`
-   hk step. See `feedback_no_mcp_registration.md`.
-
-8. **Do NOT switch `docker context` away from `desktop-linux`.** The
+7. **Do NOT switch `docker context` away from `desktop-linux`.** The
    SSH path is Docker-Desktop-only; silent drift caused session
    2026-04-09c's debug goose-chase. See
    `feedback_docker_desktop_runtime.md`.
+
+> **Relaxed 2026-07-19 — MCP registration is no longer a "do not".** Native
+> MCP registration (`claude mcp add`, a plugin's bundled servers, a project
+> `.mcp.json`) is **allowed when a plugin or tool requires it**. `mcp2cli`
+> (process-spawn, no schema-injection tax) stays the *preferred* path for
+> one-off doc/tool calls — a preference, not a gate. See
+> `research-doc-sources.md` and `feedback_no_mcp_registration.md`.
 
 ## See also
 

--- a/.claude/rules/research-doc-sources.md
+++ b/.claude/rules/research-doc-sources.md
@@ -91,35 +91,31 @@ if we need to research Anthropic docs). See
 is specifically on using it against per-repo mintlify subpath URLs,
 not on `mcp2cli` in general.
 
-## The forbidden path: `claude mcp add`
+## `mcp2cli`-first, but MCP registration is allowed when required
 
-**`claude mcp add` is forbidden in this repo.** Registering an MCP
-server via the native Claude Code mechanism injects every tool's JSON
-schema into Claude's system prompt for every conversation, forever.
-Even conversations that never use the tool pay the context tax.
+**Prefer `mcp2cli` (process-spawn) or the curl-based options above** for
+one-off doc/tool lookups. Registering an MCP server natively injects every
+tool's JSON schema into Claude's system prompt for every conversation,
+forever — even conversations that never call the tool pay that context tax.
+So for a server you would query rarely, `mcp2cli` is the cheaper path.
 
-Use `mcp2cli` (process-spawn, no schema injection) or the curl-based
-options in this chain instead. See the memory rule
-`feedback_no_mcp_registration.md` and
-`.claude/skills/mcp2cli/SKILL.md` for the rationale.
+**But native MCP registration is NOT forbidden (relaxed 2026-07-19).** When
+a third-party plugin or tool **requires** MCP for its features, registering
+it (`claude mcp add`, a plugin's bundled servers, or a project `.mcp.json`)
+is allowed — done knowingly, accepting the per-conversation schema cost. The
+former hard ban (the `no_mcp_registration` hk step) has been removed; this is
+now a documented **preference**, not a gate. See the memory rule
+`feedback_no_mcp_registration.md` and `.claude/skills/mcp2cli/SKILL.md` for
+the cost rationale (the reason to still reach for `mcp2cli` first).
 
-This rule is **machine-enforced** by the `no_mcp_registration` step in
-`hk.pkl`. Any commit introducing a `claude mcp add` invocation or a
-tracked `.mcp.json` file will be rejected by the local pre-commit hook
-(and therefore by CI, which runs the same hk config).
+## When to register natively instead
 
-## Exceptions
-
-None by default. If a genuine exception arises (e.g. an MCP server whose
-authentication model cannot be reached any other way), it requires:
-
-1. An explicit written justification in
-   `feedback_no_mcp_registration.md` (memory rule).
-2. User approval.
-3. A targeted exclusion in the `no_mcp_registration` hk step with a
-   comment pointing at the justification.
-
-Without all three, the default answer is "use `mcp2cli` instead."
+`mcp2cli` is the default because it pays no per-conversation schema cost. But
+when a third-party plugin or tool **requires** native MCP for its features,
+registering it is fine (relaxed 2026-07-19 — no longer gated). Judgement call:
+if you'd query the server rarely, `mcp2cli` still wins on cost; if the plugin's
+value depends on Claude selecting its tools natively and you'll use it often,
+register it and accept the schema cost. When unsure, reach for `mcp2cli` first.
 
 ## See also
 

--- a/.claude/skills/mcp2cli/SKILL.md
+++ b/.claude/skills/mcp2cli/SKILL.md
@@ -8,7 +8,8 @@ description: Invoke MCP servers as one-shot CLI commands (no native registration
 `mcp2cli` runs an MCP server as a subprocess, calls a single tool, prints
 the result, and exits. Unlike `claude mcp add`, nothing is registered with
 Claude Code, so **no tool schemas land in Claude's system prompt**. This
-is the only sanctioned way to reach MCP servers from this repo.
+is the **preferred** way to reach an MCP server for a one-off call; native
+registration is allowed when a plugin requires it (relaxed 2026-07-19).
 
 > See `feedback_no_mcp_registration.md` and
 > `.claude/rules/research-doc-sources.md` for the full rationale.
@@ -146,9 +147,9 @@ schemas never touch Claude's context, the process exits when done, and
 Claude sees only the tool's textual output (which you can further
 trim with `--jq`/`--head`).
 
-Rule of thumb: **if you are about to `claude mcp add`, you almost
-certainly want `mcp2cli` instead.** The exceptions require explicit user
-approval and a written justification in `feedback_no_mcp_registration.md`.
+Rule of thumb: **for a one-off call, prefer `mcp2cli` over `claude mcp
+add`** (no per-conversation schema cost). Register natively when a plugin
+or tool requires it for its features — see `feedback_no_mcp_registration.md`.
 
 ## Repo wiring
 
@@ -157,9 +158,9 @@ approval and a written justification in `feedback_no_mcp_registration.md`.
 - Global shorthands live in `~/.config/mcp2cli/` (user scope).
 - The preference chain (`curl llms.txt → curl .md → mcp2cli → context7-cli
   → raw HTML curl`) is codified in `.claude/rules/research-doc-sources.md`.
-- The ban on `claude mcp add` is enforced locally by the `no_mcp_registration`
-  step in `hk.pkl` and documented in the memory rule
-  `feedback_no_mcp_registration.md`.
+- `mcp2cli` is the preferred path; native `claude mcp add` is allowed when a
+  plugin requires it (the `no_mcp_registration` hk hard-ban was removed
+  2026-07-19). Rationale in `feedback_no_mcp_registration.md`.
 
 ## See also
 

--- a/.claude/skills/mintlify/SKILL.md
+++ b/.claude/skills/mintlify/SKILL.md
@@ -249,14 +249,15 @@ a mintlify platform update), fetch these directly:
 > Note: the user-provided URL `https://www.mintlify.com/docs/ai/mcp.md`
 > is a 404. The working page is `model-context-protocol.md` above.
 
-## Do NOT `claude mcp add` mintlify servers
+## Prefer `mcp2cli` over `claude mcp add` for mintlify servers
 
-Registering any MCP server via `claude mcp add` injects every tool's
-schema into Claude's system prompt for every conversation forever.
-Forbidden in this repo by `feedback_no_mcp_registration.md` and
-enforced by the `no_mcp_registration` step in `hk.pkl`. Even if a
-live mintlify MCP were reachable (which the catalog entries are not),
-reach it via `mcp2cli` or not at all.
+Registering an MCP server via `claude mcp add` injects every tool's
+schema into Claude's system prompt for every conversation forever, so
+`mcp2cli` is the preferred path here (relaxed 2026-07-19 — native
+registration is allowed when a plugin requires it, but a mintlify docs
+lookup does not). Even if a live mintlify MCP were reachable (which the
+catalog entries are not), reach it via `mcp2cli`. See
+`feedback_no_mcp_registration.md`.
 
 ## See also
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ the official `@devcontainers/cli` (pinned in `mise.toml`).
 | `mise.toml` + `.config/mise/conf.d/shared.toml` | Host tool versions + tasks; the 20 tools shared with the image (hk, pkl, linters, python, uv, chezmoi) live in the exact-pinned shared fragment both host and image merge (#160 T5) |
 | `mise.lock` | Locked tool versions for reproducible installs |
 | `mise.local.toml` | Gitignored per-clone overrides (e.g., `BASE_IMAGE`). See `mise.local.toml.example` |
-| `hk.pkl` | Project git hook config; imports `hk-common.pkl`; enforces `no_lint_skip`, `no_mcp_registration`, `require_pipefail`, `bash_logic_budget`, `claude_md_import_stub`, `claude_agents_md_pairs` |
+| `hk.pkl` | Project git hook config; imports `hk-common.pkl`; enforces `no_lint_skip`, `require_pipefail`, `bash_logic_budget`, `claude_md_import_stub`, `claude_agents_md_pairs` |
 | `hk-common.pkl` | Shared step definitions (hygiene, safety, security, typos) reused by `hk.pkl` and `hk-image.pkl` |
 | `hk-image.pkl` | Image-only hook config for devcontainer validation |
 | `docker-bake.hcl` | BuildKit bake config (`dev`, `dev-load` build targets + `base`/`p2996-cache` CI stages); `IMAGE_REF` consolidates registry+image |
@@ -112,9 +112,9 @@ locally before pushing Dockerfile changes.
   `.claude/rules/zero-skip-policy.md`.
 - **Zero inline suppressions**: The `no_lint_skip` hk step rejects
   `noqa`/`type: ignore`/`pylint: disable`/`nosec` in Python source.
-- **No MCP registration**: Never `claude mcp add` (enforced by the
-  `no_mcp_registration` hk step). Use `mcp2cli`/`llms.txt`/`.md` instead.
-  See `.claude/rules/research-doc-sources.md`.
+- **MCP: `mcp2cli`-first (not banned)**: prefer `mcp2cli`/`llms.txt`/`.md`
+  (no schema-injection tax); native MCP registration IS allowed when a
+  plugin/tool requires it. See `.claude/rules/research-doc-sources.md`.
 - **CI-local parity**: Every CI lint step has a local hk equivalent; every
   hk tool is in `mise.toml`. See `.claude/rules/ci-local-parity.md`.
 - **Research before fixing**: Check docs/changelogs/issues before fixing — don't guess at CI failures.

--- a/hk.pkl
+++ b/hk.pkl
@@ -381,26 +381,15 @@ local allSteps = new Mapping<String, Config.Step> {
       "for f in hk.pkl hk-common.pkl hk-image.pkl; do test -f \"$f\" || { echo \"no_hk_depends: $f is missing — the check cannot answer, so it fails loud (#299)\" >&2; exit 1; }; done; if grep -nE '^[[:space:]]*depends[[:space:]]*=' hk.pkl hk-common.pkl hk-image.pkl >&2; then echo \"hk config uses 'depends' — it DEADLOCKS under fail_fast=false when the dependency FAILS: the run wedges at 'waiting for <dep>' until mise run lint's 600s timeout (#268). Use 'exclusive = true' to order a step instead.\" >&2; exit 1; fi"
   }
 
-  // --- No MCP registration (enforces feedback_no_mcp_registration.md) ---
-  //     `claude mcp add` and tracked `.mcp.json` files inflate every
-  //     Claude conversation's system prompt with tool schemas. The
-  //     sanctioned alternatives are `mcp2cli` (process spawn) and
-  //     curl-based llms.txt/.md fetches. See
-  //     .claude/rules/research-doc-sources.md and
-  //     .claude/skills/mcp2cli/SKILL.md.
-  //
-  //     Whitelisted paths are the files that legitimately document
-  //     the ban (skills, rules, this hk step itself).
-  //
-  //     Approved exception (2026-04-07): root `.mcp.json` is allowed
-  //     to provision OMC default MCP servers (exa, context7, memory,
-  //     filesystem) at project scope. Nested `**/.mcp.json` files
-  //     remain banned. Tracked in feedback_no_mcp_registration.md;
-  //     planned migration: convert to mcp2cli wrappers later.
-  ["no_mcp_registration"] {
-    check =
-      "! git grep -nE 'claude[[:space:]]+mcp[[:space:]]+add' -- ':!.claude/skills/mcp2cli/SKILL.md' ':!.claude/skills/mintlify/SKILL.md' ':!.claude/rules/research-doc-sources.md' ':!.claude/rules/research-repo-enumeration.md' ':!.claude/CLAUDE.md' ':!AGENTS.md' ':!mise.toml' ':!docs/research/mintlify-catalog.md' ':!hk.pkl' && ! git ls-files '**/.mcp.json' | grep -q ."
-  }
+  // --- (removed 2026-07-19) `no_mcp_registration` hard ban ---
+  //     The `claude mcp add` / nested-`.mcp.json` ban was RELAXED per the
+  //     maintainer: native MCP registration is now ALLOWED when a plugin or
+  //     tool requires it for its features. `mcp2cli` (process-spawn, no
+  //     schema-injection tax) remains the PREFERRED path for one-off doc/
+  //     tool calls — a documented preference, not a gate. The schema-cost
+  //     rationale still holds, so weigh it before registering a server you
+  //     will rarely call. See .claude/rules/research-doc-sources.md and
+  //     feedback_no_mcp_registration.md.
 
   // --- Instruction-markdown size budgets, BY LOAD CLASS ---
   //     Replaces `claude_md_size_limit`, which applied ONE uniform


### PR DESCRIPTION
Per the maintainer (2026-07-19): "it is ok to use mcp if a third party
plugin requires it for its features." The former hard ban is relaxed to a
documented PREFERENCE — `mcp2cli` (process-spawn, no schema-injection tax)
stays the default for one-off doc/tool calls, but native MCP registration
(`claude mcp add`, a plugin's bundled servers, a project `.mcp.json`) is now
ALLOWED when a plugin/tool requires it for its features.

- Remove the `no_mcp_registration` hk step (the machine hard-ban).
- do-not.md: drop the MCP invariant (#7), renumber docker-context → #7, add a
  relaxation note. research-doc-sources.md: "forbidden path" → preference +
  "when to register natively". AGENTS.md: hk-step list + policy bullet.
- mcp2cli / mintlify skills: "ban/forbidden/enforced" → "preferred".
- Memory feedback_no_mcp_registration.md rewritten (keeps the cost rationale
  as the reason to prefer mcp2cli); MEMORY.md index updated.

The schema-injection cost rationale still holds — it just no longer gates.
Enforcement was one hk step with no contract/test/guard/settings dependency,
so removal is clean. All gates green (pkl eval, agnix --strict, pytest 739,
verify 93/0, md-budget, mise run lint rc=0).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016pejfQDqHy9GeN9EspGUX1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MCP usage guidance across project documentation and skills.
  * `mcp2cli` remains the preferred option for one-off documentation and tool lookups.
  * Native MCP registration is now permitted when required by a plugin or tool.
  * Removed blanket prohibition and related enforcement guidance from the documented policies.
  * Clarified when native registration may be appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->