### PR TITLE
feat(graphify): pin graphify[all] host-only + provision (#312)

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -473,6 +473,10 @@ url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/47161
 version = "0.2.2"
 backend = "pipx:deepagents-cli"
 
+[[tools."pipx:graphifyy"]]
+version = "0.9.20"
+backend = "pipx:graphifyy"
+
 [[tools."pipx:mcp2cli"]]
 version = "3.3.1"
 backend = "pipx:mcp2cli"

--- a/mise.toml
+++ b/mise.toml
@@ -31,11 +31,20 @@ zizmor = "1.26.1"
 "github:ast-grep/ast-grep" = "0.44.1"
 lefthook = "2.1.10"
 "npm:ctx7" = "0.5.4"
-rtk = "0.43.0"                                                      # re-probed at #160 T12.5: mise #10703 (2026.7.0) fixed the github-backend url_api lock hold that pinned this at 0.37.2
+rtk = "0.43.0"                         # re-probed at #160 T12.5: mise #10703 (2026.7.0) fixed the github-backend url_api lock hold that pinned this at 0.37.2
 "npm:skills" = "1.5.16"
 "npm:agent-browser" = "0.31.1"
 "npm:portless" = "0.15.1"
 "pipx:deepagents-cli" = "0.2.2"
+# graphify: host-only knowledge-graph substrate (#310 / T1 #312). The [all]
+# extra resolves on host Python 3.14 — graphify's own PEP 508 markers auto-skip
+# the leiden/graspologic extra (needs <3.13), so clustering falls back to
+# Louvain (accepted). Host-only: root mise.toml is in the container's
+# MISE_IGNORED_CONFIG_PATHS, so this never touches the image. Do NOT run
+# `graphify claude install` (writes into root CLAUDE.md, breaks the @AGENTS.md
+# stub), `graphify hook install` (post-commit auto-rebuild, violates the
+# gated/manual-build rule), or `graphify --watch` (auto-rebuild). See T6 #316.
+"pipx:graphifyy[all]" = "0.9.20"
 aws-cli = { version = "2.35.21", symlink_bins = "true" }
 azure-cli = { version = "2.88.0", uvx_args = "--prerelease=allow" }
 docker-cli = "29.6.1"

--- a/tests/test_lock_coverage.py
+++ b/tests/test_lock_coverage.py
@@ -24,6 +24,19 @@ from dotfiles_setup.lock_refresh import (
 
 _REPO_ROOT = Path(__file__).parent.parent
 _FEATURE_KEY_RE = re.compile(r'"(ghcr\.io/[^"]+/features/[^"]+)"\s*:')
+_EXTRAS_RE = re.compile(r"\[.*\]$")
+
+
+def _strip_extras(tool: str) -> str:
+    """Drop a pipx `[extras]` suffix so config keys compare to lock keys.
+
+    mise records a pipx tool's lock key WITHOUT its extras suffix (extras
+    affect the install, not the locked identity), so `pipx:graphifyy[all]`
+    in mise.toml is locked as `pipx:graphifyy`. Normalize the config side to
+    match. A genuinely unlocked tool still fails: its normalized name is
+    absent from the lock either way.
+    """
+    return _EXTRAS_RE.sub("", tool)
 
 
 def _lock_tools(lock_path: Path) -> set[str]:
@@ -93,7 +106,10 @@ def test_root_lock_covers_host_config() -> None:
     split the shared entries out of the root lock), so the shared fragment
     locks separately below.
     """
-    config = set(tomllib.loads((_REPO_ROOT / "mise.toml").read_text()).get("tools", {}))
+    config = {
+        _strip_extras(t)
+        for t in tomllib.loads((_REPO_ROOT / "mise.toml").read_text()).get("tools", {})
+    }
     locked = _lock_tools(_REPO_ROOT / "mise.lock")
     assert config - locked == set(), (
         f"tools missing from mise.lock (run `mise run lock`): {sorted(config - locked)}"


### PR DESCRIPTION
Adopt graphify as a project-scoped, host-only knowledge-graph substrate
(#310 Phase 0). Project files only — the integration never installs to or
mutates ~/.claude.

- Pin `"pipx:graphifyy[all]" = "0.9.20"` in root mise.toml [tools]
  (host-only; the container ignores root mise.toml via
  MISE_IGNORED_CONFIG_PATHS, so no image effect). The [all] extra
  resolves on host Python 3.14 — graphify's own PEP 508 markers
  auto-skip leiden/graspologic (needs <3.13), so clustering falls back
  to Louvain (accepted, Option A).
- Regenerate mise.lock (graphify locks as `pipx:graphifyy`, extras
  stripped).
- Document the never-run commands inline: `graphify install` /
  `graphify claude install` (write into ~/.claude and/or CLAUDE.md),
  `graphify hook install` (post-commit auto-rebuild), `graphify --watch`.
  The graphify capability is exposed via project mise tasks + a python
  module (later tickets), never graphify's own global skill installer.
- Fix test_root_lock_covers_host_config to normalize the pipx `[extras]`
  suffix: graphify is the first extras-bearing pipx pin, which the naive
  key set-equality flagged as "missing from lock". Control-armed — a
  genuinely unlocked tool still fails both directions.

Gates: mise run lint rc=0; pytest 739 passed; verify 93 passed / 0 failed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FQzDie4WXckQg8to3aTU8t


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Graphify 0.9.20 as a host-only development tool.

* **Bug Fixes**
  * Improved lockfile validation for tools that include pipx extras, preventing false coverage failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->