### PR TITLE
chore(graphify): output hygiene + track the research KB corpus

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,10 @@
+# Claude Code context exclusions.
+#
+# graphify writes its outputs INTO the workspace on every `extract`/`update`.
+# graph.json + graph.html are multi-MB and change on every run, which
+# invalidates Claude Code's prompt cache and forces a full re-upload at
+# cache-write rates on the following turn. Excluding them is graphify's own
+# documented recommendation (README troubleshooting).
+graphify-out/
+**/graphify-out/
+graph.json

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ mise.*.local.toml
 # Maestro Session State (Keep plans, ignore active state)
 docs/maestro/state/active-session.md
 docs/maestro/state/archive/
+
+# graphify knowledge-graph outputs (#310): ignore large/regenerable, keep only the shareable wiki
+graphify-out/
+!graphify-out/wiki/

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,0 +1,7 @@
+docs/research/mintlify-cache/
+plugins/
+.git/
+graphify-out/
+node_modules/
+.venv/
+**/.venv/

--- a/.omc/kb/raw/claudefast-free-claude-code.md
+++ b/.omc/kb/raw/claudefast-free-claude-code.md
@@ -1,0 +1,87 @@
+# Free Claude Code — configuration recipe (claudefa.st)
+
+Source: https://claudefa.st/blog/tools/customization/free-claude-code
+Type: article (fetched 2026-07-19)
+
+## Architecture
+
+Uses a **local FastAPI proxy** (NOT LiteLLM, NOT a direct base-URL override).
+The proxy listens on `localhost:8082` and translates Anthropic Messages API
+calls to upstream providers. Implementation:
+`https://github.com/Alishahryar1/free-claude-code`.
+
+## Environment variables
+
+Required for proxy redirection:
+
+```
+ANTHROPIC_AUTH_TOKEN="freecc"
+ANTHROPIC_BASE_URL="http://localhost:8082"
+```
+
+Provider keys:
+
+```
+NVIDIA_NIM_API_KEY="nvapi-your-key"
+OPENROUTER_API_KEY="sk-or-your-key"
+```
+
+Per-tier model routing — note this remaps EVERY Claude tier, so the strong
+model is replaced too:
+
+```
+MODEL_OPUS="nvidia_nim/moonshotai/kimi-k2.5"
+MODEL_SONNET="open_router/deepseek/deepseek-chat:free"
+MODEL_HAIKU="lmstudio/unsloth/GLM-4.7-Flash-GGUF"
+MODEL="nvidia_nim/z-ai/glm4.7"
+```
+
+## Providers named
+
+| Provider | Setup | Model examples |
+|---|---|---|
+| NVIDIA NIM | free tier at build.nvidia.com | `z-ai/glm4.7`, `moonshotai/kimi-k2.5` |
+| OpenRouter | direct API | DeepSeek V4, GLM, Llama variants |
+| DeepSeek | Anthropic-compatible endpoint | DeepSeek V4 |
+| LM Studio | desktop GUI + local | model-dependent tool-use support |
+| llama.cpp | embedded, needs context tuning | any GGUF |
+| Ollama | easiest local setup | Gemma, Llama 3.1 |
+
+No Groq, Cerebras, or direct Gemini integration mentioned.
+
+## Stated limitations (verbatim claims)
+
+1. **Tool-call reliability degrades** — "Models with shaky tool-call formatting
+   will return malformed deltas, omit tool names, or emit tool calls as plain
+   text."
+2. **Context window shrinks** — most alternatives cap at 32K-128K vs Opus 200K+.
+3. **Quality drop is real** — "70 to 85 percent" of Opus quality at best;
+   "Multi-step refactors, subtle bug hunts, and architectural decisions degrade
+   noticeably."
+4. **Streaming quirks** — malformed token counts occur.
+5. **Local models are slow** — "Not a real option for a workflow that fires
+   twenty tool calls per minute" without a discrete GPU.
+
+## Setup steps
+
+1. Install `uv`, Python 3.14, Claude Code.
+2. Clone `github.com/Alishahryar1/free-claude-code`.
+3. Set `.env` with provider key + `MODEL` + `ANTHROPIC_AUTH_TOKEN="freecc"`.
+4. `uv run uvicorn server:app --host 0.0.0.0 --port 8082`.
+5. `ANTHROPIC_AUTH_TOKEN="freecc" ANTHROPIC_BASE_URL="http://localhost:8082" claude`
+
+## Author's own mitigation
+
+Pair cheaper models with "a strong agent harness" — structured decomposition,
+subagent roles, pre-planning, and progressive context disclosure recover
+meaningful output quality.
+
+## Relevance to this program (annotation, not from the article)
+
+This recipe replaces **every** Claude tier including Opus, which directly
+conflicts with the locked decision "architect-only strong model (Fable 5 @ high,
+Opus 4.8 fallback)". Adopting it wholesale would remove the architect the design
+depends on. The useful extract is the **provider/model list** (NIM free tier
+serving `kimi-k2.5` and `glm4.7`) and the confirmation that the author's own
+mitigation is precisely this program's thesis: cheap models + strong harness +
+verification.

--- a/.omc/kb/raw/codex-plugin-cc-README.md
+++ b/.omc/kb/raw/codex-plugin-cc-README.md
@@ -1,0 +1,320 @@
+# Codex plugin for Claude Code
+
+Use Codex from inside Claude Code for code reviews or to delegate tasks to Codex.
+
+This plugin is for Claude Code users who want an easy way to start using Codex from the workflow
+they already have.
+
+<video src="./docs/plugin-demo.webm" controls muted playsinline autoplay></video>
+
+## What You Get
+
+- `/codex:review` for a normal read-only Codex review
+- `/codex:adversarial-review` for a steerable challenge review
+- `/codex:rescue`, `/codex:transfer`, `/codex:status`, `/codex:result`, and `/codex:cancel` to delegate work, hand off sessions, and manage background jobs
+
+## Requirements
+
+- **ChatGPT subscription (incl. Free) or OpenAI API key.**
+  - Usage will contribute to your Codex usage limits. [Learn more](https://developers.openai.com/codex/pricing).
+- **Node.js 18.18 or later**
+
+## Install
+
+Add the marketplace in Claude Code:
+
+```bash
+/plugin marketplace add openai/codex-plugin-cc
+```
+
+Install the plugin:
+
+```bash
+/plugin install codex@openai-codex
+```
+
+Reload plugins:
+
+```bash
+/reload-plugins
+```
+
+Then run:
+
+```bash
+/codex:setup
+```
+
+`/codex:setup` will tell you whether Codex is ready. If Codex is missing and npm is available, it can offer to install Codex for you.
+
+If you prefer to install Codex yourself, use:
+
+```bash
+npm install -g @openai/codex
+```
+
+If Codex is installed but not logged in yet, run:
+
+```bash
+!codex login
+```
+
+After install, you should see:
+
+- the slash commands listed below
+- the `codex:codex-rescue` subagent in `/agents`
+
+One simple first run is:
+
+```bash
+/codex:review --background
+/codex:status
+/codex:result
+```
+
+## Usage
+
+### `/codex:review`
+
+Runs a normal Codex review on your current work. It gives you the same quality of code review as running `/review` inside Codex directly.
+
+> [!NOTE]
+> Code review especially for multi-file changes might take a while. It's generally recommended to run it in the background.
+
+Use it when you want:
+
+- a review of your current uncommitted changes
+- a review of your branch compared to a base branch like `main`
+
+Use `--base <ref>` for branch review. It also supports `--wait` and `--background`. It is not steerable and does not take custom focus text. Use [`/codex:adversarial-review`](#codexadversarial-review) when you want to challenge a specific decision or risk area.
+
+Examples:
+
+```bash
+/codex:review
+/codex:review --base main
+/codex:review --background
+```
+
+This command is read-only and will not perform any changes. When run in the background you can use [`/codex:status`](#codexstatus) to check on the progress and [`/codex:cancel`](#codexcancel) to cancel the ongoing task.
+
+### `/codex:adversarial-review`
+
+Runs a **steerable** review that questions the chosen implementation and design.
+
+It can be used to pressure-test assumptions, tradeoffs, failure modes, and whether a different approach would have been safer or simpler.
+
+It uses the same review target selection as `/codex:review`, including `--base <ref>` for branch review.
+It also supports `--wait` and `--background`. Unlike `/codex:review`, it can take extra focus text after the flags.
+
+Use it when you want:
+
+- a review before shipping that challenges the direction, not just the code details
+- review focused on design choices, tradeoffs, hidden assumptions, and alternative approaches
+- pressure-testing around specific risk areas like auth, data loss, rollback, race conditions, or reliability
+
+Examples:
+
+```bash
+/codex:adversarial-review
+/codex:adversarial-review --base main challenge whether this was the right caching and retry design
+/codex:adversarial-review --background look for race conditions and question the chosen approach
+```
+
+This command is read-only. It does not fix code.
+
+### `/codex:rescue`
+
+Hands a task to Codex through the `codex:codex-rescue` subagent.
+
+Use it when you want Codex to:
+
+- investigate a bug
+- try a fix
+- continue a previous Codex task
+- take a faster or cheaper pass with a smaller model
+
+> [!NOTE]
+> Depending on the task and the model you choose these tasks might take a long time and it's generally recommended to force the task to be in the background or move the agent to the background.
+
+It supports `--background`, `--wait`, `--resume`, and `--fresh`. If you omit `--resume` and `--fresh`, the plugin can offer to continue the latest rescue thread for this repo.
+
+Examples:
+
+```bash
+/codex:rescue investigate why the tests started failing
+/codex:rescue fix the failing test with the smallest safe patch
+/codex:rescue --resume apply the top fix from the last run
+/codex:rescue --model gpt-5.4-mini --effort medium investigate the flaky integration test
+/codex:rescue --model spark fix the issue quickly
+/codex:rescue --background investigate the regression
+```
+
+You can also just ask for a task to be delegated to Codex:
+
+```text
+Ask Codex to redesign the database connection to be more resilient.
+```
+
+**Notes:**
+
+- if you do not pass `--model` or `--effort`, Codex chooses its own defaults.
+- if you say `spark`, the plugin maps that to `gpt-5.3-codex-spark`
+- follow-up rescue requests can continue the latest Codex task in the repo
+
+### `/codex:transfer`
+
+Creates a persistent Codex thread from the current Claude Code session and prints a `codex resume <session-id>` command.
+
+Use it when you started a debugging or implementation conversation in Claude Code and want to continue that same context directly in Codex.
+
+Examples:
+
+```bash
+/codex:transfer
+/codex:transfer --source ~/.claude/projects/-Users-me-repo/<session-id>.jsonl
+```
+
+The plugin's existing `SessionStart` hook supplies the current transcript path automatically; `--source` is available as a manual override. The transfer uses Codex's external-agent session importer, so it follows the same conversion rules as importing Claude history in the Codex App and creates visible turns that can be continued in the App or TUI. The source must be under `~/.claude/projects`, and older Codex versions that do not expose session import must be upgraded before using this command.
+
+### `/codex:status`
+
+Shows running and recent Codex jobs for the current repository.
+
+Examples:
+
+```bash
+/codex:status
+/codex:status task-abc123
+```
+
+Use it to:
+
+- check progress on background work
+- see the latest completed job
+- confirm whether a task is still running
+
+### `/codex:result`
+
+Shows the final stored Codex output for a finished job.
+When available, it also includes the Codex session ID so you can reopen that run directly in Codex with `codex resume <session-id>`.
+
+Examples:
+
+```bash
+/codex:result
+/codex:result task-abc123
+```
+
+### `/codex:cancel`
+
+Cancels an active background Codex job.
+
+Examples:
+
+```bash
+/codex:cancel
+/codex:cancel task-abc123
+```
+
+### `/codex:setup`
+
+Checks whether Codex is installed and authenticated.
+If Codex is missing and npm is available, it can offer to install Codex for you.
+
+You can also use `/codex:setup` to manage the optional review gate.
+
+#### Enabling review gate
+
+```bash
+/codex:setup --enable-review-gate
+/codex:setup --disable-review-gate
+```
+
+When the review gate is enabled, the plugin uses a `Stop` hook to run a targeted Codex review based on Claude's response. If that review finds issues, the stop is blocked so Claude can address them first.
+
+> [!WARNING]
+> The review gate can create a long-running Claude/Codex loop and may drain usage limits quickly. Only enable it when you plan to actively monitor the session.
+
+## Typical Flows
+
+### Review Before Shipping
+
+```bash
+/codex:review
+```
+
+### Hand A Problem To Codex
+
+```bash
+/codex:rescue investigate why the build is failing in CI
+```
+
+### Start Something Long-Running
+
+```bash
+/codex:adversarial-review --background
+/codex:rescue --background investigate the flaky test
+```
+
+Then check in with:
+
+```bash
+/codex:status
+/codex:result
+```
+
+## Codex Integration
+
+The Codex plugin wraps the [Codex app server](https://developers.openai.com/codex/app-server). It uses the global `codex` binary installed in your environment and [applies the same configuration](https://developers.openai.com/codex/config-basic).
+
+### Common Configurations
+
+If you want to change the default reasoning effort or the default model that gets used by the plugin, you can define that inside your user-level or project-level `config.toml`. For example to always use `gpt-5.4-mini` on `high` for a specific project you can add the following to a `.codex/config.toml` file at the root of the directory you started Claude in:
+
+```toml
+model = "gpt-5.4-mini"
+model_reasoning_effort = "high"
+```
+
+Your configuration will be picked up based on:
+
+- user-level config in `~/.codex/config.toml`
+- project-level overrides in `.codex/config.toml`
+- project-level overrides only load when the [project is trusted](https://developers.openai.com/codex/config-advanced#project-config-files-codexconfigtoml)
+
+Check out the Codex docs for more [configuration options](https://developers.openai.com/codex/config-reference).
+
+### Moving The Work Over To Codex
+
+Delegated tasks and any [stop gate](#what-does-the-review-gate-do) run can also be directly resumed inside Codex by running `codex resume` either with the specific session ID you received from running `/codex:result` or `/codex:status` or by selecting it from the list.
+
+This way you can review the Codex work or continue the work there.
+
+## FAQ
+
+### Do I need a separate Codex account for this plugin?
+
+If you are already signed into Codex on this machine, that account should work immediately here too. This plugin uses your local Codex CLI authentication.
+
+If you only use Claude Code today and have not used Codex yet, you will also need to sign in to Codex with either a ChatGPT account or an API key. [Codex is available with your ChatGPT subscription](https://developers.openai.com/codex/pricing/), and [`codex login`](https://developers.openai.com/codex/cli/reference/#codex-login) supports both ChatGPT and API key sign-in. Run `/codex:setup` to check whether Codex is ready, and use `!codex login` if it is not.
+
+### Does the plugin use a separate Codex runtime?
+
+No. This plugin delegates through your local [Codex CLI](https://developers.openai.com/codex/cli/) and [Codex app server](https://developers.openai.com/codex/app-server/) on the same machine.
+
+That means:
+
+- it uses the same Codex install you would use directly
+- it uses the same local authentication state
+- it uses the same repository checkout and machine-local environment
+
+### Will it use the same Codex config I already have?
+
+Yes. If you already use Codex, the plugin picks up the same [configuration](#common-configurations).
+
+### Can I keep using my current API key or base URL setup?
+
+Yes. Because the plugin uses your local Codex CLI, your existing sign-in method and config still apply.
+
+If you need to point the built-in OpenAI provider at a different endpoint, set `openai_base_url` in your [Codex config](https://developers.openai.com/codex/config-advanced/#config-and-state-locations).

--- a/.omc/kb/reports/agents/codex-nim-research.md
+++ b/.omc/kb/reports/agents/codex-nim-research.md
@@ -1,0 +1,260 @@
+# Agent report (verbatim): codex-nim-research
+
+Persisted from agent transcript `ccb182b4-5d6d-4836-adc9-18361e29fe6d.jsonl` on 2026-07-19.
+Captured per `.claude/rules/agent-report-persistence.md` (verbatim, at receipt).
+
+> **NOTE — a FINAL, RICHER version of this report was delivered directly by the
+> agent after this transcript capture.** The delivered version adds, beyond what
+> is below:
+>
+> 1. **Source-verified Rust** in `openai/codex`
+>    (`codex-rs/model-provider-info/src/lib.rs`): `pub enum WireApi` has
+>    **exactly one variant**, `Responses`, plus a
+>    `CHAT_WIRE_API_REMOVED_ERROR` const pointing at
+>    [discussion 7782](https://github.com/openai/codex/discussions/7782). The
+>    same commit removed `LEGACY_OLLAMA_CHAT_PROVIDER_ID` — **which is why our
+>    local Ollama success runs over Responses.**
+> 2. **A third independent NIM probe** agreeing with ours and with
+>    `codex-nim-wiring`: `POST /v1/responses` → 404 byte-identical to a bogus
+>    path, while `POST /v1/chat/completions` → 401 and `/v1/embeddings` → 401.
+>    NIM serves **chat/completions + embeddings only**.
+> 3. **A trap worth flagging:** LiteLLM's `nvidia_nim` docs list `/responses`
+>    among supported endpoints. That is **LiteLLM's translation surface, not
+>    NIM's native route.** Reading that page as evidence NIM serves Responses
+>    would be a false positive.
+> 4. **The sharp architectural point:** reaching NIM requires a Responses→chat
+>    shim (LiteLLM) in front of it — *"at which point Codex is a pure cost with
+>    no benefit over calling NIM's chat endpoint directly."*
+> 5. **ToS §4.12 (no competing use):** *"You will not use … the API Service
+>    including Generated Content to develop or improve products or services that
+>    compete with the API Service."* An autonomous coding-agent orchestrator is
+>    arguably adjacent — **UNVERIFIED** whether NVIDIA would read it that way.
+> 6. **Interpretive principle for the §2.3 ↔ §3.3(iv) contradiction:** *"When a
+>    ToS contradicts itself, assume the clause granting the vendor more rights is
+>    operative."*
+> 7. **Rate limit is ACCOUNT-level** — `--max-workers 16` will hit 40 RPM;
+>    graphify's OpenAI path does 6 SDK retries on 429, so it degrades rather than
+>    fails. Credits 1,000 → extendable to 5,000; forum staff cannot grant
+>    increases directly.
+> 8. **graphify escape hatch** for the `max_completion_tokens` vs `max_tokens`
+>    risk: `.graphify/providers.json` supports `extra_body` behind
+>    `GRAPHIFY_ALLOW_LOCAL_PROVIDERS=1`.
+>
+> Its corrected framing, which supersedes the "irrelevant" wording below:
+> **"Codex is a viable wrapper only for Responses-capable endpoints
+> (Ollama ✅, NIM ❌), and `codex-plugin-cc` is separately irrelevant because it
+> cannot change Claude's model."**
+
+---
+
+Findings recorded. Full report below.
+
+# NVIDIA NIM as a Free Worker Backend — Research Report
+
+**Date:** 2026-07-19 · **Bottom line up front:** `codex-plugin-cc` is **the wrong direction entirely** and does not help. NVIDIA NIM *is* a genuine free OpenAI-compatible endpoint and *does* work with graphify today (issue #959 is stale — support shipped in 0.8.40). But NVIDIA's **Trial ToS forbids production use and claims the right to train on your inputs**, which disqualifies it for ingesting this repo's corpus. The research also produced a hard architectural finding that **confirms the launcher-wrapped shell-out substrate decision**.
+
+---
+
+## 1. `openai/codex-plugin-cc` — routes the OPPOSITE way
+
+**Verdict: irrelevant to this problem. Do not adopt it for worker models.**
+
+| Fact | Value | Source |
+|---|---|---|
+| Description | "Use Codex from Claude Code to review code or delegate tasks." | [GitHub API](https://github.com/openai/codex-plugin-cc) |
+| Stars / forks | 29,331 / 1,861 | GitHub API, 2026-07-19 |
+| Open issues | 356 | GitHub API |
+| Last push | 2026-07-08 | GitHub API |
+| License / owner | Apache-2.0, **official `openai` org** | GitHub API |
+
+**Direction (this is the crux):** it is a **Claude Code plugin that delegates work FROM Claude Code TO OpenAI's Codex**. It is *not* a mechanism for Claude Code to call arbitrary OpenAI-compatible models.
+
+**Architecture** — plugin manifest, not MCP, not a proxy. The tree at [`plugins/codex/`](https://github.com/openai/codex-plugin-cc/tree/main/plugins/codex) is a standard CC plugin: `.claude-plugin/plugin.json`, `commands/*.md` (`/codex:review`, `/codex:rescue`, `/codex:transfer`…), `hooks/hooks.json`, and `scripts/lib/app-server.mjs`. The README is explicit:
+
+> "**Does the plugin use a separate Codex runtime?** No. This plugin delegates through your local Codex CLI and Codex app server on the same machine… it uses the same local authentication state."
+
+**Can it be pointed at build.nvidia.com?** Technically the README says:
+
+> "If you need to point the built-in OpenAI provider at a different endpoint, set `openai_base_url` in your Codex config."
+
+But per [Codex's own config docs](https://learn.chatgpt.com/docs/config-file/config-advanced), `openai_base_url` **"only adjusts the built-in provider"**, and non-OpenAI services are supposed to use a separate `[model_providers.<id>]` block with `base_url` / `env_key` / `wire_api`. So the *supported* route to NIM would be a Codex custom provider — which means **you'd be using Codex, not Claude Code, as the worker**, and paying an extra process hop for nothing. `codex-plugin-cc` adds no value on that path.
+
+**Conclusion:** codex-plugin-cc changes nothing about the substrate decision. Its requirement is literally *"ChatGPT subscription or OpenAI API key"* — it is a Codex-delegation UX, not a model-routing layer.
+
+---
+
+## 2. NVIDIA build.nvidia.com / NIM as a free OpenAI-compatible endpoint
+
+### 2.1 Endpoint and compatibility — CONFIRMED by direct probe
+
+- **Base URL:** `https://integrate.api.nvidia.com/v1`, endpoint `POST /v1/chat/completions` — [docs.api.nvidia.com](https://docs.api.nvidia.com/nim/reference/llm-apis). Confirmed OpenAI chat-completions compatible.
+- **Auth:** `Authorization: Bearer nvapi-…` key from [build.nvidia.com](https://build.nvidia.com/). I probed unauthenticated and got the exact error `Header of type 'authorization' was missing`, `http=401`.
+- **`/v1/models` is publicly listable with NO auth.** My probe returned `http=200` and **119 models**. *Control arm:* a bogus path (`/v1/definitely-not-a-real-endpoint`) returned `404`, so the probe discriminates — the 200 is real, not a catch-all.
+- LiteLLM ships a first-class provider: default base `https://integrate.api.nvidia.com/v1/`, env `NVIDIA_NIM_API_KEY` / `NVIDIA_NIM_API_BASE`, model prefix `nvidia_nim/<model>` — [LiteLLM docs](https://docs.litellm.ai/docs/providers/nvidia_nim).
+
+### 2.2 Free-tier limits
+
+| Limit | Value | Confidence |
+|---|---|---|
+| Default rate limit | **40 requests/minute** | NVIDIA staff confirm on the [developer forum](https://forums.developer.nvidia.com/t/api-rate-limit-increase-for-nvidia-nim/366043); **no formal docs page exists** |
+| Default credits | **1,000**, extendable to **5,000** on request | Inferred from the *volume* of NVIDIA-hosted forum threads titled literally ["1,000 → 5,000 credits, 40 → 200 RPM"](https://forums.developer.nvidia.com/t/api-access-confirmation-credit-rate-limit-increase-request-1-000-5-000-credits-40-200-rpm/375201) |
+| Increase process | Cannot be approved via forum; escalated internally | Staff quote: *"I can elevate this internally… but we cannot approve rate-limit increases directly from the forum."* |
+| Credits per request | Varies by model size | ToS §1.4 confirms a credit-deduction model exists but names no rates |
+
+**UNVERIFIED:** I could find **no official NVIDIA documentation page** stating 40 RPM or the credit allocation. `docs.api.nvidia.com/nim/docs/product` does **not** mention credits, rate limits, or key format. Treat these numbers as staff/community-corroborated, not an SLA. Also note the secondary claim that "credit limits have been removed" ([pasqualepillitteri.it](https://pasqualepillitteri.it/en/news/1621/nvidia-build-free-api-100-ai-models-2026)) **conflicts** with the active forum threads still requesting credit increases — I could not resolve which is current.
+
+### 2.3 Available models — VERIFIED against the live catalog
+
+⚠️ **Your brief's guesses were wrong.** `qwen2.5-coder`, `deepseek-v3`, and `qwen3-coder` are **NOT in the catalog**. Real IDs, pulled from the live `/v1/models` response:
+
+**Best for coding / agentic work:**
+| Model ID | Note |
+|---|---|
+| `qwen/qwen3.5-397b-a17b` | Large MoE, strongest open coder present |
+| `deepseek-ai/deepseek-v4-pro` | DeepSeek's current flagship |
+| `deepseek-ai/deepseek-v4-flash` | Faster/cheaper; graphify has a `#1621` thinking-disable note for exactly this model |
+| `moonshotai/kimi-k2.6` | Reasoning model |
+| `z-ai/glm-5.2` | GLM family (the claudefa.st article uses GLM) |
+| `openai/gpt-oss-120b` / `gpt-oss-20b` | Open-weight GPT |
+
+**Best for cheap structured extraction (graphify's actual need):**
+| Model ID | Note |
+|---|---|
+| `nvidia/nemotron-3-super-120b-a12b` | MoE, ~12B active — good quality/throughput |
+| `nvidia/nemotron-3-nano-30b-a3b` | ~3B active — very fast, ideal for bulk chunk extraction |
+| `qwen/qwen3-next-80b-a3b-instruct` | 3B active, 80B total |
+| `meta/llama-3.3-70b-instruct` | Safe baseline |
+
+Legacy/weak, avoid: `deepseek-ai/deepseek-coder-6.7b-instruct`, `meta/codellama-70b`, `bigcode/starcoder2-15b`, `mistralai/codestral-22b-instruct-v0.1`.
+
+### 2.4 Reliability caveats for sustained batch use
+
+- 40 RPM is an **account-level** cap. For graphify ingest this is *usually fine* — chunk extraction is slow per-call — but a `--max-workers 16` fan-out will hit it. Graphify's OpenAI SDK path defaults to 6 retries on 429 (`_resolve_max_retries`), so it degrades rather than fails.
+- The **credit cap is the real wall**: a large-corpus ingest can exhaust 1,000–5,000 credits in a single run, and there is no graceful behavior documented for exhaustion.
+- ToS §1.3 warns endpoints may be **pre-release** with *"reduced or different security, privacy, availability, and reliability standards"* and may be terminated *"at any time without liability."*
+
+---
+
+## 3. The claudefa.st article
+
+[claudefa.st/blog/tools/customization/free-claude-code](https://claudefa.st/blog/tools/customization/free-claude-code) describes a **local Anthropic-protocol shim**, not a plugin. Its thesis: *"Claude Code speaks the Anthropic Messages API protocol. So does any proxy that pretends to be Anthropic."*
+
+**Recipe:**
+1. Install `uv` + Python 3.14; clone the project; copy `.env.example` → `.env`.
+2. Set provider creds — for NVIDIA: `NVIDIA_NIM_API_KEY="nvapi-…"`, `MODEL="nvidia_nim/z-ai/glm4.7"` (LiteLLM prefix form).
+3. Run a FastAPI translation server: `uv run uvicorn server:app --host 0.0.0.0 --port 8082`.
+4. Launch CC redirected at it:
+   ```bash
+   ANTHROPIC_AUTH_TOKEN="freecc" ANTHROPIC_BASE_URL="http://localhost:8082" claude
+   ```
+5. Optional per-tier routing: `MODEL_OPUS`, `MODEL_SONNET`, `MODEL_HAIKU`.
+
+**Gotchas it names:** tool-use reliability degrades on weaker models; context shrinks to 32K–128K vs 200K+; quality is *"70 to 85 percent of the result"* at 2–5% of cost.
+
+**Gotcha it does NOT name (and this is the important one):** `ANTHROPIC_BASE_URL` is **process-global**. Redirecting it sends *every* request in that session — architect, subagents, compaction, title generation — to the proxy. It is all-or-nothing.
+
+---
+
+## 4. Synthesis
+
+### 4.1 Can NIM be a Claude Code *worker* model? — Only via a whole-process swap
+
+**The decisive finding: CC's subagent `model:` field cannot name a non-Claude model.** Per [the official subagents doc](https://code.claude.com/docs/en/sub-agents), `model` accepts:
+
+> `sonnet`, `opus`, `haiku`, `fable`, a full model ID (for example, `claude-opus-4-8`), or `inherit`… **Accepts the same values as the `--model` flag**
+
+There is no base-URL or provider field on a subagent. **Integration surface (A) is closed.** Combined with `ANTHROPIC_BASE_URL` being process-global, it is **architecturally impossible to run a Fable/Opus architect and NIM workers inside one Claude Code process.**
+
+And Anthropic states plainly ([llm-gateway docs](https://code.claude.com/docs/en/llm-gateway)):
+
+> "Anthropic doesn't endorse, maintain, or audit third-party gateway products, and **doesn't support routing Claude Code to non-Claude models through any gateway**."
+
+**Ranked mechanisms:**
+
+| Rank | Mechanism | Verdict |
+|---|---|---|
+| **1** | **Bash shell-out** to a NIM-backed CLI from the architect session | ✅ Only option preserving a Claude architect + NIM workers concurrently. Per-call model choice; no global state. **Confirms your existing lean.** |
+| 2 | Separate CC process with `ANTHROPIC_BASE_URL` → LiteLLM/free-claude-code | ⚠️ Works, but that whole process is non-Claude. Viable as a *detached worker pool*, never for the architect. |
+| 3 | `claude-code-router` | ⚠️ Same class as #2, more setup, unsupported by Anthropic. |
+| 4 | `codex-plugin-cc` | ❌ Wrong direction. Delegates CC→Codex. Adds nothing. |
+| 5 | Subagent `model:` field | ❌ **Impossible.** Claude model IDs only. |
+
+**Minimal concrete setup (option 1):** no proxy at all — call NIM's OpenAI endpoint directly from a worker script, since NIM *is* OpenAI-compatible:
+```bash
+export NVIDIA_API_KEY="nvapi-…"
+# worker invocation, per-call model choice
+OPENAI_BASE_URL=https://integrate.api.nvidia.com/v1 \
+OPENAI_API_KEY="$NVIDIA_API_KEY" \
+  <your-worker-cli> --model qwen/qwen3.5-397b-a17b
+```
+The LiteLLM/FastAPI shim is only needed if you want an *Anthropic-protocol* surface, which shell-out does not.
+
+### 4.2 graphify — issue #959 is STALE; support already shipped
+
+**Your brief's premise needs correcting.** [Issue #959](https://github.com/Graphify-Labs/graphify/issues/959) is **still open with 0 comments** since 2026-05-21, and its body claims the OpenAI base URL is *"hardcoded"*. **That is no longer true.** I verified against source:
+
+- `CHANGELOG.md` **0.8.40 (2026-06-16)**: *"Feat: custom OpenAI- and Anthropic-compatible endpoints via `OPENAI_BASE_URL`/`OPENAI_MODEL`… Point either backend at a self-hosted or proxy server (vLLM, llama.cpp, LM Studio, LiteLLM, gateways) (#1273)."*
+- `graphify/llm.py:112-115`: `"base_url": os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")`, `"default_model": os.environ.get("OPENAI_MODEL", "gpt-4.1-mini")`.
+- Tests exist: `tests/test_openai_custom_endpoint.py`.
+- **We run graphify 0.9.20** (verified locally), well past 0.8.40. **It works today.**
+
+**Exact invocation:**
+```bash
+OPENAI_BASE_URL=https://integrate.api.nvidia.com/v1 \
+OPENAI_API_KEY="nvapi-…" \
+OPENAI_MODEL=nvidia/nemotron-3-super-120b-a12b \
+  graphify extract ./docs --backend openai --token-budget 30000
+```
+Model pick: `nvidia/nemotron-3-super-120b-a12b` (MoE, ~12B active — quality at throughput) or `nvidia/nemotron-3-nano-30b-a3b` for max speed. `--token-budget 30000` because graphify's README explicitly recommends smaller chunks for non-frontier models.
+
+**⚠️ CONCRETE COMPATIBILITY RISK — must probe before adopting.** `graphify/llm.py:1123` sends **`max_completion_tokens`** in every request. NVIDIA's [endpoint reference](https://docs.api.nvidia.com/nim/reference/meta-llama-3_3-70b-instruct-infer) documents **`max_tokens`**, `temperature`, and `tools` — **`max_completion_tokens` is not listed**. If NIM rejects the unknown key you get an HTTP 400 on every call. I could **not verify this** — the unauthenticated probe 401s before parameter validation, so this is **UNVERIFIED** and needs a single live call with a real key as the first adoption step.
+
+Two supporting notes: graphify does **not** use `response_format`/JSON-schema on this path (it parses JSON from text), so structured-output support is not a blocker. And graphify has a `.graphify/providers.json` custom-provider mechanism with an `extra_body` escape hatch, gated behind `GRAPHIFY_ALLOW_LOCAL_PROVIDERS=1` — useful if NIM needs request-shape tweaks.
+
+### 4.3 Risks — the ToS is the actual blocker
+
+I extracted the [NVIDIA API Trial Terms of Service](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf) PDF and read it verbatim. Three clauses matter:
+
+**§1.2 / §1.4 — trial and evaluation only, NOT production:**
+> "NVIDIA will provide you access to the API Service for **limited trial purposes only and without use of the API Service or Generated Content in production**."
+> "Unless you purchase a Subscription… you may only use the API Service for **internal testing and evaluation purposes, not in production**."
+
+An autonomous orchestrator doing bulk work on your real repo is, at minimum, an aggressive reading of "internal testing and evaluation." Programmatic use per se is not banned (the only automation clause, §4.6, targets spam), but **sustained production workloads are.**
+
+**§3.3(iv) — NVIDIA trains on your inputs and outputs:**
+> "NVIDIA will collect the following data… (iv) **User Content and Generated Content to improve NVIDIA products and services, including AI models.**"
+
+Note this **directly contradicts §2.3** (*"NVIDIA will not store or use User Content or Generated Content at the end of each API Service session"*) and contradicts the NVIDIA staff reassurance on the [privacy forum thread](https://forums.developer.nvidia.com/t/clarification-on-trial-api-use/334275) that content is used *"solely to provide users with the API Service."* **When a ToS contradicts itself, assume the clause that grants the vendor more rights is the operative one.** For a graphify ingest — which by design ships your **entire source corpus** to the endpoint — this is disqualifying.
+
+**§4.12 — no competing use:**
+> "You will not use (or allow others to use) the API Service including Generated Content to develop or improve products or services that compete with the API Service."
+
+Reliability: pre-release quality bar, terminable "at any time without liability" (§1.3).
+
+### 4.4 Bottom line — ranked
+
+**(a) Claude Code worker models:**
+1. **Local Ollama via shell-out** — no ToS risk, no rate limit, no corpus egress, works offline. Default.
+2. **NIM via shell-out** — reach for *specific* large models (`qwen3.5-397b`, `deepseek-v4-pro`) that don't fit on this Mac, on non-sensitive tasks only, within evaluation framing.
+3. **NIM via `ANTHROPIC_BASE_URL` proxy** — only for a detached, disposable worker process. Never the architect.
+4. **codex-plugin-cc** — not applicable.
+
+**(b) graphify ingestion backend:**
+1. **Local Ollama** (`--backend ollama`) — **clear winner.** graphify's most-tuned path (`num_ctx` auto-derive, `keep_alive`, retry tuning, `#798`/`#1686` fixes all target Ollama). Your corpus never leaves the machine. No credits, no 40 RPM, no §3.3(iv).
+2. **NIM** — viable *technically*, but §3.3(iv) means ingesting this repo hands NVIDIA training rights over your entire source tree. **Do not use it on the dotfiles corpus.** Acceptable only for throwaway/public-code capability probes.
+
+**Is NIM worth adopting over local Ollama? No — not as a default.** The technology is sound and free; the *licence* is the problem. Adopt it as an **on-demand capability probe** (a mise task that requires an explicit opt-in flag), never as the standing ingestion or worker backend.
+
+**Highest-value corrections to your priors:**
+1. `codex-plugin-cc` routes CC→Codex — it can never be the worker-model substrate.
+2. Subagent `model:` is Claude-only ⇒ **mixed architect/worker models in one process is impossible** ⇒ **shell-out is not merely preferable, it is the only design that works.**
+3. graphify #959 is stale — `OPENAI_BASE_URL` shipped in 0.8.40; no upstream work is blocking you.
+4. `qwen2.5-coder` / `deepseek-v3` aren't on NIM; use the verified IDs above.
+
+---
+
+## GitHub repos touched
+
+- [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc) — primary subject; read README, file tree, and repo metadata to establish delegation direction and maturity.
+- [Graphify-Labs/graphify](https://github.com/Graphify-Labs/graphify) — read issue #959, `graphify/llm.py`, `CHANGELOG.md`, `README.md` to verify `OPENAI_BASE_URL` support and find the `max_completion_tokens` compatibility risk.
+- [BerriAI/litellm](https://github.com/BerriAI/litellm) — consulted its `nvidia_nim` provider docs for base URL, env vars, and model-prefix format.

--- a/.omc/kb/reports/agents/codex-nim-wiring.md
+++ b/.omc/kb/reports/agents/codex-nim-wiring.md
@@ -1,0 +1,349 @@
+# Agent report (verbatim): codex-nim-wiring
+
+Persisted from agent transcript `9d872796-45c8-4f91-9add-8e8cab52b8dc.jsonl` on 2026-07-19.
+Captured per `.claude/rules/agent-report-persistence.md` (verbatim, at receipt).
+
+---
+
+Both of your findings are **corroborated, not contradicted**. Full report follows verbatim, with a reconciliation section added at the front.
+
+---
+
+# Can OpenAI Codex CLI be pointed at NVIDIA NIM (or any third-party OpenAI-compatible endpoint)?
+
+## VERDICT
+
+**Any third-party OpenAI-compatible endpoint: YES — provided it implements `/v1/responses`.** The protocol requirement is real but satisfiable by non-OpenAI servers; Ollama is the existence proof.
+
+**NVIDIA NIM specifically:**
+- **Hosted (`https://integrate.api.nvidia.com/v1`): NO.** It does not implement `/v1/responses`. Verified first-hand today with control arms, and reproduced end-to-end through `codex exec`.
+- **Self-hosted NIM container ≥ 1.14.0: MAYBE** — NVIDIA documents an *experimental* `/v1/responses`, gpt-oss models only, with a documented memory leak. **UNVERIFIED** whether Codex actually drives it.
+- **Via a translating proxy (LiteLLM): YES-WITH-CAVEATS.** This is the only path with vendor-acknowledged support.
+
+---
+
+## 0. Reconciliation against your local findings
+
+**No disagreement on either point.** Both are independently confirmed by my research, and your #2 is the more important of the two — it converts my structural argument into a demonstrated one.
+
+### Your finding 1 — `wire_api = "chat"` string compiled into 0.144.6 → Responses-only
+
+**CONFIRMED, and I can name the source line and the commit.** From [`codex-rs/model-provider-info/src/lib.rs`](https://github.com/openai/codex/blob/main/codex-rs/model-provider-info/src/lib.rs):
+
+```rust
+const CHAT_WIRE_API_REMOVED_ERROR: &str = "`wire_api = \"chat\"` is no longer supported.\n\
+How to fix: set `wire_api = \"responses\"` in your provider config.\n\
+More info: https://github.com/openai/codex/discussions/7782";
+```
+
+That is the exact literal you found in the binary. I also reproduced it at runtime on the same 0.144.6 build (sandboxed via `CODEX_HOME`, your `~/.codex` untouched):
+
+```
+rc=1
+Error loading config.toml: `wire_api = "chat"` is no longer supported.
+How to fix: set `wire_api = "responses"` in your provider config.
+More info: https://github.com/openai/codex/discussions/7782
+in `model_providers.nvidia_nim.wire_api`
+```
+
+The enum has exactly one variant — this is not a soft deprecation:
+
+```rust
+pub enum WireApi {
+    /// The Responses API exposed by OpenAI at `/v1/responses`.
+    Responses,          // <-- the ONLY variant
+}
+// Deserialize:
+"responses" => Ok(Self::Responses),
+"chat"      => Err(serde::de::Error::custom(CHAT_WIRE_API_REMOVED_ERROR)),
+_           => Err(serde::de::Error::unknown_variant(&value, &["responses"])),
+```
+
+A second legacy ID was killed in the same sweep: `ollama-chat` → `OLLAMA_CHAT_PROVIDER_REMOVED_ERROR`.
+
+### Your finding 2 — `codex exec` with `model_provider = "ollama"` drives local Ollama, rc=0
+
+**CONFIRMED, and I can supply the upstream provenance you'd want for the writeup.** Your `ollama ps` keep-alive-refresh + absent-`auth.json` verification is a well-armed probe — it discriminates "Codex actually drove the local server" from "Codex silently fell back to OpenAI," which is the failure mode that would have made a naive rc=0 meaningless.
+
+Upstream facts that back it:
+- **Ollama added `/v1/responses` in v0.13.3**, via [ollama/ollama#13351](https://github.com/ollama/ollama/pull/13351). The feature was requested in [#10309, "Support for OpenAI Responses API (for Codex CLI compatibility)"](https://github.com/ollama/ollama/issues/10309) — Codex compatibility was the *stated motivation*. Docs/changelog gap logged at [#13595](https://github.com/ollama/ollama/issues/13595): v0.13.3/0.13.4/0.13.5 release notes never mention it.
+- Codex's built-in table was migrated to match, in [#8798 `ollama: default to Responses API for built-ins`](https://github.com/openai/codex/pull/8798) (2026-01-13) — *before* chat was dropped (2026-02-03). The ordering matters: OpenAI staged the ecosystem migration first, then cut.
+
+```rust
+(OLLAMA_OSS_PROVIDER_ID,   create_oss_provider(DEFAULT_OLLAMA_PORT,   WireApi::Responses)),
+(LMSTUDIO_OSS_PROVIDER_ID, create_oss_provider(DEFAULT_LMSTUDIO_PORT, WireApi::Responses)),
+```
+
+**One caveat on your rc=0 result worth carrying forward:** Ollama's implementation is **non-stateful** — no `previous_response_id`, no conversation support. A short `codex exec` run won't exercise that; longer multi-turn sessions may. Flagging so the success isn't over-generalized.
+
+**Your narrowing is correct.** "Codex is locked to OpenAI" is false — it's locked to a *protocol*, and that protocol is implementable by anyone. The question really is just: does NIM implement it? Answered in §2.
+
+---
+
+## 1. The `wire_api` contradiction in the docs, resolved
+
+The answer is **(b) + (d) simultaneously** — chat *was* supported and *was* removed, **and** Ollama/LM Studio *have since* implemented `/v1/responses`. The docs are correct and current; they simply don't tell you the history. Possibility (c) — special-casing for built-ins — is **false**; there is no such code path.
+
+### Timeline (from openai/codex git history — primary source)
+
+| Date | Commit / PR | What happened |
+|---|---|---|
+| 2025-05-08 | `e924070c` — [#862](https://github.com/openai/codex/pull/862) | `feat: support the chat completions API in the Rust CLI` — chat support **added** |
+| 2025-12-09 | [Discussion #7782](https://github.com/openai/codex/discussions/7782) | Deprecation **announced** by maintainer `@etraut-openai`: *"Maintaining compatibility with this legacy protocol has added complexity, introduced regressions, and increased support overhead."* |
+| 2025-12-11 | `43e6e753` — [#7897](https://github.com/openai/codex/pull/7897) | Deprecation **warning** added for `wire_api = "chat"` |
+| 2026-01-13 | `fe033207` — [#8798](https://github.com/openai/codex/pull/8798) | `ollama: default to Responses API for built-ins` |
+| **2026-02-03** | **`88598b94` — [#10498](https://github.com/openai/codex/pull/10498)** | **`feat: drop wire_api from clients` — chat support REMOVED** |
+
+Full removal landed in the **0.84.0+** era per the discussion thread; commit `88598b94` (merged 2026-02-03) is the code-level cut.
+
+### Reserved provider IDs — a trap worth documenting
+
+Built-in IDs `openai`, `ollama`, `lmstudio`, and `amazon-bedrock` (added 2026-04-21, [#18744](https://github.com/openai/codex/pull/18744)) are **reserved**. `merge_configured_model_providers` uses `.or_insert()`, so a user-defined provider reusing a built-in ID is **silently ignored** — no error, no warning. You cannot reach a third party by overriding the `openai` provider's `base_url`; you must define a new ID.
+
+The design intent is stated in the source comment:
+
+> *"We do not want to be in the business of adjudicating which third-party providers are bundled with Codex CLI, so we only include the OpenAI and open source ("oss") providers by default. Users are encouraged to add to `model_providers` in config.toml to add their own providers."*
+
+---
+
+## 2. **Does NVIDIA NIM implement a working `/v1/responses`?** — the highest-value section
+
+### Hosted API: **NO.** Probed live 2026-07-19, with both control arms
+
+A bare 404 proves nothing, so I armed the probe in both directions:
+
+| Request | Result | Reads as |
+|---|---|---|
+| `GET /v1/models` | **200** + full model list | host reachable, API live ✅ |
+| `POST /v1/chat/completions` (no auth) | **401** | route **exists**, auth enforced ✅ |
+| `POST /v1/chat/completions` (bogus key) | **403** `{"title":"Forbidden","detail":"Authorization failed"}` | route exists ✅ |
+| **`POST /v1/responses`** (no auth) | **404** `page not found` | **route does not exist** ❌ |
+| **`POST /v1/responses`** (bogus key) | **404** `page not found` | not an auth failure ❌ |
+| `POST /v1/definitely_not_an_endpoint` (negative control) | **404** `page not found` | **byte-identical to `/v1/responses`** |
+
+The negative control is the load-bearing part: `/v1/responses` is indistinguishable from a route NVIDIA never defined, while `/chat/completions` clearly discriminates (401/403, not 404). The bogus-key arm rules out "404 as an auth-masking response."
+
+> **One anomaly, reported honestly:** `GET /v1/responses` returns **405**, as does `GET /v1/chat/completions`, while `GET /v1/definitely_not_an_endpoint` returns 404. So the *edge gateway* appears to know the path string, but a POST forwards to a backend with no handler. Net effect is unchanged and confirmed end-to-end below — but I flag **UNVERIFIED** why the edge behaves this way. It may indicate NVIDIA has provisioned the route at the edge ahead of backend rollout, which would make this a moving target worth re-probing later.
+
+### End-to-end confirmation through the real binary
+
+Same 0.144.6, `CODEX_HOME`-sandboxed, custom provider pointed straight at hosted NIM with `wire_api = "responses"`:
+
+```
+OpenAI Codex v0.144.6
+model: meta/llama-3.1-8b-instruct
+provider: nvidia_nim
+warning: Model metadata for `meta/llama-3.1-8b-instruct` not found.
+         Defaulting to fallback metadata; this can degrade performance and cause issues.
+ERROR: Reconnecting... 1/5 … 5/5
+ERROR: unexpected status 404 Not Found: 404 page not found,
+       url: https://integrate.api.nvidia.com/v1/responses
+```
+
+Note what this proves **positively**, and why it complements your Ollama result: the custom-provider plumbing works flawlessly — config parsed, provider selected, correct URL constructed, auth header attached, retries performed. Your finding 2 shows the same machinery succeeding against a compliant server. **Only NVIDIA's missing endpoint fails.** Two probes, opposite outcomes, same code path — that pair isolates the defect to NVIDIA, not Codex.
+
+### Independent corroboration — someone else's POC, four months earlier
+
+[`SproutSeeds/codex-nim-poc`](https://github.com/SproutSeeds/codex-nim-poc) ran the identical experiment on **2026-03-25**. From [`docs/first-live-run-2026-03-25.md`](https://github.com/SproutSeeds/codex-nim-poc/blob/main/docs/first-live-run-2026-03-25.md), verbatim:
+
+```
+- direct `GET https://integrate.api.nvidia.com/v1/models`: `200`
+- direct `POST https://integrate.api.nvidia.com/v1/responses`: `404 page not found`
+- second direct POST check with `nvidia/llama-3.3-nemotron-super-49b-v1`: `404 page not found`
+- `codex exec` through a custom provider configured for
+  `https://integrate.api.nvidia.com/v1` and `wire_api = "responses"`:
+  repeated `404 Not Found` against `/v1/responses`
+- manual fallback `POST /v1/chat/completions` with `nvidia/nemotron-3-super-120b-a12b`: `200`
+```
+
+Their stated read:
+
+> *"NVIDIA hosted NIM on `integrate.api.nvidia.com/v1` is usable through `chat/completions`; this endpoint currently does not expose a working `/v1/responses` path for the tested model/provider path; Codex therefore fails at the Responses boundary before any provider-specific `extra_body` primitive can help direct integration."*
+
+Two probes, four months apart, different operators, different models tested, same answer.
+
+### A second-order gap even if NVIDIA ships the endpoint
+
+The same POC found that NVIDIA Nemotron models require `extra_body.chat_template_kwargs.force_nonempty_content = true` — without it, `message.content` comes back **null** with only reasoning fields populated; with it, content is non-null. **Codex exposes no provider-level request-body injection** (tracked at [openai/codex#5458](https://github.com/openai/codex/issues/5458)). So even if `/v1/responses` appeared tomorrow, Nemotron-via-Codex would likely still need a Codex-side primitive.
+
+### Self-hosted NIM container: experimental, and caveat-heavy
+
+[NIM for LLMs 1.14.0 release notes](https://docs.nvidia.com/nim/large-language-models/1.14.0/release-notes.html):
+
+- *"The Responses API is experimental. The `/v1/responses` (POST) endpoint immediately returns the complete response."*
+- Scoped to **GPT-OSS-20B / GPT-OSS-120B only** in the notes
+- GET-retrieval and cancel require `VLLM_ENABLE_RESPONSES_API_STORE=1`, which *"causes a memory leak because responses are not automatically cleaned up"*
+- *"Stored responses are not persisted to disk, so all stored data is lost on server restart"*
+- Cancel only works for `"background": true`; immediate responses can't be cancelled
+- *"When passing the payload using the Responses API, background fill is disabled"*
+
+This is a self-hosted-container capability, **not** available on `integrate.api.nvidia.com`. **UNVERIFIED** whether Codex successfully drives it — I found no report of anyone running Codex against a self-hosted NIM 1.14+ container. This is the single most valuable open experiment if you have GPU access.
+
+### Community attempts and OpenAI's position
+
+- **[openai/codex#19145 "Integrate NVIDIA NIM as an Inference Provider"](https://github.com/openai/codex/issues/19145)** (opened 2026-04-23) — **CLOSED AS NOT PLANNED.** No maintainer discussion of `/v1/responses` in-thread. Consistent with the "not adjudicating third-party providers" comment in the source — policy, not oversight.
+- **[Discussion #23156 "Community Codex v1 with NVIDIA NIM Integration"](https://github.com/openai/codex/discussions/23156)** (2026-05-17) — a **fork**, [`HackWidMaddy/OpenCodex`](https://github.com/HackWidMaddy/OpenCodex), by the same author whose feature request was rejected. Author's words: *"Version 1 is already integrated with NVIDIA NIM, which honestly I'm not sure why OpenAI wasn't doing 😭"*. **10 stars.** Working status **UNVERIFIED** — and a 10★ fork of a repo moving at openai/codex's pace is a maintenance liability regardless.
+- **[Prince Arora, "Run Codex CLI Free with NVIDIA NIM" (Medium, 2026-05-11)](https://prince-arora-aws.medium.com/run-codex-cli-free-with-nvidia-nim-c8392f24243c)** — uses LiteLLM on `localhost:4000`, explicitly warns *"`base_url` must point to LiteLLM on `localhost:4000`"* / direct NVIDIA connections fail. **Caveat: no execution logs or screenshots** — a guide, not a demonstrated run.
+- Third-party breakage reports consistent with the above: [RightNow-AI/openfang#471](https://github.com/RightNow-AI/openfang/issues/471) (NVIDIA custom provider 401s), [Hmbown/CodeWhale#1081](https://github.com/Hmbown/CodeWhale/issues/1081) ("nvidia-nim provider can not works").
+
+**Direct answer to your narrowed question: NVIDIA's hosted API does not implement `/v1/responses`. Self-hosted ≥1.14.0 does, experimentally and partially. Nobody has published a working direct Codex↔NIM config, and the one serious POC concluded it is impossible today.**
+
+---
+
+## 3. The path that works: LiteLLM bridge
+
+**LiteLLM explicitly names Codex CLI as the motivating use case** ([docs.litellm.ai/docs/response_api](https://docs.litellm.ai/docs/response_api)):
+
+> *"This is particularly useful when connecting clients that hardcode the `/responses` endpoint (e.g. **OpenAI Codex CLI**) to local or third-party OpenAI-compatible providers that only expose `/chat/completions`."*
+
+Bridge history: [#11632](https://github.com/BerriAI/litellm/pull/11632) added it, [#11685](https://github.com/BerriAI/litellm/pull/11685) improved it, [#23716](https://github.com/BerriAI/litellm/issues/23716) and [#13130](https://github.com/BerriAI/litellm/issues/13130) track opt-in for custom `api_base` providers.
+
+**`litellm_config.yaml`:**
+```yaml
+model_list:
+  - model_name: nim-nemotron
+    litellm_params:
+      model: openai/nvidia/llama-3.3-nemotron-super-49b-v1
+      api_base: https://integrate.api.nvidia.com/v1
+      api_key: os.environ/NVIDIA_API_KEY
+      use_chat_completions_api: true      # <-- the /responses -> /chat/completions bridge
+```
+```bash
+export NVIDIA_API_KEY=nvapi-...
+litellm --config litellm_config.yaml --port 4000
+```
+
+**`~/.codex/config.toml`:**
+```toml
+#:schema https://developers.openai.com/codex/config-schema.json
+
+model = "nim-nemotron"            # must match model_name in litellm_config.yaml
+model_provider = "nvidia_nim"
+
+[model_providers.nvidia_nim]
+name = "NVIDIA NIM via LiteLLM"
+base_url = "http://localhost:4000/v1"   # LiteLLM, NOT integrate.api.nvidia.com
+env_key = "LITELLM_MASTER_KEY"          # or any dummy key var; env_key must be set
+wire_api = "responses"                  # the only legal value
+supports_websockets = false
+request_max_retries = 2
+stream_max_retries = 4
+stream_idle_timeout_ms = 600000
+```
+
+Invoke: `codex`, or `codex --profile <name>`, or per-invocation `codex -c model_provider="nvidia_nim"`.
+
+**Direct-to-NIM version — DOES NOT WORK, shown for contrast.** This is [`codex-nim-poc/configs/codex.nvidia-nim.example.toml`](https://github.com/SproutSeeds/codex-nim-poc/blob/main/configs/codex.nvidia-nim.example.toml), and it 404s:
+```toml
+base_url = "https://integrate.api.nvidia.com/v1"   # <-- 404 at /v1/responses
+```
+
+**Evidence class for the LiteLLM chain: "read in docs + a blog", NOT "I ran it."** No `NVIDIA_API_KEY` in this environment. What *is* verified: the bridge key is in LiteLLM's official docs with Codex named; and the Codex half of the chain provably works (both my 404-at-the-right-URL result and your Ollama rc=0 confirm the plumbing).
+
+---
+
+## 4. Real projects pointing Codex at other backends
+
+| Backend | Status | Source |
+|---|---|---|
+| **Ollama** | ✅ **Built-in provider, works** — your rc=0 + upstream v0.13.3 | [Ollama Codex docs](https://docs.ollama.com/integrations/codex) — recommends ≥64k context window for Codex |
+| **LM Studio** | ✅ Built-in provider (port 1234), `WireApi::Responses` | codex source `built_in_model_providers()` |
+| **OpenRouter** | ✅ Documented by the vendor | [OpenRouter Codex CLI cookbook](https://openrouter.ai/docs/cookbook/coding-agents/codex-cli), [OpenRouter blog tutorial](https://openrouter.ai/blog/tutorials/codex-cli-openrouter/) — must define a new `openrouter` provider ID; cannot override built-in `openai` |
+| **vLLM** | ⚠️ Mixed — "production path" per guides, but vLLM 15.1 reported non-functional on responses at the Feb cutover | [knightli.com local-LLM guide](https://knightli.com/en/2026/07/11/use-local-llm-api-with-codex-ollama-lm-studio-vllm/); [Discussion #7782](https://github.com/openai/codex/discussions/7782) |
+| **llama.cpp** | ⚠️ Partial — newer versions convert responses back to chat completions internally | [Discussion #7782](https://github.com/openai/codex/discussions/7782) |
+| **Groq / Together / Cerebras** | **UNVERIFIED** — no first-party Codex config found; would require the LiteLLM bridge unless they ship `/v1/responses` | — |
+| **Azure OpenAI** | ✅ Supported via `query_params`, [#1435](https://github.com/openai/codex/pull/1435); `is_azure_responses_provider` special-casing in source | codex source |
+| **Amazon Bedrock** | ✅ Built-in since 2026-04-21 | [#18744](https://github.com/openai/codex/pull/18744) |
+
+Multi-backend guides: [morphllm](https://www.morphllm.com/codex-provider-configuration), [ofox.ai](https://ofox.ai/blog/codex-cli-custom-model-providers-byo-setup/), [danielvaughan Codex KB](https://codex.danielvaughan.com/2026/04/23/codex-cli-custom-model-providers-configuration-guide/), [LangWatch](https://langwatch.ai/docs/ai-gateway/cli/codex), [Unsloth](https://unsloth.ai/docs/basics/codex). **Caution: guides written pre-2026-02 show `wire_api = "chat"` and are now actively wrong** — they will hard-fail config load.
+
+Also: [`lidge-jun/opencodex`](https://github.com/lidge-jun/opencodex) — "Universal provider proxy for OpenAI Codex **&** Claude Code," covering both ends.
+
+---
+
+## 5. Known incompatibilities: Responses-oriented client → OpenAI-compatible gateway
+
+Open issues in openai/codex — what you'll actually hit behind any bridge:
+
+| Issue | Problem |
+|---|---|
+| [#31181](https://github.com/openai/codex/issues/31181) (2026-07-05) | **`max_output_tokens` sent unconditionally** → `400 Unsupported parameter: max_output_tokens`. Note: reporter says native `wire_api = "responses"` is *fine* — it's the `@ai-sdk/openai` npm wrapper path that breaks. This is the `max_tokens` / `max_completion_tokens` / `max_output_tokens` divergence in practice. |
+| [#24973](https://github.com/openai/codex/issues/24973) (2026-05-28) | Codex fails against a custom Responses-API provider with `upstream_error` **while identical curl requests succeed** |
+| [#33263](https://github.com/openai/codex/issues/33263) (2026-07-15) | **MCP tools wrapped as "namespace" tool type are ignored by non-OpenAI endpoints** — tool-calling fidelity loss |
+| [#31750](https://github.com/openai/codex/issues/31750) (2026-07-09) | Browser & Computer Use plugins **silently unusable** with a custom `model_provider` (no `tool_search` / dynamic tool discovery) |
+| [#32349](https://github.com/openai/codex/issues/32349) (2026-07-11) | Custom model metadata unresolvable despite `model_catalog_json` loading — this is the `warning: Model metadata ... not found` I hit |
+| [#29592](https://github.com/openai/codex/issues/29592) (2026-06-23) | Model-ID normalization breaks OpenAI-compatible models with **provider prefixes** — `nvidia/...` is exactly this shape |
+| [#20652](https://github.com/openai/codex/issues/20652) (2026-05-01) | MCP tool-name flattening breaks through OpenAI-compatible proxies |
+| [#8240](https://github.com/openai/codex/issues/8240) | Ollama support assumes localhost, ignoring config.toml — **relevant to your finding 2** if you ever move Ollama off-box |
+| [#5458](https://github.com/openai/codex/issues/5458) | No provider-level `extra_body` — blocks Nemotron's `force_nonempty_content` |
+| [#34138](https://github.com/openai/codex/issues/34138) (2026-07-19) | API-key length/charset validation too strict for custom `responses-api-endpoint` |
+| [#11698](https://github.com/openai/codex/issues/11698) | Allow overriding base URL for the built-in `openai` provider (the reserved-ID trap, filed as a feature request) |
+
+**Ecosystem readiness at the Feb 2026 cutover**, from [Discussion #7782](https://github.com/openai/codex/discussions/7782) — anecdotal, versions have moved:
+- **LM Studio 0.3.39** — streaming failed on `responses` despite curl working
+- **LiteLLM** — tool use broken in *both* modes at that time (bridge has since been improved)
+- **llama.cpp** — partial
+- **vLLM 15.1** — non-functional on responses
+- **Ollama** — maintainers said "near future"; **delivered in 0.13.3** ← the one that landed
+
+**State/`store`/`previous_response_id`:** Ollama is explicitly non-stateful. NIM self-hosted `store` needs an env flag and leaks memory. **Assume every bridged/local setup is stateless.**
+
+---
+
+## 6. Claude-Code-model-routing tools and NIM support
+
+For completeness — the chain the user's premise was designed to *avoid*.
+
+| Tool | NIM support | Maintained | Notes |
+|---|---|---|---|
+| [BerriAI/litellm](https://github.com/BerriAI/litellm) | ✅ **Explicit** — [NIM provider docs](https://docs.litellm.ai/docs/providers/nvidia_nim) + [Claude Code with non-Anthropic models](https://docs.litellm.ai/docs/tutorials/claude_non_anthropic_models) | ✅ 54.0k★, pushed 2026-07-19 | Translates Anthropic Messages API ↔ OpenAI-compatible. CC calls `GET /v1/models` against `ANTHROPIC_BASE_URL` and populates the `/model` picker labeled *"From gateway"*. **Most credible.** |
+| [Alishahryar1/free-claude-code](https://github.com/Alishahryar1/free-claude-code) | ✅ **Explicit** — routes CC → NVIDIA NIM / OpenRouter / DeepSeek / local | ✅ **40.9k★**, pushed 2026-07-19 | Purpose-built for exactly this |
+| [musistudio/claude-code-router](https://github.com/musistudio/claude-code-router) | ⚠️ Generic OpenAI-compatible; NIM works by config but is **not called out** | ✅ 35.9k★, pushed 2026-07-19 | "One local control plane for every AI agent" |
+| `y-router` | **UNVERIFIED** | **UNVERIFIED** | Did not verify directly — flagging rather than guessing |
+| `claude-code-proxy` | **UNVERIFIED** | **UNVERIFIED** | Same |
+
+All are **unsupported-but-working-in-practice**, via `ANTHROPIC_BASE_URL`. Third-party writeups specifically covering CC→NIM: [themenonlab](https://themenonlab.blog/blog/free-claude-code-nvidia-nim-proxy-zero-api-fees), [uright.ca](https://uright.ca/posts/running-claude-code-for-free-with-nvidia-nim/), [MindStudio](https://www.mindstudio.ai/blog/free-claude-code-alternatives-openrouter-nvidia-nim-ollama-2).
+
+**UNVERIFIED:** I could not locate the primary Anthropic doc page stating CC *"doesn't support routing Claude Code to non-Claude models through any gateway."* The claim appears in the brief and in secondary write-ups; I will not cite a source I could not read. Separately, one low-trust secondary source claims Anthropic shipped third-party inference support for **Claude Desktop** in April 2026 — **UNVERIFIED, single source, and Desktop ≠ Code.**
+
+---
+
+## 7. Bottom line for the original hypothesis
+
+The chain `Claude Code → /codex:* → codex → NIM` is **architecturally sound and blocked by exactly one missing endpoint**. It becomes:
+
+```
+Claude Code → /codex:* → codex → LiteLLM (localhost:4000) → integrate.api.nvidia.com
+```
+
+That inserts a required local daemon, but **preserves the property that motivated the design: Claude Code itself only ever talks to Claude.** All non-Claude traffic is downstream of the `codex` binary. That is a materially different trust posture from the §6 routers, which redirect Claude Code's own API calls.
+
+Two things to watch:
+- Codex's custom-provider path against non-OpenAI gateways is visibly buggy (§5 — nine-plus open issues, several filed in the last two weeks). Expect degraded tool-calling and MCP behavior, not parity.
+- The `nvidia/...` model-ID prefix is precisely the shape that trips [#29592](https://github.com/openai/codex/issues/29592). Aliasing to a flat `model_name` in LiteLLM (as in §3) sidesteps it.
+
+**On the over-confident answer the user received:** the likely path is reading the config reference, seeing `wire_api = "responses"` next to a `base_url` field, and stopping. The config is accepted and the request is well-formed — it fails one HTTP layer past where a config review can see. Your Ollama rc=0 and my NIM 404 together are the cheap disambiguator that a doc read cannot produce.
+
+**Highest-value open experiment, if you have GPU access:** run Codex against a self-hosted NIM ≥1.14.0 container with a gpt-oss model. That is the only unresolved branch, and nobody appears to have published it.
+
+---
+
+## GitHub repos touched
+
+- [openai/codex](https://github.com/openai/codex) — primary source: `WireApi` enum, `built_in_model_providers`, `merge_configured_model_providers`, commit history for the chat removal, and the issue/discussion tracker
+- [ollama/ollama](https://github.com/ollama/ollama) — `/v1/responses` support (v0.13.3, PR #13351); issues #9659, #10309, #13595 establishing Codex compatibility as the motivation
+- [BerriAI/litellm](https://github.com/BerriAI/litellm) — the `/responses` → `/chat/completions` bridge (PRs #11632, #11685; issues #13130, #17246, #23716) and NVIDIA NIM provider support
+- [SproutSeeds/codex-nim-poc](https://github.com/SproutSeeds/codex-nim-poc) — independent 2026-03-25 POC reproducing the hosted-NIM 404; source of the `force_nonempty_content` finding and the example TOML
+- [HackWidMaddy/OpenCodex](https://github.com/HackWidMaddy/OpenCodex) — community Codex fork claiming built-in NIM integration (10★, working status UNVERIFIED)
+- [Alishahryar1/free-claude-code](https://github.com/Alishahryar1/free-claude-code) — CC→NIM proxy, explicitly supports NIM, actively maintained (40.9k★)
+- [musistudio/claude-code-router](https://github.com/musistudio/claude-code-router) — generic CC model router (35.9k★); NIM by config, not called out
+- [lidge-jun/opencodex](https://github.com/lidge-jun/opencodex) — universal provider proxy covering both Codex and Claude Code
+- [RightNow-AI/openfang](https://github.com/RightNow-AI/openfang) — issue #471, third-party report of NVIDIA custom-provider auth failures (corroborating context)
+- [Hmbown/CodeWhale](https://github.com/Hmbown/CodeWhale) — issue #1081, "nvidia-nim provider can not works" (corroborating context)
+- [api-evangelist/nvidia-nim](https://github.com/api-evangelist/nvidia-nim) — NIM API surface catalog (context only)
+
+**Non-repo sources:** [Codex chat/completions deprecation Discussion #7782](https://github.com/openai/codex/discussions/7782) · [Community NIM Discussion #23156](https://github.com/openai/codex/discussions/23156) · [NIM LLM 1.14.0 release notes](https://docs.nvidia.com/nim/large-language-models/1.14.0/release-notes.html) · [NIM LLM API reference](https://docs.nvidia.com/nim/large-language-models/latest/api-reference.html) · [NIM configuration guide](https://docs.nvidia.com/nim/large-language-models/latest/configuration.html) · [LiteLLM /responses docs](https://docs.litellm.ai/docs/response_api) · [LiteLLM NVIDIA NIM provider](https://docs.litellm.ai/docs/providers/nvidia_nim) · [LiteLLM Claude Code non-Anthropic tutorial](https://docs.litellm.ai/docs/tutorials/claude_non_anthropic_models) · [LiteLLM OpenAI-compatible endpoints](https://docs.litellm.ai/docs/providers/openai_compatible) · [Ollama Codex integration](https://docs.ollama.com/integrations/codex) · [Ollama OpenAI compatibility](https://docs.ollama.com/api/openai-compatibility) · [Codex config reference](https://learn.chatgpt.com/docs/config-file/config-reference) · [Codex advanced config](https://developers.openai.com/codex/config-advanced) · [OpenRouter Codex CLI cookbook](https://openrouter.ai/docs/cookbook/coding-agents/codex-cli) · [OpenRouter Codex tutorial](https://openrouter.ai/blog/tutorials/codex-cli-openrouter/) · [Prince Arora, "Run Codex CLI Free with NVIDIA NIM" (Medium, 2026-05-11)](https://prince-arora-aws.medium.com/run-codex-cli-free-with-nvidia-nim-c8392f24243c) · [knightli local-LLM-with-Codex guide](https://knightli.com/en/2026/07/11/use-local-llm-api-with-codex-ollama-lm-studio-vllm/) · [morphllm Codex provider config](https://www.morphllm.com/codex-provider-configuration)
+
+---
+
+**Reconciliation summary: zero contradictions.** Your finding 1 is confirmed at source-line and runtime level. Your finding 2 is confirmed with upstream provenance (Ollama PR #13351, v0.13.3) — and it is the stronger of the two results, because it demonstrates the protocol requirement is satisfiable by a non-OpenAI server, which is exactly what isolates the NIM failure to NVIDIA rather than to Codex. The one caveat to carry forward: Ollama's `/v1/responses` is **non-stateful**, so a short `codex exec` won't exercise `previous_response_id` behavior.

--- a/.omc/kb/reports/agents/graphify-mining.md
+++ b/.omc/kb/reports/agents/graphify-mining.md
@@ -1,0 +1,266 @@
+# Agent report (verbatim): graphify-mining
+
+Persisted from agent transcript `5a7e97bf-884c-4514-9041-cb4b9877cca7.jsonl` on 2026-07-19.
+Captured per `.claude/rules/agent-report-persistence.md` (verbatim, at receipt).
+
+---
+
+Report complete. Findings persisted to `.omc/notepad.md`.
+
+---
+
+# Graphify community mining — practical tips, techniques & best practices
+
+**Target:** [Graphify-Labs/graphify](https://github.com/Graphify-Labs/graphify) — 91,533 ★, created 2026-04-03, default branch `v8`, homepage [graphify.com](https://www.graphify.com). PyPI package is **`graphifyy`** (double-y); CLI is `graphify`.
+
+**What I actually read:** the README (861 lines, fetched via API), `docs/how-it-works.md`, ~40 issues/PRs read in full, ~2,000 issue/PR titles swept via the GitHub search API, 83 discussions enumerated with 12 read in full including maintainer replies, `graphify.com` + `/docs` + `/llms-full.txt`, and the Discord invite API. **X/Twitter content I could NOT read** — see §3.
+
+---
+
+## 1. GitHub issues, PRs & discussions
+
+### 1a. Local inference with Ollama
+
+| # | URL | Takeaway | Status |
+|---|---|---|---|
+| **820** | [issues/820](https://github.com/Graphify-Labs/graphify/issues/820) | Ollama's default context is **2048 tokens**; graphify wasn't wiring `GRAPHIFY_OLLAMA_NUM_CTX` into `_call_openai_compat`, so every chunk >2048 tok returned `content=""` → **0 nodes, 0 edges, silently**. Surfaced as `Expecting value: line 1 column 1`. | **Fixed** (env var now reaches the API layer) — but *always set `GRAPHIFY_OLLAMA_NUM_CTX` explicitly* |
+| **798** | [issues/798](https://github.com/Graphify-Labs/graphify/issues/798) | KV-cache saturation across chunks: chunks 1–2 perfect, chunks 3–4 degrade to "few tokens"/closing-bracket-only. Ollama session wasn't reset statelessly per chunk. Restarting fixed it temporarily. | **Closed/fixed**; if you see this pattern on any local backend, suspect context leak |
+| **1686** | [issues/1686](https://github.com/Graphify-Labs/graphify/issues/1686) | A **wedged Ollama server hangs the entire extract indefinitely** despite `--api-timeout 180`. Signature: graphify at 0% CPU, Ollama idle, an independent `curl /api/generate` *also* hangs. Reproduced 3× in one session. Reporter ran `--max-concurrency 1`, `qwen3-coder-next` (extract) + `qwen3.5:122b` (label). | **Closed/fixed**; the 0%-CPU + idle-server + independently-hung-curl triage signature is worth keeping |
+| **792** | [issues/792](https://github.com/Graphify-Labs/graphify/issues/792) | Best single tuning writeup. On RTX 5090 + Ryzen 9950X3D: `max_workers` was capped at 8 (400% underuse on 32 threads); default `token_budget` 60k and `max_concurrency` 4 are **cloud defaults that cause timeouts/VRAM OOM on local**. Manual patching → **95% GPU saturation**. Requested values: `max_workers: 32`, `token_budget: 16384`, `max_concurrency: 1`, `temperature: 0.3`, `seed: 42`, `num_ctx: 65536`. | **Closed** — `--max-workers`/`--token-budget`/`--max-concurrency` now exist as flags; the proposed `graphify.yaml` did not ship |
+| **1940** | [issues/1940](https://github.com/Graphify-Labs/graphify/issues/1940) | graphify reads `OLLAMA_BASE_URL`, but Ollama itself only defines **`OLLAMA_HOST`** — no `OLLAMA_BASE_URL` concept exists upstream. | **Open bug**; two competing fix PRs [#1966](https://github.com/Graphify-Labs/graphify/pull/1966), [#2019](https://github.com/Graphify-Labs/graphify/pull/2019). **Set `OLLAMA_BASE_URL` explicitly today.** |
+| **1272** | [pull/1272](https://github.com/Graphify-Labs/graphify/pull/1272) | `OLLAMA_BASE_URL` should include the **`/v1`** path. | Open docs PR — worth doing anyway |
+| **1168** | [issues/1168](https://github.com/Graphify-Labs/graphify/issues/1168) | mDNS `.local` hostnames were **hard-blocked** as link-local (a Bonjour name always resolves an `fe80::` companion alongside its routable v4), with no override. Same host by literal IPv4 was accepted. Reporter was running **LM Studio on a second Mac**. | **Closed/fixed** — workaround was pinning the IPv4 |
+| **1549** | [pull/1549](https://github.com/Graphify-Labs/graphify/pull/1549) | Proposes laptop-safe local defaults: **`qwen2.5-coder:3b` first, then `gemma3:4b`**; routes through Ollama's native **`/api/chat`** so `num_ctx` actually applies; retry-next-local-model on failure. | **Open PR**, not merged — treat the model list as a community suggestion, not shipped behavior |
+
+### 1b. OpenAI-compatible base URLs / vLLM / NIM / LM Studio
+
+| # | URL | Takeaway | Status |
+|---|---|---|---|
+| **959** | [issues/959](https://github.com/Graphify-Labs/graphify/issues/959) | The original ask: local models were Ollama-only, OpenAI base-url hardcoded, blocking vLLM. | **Open**, but functionally superseded — `OPENAI_BASE_URL`/`OPENAI_MODEL` now exist and README explicitly lists llama.cpp/vLLM/LM Studio |
+| **981 / 1084** | [981](https://github.com/Graphify-Labs/graphify/issues/981), [1084](https://github.com/Graphify-Labs/graphify/issues/1084) | Configurable base URL for OpenAI **and** Anthropic backends. | Delivered via [#1273](https://github.com/Graphify-Labs/graphify/pull/1273), [#1113](https://github.com/Graphify-Labs/graphify/pull/1113), [#1458](https://github.com/Graphify-Labs/graphify/pull/1458) (`*_BASE_URL` for kimi/gemini/deepseek too) |
+| **1223** | [issues/1223](https://github.com/Graphify-Labs/graphify/issues/1223) | Gateways that stream when `stream` is omitted break the SDK — needed a way to force `stream:false`. | **Closed** — relevant if you front a local model with a proxy |
+| **1621** | [issues/1621](https://github.com/Graphify-Labs/graphify/issues/1621) | `deepseek-v4-flash` runs with **thinking enabled by default** with no `extra_body` override → JSON-parse failure on a semantic chunk. Same class as the kimi fix ([#623](https://github.com/Graphify-Labs/graphify/pull/623), [#610](https://github.com/Graphify-Labs/graphify/issues/610): kimi rejects `temperature=0`). | **Closed** — **reasoning models need thinking disabled or they return empty `content`** |
+| **1107 / 1041** | [1107](https://github.com/Graphify-Labs/graphify/pull/1107), [1041](https://github.com/Graphify-Labs/graphify/pull/1041) | Azure OpenAI backend (merged); OpenRouter backend (open). | Azure shipped as `--backend azure` |
+
+**No NVIDIA NIM–specific issue exists** — I searched and found none. NIM would ride the generic `--backend openai` + `OPENAI_BASE_URL` path.
+
+### 1c. Truncation / output-token limits — the biggest practical trap
+
+| # | URL | Takeaway | Status |
+|---|---|---|---|
+| **1365** | [discussions/1365](https://github.com/Graphify-Labs/graphify/discussions/1365) | User pointed the **Ollama shim at OpenRouter**; got constant `Unterminated string` + `chunk of 4 truncated at depth 0, splitting into halves of 2 and 2`. Maintainer root-caused a **real bug**: `ollama`/`openai`/`deepseek`/`kimi` configs declare `max_tokens: 16384`, but dispatch only read `max_completion_tokens` (gemini-only key) → those four silently fell back to an **8192** cap. Fixed in `5b0c154`. Maintainer's explicit advice: **prefer `--backend openai` + `OPENAI_BASE_URL` over the Ollama shim for OpenAI-compatible gateways.** | **Fixed** — confirmed-working guidance |
+| **1758** | [issues/1758](https://github.com/Graphify-Labs/graphify/issues/1758) | On the **skill/subagent path** (no API key → Claude Code Agent-tool subagents act as the LLM), each subagent must emit a whole chunk's JSON in one turn. `SKILL.md` chunks by **file count (20–25), not output size**, so `--mode deep` on dense corpora blows the **~64k output-token turn limit** → the chunk file is *never written*, no partial, no error. Presents as either an infinite hang or 12–28 min unexplained latency. Step B3's diagnostic ("you probably used a read-only Explore subagent") is a **plausible-but-wrong** explanation. This path never goes through `graphify/llm.py`, so it gets none of the bisection recovery the headless backends have. | **OPEN known-bug** — highly relevant to anyone driving graphify from an agent harness |
+
+### 1d. Video / image / document ingestion
+
+- **Video pipeline is `[video]` extra = faster-whisper + yt-dlp**, and per [`docs/how-it-works.md`](https://github.com/Graphify-Labs/graphify/blob/v8/docs/how-it-works.md) "Pass 2 — Video and audio (**local, no API calls**)". Ingest via `graphify add <youtube-url>`.
+- [#592](https://github.com/Graphify-Labs/graphify/issues/592) — **yt-dlp SSRF bypass** in `transcribe.download_audio`. Closed/fixed. [#1436](https://github.com/Graphify-Labs/graphify/pull/1436) (cap `max_filesize` to limit resource/SSRF abuse) and [#2021](https://github.com/Graphify-Labs/graphify/pull/2021) (normalize `www.`-prefixed URLs before validation) are still **open**. If you ingest untrusted URLs, this is your risk surface.
+- **[#1109](https://github.com/Graphify-Labs/graphify/issues/1109) — images are broken on headless `extract`.** `_read_files` does `path.read_text(errors="replace")` on *every* semantic file, so a PNG becomes replacement-character garbage. `--backend claude-cli` exits 1 outright; API backends emit hollow nodes guessed from the filename. **No backend ever puts the image in front of a vision model.** **OPEN.** Fix proposed in #1110. Related: #450, #181 (images inside PDFs).
+- [#259](https://github.com/Graphify-Labs/graphify/issues/259) — local PDF parsing without an LLM API: still **open**.
+
+### 1e. Query patterns (BFS/DFS, budget, affected, path, explain) — and their known defects
+
+Confirmed CLI surface (README `Full command reference`):
+```
+graphify query "what connects attention to the optimizer?"
+graphify query "..." --dfs --budget 1500
+graphify path "DigestAuth" "Response"
+graphify explain "SwinTransformer"
+graphify affected <symbol>
+```
+Note: **there is no `--context` flag** in the documented surface. I searched the README and command reference and found `--budget`, `--dfs`, `--graph`, and (open PRs only) `--recency`.
+
+| # | URL | Takeaway | Status |
+|---|---|---|---|
+| **445** | [issues/445](https://github.com/Graphify-Labs/graphify/issues/445) | BFS seeds are picked by naive substring match `sum(1 for t in terms if t in label)`. On a mixed corpus, a query about `seg_result.planes` seeded on **three PNG golden-test renders** whose captions contained the terms; all 15 real mutation sites were missed. Proposed weighting: `code 1.0 / document 0.7 / image 0.4` × degree. | **OPEN known-bug** — hits exactly the cross-cutting queries graphify markets |
+| **449** | [issues/449](https://github.com/Graphify-Labs/graphify/issues/449) | Root cause of the above: **semantic subagent labels are free-form 200-char summaries**, which accidentally match dozens of terms and crowd out precise AST symbol labels. Measured on an 8,333-node graph: top-3 seeds for *every* semantic query came from the same 20 files. Proposed schema split: short `label` + verbose `summary`. | **OPEN known-bug** |
+| **2004** | [issues/2004](https://github.com/Graphify-Labs/graphify/issues/2004) | **`affected` silently returns false negatives.** `from pkg.sub.mod import X` creates an `imports_from` edge whose target ID is derived from the *import string* (`pkg_sub_mod`), not the real scanned node (`sub_mod`). So `affected "mod.py"` and `affected "sub_mod"` both return "No affected nodes found" while `affected "pkg_sub_mod"` works. `diagnose multigraph` showed **thousands of `dangling_endpoint_edges`** on a 21k-node graph. Also: `god_nodes` is not a CLI subcommand; `--output` is ignored on `extract`. | **OPEN known-bug** — an agent reads this as "nothing depends on this" |
+| **1969** | [issues/1969](https://github.com/Graphify-Labs/graphify/issues/1969) | `explain` resolves ambiguous terms **silently** (unlike `path`, which warns); resolution degrades as the graph grows. | OPEN |
+| **1654 / 1664** | [1654](https://github.com/Graphify-Labs/graphify/issues/1654), [1664](https://github.com/Graphify-Labs/graphify/pull/1664) | Per-project `config.json` defaults for query budget/depth. | Open PR |
+| **1296** | [issues/1296](https://github.com/Graphify-Labs/graphify/issues/1296) | "query is a traversal, agents need a **name harvester**" — a label-match node enumeration subcommand. | Open, and a genuinely good idea for agent tooling |
+| **1184** | [issues/1184](https://github.com/Graphify-Labs/graphify/issues/1184) | Argues the graph *quality* is fine; the gap is the **retrieval/API surface for agents** — asks for composable structured primitives ("what files are involved in changing X", "blast radius of Y") over `graph.json`. | Open — directly on-point for building on top |
+| **977** | [issues/977](https://github.com/Graphify-Labs/graphify/issues/977) | `--exclude` / `--no-tests` to filter by `source_file` **before** BFS. | Open |
+
+### 1f. Accuracy / hallucination of semantic extraction
+
+- **[#198](https://github.com/Graphify-Labs/graphify/issues/198) — the semantic layer is mostly disconnected from the AST graph.** The two passes run in parallel, so the semantic pass can't intentionally attach to AST nodes; fusion relies on **exact node-id collision**, which almost never happens (`SentenceTransformer` vs `"sentence transformer"`). Verified on HKUDS/OpenHarness: effectively **zero `code↔document` or `code↔concept` bridges** — one code component, one separate semantic subgraph. **OPEN.** This is the single most important caveat for anyone treating graphify as a unified KB.
+- **[#437](https://github.com/Graphify-Labs/graphify/issues/437)** — cross-file inference creates **false edges via common .NET method names**; fix PR [#440](https://github.com/Graphify-Labs/graphify/pull/440) adds a BCL blocklist. Sibling: [#1221](https://github.com/Graphify-Labs/graphify/pull/1221) blocklists Python stdlib + JS globals from noise nodes and INFERRED edges. Both **open**.
+- **[#1318](https://github.com/Graphify-Labs/graphify/issues/1318)** — inconsistent node IDs at *definition* vs *reference* sites → edges connect to orphan "shadow nodes". **[#952](https://github.com/Graphify-Labs/graphify/issues/952)** — ID collisions on identical filenames across folders **merge distinct functions into one node**. Both open.
+- **Confidence tiers are the mitigation, and they work.** Per `how-it-works.md`: `EXTRACTED` (always confidence 1.0), `INFERRED` (discrete rubric, 0.0–1.0), `AMBIGUOUS` (flagged for manual review). [#1676](https://github.com/Graphify-Labs/graphify/issues/1676) is a strong independent validation — see §1i.
+- **[#2051](https://github.com/Graphify-Labs/graphify/issues/2051)** (open, actively discussed) argues staleness must be **enforced at query time**, not merely stored: *"The original harm is not that stale nodes exist. It is that they are returned in polished, canonical-sounding form with no warning."* Acceptance criteria proposed: default queries exclude or materially down-rank stale nodes. Related: [#1665](https://github.com/Graphify-Labs/graphify/pull/1665) opt-in `--recency` flag.
+
+### 1g. Memory / save-result / reflect feedback loop — **confirmed working, shipped 0.8.47**
+
+From [#1441](https://github.com/Graphify-Labs/graphify/issues/1441) (design, closed) → [#1443](https://github.com/Graphify-Labs/graphify/pull/1443) + [#1542](https://github.com/Graphify-Labs/graphify/pull/1542) (merged), and the [announcement discussion #1449](https://github.com/Graphify-Labs/graphify/discussions/1449):
+
+```bash
+graphify save-result --question "how does auth work?" \
+  --answer "JWT via verify_token()" \
+  --nodes "verify_token()" "jwt_auth.py" --outcome useful
+# --outcome ∈ useful | dead_end | corrected   (+ --correction "..." for corrected)
+
+graphify reflect                    # → graphify-out/reflections/LESSONS.md
+graphify reflect --if-stale         # no-op if LESSONS.md newer than all inputs — cheap per session
+graphify reflect --graph graphify-out/graph.json   # group by community + write .graphify_learning.json overlay
+```
+Ranking mechanics (maintainer, verbatim-sourced): **deterministic, uses no LLM**. Citations decay by recency (`--half-life-days`, default **30**). A node only becomes a *preferred* source after appearing in **≥2 separate useful results** (`--min-corroboration`, default 2) — a single save is "tentative", not trusted. Conflicts (useful once, dead-end later) surface **once with a "most recent wins" note**, not silently in both lists. Citations pointing at nodes that no longer exist are **dropped**, so deleting code clears its lessons. The overlay tags nodes preferred/tentative/contested and makes `explain`/`query` print a `Lesson:` hint, flagged **"code changed — re-verify"** when the source moved on. Git post-commit/post-checkout hooks run `reflect` automatically once you have outcomes saved.
+
+Related open work: **[#1871](https://github.com/Graphify-Labs/graphify/pull/1871) `graphify curate`** — durable *human* corrections that survive a rebuild.
+
+### 1h. Global / multi-repo graphs
+
+Confirmed CLI (README):
+```bash
+graphify extract ./docs --global --as myrepo          # extract + register into cross-project graph
+graphify global add graphify-out/graph.json --as myrepo   # → ~/.graphify/global-graph.json
+graphify global remove myrepo
+graphify global list                                   # repos + node/edge counts
+graphify global path
+graphify merge-graphs a.json b.json --out merged.json
+```
+Caveats: [#1691](https://github.com/Graphify-Labs/graphify/pull/1691) "preserve repository-local identities" on merge (open); [#569](https://github.com/Graphify-Labs/graphify/issues/569) scoped resolution for monorepos/name collisions (open); [#1177](https://github.com/Graphify-Labs/graphify/issues/1177) "how to integrate with multi repo project" (open); [#1687](https://github.com/Graphify-Labs/graphify/issues/1687) recursive `update` for monorepo/workspace layouts (open).
+
+**[Discussion #645](https://github.com/Graphify-Labs/graphify/discussions/645)** is the best practical large-project pattern I found — a user split output into type-scoped folders plus an `AllFolders/` master graph, with a `CLAUDE.md` telling the assistant to prefer the scoped `GRAPH_REPORT.md` for narrow questions. Community answer: generate the **wiki for `AllFolders` only** (per-folder wikis cause "massive token redundancy and split the navigation index"); regenerate the wiki only at major milestones, not per update; devs update only `AllFolders` locally and **offload type-scoped graph updates to nightly CI**.
+
+**[Discussion #1408](https://github.com/Graphify-Labs/graphify/discussions/1408)** (multi-machine): there is no hosting story and none is needed — **commit `graphify-out/` to git**; gitignore `graphify-out/cache/` (mtime-based, invalid after a fresh clone) and `graphify-out/cost.json`.
+
+### 1i. `merge-driver` / git-hook workflow
+
+- `graphify hook install` writes **post-commit + post-checkout** hooks (AST-only rebuild, **no API cost**) *and* registers a **git merge driver** that union-merges `graph.json`, so two devs committing in parallel never get conflict markers.
+- **[#1902](https://github.com/Graphify-Labs/graphify/issues/1902)** — `hook install` **never actually registered the merge driver** that both README and CHANGELOG 0.7.0 documented. **Closed/fixed** — but verify on your version.
+- **[#1385](https://github.com/Graphify-Labs/graphify/issues/1385)** — `hook install` wrote a junk directory and **reported false success** when `core.hooksPath` resolved to a non-POSIX (Windows) path. Closed.
+- **[#791](https://github.com/Graphify-Labs/graphify/issues/791)** — the post-commit hook **spawned unbounded detached Python rebuilds**; concurrent multi-repo commits exhausted memory. Closed. Follow-up **[#1037](https://github.com/Graphify-Labs/graphify/issues/1037)** — still raced on `graph.json` with rapid same-repo commits. Closed; `graph.json`/`manifest.json` are now written **atomically** ([#1952](https://github.com/Graphify-Labs/graphify/pull/1952)).
+- README (v0.9.x): re-run `graphify hook install` after any upgrade — the hook **embeds the interpreter path** at install time.
+
+### 1j. Performance & scale
+
+| # | URL | Takeaway |
+|---|---|---|
+| [#1958](https://github.com/Graphify-Labs/graphify/issues/1958) | open | `detect()` is CPU-bound **35+ min on a large monorepo** despite dir pruning, while `git ls-files` discovery takes ~1s |
+| [#1964](https://github.com/Graphify-Labs/graphify/issues/1964) | open | `manifest.json` uses **absolute paths as keys** → `--update` always triggers a **full rebuild on CI or a different clone path**. (README now claims keys are relative + re-anchored — verify on your version; the issue is still open.) |
+| [#2033](https://github.com/Graphify-Labs/graphify/issues/2033) | open | The update runbook **omits `kind="ast"`**, so incremental update **re-extracts the entire corpus semantically** — i.e. pays full LLM cost when it shouldn't |
+| [#2015](https://github.com/Graphify-Labs/graphify/issues/2015) | open | `watch._rebuild_code` stamps the whole corpus into the manifest on code-only rebuilds → `--update` **silently skips new docs** |
+| [#1711](https://github.com/Graphify-Labs/graphify/issues/1711) | open | `build_merge` **severs edges from unchanged files into re-extracted files** — measured **−12% doc↔code edges in one update cycle**; endpoints get replaced, survivors dangle, dangling-edge cleanup eats them |
+| [#728](https://github.com/Graphify-Labs/graphify/issues/728) | open | Large graphs carry **24% isolated dead-weight nodes** from bundled/synthetic source files |
+| [#446](https://github.com/Graphify-Labs/graphify/issues/446) | open | Leiden on code-heavy graphs → **274 communities at cohesion 0.01** (fragmentation). Mitigations that shipped: `--resolution`, `--exclude-hubs` |
+| [#1431](https://github.com/Graphify-Labs/graphify/pull/1431) | merged | Trigram candidate prefilter cuts O(N) `serve` query latency, byte-identical results |
+| [#370](https://github.com/Graphify-Labs/graphify/pull/370) | open | igraph C backend for betweenness centrality, **~100× speedup** |
+| [#1019](https://github.com/Graphify-Labs/graphify/discussions/1019) | — | `graphify export` **hard-caps at 512 MB `graph.json`**; [#1708](https://github.com/Graphify-Labs/graphify/issues/1708) proposes transparent sharded-graph loading |
+| README | — | HTML viz becomes unopenable **>5000 nodes** — use `--no-viz` and query the JSON |
+
+**Determinism ([#1090](https://github.com/Graphify-Labs/graphify/discussions/1090) / [#1105](https://github.com/Graphify-Labs/graphify/discussions/1105))** — the most useful maintainer thread in the repo. A user measured 4 runs of `graphify update` on an unchanged repo: node counts and MD5 all differed. Maintainer root-caused it to **`os.walk()` returning files in filesystem b-tree order**, with several first-writer-wins downstream passes (cross-file import resolution, label dedup, symbol resolution) — *not* Leiden, which is properly seeded (`random_seed=42, trials=1`). Fixed in `8db19d6` by lexicographically sorting `all_files`. A second residual — 77–88% of nodes "changing community" between runs — was a **labeling artifact**: community integer IDs came from size-sorting, and equal-sized small communities permuted. Fixed via a total order `(-size, sorted nodes)`. Key operational line: **"the default install uses Louvain, which is fully deterministic (verified 20/20 identical runs) — so if you need byte-stable `graph.json`, a default install (no `[leiden]` extra) gives it."** The `[leiden]`/graspologic path retains a ~0.1% residual wobble when re-splitting small low-cohesion subgraphs.
+
+### 1k. Third-party work built on graphify (best real-world validation)
+
+**[#1676](https://github.com/Graphify-Labs/graphify/issues/1676)** — [`jest-graph-tia`](https://github.com/Elbltagy2/jest-graph-tia), a Test Impact Analysis orchestrator using `graph.json` as its semantic layer. The technique is directly reusable: git diff → **reverse-BFS with per-confidence-tier hop budgets (EXTRACTED 6 / INFERRED 2 / AMBIGUOUS off)** → feed the expanded set to `jest --findRelatedTests`. Because the graph only ever *widens* Jest's input, selection can never be less safe than Jest's own. Measured on a production Next.js repo (23,403 nodes / 47,913 edges): on **5 of 10 recent commits** it selected 5–8 genuinely affected tests Jest's scanner missed (root cause: **`import type` dependencies**, which Jest drops but tree-sitter keeps as EXTRACTED edges), at ~2% of the suite. Verified schema facts: edges live under `links`, **direction = source-depends-on-target**; **INFERRED edges survive `graphify update` re-extraction**; incremental update on 23k nodes ≈ **41s**.
+
+### 1l. Benchmarks (maintainer-published, with caveats stated)
+
+[Discussion #1328](https://github.com/Graphify-Labs/graphify/discussions/1328) + [#1677](https://github.com/Graphify-Labs/graphify/discussions/1677) → [BENCHMARKS.md](https://github.com/Graphify-Labs/graphify/blob/v8/BENCHMARKS.md). Agent-capability run on **ERPNext** (~1M LOC), fixed agent (Claude Opus 4.8, ≤14 turns), real measured token usage, one added tool per treatment:
+
+| config | accuracy | tokens vs floor | $/task |
+|---|--:|--:|--:|
+| **+ graphify** | **82.0%** | **1.3×** | **$0.320** |
+| + codebase_memory | 80.5% | 2.7× | $0.599 |
+| + repomix | 80.5% | **30.0×** | $3.936 |
+| + codegraphcontext | 79.2% | 2.2× | $0.391 |
+| + claude_context | 79.1% | 1.4× | $0.340 |
+| grep/read floor | 70.8% | 1.0× | $0.322 |
+
+Memory benchmarks: LOCOMO n=300 recall@10 **0.497** (~10× mem0), QA 45.3%; LongMemEval-S n=50 **76%**. Judge blind-validated against a second judge (90.6% agreement, κ=0.81). **The maintainer flags honestly** that the LOCOMO/LongMemEval "graphify" configuration is *"an experimental engine implementing graphify's retrieval architecture over conversation turns — a benchmark prototype of the architecture, not the shipped package as-is"* (turn-level nodes in SurrealDB/HNSW with hybrid dense+lexical seeds). Independent community benchmark framework: [FolatheDuckofDuckingburg/graphify/tree/v8/benchmarks](https://github.com/FolatheDuckofDuckingburg/graphify/tree/v8/benchmarks) (16 tasks, paired trials, McNemar's test).
+
+---
+
+## 2. Discord — **invite found, history NOT read**
+
+Both invites resolve (via the public `discord.com/api/v10/invites/<code>` endpoint) to the **same guild**, id `1496114518160441345`, name **"Graphify Labs (YC S26)"**, inviter `graphifylabs` / "Safi (Graphify Labs)":
+
+- **https://discord.gg/XPPYrdw3Yp** — from [graphify.com/llms-full.txt](https://graphify.com/llms-full.txt). `expires_at: null` → **permanent, use this one**.
+- **https://discord.gg/598Ad9zQZ** — the badge in the [README](https://github.com/Graphify-Labs/graphify#readme). `expires_at: 2026-07-28` → **expires in 9 days**. Worth reporting upstream.
+
+Server description (verbatim from the invite payload): *"Join developers, builders, and contributors turning codebases into queryable knowledge. Graphify gives AI assistants a second brain that cuts token usage and keeps answers grounded instead of guessed."* Guild features include `NEWS` and `COMMUNITY`.
+
+**I did not join and I could not read any channel history, announcements, or pinned messages.** Everything I know about the Discord is the invite metadata above plus two GitHub discussions that merely *reference* it ([#1526 "Join the graphify community on Discord"](https://github.com/Graphify-Labs/graphify/discussions/1526), [#773 "Follow us on X + Discord community coming soon"](https://github.com/Graphify-Labs/graphify/discussions/773)). **No Discord content is quoted anywhere in this report.**
+
+---
+
+## 3. Twitter / X — **handle found, content NOT readable**
+
+- **Handle: [@graphify](https://x.com/graphify)** — sourced from the README footer badge (line 858 of the fetched README), which links `https://x.com/graphify`.
+- Maintainer GitHub is [safishamsi](https://github.com/safishamsi) ("Safi"); the Discord inviter's global name is "Safi (Graphify Labs)". **I did not find a verified personal X handle for him** and will not guess one.
+- **I could not read any tweets.** `WebFetch` on `https://x.com/graphify` returned **HTTP 402 Payment Required** — X blocks unauthenticated fetches. A web search surfaced the account's existence and third-party coverage but **no readable post content**. **No tweets are quoted or summarized in this report.**
+- Announcement [#773](https://github.com/Graphify-Labs/graphify/discussions/773) ("Follow us on X + Discord community coming soon") confirms X is an official channel. LinkedIn is also official ([#1598](https://github.com/Graphify-Labs/graphify/discussions/1598) "Graphify Labs is live on LinkedIn").
+- ⚠️ A web search returned **`graphify.net`** ("Graphify — Knowledge Graph Skill for AI Coding Assistants"). This is **not** linked from the repo or from `graphify.com`, and the README explicitly warns that *"Other `graphify*` packages on PyPI are not affiliated."* I did not use it as a source and **you should treat `graphify.net` as unverified/possibly unaffiliated.**
+
+---
+
+## 4. Docs / website
+
+- **[graphify.com](https://www.graphify.com)** — landing page. Positions **graphify Enterprise** as an always-on layer over meetings/files/docs/code ("free trial launching soon"). [Announcement #1798](https://github.com/Graphify-Labs/graphify/discussions/1798): "Graphify is now at graphify.com — Enterprise early access is open." The project [joined Y Combinator S26](https://github.com/Graphify-Labs/graphify/discussions/983).
+- **[graphify.com/llms-full.txt](https://graphify.com/llms-full.txt)** — the highest-signal machine-readable doc; it's what I'd point an agent at. Notable framing found only here: relation tags are **`EXTRACTED` / `INFERRED` / `AMBIGUOUS`** *"so agents distinguish grounded facts from guesses"*, and answers carry *"explicit graph paths with real file:line citations."*
+- Sub-pages: [/docs](https://graphify.com/docs), [/concepts](https://graphify.com/concepts), [/docs/mcp-tools](https://graphify.com/docs/mcp-tools), [/vs/rag](https://graphify.com/vs/rag), [/integrations](https://graphify.com/integrations).
+- In-repo docs: [`docs/how-it-works.md`](https://github.com/Graphify-Labs/graphify/blob/v8/docs/how-it-works.md) (pipeline, confidence rubric, `ProcessPoolExecutor` AST parallelism ≈1.66× over sequential on 84 files), [`ARCHITECTURE.md`](https://github.com/Graphify-Labs/graphify/blob/v8/ARCHITECTURE.md), [`BENCHMARKS.md`](https://github.com/Graphify-Labs/graphify/blob/v8/BENCHMARKS.md), [`docs/docker-mcp-sqlite.md`](https://github.com/Graphify-Labs/graphify/blob/v8/docs/docker-mcp-sqlite.md).
+- **No official blog found.** There's a paid book, ["The Memory Layer"](https://safishamsi.gumroad.com/l/qetvlo), linked from the README — I did not purchase or read it.
+- **Doc inconsistency worth knowing:** README line 536 says query logging is on by default with `GRAPHIFY_QUERY_LOG_DISABLE=1` to opt out, while lines 520–521 say it's **off** by default and needs `GRAPHIFY_QUERY_LOG_ENABLE=1` (per [#1797](https://github.com/Graphify-Labs/graphify/issues/1797)). The opt-in text is the newer one. Log path: `~/.cache/graphify-queries.log`.
+
+---
+
+## Actionable best-practices distilled
+
+**Build the graph outside your agent's context.** From [discussion #1931](https://github.com/Graphify-Labs/graphify/discussions/1931): run `graphify extract . --code-only` in a **terminal**, not `/graphify .` in chat — the latter spends your session's tokens on graph construction. Code parsing is tree-sitter-only: no API key, no LLM, zero cost.
+
+**Local Ollama — the settings that actually matter:**
+```bash
+GRAPHIFY_OLLAMA_NUM_CTX=32768 \
+GRAPHIFY_OLLAMA_KEEP_ALIVE=0 \
+OLLAMA_BASE_URL=http://localhost:11434/v1 \
+graphify extract ./docs --backend ollama \
+  --max-concurrency 1 --token-budget 4000 --api-timeout 900 --max-workers 16
+```
+- `--max-concurrency 1` — the default of 4 is a *cloud* default and causes local queue congestion / VRAM OOM ([#792](https://github.com/Graphify-Labs/graphify/issues/792)).
+- **Always set `GRAPHIFY_OLLAMA_NUM_CTX` explicitly.** Ollama's own default is 2048; anything larger silently returned empty ([#820](https://github.com/Graphify-Labs/graphify/issues/820)). Drop to 8192 if VRAM-constrained and pair with `--token-budget 4000`.
+- `GRAPHIFY_OLLAMA_KEEP_ALIVE=0` unloads the model between chunks — saves VRAM on small GPUs.
+- `--max-workers` is **AST** parallelism (independent of LLM concurrency) — raise it to your core count; the old hardcoded cap was 8.
+- Set `OLLAMA_BASE_URL` explicitly and include `/v1`; graphify does **not** yet read Ollama's real `OLLAMA_HOST` ([#1940](https://github.com/Graphify-Labs/graphify/issues/1940), unfixed).
+
+**Model choices (what's actually attested, not marketing):** community-reported working setups are `qwen3-coder-next` for extraction + `qwen3.5:122b` for labeling ([#1686](https://github.com/Graphify-Labs/graphify/issues/1686)), `gemma4:31b` on 24GB+ VRAM ([#792](https://github.com/Graphify-Labs/graphify/issues/792)), and — from an unmerged PR, so treat as a suggestion — `qwen2.5-coder:3b` then `gemma3:4b` for laptops ([#1549](https://github.com/Graphify-Labs/graphify/pull/1549)). **Disable "thinking" on any reasoning model** or `content` comes back empty (kimi #623, deepseek #1621).
+
+**For any OpenAI-compatible server (vLLM, llama.cpp, LM Studio, OpenRouter, NIM), use `--backend openai`, not the Ollama shim.** This is the maintainer's explicit recommendation in [discussion #1365](https://github.com/Graphify-Labs/graphify/discussions/1365) — it's the cleaner code path and avoids the Ollama-specific quirks entirely:
+```bash
+OPENAI_BASE_URL=http://localhost:8000/v1 OPENAI_MODEL=<name-from-/v1/models> \
+  graphify extract ./docs --backend openai
+```
+
+**When you see `LLM returned invalid JSON` / `Unterminated string`: don't panic, then fix the cap.** graphify auto-recovers by bisecting the chunk, so it's noise, not data loss. The reliable levers, in order: `GRAPHIFY_MAX_OUTPUT_TOKENS=16384` (or 32768) to lift the cap, then `--token-budget 4000` to shrink the input so the output shrinks with it. If your model has a hard output ceiling, only `--token-budget` helps.
+
+**If you drive extraction through an agent harness (no API key), cap chunk size yourself.** [#1758](https://github.com/Graphify-Labs/graphify/issues/1758) is unfixed: the skill chunks by file count (20–25), not output size, and `--mode deep` on dense corpora blows the ~64k output-token turn limit — the chunk file is never written and the failure looks like a hang. Prefer a headless backend (which has bisection recovery) over the subagent path for deep mode, and treat "chunk file never appeared" as *too big*, not *wrong subagent type*.
+
+**Query patterns that work, and the traps.** `graphify query "<q>" --dfs --budget 1500` for scoped traversal; `graphify path A B` for connection tracing; `graphify explain X` for one concept. There is **no `--context` flag**. Traps to design around: seed selection is naive substring matching on `label`, so image/doc nodes with caption-y labels hijack code queries ([#445](https://github.com/Graphify-Labs/graphify/issues/445), [#449](https://github.com/Graphify-Labs/graphify/issues/449)) — if you're building on top, do your own seed weighting by `file_type` and degree. And **`affected` silently returns empty on the natural ID guess** ([#2004](https://github.com/Graphify-Labs/graphify/issues/2004)) — resolve the real node ID first (or check `diagnose multigraph` for `dangling_endpoint_edges`) rather than trusting "No affected nodes found."
+
+**Traverse with confidence-tier hop budgets, not uniform depth.** The single best technique I found, from a production user ([#1676](https://github.com/Graphify-Labs/graphify/issues/1676)): reverse-BFS with **EXTRACTED 6 hops / INFERRED 2 hops / AMBIGUOUS off**. It exploits the fact that `EXTRACTED` edges are deterministic tree-sitter facts (confidence 1.0) while `INFERRED` edges are the ones that hallucinate ([#437](https://github.com/Graphify-Labs/graphify/issues/437), [#1221](https://github.com/Graphify-Labs/graphify/pull/1221)). Edges live under `links`; direction is **source-depends-on-target**.
+
+**Use the feedback loop — it's deterministic and free.** `save-result --outcome useful|dead_end|corrected` → `reflect --if-stale` at session start. The defaults are well-chosen: 30-day half-life, ≥2 corroborations before a node is "preferred", conflicts surfaced once with most-recent-wins, and citations to deleted nodes auto-dropped. `graphify hook install` runs `reflect` for you post-commit. Add `graphify curate` ([#1871](https://github.com/Graphify-Labs/graphify/pull/1871)) to your watch list if you need human corrections to survive rebuilds.
+
+**Want byte-stable graphs? Skip the `[leiden]` extra.** The default install uses **Louvain, verified deterministic 20/20**; graspologic-Leiden retains a ~0.1% community-count wobble ([#1090](https://github.com/Graphify-Labs/graphify/discussions/1090)). If you compare graphs across runs, compare **co-membership signatures**, not community integer IDs.
+
+**Large-project layout:** one master graph + type-scoped sub-graphs, wiki generated for the master only, scoped updates offloaded to nightly CI ([#645](https://github.com/Graphify-Labs/graphify/discussions/645)). Use `--no-viz` above ~5000 nodes. Use `--resolution` / `--exclude-hubs 99` to fight community fragmentation ([#446](https://github.com/Graphify-Labs/graphify/issues/446)). For cross-repo, `graphify extract --global --as <name>` + `graphify global list`.
+
+**Team/multi-machine: commit `graphify-out/` to git.** Gitignore `graphify-out/cost.json` and `graphify-out/cache/` (mtime-based, invalid after a fresh clone). `graphify hook install` gives you free AST rebuilds *and* the `graph.json` union merge driver — verify it actually registered, since it silently didn't for a while ([#1902](https://github.com/Graphify-Labs/graphify/issues/1902)).
+
+**Add `graph.json` + `graphify-out/` to `.claudeignore`.** Every extract writes into the workspace and invalidates Claude Code's prompt cache, forcing a full re-upload at cache-write rates on the next turn (README troubleshooting).
+
+**A rules file alone will not make an agent use the graph.** From [discussion #921](https://github.com/Graphify-Labs/graphify/discussions/921) — a user's global `CLAUDE.md` rule was ignored; the fix was `graphify claude install`, which writes a **PreToolUse hook** that fires *at the moment the agent reaches for grep*. Maintainer's framing: *"it is not a soft instruction Claude can rationalize past; it is a hook that runs at the tool layer"* — and project-level `CLAUDE.md` beats user memory. `--strict` escalates the nudge to blocking the first raw source read of a session. Even so, expect to say "use graphify to find the affected modules first" for tasks the agent frames as *implementing* rather than *asking* ([#1931](https://github.com/Graphify-Labs/graphify/discussions/1931)).
+
+**Two caveats to design around before you build a KB on this:** (1) **the semantic layer is largely disconnected from the AST graph** — fusion relies on exact node-id collision, and a real-world check found effectively zero code↔concept bridges ([#198](https://github.com/Graphify-Labs/graphify/issues/198), open). Don't assume doc→code linkage exists; measure it on your corpus. (2) **Images are read as text garbage on headless `extract`** — no backend sends them to a vision model ([#1109](https://github.com/Graphify-Labs/graphify/issues/1109), open), so image nodes are guessed from filenames. Video/audio is fine (local faster-whisper), but if you ingest untrusted URLs, note that the yt-dlp size-cap and URL-normalization hardening PRs ([#1436](https://github.com/Graphify-Labs/graphify/pull/1436), [#2021](https://github.com/Graphify-Labs/graphify/pull/2021)) are still open.
+
+---
+
+## GitHub repos touched
+
+- [Graphify-Labs/graphify](https://github.com/Graphify-Labs/graphify) — the subject: issues, PRs, discussions, README, `docs/how-it-works.md`, BENCHMARKS/ARCHITECTURE references
+- [Graphify-Labs](https://github.com/Graphify-Labs) — the org (created per discussion #1647)
+- [safishamsi](https://github.com/safishamsi) — maintainer profile, to identify the author of the technical replies quoted above
+- [Elbltagy2/jest-graph-tia](https://github.com/Elbltagy2/jest-graph-tia) — third-party Test Impact Analysis tool built on `graph.json`; source of the confidence-tier hop-budget technique and the verified schema facts (issue #1676). *Referenced from the issue; I did not read its source.*
+- [FolatheDuckofDuckingburg/graphify](https://github.com/FolatheDuckofDuckingburg/graphify/tree/v8/benchmarks) — community fork hosting an independent benchmark framework (discussion #1328). *Referenced only.*
+- [HKUDS/OpenHarness](https://github.com/HKUDS/OpenHarness) — the corpus used in issue #198 to demonstrate the AST/semantic disconnect. *Referenced only.*
+- [anthropics/skills](https://github.com/anthropics/skills) — the cross-framework Agent-Skills spec targeted by `--platform agents`. *Referenced only.*

--- a/.omc/kb/reports/followup-cc-orchestra.md
+++ b/.omc/kb/reports/followup-cc-orchestra.md
@@ -1,0 +1,273 @@
+# Follow-up: `DeL-TaiseiOzaki/claude-code-orchestra` as Prior Art for an Autonomous Multi-Agent Orchestrator
+
+**Date:** 2026-07-19
+**Scope:** Read the repo's README + key source and judge it as prior art for OUR
+planned autonomous orchestrator. Answers: (1) what it is + architecture; (2)
+reusable techniques vs our design; (3) what to avoid; (4) verdict.
+
+**Builds on, does not repeat:**
+- `followup-orchestrator-trends.md` — the `fable-orchestrator` architecture, the
+  five-part spec contract, deny-hooks, the `STATUS:`+watchdog completion contract,
+  verify-gate-as-oracle, self-repair-against-the-gate. **Assumed read.**
+- `followup-fable-opus-orchestrator.md` — the two wiring **seams** (Seam A = SDK
+  `model`-override subagent, Claude-only; Seam B = Bash shell-out to a foreign CLI).
+  I use that vocabulary throughout and do not re-derive it.
+- `followup-codex-plugin-fable-prompt.md` — the Codex-plugin-for-Claude-Code surface.
+  This repo *uses* that plugin (`openai/codex-plugin-cc`); I note the integration
+  rather than re-describe the plugin.
+
+**Citation honesty (`verify-before-advancing.md` / `probes-need-a-control-arm.md`):**
+every claim below is anchored to a file I fetched from `raw.githubusercontent.com`
+at commit range HEAD (`main`, last push 2026-07-18). Repo metadata is from the
+GitHub API. I flag what is a *template/config repo* vs *running code*, and I do not
+inflate maturity.
+
+---
+
+## 1. What it is + architecture
+
+**One-liner:** a **GitHub "Use this template" repository** — a `.claude/` +
+`.agents/` + `.codex/` config scaffold plus ~145 KB Python / 58 KB Shell of hooks,
+skills, and install/update tooling — that turns an **interactive Claude Code TUI
+session** into a tiered multi-agent dev environment. It is **not** a headless daemon
+and **not** autonomous; a human sits at the Claude Code TUI and approves at each
+gate (`README.md`, `CLAUDE.md`).
+
+**Maturity (GitHub API, 2026-07-19):** 186 stars, 33 forks, **1 open issue**,
+created 2025-12-03, last push 2026-07-18 — *actively maintained*, essentially
+**solo-author** (DeL-TaiseiOzaki; recent merges are `claude/*` self-PRs). Languages
+Python 71% / Shell 29%. `LICENSE` present. Real tests exist but thin — three files:
+`test_install_script.py`, `test_agent_model_routing.py`, `test_post_bash_check.py`.
+Bleeding-edge model pins (`gpt-5.6-sol`, "Opus 4.7+", a `fable` advisor) mean it
+drifts with vendor releases; `fable-advisor` was added late and tiers.md still calls
+its config "TBD". **Author is Japanese; the system's default user-facing language is
+Japanese** (`settings.json` `"language":"japanese"`; `language.md` SSOT: think in
+English, respond to user in Japanese). Routing keywords are bilingual JP/EN.
+
+**Orchestration model — hierarchical delegator + a native peer-team primitive.**
+The orchestrator is Claude Code itself (Opus, 1M ctx), explicitly told it is *"an
+orchestrator, not an implementer"* with *"context conservation as top priority"* and
+a hard **Non-Goal: no implementation >10 LOC** — everything larger is delegated
+(`CLAUDE.md` §2). Three permanent tiers (`.agents/tiers.md`):
+
+| Tier | Id | Who | Role | Seam |
+|---|---|---|---|---|
+| 1 | `default` | Claude subagents: `general-purpose-sonnet` (routine impl), `general-purpose-opus` (research / hard impl / 1M-ctx codebase read), `codex-debugger` | the volume of work | **A** (SDK `model` frontmatter) |
+| 2 | `sol` | **Codex CLI** (`gpt-5.6-sol`, `model_reasoning_effort="xhigh"`, `approval_policy="never"`, `sandbox=workspace-write`) | design, planning, complex code, unknown-root-cause debug | **B** (`codex exec` bash shell-out) |
+| 3 | `fable` | `fable-advisor` (`model: fable`, tools `Read/Grep/Glob/Write`, write **only** to `.claude/docs/reviews/`) | **rare** escalation: design arbitration, unblocking, final review of large changes; *never implements* | A |
+
+This is a **concrete, shipped instance of exactly the two-seam split** the
+fable-opus report derived in the abstract: cheap Claude workers via Seam A, the
+non-Claude worker (Codex) via Seam B. It confirms that report's central claim in the
+wild — Codex is reached through `codex exec ... < /dev/null`, **not** a `model`-field
+subagent, because the SDK `model` field is Claude-only.
+
+**Parallel fan-out uses Claude Code's *native* "Agent Teams"** — `settings.json`
+sets `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`, and the `team-execute` skill spawns
+**peer teammates** (not parent-child subagents) that share a task list, partition by
+**file ownership**, coordinate via teammate-to-teammate messages, and are driven from
+the TUI (`Ctrl+T` task list, `Shift+Tab` "delegate mode" so the Lead can't implement,
+`Shift+Up/Down` to read teammate output). Two phases: Phase 1 IMPLEMENT (implementers
+per module + a Tester), Phase 2 REVIEW (Security / Quality / Test reviewers in
+parallel). This is a **different coordination topology than SDK subagents** — peer
+agents with a shared mutable task list and idle-hooks, vs our hierarchical
+parent→child fan-out. (See §2.)
+
+**Claude Code primitives used:** subagents (`.claude/agents/*.md` with `model:`
+frontmatter), the experimental **Agent Teams**, **hooks** (9 of them; wiring below),
+**skills** (14 slash-command workflows), and Seam-B **CLI shell-out** to Codex. **No
+MCP, no git worktrees, no distribution** — single-machine, single-session, one
+working tree. State is **markdown files**, not a database.
+
+**Hook wiring** (`settings.json`) — note these are almost all **advisory** (they emit
+`additionalContext` suggestions, they do not `deny`):
+- `UserPromptSubmit → agent-router.py` — keyword-matches the prompt (bilingual
+  substring lists) and *suggests* Fable / Codex-plugin / Codex / Opus-research.
+- `PreToolUse: Edit|Write → check-codex-before-write.py` — *suggests* consulting Codex.
+- `PostToolUse: Task → check-codex-after-plan.py`; `Bash → post-bash-check.py`
+  (in-process dispatcher: error-to-codex, test-failure analysis, `log-cli-tools.py`
+  which appends Codex I/O to `.claude/logs/cli-tools.jsonl`); `Edit|Write →
+  lint-on-save.py + post-implementation-review.py`.
+- `TeammateIdle` — a static reminder to write the work log + check the shared task list.
+- `PreCompact: auto` — injects "re-read CLAUDE.md / DESIGN.md / rules" on compaction.
+
+**State & context management** (all files, human-paced):
+- **3-zone `CLAUDE.md`**: Zone A (template, replaced on update) · Zone B (repo
+  identity, `/init`-managed) · Zone C (working state), split by `@orchestra:*`
+  markers; a conflict-aware `install.sh`/`update.sh` preserves B/C across template
+  bumps.
+- **`.claude/docs/DESIGN.md`** (要件定義書 = macro requirements) + rolling
+  **`PROGRESS.md`** (latest 5 checkpoint summaries) + `.claude/checkpoints/*`.
+- **`/checkpointing`** records the session, regenerates `PROGRESS.md`, and runs a
+  **Compact Phase** that prunes stale Zone-C blocks — a manual context-GC ritual.
+- **Save-to-file discipline**: any subagent result >20 lines → `.claude/docs/`,
+  return only a summary (`CLAUDE.md` §5C) — the context-isolation lever.
+- **Work-log SSOT** (`_shared/work-log-format.md`): every teammate writes a
+  5-section log to `.claude/logs/agent-teams/{team}/{name}.md`, machine-validated by
+  `validate_work_log.py` (exit 3 = missing sections) before the Lead reads it.
+
+---
+
+## 2. Reusable techniques vs our design — what THIS repo adds
+
+Our planned design: Fable/Opus architect → cheap workers over Seam A/B, five-part
+spec contract, **verify-gate-as-oracle**, **DAG frontier** scheduler, **SQLite/DBOS
+control plane**. Against that baseline, most of orchestra is *already covered* by the
+prior reports (the two seams, the spec contract, save-to-file, model routing). Four
+things are **genuinely additive** and worth pulling in; one is worth evaluating.
+
+### 2a. A concrete **"cheating-detection" acceptance rubric** — ADOPT into the verifier
+`.agents/AGENTS.md` §8 ("Guardrails — Completion Verification") and the mirror in
+`codex-delegation.md` give a **named adversarial checklist** the caller runs on a
+worker's "done", precisely because `approval_policy="never"` means *"verification
+replaces approval"*:
+- **(a) diff inspection** — reject unapproved deletions, stub/placeholder completions
+  (`pass`/`TODO`/`NotImplementedError` where real logic was asked), out-of-scope file
+  edits;
+- **(b) cheating detection** — reject if tests were **deleted / `@pytest.mark.skip`'d
+  / assertions loosened** to go green, exceptions **silently swallowed** (`except:
+  pass`), or **hardcoded returns** substituted for logic;
+- **(c) false-completion protocol** — report evidence, **re-delegate exactly ONCE**
+  with failure context appended, then **halt for explicit user approval**.
+
+Our verify-gate-as-oracle already answers *"did the objective checks pass?"* This
+rubric answers the orthogonal *"did the worker cheat to make them pass?"* — a
+gate can be defeated by a worker that weakens the gate's own inputs. **This is the
+one substantive technique the prior reports don't state as an explicit rubric.**
+Fold checks (a)+(b) into our worker-acceptance step (they map cleanly onto our
+`zero-skip` / `no_lint_skip` values already), and adopt the **hard retry cap of 1**
+(orchestra caps at 1; `fable-orchestrator` at ~3 — pick per cost tolerance).
+
+### 2b. **Native Agent Teams** as a *peer-parallel* topology — EVALUATE (with caveats)
+Our fan-out is hierarchical SDK subagents (parent holds the frontier; children are
+leaves that return one message). Orchestra's `team-execute` uses Claude Code's
+**experimental Agent Teams**: **peers** sharing a mutable **task list**, coordinating
+by direct messages, with a `TeammateIdle` hook that nudges an idle peer to pick up
+pending work. That is closer to a **work-stealing pool over a shared frontier** than
+to a tree — arguably a better fit for our **DAG frontier** than pure parent-child
+fan-out, because peers can pull the next ready task themselves. **Caveats before
+adopting:** it is (i) **experimental/undocumented** (a bare env flag), (ii)
+**single-machine + TUI-bound** (`Ctrl+T`/`Shift+Tab` are interactive affordances; not
+obviously drivable headless), and (iii) its conflict-avoidance is **file-ownership by
+convention**, not isolation (see §3). Treat it as *a topology to prototype*, not a
+dependency — our worktree isolation + SQLite frontier is the more robust substrate.
+
+### 2c. **Tool-neutral CLI-subagent contract** (`.agents/`) — ADOPT the abstraction
+The split `.claude/` (Claude-orchestrator spec) · `.agents/` (**tool-neutral** CLI
+subagent contract: Codex/Antigravity/Grok) · `.codex/` (Codex adapter) is a clean way
+to make **Seam-B workers provider-swappable**: `.agents/AGENTS.md` defines a required
+**response structure** (`TL;DR / Analysis / Plan / Patch Strategy / Validation /
+Risks`) and the completion guardrails **once**, and each vendor gets a thin adapter.
+This is the structural answer to "how do you keep one worker contract while swapping
+Codex↔Grok↔local" that the multiprovider report raised — worth mirroring so our
+Seam-B launcher targets an *interface*, not a specific CLI. `.codex/config.toml`
+centralizes model+effort; `check.sh` asserts `settings.json env.CODEX_MODEL` and
+`config.toml model` stay in sync (a small **config-coherence contract**, same spirit
+as our `suites.toml` wiring assertions).
+
+### 2d. **Machine-validated worker reports + Codex I/O audit log** — ADOPT-small
+`validate_work_log.py` (exit-3 on missing sections) makes the structured worker
+report a **checked artifact**, not a hope — the enforcement half our
+`agent-report-persistence.md` rule wants. And `log-cli-tools.py → cli-tools.jsonl`
+gives a lightweight **audit trail of every Seam-B shell-out's I/O** — cheap
+observability that our control plane should capture natively (it belongs in the
+SQLite control plane as a first-class row, not a sidecar JSONL).
+
+### Already-covered (no new signal): model routing (sonnet default / opus hard /
+codex sol / fable rare), the five-part **Prompt Contract** (Objective · Constraints ·
+Files · Acceptance checks · Output format — identical to our spec contract),
+save-to-file context isolation, "cost awareness: each teammate is a full Claude
+instance." Orchestra is a **cleaner-packaged restatement** of these, not a new idea.
+
+---
+
+## 3. What to avoid — anti-patterns & limitations
+
+1. **It is NOT autonomous — human approval gates everywhere.** Every `/feature` ends
+   *"Shall we proceed with fixes?"*; delegate mode, task-list monitoring, and review
+   synthesis all assume a human at the TUI. There is **no DAG scheduler, no frontier,
+   no persistent control plane, no budget enforcement, no resumability primitive**
+   beyond re-reading markdown. This is the fundamental mismatch: orchestra optimizes a
+   *human-in-the-loop session*; our program optimizes an *unattended run*. Do not
+   model our scheduler on it.
+2. **Advisory hooks decay under pressure.** 8 of 9 hooks only *suggest* via
+   `additionalContext`; the sole `PreToolUse` merely nudges "consider Codex." There is
+   **no hard `deny`** anywhere (contrast our `hook_guard.py` and `fable-orchestrator`'s
+   `block-named-cli-lane.py`). Routing is **brittle bilingual substring matching** —
+   any prompt containing "review"/"レビュー" fires the codex-plugin suggestion
+   regardless of intent. Our prior reports already concluded prose+advisory doesn't
+   hold a cheap worker on-task; orchestra is a live example of the weaker choice.
+3. **Parallel safety is file-ownership *by convention*, not isolation.** `team-execute`
+   explicitly lists *"two teammates editing the same file → overwrite risk"* as an
+   anti-pattern it prevents only by **discipline** — no worktree, no lock, no merge.
+   Our `EnterWorktree`/worktree-per-worker isolation is strictly stronger; keep it.
+4. **No watchdog / timeout on the Seam-B worker.** Codex runs with
+   `approval_policy="never"` and `sandbox=workspace-write` and the *only* safety is the
+   **caller-run** completion checklist (§2a) — which fires *after* the worker returns.
+   There is **no wall/stall watchdog, no `STATUS:` self-report, no PID-lane identity**
+   like `fable-orchestrator`. A hung or silently-idle `codex exec` is not caught. Our
+   launcher must keep the watchdog; do not copy orchestra's "just run it, verify after."
+5. **State is markdown-only** (`PROGRESS.md`, `DESIGN.md`, `checkpoints/`, work logs).
+   Fine for human pace; it does **not** give queryable frontier state, atomic task
+   transitions, or crash-resumability. Our SQLite/DBOS control plane exists precisely
+   to replace this. `/checkpointing`'s "Compact Phase" is a **manual** context-GC — an
+   autonomous run needs this to be automatic and bounded, not a slash command a human
+   remembers to invoke.
+6. **Cost control is guidance, not enforcement** — routing tables + a "cost awareness"
+   tip ("3 reviewers = 3× tokens"). No token budget, no task budget, no per-run cap.
+   The webinar/advisor-orchestrator cost story in the fable-opus report needs
+   *enforced* budgets; orchestra provides none.
+7. **Maturity honesty:** solo-author, thin test coverage (3 files), depends on an
+   **experimental** Claude Code flag, several "TBD"/"experimental/inactive" corners
+   (`fable-advisor` config, Antigravity workflows), and pins to unreleased-sounding
+   model names it must chase. It is a polished *template*, not a battle-tested engine.
+
+---
+
+## 4. Verdict — **adopt-pattern; not-a-fit as a whole**
+
+**Not-a-fit to adopt whole.** claude-code-orchestra is an **interactive,
+human-in-the-loop, single-machine multi-agent *config template*** whose value is
+*organizational* (clean tier taxonomy, seam split, doc/state conventions, a template
+updater). Our program is an **autonomous, DAG-scheduled, control-plane-backed
+orchestrator**. Their scheduler is a human pressing enter; ours is a frontier loop.
+Adopting the repo wholesale would import the exact things we deliberately reject —
+advisory-only enforcement, markdown-only state, convention-based parallel safety, no
+watchdog, no budgets.
+
+**Adopt these specific patterns** (ranked by payoff):
+1. **The cheating-detection acceptance rubric** (§2a) — add diff-inspection +
+   test-tampering + swallowed-exception + hardcoded-return checks and a hard retry cap
+   to our worker verifier. Highest-value, lowest-cost, and genuinely additive to
+   verify-gate-as-oracle (it guards the gate's *inputs*, which the gate can't).
+2. **Machine-validated structured worker reports + first-class shell-out audit log**
+   (§2d) — make `validate_work_log`-style section-checking and `cli-tools.jsonl`-style
+   I/O capture native rows in our control plane.
+3. **Tool-neutral `.agents/` Seam-B contract + a `check.sh`-style config-coherence
+   assertion** (§2c) — so Seam-B workers are provider-swappable behind one interface.
+4. **Prototype native Agent Teams** (§2b) as a peer/work-stealing topology over our
+   frontier — *evaluate only*, gated on it being drivable headless; it is experimental
+   and TUI-shaped, so it stays a spike, not a dependency.
+
+**Reject** (keep our stronger equivalents): advisory keyword-routing hooks (we use
+hard `deny`), file-ownership-by-convention (we use worktree isolation), markdown-only
+state (we use SQLite/DBOS), no-watchdog shell-out (we keep the STATUS+watchdog
+launcher), and the human-approval-gated non-autonomy (the whole point of our program).
+
+**Net:** worth mining for its taxonomy and its one sharp idea (cheating-detection),
+worthless to fork. It validates our two-seam architecture by shipping it, and it
+usefully marks the boundary between a *disciplined interactive scaffold* (what it is)
+and an *autonomous engine* (what we are building) — the gap between them is exactly
+the DAG frontier + control plane + hard enforcement + watchdog our design already
+carries.
+
+---
+
+## GitHub repos touched
+
+- [DeL-TaiseiOzaki/claude-code-orchestra](https://github.com/DeL-TaiseiOzaki/claude-code-orchestra) — primary subject; read README, CLAUDE.md, AGENTS.md, `.agents/{tiers,INDEX,AGENTS}.md`, `.claude/rules/codex-delegation.md`, `.claude/agents/fable-advisor.md`, `.claude/skills/{team-execute,checkpointing}/SKILL.md`, `.claude/skills/_shared/work-log-format.md`, `.claude/hooks/agent-router.py`, `.claude/settings.json`, `.agents/check.sh`; GitHub API for stars/forks/activity.
+- [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc) — referenced (not re-read; covered by `followup-codex-plugin-fable-prompt.md`) as the Codex-plugin-for-Claude-Code that orchestra optionally installs (`/codex:review`, `/codex:rescue`, `/codex:adversarial-review`).
+- [BuildContext/fable-orchestrator](https://github.com/BuildContext/fable-orchestrator) — referenced (not re-read) as the contrast for watchdog / `STATUS:` completion contract / deny-hook, carried from `followup-orchestrator-trends.md`.
+
+_No primary vendor docs were newly fetched for this report; the SDK `model`-field
+and Agent-SDK facts are carried from `followup-fable-opus-orchestrator.md`._

--- a/.omc/kb/reports/followup-codex-plugin-fable-prompt.md
+++ b/.omc/kb/reports/followup-codex-plugin-fable-prompt.md
@@ -1,0 +1,404 @@
+# Follow-up: codex-plugin-cc Two-Agent Wiring, "Fable-5 prompt on Opus 4.8" Articles, and In-Claude-Code Multi-Model Trends
+
+**Date:** 2026-07-19
+**Scope:** Three concrete questions the prior two reports did **not** cover:
+(1) exactly how `openai/codex-plugin-cc` wires Codex as a second agent inside
+Claude Code, and how that compares to the plain `codex exec` shell-out;
+(2) the specific articles Ray referenced about extracting Fable 5's system
+prompt and running it on an Opus 4.8 agent — honest assessment;
+(3) last-month (2026-06/07) trends for multi-model orchestration **inside Claude
+Code specifically** (plugins that add non-Claude models as agents/workers).
+
+**Builds on, does not repeat:**
+- `followup-orchestrator-trends.md` — the `fable-orchestrator` architecture,
+  five-part spec contract, deny-hooks, `STATUS:`+watchdog completion contract,
+  structured reports, self-repair-against-the-gate, and the Fugu/RouteLLM/GraphRAG
+  trend survey. **Assumed read; I reference its mechanisms, not restate them.**
+- `followup-fable-opus-orchestrator.md` — the two wiring seams (A = Claude-only
+  SDK `model` override; B = Bash shell-out for non-Claude), the honest read of the
+  ~120k-char leaked *product* prompt vs the public "Prompting Claude Fable 5" doc,
+  and the worker-guardrail stack. **Assumed read.** This report adds the *specific
+  plugin/article evidence* those two summarized abstractly.
+
+**Citation discipline** (`verify-before-advancing.md`, `probes-need-a-control-arm.md`):
+plugin source / repo files / vendor docs are marked plainly; blog/newsletter/tweet
+claims are **[secondary]** or **[informal]**; author-reported numbers carry that
+label and their condition. Where a claim is load-bearing I traced it to the repo's
+own README/DeepWiki; where I could not verify (one 429), I say so.
+
+---
+
+## 1. `openai/codex-plugin-cc` — the concrete two-agent wiring, and how it differs from `codex exec`
+
+**Read from:** the repo README (raw.githubusercontent.com), the GitHub repo tree,
+the DeepWiki architecture page, and the David Paluy LinkedIn article. Official
+OpenAI repo; tagline *"Use Codex from Claude Code to review code or delegate tasks."*
+
+### 1.1 The mechanism — NOT plain `codex exec`; a persistent app-server broker + slash commands + a Stop hook
+
+The prior report modelled the Codex lane as **Seam B: a one-shot `codex exec`
+process per delegation** (`echo "$SPEC" | codex exec --full-auto --sandbox
+workspace-write -`), the orchestrator reading stdout. `codex-plugin-cc` is a
+**heavier, stateful** realization of the same "shell-out to the local Codex" idea,
+with four moving parts (file names per DeepWiki):
+
+- **Slash commands** are the user/orchestrator interface — `/codex:review`,
+  `/codex:adversarial-review`, `/codex:rescue`, `/codex:transfer`, `/codex:status`,
+  `/codex:result`, `/codex:cancel`, `/codex:setup`. There is **no MCP server** and
+  **no `codex exec` per call**.
+- **`codex-companion.mjs`** — "main entry point for all slash commands; parses
+  arguments and routes to logic" (DeepWiki). A Node dispatcher.
+- **`app-server-broker.mjs`** — the load-bearing difference: it *"manages a
+  persistent session with the Codex app-server to avoid startup overhead"*
+  (DeepWiki). Instead of cold-spawning `codex` per task, it keeps a **long-lived
+  connection to Codex's internal app-server** (the same protocol `codex` uses
+  under the hood), enabling bidirectional streaming. A `tsconfig.app-server.json`
+  build step generates TypeScript types for that app-server API.
+- **`state.mjs` → `state.json`** — "persists job IDs, status, and results";
+  background jobs run under unique IDs, queried by `/codex:status` and
+  `/codex:result`.
+
+It uses the **global `codex` binary** and honours the user's existing
+`~/.codex/config.toml` / `.codex/config.toml` (default model + reasoning effort);
+per-call `--model` / `--effort` override.
+
+### 1.2 Division of labor — Codex is BOTH executor AND peer reviewer
+
+The plugin does not pick one role; it ships both, and Paluy's article frames the
+default loop as **Claude = orchestrator, Codex = executor**:
+
+- **Claude** owns *"repository orientation, architecture decisions, task
+  decomposition, implementation planning, review of completed change"*
+  [secondary — Paluy].
+- **Codex-as-executor** — `/codex:rescue` hands a *bounded* task to Codex (via a
+  `codex:codex-rescue` **subagent**): *"focused implementation tasks, debugging,
+  failing-test fixes, refactors, multi-file edits."* Supports `--background`,
+  `--wait`, `--resume`, `--fresh`, `--model`. The loop is *"plan → delegate bounded
+  task → review → accept/revise/revert."*
+- **Codex-as-reviewer** — `/codex:review` (read-only review of uncommitted changes
+  or `--base <ref>`) and `/codex:adversarial-review` (steerable challenge review)
+  are peer-review, a *second model's* eyes on Claude's work.
+- **`/codex:transfer`** — creates a **persistent Codex thread from the current
+  Claude session, preserving context/history**, and exports a `codex resume
+  <session-id>` command. This is a full context handoff, not a stateless spec.
+- **The "review gate" is a Claude Code Stop hook.** `/codex:setup
+  --enable-review-gate` installs a **Stop hook** that runs *"a targeted Codex review
+  based on Claude's response"* and **blocks until issues are addressed.** The README
+  itself warns this *"can create a long-running Claude/Codex loop and may drain
+  usage limits quickly"* — i.e. it is the auto-verifier-every-turn pattern, and it
+  is explicitly unbounded unless you cap it.
+
+Paluy's headline claim: *"at least 60% savings in Fable 5 token consumption"*
+[informal — author-reported, no benchmark, single-author blog]. The mechanism he
+credits is the same one both prior reports credit — *"let Claude understand the
+work, let Codex execute a bounded piece, then let Claude decide whether to keep
+it"* — role-partitioned tokens, not a measured study.
+
+### 1.3 How it compares to the prior report's plain `codex exec` shell-out
+
+| Axis | Plain `codex exec` (prior report, `fable-orchestrator` launcher) | `codex-plugin-cc` |
+|---|---|---|
+| Invocation | one-shot `codex exec --full-auto -` per delegation | warm **app-server broker**, persistent session |
+| Cold-start cost | paid every call | paid once (broker stays warm) — wins at high delegation volume |
+| Cross-vendor | **generic** — same launcher wraps Grok/Gemini/local CLIs | **Codex-only**, coupled to the Codex app-server protocol |
+| Completion/hang safety | **you build it** — `STATUS:` contract, wall/stall watchdog, PID identity, incomplete-stamp (`run-grok-headless.sh`) | job-lifecycle via `state.json` + `/codex:cancel`; **no watchdog/`STATUS:` contract shown** — relies on the app-server |
+| Auto-review | not built in (you add a hook) | **built-in Stop-hook review gate** (but self-warns it can loop/drain) |
+| Context model | workers share **zero** orchestrator context (clean spec-contract) | `/codex:transfer` deliberately **shares full context** (coupled thread) |
+| Install/maintenance | a shell script you own (zero-bash-thin-wrapper) | a Node/TS plugin + marketplace install; a stateful daemon to manage |
+| Governance fit | matches our `ai-cli-invocation.md` + launcher discipline | a third-party plugin; opaque broker; harder to gate |
+
+**Reusable-as-pattern (what to steal):**
+1. **Warm broker to kill cold-start** — if our orchestrator fires many small
+   delegations, a persistent worker process (vs `codex exec` per call) is a real
+   latency/cost win. Adopt *only if* per-call cold-start is measured to dominate;
+   otherwise it adds a stateful daemon for nothing.
+2. **Background-job ledger (`state.json`)** — this is the prior report's external
+   ledger + `metrics.jsonl`, productized: job IDs, status, results, `--background`
+   + `/status`/`/result`/`/cancel`. Confirms the ledger pattern is the right shape.
+3. **Stop-hook auto-review as an optional second-model gate** — a concrete
+   instance of "cheap/other model verifies every turn." Adopt it **bounded**
+   (retry cap, our `long-running-command-hangs.md`), because the plugin's own README
+   proves the failure mode is an unbounded loop.
+
+**Not worth copying for our design:** the Codex-only coupling and the
+`/codex:transfer` full-context handoff. Our cost win depends on workers sharing
+**zero** orchestrator context (the five-part spec contract); `transfer` is the
+opposite trade (context fidelity over token thrift) and belongs to a different
+use case (escalating a hard, context-heavy debugging session to Codex).
+
+**Net:** `codex-plugin-cc` is the *official, ergonomic, stateful* cousin of the
+prior report's launcher-wrapped `codex exec`. It proves the two-agent-inside-CC
+pattern is mainstream and gives three cherry-pickable ideas (warm broker, job
+ledger, Stop-hook gate) — but its Codex-only, plugin-coupled, watchdog-less shape
+is **less general** than our launcher approach, which already carries the
+hang/fake-success rails and works for every vendor.
+
+---
+
+## 2. "Get Fable 5's system prompt, run it on an Opus 4.8 agent" — the actual articles, honestly assessed
+
+Ray's reference resolves to a small cluster of 2026-07 posts. The two most
+on-point are opposite in quality, and the contrast **is** the finding.
+
+### 2.1 linas.substack — "Unlock Claude Fable 5 Lite: Opus 4.8" (the literal "paste the leak" article)
+
+**Method:** paste the **complete leaked ~1,585-line Fable 5 system prompt** into
+Opus 4.8's system field (API, project instructions, or Claude Code) to make
+*"Claude Fable 5 Lite."* Full prompt + setup gated behind a paywall.
+
+**The author's own honest caveat is the headline:** what transfers is *"identity,
+autonomy defaults, frontend-design instincts, tool-use posture, and response
+style,"* with *"visible deltas on design generation, agentic coding, structured
+analysis, and long-context work"* — **but** *"on benchmarks that test raw model
+intelligence, it is actually zero."* Evidence offered is a single *"public
+head-to-head demonstration"* on a landing-page brief where *"the two outputs
+looked like products from different companies"* — a design/style delta, no metrics
+[secondary/informal — single author, paywalled, one demo].
+
+**Assessment (confirms the prior report exactly):** this is the **leaked *product*
+harness prompt** — §2a of `followup-fable-opus-orchestrator.md`. It is not an
+orchestrator mode. By the author's *own* admission it moves *style, identity, and
+design instinct*, not reasoning or delegation reliability. Pasting all 1,585 lines
+onto Opus 4.8 buys the "looks like Fable" surface at a **~30k-token permanent
+context tax** of product-harness plumbing (artifacts, web-tool schemas, safety
+postmortems) that is **irrelevant to orchestration** and risks the
+`reasoning_extraction` refusal traps the official doc warns about. **Do not adopt
+this.** It is the exact move the prior report flagged as a context tax, not a
+capability — and the author, to his credit, half-says so.
+
+### 2.2 dev.to/toffy — "Teach Opus and Sonnet to 'behave' like Fable 5" (the good one — codify *procedures*, not the prompt)
+
+**Method (explicitly the opposite of 2.1):** *don't* copy Fable's prompt — reverse-
+engineer *how it works* and codify that as discipline rules for weaker models.
+Ships as an npm package (`ccteams`) of pre-built teams. Five axes:
+1. **Pre-writing routine** — read repo context before deciding (*"Read `go.mod`
+   before using a language feature"*).
+2. **Failure-pattern catalogs** — symptom → wrong instinct → correct move.
+3. **Decision gates** — e.g. *"Before launching goroutines: who cancels it, who
+   waits, where does the error go?"*
+4. **Verification sequences** — ordered commands (*"`go build`, then `go vet`,
+   then `go test -race`"*).
+5. **Learning loops** — absorb new failures as playbook entries after approval.
+
+Its thesis, verbatim: *"The gap between Fable 5 and Opus/Sonnet is not
+intelligence."* What transfers is *"discipline, sequencing, verification
+procedures"*; what does **not** is *"noticing something is off when no checklist
+applies."* No benchmarks — subjective *"bugs Opus used to miss are now getting
+caught… closed most of the gap for routine work."* [secondary].
+
+**Concrete pattern worth stealing — evidence labels on every claim:** reject a
+worker's claim unless tagged **`VERIFIED` (ran it) / `REASONED` (read the code) /
+`ASSUMED`**, plus *"state hypothesis before touching code; a fix without a
+confirmed root cause is a guess."* This is **our own repo rules mechanized**
+(`verify-before-advancing.md` "read the real rc, not a piped tail";
+`probes-need-a-control-arm.md" "a redirect/parse-error is not a 'no'"). The
+`VERIFIED/REASONED/ASSUMED` label is a genuinely good, cheap addition to a worker
+report shape (drop it into the prior report's `GROK REPORT` / `VERIFY REPORT`).
+
+### 2.3 imCorfitz gist — "Use Fable 5 as orchestrator, Opus + Codex to execute" (ties directly to our design)
+
+A concrete, minimal instance of exactly our target architecture, and it uses
+**both** wiring seams from the prior report simultaneously:
+- **Fable 5** = orchestrator/tech-lead (the session model).
+- **`deep-reasoner`** subagent pinned to **Opus** (`model:` frontmatter; tools
+  Read/Grep/Glob/Bash) — *"reasoning-heavy phases, architecture, debugging,
+  algorithm design."* **Seam A.**
+- **`fast-worker`** subagent pinned to **Sonnet** — *"mechanical tasks,
+  boilerplate, tests, formatting, simple edits."* **Seam A.**
+- **Codex** = cross-vendor peer review via `/codex:rescue --background`
+  (i.e. `codex-plugin-cc`, §1). **Seam B, productized.**
+
+It is built from Claude Code's **native `/agents` wizard + `.claude/agents/*.md`
+`model:` pins + CLAUDE.md routing doctrine** — no custom proxy, no LiteLLM. This
+gist is the cleanest published confirmation of the prior report's "Seam A for cheap
+*Claude* workers, Seam B for the non-Claude worker" split, and it independently
+lands on `codex-plugin-cc` for the Codex lane.
+
+**Bottom line for Q2:** the "Fable-5 prompt on Opus 4.8" genre splits cleanly.
+The *paste-the-leak* version (2.1) is style-transfer of the **product** prompt —
+its own author says raw-intelligence gain is **zero** — skip it. The *codify-the-
+procedures* version (2.2) is the useful one, and it is really the same thing as the
+prior report's **public "Prompting Claude Fable 5" doc patterns + our verify-gate**:
+model-agnostic discipline rules, not a trained-capability transfer. Adopt the
+*procedure patterns* (evidence labels, hypothesis-before-fix, ordered verification,
+pre-read routine); do not adopt the *leaked prompt*.
+
+---
+
+## 3. Last-month trends (2026-06/07): multi-model orchestration **inside Claude Code**
+
+Distinct from the prior report's Fugu/RouteLLM/GraphRAG survey (those are *models*
+and *general* routing). These are all *inside the Claude Code harness*, adding
+**non-Claude** models as agents/workers. The load-bearing signal: **a whole
+"`*-plugin-cc`" bridge family standardized this quarter around one shape** —
+slash commands + a `<vendor>:*-rescue` subagent + shell-out to the vendor CLI +
+an optional review-gate hook.
+
+**A. The `*-plugin-cc` bridge family (the dominant pattern).**
+- **`openai/codex-plugin-cc`** — §1; the reference implementation, official OpenAI,
+  ~1.5k+ stars in days [secondary — CoddyKit, AIToolly coverage].
+- **`abiswas97/gemini-plugin-cc`** — verified from its README: *"Based on
+  `openai/codex-plugin-cc`, adapted for the Gemini CLI."* Same six-command shape
+  (`/gemini:review`, `/gemini:adversarial-review`, `/gemini:rescue`,
+  `/gemini:task`, status/result/cancel, `/gemini:setup`), a **`gemini:gemini-rescue`
+  subagent**, shell-out to the Gemini CLI, and the same review-gate toggle. It is a
+  literal fork of the Codex plugin for a different vendor — proof the pattern is now
+  a template.
+- **`sakibsadmanshajib/gemini-plugin-cc`** — a variant wiring Gemini via **ACP
+  (Agent Client Protocol)** rather than a bespoke broker [secondary — search
+  result; not deep-read]. ACP is the emerging standardized agent-to-agent wire, a
+  cleaner substrate than each plugin hand-rolling a broker.
+- **`m-ghalib/gemini-plugin-cc`** — review + adversarial-review only.
+- **Caveat (flag, don't rely):** one search snippet claims Google retires the free
+  **Gemini CLI on 2026-06-18** in favour of an **Antigravity CLI (`agy`)**, which
+  would break Gemini-CLI-based bridges [informal — unverified; `abiswas97`'s README
+  makes **no** mention of it and treats Gemini CLI as current]. Today is 2026-07-19,
+  *past* that alleged date, and the plugins still ship — so treat the retirement
+  claim as **unconfirmed**. It is a shelf-life *risk* to note, not a fact to cite.
+
+**B. Two-agent peer-review plugins (Claude writes, other model reviews).**
+- **`jcputney/agent-peer-review`** (v2.1.0, updated **2026-06-03**, 34★) — verified:
+  a **symmetric** peer-review plugin. Round 0: *"Claude and Codex independently
+  review the same scope with the same prompt; neither sees the other's findings"*;
+  issues canonicalized by **content hash** (duplicates collapse to high-confidence
+  flags); rounds 1+ run a **per-issue deterministic state machine** to debate to
+  convergence **without an LLM judge**. Slash command `/codex-peer-review`
+  (`--base`, `--uncommitted`); runs in a **subagent** so only the synthesized
+  verdict returns to the main context; auto-trigger **hooks** remind Claude to
+  dispatch review before presenting plans/architecture/refactors. This is the
+  blind-independent-review-then-debate discipline our own `feedback_adversarial_
+  review_convention` describes, packaged as a CC plugin.
+- **Two-agent PR workflow** [secondary — salmanalibanani 2026-07-04]: Claude writes,
+  Codex reviews the PR in **GitHub Actions**, *"one review pass, one fix pass, then
+  merge"* — deliberately bounded to avoid an endless loop (the same bound
+  `codex-plugin-cc`'s review-gate lacks by default).
+
+**C. Whole-harness routers (the session-wide, all-or-nothing seam).**
+- **Claude Code Router (`@musistudio/claude-code-router`, `ccr`)** [secondary —
+  morphllm guide; direct fetch 429'd, characterized from search + guide]: an
+  OpenAI-compatible **proxy** — launch `ccr code` instead of `claude`; it rewrites
+  requests to any provider and **routes by request *category*** (`default`,
+  `background`, `think`, `longContext`, `webSearch`). This is the prior report's
+  `ANTHROPIC_BASE_URL`→LiteLLM seam, productized. The one refinement worth noting:
+  because it can route the **`background`** class to a cheap model while `default`
+  stays frontier, it is *slightly* more granular than "all-or-nothing" — but it
+  routes by **request type, not by named subagent to arbitrary providers**, and the
+  orchestrator itself runs through the proxy (not a native Anthropic key). It still
+  **cannot** express "native strong Claude orchestrator + cheap non-Claude worker
+  per-agent" the way Seam A + Seam B can.
+- **Free-model playbooks** [informal — agentconn 2026]: pointing Claude Code + Codex
+  at OpenRouter/OmniRoute free tiers via the same proxy trick.
+
+**D. Anthropic's own native multi-agent (all-Claude, for contrast).**
+- Native `/code-review` + the `anthropics/claude-code` `code-review` plugin: *"a
+  fleet of specialized agents examine the diff in parallel, each looking for a
+  different class of issue, then a verification step checks candidates against
+  actual behavior to filter false positives"* [secondary — The New Stack, InfoQ,
+  Anthropic docs]. Same fan-out-then-verify shape as the cross-vendor plugins, but
+  single-vendor — useful as the "Seam A only" baseline.
+
+**Net trend for the quarter:** the *inside-Claude-Code* ecosystem converged on one
+template — **slash command + `<vendor>:rescue` subagent + shell-out to the vendor
+CLI + optional review-gate hook** — and forked it across Codex and Gemini within
+weeks. Peer-review-as-a-plugin (blind independent review → deterministic debate)
+emerged as the second stable shape. Whole-harness routers (`ccr`) remain the
+session-wide cheap-mode seam, unchanged in kind from the prior report. The
+category the prior report saw productized as a *model* (Fugu) is, *inside the
+harness*, being productized as a **plugin template**.
+
+---
+
+## 4. Concrete recommendation
+
+**Q: codex-plugin-cc-style plugin vs raw shell-out vs LiteLLM proxy — which fits
+our cost-optimized orchestrator?**
+
+**Substrate = the prior report's launcher-wrapped shell-out (Seam B), not the
+plugin, not the proxy** — for three repo-specific reasons:
+1. **Cross-vendor generality.** Our design wants Codex *and* Grok *and* Gemini *and*
+   local (Ollama/MLX) behind **one** contract. The `fable-orchestrator`
+   `run-grok-headless.sh` launcher already does this and already carries the
+   hang/fake-success rails (`STATUS:` + wall/stall watchdog + PID identity +
+   incomplete-stamp) that `codex-plugin-cc` does **not** expose. A `*-plugin-cc`
+   plugin is **Codex-only** (or Gemini-only) and hides its broker behind an opaque
+   Node daemon we can't gate.
+2. **Governance fit.** The launcher is a thin shell wrapper we own, matching
+   `ai-cli-invocation.md` and our zero-bash-thin-wrapper discipline; a marketplace
+   plugin with a stateful app-server is harder to pin, audit, and hook-guard.
+3. **The LiteLLM/`ccr` proxy is the wrong tool for role-splitting.** It is
+   session-wide (even `ccr`'s per-category routing runs the orchestrator through the
+   proxy) and therefore **cannot** give "native strong Claude orchestrator + cheap
+   non-Claude worker." Reserve it for a *fully-cheap, no-role-split* mode only.
+
+**But cherry-pick three `codex-plugin-cc` ideas** as bounded add-ons to the
+launcher substrate:
+- a **warm worker process** (broker) *iff* measured per-call cold-start dominates;
+- the **background-job ledger** (`state.json`-style) — it validates our external-
+  ledger plan;
+- an **optional Stop-hook auto-review gate**, **bounded with a retry cap** (the
+  plugin's own README proves the unbounded version drains usage — exactly
+  `long-running-command-hangs.md`).
+
+Keep **cheap *Claude* workers on Seam A** (`.claude/agents/*.md` `model: haiku|
+sonnet`) — the imCorfitz gist (§2.3) confirms this is the clean native path and
+that the community independently lands on the **A-for-Claude / B-via-codex-plugin
+split** the prior report recommended.
+
+**If you want a turnkey today with zero build:** install `codex-plugin-cc` for the
+Codex lane and use `agent-peer-review` for blind two-model review — both are the
+`*-plugin-cc` template, work immediately, and match the gist. Accept their Codex-
+coupling and unbounded-gate caveat as the price of not building. Migrate the lane
+to the launcher substrate when you need Grok/Gemini/local behind the same contract.
+
+**Q: which Fable-5 prompt patterns are worth adopting for our Opus-4.8/Fable-5
+orchestrator?**
+
+- **Reject the leaked 1,585-line product prompt** (linas "Fable 5 Lite"). By its
+  own author's admission the raw-capability gain is **zero**; it transfers style/
+  design-instinct at a ~30k-token tax and risks Fable's `reasoning_extraction`
+  refusals. This is the harness prompt, not an orchestrator mode (prior report §2a,
+  now confirmed by a concrete article).
+- **Adopt the *procedure* patterns** (dev.to/toffy + the public "Prompting Claude
+  Fable 5" doc from the prior report) — they are model-agnostic and map 1:1 onto
+  our existing rules:
+  - **`VERIFIED / REASONED / ASSUMED` evidence labels** on every worker claim —
+    add to the prior report's `GROK REPORT`/`VERIFY REPORT` shapes; it is
+    `verify-before-advancing.md` in one word per line.
+  - **State the hypothesis before touching code** (*"a fix without a confirmed root
+    cause is a guess"*) — twin of `probes-need-a-control-arm.md`.
+  - **Ordered verification sequences** — ours is literally `mise run lint` →
+    `pytest` → `dotfiles-setup verify run`; make the worker run them in order and
+    report exit codes, not prose.
+  - **Pre-read routine** (read the relevant context before deciding) and
+    **failure-pattern catalogs** — cheap-worker discipline scaffolding, applied
+    *thicker* for cheap workers than for a Fable worker (prior report §3's
+    inverse-proportionality rule).
+- These are **prompt/skill additions authored by us**, not a Fable secret; apply
+  them to whichever Claude orchestrates and, in the *enumerated/thick* form, to
+  every cheap worker. They buy Fable-*style* discipline, never Fable's *trained*
+  long-horizon delegation — the choreography, not the stamina (prior report §2).
+
+**Caveats carried forward:** Paluy's "60% savings", linas's design demo, and
+toffy's "closed most of the gap" are all **author-reported, no benchmark** —
+direction, not targets; re-measure on our own workloads
+(`probes-need-a-control-arm.md`). The Gemini-CLI→Antigravity retirement is
+**unconfirmed** — do not build a Gemini lane on the assumption it is permanent.
+The architecture recommendation does not depend on any of these numbers; it depends
+on two robust facts: the `*-plugin-cc` shape is Codex/vendor-coupled and watchdog-
+less (so the launcher substrate is more general), and the leaked prompt transfers
+style not reasoning (so adopt procedures, not the prompt).
+
+---
+
+## GitHub repos touched
+
+- [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc) — read README (raw), repo tree, and DeepWiki architecture page for the app-server-broker + slash-command + Stop-hook review-gate wiring, background-job state, and division of labor (§1).
+- [abiswas97/gemini-plugin-cc](https://github.com/abiswas97/gemini-plugin-cc) — read README; verified it is a literal fork of codex-plugin-cc for the Gemini CLI (`gemini:gemini-rescue` subagent, same command set) (§3A).
+- [sakibsadmanshajib/gemini-plugin-cc](https://github.com/sakibsadmanshajib/gemini-plugin-cc) — referenced (search-level) as the ACP-based Gemini bridge variant (§3A); not deep-read.
+- [m-ghalib/gemini-plugin-cc](https://github.com/m-ghalib/gemini-plugin-cc) — referenced as a review-only Gemini bridge (§3A); not deep-read.
+- [jcputney/agent-peer-review](https://github.com/jcputney/agent-peer-review) — read README; verified the blind-independent-review + content-hash + deterministic-debate peer-review plugin using the Codex CLI (§3B).
+- [musistudio/claude-code-router](https://github.com/musistudio/claude-code-router) — referenced (direct fetch 429'd; characterized via morphllm guide + search) as the session-wide `ccr` proxy with per-request-category routing (§3C).
+- [anthropics/claude-code](https://github.com/anthropics/claude-code) — referenced for the native `code-review` multi-agent plugin as the all-Claude baseline (§3D); not deep-read.
+- [BuildContext/fable-orchestrator](https://github.com/BuildContext/fable-orchestrator) — referenced (not re-read) for the `run-grok-headless.sh` launcher / `STATUS:`-contract / watchdog mechanisms compared against codex-plugin-cc (§1.3), carried from the prior two reports.
+
+_Non-GitHub primary/secondary sources: David Paluy, "Run Codex Inside Claude Code: A Practical Two-Agent Coding" (LinkedIn); linas.substack "Unlock Claude Fable 5 Lite: Opus 4.8"; dev.to/toffy "Want to keep using Fable 5? Teach Opus and Sonnet to 'behave' like it" (ships as npm `ccteams`); gist.github.com/imCorfitz "Use Fable 5 as orchestrator and Opus + Codex to execute"; DeepWiki openai/codex-plugin-cc; morphllm.com Claude Code Router guide; salmanalibanani.com two-agent PR workflow; The New Stack / InfoQ on Anthropic's native multi-agent review. All blog/tweet/newsletter claims labelled [secondary]/[informal] inline; the Gemini-CLI→Antigravity retirement is explicitly unconfirmed._

--- a/.omc/kb/reports/followup-discord-plugins.md
+++ b/.omc/kb/reports/followup-discord-plugins.md
@@ -1,0 +1,236 @@
+# Follow-up: Discord Plugins for Mining the graphify Server
+
+**Question.** Which Claude Code Discord plugin (if any) can *read/search* the
+graphify project's Discord server (human invite `https://discord.com/invite/598Ad9zQZ`)
+for discussion of backends / cost / multi-model / ingestion — and what is the
+concrete, honest path to do it?
+
+**Bottom line up front.**
+
+- The **official Anthropic Discord plugin is a two-way *messaging channel*, not a
+  history miner.** It can `fetch_messages` (≤100, oldest-first, one channel at a
+  time) but Discord's search API "isn't exposed to bots", so it cannot do the
+  keyword/topic mining the task needs. It is built to talk to *you*, not to crawl
+  a server. (Source: official README, below.)
+- The tool actually fit for mining is a **community plugin — `lycfyi/community-agent-plugin`** — which syncs a server's channel history to local Markdown and gives `discord-read` / `discord-chat-summary` keyword + date search over it.
+- **The real blocker is access, not tooling.** A *human invite link is not
+  programmatic read access.* To mine graphify you need either (a) a **bot** added
+  to the graphify server — which requires a graphify **admin** to authorize the
+  OAuth invite (Ray only holds a member invite, so he cannot do this himself), or
+  (b) a **user token** for Ray's own logged-in account after he joins — which
+  works without admin but is a **Discord-ToS gray area / self-bot** that risks
+  account termination.
+
+---
+
+## 1. Official Anthropic Discord plugin
+
+Repo: `anthropics/claude-plugins-official/external_plugins/discord`. Files:
+`.claude-plugin/plugin.json`, `.mcp.json`, `server.ts` (~33 KB), `package.json`,
+`bun.lock`, `ACCESS.md`, `skills/`.
+
+**What it is.** A *channel* — a messaging bridge so you can talk to a running
+Claude Code session from Discord (announced with Claude Code Channels, Mar 20
+2026). `plugin.json` describes it as "Discord channel for Claude Code — messaging
+bridge with built-in access control." Keywords: `discord, messaging, channel, mcp`.
+
+**Is it MCP?** Yes. `.mcp.json` declares one stdio server:
+```
+command: "bun"
+args: ["run","--cwd","${CLAUDE_PLUGIN_ROOT}","--shell=bun","--silent","start"]
+```
+i.e. it runs `server.ts` (discord.js + MCP SDK) over stdio.
+
+**Can it read history? Barely.** Its five tools are `reply`, `react`,
+`edit_message`, `fetch_messages`, `download_attachment`. `fetch_messages` pulls
+"recent history from a channel (oldest-first). Capped at 100 per call." The README
+is explicit about the limit that kills mining:
+
+> "Discord's search API isn't exposed to bots, so this is the only lookback."
+
+So there is no server-wide search, no topic query — just sequential 100-message
+pages from one channel the bot can see. Everything else (`reply`, `react`,
+`edit_message`) is **post/interact**, not read.
+
+**What it requires.**
+- A **Discord bot token** (`/discord:configure <TOKEN>`).
+- **MESSAGE CONTENT intent** — "without this the bot receives messages with empty
+  content." (So for mining, empty message bodies unless enabled.)
+- OAuth bot permissions: View Channels, Send Messages, Send Messages in Threads,
+  Read Message History, Attach Files, Add Reactions.
+- **The bot must share the server** — "Discord won't let you DM a bot unless you
+  share a server with it"; the bot is added via the generated OAuth invite URL.
+
+**Install.**
+```
+/plugin install discord@claude-plugins-official
+/reload-plugins
+/discord:configure <TOKEN>
+# restart:
+claude --channels plugin:discord@claude-plugins-official
+/discord:access pair <code>
+```
+Requires Claude Code ≥ v2.1.80, Bun runtime, Pro/Max. (code.claude.com/docs/en/channels.)
+
+**Verdict for mining graphify:** *Wrong tool.* It is designed for you to receive
+and answer messages, not to crawl and search someone else's server. The 100-msg,
+no-search cap makes topic mining impractical.
+
+---
+
+## 2. Community plugins — read/mining capability
+
+| Plugin | Read server history? | What it actually is | Creds |
+|---|---|---|---|
+| **`lycfyi/community-agent-plugin`** | **YES — the one built for this** | Syncs Discord (+Telegram) channel history to local Markdown; `discord-read` / `discord-chat-summary` do keyword + date-range search + AI summary | **Bot token** (bot-connector, ToS-OK, needs SERVER MEMBERS INTENT + bot added to server) **or user token** (user-connector, "gray area") |
+| `AxiumFoundry/claude-discord-threads-plugin` | Limited (same as official) | A **derivative/fork of the official channel** — identical tool set (`fetch_messages` ≤100 oldest-first, no search API), adds private-thread support | Bot token, MESSAGE CONTENT intent, server membership, MCP (Bun + discord.js). Maintenance status not stated in README |
+| `yusufkaraaslan/Skill_Seekers` | Only from **exports** | "Data layer for AI" — ingests a *pre-exported* Slack/Discord dump (`--chat-export-path`) into skills; ships a 40-tool MCP. No live Discord API, no bot | None (you supply the export file) |
+| `ndjordjevic/pinrag` | Only from **exports** | RAG/MCP server; accepts "Discord export (.txt)" (e.g. DiscordChatExporter output) as an input format. No live access | None (static exports) |
+| `getsocialclaw.com` (SocialClaw) | **NO** | Social *publishing* layer for agents (MCP + skill); lists Discord as a post target only ("upload media, schedule posts, publish") | Workspace API key; post-only |
+| `docs.keeperhub.com` plugin | **NO** | Automation-workflow plugin; Discord is a *notification action* (post-only) | KeeperHub account / `kh` CLI |
+| `AxiumFoundry` (above) | see row | — | — |
+| `CloudPlayPlus/cloudplayplus-cc-plugin` | **NO Discord** | A Claude Code *channel* for a local Flutter app (same `reply/fetch_messages` channel API, but the peer is CloudPlayPlus, not Discord) | Local MCP endpoint |
+| `QuantumInkDev/claude-discord-status` | **NO** | Discord **Rich Presence** — shows your Claude activity as a status. IPC via Application ID; "zero message history or server inspection capabilities" | Discord Application ID only; post/status-only |
+
+**Also surfaced (not in the task list but relevant):**
+- `zebbern/claude-code-discord` — a self-hosted **bot that runs Claude Code from
+  Discord commands** (execute code, threads, MCP mgmt). It is a control surface,
+  not a history miner. Bot token + Application ID; MESSAGE CONTENT intent only if
+  channel-monitoring is used.
+- `Tyrrrz/DiscordChatExporter` — the canonical **standalone exporter**; produces
+  the `.txt`/HTML/JSON dumps that Skill_Seekers and PinRAG consume. Its own docs
+  warn that automating a **user account violates Discord ToS**.
+
+**Only `lycfyi/community-agent-plugin` mines an *existing* server's history**
+through Claude Code end-to-end (sync → local files → search/summarize). The
+export-based tools (Skill_Seekers, PinRAG) can also mine, but only *after* you
+obtain a dump by other means (e.g. DiscordChatExporter). Everything else is
+post-only, status-only, or a live two-way channel with no real search.
+
+### How the winning path stores/searches (lycfyi)
+
+Sync writes `data/{server_id}-{slug}/{channel}/messages.md`; `discord-read` is "a
+command-line utility for reading and searching locally synced Discord messages"
+(read all / last-N, keyword search, date-range, select by server ID),
+`discord-chat-summary` adds AI summarization. Sync is incremental by default
+(`--full` to re-pull). Install:
+```
+/plugin marketplace add https://github.com/lycfyi/community-agent-plugin
+# then install discord-init + a connector + discord-read (+ discord-chat-summary)
+```
+
+Two connectors, with the trade-off the README states verbatim:
+
+| | Bot Connector | User Connector |
+|---|---|---|
+| Member sync | Fast, complete | Cached only |
+| Message sync | Yes | Yes |
+| DM access | No | Yes |
+| Rich profiles | No | Yes |
+| **ToS compliant** | **Yes** | **Gray area** |
+
+Bot connector needs **SERVER MEMBERS INTENT** and **the bot added to the target
+server**. User connector uses "your personal account" — no admin needed — and
+carries the README's own warning:
+
+> "Using a user token may violate Discord's Terms of Service. This tool is
+> intended for personal archival and analysis only. Use at your own risk."
+
+---
+
+## 3. Practical recommendation for graphify
+
+**Goal:** search graphify's Discord for backends / cost / multi-model / ingestion.
+
+**Recommended tool:** `lycfyi/community-agent-plugin` (`discord-init` +
+connector + `discord-read`/`discord-chat-summary`). It is the only option that
+turns an existing server's history into searchable local data inside Claude Code.
+Not the official plugin (no search, 100-msg cap) and not the export tools (they
+need a dump you don't yet have).
+
+**Access is the hard part — a human invite link ≠ programmatic read.** Ray must
+first *join* graphify with `https://discord.com/invite/598Ad9zQZ`. Then one of:
+
+- **Option A — bot connector (ToS-clean but needs an admin).** Register a Discord
+  application, enable SERVER MEMBERS INTENT (+ MESSAGE CONTENT intent for message
+  bodies), and add the bot to the graphify server via its OAuth invite. **This
+  requires "Manage Server" / admin on graphify — Ray only holds a member invite,
+  so a graphify maintainer must authorize the bot.** Not automatable by Ray alone.
+  *Recommended if a graphify admin will add the bot* — it is the only clean path.
+
+- **Option B — user connector (works solo, but ToS gray area).** Use Ray's own
+  logged-in-account **user token** after joining. No admin, no bot approval — it
+  reads exactly what Ray can already see in the UI. **But this is a "self-bot":
+  the plugin's own README and DiscordChatExporter both warn it may violate Discord
+  ToS and risks account termination.** Only defensible framing is personal,
+  read-only archival of a server Ray is a legitimate member of, at his own risk.
+
+- **Option C — one-shot export (no plugin persistence).** Join, run
+  **DiscordChatExporter** against the channels Ray can see, then feed the dump to
+  `Skill_Seekers` or `PinRAG`. Same user-token ToS caveat as B for the export
+  step; decouples mining from any live connection afterward.
+
+**What cannot be automated / honest blockers:**
+1. **Membership is a prerequisite** — no tool reads a server Ray hasn't joined.
+2. **Bot path needs a graphify admin.** Ray's invite link authorizes *him* to
+   join, not a bot; adding a bot is a privileged server action he cannot perform.
+3. **MESSAGE CONTENT is a privileged intent.** Without it, bot-fetched messages
+   have empty bodies — useless for topic mining. (Below the 100-server threshold
+   it's toggle-only; still a required, deliberate step.)
+4. **User tokens are ToS gray-area self-botting** — the only solo path, and it
+   carries real account-ban risk; not something to run silently.
+5. **No server-side search via bots at all** — even with access, the official/bot
+   API has no search; mining means *syncing then searching locally*, which is
+   exactly why lycfyi (local-file search) beats the official channel.
+
+**Suggested concrete sequence (if a graphify admin is reachable → Option A):**
+join server → ask a graphify maintainer to add your bot (SERVER MEMBERS + MESSAGE
+CONTENT intents) → `/plugin marketplace add https://github.com/lycfyi/community-agent-plugin`
+→ `discord-init` → `discord-bot-connector:discord-sync --full` over the relevant
+channels → `discord-read` / `discord-chat-summary` with keywords
+`backend`, `cost`, `multi-model`, `ingestion`. If no admin is reachable, Option B
+(user connector) is the only solo route and must be an explicit, risk-accepted
+decision by Ray — not a default.
+
+---
+
+## 4. Last-month trends (2026-06 / 07) on Claude Code ↔ Discord
+
+- **Channels is now core, not preview.** Claude Code Channels (Telegram + Discord,
+  launched Mar 20 2026; iMessage a week later) has settled into the official
+  plugin ecosystem. VentureBeat framed it as "an OpenClaw killer." Discord is
+  consistently positioned as the channel to pick *when you want message history,
+  guild channels, or team collaboration* (vs Telegram) — but "history" here means
+  the channel conversation with your agent, not server mining.
+- **July 2026 Anthropic release notes** emphasize a "stability and safety update":
+  tighter permission checks, safer Bash/PowerShell handling, background-session
+  cleanup, and "better remote and **plugin** reliability" — i.e. hardening the
+  channel/plugin surface rather than adding read/mining features.
+- **A cottage industry of third-party "Discord read/search/sync" skills** has
+  appeared on skill marketplaces (mcpmarket.com, lobehub.com, claudeskills.club) —
+  `discord-sync`, `discord-read`, `discord-message-reader`, `discord-chat-summary`,
+  etc. Almost all follow the same architecture as lycfyi: **sync history to local
+  files first, then search offline.** This is the emergent pattern for "mine a
+  Discord server," precisely because the bot API exposes no search.
+- Guides proliferated (claudefa.st, DataCamp, TowardsAI, DanubeData VPS setup)
+  but they cover *setting up the channel*, not history mining — reinforcing that
+  Anthropic's own tooling remains conversation-bridge-first.
+
+---
+
+## GitHub repos touched
+
+- [anthropics/claude-plugins-official](https://github.com/anthropics/claude-plugins-official) — official Discord channel plugin README, `plugin.json`, `.mcp.json`, file tree.
+- [lycfyi/community-agent-plugin](https://github.com/lycfyi/community-agent-plugin) — the recommended history-mining plugin (sync + read/summarize); connector trade-off + ToS warnings.
+- [AxiumFoundry/claude-discord-threads-plugin](https://github.com/AxiumFoundry/claude-discord-threads-plugin) — official-derivative channel plugin with threads; same fetch limits.
+- [yusufkaraaslan/Skill_Seekers](https://github.com/yusufkaraaslan/Skill_Seekers) — export-ingesting data-layer/MCP; no live Discord.
+- [ndjordjevic/pinrag](https://github.com/ndjordjevic/pinrag) — RAG/MCP consuming Discord `.txt` exports; no live access.
+- [QuantumInkDev/claude-discord-status](https://github.com/QuantumInkDev/claude-discord-status) — Rich Presence status only; no read.
+- [CloudPlayPlus/cloudplayplus-cc-plugin](https://github.com/CloudPlayPlus/cloudplayplus-cc-plugin) — Flutter-app channel; not Discord.
+- [zebbern/claude-code-discord](https://github.com/zebbern/claude-code-discord) — bot to run Claude Code from Discord; control surface, not miner.
+- [Tyrrrz/DiscordChatExporter](https://github.com/Tyrrrz/DiscordChatExporter) — canonical standalone exporter feeding the export-based tools; user-token ToS warning.
+
+Non-repo sources: getsocialclaw.com (post-only), docs.keeperhub.com (post-only),
+mcpmarket.com / lobehub.com / claudeskills.club (skill marketplaces),
+code.claude.com/docs/en/channels, claudefa.st, DataCamp, TowardsAI, DanubeData,
+VentureBeat, releasebot.io (Anthropic July 2026 notes).

--- a/.omc/kb/reports/followup-fable-opus-orchestrator.md
+++ b/.omc/kb/reports/followup-fable-opus-orchestrator.md
@@ -1,0 +1,398 @@
+# Follow-up: Fable 5 / Opus 4.8 as a Cost-Efficient ORCHESTRATOR over Cheap/Free/Local Workers
+
+**Date:** 2026-07-19
+**Scope:** How to run a Claude **Fable 5** (`claude-fable-5`) or **Opus 4.8**
+(`claude-opus-4-8`) orchestrator that spends minimal tokens itself and dispatches
+well-specified work to cheaper workers — paid (Codex), free-hosted (NVIDIA NIM /
+Gemini free tier), or local (Ollama/MLX). Focuses on the *Anthropic-model* side of
+the question: the Agent-SDK model-override layer, the honest "Fable-5 system
+prompt" analysis, and official Fable-5 worker-guardrail prompting.
+
+**Builds on, does not repeat:**
+- `followup-orchestrator-trends.md` — the fable-orchestrator (`BuildContext/fable-orchestrator`)
+  architecture, five-part spec contract, deny-hooks, `STATUS:`+watchdog completion
+  contract, structured reports, self-repair-against-the-gate. **Assumed as read; I
+  reference its mechanisms rather than restate them.**
+- `followup-multiprovider.md` — the *plumbing* to reach non-Claude workers:
+  `ANTHROPIC_BASE_URL` + LiteLLM/`fcc-server` proxies, free NVIDIA NIM, Ollama/MLX,
+  `codex exec`, Gemini free tier, and graphify's `--backend {openai,ollama,gemini}`
+  + `OPENAI_BASE_URL`. **Assumed as read; §1 below adds only the SDK-subagent layer
+  those reports don't cover and the routing decision between the two seams.**
+
+**Citation honesty (repo discipline, `verify-before-advancing.md` /
+`probes-need-a-control-arm.md`):** primary sources (Anthropic platform docs, the
+Agent-SDK docs) are marked plainly. Blog/newsletter/tweet-sourced claims are
+**[secondary]** or **[informal]**. Benchmark numbers are carried **with the
+condition that makes them true**; a bare percentage is not carried forward.
+
+---
+
+## 1. How a Claude orchestrator dispatches to OTHER models — two seams, and which is which
+
+There are exactly **two** wiring seams, and the crucial fact the other two reports
+don't state outright is that **they operate at different layers and only one of
+them can address non-Claude models per-worker.**
+
+### Seam A — the Agent-SDK `model` override: powerful, but **Claude-only**
+
+The Claude Agent SDK lets an orchestrator define subagents with a per-agent
+`model` override. From the SDK `AgentDefinition` reference (primary —
+code.claude.com/docs/en/agent-sdk/subagents):
+
+> `model` … *"Model override for this agent. Accepts an alias such as `'fable'`,
+> `'opus'`, `'sonnet'`, `'haiku'`, `'inherit'`, or a full model ID. Defaults to
+> main model if omitted."*
+
+So a Fable-5 (or Opus-4.8) main loop can fan out Haiku/Sonnet subagents, each with
+its own `prompt`, `tools` allowlist, `skills`, `effort`, `maxTurns`,
+`permissionMode`, and `background` — full context isolation (each subagent gets a
+fresh window; only its final message returns to the parent). The `model` field
+also works in filesystem subagents (`.claude/agents/*.md` YAML frontmatter:
+`model: haiku|sonnet|opus|fable|inherit`) [secondary — developersdigest, consistent
+with the SDK doc].
+
+**The limit that matters for this task:** every value the `model` field accepts is
+a *Claude* alias or a Claude model ID. The whole SDK/harness authenticates against
+one Anthropic-compatible endpoint (`ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN`),
+and a subagent inherits that endpoint. **There is no per-subagent provider field.**
+A GitHub feature request against `github/copilot-cli` (#2939) asks for exactly this
+cross-provider parity and frames the Claude Agent SDK as *"supports `model` field
+on AgentDefinition"* but still single-provider [secondary — github issue, treated
+as a statement of the gap, not proof]. Consequence: **you cannot make a Fable-5
+orchestrator's SDK subagent run on Codex/Grok/NIM/Ollama by setting `model`.** Those
+workers are not subagents at all — they are Bash tool calls (Seam B).
+
+The one way to bend Seam A to a non-Claude model is to point the *entire harness*
+at a translating proxy (`ANTHROPIC_BASE_URL` → LiteLLM/`fcc-server` → NIM/Ollama).
+But that is **session-wide** — it swaps the model under the orchestrator *and* every
+subagent at once (`followup-multiprovider.md` §1). It cannot give you "strong Claude
+orchestrator, cheap non-Claude worker" because there is only one endpoint for the
+whole tree. Proxy-swapping is how you run *the whole thing* cheap, not how you split
+roles across vendors.
+
+### Seam B — shell-out to an external CLI: the real cross-vendor path
+
+Cross-vendor delegation is a **tool call**, not a subagent. The orchestrator (native
+Anthropic API, its own key) calls Bash to run a headless worker CLI and reads its
+stdout as a structured report:
+
+- **`codex exec`** — `echo "$SPEC" | codex exec --full-auto --sandbox workspace-write -`
+  for implementation, or `--ephemeral --sandbox read-only -` for research
+  (`.claude/rules/ai-cli-invocation.md`; plumbing in `followup-multiprovider.md` §3).
+- **`gemini -o text --approval-mode yolo -p ""`** (stdin prompt), free tier.
+- **`graphify … --backend {ollama,openai,gemini}`** — extraction workers where
+  `--backend ollama` is $0/local, `--backend openai` + `OPENAI_BASE_URL` reaches a
+  free NIM endpoint, `--backend gemini` the free tier (`followup-multiprovider.md`
+  §4). graphify also **auto-detects** a backend by API-key priority
+  (Gemini→Kimi→Claude→OpenAI→DeepSeek→Azure→Bedrock→Ollama) if `--backend` is
+  omitted [secondary — safishamsi/graphify README].
+- **A LiteLLM-fronted generic worker CLI** — one OpenAI-compatible endpoint that
+  fans out to NIM/Ollama/OpenRouter behind config, so the orchestrator's Bash call
+  is provider-agnostic.
+
+This is precisely what `fable-orchestrator` does: Grok 4.5 is reached through
+`run-grok-headless.sh` (a Bash launcher), **not** an SDK subagent
+(`followup-orchestrator-trends.md`). The launcher is load-bearing because a raw
+shell-out has none of the SDK's safety rails — so it must carry the completion
+contract (`STATUS:` + incomplete-stamp), the wall/stall watchdog, and PID-file lane
+identity itself.
+
+### The clean wiring for "strong Claude orchestrator → cheap/free/local workers"
+
+Combine both seams by *worker vendor*, not by habit:
+
+| Worker | Seam | Mechanism | Why |
+|---|---|---|---|
+| Cheap **Claude** (Haiku/Sonnet) | **A (SDK subagent)** | `model: 'haiku'` / `'sonnet'` + `tools` allowlist + `effort` | free context isolation, tool restriction, per-agent skills, cost tracking — all native |
+| **Non-Claude** (Codex/Grok/NIM/Gemini) | **B (Bash shell-out)** | `codex exec` / CLI behind a completion-contract launcher | SDK can't address a foreign provider per-subagent; a wrapped CLI can |
+| **Local** (Ollama/MLX) | **B (Bash shell-out)** | `graphify --backend ollama`, or a llama.cpp/Ollama CLI | $0, private, no rate limit; still needs the launcher's watchdog |
+| *Everything cheap, no role split* | **proxy (session-wide A)** | `ANTHROPIC_BASE_URL` → LiteLLM → NIM/Ollama | only when you don't need a strong orchestrator at all |
+
+**Net:** keep the **orchestrator native** (real Anthropic key, so it's genuinely
+Fable/Opus and not a proxied impostor); use **Seam A** for cheap *Claude* workers
+(the SDK does the isolation for free) and **Seam B** for every *non-Claude/local*
+worker (wrapped in `fable-orchestrator`'s launcher so a foreign CLI can't hang or
+fake success). Do **not** try to force non-Claude workers through the `model` field —
+it silently can't, and the failure mode is the orchestrator quietly doing the work
+itself (`fable-orchestrator`'s `block-named-cli-lane.py` guards exactly this class).
+
+---
+
+## 2. "Opus 4.8 with Fable 5's system prompts" — precise and honest
+
+### Is there a "Fable 5 system prompt"? Two very different artifacts — don't conflate them.
+
+**(a) The leaked prompt is the Claude *product* harness prompt, NOT an "orchestrator
+mode."** On ~2026-06-10 (a day after Fable 5's June 9 launch) a ~**120,040-char /
+1,585-line / ~30k-token** file surfaced (Pliny "the Liberator"; mirrored in
+`asgeirtj/system_prompts_leaks` and the CL4R1T4S repo). Multiple write-ups agree it
+*"reads like a product spec: tool schemas, search rules, safety postmortems"* with
+**18 full tool definitions** and an identity line (*"The assistant is Claude…"*) not
+appearing until line 1,351 — and a section on *"Claudeception"* (Claude artifacts
+calling the Claude API) [secondary — nowrap.ai "what we could verify", horiamc.com,
+analyticsvidhya, alphasignal; **Anthropic has not confirmed it**, and extraction can
+introduce gaps or hallucinated passages]. **This is the consumer/Claude-Code product
+system prompt.** It is *not* an orchestration playbook, contains no "delegate to
+cheap workers" doctrine, and copying it onto Opus 4.8 would only import ~30k tokens
+of product-harness plumbing (artifacts, web tools, safety) irrelevant to
+orchestration — a context tax, not a capability. **Do not use the leak as an
+"orchestrator system prompt." It isn't one.**
+
+**(b) The real, official, citable orchestration guidance is a public Anthropic doc:
+"Prompting Claude Fable 5"** (primary — platform.claude.com/…/prompting-claude-fable-5).
+It contains the actual delegation/long-run prompt snippets (quoted in §3). *This* is
+what "Fable-5 orchestration prompting" means, and it is not secret or leaked — it's
+documentation. There is also an official Anthropic **webinar** *"Building on the
+Claude Platform: Claude Fable 5 and model orchestration patterns"* whose page
+teaches *"when Fable or Opus should plan and delegate while Sonnet and Haiku
+execute"* and cost management via *"effort levels, prompt caching, batch processing,
+and task budgets"* — but the page carries **no benchmark numbers or concrete
+orchestrator-prompt text** (recording not posted at fetch time) [primary page,
+thin].
+
+### What transferring a system prompt to Opus 4.8 CAN and CANNOT do
+
+This is the crux the maintainer flagged, and the honest answer is a clean split:
+
+- **CAN transfer (workflow / behavior / output-format):** the *instructions* in the
+  "Prompting Claude Fable 5" doc — act-when-ready, state-boundaries, ground-progress,
+  the autonomous-operation stop-contract, the send-to-user tool, fresh-context
+  verifier subagents. **These are model-agnostic system-prompt ADDITIONS authored by
+  the user** (not weights, not secret to Fable). They will make Opus 4.8 *behave*
+  more like a disciplined orchestrator — shorter messages, fewer fabricated status
+  reports, cleaner stop conditions. **You should apply them to Opus 4.8.** There is
+  nothing to "leak" here; it's a docs page.
+
+- **CANNOT transfer (trained capability):** the doc explicitly frames Fable 5's edge
+  over Opus 4.8 as *trained*, not promptable — *"Long-horizon autonomy… completing
+  multiday, goal-directed runs"* and *"Delegation and collaboration. Claude Fable 5
+  is significantly more dependable at dispatching and sustaining parallel subagents,
+  and reliably manages ongoing communication with long-running subagents and peer
+  agents"* (primary). A system prompt cannot give Opus 4.8 Fable's trained
+  delegation reliability or its multiday instruction-retention. You get the
+  *choreography*, not the *stamina*. Prompt = the score; the model = the musician.
+
+- **A real trap when copying prompts to/from Fable:** the same doc warns *"Prompts,
+  skills, or harness instructions that tell the model to echo, transcribe, or explain
+  its internal reasoning as response text can trigger the `reasoning_extraction`
+  refusal category on Claude Fable 5, causing elevated fallbacks to Claude Opus 4.8"*
+  (primary). And *"Skills developed for prior models are often too prescriptive for
+  Claude Fable 5 and can degrade output quality."* So the transfer is **not
+  symmetric**: heavy scaffolding that helps Opus (or a cheap worker) can *hurt* Fable,
+  and a show-your-reasoning instruction that's fine on Opus can force refusals on
+  Fable. Prompts must be tuned per model, not cloned.
+
+**Bottom line for Q2:** There is no secret "Fable 5 orchestrator prompt" to graft
+onto Opus 4.8. The leaked file is the product prompt (skip it). The *useful*
+Fable-orchestration prompting is a public doc, is model-agnostic, and *should* be
+applied to whichever Claude you orchestrate with — but applying it to Opus 4.8 buys
+you Fable-*style behavior*, never Fable's *trained* long-horizon-delegation ability.
+
+---
+
+## 3. Worker-guardrail design — official Fable-5 additions on top of the prior report
+
+`followup-orchestrator-trends.md` already establishes the buildable guardrail stack
+(tight role/scope; five-part spec contract — Objective+MODE · Files · Interfaces ·
+Constraints · Verification; structured/constrained output; PreToolUse **deny**
+tool-allowlist; `STATUS:` completion contract + wall/stall watchdog + retry cap ~3;
+verify-gate-as-oracle = `mise run lint` + `pytest` + `dotfiles-setup verify run`).
+The new, **primary-sourced** contribution here is that Anthropic's "Prompting Claude
+Fable 5" doc ships *exact prompt text* for several of those guardrails — use these
+verbatim as worker/orchestrator system-prompt blocks (all primary):
+
+- **Explicit completion / stop contract** (the mechanism behind "worker claims done
+  but stalls"): *"You are operating autonomously. The user is not watching in real
+  time… asking 'Want me to…?' will block the work. For reversible actions that follow
+  from the original request, proceed without asking… Before ending your turn, check
+  your last paragraph. If it is a plan, an analysis, a question, a list of next steps,
+  or a promise about work you have not done ('I'll…'), do that work now with tool
+  calls. End your turn only when the task is complete or you are blocked on input only
+  the user can provide."* This is the prose twin of `fable-orchestrator`'s `STATUS:`
+  contract — put it in every autonomous worker.
+- **Progress-claim grounding (anti-hallucinated-status):** *"Before reporting
+  progress, audit each claim against a tool result from this session. Only report work
+  you can point to evidence for; if something is not yet verified, say so explicitly.
+  If tests fail, say so with the output."* The doc reports this *"nearly eliminated
+  fabricated status reports even on tasks designed to elicit them"* — directly the
+  same failure our `verify-before-advancing.md` guards against. Pair it with the
+  gate-as-oracle so "done" means an exit code, not a sentence.
+- **Verification by a fresh-context verifier subagent, not self-critique:**
+  *"Separate, fresh-context verifier subagents tend to outperform self-critique… Run
+  this every [X interval], verifying your work with subagents against the
+  specification."* Matches `fable-advisor`'s "fresh context = no sunk-cost bias" role
+  in the prior report.
+- **Scope containment:** *"Don't add features, refactor, or introduce abstractions
+  beyond what the task requires… Only validate at system boundaries."* and *"the
+  deliverable is your assessment. Report your findings and stop. Don't apply a fix
+  until they ask for one."* — cheap workers burn the most context on unrequested
+  tidying; this is the brevity lever.
+- **Verbatim-output channel:** the `send_to_user` tool + elicitation snippet, so a
+  long worker surfaces a deliverable *"exactly as written"* without ending its turn
+  (tool inputs are never summarized).
+
+**Honest caveat on applying these to *cheap/local* workers.** These snippets were
+written for Fable 5, which *"you can steer… with a brief instruction rather than
+enumerating each behavior."* A Haiku/Sonnet or a small local model is the **opposite**
+— it needs the *more* prescriptive, enumerated version, plus the hard mechanical
+rails (constrained decoding, deny-hook, watchdog) because it will not reliably follow
+a terse instruction. So the guardrail intensity is **inversely proportional to worker
+capability**: thin prose for a Fable worker, thick prose + machine gates for a cheap
+one. One measured cheap-worker knob [secondary — explainx, attributed to Anthropic
+internal evals]: for a Haiku executor, *"nudge on turn 2 if [the] advisor [was]
+skipped turn 1"* gave a **~7-percentage-point lift** — condition: Haiku-executor +
+advisor pattern, Anthropic-internal, not independently reproduced.
+
+**The single most load-bearing guardrail remains the objective gate.** Everything
+above shapes *behavior*; only the verify-gate (compiler/tests/`verify run`) makes a
+cheap model's *output* trustworthy, and it's the one the strong model defines and
+reads (`followup-orchestrator-trends.md` §4; carried forward).
+
+---
+
+## 4. Articles / blogs, last ~1 month (2026-06 / 2026-07)
+
+Ordered primary → secondary → informal. Trace load-bearing numbers to their stated
+condition.
+
+**Primary (Anthropic):**
+- **"Introducing Claude Fable 5 and Claude Mythos 5"** — launch June 9, 2026;
+  `claude-fable-5`; **1M context, 128k output; $10/M in, $50/M out**; adaptive
+  thinking only; raw CoT never returned; safety classifiers can return
+  `stop_reason:"refusal"` and route to a fallback (Opus 4.8). (platform.claude.com)
+- **"Prompting Claude Fable 5"** — the orchestration/delegation prompt snippets used
+  in §3; the `reasoning_extraction` refusal trap; "skills too prescriptive for Fable
+  can degrade output." (platform.claude.com)
+- **Webinar: "Fable 5 and model orchestration patterns"** — official framing of
+  advisor/orchestrator ("*a smaller, cheaper model does the work and Fable 5 sets the
+  strategy*", "*frontier-level results at a fraction of the token cost*"); no numbers
+  on the page. (anthropic.com/webinars)
+- **"Redeploying Fable 5"** — Anthropic news noting access to Fable 5 was
+  *restored* (there was an interruption; details not load-bearing here).
+  (anthropic.com/news)
+
+**Secondary (numbers, condition-flagged — treat as direction, not targets):**
+- **explainx "Fable 5 Advisor & Orchestrator patterns" (July 2026)** — the two named
+  patterns and their evals: **Advisor (Sonnet 5 executes, Fable advises): ~92%
+  quality / ~63% cost vs Fable-solo on SWE-bench Pro**; **Orchestrator (Fable plans,
+  Sonnet workers execute): ~96% quality / ~46% cost vs Fable-solo on BrowseComp
+  (CMA)**. Attribution stated in-article: *"@ClaudeDevs July 8 tweets… Anthropic
+  internal evals, not independent reproduction."* Also: advisor tokens bill as
+  `type:"advisor_message"` in `usage.iterations[]`; cap advisor output via
+  `max_tokens` (≥1,024; 2,048 rec.); enable ephemeral prompt caching on tool defs if
+  ≥3 advisor calls. **[secondary/informal — tweet-sourced, unreproduced].**
+- **developersdigest "Fable 5 Orchestrator Playbook"** — worked 12-worker audit:
+  Fable-orchestrator **$2.50**; mixed Fable+Sonnet fleet **$6.10**; all-Fable
+  **$14.50** → *"58% savings vs all-Fable; 74% with Haiku workers."* Worker routing:
+  Sonnet=implementation, Haiku=search/read-only, Opus 4.8=escalation for
+  safeguarded/complex. Hard constraints: **Haiku 200k context cap** (vs 1M);
+  Fable/Opus tokenizer produces *"up to 35% more tokens for the same text"*; Fable
+  30-day retention (incompatible with ZDR). **[secondary — the dollar figures are an
+  illustrative worked example, not a benchmark].**
+- **mindstudio "Fable 5 orchestrator without burning your token budget"** — general
+  cost framing consistent with the above. **[secondary].**
+- Leak analyses (**ayautomate, analyticsvidhya, alphasignal, horiamc, nowrap,
+  memeburn, Medium/Mehul Gupta**) — all describe the same ~120k-char product-prompt
+  leak (§2a). nowrap's *"what we could verify"* is the most careful. **[secondary;
+  Anthropic-unconfirmed].**
+
+**Informal:** the `@socialwithaayan` / `@ClaudeDevs` X posts are the origin of the
+leak-size figures and the advisor/orchestrator eval numbers respectively; both are
+**tweets**, load-bearing claims traced above to the more careful secondary write-ups
+and, where possible, to the primary docs.
+
+**Net trend for this quarter:** Anthropic itself is now *promoting* the
+strong-plans/cheap-executes split as the headline cost pattern for Fable 5 (a
+webinar, a prompting doc section, an official advisor/orchestrator vocabulary) — the
+category the prior report saw productized in Sakana Fugu is, for the Claude stack,
+now first-party guidance.
+
+---
+
+## 5. Concrete recommended orchestrator setup (has BOTH Opus 4.8 + Fable 5 + free/local workers)
+
+**Which model orchestrates: Fable 5, at `effort: high`, kept token-thin — Opus 4.8
+as the *fallback* target, not the primary orchestrator.** The reasoning is
+cost-honest, not brand loyalty:
+
+- The orchestrator's job *is* the one thing Fable 5 is specifically trained to do
+  better than Opus 4.8 — *"dispatching and sustaining parallel subagents… long-horizon
+  autonomy"* (primary). Spend the frontier rate ($10/$50) on the **small,
+  role-partitioned orchestrator token budget** (specs + accept/reject only), and the
+  commodity rate on the volume — *"the frontier rate where errors compound and the
+  commodity rate where they do not"* [secondary — developersdigest]. In the worked
+  example the Fable orchestrator was ~$2.50 of a $6.10 mixed run; the delegation
+  reliability is worth the small premium exactly because the orchestrator emits few
+  tokens.
+- **Opus 4.8 earns two roles regardless:** (1) it is the **mandatory refusal
+  fallback** — Fable's safety classifiers return `refusal` on cybersecurity/bio/
+  reasoning-extraction and the docs route those to Opus 4.8 (wire `fallbacks` or SDK
+  middleware); (2) it is the **cheaper-orchestrator option** ($5/$25) when the run is
+  latency-sensitive, ZDR-bound (Fable mandates 30-day retention), or the orchestrator
+  token budget is *not* small — then orchestrate on Opus 4.8 and accept somewhat
+  weaker trained delegation. Give Opus 4.8 the §3 prompt snippets to close as much of
+  the behavioral gap as prompting can (which is the choreography, not the stamina).
+
+**Prompt / skill scaffolding (thin, on-demand):**
+1. **Thin orchestrator system prompt** built from the *public* "Prompting Claude Fable
+   5" snippets (§3): act-when-ready, state-boundaries, autonomous-operation
+   stop-contract, ground-progress, self-verification-via-fresh-context-verifier,
+   `send_to_user`. **Do NOT paste the leaked product prompt** (~30k-token tax,
+   product-not-orchestrator, unconfirmed). Do NOT add show-your-reasoning
+   instructions (Fable `reasoning_extraction` refusal trap).
+2. **Orchestration doctrine as an on-demand skill**, not always-on context
+   (`fable-orchestrator`'s pattern; keeps the permanent prompt to ~one screen and
+   prompt-cache-friendly). Refactor/trim prescriptive legacy skills for Fable
+   (docs: over-prescription degrades its output).
+3. **Five-part spec contract** as the only orchestrator→worker interface; workers
+   share zero orchestrator context and return only compressed structured reports
+   (`followup-orchestrator-trends.md`).
+
+**Guardrails on workers (intensity inversely proportional to worker capability):**
+- **Cheap Claude workers (Seam A subagents):** `model: 'haiku'|'sonnet'`, a hard
+  `tools` allowlist, `effort` tuned down, `maxTurns` capped; the §3 prompt blocks in
+  the *enumerated* (thicker) form.
+- **Non-Claude / local workers (Seam B shell-outs):** wrap every `codex exec` /
+  `graphify --backend ollama` / LiteLLM-CLI call in `fable-orchestrator`'s
+  completion-contract launcher (`STATUS:` + incomplete-stamp + wall/stall watchdog +
+  PID-file identity); **constrained/structured output** (Ollama's native `format:`
+  JSON-schema, `followup-multiprovider.md`) to cut retries; retry cap ~3.
+- **Everyone:** the **objective verify-gate as the completion oracle** — `mise run
+  lint` + `pytest` + `dotfiles-setup verify run`; `STATUS: pass` only on green
+  exit codes; self-repair-against-the-gate loop (cap ~3, arXiv 2607.05197 per prior
+  report). Enforce the orchestrator's no-product-write with a **PreToolUse deny-hook**
+  (our `hook_guard.py` precedent), because "prose is ignored under pressure."
+
+**Honest trade-offs:**
+- **Seam A can't reach non-Claude models** — the `model` field is Claude-only; every
+  free/local worker is a Bash shell-out (Seam B), which *loses* the SDK's automatic
+  context-isolation and cost-tracking and *gains* vendor diversity + $0/local cost.
+  You maintain the launcher yourself.
+- **`ANTHROPIC_BASE_URL` proxying is session-wide**, so it cannot express "strong
+  orchestrator + cheap worker" — it's an all-or-nothing cheap mode. Don't reach for it
+  to split roles.
+- **Fable specifics:** 30-day retention (no ZDR); tokenizer ~35% more tokens for the
+  same text (so its per-token price bites a bit harder than the sticker); refusal
+  classifiers mean you *must* build the Opus-4.8 fallback path before shipping.
+- **The eval numbers (92/63, 96/46, 58%/74%) are tweet-/example-sourced, Anthropic-
+  internal or illustrative, and unreproduced** — use them as direction and
+  **re-measure on our own workloads** (`probes-need-a-control-arm.md`). The
+  architecture recommendation does **not** depend on the exact deltas; it depends on
+  the two robust facts: (a) Fable is *trained* for delegation and (b) the orchestrator
+  emits few tokens, so paying frontier rate for it is cheap in absolute dollars.
+- **The maintainer's real lever is the worker contract, not the orchestrator model.**
+  Whether you orchestrate on Fable or Opus, a cheap worker stops burning context on
+  wrong turns because of the spec contract + constrained output + tool-allowlist +
+  watchdog + verify-gate — the same stack in both reports. The model choice moves the
+  cost/reliability of the *dispatch*; the guardrails move the cost of the *work*.
+
+---
+
+## GitHub repos touched
+
+- [BuildContext/fable-orchestrator](https://github.com/BuildContext/fable-orchestrator) — referenced (not re-read) for the launcher / deny-hook / STATUS-contract mechanisms carried from `followup-orchestrator-trends.md`.
+- [safishamsi/graphify](https://github.com/safishamsi/graphify) (a.k.a. Graphify-Labs/graphify) — read README/search for `--backend {ollama,openai,gemini}`, `OPENAI_BASE_URL`/`OLLAMA` overrides, and the API-key backend auto-detect priority.
+- [asgeirtj/system_prompts_leaks](https://github.com/asgeirtj/system_prompts_leaks) — the `Anthropic/claude-fable-5.md` leaked *product* system prompt (§2a); cited as the leak artifact, **not** as an orchestrator prompt; Anthropic-unconfirmed.
+- [github/copilot-cli](https://github.com/github/copilot-cli) (issue #2939) — cited as evidence that per-subagent *provider* override is a not-yet-shipped feature, and that the Claude Agent SDK's `model` override is single-provider.
+
+_Primary docs consulted (not GitHub repos): platform.claude.com "Introducing Claude Fable 5 / Mythos 5", "Prompting Claude Fable 5", and code.claude.com/docs Agent-SDK "Subagents in the SDK"; anthropic.com webinar + "Redeploying Fable 5" news. Secondary/informal blogs enumerated in §4._

--- a/.omc/kb/reports/followup-graphify-adoption.md
+++ b/.omc/kb/reports/followup-graphify-adoption.md
@@ -1,0 +1,237 @@
+# Follow-up: graphify real-world adoption, best-practices, and maturity
+
+**Question (from maintainer):** before we build a whole agent-memory architecture on
+graphify, did we research *other projects that use it* and *its documented best
+practices*? Prior research only read graphify's own source + competitors' docs.
+
+**Package:** PyPI `graphifyy` · **Repo:** `Graphify-Labs/graphify` (moved from
+`safishamsi/graphify` on 2026-07-18; the old path still redirects) ·
+**Author:** Safi Shamsi · **License:** MIT · **Backing:** Y Combinator S26.
+
+**Bottom line up front:** graphify is NOT a thin/abandoned hobby project — it is one
+of the most-starred AI-coding-skill repos on GitHub (91k★) with ~1.4M PyPI
+downloads/month, YC backing, and a real third-party ecosystem that already uses it
+*specifically as agent memory*. The risk is not abandonment; it is **pre-1.0 schema/CLI
+churn** on a **near-daily release cadence driven by essentially one maintainer**.
+Net verdict: **MEDIUM risk**, well-mitigated by our chosen posture (pinned version,
+host-only/removable, portable NetworkX JSON, thin `/graphify` skill coupling).
+
+All figures captured **2026-07-19**; a viral repo's counts move fast.
+
+---
+
+## 1. Adoption signals (primary: `gh api`, PyPI, pypistats)
+
+| Signal | Value | Source |
+|---|---|---|
+| Stars | **91,449** (cross-checked via two API routes: `repos/...` and `search/repositories`) | `gh api repos/Graphify-Labs/graphify` |
+| Forks | 8,918 | same |
+| Watchers/subscribers | 315 | `gh api` |
+| Contributors | **100+** (API page capped at 100; site claims 71 "real" contributors) | `contributors?per_page=100` |
+| Open issues (real, non-PR) | 258 | `search/issues type:issue state:open` |
+| Closed issues | 712 | same |
+| Open PRs | 323 | `search/issues type:pr state:open` |
+| Closed/merged PRs | 633 | same |
+| Commits (~default branch) | ~1,181 | `stats/participation` |
+| Repo created | **2026-04-03** (≈3.5 months old) | `gh api` |
+| Last push | 2026-07-18 | `gh api` |
+| Default branch | `v8` | `gh api` |
+| Org `Graphify-Labs` created | 2026-06-28; 162 followers; email `founders@graphify.com`; site graphify.com | `gh api orgs/Graphify-Labs` |
+
+**PyPI `graphifyy`:**
+- Version **0.9.20** (2026-07-18); requires Python ≥3.10; MIT, © 2026 Safi Shamsi.
+- **188 releases** on PyPI in ~3.5 months.
+- Downloads (pypistats): **last day 46,173 · last week 442,808 · last month 1,409,515**.
+- Bare name `graphify` on PyPI is unclaimed (404) — the shipping name is the
+  double-y `graphifyy`.
+
+**Release cadence (primary: `releases` API).** Effectively **one release every 1–2
+days**: v0.9.1 (2026-06-28) → v0.9.20 (2026-07-18) is 20 minor bumps in 3 weeks, on
+top of a prior 0.8.x line (…0.8.43–0.8.51 tags visible). Momentum is *high*, not
+stagnant.
+
+**Versioning oddity worth flagging:** a `v1.0.0` git tag exists but is dated
+**2026-04-05** — i.e. an early throwaway tag from the repo's first days, *behind* the
+entire 0.8.x/0.9.x line. The real project is **pre-1.0** (current 0.9.20); the
+"1.0.0" tag does **not** signal API maturity. Do not read it as a stability guarantee.
+
+**Team vs one-maintainer:** functionally **one dominant maintainer** with a long tail
+of drive-by fixers. Contribution counts: `safishamsi` **853** vs the next contributor
+**27**, then 17, 16, 10, … The recent commit log confirms it — `safishamsi` authors
+almost all release/changelog/docs commits and the bulk of fixes; others land single
+targeted patches (Windows path bugs, language-specific extraction fixes). So: a
+funded solo-lead project with community patch flow, **not** a multi-maintainer team.
+
+---
+
+## 2. Who uses it in the wild (beyond the author)
+
+Yes — there is a **real third-party ecosystem**, and notably several projects use
+graphify **exactly as persistent agent memory / a knowledge base**, not just one-shot
+code graphing:
+
+- **`lucasrosati/claude-code-memory-setup`** — **867★**, created 2026-04-12, PT-BR
+  included. Description: *"Up to 71.5x fewer tokens per session on Claude Code with
+  Obsidian + Graphify. Persistent memory, codebase knowledge graphs, and chat import
+  pipeline."* This is a full agent-memory stack built on graphify.
+- **`mir_mursalin_ankur` — "Graphify + code-review-graph: Build a Self-Updating
+  Knowledge Graph for Claude Code"** (DEV Community, long technical writeup). Treats
+  graphify as a *persistent knowledge layer* that replaces per-session file re-reads;
+  wires auto-updates via **git hooks** and a "smart grep" PreToolUse hook. (Its
+  companion repo `code-review-graph`/CRG is currently 404 — renamed or private — but
+  the article is detailed and load-bearing; see §5 for its cautionary notes.)
+- **Issue #152 (8 comments): "Integration idea: agentmemory for temporal memory +
+  graphify for structural knowledge."** The community explicitly frames graphify as
+  the *structural* knowledge layer, to be paired with a separate *temporal* memory —
+  a useful mental model for our architecture.
+- **GitHub code search:** `graphifyy` appears in **142** `pyproject.toml` and **106**
+  `requirements.txt` files; `"graphify-out" filename:graph.json` matches **105**
+  repos that have **committed a built graph** (the author's recommended
+  "commit graphify-out/ to git" pattern, in the wild).
+- **Third-party writeups / coverage** (leads, not primary): MindStudio (two posts,
+  incl. "70x large-codebase cost cut" and "knowledge graph for your AI agent"),
+  Augment Code ("Graphify hits 58.3K stars"), Analytics Vidhya ("From Karpathy's LLM
+  Wiki to Graphify: Building AI Memory Layers"), Developers Digest ("Codebase Graphs
+  Are the New Agent Map"), AlphaMatch, knightli.com setup guide, plus skill
+  directories (openagentskill.com, skillsllm.com — the latter shows the star count
+  climbing **58.3k → 76.3k → 91k** across successive snapshots, corroborating rapid
+  organic growth).
+
+**Honest caveat:** I found **little first-person critical discussion on HN/Reddit/X**
+in these searches — most web hits are SEO-flavored vendor/tool blogs rather than
+independent user postmortems. The strongest *independent* signals are the two
+third-party GitHub projects above and the graphify issue tracker itself (§5), not
+forum threads. So "widely adopted" is well-supported; "battle-tested by many
+independent voices writing up failures" is only weakly supported.
+
+---
+
+## 3. Documented best-practices (author's recommended usage)
+
+There is a docs site at **graphify.com** (with an `llms.txt` / `llms-full.txt` LLM
+index) plus a marketing mirror at **graphify.net**; the substantive how-to lives in
+the **README** and the installed **SKILL.md**. Author-recommended workflow for using
+it as a persistent knowledge base:
+
+- **Build cadence / auto-rebuild:** commit `graphify-out/` to git so a team clones a
+  pre-built map; run **`graphify hook install`** to auto-rebuild after each commit
+  (AST-only, no API cost).
+- **Incremental updates:** **`--update`** re-extracts only changed files;
+  **`--watch`** mode keeps the graph live as the codebase changes.
+- **Provenance:** **`graphify add <url> --author "Name" --contributor "Name"`** tags
+  external papers/videos/docs with attribution; every edge is tagged **EXTRACTED**
+  (explicit in source) vs **INFERRED** (resolved by graphify) so query results carry
+  confidence.
+- **Multi-repo / global:** **`graphify global add graphify-out/graph.json --as
+  myrepo`** registers project graphs into a unified index;
+  **`graphify merge-graphs a.json b.json`** combines corpora into one searchable
+  graph (issue #585 shows users actively asking how to combine graphs).
+- **Wiki export:** **`graphify export … --wiki`** emits an agent-crawlable markdown
+  wiki (Obsidian-compatible reports; community detection via Louvain/Leiden).
+- **MCP server:** `python -m graphify.serve graphify-out/graph.json --transport http
+  --host 0.0.0.0 --api-key "$SECRET"` exposes tools (`query_graph`, `get_node`,
+  `shortest_path`, `semantic_search_nodes_tool`, …) for always-on access across
+  sessions.
+- **Agent-memory overlay (most relevant to our program):** `save-result` / `reflect`
+  build an overlay under `graphify-out/memory/` recording which query paths were
+  useful, dead ends, or later corrected; **`graphify reflect`** aggregates outcomes
+  into a `LESSONS.md` and tags nodes preferred/tentative/contested by recency. This
+  is the author's own "graph that learns from your query patterns" story — i.e.
+  graphify explicitly markets a persistent-memory mode, not just static code graphing.
+- Extraction is **local, deterministic, tree-sitter AST across 33 languages, zero API
+  calls** for the code-parsing step; the optional semantic layer is where an LLM is
+  involved.
+
+---
+
+## 4. Maturity / bus-factor / risk verdict
+
+**Verdict: MEDIUM risk** (well-mitigated for our specific use).
+
+**What lowers the risk (healthy momentum):**
+- Enormous, *growing* adoption (91k★, 1.4M downloads/mo, 58k→91k in weeks); YC S26
+  backing and a founding org with a website and revenue motion ("graphify
+  Enterprise" per recent commits) — this is being built as a company, not abandoned.
+- Very fast fix turnaround; active community PR flow; MIT-licensed; built on trusted
+  libs (NetworkX, tree-sitter).
+- Our coupling is *shallow*: we invoke via a `/graphify` skill, we **pin** the
+  version, it's **host-only and removable**, and the artifact is a **portable
+  NetworkX node-link JSON** — no proprietary lock-in, exportable/queryable outside
+  graphify if we ever drop it.
+
+**What raises the risk (real, concrete):**
+- **Single-maintainer concentration.** 853 vs 27 contributions. If Safi Shamsi
+  stops, the release engine largely stops. YC funding mitigates but does not remove
+  this.
+- **Pre-1.0, schema/CLI NOT stable — churn is frequent and behavioral.** Evidence
+  from the tracker: node-ids broke at **v0.9.0** (per our prior notes); **`source_file`
+  changed shape twice** — relative path → bare basename in **0.9.16**, which *broke
+  resolution against a code root* (#1941, since patched); **non-deterministic
+  community assignments across identical-corpus runs** (#1667, 0.9.6) — a
+  reproducibility hazard for a knowledge base; **silent "wrote 0 entries" / wrong
+  checkpoint dir** bugs with `--out` (#1990/#1991); **weight:null edges crash the
+  build** (#1960). A near-daily release cadence means the graph format and CLI flags
+  are a moving target across versions.
+- **The installed skill marker / hook wiring churns** (recent commits: search-nudge
+  now fires on Grep as well as Bash #1986; Windows hook-path fixes #1987) — so the
+  *integration surface* we'd wire into agent memory is itself unstable release-to-release.
+
+**Mitigations we should keep / add:**
+1. **Pin `graphifyy==0.9.20`** and bump deliberately, reading release notes each time
+   (schema shape can change between patch releases — see #1941).
+2. Treat the graph JSON as the **source of truth we own** (portable node-link format);
+   never build logic that can't survive a graphify uninstall.
+3. If we ever auto-rebuild, use **git hooks, not PostToolUse/Stop hooks**, with CPU/
+   memory guards — see §5; this is the single most important operational caution.
+4. Keep graphify **host-only** and out of the devcontainer image (matches the PRD
+   #310 pin 0.9.20 host-only decision), so image reproducibility is unaffected by its
+   churn.
+
+---
+
+## 5. Cautionary tales / known limitations (from real users + issues)
+
+From the `mir_mursalin_ankur` third-party writeup (independent operational experience):
+- **Do NOT put `graphify update` in Claude `PostToolUse`/`Stop` hooks.** On large
+  monorepos it runs **~10s+**, spawning **hanging background processes, CPU spikes,
+  and swap exhaustion** — observed 3 concurrent processes at 65–73% CPU, load average
+  12+, machine unresponsive. Move rebuilds to **git hooks** (detached, post-developer-
+  action) with **CPU load checks (≤50% cores), memory guards (≥2GB free), and
+  `pgrep` dedup**, or rapid commit chains (amend/rebase) saturate the box.
+- **MCP tool-schema bloat:** graphify's ~25 MCP tool schemas cost **~6,000 tokens
+  always in context**; the author strips to ~8 via an allow-list (−70% schema
+  overhead). Relevant if we register its MCP server (weigh against our
+  `mcp2cli`-first preference).
+- **Query output bloat:** `graphify query` BFS depth=2 returns 87–378 nodes
+  (~1,500 tokens) regardless of query specificity — great for exploration, wasteful
+  for symbol lookup; route targeted lookups to a cheaper semantic tool.
+
+From the graphify issue tracker (author's own repo):
+- **#1941** — `source_file` silently reduced to bare basename in 0.9.16 (was relative
+  path in 0.9.13), breaking resolution against a code root. (Schema regression.)
+- **#1667** — non-deterministic community/cluster assignments across identical-corpus
+  runs (0.9.6). (Determinism/reproducibility gap.)
+- **#198** — "semantic layer is mostly disconnected from the AST graph." (The LLM
+  concept layer and the deterministic AST graph don't fully join.)
+- **#1948 / #1954** — semantic-doc gating bugs cause promised re-runs to silently not
+  happen / docs to be quick-scanned instead of fully processed. (Silent under-processing.)
+- **#162 / #265** — open questions about upper file/word limits and the need for
+  hierarchical aggregation on very large corpora. (Scale ceiling not fully characterized.)
+- **#722** — `manifest.json` writes absolute paths and no `graphify-out/.gitignore`
+  by default. (Portability/commit-hygiene footgun for the "commit graphify-out/"
+  workflow.)
+
+---
+
+## GitHub repos touched
+
+- [Graphify-Labs/graphify](https://github.com/Graphify-Labs/graphify) — primary
+  subject: repo metadata, contributors, releases/tags, commits, issues, README.
+- [safishamsi/graphify](https://github.com/safishamsi/graphify) — former repo path
+  (redirects to Graphify-Labs/graphify); confirms the 2026-07-18 org move.
+- [lucasrosati/claude-code-memory-setup](https://github.com/lucasrosati/claude-code-memory-setup)
+  — third-party agent-memory stack built on graphify (867★); primary evidence of
+  in-the-wild persistent-memory usage.
+- [mir-mursalin-ankur/code-review-graph](https://github.com/mir-mursalin-ankur/code-review-graph)
+  — companion repo to the DEV writeup (currently 404 — renamed/private); article
+  used as the operational-cautions source.

--- a/.omc/kb/reports/followup-graphify-github-mining.md
+++ b/.omc/kb/reports/followup-graphify-github-mining.md
@@ -1,0 +1,384 @@
+# Graphify GitHub Mining — Maintainer & Community Knowledge
+
+**Repo:** [Graphify-Labs/graphify](https://github.com/Graphify-Labs/graphify) —
+91.5k stars, created 2026-04-03, latest release **v0.9.20** (2026-07-18).
+Discussions **enabled** (83 threads, active Q&A/Ideas/Announcements). Issue
+tracker is extremely active (issues in the ~2050 range as of 2026-07-19),
+release cadence is ~daily-to-weekly on the `0.9.x` line. PyPI package name is
+**`graphifyy`** (double-y) — `graphify` alone is a different/unclaimed package
+(the `pip install 'graphify[postgres]'` error in
+[#1906](https://github.com/Graphify-Labs/graphify/issues/1906) points users at
+the wrong name).
+
+Maintainer voice = **@safishamsi** ("Safi", founder), with @TPAteeq,
+@FolatheDuckofDuckingburg, @daveshenal answering community threads. Commercial
+turn is live: **graphify.com + Graphify Enterprise early access**
+([Disc #1798](https://github.com/Graphify-Labs/graphify/discussions/1798)), and
+the project **joined Y Combinator S26**
+([Disc #983](https://github.com/Graphify-Labs/graphify/discussions/983)). Open
+source is stated to "stay free and local."
+
+This is a **fast-churning pre-1.0 tool**: much of what is cited below as
+"fixed" landed on the `v8` branch and shipped in a subsequent `0.9.x`. Pin a
+version and re-verify before betting on any single behavior.
+
+---
+
+## 1. Backends / cost / local + free models
+
+**Backend auto-detect priority chain** (from the maintainer, closing
+[#1086](https://github.com/Graphify-Labs/graphify/issues/1086)):
+`detect_backend()` picks **Gemini → Kimi → Claude → OpenAI → DeepSeek → Bedrock
+→ Ollama**, by "whichever API key is set." Historically the Python API
+`extract_files_direct()` **silently defaulted to `kimi` (Moonshot AI, a Chinese
+endpoint `api.moonshot.ai`)** when called as a library — a data-residency
+footgun. Fixed in commit `006e159`: it now calls `detect_backend()` and raises a
+clear `ValueError` listing every env var if nothing is configured.
+
+**First-class backends today:** Gemini, Kimi, Claude (API + `claude-cli`),
+OpenAI, **DeepSeek** (`DEEPSEEK_API_KEY`, default `deepseek-v4-flash`,
+`DEEPSEEK_BASE_URL` for OpenAI-compat endpoints — [#1422](https://github.com/Graphify-Labs/graphify/issues/1422)),
+Bedrock, Ollama. No NIM/MLX backend surfaced in issues (MLX search returned
+nothing — treat MLX as unsupported/unrequested).
+
+**The "0 tokens for code" path is real and maintainer-endorsed.** AST/structural
+extraction builds the graph with **zero LLM credits**; only doc/semantic
+extraction needs a model. Key threads:
+- [#1734](https://github.com/Graphify-Labs/graphify/issues/1734) (CLOSED) — added
+  **`graphify extract . --code-only`**: indexes code via local AST, **no API key
+  needed**, explicitly reports skipped non-code files. This is the recommended
+  "no API key" path.
+- [Disc #1931](https://github.com/Graphify-Labs/graphify/discussions/1931) —
+  maintainer (@TPAteeq): *"Build the graph from your terminal, not chat:
+  `graphify extract . --code-only`. Local AST parsing, no API key, nothing in
+  your chat context."* Building via `/graphify .` **inside the agent chat burns
+  tokens** — a common misuse.
+- **`claude-cli` backend / subscription (no per-token API bill):** when no
+  headless API key is set, `SKILL.md` Part B dispatches semantic extraction to
+  **Claude Code Agent-tool subagents — "the host session itself is the LLM"**
+  ([#1758](https://github.com/Graphify-Labs/graphify/issues/1758)). This uses
+  your Claude subscription rather than a metered API key, but has a sharp edge
+  (see Part 2 / Part 5). Setup help: [#749](https://github.com/Graphify-Labs/graphify/issues/749).
+
+**Local models (Ollama / OpenAI-compatible):** heavily requested, partially
+landed, with gotchas:
+- [#959](https://github.com/Graphify-Labs/graphify/issues/959) (OPEN) — OpenAI
+  backend base_url was hardcoded; **vLLM / local OpenAI-compat servers blocked**.
+- [#981](https://github.com/Graphify-Labs/graphify/issues/981) (OPEN) —
+  configurable base URL for OpenAI **and** Anthropic backends (Z.ai, OpenRouter,
+  Together, Groq, Azure). Related open PRs: **#723** (`custom` backend via
+  `GRAPHIFY_LLM_BASE_URL`), **#935** (OpenRouter backend). Community advice in
+  thread: separate *provider type* (openai-compatible/anthropic-compatible) from
+  *transport endpoint* so response parsing is validated independently.
+- Ollama-specific bugs: [#820](https://github.com/Graphify-Labs/graphify/issues/820)
+  (`GRAPHIFY_OLLAMA_NUM_CTX` not wired → silent empty responses),
+  [#798](https://github.com/Graphify-Labs/graphify/issues/798) (context-window
+  saturation / missing session reset between chunks),
+  [#792](https://github.com/Graphify-Labs/graphify/issues/792) (local-LLM perf /
+  high-core CPU scaling), [#1686](https://github.com/Graphify-Labs/graphify/issues/1686)
+  (a **hung Ollama request stalls the whole run despite `--api-timeout`**),
+  [#1168](https://github.com/Graphify-Labs/graphify/issues/1168) (`.local`
+  mDNS hosts hard-blocked as link-local). Env var confusion:
+  `OLLAMA_HOST` vs `OLLAMA_BASE_URL` (PRs #1966/#2019).
+- Requested-but-not-yet: **Vertex AI** ([#974](https://github.com/Graphify-Labs/graphify/issues/974)),
+  **GitHub Models** ([#975](https://github.com/Graphify-Labs/graphify/issues/975)),
+  **copilot-cli** ([#976](https://github.com/Graphify-Labs/graphify/issues/976)).
+
+**Cost/token accounting is imperfect.** [#1769](https://github.com/Graphify-Labs/graphify/issues/1769)
+— `cost.json` **never appends after the initial run** (token counts printed but
+not persisted). [#1694](https://github.com/Graphify-Labs/graphify/issues/1694) —
+`cluster-only`/`label` LLM calls had a **hardcoded `tokens={"input":0,"output":0}`
+placeholder**, not a real accumulator. [#730](https://github.com/Graphify-Labs/graphify/issues/730)
+— hardcoded `max_tokens=8192` caused a **truncation cascade → 3× cost overhead**
+on dense docs. [#1277](https://github.com/Graphify-Labs/graphify/issues/1277) —
+`cluster-only` auto-picked the wrong Gemini model and hit free-tier rate limits.
+
+**Recommended setup (synthesized from maintainer answers):**
+- For **cost-free / no-key** graphing: `graphify extract . --code-only` from the
+  terminal (AST only, 0 tokens).
+- To add the semantic layer cheaply: set **one** API key; the priority chain
+  auto-selects. Gemini wins the chain if `GEMINI_API_KEY`/`GOOGLE_API_KEY` is set
+  (watch free-tier rate limits + model auto-pick bug).
+- Use the **`claude-cli`/subagent path** to spend a Claude subscription instead
+  of a metered key — but cap chunk size (Part 5).
+- For **local models**, Ollama is the only fully-wired local backend today;
+  vLLM/OpenAI-compat needs the still-open base-URL work (#959/#981/#723).
+
+---
+
+## 2. Ingestion at scale / best practices
+
+**The AST path is the token-free workhorse; the LLM/doc path is where cost and
+fragility live.** Maintainer guidance and recurring issues:
+
+**Incremental update / watch — the big correctness area.**
+- [#2033](https://github.com/Graphify-Labs/graphify/issues/2033) (OPEN, PR #2050)
+  — **the shipped `--update` runbook omits `kind="ast"`**, so
+  `detect_incremental()` defaults to `kind="semantic"`; on an AST-only graph
+  **every file reports as changed → the whole corpus is re-extracted
+  semantically** every update. On a 629-file corpus, `new_total: 629`. This is a
+  direct "incremental update silently degrades to full re-extract" trap.
+- [#1765](https://github.com/Graphify-Labs/graphify/issues/1765) — `check-update`
+  is **blind to newly-created files** (manifest-only comparison) and silent.
+- [#1837](https://github.com/Graphify-Labs/graphify/issues/1837) — `graphify
+  update <path>` **silently fails to discover newly-added files/dirs even with
+  `--force` and a cleared cache**.
+- [#1925](https://github.com/Graphify-Labs/graphify/issues/1925) — `--update`
+  with a missing `manifest.json` degrades to full scan, and with `--code-only`
+  **silently discards the entire semantic layer**.
+- [#1915](https://github.com/Graphify-Labs/graphify/issues/1915) —
+  `watch._rebuild_code` produced a **~4× bloated graph** vs `graphify . --update`
+  (AST-scanned Markdown, then merged semantic nodes on top).
+- **`--force` downside** ([Disc #1648](https://github.com/Graphify-Labs/graphify/discussions/1648)):
+  users default to `--force` to bypass the "fewer nodes → refuse to overwrite"
+  shrink guard; that guard exists precisely to stop a bad partial extract from
+  clobbering a good graph, so blanket `--force` reintroduces silent data loss
+  (see also the shrink-guard bypass in [#1871](https://github.com/Graphify-Labs/graphify/pull/1871)).
+
+**Chunking / subagent sizing.**
+- [#1758](https://github.com/Graphify-Labs/graphify/issues/1758) — SKILL.md
+  chunking is **file-count-based (20-25 files/chunk), not output-size-aware**.
+  Dense chunks blow past Claude's **64k output-token turn cap** and **silently
+  crash**; a reporter measured **6/17 chunks (~35%) failing** on a ~370-file
+  corpus. PR #1938 proposes output-sized chunks; #1945 adds
+  `GRAPHIFY_FILE_CHAR_CAP`.
+- [#450](https://github.com/Graphify-Labs/graphify/issues/450) — the "one
+  subagent per image" rule forces **59 images ≈ 59 agents** (~28-30k tokens each
+  for ~5 nodes); batching would be ~8× cheaper.
+
+**Deep mode.**
+- [#1894](https://github.com/Graphify-Labs/graphify/issues/1894) — semantic
+  **cache key ignored extraction mode and `extract` had no `--force`, so
+  `--mode deep` over a warm cache was a silent no-op** (you thought you deepened;
+  nothing happened). Fixed. [#1895](https://github.com/Graphify-Labs/graphify/issues/1895)
+  — deep mode wrote out-of-scope `source_file` nodes anyway.
+
+**Caching hazards.**
+- [#1939](https://github.com/Graphify-Labs/graphify/issues/1939) — **semantic
+  cache had no prompt/skill-version component**, so **upgrades replayed stale
+  extractions** (fixed, PR #1942 keys on the prompt).
+- [#1757](https://github.com/Graphify-Labs/graphify/issues/1757) /
+  [#1504](https://github.com/Graphify-Labs/graphify/issues/1504) — subagent
+  mis-attributing `source_file` **overwrites another file's cache** / same-name
+  docs in different dirs collide.
+
+**Scaling large repos (maintainer patterns).**
+- [Disc #645](https://github.com/Graphify-Labs/graphify/discussions/645) — split
+  a large project into **type-scoped folders + one `AllFolders/` master graph**;
+  read `GRAPH_REPORT.md` for daily context (token-efficient), reserve the wiki
+  for onboarding/milestones (regenerating the wiki every update is wasteful).
+- [Disc #1019](https://github.com/Graphify-Labs/graphify/discussions/1019) —
+  **`graphify export` hard-caps at 512 MB `graph.json`**; sharded loading is
+  requested ([#1708](https://github.com/Graphify-Labs/graphify/issues/1708)) and
+  a **SQLite tiered storage backend for `serve`** is proposed
+  ([#1297](https://github.com/Graphify-Labs/graphify/issues/1297), ~17-64× lower
+  query latency).
+- **Recommended cadence:** commit `graphify-out/` to git; install the
+  **git post-commit hook** to keep it current
+  ([Disc #1408](https://github.com/Graphify-Labs/graphify/discussions/1408)) —
+  but beware the hook fires in worktrees / ignores `GRAPHIFY_SKIP_HOOK`
+  ([#1809](https://github.com/Graphify-Labs/graphify/issues/1809),
+  [#1810](https://github.com/Graphify-Labs/graphify/issues/1810)).
+
+---
+
+## 3. Agent memory / RAG usage
+
+**Graphify markets itself as both a code index AND a long-term memory system,
+and has published benchmarks for both** ([Disc #1677](https://github.com/Graphify-Labs/graphify/discussions/1677),
+[BENCHMARKS.md](https://github.com/Graphify-Labs/graphify/blob/v8/BENCHMARKS.md)):
+- **Code intelligence (ERPNext, ~1M LOC):** a single graphify tool takes a fixed
+  agent from **70.8% → 82.0% key-fact coverage at ~1.3× floor tokens / $0.32 per
+  task**, beating codebase_memory (embeddings, 2.7× tokens) and repomix
+  ([Disc #1328](https://github.com/Graphify-Labs/graphify/discussions/1328)).
+- **Conversational memory (LOCOMO n=300, LongMemEval-S n=50):** claims
+  **recall@10 0.497 (~10× mem0)**, +18 pts accuracy-per-dollar over mem0, ~1/10
+  supermemory ingest cost; LongMemEval 76% (tied with strong dense-RAG). Honest
+  caveat: **supermemory still beats graphify on some axes**. Reproduction Qs in
+  [#1706](https://github.com/Graphify-Labs/graphify/issues/1706). *Treat vendor
+  self-benchmarks as directional, not independent.*
+
+**Querying the graph from agents.** The install per-IDE writes an **always-on
+rule/hook** that tells the agent to run `graphify query "<question>"` (or read
+`GRAPH_REPORT.md`) **before** grep/read. Without that wiring, **a `graph.json` on
+disk does nothing** — agents ignore it and re-read the whole codebase
+([Disc #1931](https://github.com/Graphify-Labs/graphify/discussions/1931),
+[#749](https://github.com/Graphify-Labs/graphify/issues/749),
+[Disc #921](https://github.com/Graphify-Labs/graphify/discussions/921) "Claude
+ignoring Graphify"). The PreToolUse "graphify-first" nudge has gaps: only matched
+Bash not Grep ([#1986](https://github.com/Graphify-Labs/graphify/issues/1986),
+fixed #2003), and fires on out-of-project files / stale graphs with no freshness
+gate ([#1840](https://github.com/Graphify-Labs/graphify/issues/1840)).
+
+**MCP server (`graphify serve` / `serve.py`).** **stdio-only today** — one local
+process per IDE session against a local `graph.json`
+([Disc #1052](https://github.com/Graphify-Labs/graphify/discussions/1052)).
+**Streamable HTTP + OAuth/API-key for a shared team server is requested and the
+maintainer wants to support it, but it is not built yet.** If you want a central
+team-queryable graph now, you self-host the stdio process or commit
+`graphify-out/` and let each dev query locally. Perf work landed in `serve`
+(#1889/#1918 collapse per-term scoring passes).
+
+**"Work memory" (self-improving loop)** — [Disc #1449](https://github.com/Graphify-Labs/graphify/discussions/1449),
+shipped 0.8.47: `graphify save-result --question … --answer … --nodes … --outcome
+useful|dead_end|corrected [--correction …]`. **Deterministic, no LLM**, records
+which nodes actually answered a question and prefers them next session. This is
+the closest thing to native provenance/feedback.
+
+**god_nodes / provenance / confidence / staleness (the "can I trust it" axis):**
+- **god_nodes** = highest-degree hub nodes surfaced in `GRAPH_REPORT.md`.
+  Note [#2004](https://github.com/Graphify-Labs/graphify/issues/2004):
+  `god_nodes` is **not a CLI subcommand**, and `affected`/reverse-dep lookups
+  return **false negatives** because import-derived edge target IDs
+  (`pkg_sub_mod`) don't match the scanned node's ID.
+- **Confidence is poorly calibrated.** [#540](https://github.com/Graphify-Labs/graphify/issues/540)
+  — INFERRED-edge confidence is **bimodal**: subagents cluster at exactly **0.5
+  and ~0.85** with almost nothing between, ignoring the prompt's "most edges
+  0.6-0.9" guidance (reproduced independently). Don't threshold on confidence
+  expecting a smooth distribution.
+- **Staleness/freshness is a live, unsolved safety problem.**
+  [#2051](https://github.com/Graphify-Labs/graphify/issues/2051) (OPEN) — **stale
+  semantic nodes for deleted files are preserved indefinitely and returned as
+  authoritative**; one repo accumulated **1,444 nodes for files that no longer
+  exist**, including deleted security surfaces (`policy_hard_deny.py`). The
+  reporter argues **staleness must be enforced at query time, not just stored as
+  a flag** — a stored `stale:true` that `query` still returns in canonical form
+  preserves the "false authority" failure. Directly relevant if you make
+  graphify the first navigation path for an agent.
+  [#1650](https://github.com/Graphify-Labs/graphify/issues/1650) — temporal
+  validity + recency weighting requested for living corpora.
+- **Provenance `add --author/--contributor`:** **no issue surfaced** for those
+  flags (searches returned nothing) — treat as unverified / possibly not a real
+  feature. The durable-human-correction story is instead **PR #1871 `graphify
+  curate`** (OPEN): today **every edge is extractor-derived, so hand corrections
+  are transient by construction** — a deleted edge is re-injected from the
+  content-keyed cache, and an added edge is destroyed by `build_merge`'s
+  per-`source_file` replace, silently, while node count grows. If you need
+  human-authored facts to survive rebuilds, this is unsolved in released
+  versions.
+
+---
+
+## 4. Multi-agent / orchestration
+
+- **One shared graph serves all agents/IDEs.** [Disc #1117](https://github.com/Graphify-Labs/graphify/discussions/1117)
+  — `graphify-out/` is tool-agnostic; build once, and Codex/Antigravity/Claude
+  all query the same graph. Each tool only needs its own **always-on hook**
+  installed once (`graphify install --project --platform <codex|cursor|gemini|…>`).
+- **Extraction itself is multi-agent** when no headless key is set: the skill
+  **fans out semantic extraction to Claude Code Agent-tool subagents** (Part B,
+  "the host session is the LLM"). This is the cost-optimized path (uses your
+  subscription) **but** is where the 64k-output-token silent-crash and
+  file-count-chunking problems bite ([#1758](https://github.com/Graphify-Labs/graphify/issues/1758),
+  [#450](https://github.com/Graphify-Labs/graphify/issues/450),
+  [#537](https://github.com/Graphify-Labs/graphify/issues/537) "do connections
+  only get found within a subagent's file list?" — cross-chunk edges are a known
+  weakness).
+- **Multi-agent maintenance / deployment idea:** [#1550](https://github.com/Graphify-Labs/graphify/issues/1550)
+  (dependency-manager for the many per-agent installs),
+  [Disc #1730](https://github.com/Graphify-Labs/graphify/discussions/1730) (why
+  per-agent installers exist vs one `--platform agents`: each tool picks its own
+  dir + format + registration, so a generic copy silently fails to load).
+- **agentmemory integration** ([#152](https://github.com/Graphify-Labs/graphify/issues/152))
+  — proposal to pair graphify (structure) with agentmemory (cross-session
+  decisions/temporal), community-endorsed, not merged.
+
+---
+
+## 5. Known bugs / limitations / roadmap — betting risk
+
+**The single most important architectural caveat:
+[#198](https://github.com/Graphify-Labs/graphify/issues/198) (OPEN) — "Semantic
+layer is mostly disconnected from the AST graph."** Confirmed by multiple users
+on real repos (e.g. OpenHarness): AST and semantic passes run **in parallel**,
+the semantic pass **doesn't know which AST nodes exist this run**, so fusion
+relies on **exact node-id collisions** — brittle (`SentenceTransformer` vs
+`"sentence transformer"` never match). Result: **one connected code graph + one
+separate semantic/document subgraph, with very few real `code↔concept` bridges.**
+A contributor (@karthick1005) is exploring identifier normalization + fuzzy
+bridging; **not fixed**. If your value hypothesis is "semantic docs enrich the
+code graph," verify this holds on *your* corpus before committing.
+
+**Other load-bearing limitations for a knowledge architecture:**
+- **Non-determinism.** [Disc #1090](https://github.com/Graphify-Labs/graphify/discussions/1090)
+  / [#1105](https://github.com/Graphify-Labs/graphify/discussions/1105) —
+  identical inputs produced different node/edge/community counts across runs.
+  Root cause (per maintainer): **`os.walk()` returns files in FS b-tree order**,
+  and several passes are **first-writer-wins** (import resolution, label dedup,
+  symbol resolution), so collisions resolve differently each run; Leiden itself
+  is seeded (`random_seed=42`). Partially fixed (stable community ID ordering,
+  #1667/#1753); a ~0.1% residual community-count drift remained. LLM extraction
+  adds its own non-determinism ([#1695](https://github.com/Graphify-Labs/graphify/issues/1695)
+  — no seed/prompt-override; `extract_corpus_parallel` ignores the extraction
+  spec).
+- **`source_file` path instability (schema churn across patch releases).**
+  [#1941](https://github.com/Graphify-Labs/graphify/issues/1941) — `source_file`
+  was reduced to a **bare basename in 0.9.16** (was a relative path in 0.9.13),
+  breaking resolution against a code root; [#1789](https://github.com/Graphify-Labs/graphify/issues/1789)
+  — node IDs / `source_file` **embedded the absolute scan path** (leaks
+  username, makes committed `graph.json` non-portable / non-idempotent);
+  residuals in [#1899](https://github.com/Graphify-Labs/graphify/issues/1899),
+  reopened as [#1825](https://github.com/Graphify-Labs/graphify/issues/1825).
+  **Node-ID and path semantics have shifted repeatedly within 0.9.x** — any
+  tooling that parses `source_file` or node IDs is exposed to churn.
+- **Silent failures are a recurring class** (this project's own "zero-skip"
+  concern applies): LLM-omitted documents vanish with no reconciliation
+  ([#1890](https://github.com/Graphify-Labs/graphify/issues/1890) — **53% of docs
+  lost even with gpt-5**), nested `.gitignore`/`.graphifyignore` rules zero the
+  entire corpus ([#1873](https://github.com/Graphify-Labs/graphify/issues/1873),
+  [#1887](https://github.com/Graphify-Labs/graphify/issues/1887),
+  [#1922](https://github.com/Graphify-Labs/graphify/issues/1922),
+  [#1975](https://github.com/Graphify-Labs/graphify/issues/1975)), truncated LLM
+  chunks promoted to cache as complete ([#1950](https://github.com/Graphify-Labs/graphify/issues/1950)),
+  same-named classes across modules silently overwrite each other
+  ([#1744](https://github.com/Graphify-Labs/graphify/issues/1744)), cross-language
+  phantom edges bind by name ([#1749](https://github.com/Graphify-Labs/graphify/issues/1749)),
+  `weight:null` edges crash clustering ([#1960](https://github.com/Graphify-Labs/graphify/issues/1960)),
+  XSS in the HTML export ([#1838](https://github.com/Graphify-Labs/graphify/issues/1838)).
+  The maintainer is responsive (many closed within a day), but the **rate of
+  new silent-failure reports is high** and Windows is a persistent weak spot
+  ([#1892](https://github.com/Graphify-Labs/graphify/issues/1892),
+  [#1987](https://github.com/Graphify-Labs/graphify/issues/1987),
+  [#1907](https://github.com/Graphify-Labs/graphify/issues/1907)).
+
+**Roadmap / direction (from Announcements + maintainer):**
+- **v8 branch is the near-term staging line**; fixes land there then ship in the
+  next `0.9.x`. No public "v1.0" date surfaced — releases are rapid `0.9.x`.
+- **Graphify Enterprise** (self-hosted, "trust AI-written code," team scale) is
+  in **early access**; OSS stays free/local ([Disc #1798](https://github.com/Graphify-Labs/graphify/discussions/1798)).
+  **YC S26** ([Disc #983](https://github.com/Graphify-Labs/graphify/discussions/983)).
+- Actively wanted/proposed: **Streamable-HTTP MCP + auth** (#1052), **SQLite
+  tiered `serve` storage** (#1297), **sharded graph loading** (#1708),
+  **temporal/recency-weighted facts** (#1650/#1115), **durable human curation**
+  (#1871), **AST↔semantic alignment** (#198), custom/local backend base-URLs
+  (#959/#981/#723/#935).
+
+**Net "should we bet on it" read:** graphify is a **fast-moving, single-maintainer-
+led, pre-1.0, now-commercializing** tool with a compelling zero-token AST core
+and published (self-run) benchmarks. The **AST/structural graph is the solid
+part**. The risks that matter for a durable knowledge architecture are (a) the
+**AST↔semantic disconnect (#198)**, (b) **stale-node false authority (#2051)**,
+(c) **non-determinism + node-ID/`source_file` schema churn across patch
+releases**, (d) **human corrections don't survive rebuilds (#1871)**, and (e)
+**no shared/HTTP MCP yet**. Pin a version, prefer `--code-only` for the
+deterministic token-free layer, and validate the semantic-enrichment claim on
+your own corpus before depending on it.
+
+---
+
+## GitHub repos touched
+
+- [Graphify-Labs/graphify](https://github.com/Graphify-Labs/graphify) — primary
+  subject; issues, PRs, discussions, and releases mined for backends, cost,
+  ingestion, agent-memory, multi-agent, and roadmap/limitations.
+- [FolatheDuckofDuckingburg/graphify](https://github.com/FolatheDuckofDuckingburg/graphify/tree/v8/benchmarks)
+  — community benchmark framework fork referenced in [Disc #1328](https://github.com/Graphify-Labs/graphify/discussions/1328).
+- [rohitg00/agentmemory](https://github.com/rohitg00/agentmemory) — temporal
+  agent-memory tool proposed for integration in [#152](https://github.com/Graphify-Labs/graphify/issues/152).
+- [oraios/serena](https://github.com/oraios/serena) — compared vs graphify in
+  [Disc #1124](https://github.com/Graphify-Labs/graphify/discussions/1124).
+- [HKUDS/OpenHarness](https://github.com/HKUDS/OpenHarness) — the corpus a user
+  ran to demonstrate the AST↔semantic disconnect in [#198](https://github.com/Graphify-Labs/graphify/issues/198).
+- [Lum1104/Understand-Anything](https://github.com/Lum1104/Understand-Anything),
+  [AsyncFuncAI/deepwiki-open](https://github.com/AsyncFuncAI/deepwiki-open) —
+  alternative GraphRAG-style tools named by commenters in [#198](https://github.com/Graphify-Labs/graphify/issues/198).

--- a/.omc/kb/reports/followup-graphiti-embedded.md
+++ b/.omc/kb/reports/followup-graphiti-embedded.md
@@ -1,0 +1,206 @@
+# Follow-up — Graphiti embedded/no-server backends (G1 staleness re-evaluation)
+
+Agent: followup-graphiti-embedded · Date: 2026-07-19 · Host: Ray's Mac (Python
+3.14 host). Scope: ONE capability — age-based / bi-temporal staleness
+invalidation of KG facts (gap "G1"). The maintainer challenged the prior
+report's premise that **Neo4j (a resident server) is the only Graphiti backend**,
+and therefore that host-only Graphiti is impossible. This re-verifies against
+current source/docs and re-issues the G1 verdict only.
+
+**Headline:** The maintainer is **factually right**. The prior claim ("Graphiti
+needs Neo4j/FalkorDB + a resident server, violating our host-only constraint")
+is **wrong as stated** — Graphiti ships **two** embedded, no-server backends in
+its driver tree today (Kuzu, in-process; FalkorDB Lite, subprocess-no-Docker).
+BUT the two caveats matter: Kuzu is **deprecated and being removed**, and the
+FalkorDB-Lite *Graphiti driver* is **an unmerged draft**. And even fully
+embedded, Graphiti **still requires an LLM API key** for its extraction pipeline
+and a **second graph store** alongside graphify. So the corrected reasoning lands
+on the **same G1 verdict** (build age-scoring on graphify's `captured_at`) — but
+for a sounder reason than the prior report gave.
+
+All facts below checked 2026-07-19 against `getzep/graphiti@main`
+(graphiti-core **0.29.2**, `requires-python = ">=3.10,<4"`).
+
+---
+
+## Q1 — Does Graphiti support an embedded / no-server backend?
+
+**Yes — two of them.** Full backend inventory from `graphiti_core/driver/`
+(`falkordb_driver.py`, `kuzu_driver.py`, `neo4j_driver.py`, `neptune_driver.py`)
++ `pyproject.toml` extras:
+
+| Backend | Extra (`graphiti-core[...]`) | Embedded / no-server? | Evidence |
+|---|---|---|---|
+| **Kuzu** `>=0.11.3` | `kuzu` | ✅ **Embedded, in-process, no server** | `kuzu_driver.py`: `self.db = kuzu.Database(db)`, `db: str = ':memory:'` default, file path also accepted. |
+| **FalkorDB Lite** `>=0.5.0` (py≥3.12) | `falkordblite` | ✅ **Embedded subprocess, no Docker/server** | Extra declared in `pyproject.toml` (`falkordblite>=0.5.0; python_version>='3.12'` + `redis<9`). But driver **not yet merged** — see caveat. |
+| **FalkorDB** (standard) `1.1.2+` | `falkordb` | ❌ **Requires a running server / Docker** | `falkordb_driver.py` `FalkorDriver(host, port, ...)`; config docs show `pip install graphiti-core[falkordb]` + `host='localhost', port='6379'` (Redis-protocol server). |
+| **Neo4j** `5.26` | (default) | ❌ **Requires a running server** | Traditional server deployment. |
+| **Amazon Neptune** | `neptune` | ❌ **Managed cloud service** | Needs Neptune + Amazon OpenSearch Serverless for full-text; `boto3`, `langchain-aws`, `opensearch-py`. |
+
+### Kuzu — embedded, but a dead end
+Kuzu is genuinely in-process (no server, `:memory:` or file). **However it is
+deprecated in Graphiti.** `kuzu_driver.py` emits on init:
+
+> "The Kuzu backend is deprecated and will be removed in a future release — the
+> upstream Kuzu project is no longer maintained." (recommends Neo4j or FalkorDB)
+
+So "embedded Graphiti via Kuzu" works *today* but is a **removal-scheduled path
+on an unmaintained DB** — not something to build a durable dependency on. (A Kuzu
+successor, "LadybugDB", is only a driver *request* — issue #1509 — not shipped.)
+
+### FalkorDB Lite — the real embedded story, but the driver isn't merged
+- The **standalone `falkordblite` package is mature**: latest **0.10.0, released
+  2026-05-02**; classifiers list **Python 3.12, 3.13, and 3.14**; wheels include
+  **`cp314` for macOS (x86_64 + arm64)** and Linux (x86_64 + aarch64). It "forks
+  a lightweight sub-process next to your application" over a **Unix domain
+  socket** — **no Docker, no server, no admin privileges, just a file path**.
+  Limitation: **single-process access per DB file** (embedded-Redis constraint);
+  positioned for local/dev/prototyping, not high-concurrency production.
+- The **Graphiti integration is NOT GA.** Issue #1240 / **PR #1250 is a DRAFT,
+  unmerged** (blocked on a CLA signature). The shipped `falkordb_driver.py` only
+  accepts `host`/`port` — it does **not** accept a file/socket path. The
+  `falkordblite` *extra* exists in `pyproject.toml`, but the `FalkorLiteDriver`
+  class (`graphiti_core.driver.falkordb_lite_driver.FalkorLiteDriver`,
+  `FalkorLiteDriver(path="~/.../knowledge.db")`) that the extra is for is **still
+  in the draft PR**, not on `main`.
+
+**Bottom line for Q1:** Neo4j is *not* the only option. Graphiti has an embedded,
+no-server path — but the *supported* one (Kuzu) is deprecated/being-removed, and
+the *good* one (FalkorDB Lite) is an unmerged draft. There is no GA, non-deprecated
+embedded Graphiti backend as of 2026-07-19.
+
+---
+
+## Q2 — Is a host-only Graphiti viable on this Mac?
+
+**Technically yes** (Kuzu today, or falkordblite once #1250 lands / by running the
+draft/fork) — no Docker, no cloud, no resident server. **But "embedded backend"
+removes only the database server; it does not make Graphiti lightweight.** Even
+fully embedded, Graphiti-on-Mac still requires:
+
+1. **A mandatory LLM API key for extraction.** This is the load-bearing cost.
+   Graphiti's entire value is **LLM-based** entity/relationship extraction from
+   "episodes" into a temporal graph; it "defaults to OpenAI for LLM inference and
+   embedding" and "works best with LLM services that support Structured Output
+   (OpenAI, Anthropic, Gemini)". Every write (episode ingest) spends LLM tokens.
+   There is no non-LLM ingestion path — unlike graphify's `update` (AST via
+   tree-sitter, no LLM).
+2. **The `graphiti-core` dependency tree** (pydantic, tenacity, numpy, the
+   provider SDK, diskcache, etc.) **plus** the backend driver deps — for
+   falkordblite, a compiled wheel that **bundles an embedded Redis**; for kuzu, a
+   compiled C++ extension. Heavier than graphify's pipx footprint.
+3. **Python:** graphiti-core needs ≥3.10; **falkordblite needs ≥3.12** — the host
+   is **3.14**, satisfied, and `cp314` wheels exist for both host arm64-Mac and
+   the amd64 devcontainer. So the version/arch gate is clear; this is not the
+   blocker.
+4. **A second graph store on disk**, separate from graphify's `graph.json` — its
+   own file (Kuzu DB dir / falkordblite `.db`), its own single-process-access
+   constraint, its own sync problem.
+
+So: host-only Graphiti is **possible**, not **cheap**. The real footprint is "an
+LLM extraction bill on every write + a second embedded graph store + the
+graphiti-core deps," not "just a Neo4j server we can't run."
+
+---
+
+## Q3 — Re-verdict for G1 ONLY (staleness / bi-temporal invalidation)
+
+**Recommendation: BUILD age-scoring on graphify's existing `captured_at`. Do NOT
+adopt Graphiti (even embedded) for staleness alone.** The prior report's
+*conclusion* for G1 stands; its *reason* is corrected.
+
+**Corrected reasoning.** The prior report justified "don't adopt" with "Graphiti
+needs Neo4j + a server (host-only impossible)." That premise is false — embedded
+backends exist. But the verdict survives on a stronger argument specific to G1:
+
+- **G1 is one narrow capability**: rank/flag facts by age, and know "was true
+  then, invalid now." graphify **already stores `captured_at`** on every node.
+  Age-scoring is a **thin post-filter over the committed `graph.json`** at query
+  time — no new store, no LLM, no new process.
+- **Adopting Graphiti for staleness alone forces disproportionate machinery:**
+  - a **second graph store** (Kuzu-file or falkordblite `.db`) running *parallel*
+    to graphify — against the explicit "we already have graphify as primary; a
+    second store just for temporal facts is a real cost" premise;
+  - an **LLM extraction pipeline** to get facts *into* Graphiti in the first
+    place — Graphiti's celebrated bi-temporal auto-invalidation only applies to
+    edges **Graphiti itself** extracted (with `valid_at`/`invalid_at`), so you
+    can't point it at graphify's graph and get invalidation for free; you'd
+    re-ingest content through Graphiti's LLM, paying twice;
+  - a **deprecated backend** (Kuzu, removal-scheduled) or an **unmerged driver**
+    (falkordblite draft PR #1250) — neither is a stable foundation today;
+  - a **sync/duplication** problem between the two stores.
+
+**The trade, concretely.** Adopting Graphiti-embedded *buys* a battle-tested
+bi-temporal model (automatic fact invalidation, point-in-time "what was true
+when" queries, full episode→fact lineage) — genuinely better than a hand-rolled
+age filter. It *costs* a second LLM-fed graph store, the graphiti-core deps, a
+not-yet-GA/deprecated backend choice, and ongoing two-store sync — **to deliver
+one capability we can approximate with a `captured_at` post-filter over the store
+we already have.** For **staleness alone**, that is a bad trade. Borrow Graphiti's
+*pattern* (score/invalidate on a stored timestamp; keep old facts flagged, not
+deleted), not its engine — exactly the prior report's "steal the pattern" line,
+now on firmer ground.
+
+**Scope note (not a reversal).** The embedded-backend finding *does* matter for a
+**different, larger** question the prior report foreclosed too casually: if the
+program ever reconsiders its **primary** substrate wholesale, "Graphiti on
+falkordblite" is a legitimate **host-only** candidate (bi-temporal invalidation
+built in, no server, cp314 wheels) once PR #1250 merges. That is a
+whole-substrate decision, explicitly **out of scope for G1** and against the
+"graphify is primary" premise — but the maintainer's instinct that "server-only"
+was an over-broad dismissal is correct and worth recording for any future
+primary-store bake-off.
+
+---
+
+## Q4 — mem0 / cognee embedded modes (does the "too heavy" verdict change?)
+
+Both have genuine embedded/no-external-service modes; the prior "too heavy"
+verdicts **soften but do not flip for G1**, because both still (a) require an LLM
+for extraction and (b) would be a **second store** — the same disqualifiers as
+Graphiti for staleness-alone.
+
+- **cognee** — the prior "Docker + Postgres" characterization is **outdated for
+  its default**. cognee's **default local stack is fully embedded: SQLite +
+  LanceDB + Kuzu**, file-based, **no Docker, no external services**. (It *can*
+  scale to Neo4j/FalkorDB/Qdrant/Postgres, but doesn't require them.) So cognee is
+  lighter than the prior report implied — **however** its default graph store is
+  **Kuzu** (the same deprecated-in-Graphiti embedded DB), and its ECL pipeline
+  still needs an LLM. Still a second LLM-fed store for G1's purpose.
+- **mem0** — OSS mem0-core runs local: an embeddable vector store (e.g.
+  Chroma/FAISS) + an **optional** graph layer (Kuzu/Neo4j/Memgraph). Its
+  **OpenMemory MCP** server is the heavy part (Qdrant + Postgres/Docker), but the
+  *library* need not use it. Still LLM-dependent for extraction, vector-first (not
+  provenance-KG), and a second store. Verdict unchanged for G1.
+
+Neither changes the G1 answer: for **staleness of graphify facts**, an embedded
+mem0/cognee is still a second LLM-fed store, not a reason to abandon the
+`captured_at` post-filter.
+
+---
+
+## Net answer to the maintainer's challenge
+
+- **Is Neo4j the only option? No.** Graphiti has embedded, no-server backends
+  (Kuzu in-process; FalkorDB Lite subprocess-no-Docker), and cognee/mem0 have
+  embedded modes too. The prior report was **wrong** to call Graphiti
+  server-only, and that correction is now recorded.
+- **Does that reopen G1? No.** Kuzu is deprecated/being-removed; the falkordblite
+  Graphiti driver is an unmerged draft; and *any* Graphiti/cognee/mem0 adoption
+  for staleness alone means an LLM-extraction pipeline + a second graph store —
+  disproportionate to a `captured_at` age post-filter over the graph we already
+  have. **Build age-scoring on graphify; borrow Graphiti's bi-temporal pattern,
+  not its engine.**
+- **Version/arch is not the blocker:** falkordblite 0.10.0 (2026-05-02) ships
+  `cp314` wheels for macOS arm64 + Linux — Python 3.14 host is fine. The blockers
+  are the LLM bill, the second store, and the not-GA/deprecated backend status.
+
+---
+
+## GitHub repos touched
+
+- [getzep/graphiti](https://github.com/getzep/graphiti) — subject; read `graphiti_core/driver/` tree, `falkordb_driver.py`, `kuzu_driver.py`, `pyproject.toml` (0.29.2), README, issue #1240, PR #1250 (draft), issue #1509 (LadybugDB request).
+- [FalkorDB/falkordblite](https://github.com/FalkorDB/falkordblite) — via PyPI JSON (`falkordblite` 0.10.0, 2026-05-02, cp314 wheels) + FalkorDB blog on the embedded subprocess/Unix-socket model and limitations.
+- [topoteretes/cognee](https://github.com/topoteretes/cognee) — docs.cognee.ai + repo: default embedded SQLite + LanceDB + Kuzu local stack, no Docker.
+- [mem0ai/mem0](https://github.com/mem0ai/mem0) — embedded vector (Chroma/FAISS) + optional Kuzu/Neo4j graph; OpenMemory MCP is the heavy (Qdrant+Postgres) path.
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — this repo: prior `track-b-graphify-priorart.md` (the G1 claim under re-evaluation) and graphify's `captured_at` schema field.

--- a/.omc/kb/reports/followup-iceoryx-fit.md
+++ b/.omc/kb/reports/followup-iceoryx-fit.md
@@ -1,0 +1,176 @@
+# Fit assessment: iceoryx / iceoryx2 as plumbing for a single-Mac autonomous AI-agent orchestrator
+
+**Date:** 2026-07-19
+**Question:** Is Eclipse iceoryx (C++) / iceoryx2 (Rust) an appropriate transport/coordination
+substrate for an orchestrator that runs on ONE Mac, coordinating a handful of multi-minute
+`claude -p` / subagent LLM tickets, with occasional human escalation via GitHub/Slack/Discord?
+
+**Verdict up front:** **Category mismatch. Do not use iceoryx/iceoryx2.** It is a
+microsecond-latency, zero-copy, real-time shared-memory data plane built to move camera/LiDAR
+frames between C++ processes on one machine. Our unit of work is a multi-*minute* LLM ticket in
+Python, often escalating cross-machine through cloud services. The workload iceoryx optimizes for
+and the workload we have are separated by roughly **10 orders of magnitude in latency** and a
+similar gulf in message frequency. Its entire value proposition (avoiding a memory copy of a large
+payload) is worth nothing when the payload is a few KB of JSON produced once every few minutes.
+The right primitive is Claude Code's native subagent/channel model plus a lightweight durable
+queue (SQLite/file or Postgres-pgmq) — see §4.
+
+---
+
+## 1. What iceoryx actually IS
+
+**Design goal.** iceoryx2 states its goal as: *"Move high-volume data efficiently and
+deterministically inside data-intensive systems. Without moving the payload."* ([iceoryx.io](https://iceoryx.io/))
+The original iceoryx describes a *"true zero-copy, shared memory approach that allows to transfer
+data from publishers to subscribers without a single copy,"* giving *"data transmissions with
+constant latency, regardless of the size of the payload."* ([eclipse-iceoryx/iceoryx README](https://github.com/eclipse-iceoryx/iceoryx))
+
+**Latency profile.** This is a *real-time, sub-microsecond* IPC layer. iceoryx2 advertises
+*"< 1 µs Latency"* and *"0 Copies per message"* with *"flat latency, independent of payload size"*
+([iceoryx.io](https://iceoryx.io/)); benchmark commentary reports it reaching *~100 nanoseconds*
+latency on some systems ([iceoryx2 v0.6 announcement](https://community.nodebb.org/topic/51c029fc-ffc5-42cc-9e86-c79abbb8f645/announcing-iceoryx2-v0.6-true-zero-copy-inter-prozess-communication)).
+The whole point is *deterministic, constant* latency regardless of payload size — a hard-real-time
+property.
+
+**Origin.** Automotive. The iceoryx docs say it has *"origins in the automotive industry"* where
+inter-process data transfers are critical for *"driver assistance or automated driving systems,"*
+and it is *also* applied to *"robotics or game development"* ([iceoryx README](https://github.com/eclipse-iceoryx/iceoryx)).
+It originated at Bosch and integrates with **AUTOSAR Adaptive** stacks (ETAS RTA-VRTE, AVIN AGNOSAR)
+and **ROS 2** via `rmw_iceoryx` ([iceoryx README](https://github.com/eclipse-iceoryx/iceoryx)).
+iceoryx2's own framing targets *"physical AI and other mission-critical systems"* with example
+sources listed as *Camera, LiDAR, IMU, Actuators* ([iceoryx.io](https://iceoryx.io/)).
+
+**Language.** Original iceoryx is **C++** (~91% of the repo). iceoryx2 is *"written in safe Rust"*
+with a Rust core (~72% of the codebase) ([eclipse-iceoryx/iceoryx2 README](https://github.com/eclipse-iceoryx/iceoryx2)).
+
+**Canonical use cases.** Real-time publish–subscribe streaming of large sensor payloads,
+request–response, event signaling, and a shared-state *Blackboard*, between processes in
+*mission-critical* systems ([iceoryx.io](https://iceoryx.io/)) — i.e. moving high-rate sensor and
+actuator data inside a robot or an autonomous vehicle with bounded, predictable latency.
+
+## 2. Transport model
+
+**Shared-memory, same-machine.** iceoryx is fundamentally a **single-machine** shared-memory
+transport — data lives in shared-memory segments and processes read it in place. iceoryx2 is
+described as *"same-machine only … communication between multiple processes/applications on a single
+system"* ([eclipse-iceoryx/iceoryx2 README](https://github.com/eclipse-iceoryx/iceoryx2)).
+Cross-machine reach exists only through **add-on gateways**: iceoryx v1 offers a *"Gateway for
+Cyclone DDS"* ([iceoryx README](https://github.com/eclipse-iceoryx/iceoryx)); iceoryx2 has a
+**network tunnel** (Zenoh-based) that is *"still in development, so some patterns, like
+request–response and blackboard, aren't supported yet"* ([iceoryx2 v0.7 release](https://ekxide.io/blog/iceoryx2-0-7-release/)).
+So cross-machine is a bolt-on, not the design center.
+
+**Message size/frequency it targets.** Large payloads (sensor frames), streamed at high frequency
+(the "high-volume … data-intensive" framing). Its differentiator — *"many times faster for large
+payloads"* — only materializes when payloads are big and copies are expensive ([iceoryx.io](https://iceoryx.io/)).
+
+**Daemon (RouDi).** Original iceoryx **requires a central daemon, RouDi** ("Routing and Discovery"):
+a broker that manages shared-memory segments, communication ports, service discovery, and process
+lifecycle, connecting compatible publishers/subscribers — while *not* being in the data path
+([RouDi Daemon, DeepWiki](https://deepwiki.com/eclipse-iceoryx/iceoryx/3.2-roudi-daemon)). A major
+architectural change in **iceoryx2 is the elimination of the central daemon**: it *"embraces a fully
+decentralized architecture, eliminating the need for a central daemon entirely"*
+([RouDi/decentralization summary](https://deepwiki.com/eclipse-iceoryx/iceoryx/3.2-roudi-daemon)).
+Either way you are operating shared-memory-segment infrastructure, not a job queue.
+
+**Language bindings / Python.** iceoryx2 lists first-class bindings for C, C++, C#, Python and
+others; Python is marked *"done"* in the README's binding matrix ([iceoryx2 README](https://github.com/eclipse-iceoryx/iceoryx2)).
+But "done" here means the binding *exists* — it is a young binding over a young (post-1.0, formerly
+0.x) core, wrapping a Rust real-time IPC API. There is no evidence of a mature, widely-deployed
+Pythonic ecosystem the way there is for, say, `sqlite3`, `redis-py`, or `psycopg`. Python is also
+the *worst* fit for iceoryx's premise: the GIL, garbage collection, and interpreter overhead
+obliterate the nanosecond determinism that justifies the library's existence.
+
+## 3. Fit for THIS workload — blunt quantification
+
+The mismatch is not marginal; it is categorical. Line the two workloads up:
+
+| Dimension | iceoryx targets | Our orchestrator | Mismatch |
+|---|---|---|---|
+| **Per-message latency that matters** | ~100 ns – <1 µs, *deterministic* | Multi-**minute** ticket; a scheduling decision that takes 100 ms is invisible | ~**10^9–10^10×** (nanoseconds vs minutes) |
+| **Message frequency** | 10^4–10^6+ msg/s (sensor streams) | A handful of tickets; state changes every few seconds–minutes | ~**10^6–10^8×** |
+| **Payload** | Large binary frames (camera/LiDAR), copy-cost-dominated | KB-scale JSON/text; copy cost irrelevant | zero-copy buys **nothing** |
+| **Language** | C++ / Rust, real-time, no GC | Python / CLI, GC'd, `claude -p` subprocesses | GIL/GC negate determinism |
+| **Topology** | Same-machine shared memory | Single Mac now, but escalation is **cloud/cross-machine** (GitHub/Slack/Discord) | cross-machine is iceoryx's weak, in-dev path |
+| **Durability** | In-memory, ephemeral (data plane) | Tickets must **survive crashes/restarts** for minutes–hours | iceoryx has no durability story |
+| **Real-time guarantee** | Load-bearing (safety-critical) | Irrelevant — we wait on network-bound LLM calls | paying for a guarantee we never use |
+
+The killer points:
+
+1. **Zero-copy is the whole product, and we don't need it.** iceoryx exists to avoid copying a
+   large payload. Copying a few KB of JSON is free at our scale. We would adopt a library whose
+   central feature is inert for us.
+2. **Its latency budget is ~10 orders of magnitude tighter than ours.** When the *task* takes
+   minutes and blocks on network I/O to an LLM, sub-microsecond transport latency is
+   indistinguishable from any other option. Optimizing it is meaningless.
+3. **Durability is the property we actually need, and iceoryx doesn't provide it.** A multi-minute
+   ticket must survive an orchestrator restart. iceoryx is an ephemeral in-memory *data plane*; the
+   moment the process dies, in-flight state is gone. Our real requirement is a *durable work queue*,
+   which is a different category of tool entirely.
+4. **We're often cross-machine, which is iceoryx's weakest path.** Escalation to GitHub/Slack/Discord
+   and any cross-machine coordination go through cloud APIs — exactly where iceoryx's shared-memory
+   model does not reach without an in-development gateway.
+5. **Operational cost with no payoff.** iceoryx v1 means running and configuring RouDi; iceoryx2
+   means driving a young Rust IPC core through young Python bindings and managing shared-memory
+   segments — real complexity, in exchange for solving a problem (fast local data movement) we do
+   not have.
+
+**Bottom line for §3:** using iceoryx here is like laying fiber-optic backbone to pass notes between
+two people sitting at the same desk. Impressive, correct engineering — for a different problem.
+
+## 4. What IS the right primitive at this scale
+
+Order the candidates by how much machinery they add, and stop at the first that covers the need:
+
+1. **Claude Code's native channels + subagents + defer (start here).** The orchestrator is already
+   an agent harness. Subagents/`Agent` delegations, `SendMessage` for continuing a running agent, and
+   deferring/scheduling are the *native* coordination primitives — no external broker, no transport
+   layer, no daemon. For "spawn a ticket, get its result back, escalate to a human," this is the
+   intended mechanism and adds zero infrastructure. This is the `use-tool-builtins` answer: prefer
+   the harness's built-in coordination before importing any transport.
+
+2. **A durable work queue — the real gap iceoryx doesn't fill.** Because tickets run for minutes and
+   must survive restarts, back the coordination with a *durable* store:
+   - **File/SQLite queue** for a single Mac: one process, ACID, zero services to run, trivially
+     inspectable, survives reboots. This is almost certainly the right weight for "a handful of
+     multi-minute tickets on one machine." (The file-vs-SQLite choice is being researched
+     separately — either is orders of magnitude better-matched than iceoryx.)
+   - **Postgres + pgmq** if/when you outgrow one machine or want multiple orchestrator processes,
+     `LISTEN/NOTIFY`, visibility timeouts, and SQL introspection. Adds a service to run; buys
+     multi-consumer durability. (Also under separate research.)
+
+   Either gives the two things iceoryx lacks and we actually need: **durability** and **at-least-once
+   delivery across restarts** — at human-scale message rates where their overhead is irrelevant.
+
+3. **Plain files / a directory as a blackboard.** For shared state between a few agents, a
+   well-structured directory (or a single JSON/SQLite state file) is legible, greppable, diffable,
+   and crash-safe. This matches the repo's existing `.omc/notepad.md` / `.omc/state/` conventions
+   and needs no new dependency.
+
+4. **An MCP-based blackboard** only if agents genuinely need a *shared, queryable* live state surface
+   with typed access (the repo already ships a `memory` MCP). Use it when structured shared state
+   earns its keep — not as the default; it adds a server and per-call cost.
+
+**Human escalation** (GitHub/Slack/Discord) stays exactly where the prompt puts it: cloud APIs and
+`gh`. None of that belongs on a shared-memory bus.
+
+### Recommendation
+
+Use **Claude Code native subagents/channels/defer** for coordination, backed by a **durable
+file/SQLite (or later Postgres/pgmq) queue** for ticket state and restart-survival, with **plain
+files** for shared blackboard state and **cloud APIs** for human escalation. Reserve an **MCP
+blackboard** for the specific case of shared queryable live state.
+
+**Do not adopt iceoryx or iceoryx2.** Judged purely on fit — setting aside how genuinely impressive
+the technology is — it is a hard-real-time, zero-copy, same-machine *sensor data plane*. Our
+orchestrator is a low-frequency, minutes-scale, durable, partly-cross-machine *control plane* in
+Python. Overkill understates it; it is a category mismatch. The engineering it optimizes (nanosecond
+copy-free transport) is precisely the dimension our workload does not care about, and the property we
+do need (durability across restarts) is one it does not offer.
+
+## GitHub repos touched
+
+- [eclipse-iceoryx/iceoryx](https://github.com/eclipse-iceoryx/iceoryx) — original C++ iceoryx: zero-copy shared-memory model, automotive/AUTOSAR/ROS 2 origin, DDS gateway.
+- [eclipse-iceoryx/iceoryx2](https://github.com/eclipse-iceoryx/iceoryx2) — Rust successor: latency claims, same-machine scope, Python-binding status, decentralized (no-RouDi) design.
+- [ros2/rmw_iceoryx](https://github.com/ros2/rmw_iceoryx) — referenced as the ROS 2 middleware integration for iceoryx (robotics use case).
+- [eclipse-zenoh/zenoh](https://github.com/eclipse-zenoh/zenoh) — the network layer behind iceoryx2's in-development cross-machine tunnel.

--- a/.omc/kb/reports/followup-multiprovider.md
+++ b/.omc/kb/reports/followup-multiprovider.md
@@ -1,0 +1,353 @@
+# Follow-up: Multi-Provider / Multi-Subscription Backends for Cheap Bulk LLM Work
+
+**Date:** 2026-07-19
+**Question:** How do we route bulk LLM grunt work (graphify knowledge-graph
+ingestion, sub-agent tasks) to free / cheap / local models on a Mac, and reserve
+the Claude subscription for orchestration? Emphasis on **features/techniques to
+adopt or build**, not just products. Free/self-hostable options only for
+adoption; paid ones cited as feature references.
+
+**Bottom line up front:** graphify's extractor already has the seam we need —
+`--backend openai` honours `OPENAI_BASE_URL`, and `--backend ollama` needs no
+key. That single fact means **doc ingestion can run at $0 against a local Ollama
+model, or against NVIDIA's free OpenAI-compatible endpoint, without spending one
+Claude token.** For Claude Code itself (and sub-agents), the `ANTHROPIC_BASE_URL`
+/ `ANTHROPIC_AUTH_TOKEN` env pair lets a proxy swap the model under the harness.
+Concrete recommendation and setup at the end.
+
+---
+
+## 1. NVIDIA NIM as a free Claude Code backend
+
+There are **two distinct paths**, and they are frequently conflated. Both are
+real; they differ in where inference runs and which wire protocol is spoken.
+
+### Path A — self-hosted NIM, native Anthropic protocol (official NVIDIA doc)
+
+NVIDIA's official Claude Code integration doc
+([docs.nvidia.com/nim/.../claude-code.html](https://docs.nvidia.com/nim/large-language-models/latest/ai-assistant-integrations/claude-code.html))
+assumes **you have deployed a NIM container yourself** and it serves an
+**Anthropic-compatible `/v1/messages` endpoint**. Claude Code is pointed at it
+purely through env vars — no code change:
+
+```bash
+export ANTHROPIC_BASE_URL="http://${NIM_ENDPOINT}:${NIM_SERVER_PORT}"   # default port 8000
+export ANTHROPIC_API_KEY="not-used"          # "NIM does not validate ANTHROPIC_API_KEY. Set it to any non-empty string"
+export ANTHROPIC_CUSTOM_MODEL_OPTION="${MODEL_NAME}"
+export ANTHROPIC_DEFAULT_HAIKU_MODEL="${MODEL_NAME}"
+export ANTHROPIC_DEFAULT_SONNET_MODEL="${MODEL_NAME}"
+export ANTHROPIC_DEFAULT_OPUS_MODEL="${MODEL_NAME}"
+export CLAUDE_CODE_SUBAGENT_MODEL="${MODEL_NAME}"
+```
+
+Notes from the doc: Claude Code **requires tool calling**, so the served model
+must support tool use. This is the mechanism that makes NIM look like Anthropic
+to Claude Code: it re-implements the `/v1/messages` shape. **Cost is your own
+GPU / DGX** — "free" only if you already own the hardware. On an arm64 Mac this
+is **not** a practical local path (NIM containers target NVIDIA GPUs), so Path A
+matters to us only if we ever run NIM on a rented/owned GPU box.
+
+### Path B — free *hosted* NIM at build.nvidia.com, via a translating proxy (the blog)
+
+The blog
+([themenonlab.blog/.../free-claude-code-nvidia-nim-proxy-zero-api-fees](https://themenonlab.blog/blog/free-claude-code-nvidia-nim-proxy-zero-api-fees))
+describes the genuinely-free path: NVIDIA hosts 100+ models on
+**`https://integrate.api.nvidia.com/v1`**, an **OpenAI-compatible** endpoint
+(vLLM-backed), free to NVIDIA Developer Program members. Because Claude Code
+speaks Anthropic and NIM-hosted speaks OpenAI, the blog puts a **proxy** in
+between (`free-claude-code` / `fcc-server`; LiteLLM is the general-purpose
+equivalent) that translates Anthropic `/v1/messages` ⇄ OpenAI
+`/v1/chat/completions`:
+
+```bash
+# 1. Get a free key at build.nvidia.com/settings/api-keys  (no credit card)   → nvapi-...
+# 2. Run a translating proxy (fcc-server, or LiteLLM) and paste NVIDIA_NIM_API_KEY in its admin UI
+# 3. Point Claude Code at the proxy's Anthropic endpoint:
+export ANTHROPIC_BASE_URL="http://localhost:<proxy-port>"
+export ANTHROPIC_AUTH_TOKEN="anything-nonempty"     # proxy holds the real nvapi- key
+```
+
+**Free-tier limits (corroborated across sources):** **~40 requests/minute**,
+account-level, across NIM models; upgrade to ~200 RPM by request. Historical
+"1,000 signup credits, up to 5,000 total" appears to have shifted toward pure
+rate-limiting with no per-token billing on the free tier — treat the credit
+numbers as stale and the **40 RPM** as the real constraint. Sources:
+[decodethefuture](https://decodethefuture.org/en/nvidia-nim-api-pricing-limits-guide/),
+[yangmao.ai free-tier](https://yangmao.ai/en/providers/nvidia-build/free-tier/),
+[NVIDIA dev forums rate-limit thread](https://forums.developer.nvidia.com/t/api-rate-limit-increase-for-nvidia-nim/366043).
+
+**Models (truly free):** 100+ open-weight models — Llama (incl. 405B), Qwen3 /
+Qwen3-Coder, DeepSeek, Kimi K2, Mistral, Gemma, GLM, MiniMax, and NVIDIA
+Nemotron. Sources:
+[ai-sdk.dev NIM provider](https://ai-sdk.dev/providers/openai-compatible-providers/nim),
+[NVIDIA LLM API reference](https://docs.api.nvidia.com/nim/reference/llm-apis).
+*(Caveat / control-arm: a page-summarizer returned some exotic version strings —
+"nemotron-3-super-120b", "kimi-k2.5", "glm5.1", "minimax-m2.5" — that I could not
+independently confirm; treat the **build.nvidia.com catalog UI as the authority**
+for exact model IDs before pinning one.)*
+
+**Quality tier:** frontier-open-weight. Llama-405B / Qwen3-Coder-480B / Kimi-K2
+are strong on structured extraction and summarization — below top Claude/Gemini
+on hard reasoning, comfortably adequate for graphify node/edge extraction and
+doc/code summarization.
+
+**Is it OpenAI-compatible (so graphify `--backend openai` + a base URL works)?**
+**Yes — directly, with no proxy.** `integrate.api.nvidia.com/v1` is a standard
+OpenAI endpoint. For graphify we skip the Anthropic proxy entirely and point the
+OpenAI backend at it (see §4a). The proxy is only needed to feed **Claude Code
+itself**, which speaks Anthropic.
+
+---
+
+## 2. Local models on an Apple-Silicon Mac
+
+All four runtimes below run natively on M-series and expose an
+**OpenAI-compatible** HTTP endpoint, so graphify `--backend openai`
+(`OPENAI_BASE_URL=...`) or `--backend ollama` can drive them, and a proxy can put
+them behind Claude Code's `ANTHROPIC_BASE_URL`.
+
+| Runtime | Endpoint | Notes |
+|---|---|---|
+| **Ollama** | `http://localhost:11434/v1` (OpenAI) + native `/api` | **0.19+ (Mar 2026) replaced its engine with Apple MLX on Apple Silicon** — big throughput win (M5 Max Qwen3.5-35B-A3B: decode +93%). Native `format` param takes a **JSON schema** for constrained structured output. graphify has a first-class `--backend ollama` (no key). Easiest path. |
+| **LM Studio** | local server, OpenAI drop-in | GUI for browse/download/chat; serves **MLX-optimized** models; "drop-in replacement for OpenAI's API." Good for humans picking models. |
+| **MLX / mlx-lm** | `mlx_lm.server` (OpenAI-compatible) | Apple's native framework; "**fastest way to run** [models]… beating llama.cpp by 30–40% on M5." Lowest-level, highest-throughput; more setup. |
+| **llama.cpp** | `llama-server` (OpenAI-compatible) | Mature, portable, GGUF; MLX now edges it on Mac but llama.cpp remains the compatibility baseline and graphify lists it explicitly as an `OPENAI_BASE_URL` target. |
+
+Sources: [Ollama MLX blog](https://ollama.com/blog/mlx),
+[Ollama structured outputs](https://ollama.com/blog/structured-outputs),
+[SitePoint local-LLMs Apple Silicon 2026](https://www.sitepoint.com/local-llms-apple-silicon-mac-2026/),
+[gingter.org Ollama-goes-MLX](https://gingter.org/2026/04/23/ollama-goes-mlx/).
+
+**Which models are strong enough?**
+- **(a) graphify semantic extraction (structured JSON nodes/edges):** a **Qwen3
+  ~7–32B** or **Llama-3.x-8B/70B** instruct model, run with **schema-constrained
+  decoding** (Ollama `format: <json-schema>`, or llama.cpp/vLLM grammar). The
+  constraint matters more than raw model size here — a 7–14B model with a JSON
+  schema reliably emits valid node/edge objects. On a 32–64GB Mac a 32B (4-bit)
+  fits; on 16GB stick to 7–8B.
+- **(b) code/doc summarization:** **Qwen3-Coder** or **Llama-3.x** at 8–14B is
+  ample for file/section summaries; larger (32–70B) only if summary quality
+  visibly lags. Apple's own 3B on-device model is explicitly tuned for
+  "summarization, classification, structured extraction" — fine for the cheapest
+  tier.
+
+**Realistic quality vs Claude:** local 7–14B is clearly weaker on multi-hop
+reasoning and long-context synthesis, but for **mechanical extraction and
+per-file summarization** (graphify's actual grunt work) the gap is small,
+especially with schema constraints. Reserve Claude for the *orchestration* and
+the final synthesis/GRAPH_REPORT reasoning, not the per-file passes.
+
+---
+
+## 3. Codex and Google Antigravity as scriptable backends
+
+### OpenAI Codex CLI — scriptable today
+
+`codex exec` is a **headless, non-interactive** mode: prompt in on argv/stdin,
+final agent message out on stdout, progress on stderr, then exit — no TUI, no
+approval prompt, sandbox-policed (default **read-only**). It's built for CI /
+cron / git-hooks / batch loops over many files, and composes in pipes. This is
+exactly the shape for "agent grunt work": fan a directory of files through
+`codex exec` and collect stdout. Backed by the Codex model family (400K context
+in-CLI). Sources: [OpenAI non-interactive-mode docs](https://developers.openai.com/codex/noninteractive),
+[codex/docs/exec.md](https://github.com/openai/codex/blob/main/docs/exec.md),
+[Developers Digest headless guide](https://www.developersdigest.tech/blog/codex-exec-ci-headless-guide).
+This repo already sanctions Codex CLI usage (ai-cli-invocation rule / reference
+memory: stdin + `-` flag, `--ephemeral` for research). **Realistically
+scriptable: fully.** Cost = ChatGPT/Codex subscription or API; not free, so it's
+a *feature reference* for headless agent orchestration, not a free-tier adopt.
+
+### Google Antigravity — mostly GUI, but a headless CLI now exists
+
+Antigravity is Google's agent-first platform: **Antigravity 2.0** is a standalone
+desktop IDE for orchestrating parallel agents (GUI), and **Antigravity CLI** is a
+terminal surface that shares the same agent harness and supports **headless
+execution**. Critically, **Gemini CLI was folded into Antigravity CLI** — as of
+**June 18, 2026** the old Gemini CLI / Code Assist paths stopped serving free and
+Pro/Ultra requests. So "script Gemini agentically from a terminal" now means
+**Antigravity CLI**. Sources:
+[Google "transitioning Gemini CLI to Antigravity CLI"](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/),
+[Choosing Antigravity or Gemini CLI](https://cloud.google.com/blog/topics/developers-practitioners/choosing-antigravity-or-gemini-cli),
+[Build with Antigravity](https://developers.googleblog.com/build-with-google-antigravity-our-new-agentic-development-platform/).
+**Realistically scriptable:** the CLI is headless-capable; the desktop app is
+GUI-only orchestration. For *our* purpose the simpler lever is the **Gemini
+Developer API free tier** (§4c) driven straight from graphify `--backend gemini`
+— no IDE, no agent harness. Use Antigravity when you want a full agent loop with
+Gemini 3's reasoning; use the raw API for cheap bulk extraction.
+
+---
+
+## 4. Pointing graphify's `--backend` at cheap/free extraction
+
+graphify's extractor env-var seam (verified against the PyPI `graphifyy` README /
+"LLM Dependencies"):
+
+| Backend | Key env | Base-URL override | Default model | Cost |
+|---|---|---|---|---|
+| `gemini` | `GEMINI_API_KEY` / `GOOGLE_API_KEY` | — | `gemini-3.1-pro-preview` *(version-dependent; older builds defaulted to a flash preview — pin `--model`)* | free tier |
+| `openai` | `OPENAI_API_KEY` | **`OPENAI_BASE_URL`** ("any OpenAI-compatible server: llama.cpp, vLLM, LM Studio") | `gpt-4.1-mini` | $0 if base-URL → local/NIM |
+| `ollama` | none | `OLLAMA_BASE_URL` (`http://localhost:11434`), `OLLAMA_MODEL`, `GRAPHIFY_OLLAMA_NUM_CTX` | auto-detect | $0, local |
+| `claude` | `ANTHROPIC_API_KEY` | `ANTHROPIC_BASE_URL` (Anthropic-compatible, e.g. LiteLLM proxy / self-hosted NIM) | `claude-sonnet-4-6` | subscription |
+| `deepseek` | `DEEPSEEK_API_KEY` | — | — | cheap paid |
+| `kimi` | `MOONSHOT_API_KEY` | — | — | cheap paid |
+
+The `OPENAI_BASE_URL` and `ANTHROPIC_BASE_URL` overrides are the whole game: they
+turn the `openai`/`claude` backends into pointers at **any** compatible server.
+
+### (a) graphify against a free NIM endpoint — no proxy needed
+
+```bash
+export OPENAI_API_KEY="nvapi-YOUR_FREE_KEY"          # from build.nvidia.com
+export OPENAI_BASE_URL="https://integrate.api.nvidia.com/v1"
+graphify extract ./docs --backend openai --model meta/llama-3.3-70b-instruct
+#   (pick an exact model ID from the build.nvidia.com catalog)
+```
+
+Cost: **$0** within the **~40 RPM** free limit. Because extraction is per-file
+and rate-limited, add a small concurrency cap / retry-with-backoff so a large
+corpus doesn't trip 40 RPM (graphify's incremental SHA256 cache already bounds
+re-runs to changed files).
+
+### (b) graphify against local Ollama — fully offline, no key, no limit
+
+```bash
+ollama pull qwen3:14b        # or a Qwen3-Coder / Llama-3.x tag
+graphify extract ./docs --backend ollama --model qwen3:14b
+#   OLLAMA_BASE_URL defaults to http://localhost:11434; GRAPHIFY_OLLAMA_NUM_CTX to widen context
+```
+
+Cost: **$0**, private, unlimited. Quality slightly below NIM's big models but the
+JSON-schema constraint keeps node/edge output valid. **This is the recommended
+default** (§ recommendation).
+
+### (c) graphify against Gemini free tier
+
+```bash
+export GEMINI_API_KEY="..."      # AI Studio, no card
+graphify extract ./docs --backend gemini --model gemini-2.5-flash
+```
+
+**Free-tier limits (2026, moving target):** Google **no longer publishes a fixed
+universal table** — active quotas are project-specific in AI Studio, and **free
+quotas were cut 50–80% on 2025-12-07**. Widely-reported current figures for the
+flash tier: **~10 RPM, ~250K TPM, ~250–1,500 RPD** depending on model/account.
+**Verify in the AI Studio rate-limit dashboard** before relying on a number.
+Sources: [Gemini rate-limits doc](https://ai.google.dev/gemini-api/docs/rate-limits),
+[Gemini pricing](https://ai.google.dev/gemini-api/docs/pricing),
+[TokenMix free-tier writeup](https://tokenmix.ai/blog/gemini-api-free-tier-limits).
+Flash is fast and cheap-to-free and handles structured extraction well; the RPD
+cap makes it a **second** choice behind local Ollama for a large corpus.
+
+---
+
+## 5. Cost-control techniques worth *building* (not just buying)
+
+Ordered by ROI for our setup. The recurring theme: put a **seam** between "work"
+and "which model does it," then optimize behind the seam.
+
+1. **Provider routing + fallback (BUILD — highest value).** A single
+   OpenAI/Anthropic-compatible **gateway** in front of everything, with an
+   ordered model list: *local Ollama → free NIM → Gemini free → Claude
+   (last-resort)*. On rate-limit / low-confidence, fall through to the next tier.
+   **LiteLLM** is the canonical open-source implementation (universal gateway,
+   hard budget caps, spend tracking, fallback routing across 100+ providers) and
+   speaks **both** OpenAI and Anthropic wire formats — so it simultaneously backs
+   graphify `--backend openai` *and* Claude Code's `ANTHROPIC_BASE_URL`. Adopt
+   LiteLLM as the seam rather than hand-rolling per-tool env-var juggling.
+   ([LiteLLM router guide](https://www.gingerlabs.ai/blog/litellm-router-setup-guide),
+   [LLM-router comparison 2026](https://www.developersdigest.tech/blog/llm-router-comparison-2026)).
+
+2. **Cheap-draft-then-strong-verify / confidence-gated escalation (BUILD).**
+   Run the cheap tier first; only escalate the *hard* items to Claude.
+   **RouteLLM** demonstrates the pattern: route simple queries to cheap models,
+   reportedly **~95% of frontier quality at a 75–85% cost cut**. For graphify:
+   extract with local/NIM, and have Claude *review only* the low-confidence or
+   god-node fragments — not every file. ([RouteLLM / routing evidence](https://wavect.io/blog/reduce-llm-token-costs-2026/)).
+
+3. **Embedding-based dedup before LLM calls (BUILD — cheap, big win).** Before
+   sending a doc/section to any model, embed it (local embedding model, ~free)
+   and skip near-duplicates / unchanged content. graphify already does SHA256
+   incremental caching (exact-match); an embedding pass catches *semantic*
+   duplicates the hash misses. This is the single cheapest lever for a corpus
+   full of near-identical rule/agent docs like ours.
+
+4. **Semantic caching (ADOPT — GPTCache).** Cache by embedding-similarity so
+   "similar" prompts reuse a prior answer; reported **~70% cost reduction on
+   high-repetition workloads**. Useful for repeated sub-agent queries; less so
+   for one-shot ingestion. ([GPTCache / caching](https://www.finout.io/blog/5-open-source-tools-to-control-your-ai-api-costs-at-the-code-level)).
+
+5. **Prompt/context compression (ADOPT selectively — LLMLingua).** Compress
+   verbose context up to ~20× "with minimal performance loss." Worth it when we
+   *must* use a paid/frontier model on long context; wasteful on already-free
+   local calls. ([LLMLingua](https://wavect.io/blog/reduce-llm-token-costs-2026/)).
+
+6. **Batching (ADOPT where offered).** Provider batch endpoints run ~50% cheaper
+   for non-latency-sensitive bulk work — exactly ingestion's profile. Free-tier
+   NIM/Gemini batch availability is limited, but the pattern (queue → batch →
+   collect) is the right shape for our offline periodic builds.
+
+**Recommended build order** (mirrors the field's consensus "caching → batching →
+routing → right-size model → semantic-cache → compress"): the two homegrown
+pieces worth owning are the **routing/fallback seam** (LiteLLM, config not code)
+and the **embedding dedup + confidence-gated escalation** in front of graphify.
+Everything else is adopt-off-the-shelf. ([token-optimization order-of-operations](https://wavect.io/blog/reduce-llm-token-costs-2026/),
+[awesome-llm-token-optimization](https://github.com/pleasedodisturb/awesome-llm-token-optimization)).
+
+---
+
+## Concrete recommendation
+
+**For graphify ingestion — start here, in this order:**
+
+1. **Local Ollama (MLX) + `--backend ollama`.** `$0`, private, no rate limit,
+   MLX-accelerated on Apple Silicon, first-class graphify support, JSON-schema
+   constrained output. This is the default. Model: `qwen3:14b` (or a Qwen3-Coder
+   tag for code-heavy corpora); drop to 7–8B on ≤16GB RAM, go 32B (4-bit) on
+   ≥32GB.
+   ```bash
+   ollama pull qwen3:14b
+   graphify extract ./docs --backend ollama --model qwen3:14b
+   ```
+2. **Free NVIDIA NIM via `--backend openai` + `OPENAI_BASE_URL`** as the
+   stronger-quality free fallback for hard docs where the local model's
+   extraction is thin — `integrate.api.nvidia.com/v1`, free `nvapi-` key,
+   ~40 RPM, big open-weight models (Llama-405B / Qwen3-Coder). No proxy needed
+   for graphify.
+3. **Gemini free tier (`--backend gemini`)** as a third option — verify the
+   current AI Studio RPD before a big run (quotas were cut 50–80% in Dec 2025).
+
+**Reserve Claude** for orchestration and final synthesis (the skill's
+subagent-driven build, GRAPH_REPORT reasoning) — never for the per-file
+extraction passes.
+
+**For agent grunt work / Claude Code sub-agents:** put **LiteLLM** in front as
+the routing seam. It backs graphify's OpenAI backend *and* fronts Claude Code via
+`ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN`, with an ordered fallback chain
+(local → free NIM → Gemini free → Claude). `codex exec` is the ready-made
+headless loop if we want a second scriptable agent for read-only analysis
+batches, though it's subscription-priced (feature reference, not a free adopt).
+
+**One config, three consumers:** the `OPENAI_BASE_URL` / `ANTHROPIC_BASE_URL`
+override is the common seam. Set it once (to LiteLLM, or straight to Ollama/NIM)
+and graphify extraction, Claude Code, and any sub-agent all ride the same
+cheap/free backend routing without per-tool changes.
+
+**Verification caveats (control-arm discipline):** (1) exact NIM model IDs move —
+confirm against the build.nvidia.com catalog before pinning; (2) Gemini free RPD
+is project-specific and was recently cut — read the AI Studio dashboard, don't
+trust a blog number; (3) graphify's default `gemini` model string differs by
+version (task brief said a flash preview; current PyPI README says
+`gemini-3.1-pro-preview`) — always pass `--model` explicitly rather than relying
+on the default.
+
+---
+
+## GitHub repos touched
+
+- [openai/codex](https://github.com/openai/codex) — `codex exec` headless/non-interactive mode for scriptable agent grunt work (docs/exec.md).
+- [pleasedodisturb/awesome-llm-token-optimization](https://github.com/pleasedodisturb/awesome-llm-token-optimization) — curated list of LLM cost-reduction tools/techniques (routing, caching, compression, dedup).
+
+*(graphify/`graphifyy`, NVIDIA NIM, LiteLLM, RouteLLM, LLMLingua, GPTCache,
+Ollama, LM Studio, MLX referenced via their docs/PyPI/vendor pages rather than
+direct GitHub source reads — enumerated here for traceability but not "source
+files read".)*

--- a/.omc/kb/reports/followup-orchestrator-trends.md
+++ b/.omc/kb/reports/followup-orchestrator-trends.md
@@ -1,0 +1,462 @@
+# Follow-up: Strong-Model-as-Orchestrator over Cheaper/Local Workers — Techniques to Build
+
+**Date:** 2026-07-19
+**Scope:** Techniques and features (not just products) for a strong model
+(Claude/Fable 5) acting as an ORCHESTRATOR that plans and delegates to
+cheaper/local worker models, optimizing cost + context + code-output quality.
+Anchored on the maintainer's reference to **BuildContext/fable-orchestrator**
+(Fable 5 conducts, Grok 4.5 Heavy implements).
+
+**How to read the citations:** claims traced to a primary source (a repo's own
+files, an arXiv paper, a vendor doc) are marked plainly. Claims that survive
+only on a blog/newsletter/vendor-marketing source are labelled **[secondary]**
+or **[informal]**, per the repo's "a fact needs its source AND its condition"
+discipline (`.claude/rules/verify-before-advancing.md`,
+`probes-need-a-control-arm.md`). Benchmark numbers are reported WITH the
+condition that makes them true (model pairing, dataset) — a bare percentage is
+not carried forward.
+
+---
+
+## 1. BuildContext/fable-orchestrator — concrete read of the source
+
+Read directly from the repo (`master` branch, v1.2.2, updated 2026-07-19):
+`README.md`, `skills/orchestration/SKILL.md`, `agents/grok-implementer.md`,
+`agents/fable-advisor.md`, `scripts/run-grok-headless.sh`, `hooks/`.
+
+### What it is
+
+A **Claude Code plugin** that runs the "architect pattern": the smartest model
+in the chair (Claude **Fable 5**) owns requirements, decomposition, specs,
+routing, and accept/reject; a **cheaper cross-vendor lane** (Grok 4.5 Heavy via
+its headless CLI) does all the typing. It is a hardened fork of
+`DannyMac180/fable-advisor` (the "pure cost/routing essay"); this fork adds
+**hard gates** (deny-hooks, a shell launcher, a completion contract) learned
+from real React-Native/Expo autonomous sessions. Tagline: *"Fable thinks. Grok
+types. STATUS decides. Ledger remembers."*
+
+### The orchestration model — yes, strong-plans / cheap-executes
+
+The README's own diagram: Fable 5 = "session architect · specs · routing ·
+STATUS accept/reject · ledger"; below it three MODE lanes (`explore` /
+`implement` / `verify`) all feeding **Grok 4.5 Heavy · headless CLI**. The core
+principle, verbatim:
+
+> **"Tokens route by role, not by habit:** Fable emits judgment; Grok emits
+> volume; Argent evidence comes back as paths, not screenshot dumps into the
+> architect transcript."
+
+The `orchestration` SKILL states it as a cost model: *"Architect tokens are the
+scarce resource; external CLI tokens are the volume path… Inline architect
+implementation is a **quota failure**."* The strong model is explicitly
+forbidden from editing product code — enforced by a hook, not prose (see below).
+
+### Token / context optimizations it actually implements
+
+These are the reusable parts — each is a buildable technique, not a product:
+
+1. **Role-partitioned token budget.** The architect emits only specs +
+   accept/reject verdicts. Any "broad search/read/log/diff" is pushed to a Grok
+   lane; only *conclusions* return to the architect session. The architect has
+   an explicit **"no-touch" table**: no `Write/Edit` under `src/`, no reading
+   product files >~80 lines "to understand", no full `git diff`/`tsc`/jest logs
+   in the transcript — those become `MODE: explore`/`verify` specs that return
+   "tables + exit codes".
+
+2. **Compressed structured reports as the only interface.** Workers return one
+   of three fixed shapes — `EXPLORE REPORT` (paths, symbols, ≤15-line
+   excerpts), `GROK REPORT` (STATUS, CHANGES one-line-per-file, DIFF STAT, ≤3
+   RISKY HUNKS of ≤15 lines, VERIFIED, GAPS), `VERIFY REPORT` (commands, exit
+   codes, first N errors). The architect *"does not re-read the whole tree to
+   double-check"* — it trusts the structured evidence. This is the single
+   biggest context saver: the expensive context never ingests the raw tree.
+
+3. **Doctrine in an on-demand skill, not always-on context.** The routing rules
+   live in `skills/orchestration/SKILL.md` (loaded only when orchestration is
+   relevant), keeping the always-on `CLAUDE.md` to "~one screen". Rationale
+   verbatim: *"Always-on project docs stay thin… Full doctrine loads when
+   orchestration is relevant — less permanent context tax."* Device/UI ("Argent")
+   skills are likewise loaded on demand ("Fourteen full device skill bodies
+   would drown the architect").
+
+4. **A durable ledger to survive compaction.** `docs/LEDGER.md` holds one
+   checkbox line per work unit; ticked `[x]` **only** on a `STATUS: pass|complete`
+   report + evidence. It is the "shared truth across turns when chat context is
+   compacted" — an external, cheap state store so the long chain doesn't
+   recompute what it already accepted. *"Do not dump full agent reports into the
+   ledger — paths and STATUS only."*
+
+5. **Metrics without transcript bloat.** Each headless run appends ONE JSON line
+   to `~/.claude/fable-orch/metrics.jsonl` — `{ts, rc, wall_s, best_of_n, cwd,
+   status, stall_s}`, **no prompt text** (confirmed in `run-grok-headless.sh`).
+   Observability that costs zero context.
+
+### How it routes work
+
+- **Five-part spec contract** on every delegation (workers share *none* of the
+  architect's context): **Objective (with MODE) · Files · Interfaces ·
+  Constraints · Verification**. "Can't finish the spec → the decision isn't made
+  yet. That's architect work, not a reason to dump ambiguity on Grok."
+- **Two-level parallelism.** *Level A* — the architect fans out N
+  `grok-implementer` agents in ONE message over independent (non-overlapping
+  write-path) units (prefers 3–6 parallel explores). *Level B* — a single Grok
+  session spawns its own depth-1 `explore`/`plan` subagents and merges before
+  reporting (`SUBAGENTS: N`). Routing rule: independent units with separate
+  accept/reject → Level A; one unit with internal parallel research → Level B.
+- **A second opinion via `fable-advisor`** — same strong model, *fresh context*,
+  read-only, ≤300 words, invoked at commitment boundaries (architecture,
+  migration, "are we done?", or after two failed attempts). Fresh context =
+  "reads code without the conversation's sunk-cost bias."
+
+### The hard-gate mechanisms (the "field manual" delta over upstream)
+
+These are the parts worth stealing wholesale, because each fixes a *measured*
+autonomous-agent failure:
+
+- **`hooks/block-architect-product-write.py`** (PreToolUse deny): the strong
+  model physically cannot write `src/`, `ios/`, `android/`, lockfiles,
+  `app.config.*`, `eas.json`, `locales/`, `assets/`. Rationale: *"Prose ('don't
+  implement yourself') is ignored under pressure. Hooks deny."* (This is exactly
+  our repo's own PreToolUse-guard philosophy — `mise-tasks-only.md`.)
+- **`hooks/block-named-cli-lane.py`**: blocks spawning the worker **with** a
+  `name` parameter. Combat bug: a *named* spawn "can strip the agent tool
+  whitelist → Sonnet **silently self-implements** and fakes a Grok report." The
+  fix is a hook + "spawn without name." (A concrete instance of a cheap-model
+  handoff silently degrading to the expensive model doing the work — worth
+  guarding against in any router.)
+- **`STATUS:` completion contract + `run-grok-headless.sh`.** Done ⇔ the report
+  body contains `STATUS: …`. If the model exits without it, the launcher
+  **stamps `STATUS: incomplete`** (never auto-`complete`). The launcher also
+  carries a **wall-clock + stall watchdog** (kills the headless PID if
+  `final.txt` stops growing; default stall = timeout/3, clamped 300–900s),
+  uses `${FINAL}.pid` for lane identity (never `ps | grep grok` — a false-alive
+  trap), and forces one-shot headless flags: `--prompt-file · -m grok-4.5 ·
+  --always-approve · --output-format plain · --cwd · stdin /dev/null`. The
+  "worker claims done but did nothing / hangs forever" class is solved
+  mechanically, not by hope.
+- **Optional best-of-N** for *hard* implement tasks only: `GROK_BEST_OF_N=3`
+  (5th arg). A cheap-model quality knob applied selectively, logged in metrics.
+
+### Reusable-as-technique summary
+
+The transferable ideas: (a) role-partitioned token budget with a strong-model
+no-touch list enforced by a **deny-hook**; (b) **compressed structured reports**
+as the only cross-model interface; (c) a **five-part spec contract** so workers
+need zero shared context; (d) an **external ledger** for state across
+compaction; (e) a **machine completion contract** (`STATUS:` + watchdog +
+incomplete-stamp) so autonomy can't hang or fake success; (f) **on-demand skill
+loading** to keep permanent context thin; (g) **selective best-of-N** only where
+quality is hard.
+
+---
+
+## 2. Orchestrator → worker patterns generally
+
+### Plan-and-execute (planner/executor split)
+
+A planner LLM produces an inspectable step plan; a cheaper executor carries out
+each step and the planner revises on results. "The Executor can be a much
+simpler, more specialized, less computationally expensive component than the
+Planner — a smaller/faster LLM, a simple ReAct agent, or even deterministic
+code" [secondary — futureagi.com, aimultiple.com, 2026]. Security-hardened
+"plan-then-execute" variants exist as a design guide (arXiv 2509.08646). Fits
+**multi-step agent tasks** and **ticket implementation** best: the plan is the
+audit surface, execution nodes are swappable/cheap.
+
+### Strong-plans + cheap-executes / router + cascade
+
+Two production idioms, both measured:
+
+- **Routing** (pick the cheapest capable model per query up front) and
+  **cascading** (flow through increasingly capable models, stop when a quality
+  threshold is met). "Pre-request rules are cheapest; at-inference cascades are
+  most accurate; post-response retry is the safety net" [secondary — TianPan,
+  digitalapplied.com]. A unified routing+cascading treatment: ETH Zürich, arXiv
+  2410.10347; calibrated-uncertainty cascade routing, arXiv 2605.18796; cluster-
+  route-escalate, arXiv 2606.27457.
+- **RouteLLM** (LMSYS) is the canonical open router: in its own evals, **85%
+  cost savings while keeping 95% of GPT-4 quality — condition: MT-Bench, GPT-4-
+  Turbo vs Mixtral-8x7B pairing**; with LLM-judge data augmentation, 95% quality
+  at 14% strong-model calls (~75% cost reduction). The authors explicitly say
+  these numbers are "proof the technique works, not the number you will hit"
+  [RouteLLM paper via LMSYS, cited in leanlm.ai/burnwise 2026]. Best cost/quality
+  trade for **high-volume, heterogeneous-difficulty** work; less so for a small
+  number of hard tickets where you'd always route strong anyway.
+
+### Draft-then-verify (cheap draft, strong critique)
+
+Two distinct things share this name — don't conflate:
+
+- **Token-level speculative decoding**: a small draft model proposes N tokens;
+  the target verifies them in one forward pass; output is *provably identical* to
+  the target alone. 2–5× faster inference, up to 3.78× on code-gen benchmarks
+  with no quality loss (arXiv 2510.00294, 2412.00061; BentoML/Friendli guides
+  2026). This is an *inference-speed* optimization inside one model pair, mostly
+  a serving-layer concern (vLLM/SGLang) — relevant only if we self-host workers.
+- **Agent-level draft-then-critique**: cheap model drafts an artifact, strong
+  model critiques/repairs. This is the orchestration-level pattern and is where
+  the cost/quality lift for **code generation** comes from (see §4).
+
+### Map-reduce over chunks
+
+Split a large corpus/task into independent chunks, process each with a cheap
+worker (map), then a strong model reduces/merges. This is exactly Fable's Level-A
+explore fan-out, and exactly GraphRAG's "extract per chunk → summarize community
+clusters" pipeline (Microsoft GraphRAG, arXiv 2404.16130). **Best fit for
+knowledge-graph extraction** and for repo-wide exploration.
+
+### Spec-then-implement
+
+Strong model writes a precise spec (interfaces, constraints, verification), cheap
+model implements against it. Fable's five-part contract is the concrete
+instance. Best cost/quality for **code generation with clear interfaces**; the
+strong model's tokens go into the spec once, the cheap model absorbs the volume.
+
+### Which pattern wins per workload
+
+| Workload | Best pattern | Why |
+|---|---|---|
+| (a) Code generation (tickets) | **spec-then-implement + cheap-executes + a hard verify gate** | interfaces pin the cheap model; the gate (tests/compiler) is what actually lifts quality (§4) |
+| (b) KG extraction (graphify) | **map-reduce + structured-output workers + strong-model reduce** | per-chunk extraction is embarrassingly parallel; strong model only merges/dedupes entities |
+| (c) Multi-step agent tasks | **plan-and-execute + router/cascade + ledger** | inspectable plan, cheap steps, escalate hard steps, external state across compaction |
+
+---
+
+## 3. Context + token optimization techniques (buildable)
+
+Ranked by build-value for our orchestrator:
+
+1. **Sub-agent context isolation (highest value, already native).** Route the
+   main loop to the strong model; spawn small-model sub-agents for cheap,
+   parallelizable sub-tasks so the main loop's cache and budget stay intact. In
+   the Claude Agent SDK every `ResultMessage` carries `total_cost_usd` + per-model
+   token usage, so you can measure the split [secondary — helply.com,
+   totalum.app 2026; consistent with Anthropic SDK docs]. This is Fable's whole
+   design and our existing sub-agent model — extend it, don't rebuild it.
+
+2. **Prompt caching (highest ROI, must design for).** Anthropic cached reads
+   cost **10% of normal input** ($0.50/M vs $5/M); at a 90% hit rate a "$100
+   session costs ~$19" [secondary — finout.io, mindstudio 2026; primary:
+   platform.claude.com prompt-caching doc]. **Buildable lever:** put the STABLE
+   prefix (system prompt, orchestration doctrine, spec templates, graph schema)
+   FIRST and identical across calls so it caches; put volatile per-task content
+   last. This interacts with our concern about MCP schema injection — a stable
+   tool schema is cache-friendly; a churning one busts the cache.
+
+3. **Context compaction / summarization.** Anthropic ships server-side
+   compaction (beta header `compact-2026-01-12`) that condenses older history to
+   a summary as the window fills [secondary — mindstudio; primary: platform docs].
+   For our own orchestrator the buildable equivalent is the **external ledger**
+   (Fable's `LEDGER.md`) — cheaper and more controllable than re-summarizing,
+   because *we* decide what persists (STATUS + evidence paths only).
+
+4. **RAG over our own graphify graph (strong fit for our goal).** GraphRAG's
+   "traverse the subgraph for multi-hop context" is the retrieval story; a May-2026
+   benchmark across 47 deployments claims agentic-RAG-with-KG cut hallucination
+   ~62% at the cost of latency/orchestration complexity [secondary — MLOps
+   Community via jobsbyculture 2026]. **Buildable:** the graphify graph becomes
+   the retrieval index that injects *just the relevant subgraph* into a worker's
+   context instead of raw files — turning "read the tree to understand" into a
+   cheap, targeted injection. This is the highest-leverage synergy with our
+   existing graphify investment.
+
+5. **Structured-output constraint to cut retries.** Constrained/grammar decoding
+   (Outlines, Guidance, XGrammar — the default backend for vLLM/SGLang/TensorRT-LLM
+   as of March 2026) compiles a JSON schema into an FSM so only schema-valid
+   tokens are emitted. Reported effect: retry rates **5–15% → <1%** in production
+   pipelines [secondary — letsdatascience, aipromptarchitect 2026]; small-model-
+   specific reliability study at arXiv 2605.02363. Directly relevant to KG
+   extraction (entities/relations must be schema-valid) and to any tool-calling
+   worker.
+
+6. **Semantic caching of results.** Cache worker outputs keyed by a semantic hash
+   of the sub-task so repeated/near-repeated extractions or implementations skip
+   the model entirely [secondary — multiple 2026 routing guides]. Buildable as a
+   thin layer keyed on (spec-hash, file-hash); high value for graphify re-ingestion
+   of unchanged inputs.
+
+7. **KV-cache reuse (only if we self-host workers).** Serving-layer reuse of the
+   attention KV cache across requests with a shared prefix; overlaps with prompt
+   caching conceptually but lives in vLLM/SGLang. Skip unless local workers are
+   self-served.
+
+**Worth building into the orchestrator (in order):** prompt-cache-friendly stable
+prefix → external ledger for compaction → structured-output constraints on
+workers → RAG-over-graphify subgraph injection → semantic result cache. KV-cache
+and speculative decoding are serving-layer, deferred until/unless we self-host.
+
+---
+
+## 4. Code-output QUALITY when a cheap model writes the code
+
+The consistent 2026 finding: **the quality lift comes from the verification
+loop, not from the model.** Evidence:
+
+- **Iterative self-repair is universally effective.** "How Many Tries Does It
+  Take?" (arXiv 2604.10508): with ≤5 attempts and error feedback, pass rates rise
+  **+4.9 to +17.1 pts on HumanEval and +16.0 to +30.0 pts on MBPP**, across seven
+  models / three families. Condition: the feedback must be real execution/error
+  output, not self-reflection alone.
+- **Compiler + static-analysis + test loops stack.** LLMLOOP (arXiv 2603.23613)
+  runs five refinement loops (fix compile errors → fix static-analysis issues →
+  fix failing generated tests → improve tests via mutation) and reports **pass@10
+  90.24% vs 76.22% baseline**. Compiler-guided inference-time adaptation for a
+  typed language: arXiv 2602.11481. "Is Three the Magic Number?" (arXiv
+  2607.05197) studies repair-budget limits — diminishing returns set in, so cap
+  the loop (≈3 iterations is a common sweet spot).
+- **Best-of-N with a strong verifier** lifts a cheap generator when a reliable
+  discriminator scores samples — this is Fable's optional `--best-of-n` and the
+  RouteLLM "LLM-judge augmentation" result. Works only when the verifier is
+  cheaper-than-generation and trustworthy (a compiler/test suite is the ideal
+  verifier: free and objective).
+- **Spec-conformance checks**: the strong model's spec doubles as the
+  acceptance oracle (Fable's `Verification` field: "commands / checklist that
+  prove it works — not `true`/`echo ok`").
+
+**Takeaway for us:** a cheap worker's code becomes acceptable *when it must pass
+an objective gate the strong model defined*. Our repo already has the perfect
+gate — **`mise run lint` + `pytest` + `dotfiles-setup verify run`**. The
+buildable pattern: cheap worker implements against a spec → runs the gate →
+self-repairs on failure (cap ~3) → returns STATUS + evidence → strong model
+accepts only on green. This is `verify-before-advancing.md` mechanized as an
+orchestration loop, and TDD-first (`mattpocock-skills:tdd`) makes the gate exist
+before the worker writes a line.
+
+---
+
+## 5. Trends, last ~1 month (2026-06 / 2026-07)
+
+**Router/orchestration models became first-class products.**
+
+- **Sakana AI Fugu / Fugu Ultra** (launched **2026-06-22**): an orchestration
+  *model* — "a language model trained to call other LLMs in an agent pool,
+  including instances of itself, recursively," exposed via one OpenAI-compatible
+  API. It learns *when to delegate, how agents communicate, how to combine
+  outputs*. Builds on two ICLR-2026 papers, **Trinity** (a lightweight evolved
+  coordinator assigning Thinker/Worker/Verifier roles) and **the Conductor**.
+  Primary: Sakana Fugu technical report, arXiv 2606.21228. Benchmark numbers are
+  **inconsistent across write-ups** and should be treated cautiously: MarkTechPost
+  [secondary] reports Fugu Ultra **73.7 on SWE-Bench Pro** vs "Claude Opus 69.2",
+  while another [secondary — theplanettools] reports **Fable 5 at 86.0 vs Fugu
+  Ultra 73.7** on the same bench. The *direction* (a learned orchestrator over a
+  swappable pool is now a shipped category) is the load-bearing trend; the exact
+  deltas are not settled — cross-check before quoting.
+  → The meaningful signal for us: orchestration is being *productized as a model*,
+  which validates building the routing logic as a first-class, measurable layer
+  rather than ad-hoc prompt glue.
+
+- **Multi-model routing is now claimed production infra** with **40–85% cost
+  cuts** while "holding quality within 2–3 points of frontier baselines"
+  [secondary — mindstudio, velsof, scalacode 2026; the 40–85% band traces back to
+  RouteLLM's conditioned numbers, so treat as order-of-magnitude, not a promise].
+  Cascade chains, ensemble+judge merging, and "optimize-for-cost/latency/quality"
+  per-route policies are the recurring buildable primitives.
+
+- **`fable-orchestrator` itself** (our anchor repo) is part of this wave — a
+  Claude-Code-plugin instance of strong-plans/cheap-executes, actively updated
+  (v1.2.2, 2026-07-19), i.e. this pattern is being battle-tested *in the exact
+  harness we use*.
+
+- **Local-model-as-worker / edge specialists** [secondary — agentcommunity.org
+  2026-07-13 newsletter, treat as informal]: claims of tiny tool-calling
+  specialists (a "Needle" 26M-param model at ~1,200 tok/s on a Pi) and very-long-
+  context workers. Provenance is a newsletter; the *specific model names are not
+  independently verified here* and some read as illustrative — do not cite as
+  fact. The verifiable local-stack reality: Ollama v0.21.x (~June 2026) with MLX
+  on Apple Silicon, plus vLLM/SGLang/llama.cpp, is the practical worker substrate
+  [secondary — multiple local-LLM roundups].
+
+- **Anthropic cost levers shipped/hardened**: automatic prompt caching and
+  server-side context compaction (beta `compact-2026-01-12`) are the platform's
+  answer to long-agent cost; Agent SDK exposes per-model cost tracking. These are
+  the native features our orchestrator should lean on rather than reinvent
+  (aligns with `use-tool-builtins.md`).
+
+**Net trend:** the field converged this quarter on "frontier model orchestrates,
+cheap/local models execute, a learned or rules-based router decides, and an
+objective gate verifies" — precisely the fable-orchestrator shape, now with a
+productized model (Fugu) proving the category.
+
+---
+
+## Synthesized recommendation
+
+**Goal:** autonomous agents doing (i) graphify ingestion and (ii) ticket
+implementation *cheaply*, with Claude/Fable 5 as the smart layer.
+
+**Architecture — adopt the fable-orchestrator shape, mapped onto our existing
+gates:**
+
+1. **Strong model = architect only.** Fable 5 owns decomposition, five-part
+   specs, routing, and accept/reject. Enforce a **no-product-write deny-hook** on
+   the architect (we already run a PreToolUse guard — `hook_guard.py`; add an
+   architect-role rule). Prose is not enough; a hook is (`mise-tasks-only.md`
+   precedent, and Fable's own combat lesson).
+
+2. **Cheap/local models = workers, addressed by a five-part spec** (Objective+MODE
+   · Files · Interfaces · Constraints · Verification). Workers share zero
+   architect context; they return **only compressed structured reports** (STATUS
+   + CHANGES + evidence paths). Start with an existing cheap cloud tier (Haiku /
+   a Grok/Sonnet lane); add local (Ollama/vLLM) workers behind the same spec+report
+   interface once the contract is stable.
+
+3. **Route with a simple cascade first, learn later.** Rules-based routing (easy
+   → cheap, hard/ambiguous → strong, escalate on gate-failure) captures most of
+   the 40–85% savings with days of work; a learned router (à la Fugu/Trinity) is
+   a later optimization, not a v1 need.
+
+4. **Quality gate = our real checks, mechanized as a self-repair loop.** Every
+   ticket worker must pass `mise run lint` + `pytest` + `dotfiles-setup verify
+   run`, self-repairing on failure (cap ~3 iterations — arXiv 2607.05197), and
+   may only report `STATUS: pass` on green. TDD-first so the gate exists before
+   the worker writes code. This is where cheap-model code quality is actually
+   made acceptable (§4 evidence), and it is `verify-before-advancing.md` turned
+   into an orchestration primitive.
+
+5. **For graphify ingestion: map-reduce + structured-output workers + RAG over
+   the graph itself.** Chunk inputs → parallel cheap workers extract
+   entities/relations under a **constrained JSON schema** (retries 5–15% → <1%) →
+   strong model reduces/dedupes into the graph. Then close the loop: the graph
+   becomes the **retrieval index** that injects the relevant subgraph into ticket
+   workers instead of raw files — the highest-leverage reuse of our graphify
+   investment.
+
+**Buildable techniques to prioritize (in order):**
+
+1. Deny-hook enforcing the architect no-touch list (cheapest, biggest safety win).
+2. Five-part spec contract + three fixed report shapes as the only cross-model
+   interface (the core context saver).
+3. Machine completion contract: `STATUS:` + wall/stall watchdog +
+   incomplete-stamp launcher — steal `run-grok-headless.sh` almost verbatim so
+   autonomy can neither hang nor fake success.
+4. External ledger for state across compaction (STATUS + evidence paths only).
+5. Prompt-cache-friendly stable prefix (system+doctrine+schema first, volatile
+   last) — free ~10× read savings on the stable portion.
+6. Constrained/structured output on all extraction + tool-calling workers.
+7. Self-repair-against-our-gate loop for ticket workers (capped ~3).
+8. RAG-over-graphify subgraph injection.
+9. Selective best-of-N only for *hard* implement tasks, logged in a
+   `metrics.jsonl`-style one-line-per-run ledger.
+
+**Defer:** speculative decoding and KV-cache reuse (serving-layer; only if we
+self-host workers); a learned router model (v2). **Lean on native, don't
+rebuild:** Anthropic prompt caching, server-side compaction, and Agent-SDK cost
+tracking (`use-tool-builtins.md`).
+
+**Caveats carried forward:** the "40–85%" and Fugu SWE-Bench numbers are
+condition-bound and inconsistent across secondary write-ups — use them as
+direction, not targets, and re-measure on our own workloads
+(`probes-need-a-control-arm.md`). The single most important design choice is #4:
+without an objective gate, cheap-model code quality does not hold.
+
+---
+
+## GitHub repos touched
+
+- [BuildContext/fable-orchestrator](https://github.com/BuildContext/fable-orchestrator) — primary anchor; read README, orchestration SKILL, both agent defs, `run-grok-headless.sh`, hooks for the strong-plans/cheap-executes model, token optimizations, completion contract, and hard-gate hooks.
+- [DannyMac180/fable-advisor](https://github.com/DannyMac180/fable-advisor) — the upstream "architect pattern" essay that fable-orchestrator forks (referenced via README lineage; not deep-read).
+- [lm-sys/RouteLLM](https://github.com/lm-sys/RouteLLM) — canonical open router; cost/quality-threshold benchmark numbers cited via LMSYS write-ups (repo referenced, numbers from paper/secondary blogs).
+- [microsoft/graphrag](https://github.com/microsoft/graphrag) — map-reduce KG-extraction + community-summary pipeline referenced for graphify ingestion pattern (via arXiv 2404.16130; repo not deep-read).
+- [SakanaAI](https://github.com/SakanaAI) — Fugu / Trinity / Conductor learned-orchestration line referenced via the arXiv 2606.21228 tech report and secondary coverage (org referenced; no Fugu repo deep-read).
+- [dottxt-ai/outlines](https://github.com/dottxt-ai/outlines) and [mlc-ai/xgrammar](https://github.com/mlc-ai/xgrammar) — constrained/grammar decoding backends cited for structured-output retry reduction (referenced, not deep-read).
+- [ollama/ollama](https://github.com/ollama/ollama) — local-worker substrate (Apple-Silicon MLX) referenced as the practical local-model runtime (referenced, not deep-read).

--- a/.omc/kb/reports/followup-postgres-infra.md
+++ b/.omc/kb/reports/followup-postgres-infra.md
@@ -1,0 +1,330 @@
+# Follow-up — Is Postgres (+ extensions) the right "prebuilt substrate" for the orchestrator's plumbing?
+
+Agent: followup-postgres-infra · Date: 2026-07-19 · Host: Ray's single Mac
+(host-only is a HARD constraint — already ruled out Neo4j and
+Postgres-server-based memory tools). Scope: evaluate Postgres + extensions
+(pgmq, pgq, LISTEN/NOTIFY, pg_cron) as the queue / async / scheduling / state
+substrate for a single-node autonomous AI-agent orchestrator so the team writes
+only their logic, not queue/async machinery.
+
+**Workload under evaluation (the number that decides everything):** ONE machine,
+a *handful* of *multi-minute* LLM-agent tickets in flight, occasional human
+escalation via GitHub/Slack/Discord. Low frequency (jobs/minute, not
+jobs/second), high latency per job (minutes), single control plane. No
+horizontal scaling, no multi-writer contention, no cross-host coordination.
+
+**Headline recommendation (stated up front):** For THIS workload, a resident
+Postgres server is **over-engineered** — it buys durability and SKIP-LOCKED
+concurrency you can already get from SQLite (or even a directory of files),
+while imposing a background daemon, `shared_preload_libraries` config, and a
+service-lifecycle burden that fights the host-only, single-Mac constraint. The
+right substrate is **SQLite in WAL mode with a `SELECT ... FOR UPDATE SKIP
+LOCKED`-equivalent claim pattern** for the queue + state, plus the **native
+harness primitives** (background tasks, `SessionEnd`/`Stop` hooks, Routines/the
+`schedule` skill, the `loop` skill) for scheduling and the agent event loop.
+**Postgres becomes the correct answer at a specific, nameable threshold — the
+moment the control plane must be shared by more than one machine (or many
+truly-concurrent workers contending on one queue).** Below that line it is
+weight without payoff. The threshold is scale-of-*coordination*, not
+scale-of-*data*.
+
+Two important nuances the naive "no server" story misses, both verified below:
+
+1. **You CAN get `pgmq` with no resident server** — via PGlite (in-process WASM
+   Postgres) + `@electric-sql/pglite-pgmq`. So "we want pgmq specifically"
+   does not force a daemon. But PGlite is single-connection, JS/WASM-hosted, and
+   *is itself* the embedded-DB story — at which point it competes with SQLite,
+   not with server Postgres, and SQLite wins on maturity/footprint for this job.
+2. **`pg_cron` CANNOT run without a resident server** (it is a background worker
+   loaded via `shared_preload_libraries`) — so the scheduling half of the
+   "Postgres does everything" pitch is exactly the half that requires the daemon
+   we are trying to avoid. Scheduling should come from the harness, not the DB.
+
+---
+
+## Q1 — Postgres for queues: pgmq vs pgq vs LISTEN/NOTIFY
+
+### pgmq (PostgreSQL Message Queue) — the modern, maintained choice
+
+`pgmq` is a lightweight SQS/RSMQ-style message queue implemented as a Postgres
+extension, created and backed by **Tembo** (the repo has since moved to its own
+`pgmq/pgmq` org). Supported on Postgres 14–18.
+[[pgmq/pgmq](https://github.com/pgmq/pgmq)] [[docs](https://pgmq.github.io/pgmq/latest/)]
+
+What it gives you:
+
+| Capability | pgmq behavior | Evidence |
+|---|---|---|
+| **Visibility timeout (VT)** | `read()` makes a message invisible for VT seconds; if not deleted/archived it reappears — the SQS model, done in-DB with `FOR UPDATE SKIP LOCKED`. | [Tembo "self-regulating queue" blog](https://legacy.tembo.io/blog/pgmq-self-regulating-queue/) |
+| **Delivery guarantee** | **Exactly-once *within* a visibility timeout** (i.e. at-least-once overall with a dedup window — the standard queue semantic). Not distributed exactly-once. | [Supabase PGMQ docs](https://supabase.com/docs/guides/queues/pgmq) |
+| **Dead-letter / archive** | `archive()` moves a message to an `a_<queue>` archive table (replayable, auditable) rather than deleting. Retries via VT expiry; you build DLQ policy on `read_ct`. | [pgmq docs](https://pgmq.github.io/pgmq/latest/) |
+| **No background worker** | Core queue is **pure SQL functions** — no daemon, no `shared_preload_libraries`. This is the headline design point and why it embeds cleanly. | [Tembo blog: "No Background Worker"](https://legacy.tembo.io/blog/pgmq-self-regulating-queue/) |
+| **Partitioned queues (optional)** | Only if you want time/size-partitioned queues do you add `pg_partman` (which *does* use a bgw, `pg_partman_bgw` in `shared_preload_libraries`). Unpartitioned queues need none of that. | [pgxn pgmq README](https://pgxn.org/dist/pgmq/1.4.0/README.html), [pgpartman/pg_partman](https://github.com/pgpartman/pg_partman) |
+
+Maturity/backers: actively maintained (1.8.x on PGXN as of mid-2026), adopted by
+**Supabase** as its official Queues product, packaged for PGlite by ElectricSQL.
+This is the one to pick *if* Postgres is chosen.
+
+### pgq (Skype PgQ) — battle-proven but effectively legacy
+
+`pgq` was designed at **Skype in 2006** to run messaging for hundreds of
+millions of users; **Londiste** (replication) is a consumer built on it. It is
+genuinely battle-tested, but for a greenfield single-Mac orchestrator it is the
+wrong tool:
+
+- It depends on a **C extension (`pgq`) AND an external daemon (`pgqd`)** — two
+  native moving parts, neither of which runs on managed/embedded Postgres.
+  [[pgq.github.io](https://pgq.github.io/)] [[pgq/skytools-legacy — "Obsolete"](https://github.com/pgq/skytools-legacy)]
+- Its model is **batch/snapshot consumption**, not per-message visibility
+  timeouts — a coarser fit for "claim one ticket, work it for minutes, ack".
+- The original Skytools tree is marked **obsolete**; maintained code moved to
+  the `pgq/` org but the ecosystem energy is clearly on pgmq.
+
+A modern pure-PL/pgSQL revival, **PgQue** (`NikolayS/pgque`, by Nikolay
+Samokhvalov), rebuilds the PgQ engine with **no C extension, no
+`shared_preload_libraries`, no daemon** — one SQL file + `pg_cron` to "tick". It
+is interesting (TRUNCATE-based rotation → zero dead tuples, no autovacuum
+pressure) but it is young and it *depends on pg_cron for the tick* — i.e. it
+re-introduces the resident-server requirement through the back door.
+[[NikolayS/pgque](https://github.com/NikolayS/pgque)] [[pgque.dev](https://pgque.dev/)]
+
+### LISTEN/NOTIFY — native async pub/sub, but not a queue
+
+`LISTEN`/`NOTIFY` is built into core Postgres: a session `LISTEN`s on a channel,
+another issues `NOTIFY channel, 'payload'`, and listeners get an async event.
+What it *is*: cheap in-process pub/sub for "something changed, go look". What it
+is **not**:
+
+- **Not durable** — a notification delivered while no one is listening is
+  **lost**; there is no replay, no persistence, no visibility timeout, no DLQ.
+- **Payload-limited** (~8000 bytes) and fire-and-forget.
+
+So the canonical Postgres queue pattern is **table-as-queue + `SKIP LOCKED` for
+the durable claim + LISTEN/NOTIFY only as a low-latency wakeup** so workers
+don't poll. pgmq essentially packages the first half; NOTIFY is an optional
+latency optimization on top. For a handful of multi-minute jobs, **polling every
+few seconds is completely adequate** and NOTIFY's wakeup latency win is
+irrelevant.
+
+---
+
+## Q2 — Postgres for scheduling + async
+
+### pg_cron — real cron in the DB, but requires a resident server
+
+`pg_cron` is a cron-syntax job scheduler by **Citus Data (now part of
+Microsoft)**, widely deployed on RDS/Aurora/Supabase.
+[[citusdata/pg_cron](https://github.com/citusdata/pg_cron)]
+
+The disqualifying detail for a "no-server" ambition: pg_cron **registers a
+background worker** that wakes every minute and reads `cron.job`, and it **must
+be added to `shared_preload_libraries`** — `CREATE EXTENSION` alone fails with
+*"pg_cron can only be loaded via shared_preload_libraries"* and requires a
+server restart.
+[[pg_cron#167](https://github.com/citusdata/pg_cron/issues/167)]
+[[DeepWiki install guide](https://deepwiki.com/citusdata/pg_cron/3.1-installation-and-configuration)]
+
+Consequence: **pg_cron cannot run in an embedded/in-process Postgres** (PGlite
+has no background workers — see Q3). The scheduling half of "Postgres does
+everything" is precisely the half that mandates the resident daemon we are
+trying to avoid on this Mac.
+
+### Does LISTEN/NOTIFY cover the async/event needs of an agent loop?
+
+Partially, and not the important part. An autonomous agent loop needs:
+(a) "a new ticket arrived / a timer fired" wakeups, and (b) durable state so a
+crash mid-multi-minute-job doesn't lose work. LISTEN/NOTIFY gives (a) with
+**no durability** — exactly backwards for multi-minute jobs where the whole
+point is surviving a restart. You would still need the durable claim table
+underneath. And the *scheduling* trigger (run every N minutes, escalate after a
+timeout) is better served by the harness's own timer primitives than by holding
+a Postgres session open to `LISTEN`. **Net: LISTEN/NOTIFY is a nice-to-have
+wakeup, never the backbone.**
+
+---
+
+## Q3 — Can Postgres be EMBEDDED / zero-server? (the concrete question)
+
+Three candidate "no daemon" paths, and what each actually delivers:
+
+### PGlite (`electric-sql/pglite`) — genuinely in-process, and it CAN run pgmq
+
+PGlite is a **WASM build of Postgres packaged as a TypeScript library** (~3 MB
+gzipped) that runs in-process in Node/Bun/Deno/browser with no separate server.
+[[electric-sql/pglite](https://github.com/electric-sql/pglite)]
+[[pglite.dev](https://pglite.dev/)]
+
+Crucially for this question: **pgmq is officially available for PGlite** as a
+separate package, `@electric-sql/pglite-pgmq` — you `import { pgmq }`, register
+it, and `CREATE EXTENSION IF NOT EXISTS pgmq;`.
+[[PGlite extensions catalog](https://pglite.dev/extensions/)]
+This works precisely *because* pgmq's core is pure SQL with **no background
+worker**. So the concrete answer to "can we get pgmq WITHOUT a resident server?"
+is **yes — via PGlite**.
+
+But the fine print reframes it as an anti-recommendation for our stack:
+
+- **Single-connection, single-process.** PGlite runs Postgres in *single-user
+  mode* (Emscripten can't fork), so it is one in-process instance — great for
+  embedding, but it is not a shared control plane and gives no more concurrency
+  than SQLite. [[pglite.dev/docs/about](https://pglite.dev/docs/about)]
+- **No background workers → no pg_cron, no pg_partman bgw.** The extensions
+  requiring `shared_preload_libraries` are simply **not available** in PGlite.
+  The catalog lists pgmq and pgvector; **pg_cron and pg_partman are absent.**
+  [[PGlite extensions](https://pglite.dev/extensions/)]
+- **It's a JS/WASM runtime.** Adopting PGlite means hosting the plumbing in a
+  Node/Bun process. If the orchestrator is Python (this repo's world), that is a
+  foreign runtime dependency to carry for a queue.
+
+So PGlite proves the "embedded pgmq" point but, being a single-connection
+in-process DB, it **competes with SQLite, not with server Postgres** — and for a
+Python-centric single-Mac orchestrator, SQLite is the more mature, zero-dep,
+same-language choice (Q5).
+
+### electric-sql (the sync product) — not relevant here
+
+ElectricSQL's flagship is **Postgres→client sync** (a sync engine over a
+*real, resident* Postgres). That is a multi-device data-sync story, not an
+embedded-server story; it does not remove the server. PGlite is the piece of
+ElectricSQL's world that matters for this question, and it's covered above.
+
+### embedded-postgres binaries (`zonkyio`, `fergusstrange`, etc.) — a *managed* server, not serverless
+
+These libraries (JVM: `zonkyio/embedded-postgres`; Go:
+`fergusstrange/embedded-postgres`; Python: `pyben`/`testing.postgresql`-style
+wrappers) **download a real `postgres` binary and spawn it as a child process**,
+usually for tests. You *do* get full extension support (including
+`shared_preload_libraries`, so pg_cron works) — but that is **exactly a resident
+Postgres server**, just one your process starts and stops. It carries the full
+initdb/data-dir/port/lifecycle burden. It is "embedded" only in the packaging
+sense; operationally it is the daemon we set out to avoid.
+
+### Verdict on Q3
+
+To get the **full** Postgres extension experience (pgmq partitioned + pg_cron +
+NOTIFY across sessions), a **real resident `postgres` server is unavoidable** —
+because pg_cron/pg_partman need `shared_preload_libraries` and multi-session
+NOTIFY needs multiple backends. You can get **pgmq alone** with no server via
+PGlite, but PGlite is a single-connection in-process DB that is functionally in
+SQLite's weight class, minus SQLite's maturity and Python-native fit.
+
+---
+
+## Q4 — Fit assessment (honest, YAGNI lens)
+
+For **one machine, a handful of multi-minute tickets, occasional human
+escalation**, Postgres+pgmq is **over-engineered**. The reasoning:
+
+**What a durable queue actually needs to buy here:**
+1. *Don't lose a ticket if the process crashes mid-job* → durability.
+2. *Don't hand the same ticket to two workers* → an atomic claim.
+3. *Retry a ticket that timed out / escalate after N tries* → visibility-timeout
+   + retry-count semantics.
+
+**What pgmq/Postgres buys beyond that** — and why it's wasted here:
+- **High-concurrency `SKIP LOCKED` claiming** across many contending consumers.
+  With a *handful* of jobs and effectively one control loop, there is **no
+  contention to solve.**
+- **Multi-writer / networked access** — a server on a socket many clients hit.
+  Single Mac, single process: **not needed.**
+- **MVCC, autovacuum tuning, partitioning for queue bloat** — real operational
+  concerns *at throughput*, pure overhead at a handful of jobs/minute.
+
+**What it costs:** a resident daemon to install/run/monitor on the Mac (fighting
+the host-only, "no server-based tools" posture that already killed
+Neo4j/Postgres-memory), `shared_preload_libraries` + restart rituals for the
+scheduling/partitioning extensions, and a second data store to back up and
+reason about alongside whatever else the orchestrator persists.
+
+**What a file/SQLite queue buys instead:** items 1–3 above, with **zero
+daemon**, a single file, and (for SQLite) `SELECT ... RETURNING` +
+`BEGIN IMMEDIATE` giving an atomic claim that is entirely sufficient for
+single-writer-ish workloads. YAGNI says: build the three semantics you need on
+the substrate you already trust, not a queue product sized for SQS traffic.
+
+**The scale threshold where the answer flips to Postgres** (name it, so the next
+reader can check "is it true HERE?"):
+
+| Condition | Still SQLite/files? | Postgres justified? |
+|---|---|---|
+| 1 machine, 1 orchestrator loop, handful of jobs | ✅ yes | ❌ no |
+| 1 machine, **many truly-concurrent workers** contending on one queue (dozens+ claiming/sec) | borderline (SQLite serializes writes) | ⚠️ leaning yes |
+| **>1 machine sharing one control plane / queue** | ❌ no (SQLite is not a network DB) | ✅ **clearly yes** |
+| Need SQL analytics / joins / concurrent readers over live queue+state | ⚠️ | ✅ yes |
+| Need managed durability, PITR, replication, RBAC across a team | ❌ | ✅ yes |
+
+The single load-bearing flip is the **shared control plane**: the day a second
+machine (or a genuinely concurrent worker pool) must claim from the same queue,
+SQLite's single-file/single-writer model stops fitting and a networked server
+(Postgres + pgmq) becomes the right — and now proportionate — substrate. Until
+that day, it is weight without payoff.
+
+---
+
+## Q5 — Lightweight alternatives for THIS workload
+
+| Option | What it gives | Fit for single-Mac, handful of multi-min tickets |
+|---|---|---|
+| **SQLite (WAL) + claim pattern** | Durable state + queue in one file. WAL → concurrent readers + one writer. Atomic claim via `UPDATE ... WHERE id IN (SELECT ... WHERE status='ready' LIMIT 1) RETURNING` inside `BEGIN IMMEDIATE`. Visibility-timeout = a `claimed_at`/`lease_until` column + a sweep. Same-language (Python `sqlite3`, zero dep). | ✅ **Best fit.** Delivers durability + atomic claim + retry/lease with no daemon. Matches host-only perfectly. |
+| **File-based queue** (a dir of JSON files, atomic `rename()` to claim; e.g. maildir-style) | Dead-simple, inspectable, git-diffable, no dependency at all. `rename()` is atomic on the same filesystem → the claim primitive is free. | ✅ Great for *very* low volume + human-auditable tickets. Weaker on rich queries/ordering; fine at "handful". A strong default if you value inspectability over SQL. |
+| **Redis** (lists/streams) | Fast queues, pub/sub, consumer groups (Streams gives visibility/ack/DLQ-ish semantics). | ⚠️ **Another resident server** — same host-only objection as Postgres, and *less* durable by default. No advantage over SQLite here; the concurrency it exists to solve isn't present. |
+| **PGlite + pgmq** | Embedded pgmq semantics, no server. | ⚠️ Single-connection in-process DB in SQLite's weight class, but JS/WASM runtime + younger. Only compelling if the stack is already Node/Bun *and* you specifically want SQS-shaped semantics off the shelf. |
+| **Postgres server + pgmq + pg_cron** | The full SQS+cron+SQL substrate. | ❌ Over-scaled per Q4 until the shared-control-plane threshold. |
+| **Native harness primitives** (background Bash tasks, `SessionEnd`/`Stop` hooks, Routines / the `schedule` skill for cron, the `loop` skill for intervals) | Scheduling, recurring polls, one-shot timers, and "run this on completion" — **already built, already on this Mac, zero new infra.** Routines/`schedule` = cron-style cloud/local recurring agents; `loop` = run a prompt on an interval; `SessionEnd` = fire-once-at-end (cannot block); background tasks = long-running work that re-invokes on exit. | ✅ **Use these for the scheduling + event-loop half** in place of pg_cron/LISTEN-NOTIFY. They cover "wake every N minutes", "escalate after a timeout", "run on completion" natively. |
+
+**Recommended composition for the workload:**
+- **Queue + state:** SQLite (WAL) with a `tickets` table carrying
+  `status/lease_until/attempts`, claimed atomically; sweep expired leases to
+  re-queue. (Or a file/dir queue if inspectability trumps SQL.) This *is* the
+  "write only your logic" win — the claim + lease + retry is ~40 lines, not a
+  new service.
+- **Scheduling + async wakeups:** the harness's Routines/`schedule` (cron) and
+  `loop` (intervals) + background tasks + `SessionEnd`/`Stop` hooks — not
+  pg_cron, not LISTEN/NOTIFY.
+- **Escalation:** the existing GitHub/Slack/Discord paths, triggered from the
+  sweep/loop.
+
+This gives the team "write only their logic" *more* cheaply than Postgres would,
+because there is **no substrate daemon to operate at all** — the substrate is a
+file and the primitives the harness already ships.
+
+---
+
+## Recommendation
+
+**For a single-Mac agent orchestrator doing handfuls of multi-minute tickets,
+Postgres is heavier than the workload warrants.** Its distinctive value —
+networked multi-client access, high-concurrency `SKIP LOCKED` claiming, MVCC,
+managed durability — is exactly the value this workload does not consume, while
+its cost (a resident daemon, `shared_preload_libraries`/restart rituals for the
+scheduling extensions) directly contradicts the host-only constraint that
+already retired Neo4j and Postgres-memory tools.
+
+- **Do:** SQLite (WAL) + an atomic-claim/lease table for queue+state (or a
+  file/dir queue for max inspectability), and the **native harness primitives**
+  (Routines/`schedule`, `loop`, background tasks, `SessionEnd`/`Stop` hooks) for
+  scheduling and the event loop. This is the true "write only your logic"
+  outcome — no substrate service to run.
+- **Don't (yet):** stand up a resident Postgres for pgmq+pg_cron. If you want
+  *pgmq specifically* with no server, PGlite+`pglite-pgmq` exists — but it's a
+  single-connection in-process DB in SQLite's weight class on a foreign
+  (JS/WASM) runtime, so it's not worth displacing SQLite for.
+- **The flip point (watch for it):** adopt Postgres+pgmq the moment the control
+  plane must be **shared across more than one machine**, or a genuinely
+  concurrent worker pool contends on one queue (dozens+ claims/sec). That is
+  when SQLite's single-file/single-writer model stops fitting and Postgres
+  becomes proportionate rather than aspirational. It is a coordination
+  threshold, not a data-size one.
+
+---
+
+## GitHub repos touched
+
+- [pgmq/pgmq](https://github.com/pgmq/pgmq) — the message-queue extension; visibility timeout, exactly-once-within-VT, archive/DLQ, "no background worker" design; Postgres 14–18; Tembo-originated. Also [docs](https://pgmq.github.io/pgmq/latest/) and [PGXN 1.4.0 README](https://pgxn.org/dist/pgmq/1.4.0/README.html) (partitioned-queue → pg_partman/`shared_preload_libraries` caveat).
+- [citusdata/pg_cron](https://github.com/citusdata/pg_cron) — cron-in-DB by Citus/Microsoft; background worker + `shared_preload_libraries` requirement ([issue #167](https://github.com/citusdata/pg_cron/issues/167)) that disqualifies it from embedded/PGlite use.
+- [electric-sql/pglite](https://github.com/electric-sql/pglite) — in-process WASM Postgres (single-user mode, single connection); the [extensions catalog](https://pglite.dev/extensions/) confirms pgmq + pgvector present, pg_cron/pg_partman absent; [`@electric-sql/pglite-pgmq`](https://pglite.dev/extensions/) is the no-server pgmq path.
+- [pgq (Skytools/PgQ)](https://github.com/pgq) — Skype-origin queue + `pgqd` daemon + C extension; original tree marked [obsolete](https://github.com/pgq/skytools-legacy); [docs](https://pgq.github.io/). Legacy for a greenfield single-node orchestrator.
+- [NikolayS/pgque](https://github.com/NikolayS/pgque) — modern pure-PL/pgSQL PgQ revival (no C ext, no daemon) but ticks via pg_cron; [pgque.dev](https://pgque.dev/).
+- [pgpartman/pg_partman](https://github.com/pgpartman/pg_partman) — partition manager pgmq uses for partitioned queues; its bgw needs `shared_preload_libraries`.
+- [zonkyio/embedded-postgres](https://github.com/zonkyio/embedded-postgres) / [fergusstrange/embedded-postgres](https://github.com/fergusstrange/embedded-postgres) — "embedded" binaries that spawn a real `postgres` child process (full extensions, but a resident server in practice).
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — this repo; host-only single-Mac constraint and native-harness-primitives context that frame the recommendation.

--- a/.omc/kb/reports/followup2-iceoryx-corrected.md
+++ b/.omc/kb/reports/followup2-iceoryx-corrected.md
@@ -1,0 +1,255 @@
+# Corrected ground-truth re-assessment: iceoryx / iceoryx2 for a distributed AI-agent orchestrator
+
+**Date:** 2026-07-19
+**Supersedes (on the multi-machine facts):**
+`followup-iceoryx-fit.md` in this same directory.
+**Why this exists:** the maintainer flagged the prior report's core premise —
+"iceoryx is same-machine only, cross-machine is a weak in-development bolt-on,
+category mismatch, don't use" — as **factually wrong and unfairly dismissive**.
+This report re-establishes ground truth from current (2025-2026) sources and
+real-project evidence, then re-judges fit honestly. **Two of the prior report's
+factual claims were wrong or stale; one structural objection survives the
+correction and is still decisive for *our* use.** Details below, not a verdict
+inherited from the earlier file.
+
+---
+
+## 0. What the prior report got wrong (the corrections, up front)
+
+| Prior claim | Corrected fact | Evidence |
+|---|---|---|
+| "iceoryx2 is **same-machine only**; cross-machine exists only through add-on gateways." | **False as of v0.7.0 (2025-09-13).** iceoryx2 ships a **Zenoh network tunnel** (`iceoryx2-tunnels-zenoh` crate, run via `iox2 tunnel zenoh`) that makes **publish-subscribe and event** communication work **across machines** out of the box, "with no complicated configuration." | [v0.7 release](https://ekxide.io/blog/iceoryx2-0-7-release/); [iceoryx2-tunnels-zenoh on crates.io](https://crates.io/crates/iceoryx2-tunnels-zenoh) |
+| "cross-machine is iceoryx's **weak, in-development** path" (used as a disqualifier) | **Half-right, over-weighted.** The tunnel *is* still early-stage/in-development and does **not yet** carry request-response or blackboard across hosts — but it is **released and functional** for pub-sub + event, not vaporware. The dismissive framing was overstated. | [v0.7 release](https://ekxide.io/blog/iceoryx2-0-7-release/) |
+| "Blackboard status?" left as an open question; "Python binding is young, worst fit (GIL kills it)." | **Blackboard is DONE and usable from Python** (bindings finalized v0.8.0, 2025-12-23). Python is a **first-class binding**; v0.9.0 (2026-05-18) made Python blocking APIs **release the GIL while waiting**, directly addressing the GIL objection. | [v0.8 release](https://ekxide.io/blog/iceoryx2-0.8-release/); [v0.9 release](https://ekxide.io/blog/iceoryx2-0.9-release/) |
+| (implicit) "category mismatch, do not use." | **Not a-priori true.** iceoryx2 is a legitimate, cross-language, cross-machine-*capable* data plane used in real robotics systems. The honest verdict is narrower and rests on one real gap (durability), not on a category error — see §4. | this report |
+
+**What the prior report got right and still stands:** iceoryx2 is a
+zero-copy, sub-microsecond *data plane*; its headline value (avoiding a copy of
+a large payload) is inert for KB-scale JSON at minute cadence; and it has **no
+durability across restarts**. Those points survive the correction and turn out
+to be the load-bearing ones (§4).
+
+---
+
+## 1. Multi-machine / network transport — the corrected facts (with versions + dates)
+
+**iceoryx2 (Rust core) cross-machine, via the Zenoh tunnel:**
+
+- **Shipped v0.7.0, 2025-09-13.** The `iceoryx2-tunnels-zenoh` package was
+  published at 0.7.0. You run `iox2 tunnel zenoh` on each host and
+  "publish-subscribe and event communication is instantly available across
+  machines." ([v0.7 release](https://ekxide.io/blog/iceoryx2-0-7-release/),
+  [crates.io versions](https://crates.io/crates/iceoryx2-tunnels-zenoh/versions))
+- **What crosses the network today:** pub-sub ✅, event ✅.
+  **Request-response ❌ and blackboard ❌** are *not yet* supported over the
+  tunnel — "still in development, so some patterns, like request-response and
+  blackboard, aren't supported yet."
+  ([v0.7 release](https://ekxide.io/blog/iceoryx2-0-7-release/))
+- **Gateway roadmap:** the tunnel is "the first step toward a full gateway"
+  where "you start a gRPC, MQTT, or DDS gateway, and suddenly your iceoryx2
+  application can talk to anything" without code changes. The
+  [ROADMAP](https://github.com/eclipse-iceoryx/iceoryx2/blob/main/ROADMAP.md)
+  lists host-to-host via `smoltcp`, Zenoh (MVP), plus MQTT/DDS/SOME-IP/DBus/
+  WebSocket gateways as future work.
+- **Latest release:** **v0.9.0, 2026-05-18.** ekxide states iceoryx2 **v1.0 is
+  planned before the end of 2026.**
+  ([v0.9 release](https://ekxide.io/blog/iceoryx2-0.9-release/))
+
+**iceoryx v1 (C++) cross-machine:** production-proven path is the **Cyclone DDS
+gateway** (`iceoryx-gw-iox-dds`), long used in the ROS 2 ecosystem. This is the
+mature, battle-tested cross-machine story if you want DDS/ROS 2 interop today.
+([iceoryx README](https://github.com/eclipse-iceoryx/iceoryx))
+
+**Bottom line:** cross-machine messaging is real and released — but as of
+mid-2026 the network tunnel is a **pub-sub + event** transport, still pre-1.0,
+and does **not** yet carry the request-response or blackboard patterns across
+hosts. "Weak bolt-on" was too harsh; "released, early, pattern-limited" is
+accurate.
+
+## 2. Full current feature set (v0.9.0, 2026-05)
+
+**Messaging patterns — all implemented today (same-machine):**
+
+| Pattern | Status | Notes |
+|---|---|---|
+| Publish-Subscribe | ✅ done | zero-copy; cross-machine via tunnel |
+| Event / signalling | ✅ done | cross-machine via tunnel |
+| Request-Response (streams) | ✅ done | v0.9 added source `UniqueNodeId` in headers; **same-machine only** across the tunnel |
+| **Blackboard** (shared-memory **key-value** repository) | ✅ done | introduced v0.7 (Rust), **C/C++/Python bindings finalized v0.8**; **same-machine only** |
+| WaitSet (event multiplexer, reactor pattern) | ✅ done | multiplex across many services |
+| Pipeline | ⏳ planned | on roadmap |
+
+Sources: [iceoryx2 README](https://github.com/eclipse-iceoryx/iceoryx2),
+[v0.7](https://ekxide.io/blog/iceoryx2-0-7-release/),
+[v0.8](https://ekxide.io/blog/iceoryx2-0.8-release/),
+[v0.9](https://ekxide.io/blog/iceoryx2-0.9-release/),
+[iceoryx2 Book](https://ekxide.github.io/iceoryx2-book/main/introduction.html).
+
+Note on the **blackboard**: it is a *key-value repository in shared memory* for
+the "one writer, many readers of current state" case (introduced to serve
+"hundreds or thousands of subscribers" from a single publisher). It is a
+*current-state* store — conceptually adjacent to an "agent blackboard," but it
+is sensor/state-repository semantics, **not** a durable/queryable database.
+
+**Language bindings:** Rust (core), **C, C++, Python, C#** — all shipping.
+Python got **full bindings in v0.7** and **GIL-release on blocking calls in
+v0.9**. Cross-language **zero-copy** works across Rust/C/C++/Python (no
+serialization). Go/Lua/Java/Zig are mentioned as further targets.
+([README](https://github.com/eclipse-iceoryx/iceoryx2),
+[v0.9](https://ekxide.io/blog/iceoryx2-0.9-release/))
+
+**Platforms:** Linux (x86_64/aarch64/32-bit), macOS, Windows, FreeBSD, QNX 7.1
+& 8.0 done; Android/VxWorks experimental. **no_std** support added (v0.8),
+enabling bare-metal / RTOS. v0.9 added **Docker support with PID-namespace
+handling** and a **decentralized crash-recovery** mechanism (recovers leaked
+indices when a process dies — *within a live session*).
+
+**Durability — the persistent gap:** iceoryx2's shared memory is **volatile /
+ephemeral**. v0.9's recovery survives *process crashes within the same system
+session*; it does **not** persist across a full stop / reboot. The sender owns
+the payload and cleans it up when it goes out of scope — this is a *data-plane*
+lifetime model, not a durable message queue.
+([v0.9 release](https://ekxide.io/blog/iceoryx2-0.9-release/);
+[FAQ](https://github.com/eclipse-iceoryx/iceoryx2/blob/main/FAQ.md);
+["The Many Challenges of Shared Memory"](https://www.danscoding.world/posts/iceoryx2/))
+
+## 3. Real projects using iceoryx / iceoryx2 (the core ask)
+
+I searched GitHub, crates.io reverse-deps, release notes, blogs, HN, and FOSDEM.
+Honest findings — what's real, and how central iceoryx2 actually is in each:
+
+**Genuine adopters (robotics / middleware):**
+
+- **Copper** — [`copper-project/copper-rs`](https://github.com/copper-project/copper-rs),
+  a deterministic robot OS in Rust. Ships a **`cu_iceoryx2_bridge`** for IPC,
+  bumped to **iceoryx2 0.8** in Copper v0.13.0 (Feb 2026). **Honest nuance:**
+  iceoryx2 is an **optional transport bridge**, *not* Copper's backbone —
+  Copper's runtime is CopperList local scheduling, and its **distributed /
+  multi-robot** deployments actually go through **Zenoh bridges** and explicit
+  multi-Copper topology configs, not the iceoryx2 tunnel. So Copper is real
+  usage, but it is *not* evidence that iceoryx2 is a multi-machine backbone —
+  it's evidence that even a Copper-scale robotics project reaches for **Zenoh**
+  for the cross-machine tier. ([Copper release notes](https://github.com/copper-project/copper-rs/wiki/Copper-Release-Notes))
+- **rmw_iceoryx2** — [`ekxide/rmw_iceoryx2`](https://github.com/ekxide/rmw_iceoryx2),
+  a **ROS 2 middleware (RMW) implementation** on iceoryx2. This *does* make
+  iceoryx2 a messaging backbone for ROS 2 robotics stacks. Maintained by ekxide
+  (the company behind iceoryx2).
+- **iceoryx v1** in production ROS 2 via `rmw_iceoryx` + the Cyclone DDS
+  gateway; automotive/AUTOSAR Adaptive heritage (Bosch origin).
+- ekxide states iceoryx2 "is already used in **robotics, automotive, medical,
+  finance**" — but **customers are unnamed** (open-core model; named production
+  users are not public). Treat the domain list as vendor claim, not verified
+  deployments. ([ekxide philosophy](https://ekxide.io/philosophy/))
+
+**AI / model-serving interest (proposed, not adopted):**
+
+- **LitServe** (Lightning AI's LLM/model serving framework) —
+  [issue #559 "Iceoryx2 queues"](https://github.com/Lightning-AI/litserve/issues/559):
+  a user **proposed** iceoryx2 for LitServe's inter-process queue mechanism,
+  citing zero-copy, <1µs latency, GB/s transfers. **Status: open, no maintainer
+  buy-in, no PR, no decision.** So there is *interest* in the AI-serving space —
+  but for the **data plane** (moving large tensors/batches between serving
+  processes), not for agent orchestration.
+
+**Multi-agent AI orchestration / LLM message bus / agent blackboard —
+searched, found NONE.** Despite iceoryx2 having a "blackboard" pattern, I found
+**no** project using iceoryx/iceoryx2 as an AI/LLM multi-agent coordination bus
+or an agent-state blackboard. The "blackboard" in iceoryx2 is a shared-memory
+current-state key-value store for high-fan-out sensor/state distribution — the
+name collides with the AI "blackboard architecture," but the real usage is
+robotics state, not agent reasoning. This is an **honest negative**, reported as
+requested: the AI-agent-bus use case is not one iceoryx2 is used for in the
+wild today.
+
+## 4. Honest fit re-assessment for OUR use
+
+Our need: a distributed AI-agent orchestrator with (a) a pub-sub or blackboard
+bus for agent-to-agent coordination + shared state, (b) possibly multi-machine,
+(c) control plane may run **in a container** (host-only constraint applies to
+the graphify substrate, not the control plane).
+
+**Where iceoryx2 genuinely could fit (correcting the prior over-dismissal):**
+
+- It **does** have pub-sub + event **across machines** (Zenoh tunnel), and a
+  **blackboard** shared-state store usable **from Python** — the two primitives
+  the ask names. This is no longer a "same-machine only" tool.
+- **Container is fine.** v0.9 added Docker/PID-namespace support; running the
+  control plane in a container is not a blocker.
+- **Polyglot zero-copy** is a real asset *if* the fleet mixes Rust/C++/Python
+  processes moving large payloads (model outputs, artifacts) between co-located
+  agents.
+
+**Where it still falls short — and these are decisive for a control plane:**
+
+1. **No durability across restarts (the killer, unchanged by the corrections).**
+   Agent tickets run minutes-to-hours and must survive an orchestrator
+   restart/reboot. iceoryx2 is a *volatile data plane*: the blackboard and
+   queues live in shared memory that is gone on a full stop. v0.9's recovery is
+   *crash-recovery within a live session*, not persistence. A control plane
+   needs a durable store (SQLite/Postgres/pgmq, or a broker with persistent
+   subscriptions) — a **different category of tool**. This is architectural, not
+   a maturity gap that a version bump fixes.
+2. **Cross-machine covers the wrong patterns for coordination.** The tunnel
+   carries **pub-sub + event** across hosts, but **not request-response or
+   blackboard**. Multi-machine *shared agent state* (blackboard) and *ask-and-
+   wait* coordination (request-response) — the two things an agent orchestrator
+   most wants across hosts — are exactly what the tunnel does **not** do yet.
+3. **No queue/broker semantics.** No at-least-once-across-restart, no
+   dead-letter, no durable consumer groups, no ack/retry. You'd rebuild all of
+   that on top. It's sensor-firehose semantics, not work-queue semantics.
+4. **Its headline value is inert for us.** Nanosecond zero-copy of large
+   payloads buys nothing for KB JSON tickets at minute cadence — a real cost
+   (pre-1.0 IPC core, shared-memory ops) for a benefit we don't consume. (Prior
+   report was right here.)
+5. **Human escalation** (GitHub/Slack/Discord) is cloud-API territory and never
+   belongs on a shared-memory bus. Unchanged.
+6. **Pre-1.0** (0.9.0). API still converging toward the end-of-2026 1.0.
+
+**Evidence-based verdict (not a-priori):**
+
+- For the **durable control plane / message bus / agent blackboard we actually
+  need** — the answer is still **no, don't build it on iceoryx2**, but for a
+  *corrected and narrower* reason than the prior report gave: not "same-machine
+  category mismatch," but **"it is a non-durable data plane, and its
+  cross-machine transport doesn't yet carry the coordination patterns
+  (request-response, blackboard) we'd depend on."** The real-project evidence
+  agrees — even Copper reaches for **Zenoh**, not the iceoryx2 tunnel, for its
+  distributed tier, and the one AI-serving nibble (LitServe) is about the *data
+  plane*, not orchestration.
+- For a hypothetical **future high-throughput data-plane tier** — co-located
+  polyglot processes shovelling large tensors/artifacts with zero copies —
+  iceoryx2 is a **legitimate, credible option** (that's precisely what LitServe
+  and Copper eye it for). If the program ever grows that tier, revisit it there.
+  That is not our control-plane need today.
+
+**Recommended primitive (unchanged in destination, corrected in reasoning):**
+a **durable queue/store** for control-plane state and restart-survival (SQLite
+or file on one node; Postgres + pgmq / a persistent broker when multi-process
+or multi-machine), plain files / a small DB for the shared blackboard, and
+**Zenoh** (not the iceoryx2 tunnel) if/when a true cross-machine pub-sub bus is
+needed — because Zenoh is the mature, durable-capable, routed transport the
+robotics projects themselves pick for that job, and iceoryx2 sits *on top of*
+Zenoh for its own cross-machine story anyway.
+
+**One-line honest summary:** the prior report's *facts* about multi-machine were
+outdated (cross-machine pub-sub/event is real and released; blackboard + Python
+are done) and its *tone* was unfairly dismissive — but its *conclusion for our
+control plane* happens to survive on a different, correct basis: iceoryx2 is a
+non-durable data plane whose network tier doesn't yet carry request-response or
+blackboard, so it is the wrong tool for a durable, coordinating agent control
+plane, while remaining a genuine candidate for a future co-located zero-copy
+*data* tier.
+
+## GitHub repos touched
+
+- [eclipse-iceoryx/iceoryx2](https://github.com/eclipse-iceoryx/iceoryx2) — README feature/binding matrix, ROADMAP, FAQ (durability), versions/patterns.
+- [eclipse-iceoryx/iceoryx](https://github.com/eclipse-iceoryx/iceoryx) — iceoryx v1 (C++): Cyclone DDS gateway cross-machine path, ROS 2 / AUTOSAR heritage.
+- [ekxide/rmw_iceoryx2](https://github.com/ekxide/rmw_iceoryx2) — ROS 2 RMW implementation on iceoryx2 (real messaging-backbone usage).
+- [copper-project/copper-rs](https://github.com/copper-project/copper-rs) — Rust deterministic robot OS; `cu_iceoryx2_bridge` on iceoryx2 0.8, but uses Zenoh for its distributed tier.
+- [Lightning-AI/litserve](https://github.com/Lightning-AI/litserve) — issue #559 proposing iceoryx2 for AI model-serving queues (open, no adoption).
+- [eclipse-zenoh/zenoh](https://github.com/eclipse-zenoh/zenoh) — the routed transport behind iceoryx2's cross-machine tunnel; the primitive robotics projects pick for the distributed tier.
+
+_Non-repo sources also consulted:_ ekxide release blogs v0.7 (2025-09-13), v0.8
+(2025-12-23), v0.9 (2026-05-18); the iceoryx2 Book; `iceoryx2-tunnels-zenoh` on
+crates.io; FOSDEM 2026 "Meet iceoryx2" listing; "The Many Challenges of Shared
+Memory" (danscoding.world).

--- a/.omc/kb/reports/followup2-postgres-realprojects.md
+++ b/.omc/kb/reports/followup2-postgres-realprojects.md
@@ -1,0 +1,287 @@
+# Follow-up 2 — Postgres as the "prebuilt substrate" for an AI-agent orchestrator: REAL projects, evidence-first
+
+Agent: followup2-postgres-realprojects · Date: 2026-07-19 · Host: Ray's single Mac (with a devcontainer)
+
+## What changed since the first Postgres report (`followup-postgres-infra.md`)
+
+The prior report's headline — "Postgres is over-engineered, use SQLite" — rested
+almost entirely on **one premise: a resident daemon fights the host-only,
+single-Mac constraint.** This follow-up was commissioned because that premise is
+wrong for the control plane:
+
+- **Host-only is a constraint on the *graphify knowledge substrate*, not on the
+  orchestrator's control plane.** The two were conflated.
+- **This repo has a devcontainer.** A containerized Postgres is a
+  `docker compose` service (or a devcontainer feature) with a named volume — no
+  Homebrew daemon on the Mac, no `launchd` plist, no host `shared_preload_libraries`
+  ritual. `shared_preload_libraries` becomes **one line in a container config
+  file**, exactly the thing containers exist to make disposable.
+
+Once the "no daemon on the host" objection is void, the prior report's own
+threshold table (Q4) already conceded the flip conditions — *"need SQL analytics
+/ joins / concurrent readers"*, *"one store for queue+state+vector+graph"*, *"many
+truly-concurrent workers"* — and every one of those is squarely in play for
+"autonomous multi-agent orchestration + observability + write-back queue growing
+toward many specialist agents." So the honest re-read is: **the first report
+answered a different (host-bound) question and its conclusion does not transfer to
+the containerized case.** Below is the evidence the first report never gathered:
+the real projects doing exactly this.
+
+---
+
+## Q1 — REAL projects using Postgres as the AI-agent orchestration backbone
+
+This is the core ask, and the evidence is overwhelming: **Postgres-as-agent-backbone
+is not a thesis, it is the mainstream 2026 pattern.** Star counts and last-push
+dates fetched live from the GitHub API on 2026-07-19.
+
+### Durable agent state / memory / checkpointing
+
+| Project | Stars | What it is | Who / how it's used |
+|---|---|---|---|
+| **[langchain-ai/langgraph](https://github.com/langchain-ai/langgraph)** + `langgraph-checkpoint-postgres` | 37.6k | LangGraph's `PostgresSaver` checkpointer persists graph/agent state to Postgres | The **de-facto standard** for durable LangGraph agents in production. `MemorySaver` is dev-only; production docs explicitly route you to Postgres for durability, pause/resume, human-in-the-loop, and crash replay. [Persistence docs](https://docs.langchain.com/oss/javascript/langgraph/persistence) · [PyPI](https://pypi.org/project/langgraph-checkpoint-postgres/) |
+| **[getzep/zep](https://github.com/getzep/zep)** | 4.8k | Agent memory layer (temporal knowledge graph + facts) | Memory-as-a-service for agents; the community edition is Postgres-backed. Relevant to the graphify work — it's the "memory + graph" shape done on Postgres. |
+| **[pgvector/pgvector](https://github.com/pgvector/pgvector)** | 22.3k | Vector similarity search extension | The vector-memory / RAG standard. Used in production by **OpenAI, Supabase, Neon**. Handles ~2M vectors on a single server before you feel it; HNSW indexes; `halfvec`/Matryoshka quantization for scale. This is the "agent long-term memory" substrate most teams pick in 2026. [pgvector RAG 2026](https://www.digitalapplied.com/blog/build-self-hosted-rag-postgres-pgvector-tutorial-2026) |
+
+### Durable execution / workflow orchestration for agents (the "write only your logic" layer)
+
+| Project | Stars | What it is | Agent relevance |
+|---|---|---|---|
+| **[dbos-inc/dbos-transact-py](https://github.com/dbos-inc/dbos-transact-py)** | 1.5k | **Durable workflows as a pip-installable Python library, Postgres as the *only* infrastructure** | **The single most on-target project for this ask.** Annotate a function `@DBOS.workflow` and it checkpoints each step to Postgres; on crash/restart it resumes from the last completed step. Ships **first-party integrations with Pydantic AI, OpenAI Agents SDK, and LlamaIndex** — `DBOSAgent` wraps `Agent.run` as a durable workflow, model/MCP calls as steps. Its **queues** (concurrency limits, rate limits, timeouts, retries, priority) live in the same Postgres — no separate broker. [Pydantic AI + DBOS](https://ai.pydantic.dev/durable_execution/dbos/) · [dbos.dev](https://www.dbos.dev/) |
+| **[temporalio/temporal](https://github.com/temporalio/temporal)** | 21.7k | Durable-execution engine; **Postgres is a supported persistence backend** | The heavyweight incumbent for durable agent workflows ("resume a 50-step research task from the last tool call after a restart"). Self-host = Temporal server (Go) + **Postgres** + optional Elasticsearch. More infra than DBOS. [Temporal for AI agents 2026](https://effloow.com/articles/temporal-ai-agents-durable-execution-guide-2026) |
+| **[microsoft/pg_durable](https://github.com/microsoft/pg_durable)** | 2.7k | **Microsoft's in-*database* durable execution** (open-sourced 2026-06) | Durable, fault-tolerant SQL functions **entirely inside Postgres** — a `pgrx` extension with a background worker (built on Rust `duroxide`/`duroxide-pg`). Explicitly targets *"vector embedding pipelines, ingest pipelines, fan-out aggregation, external API workflows"* — i.e. agent plumbing — without stitching together cron + workers + queues + external orchestrators. Ships to **Azure HorizonDB**. Needs `shared_preload_libraries` (fine in a container). [InfoQ](https://www.infoq.com/news/2026/06/postgresql-pg-durable/) · [MS techcommunity](https://techcommunity.microsoft.com/blog/adforpostgresql/introducing-durable-functions-in-postgresql/4526821) |
+
+### Postgres-backed job/task queues (the durable claim + retry + DLQ layer)
+
+| Project | Stars | Lang | Notes for an agent orchestrator |
+|---|---|---|---|
+| **[pgmq/pgmq](https://github.com/pgmq/pgmq)** | 5.0k | SQL ext (Rust) | SQS/RSMQ-style: visibility timeout, exactly-once-within-VT, archive/DLQ, **no background worker** (pure SQL). **Adopted by Supabase as its official Queues product.** The canonical "Postgres message queue for agents." [Supabase Queues](https://supabase.com/blog/supabase-queues) |
+| **[riverqueue/river](https://github.com/riverqueue/river)** | 5.5k | Go | Fast, typed, `SKIP LOCKED` job queue; strong chaos-recovery in benchmarks. |
+| **[oban-bg/oban](https://github.com/oban-bg/oban)** | 3.9k | Elixir | Robust job processing; one of only three queues to survive all sustained-pressure scenarios in the benchmark below. |
+| **[timgit/pg-boss](https://github.com/timgit/pg-boss)** | 3.8k | Node | Queueing + scheduling + pub/sub on Postgres; basis of `pg-workflows` (a Temporal-lite). |
+| **[graphile/worker](https://github.com/graphile/worker)** | 2.3k | Node | High-perf; ~100–200 jobs/s before lock contention on typical hardware. |
+| **[procrastinate-org/procrastinate](https://github.com/procrastinate-org/procrastinate)** | 1.3k | **Python** | Celery-alternative task queue on Postgres 13+; `LISTEN/NOTIFY` + `SKIP LOCKED`; sync+async, Django/ASGI. Python-native fit for this repo. |
+| **[janbjorge/pgqueuer](https://github.com/janbjorge/pgqueuer)** | 1.5k | **Python** | `LISTEN/NOTIFY` for instant wakeups + `FOR UPDATE SKIP LOCKED`; first-class async/await. Python-native. |
+| **[NikolayS/pgque](https://github.com/NikolayS/PgQue)** | 1.7k | SQL | Zero-bloat PgQ revival (TRUNCATE rotation → no dead tuples); ticks via `pg_cron`. |
+
+### Graph in Postgres (directly relevant to the graphify program)
+
+| Project | Stars | What it is |
+|---|---|---|
+| **[apache/age](https://github.com/apache/age)** | 4.7k | Apache AGE — openCypher graph queries **as a Postgres extension**. Hybrid graph+SQL in one query. Marketed explicitly for knowledge graphs / agent episodic memory: "write entities, relationships, and episode nodes to a graph during each interaction." Azure Database for PostgreSQL ships it. [age.apache.org](https://age.apache.org/) |
+
+**Takeaway for Q1:** every layer an autonomous multi-agent orchestrator needs —
+durable state (LangGraph PostgresSaver, DBOS, Temporal, pg_durable), a task queue
+(pgmq + 6 others), vector memory (pgvector, 22k stars, OpenAI/Supabase/Neon), and
+even the knowledge graph (Apache AGE) — has a **mature, well-starred, actively-pushed
+(all pushed within the last ~2 weeks) project that puts it on Postgres.** This is
+not a fringe pattern; it is the center of gravity of 2026 agent infrastructure.
+
+---
+
+## Q2 — The "one substrate, many extensions" thesis: does it hold?
+
+**Yes, and it's a named, productized movement — "Postgres maximalism" / "Postgres-first."**
+A single containerized Postgres can provide, via extensions, all of:
+
+| Need | Extension / feature | Resident-server / bgw? |
+|---|---|---|
+| Durable task queue | **pgmq** | No bgw (pure SQL) — but needs the server for multi-client access |
+| Async events / wakeups | **LISTEN/NOTIFY** (core) | Needs the server (multi-backend) |
+| Scheduling (cron) | **pg_cron** | **Yes** — bgw + `shared_preload_libraries` |
+| In-DB durable workflows | **pg_durable** (Microsoft) | **Yes** — bgw + `shared_preload_libraries` |
+| Vector memory / RAG | **pgvector** | No bgw |
+| Knowledge graph | **Apache AGE** | No bgw (loaded lib) |
+
+**Who runs this in production:**
+
+- **Supabase** — "the complete Postgres platform built for agentic workloads":
+  Postgres + pgvector (Supabase Vector) + pgmq (Supabase Queues) + auth + storage,
+  "one dashboard, one connection string, one bill." Explicitly positions itself as
+  replacing "a vector database + auth + file store + API layer + a separate
+  Postgres" with one Postgres. [Supabase for Agents](https://supabase.com/solutions/agents) · 106k-star repo.
+- **Tembo** — "Postgres Stacks": pre-bundled extension sets (message-queue stack =
+  pgmq, VectorDB stack = pgvector + `pg_vectorize`, OLAP, search) so you *"replace
+  multiple separate services with a single Postgres deployment."* pgmq itself is a
+  Tembo project. [PostgreSQL maximalism](https://datalabtechtv.com/posts/postgresql-maximalism/)
+
+**The real limit of the thesis** (stated so the next reader can check it *here*):
+the "many extensions" story only fully works on a **real server** — the two
+highest-value orchestration extensions (`pg_cron` for scheduling, `pg_durable` for
+in-DB durable execution) require a background worker via `shared_preload_libraries`,
+which the embedded PGlite path **cannot** run (the first report's Q3 finding stands).
+**In a container that limitation evaporates** — you run the real server, so
+`shared_preload_libraries = 'pg_cron,pg_durable'` is a one-line container config.
+The thesis holds *precisely because* we accepted a containerized server.
+
+---
+
+## Q3 — What did the single-Mac report miss?
+
+Three things, in order of importance:
+
+1. **It scoped the whole decision to "no daemon on the host," then never asked
+   the container question.** The report's own words: *"a resident daemon to
+   install/run/monitor on the Mac (fighting the host-only… posture)."* A container
+   *is* the standard answer to "I don't want a daemon fighting my host" — the
+   daemon lives in a disposable, volume-backed, `docker compose down`-able box.
+   Every "cost" the report charges to Postgres (install/run/monitor on the Mac,
+   `shared_preload_libraries` restart rituals, "a second data store to back up")
+   is a container concern, not a host concern, once you containerize — and this
+   repo already runs a devcontainer as its *real* dev environment.
+
+2. **It evaluated Postgres as a *queue*, and missed Postgres as a *prebuilt agent
+   platform*.** The report's Q1–Q5 are entirely about queue mechanics (pgmq vs pgq
+   vs LISTEN/NOTIFY vs SQLite claim patterns). It never surfaced **DBOS, LangGraph
+   PostgresSaver, Temporal, pg_durable, pgvector, or Apache AGE** — i.e. the
+   layers that make Postgres a "just add your logic" substrate. The maintainer's
+   ask — "prebuilt plumbing, write only our logic" — is answered *far* better by
+   DBOS-on-Postgres (annotate a Python function, get durable checkpointed
+   workflows + queues + scheduling) than by hand-rolling a 40-line SQLite claim
+   loop, which is exactly the "write your own plumbing" outcome the maintainer
+   said they wanted to avoid.
+
+3. **It optimized for today's workload and ignored the stated trajectory.** The
+   brief says *"growing toward many specialist agents."* The report's flip table
+   already marks "many truly-concurrent workers contending on one queue" and
+   "one store for queue+state+vector+graph" as the Postgres-wins conditions —
+   then recommended against Postgres anyway on the host-only premise. Remove that
+   premise and the report's *own* analysis points at Postgres for the target
+   state.
+
+**What the report got right and still stands:** for a *pure queue* at a handful of
+jobs/minute, raw Postgres throughput (pgmq benchmarked at ~11k jobs/s) is
+irrelevant, and `LISTEN/NOTIFY` is a nice-to-have wakeup, not a backbone. Those
+facts are true — they just don't decide the platform question, because the value
+of Postgres here is **consolidation + prebuilt agent frameworks + optionality**,
+not throughput.
+
+---
+
+## Q4 — Honest comparison vs SQLite + native-CC primitives (container available)
+
+### The genuinely hard counter-argument, stated fairly
+
+The strongest anti-Postgres case is **no longer "no server on the host"** — it's
+**"the prebuilt durable-workflow win doesn't require Postgres either."** As of
+2026, **DBOS Transact supports a SQLite backend** ("SQLite is all you need for
+durable workflows"), so you can get `@DBOS.workflow` durability, resume-from-step,
+and queues **on SQLite, zero server.** [DBOS June 2026](https://www.dbos.dev/blog/new-in-dbos-june-2026)
+That means the "write only your logic" ergonomic is available *without* committing
+to Postgres. This is the real decision axis, and it's a closer call than either
+report acknowledged.
+
+### Where Postgres clearly wins (container assumed)
+
+| Dimension | Why Postgres wins | Evidence |
+|---|---|---|
+| **One store for queue + state + vector + graph** | pgmq + PostgresSaver/DBOS + pgvector + Apache AGE under **one connection string**, updated in **one transaction** (workflow metadata + app data atomic). SQLite would be file + `sqlite-vec` (less adopted) + no real graph ext. | Supabase/Tembo consolidation story; DBOS "same transaction" atomicity. |
+| **Vector memory maturity** | pgvector: 22k stars, OpenAI/Supabase/Neon in prod, HNSW, quantization to millions of vectors. `sqlite-vec` is real but far less battle-tested for agent memory at scale. | [pgvector adoption](https://www.digitalapplied.com/blog/build-self-hosted-rag-postgres-pgvector-tutorial-2026) |
+| **Cross-process/agent pub-sub** | `LISTEN/NOTIFY` gives **real inter-process events** so N specialist agents react to "new ticket / state changed" without each polling a file. SQLite has **no pub/sub** — many agents = many pollers on one file, and SQLite serializes writes. | First report Q1; procrastinate/pgqueuer both build on NOTIFY. |
+| **Off-the-shelf durable-execution + framework integration** | LangGraph, Pydantic AI, OpenAI Agents SDK, LlamaIndex, Temporal, pg_durable all target **Postgres first**. Choosing Postgres means the prebuilt integration exists; SQLite is the second-class backend where it exists at all. | DBOS first-party integrations; LangGraph PostgresSaver. |
+| **Concurrency at the target state** | "Many specialist agents" contending on one queue is exactly what `SKIP LOCKED` on a real server is for. SQLite serializes writers — fine for a handful, a ceiling as you fan out. | Benchmark: pgmq 11k jobs/s vs SQLite's single-writer model. |
+| **Observability / write-back queue as SQL** | The brief wants "observability + write-back queue." Postgres gives ad-hoc SQL joins across live queue+state+memory, plus tools (DBOS Argus, Supabase dashboard) that read the same DB. | DBOS Argus; Supabase agent dashboard. |
+
+### Where Postgres is still overkill
+
+- **If you stay at a handful of jobs AND don't use vector/graph**, DBOS-on-SQLite
+  gives durable workflows with **zero server** — Postgres buys nothing.
+- **Queue bloat under sustained load is real** but doesn't bite here: the
+  benchmark found `SKIP LOCKED` queues (pgmq, river, pg-boss, oban, graphile)
+  churn dead tuples needing VACUUM, and **5 of 8 queues timed out under
+  sustained pressure** (only awa, oban, pgque survived all four). At a
+  handful of multi-minute jobs you are nowhere near that regime — but it means
+  "pgmq at 11k jobs/s" is a peak headline, not a sustained guarantee.
+  [hardbyte/postgresql-job-queue-benchmarking](https://github.com/hardbyte/postgresql-job-queue-benchmarking)
+- **`pg_cron`/`pg_durable` background-worker config** is a container-config line,
+  but it is still a moving part SQLite doesn't have. Scheduling can equally come
+  from the harness primitives (Routines/`schedule`, `loop`, `SessionEnd`/`Stop`
+  hooks, background tasks) the first report correctly identified.
+
+### Evidence-based verdict
+
+**For THIS project — autonomous multi-agent orchestration + observability +
+write-back queue, explicitly growing toward many specialist agents, with a
+container available — a containerized Postgres is now an *attractive and
+proportionate* control-plane substrate, not over-engineering.** The first report's
+verdict inverts once its host-only premise is removed, and the maintainer's
+instinct is correct: it missed the container flip and missed the prebuilt-platform
+projects (DBOS, PostgresSaver, pgvector, AGE, pg_durable) that make Postgres a
+"just add your logic" backbone rather than a bare queue.
+
+The one honest caveat: **the durable-workflow ergonomic itself is now
+backend-agnostic (DBOS runs on SQLite too).** So the decision is not "Postgres for
+durability" — it's **"Postgres for *consolidation*"**: do you want queue + durable
+state + vector memory + knowledge graph + cross-agent pub/sub behind one
+connection string and one transaction, with first-party agent-framework
+integrations? For the stated trajectory, **yes.** If you were certain you'd stay
+at a handful of jobs and skip vector/graph, DBOS-on-SQLite would be the leaner
+call.
+
+### Concrete recommended stack if you go Postgres
+
+Run Postgres as a `docker compose` service beside the devcontainer (named volume
+for the data dir; **not** on the Mac host), `shared_preload_libraries =
+'pg_cron'` (add `pg_durable` only if you want in-DB workflows). Then, per layer:
+
+1. **Durable workflows + queue + scheduling (the "write only your logic" layer):**
+   **DBOS Transact (Python)** — `@DBOS.workflow`/`@DBOS.step`, DBOS queues for
+   ticket dispatch, DBOS scheduled workflows for polling/escalation. Postgres is
+   its only dependency. Wrap agents with `DBOSAgent` (Pydantic AI / OpenAI Agents
+   SDK) for free crash-resume. **This is the piece that delivers the maintainer's
+   ask most directly.**
+2. **Agent state / checkpoints:** if you adopt LangGraph, use its `PostgresSaver`
+   in the same DB; otherwise DBOS already checkpoints workflow state.
+3. **Vector memory:** **pgvector** (HNSW) in the same DB for agent long-term
+   memory / RAG.
+4. **Cross-agent events:** `LISTEN/NOTIFY` for "new ticket / state changed"
+   wakeups so specialist agents don't poll.
+5. **Message queue (if you prefer an explicit queue over DBOS queues):** **pgmq**
+   (Supabase-blessed) for SQS-shaped visibility-timeout/archive semantics.
+6. **Knowledge graph (optional, revisit host-only):** **Apache AGE** *could*
+   co-locate the graph in the same Postgres — but **the graphify knowledge
+   substrate is under the host-only constraint**, so putting it in the
+   containerized control-plane DB is a **policy decision to confirm with the
+   maintainer**, not a free default. Flagged, not assumed.
+
+Scheduling can still come from the harness primitives (Routines/`schedule`,
+`loop`, `SessionEnd`/`Stop` hooks) instead of `pg_cron` if you want one fewer
+background worker — the first report's guidance there remains sound.
+
+---
+
+## Bottom line
+
+The first report answered "does a resident daemon fit a host-only Mac?" (no) and
+mislabeled it "is Postgres right for this orchestrator?" With a container in play,
+the correct question — **"is a consolidated Postgres a good prebuilt substrate for
+autonomous multi-agent orchestration?"** — has a strong, evidence-backed **yes**,
+demonstrated by the mainstream of 2026 agent infrastructure (LangGraph
+PostgresSaver, DBOS, Temporal, Microsoft pg_durable, pgmq/Supabase Queues,
+pgvector, Apache AGE). The sharpest remaining nuance is that DBOS now runs on
+SQLite too, so the real choice is **consolidation (Postgres) vs minimalism
+(SQLite)** — and for a project explicitly scaling toward many specialist agents
+with observability and memory needs, consolidation wins.
+
+## GitHub repos touched
+
+- [langchain-ai/langgraph](https://github.com/langchain-ai/langgraph) — 37.6k★; `PostgresSaver` checkpointer = the standard for durable LangGraph agent state.
+- [pgvector/pgvector](https://github.com/pgvector/pgvector) — 22.3k★; vector memory/RAG standard (OpenAI/Supabase/Neon in prod).
+- [temporalio/temporal](https://github.com/temporalio/temporal) — 21.7k★; durable-execution engine with Postgres persistence backend for agents.
+- [electric-sql/pglite](https://github.com/electric-sql/pglite) — 15.6k★; embedded WASM Postgres (context for the "embedded can't run bgw extensions" limit that the container removes).
+- [pgmq/pgmq](https://github.com/pgmq/pgmq) — 5.0k★; SQS-style Postgres queue, no bgw; Supabase Queues is built on it.
+- [riverqueue/river](https://github.com/riverqueue/river) — 5.5k★; Go `SKIP LOCKED` job queue; strong chaos recovery.
+- [getzep/zep](https://github.com/getzep/zep) — 4.8k★; Postgres-backed agent memory layer (temporal knowledge graph).
+- [apache/age](https://github.com/apache/age) — 4.7k★; openCypher graph as a Postgres extension; knowledge-graph / agent episodic memory.
+- [oban-bg/oban](https://github.com/oban-bg/oban) — 3.9k★; Elixir Postgres job queue; survived all sustained-pressure benchmark scenarios.
+- [timgit/pg-boss](https://github.com/timgit/pg-boss) — 3.8k★; Node Postgres queue + scheduling + pub/sub.
+- [microsoft/pg_durable](https://github.com/microsoft/pg_durable) — 2.7k★; Microsoft in-database durable execution (2026-06); bgw via `shared_preload_libraries`.
+- [graphile/worker](https://github.com/graphile/worker) — 2.3k★; Node Postgres job queue (~100–200 jobs/s ceiling).
+- [NikolayS/PgQue](https://github.com/NikolayS/PgQue) — 1.7k★; zero-bloat PgQ revival; ticks via pg_cron.
+- [dbos-inc/dbos-transact-py](https://github.com/dbos-inc/dbos-transact-py) — 1.5k★; **durable Python workflows, Postgres-only (now also SQLite); first-party Pydantic AI / OpenAI Agents / LlamaIndex integrations — the closest fit to "write only your logic."**
+- [dbos-inc/dbos-transact-ts](https://github.com/dbos-inc/dbos-transact-ts) — 1.3k★; TypeScript sibling of the above.
+- [janbjorge/pgqueuer](https://github.com/janbjorge/pgqueuer) — 1.5k★; Python Postgres queue (LISTEN/NOTIFY + SKIP LOCKED, async).
+- [procrastinate-org/procrastinate](https://github.com/procrastinate-org/procrastinate) — 1.3k★; Python Postgres task queue (Celery alternative).
+- [hardbyte/postgresql-job-queue-benchmarking](https://github.com/hardbyte/postgresql-job-queue-benchmarking) — benchmark harness; peak throughput + sustained-pressure survival (only awa/oban/pgque passed all four) + dead-tuple/VACUUM caveat.
+- [supabase/supabase](https://github.com/supabase/supabase) — 106k★; "Postgres platform for agentic workloads" (pgvector + pgmq consolidation reference).
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — this repo; the devcontainer that makes a containerized Postgres control plane viable, and the host-only constraint that applies to graphify (not the control plane).

--- a/.omc/kb/reports/session-20260719d-codex-nim-probes.md
+++ b/.omc/kb/reports/session-20260719d-codex-nim-probes.md
@@ -1,0 +1,220 @@
+# Codex CLI ↔ NVIDIA NIM — empirical probe results (session 2026-07-19-d)
+
+Original findings from local probes, not from documentation. Every claim below
+was produced by running a command on this machine on 2026-07-19. Where a probe
+failed its own control arm, that is recorded rather than hidden.
+
+## Verdict summary
+
+| Question | Answer | Basis |
+|---|---|---|
+| Does codex-plugin-cc let Claude Code use arbitrary models? | **No** | plugin delegates CC → local `codex`; `openai_base_url` repoints Codex's own provider only |
+| Can Codex be a wrapper over NIM (CC → codex → NIM)? | **NO — hosted NIM has no `/v1/responses`** | RESOLVED: agent probe (401/403 on chat vs 404 byte-identical to a fake route) + `codex exec` 404 + independent POC `SproutSeeds/codex-nim-poc` 4 months earlier. See `agents/codex-nim-wiring.md` |
+| Why did GET `/v1/responses` return 405 then? | **Edge gateway knows the path; backend has no handler** | POST forwards to a nonexistent handler. Confirms 405 was never evidence of function — re-probe later, it may be a moving target |
+| Is there a working NIM path? | **Yes — LiteLLM bridge** (`use_chat_completions_api: true`) | LiteLLM docs name Codex CLI as the motivating use case. UNVERIFIED locally (no key) |
+| **Can Codex be a wrapper over a LOCAL free model (CC → codex → Ollama)?** | **YES — CONFIRMED, rc=0** | Probe 6; `ollama ps` keep-alive refreshed during run, no `auth.json` present |
+| Does Ollama implement a real Responses API? | **Yes — full payload, HTTP 200** | Probe 6 |
+| Does codex 0.144.6 support `wire_api = "chat"`? | **No — removed** | string compiled into the binary |
+| Does NIM register a `/v1/responses` route? | **Yes** | GET → 405 vs 404 for fake paths |
+| Does that prove NIM's Responses API *works*? | **No** | control arm: Ollama returns 405 too |
+| Can Claude Code itself route to non-Claude models? | **No, unsupported** | Anthropic docs + process-global `ANTHROPIC_BASE_URL` |
+| Does graphify 0.9.20 support custom OpenAI endpoints? | **Yes** | installed `llm.py:112` |
+
+## Probe 1 — `wire_api = "chat"` is removed from Codex
+
+`codex-cli 0.144.6` (installed at
+`~/.local/share/mise/installs/codex/0.144.6/bin/codex`). Running `strings` over
+the binary surfaces this literal, compiled-in message:
+
+```
+`wire_api = "chat"` is no longer supported.
+remote thread config returned unknown wire_api:
+```
+
+Adjacent provider-config keys also present in the binary:
+`base_url`, `env_key`, `env_key_instructions`, `experimental_bearer_token`,
+`bearer_token`, `wire_api`, `query_params`, `request_max_retries`,
+`stream_max_retries`, `stream_idle_timeout_ms`, `requires_openai_auth`,
+`supports_websockets`, `startup_timeout_ms`.
+
+**Reading:** the config docs are correct for this version — `responses` is the
+only accepted `wire_api`. Chat/completions support existed historically and was
+deliberately removed. Any third-party endpoint must therefore speak the
+**Responses API**, not chat/completions, to work with Codex.
+
+## Probe 2 — NIM endpoint existence (control-armed)
+
+A POST-based probe was run first and **failed its control arm**: both
+`/v1/chat/completions` (certainly real) and `/v1/bogus-endpoint-xyz` returned
+`404`, so 404 carried no information. Recorded here because the failed probe is
+the reason the second one was designed differently.
+
+A GET-based probe discriminates, because real routes reject the method (405)
+while unknown routes 404:
+
+```
+GET https://integrate.api.nvidia.com/v1/responses          -> 405
+GET https://integrate.api.nvidia.com/v1/chat/completions   -> 405
+GET https://integrate.api.nvidia.com/v1/completions        -> 405
+GET https://integrate.api.nvidia.com/v1/embeddings         -> 405
+GET https://integrate.api.nvidia.com/v1/models             -> 200
+GET https://integrate.api.nvidia.com/v1/bogus-endpoint-xyz -> 404
+GET https://integrate.api.nvidia.com/v1/another-fake-abc   -> 404
+```
+
+`/v1/responses` is a **registered route** on NIM.
+
+## Probe 3 — the control arm that weakened Probe 2
+
+The same GET probe against local Ollama 0.32.1:
+
+```
+GET http://localhost:11434/v1/responses        -> 405
+GET http://localhost:11434/v1/chat/completions -> 405
+GET http://localhost:11434/v1/models           -> 200
+GET http://localhost:11434/v1/bogus-xyz        -> 404
+```
+
+Ollama registers `/v1/responses` too. Therefore **405 proves route
+registration, not a working Responses implementation.** The honest conclusion
+from Probes 2+3 is "NIM plausibly speaks Responses", not "NIM speaks
+Responses". Settling it requires a real authenticated POST.
+
+## Probe 4 — NIM catalog is publicly listable
+
+`GET /v1/models` → 200 with **119 models**, no auth required. Confirms the
+endpoint is live and NVIDIA-operated. Real model IDs (note: `qwen2.5-coder` and
+`deepseek-v3` are **not** in the catalog — those were guesses):
+
+- `moonshotai/kimi-k2.6`
+- `z-ai/glm-5.2`
+- `deepseek-ai/deepseek-v4-pro`, `deepseek-ai/deepseek-v4-flash`
+- `openai/gpt-oss-120b`
+- `nvidia/nemotron-3-super-120b-a12b`
+- `qwen/qwen3.5-397b-a17b`
+
+## Probe 5 — graphify 0.9.20 custom-endpoint support (issue #959 is stale)
+
+Installed source, `graphify/llm.py:112`:
+
+```python
+"base_url": os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1"),
+```
+
+with the comment at line 108: *"OPENAI_BASE_URL points the backend at any
+OpenAI-compatible server"*. Sibling providers each take their own override:
+`ANTHROPIC_BASE_URL`, `KIMI_BASE_URL`, `OLLAMA_BASE_URL`
+(default `http://localhost:11434/v1`), `GEMINI_BASE_URL`, `DEEPSEEK_BASE_URL`.
+
+graphify also ships `provider_base_url_ok()`, whose docstring states a custom
+`base_url` "is an exfiltration channel" — the maintainers explicitly treat
+pointing a corpus at a third party as a security decision.
+
+**GitHub issue #959 ("OpenAI base_url hardcoded") is stale-open.** The feature
+shipped in 0.8.40. An earlier research pass read the open issue and concluded
+custom endpoints were blocked; reading the installed source refuted it. *Source
+beats issue tracker.*
+
+## Blocking constraint — NVIDIA API Trial ToS
+
+Independent of any technical result:
+
+- **§1.2 / §1.4** — trial access is for *"internal testing and evaluation
+  purposes, not in production"* without a paid Subscription.
+- **§3.3(iv)** — NVIDIA collects *"User Content and Generated Content to
+  improve NVIDIA products and services, including AI models."* This contradicts
+  §2.3's no-storage language; the training-use clause is the operative one.
+- Practical ceiling: **40 RPM, ~1,000 credits**.
+
+**Consequence:** do not send private repo/corpus content to NIM. The technical
+path being open does not make the data path acceptable.
+
+## Why Claude Code cannot mix a Claude architect with non-Claude workers
+
+Three independent confirmations:
+
+1. Subagent `model:` accepts only `sonnet|opus|haiku|fable|<claude model id>|
+   inherit` — "the same values as the `--model` flag".
+2. `ANTHROPIC_BASE_URL` is **process-global** — all-or-nothing. This is why the
+   claudefa.st recipe must remap `MODEL_OPUS` as well.
+3. Anthropic states Claude Code "doesn't support routing Claude Code to
+   non-Claude models through any gateway"
+   (<https://code.claude.com/docs/en/llm-gateway>).
+
+This **confirms** the program's already-locked launcher-wrapped shell-out
+substrate: a separate process with separate auth is the only working shape.
+
+## GitHub repos touched
+
+- [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc) — README
+  read directly; established the plugin's direction and its `openai_base_url`
+  semantics.
+- [Graphify-Labs/graphify](https://github.com/Graphify-Labs/graphify) —
+  issue #959 status vs installed 0.9.20 source; `llm.py` provider table.
+- [DeL-TaiseiOzaki/claude-code-orchestra](https://github.com/DeL-TaiseiOzaki/claude-code-orchestra)
+  — cloned; prior art already built on codex-plugin-cc (3-tier routing,
+  `agent-router.py`, Sol Guardrails), running `gpt-5.6-sol` with no custom
+  base_url.
+- [Alishahryar1/free-claude-code](https://github.com/Alishahryar1/free-claude-code)
+  — the FastAPI Anthropic→NIM proxy behind the claudefa.st recipe.
+
+---
+
+## CONFIRMED (Probe 6): Codex CLI drives a local model end-to-end — no OpenAI, no NIM, no cost
+
+**This supersedes the "plausible/unverified" framing above for the LOCAL case.**
+
+### Ollama implements a real Responses API
+
+`POST http://localhost:11434/v1/responses` → **HTTP 200** with a correct
+OpenAI Responses payload: `object:"response"`, `output[]` containing a
+`reasoning` item and a `message` item, plus `previous_response_id`, `store`,
+`tool_choice`, `parallel_tool_calls`, and `usage.output_tokens_details.
+reasoning_tokens`. Not a stub — the full shape.
+
+This explains why Codex ships built-in `ollama` / `lmstudio` providers despite
+`wire_api = "chat"` being removed: those servers speak **Responses**.
+
+### End-to-end run
+
+```toml
+# $CODEX_HOME/config.toml   (scratch dir — user's ~/.codex untouched)
+model = "qwen3:0.6b"
+model_provider = "ollama"
+approval_policy = "never"
+sandbox_mode = "read-only"
+```
+
+```
+CODEX_HOME=<scratch> codex exec --skip-git-repo-check "say OK"   ->  RC=0
+```
+
+Completed successfully, 10,022 tokens.
+
+### Control arms (this is what makes it evidence)
+
+| arm | result | what it rules out |
+|---|---|---|
+| no `auth.json` in scratch `CODEX_HOME` | absent | ChatGPT/OpenAI credentials — fallback impossible |
+| `ollama ps` UNTIL timer **before** run | "About a minute from now" (decaying) | — |
+| `ollama ps` UNTIL timer **during** run | **"4 minutes from now" (refreshed)** | proves the request reached Ollama; keep-alive only resets on a request |
+| dead-port provider | **INVALID** — hung on stdin, never tested the socket | recorded as failed, not counted as evidence |
+
+### Consequence
+
+The chain **`Claude Code → /codex:* (codex-plugin-cc) → codex → local Ollama`
+works today**: free, fully local, no third-party ToS, no rate limit, no data
+egress. This is strictly better than the NIM variant for any work touching
+private repo content.
+
+It also raises confidence that **NIM would work if its `/v1/responses` is
+functional** — the protocol requirement is satisfiable by non-OpenAI servers,
+which was the open question. Confirming NIM specifically still needs one
+authenticated call.
+
+### Caveat
+
+`qwen3:0.6b` followed instructions poorly (it summarized `AGENTS.md` instead of
+replying "OK"). The chain is proven; **worker quality is a separate axis** and
+argues for `qwen3:14b` or a stronger free endpoint. `qwen3:14b` exceeded a
+2-minute foreground budget on cold load — size the timeout accordingly.

--- a/.omc/kb/reports/session-20260719d-graphify-doc-ingestion-validation.md
+++ b/.omc/kb/reports/session-20260719d-graphify-doc-ingestion-validation.md
@@ -1,0 +1,200 @@
+# graphify doc-ingestion: validation on OUR corpus — NEGATIVE result
+
+Date: 2026-07-19. Backend: local Ollama `qwen3:14b` via `--backend openai`
++ `OPENAI_BASE_URL=http://localhost:11434/v1` (maintainer-preferred path).
+Corpus: 2 documents, 17 KB — one YouTube transcript
+(`22iy2mDFiF8.md`, "Graphify + Obsidian") and one dense technical report
+(`session-20260719d-codex-nim-probes.md`).
+
+This is the test the community-mining report said to run before betting on
+semantic enrichment: *"validate the semantic-enrichment claim on your own corpus
+before committing."* **It failed.**
+
+## Run result
+
+```
+found 0 code, 2 docs, 0 papers, 0 images
+semantic extraction on 2 files via openai... chunk 1/1 done
+wrote graph.json: 9 nodes, 6 edges, 3 communities
+tokens: 5,315 in / 2,013 out
+rc=0, elapsed 165s
+```
+
+The pipeline **works** — rc=0, no hangs, no crashes, 165 s for 2 docs
+(≈35 min extrapolated for all 26). Mechanically sound. The problem is the
+output.
+
+## Finding 1 (STRUCTURAL, will NOT improve with a better model)
+
+**Node IDs are namespaced by source file, so there is zero cross-document
+fusion.**
+
+```
+22iy2mDFiF8_graphify                          :: "Graphify"
+session-20260719d-codex-nim-probes_graphify_0_9_20 :: "Graphify 0.9.20"
+```
+
+Both documents discuss graphify. They produce **separate, unlinked nodes**.
+
+Measured:
+- **cross-document edges: 0 / 6**
+- duplicate labels across docs: **none** (because each is namespaced apart)
+- **all 3 communities span exactly 1 document each**
+
+Clustering cannot fix this: community detection runs over the edge set, and the
+edge set has no cross-document edges to find.
+
+**Consequence:** what is produced is not *a* knowledge graph. It is *N
+disconnected per-document mini-graphs* sharing a file. A query like "what do we
+know about graphify across every source we've ingested" cannot be answered by
+traversal, because no path exists between documents.
+
+This is the documented issue [#198](https://github.com/Graphify-Labs/graphify/issues/198)
+("semantic layer is mostly disconnected") in a sharper form — not merely
+AST↔semantic disconnect but **doc↔doc** disconnect, caused by ID namespacing
+rather than by extraction quality. `merge-graphs` / `global add` union files;
+they do not create semantic bridges.
+
+## Finding 2 (QUALITY, may partly improve with a stronger model)
+
+**Extraction is shallow.** 17 KB of dense prose yielded **9 concept nodes**.
+The probe report alone contains dozens of discrete, load-bearing facts
+(the compiled-in `wire_api = "chat"` removal string, the 405-vs-404
+discrimination method, ToS §1.2/§3.3(iv), six real NIM model IDs, issue
+numbers). Essentially none were captured.
+
+Compare maintainer-acknowledged
+[#1890](https://github.com/Graphify-Labs/graphify/issues/1890): 53% of docs lost
+**even with gpt-5** — so this is not purely a small-model artifact.
+
+## Finding 3 (ACCURACY — the dangerous one)
+
+The extractor emitted:
+
+```
+NVIDIA NIM --supports--> Responses API   (confidence: EXTRACTED)
+```
+
+The source document **explicitly refuses that claim.** It states: *"405 proves
+route registration, not a working Responses implementation"* and *"NIM plausibly
+speaks Responses — unconfirmed."*
+
+The extractor **flattened a carefully hedged, control-armed finding into a
+confident assertion.** A future agent querying this graph would be told, with
+apparent authority, something the underlying evidence explicitly does not
+support — and the hedge is not recoverable from the graph.
+
+This is the **false-authority** failure mode that
+[#2051](https://github.com/Graphify-Labs/graphify/issues/2051) raises for stale
+nodes, arriving here through a different door: not staleness, but
+**hedge-flattening at extraction time.** For a knowledge base whose whole
+purpose is feeding autonomous agents, this is the most serious defect of the
+three.
+
+## Finding 4 — confidence is not a number
+
+Every edge carries `confidence: "EXTRACTED"` — a constant string. There is no
+numeric confidence to threshold on, so any design that planned to filter edges
+by confidence has nothing to filter on. (Note this differs from
+[#540](https://github.com/Graphify-Labs/graphify/issues/540)'s bimodal-0.5/0.85
+report, which described INFERRED edges; the doc path here emits a literal.)
+
+## What still holds
+
+- **The AST/code path remains excellent** and is unaffected: deterministic,
+  0 tokens, 3,157 nodes for this repo, 446 for claude-code-orchestra, with
+  working control-armed BFS query. That was always the solid part.
+- The ingestion **mechanism** is reliable — bounded, resumable, cheap locally.
+  If the fusion and hedging problems were solved, the plumbing is ready.
+
+## Recommendation
+
+**Do not build the autonomous program's knowledge layer on graphify's semantic
+doc ingestion as it currently behaves.** Specifically:
+
+1. **Keep** graphify for what it is good at: the deterministic code graph.
+2. **Do not** treat the doc graph as a cross-source knowledge base — it cannot
+   join sources, which is the single property the knowledge layer needs.
+3. If doc retrieval is needed now, prefer a method that preserves the source
+   text and its hedges (the documents are already clean Markdown in
+   `.omc/kb/`; plain retrieval over them loses nothing that the graph adds).
+4. Re-test if upstream lands identifier normalization / fuzzy bridging (the
+   contributor work referenced in #198). This validation is cheap to repeat —
+   165 s.
+
+## Reproduction
+
+```
+INGEST_TIMEOUT=900 INGEST_LOG=/tmp/kb-probe.log \
+  ingest_kb.sh .omc/kb/probe .omc/kb/graphs/probe qwen3:14b
+```
+
+## GitHub repos touched
+
+- [Graphify-Labs/graphify](https://github.com/Graphify-Labs/graphify) — the tool
+  under validation; issues #198, #540, #1890, #2051 referenced against observed
+  behavior.
+
+---
+
+## ADDENDUM — a confound was raised, tested, and REFUTED (same session)
+
+After the original run, `graphify-mining`'s best-practices section surfaced:
+*"**Disable 'thinking' on any reasoning model** or `content` comes back empty"*
+(kimi #623, deepseek #1621). The probe above used **qwen3:14b — a reasoning
+model** — so the shallow-extraction finding was potentially measuring a starved
+model rather than graphify.
+
+### The confound is real at the API level
+
+```
+qwen3:14b via /v1/chat/completions, max_tokens=600:
+  reasoning chars: 2459
+  content   chars: 0          <-- ZERO
+  finish_reason  : length
+```
+
+At `max_tokens=4000`: reasoning 2618 **+ content 563**, `finish=stop`. Ollama's
+native API with `think:false`: thinking 0, clean content. So the mechanism is
+genuine — a reasoning model can consume its entire output budget before emitting
+anything. `/no_think` does **not** pass through the OpenAI-compat layer.
+
+### But it did NOT affect graphify — tested directly
+
+`GRAPHIFY_MAX_OUTPUT_TOKENS` **is** honored by 0.9.20 (`llm.py:264-265`). Re-ran
+the identical corpus with it raised to `16384`, into a **separate output
+directory**:
+
+| | probe 1 | probe 2 (`MAX_OUTPUT_TOKENS=16384`) |
+|---|---|---|
+| nodes / edges / communities | 9 / 6 / 3 | **9 / 6 / 3** |
+| tokens | 5,315 in / 2,013 out | **5,315 in / 2,013 out** |
+| cross-document edges | 0 / 6 | **0 / 6** |
+| `graph.json` md5 | `87061d46…7bc6b` | **`87061d46…7bc6b`** |
+
+**Freshness control (this is what makes the comparison valid):** probe2 wrote its
+own semantic cache at **18:10:51** vs probe1's **17:45:17**, in its own
+directory. A real re-extraction, not a replayed cache — which matters, since
+graphify's semantic cache has a history of stale replays (#1939, #1894).
+
+### Conclusion
+
+**Confound REFUTED.** The output cap was never the binding constraint — the
+model produced 2,013 output tokens and stopped naturally, with room for both
+reasoning and content. **Findings 1, 2 and 3 stand as originally reported.**
+
+Two bonus results:
+- **Byte-identical `graph.json` across two independent runs** corroborates the
+  maintainer's determinism claim for the default (Louvain) install — 2/2 here
+  against their reported 20/20. Our `[all]` pin lands on the deterministic side.
+- Still **UNVERIFIED**: whether a *non-reasoning* model yields richer extraction.
+  The "starved by cap" mechanism is dead, but reasoning tokens still occupy part
+  of each response. Testing that needs a non-reasoning model pulled locally.
+
+### Method note
+
+The original write-up asserted three findings as if equally supported. Only
+Finding 1 (structural ID namespacing) was ever immune to model choice; 2 and 3
+required this second arm before they deserved the same confidence. Raising a
+confound and testing it cost ~5 minutes and converted an assumption into a
+result.

--- a/.omc/kb/reports/track-a-cc-autonomy.md
+++ b/.omc/kb/reports/track-a-cc-autonomy.md
@@ -1,0 +1,529 @@
+# Unattended-but-Escalating Claude Code Orchestrator — Research Report
+
+**Date**: 2026-07-19  
+**Scope**: Building autonomous, ticketed Claude Code loops that run well-specified tasks to completion, auto-merge on green, and escalate only genuine decisions to a human
+
+---
+
+## 1. Fork vs. Continue vs. Subtask: Exact Semantics
+
+### `/fork` (Agent SDK: `fork_session=true`)
+
+**Documentation**: https://code.claude.com/docs/en/agent-sdk/sessions.md
+
+**Exact semantics**:
+- Creates a **new session** that starts with a **copy** of the original's entire conversation history
+- The fork gets a **distinct session ID**; the original session's ID and history remain **unchanged**
+- Both sessions are **independent** after the fork point: changes made in the fork do not affect the original, and vice versa
+- Both can be resumed and worked on separately using their respective session IDs
+
+**SDK interfaces**:
+- Python: `fork_session=True` in `ClaudeAgentOptions` passed to `query()`
+- TypeScript: `forkSession: true` in `Options` passed to `query()`
+- Example (Python):
+  ```python
+  async for message in query(
+      prompt="Outline how OAuth2 would work",
+      options=ClaudeAgentOptions(
+          resume=session_id,
+          fork_session=True,  # Creates a branch, not a mutation
+          max_turns=5,
+      ),
+  ):
+  ```
+- The fork fires immediately; the original **remains idle** until resumed separately
+
+**How to resume / list / drive**:
+- Capture the fork's session ID from the `session_id` field on the `ResultMessage` 
+- Pass to `resume=fork_id` on the next `query()` call
+- List all sessions: `list_sessions()` (Python) / `listSessions()` (TypeScript)
+- Retrieve past messages: `get_session_messages(session_id)` (Python) / `getSessionMessages(session_id)` (TypeScript)
+
+---
+
+### `continue` (Not a fork — reuses the most recent session)
+
+**Documentation**: https://code.claude.com/docs/en/agent-sdk/sessions.md
+
+**Exact semantics**:
+- Finds and resumes the **most recent session** in the current project directory
+- **No explicit session ID tracking required**
+- Appends new messages to the same conversation history
+- Best for multi-turn chat within a single process
+
+**SDK interfaces**:
+- Python: `continue_conversation=True` in `ClaudeAgentOptions`
+- TypeScript: `continue: true` in `Options`
+
+---
+
+### `/subtask` (Does Not Exist)
+
+`/subtask` **is not documented** in the Claude Code or Agent SDK documentation. The equivalent is **`subagent`** (a distinct concept: a nested agent spawned by Claude during a task) or the **Task tool** (for parallel work). There is no `/subtask` slash command.
+
+If you're looking to spawn parallel child agents: use the **`Agent` tool** (built-in), or define custom **subagent definitions** in the Agent SDK. See https://code.claude.com/docs/en/sub-agents.md.
+
+---
+
+## 2. Unattended-but-Escalating Loop: Exact Pause/Resume Mechanism
+
+### When No Human Is Present: Behavior Matrix
+
+| Scenario | Current Behavior | Configurable? |
+|----------|------------------|---------------|
+| Permission prompt (`Bash`, `Write`, etc.) in auto mode | **Auto-approved** (via classifier) or **denied** | Yes: `permissions.ask` forces prompt; `permissions.deny` blocks |
+| Permission prompt in `dontAsk` mode | **Denied** (never prompts) | Yes: `permissionMode` setting |
+| Permission prompt in default mode, no human | **Blocks indefinitely** (waits for input) | Yes: use auto mode, or set `canUseTool` callback |
+| `AskUserQuestion` tool (Claude asks for clarification) | **Blocks indefinitely** | Yes: implement `canUseTool` callback to answer; or channel via `PermissionRequest` hook |
+| Tool call denied by hook | **Blocks indefinitely** | Yes: hook returns `defer` to exit and resume later |
+
+### The `defer` Mechanism (From Hook Return)
+
+**Documentation**: https://code.claude.com/docs/en/agent-sdk/hooks.md
+
+A `PreToolUse` hook can return `"defer"` as the `permissionDecision`:
+```python
+return {
+    "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "defer",
+        "permissionDecisionReason": "Awaiting human review of production deploy"
+    }
+}
+```
+
+**Behavior**:
+- Ends the current `query()` call **immediately**
+- The session is **persisted** to disk and remains **resumable**
+- The tool call is **not executed**
+- Resume with `--resume <session-id>` to continue; Claude reattempts the tool call or takes an alternative path
+
+**Why this matters for autonomous loops**:
+- An autonomous agent can hit a hook that says "I need human approval for this database write"
+- The hook returns `"defer"`
+- The agent loop exits cleanly (not crashed)
+- The human is notified (via a Notification hook or Channel)
+- The human reviews and later resumes the session
+- Claude continues from exactly where it left off
+
+---
+
+### Escalation Without Blocking: Channels + Permission Relay
+
+**Documentation**: https://code.claude.com/docs/en/channels-reference.md
+
+**What they are**:
+- MCP servers that push events INTO a Claude Code session (one-way or two-way)
+- Two-way channels can **relay permission prompts** to external systems (Slack, mobile app, etc.)
+
+**Permission relay flow** (no local terminal needed):
+1. Claude tries to call a tool that needs approval (e.g., `Bash`)
+2. Server generates a 5-letter request ID (e.g., `abcde`)
+3. Sends `notifications/claude/channel/permission_request` to the channel server
+4. Channel forwards the prompt to Slack/Discord/etc. with the ID
+5. Human replies `yes abcde` or `no abcde`
+6. Channel sends back `notifications/claude/channel/permission` with the verdict
+7. Claude Code **applies the verdict** and continues (or blocked if `deny`)
+8. Local terminal dialog also stays open — first answer wins
+
+**Key**: Both the local and remote approval dialogs stay open. The agent is **unblocked** in seconds (remotely answered) rather than indefinitely (waiting for the Mac user to notice).
+
+**Example Zod schema for permission relay**:
+```typescript
+const PermissionRequestSchema = z.object({
+  method: z.literal('notifications/claude/channel/permission_request'),
+  params: z.object({
+    request_id: z.string(),     // five lowercase [a-km-z]
+    tool_name: z.string(),      // e.g. "Bash", "Write"
+    description: z.string(),    // untrusted, sanitized by CC v2.1.211+
+    input_preview: z.string(),  // tool args, untrusted
+  }),
+})
+```
+
+Requires:
+- Channel capability: `experimental['claude/channel/permission']: {}`
+- https://code.claude.com/docs/en/channels-reference.md#relay-permission-prompts
+
+---
+
+## 3. Claude Code Autonomy Features: Changelog & Current Capabilities
+
+### Complete Feature Map (v2.1.212+)
+
+**Built-in**: Direct slash commands and modes
+
+| Feature | Type | Entry Point | Use Case | Docs |
+|---------|------|------------|----------|------|
+| **Auto Mode** | Permission classifier | `permissionMode: "auto"` | Block destructive operations; allow routine internal work | https://code.claude.com/docs/en/permission-modes#eliminate-prompts-with-auto-mode |
+| **`/goal`** | Continuous execution gate | `/goal <condition>` | Keep running until condition met (e.g., "all tests pass") | https://code.claude.com/docs/en/goal.md |
+| **`/loop`** | Fixed or dynamic interval | `/loop <interval> <prompt>` or `/loop` | Re-run prompt every N minutes, or let Claude pick interval | https://code.claude.com/docs/en/scheduled-tasks.md |
+| **Headless (`-p`)** | CLI non-interactive | `claude -p "prompt"` | One-shot unattended run; combines with `--allowedTools`, `--permission-mode auto` | https://code.claude.com/docs/en/headless.md |
+| **Channels** | External event injection | MCP server + `--channels` | Receive webhooks, Slack messages, alerts; relay approvals back | https://code.claude.com/docs/en/channels-reference.md |
+| **Hooks** | Execution intercepts | `hooks.PreToolUse`, `PostToolUse`, `Stop`, `Notification` | Enforce policy, gate operations, log/notify, defer escalations | https://code.claude.com/docs/en/agent-sdk/hooks.md |
+| **Background sessions** | Agent view UI | `/agent start ...` in CLI | Run a session in the background; still consumes your terminal but stays live | https://code.claude.com/docs/en/agent-view.md |
+| **Routines (Cloud)** | Managed infrastructure | `claude /schedule daily <prompt>` | Run on cloud infrastructure on a cron, GitHub event, or API call; no machine needed | https://code.claude.com/docs/en/routines.md |
+| **Auto mode + environment** | Config-driven trust | `autoMode.environment` in settings | Tell classifier which repos, buckets, domains to trust for safe auto-approval | https://code.claude.com/docs/en/auto-mode-config.md |
+| **Fork sessions** | Branching history | `fork_session=True` in SDK | Explore alternative approaches without losing the original thread | https://code.claude.com/docs/en/agent-sdk/sessions.md |
+
+### Channels (Research Preview)
+
+**Status**: Research preview (requires `--dangerously-load-development-channels` for custom channels)
+
+**Supported out-of-the-box**: Telegram, Discord, iMessage, fakechat
+
+**What they do**:
+- **One-way**: forward alerts/webhooks into Claude (e.g., CI failure → Claude investigates)
+- **Two-way**: Claude can reply via the channel's reply tool
+- **Permission relay**: Forward approval prompts to external systems; remote user answers via text
+
+**Key limitation**: Not eligible for Zero Data Retention (ZDR) because events persist in the session transcript.
+
+**Certificate**: https://code.claude.com/docs/en/channels-reference.md
+
+---
+
+### Checkpointing & Rewind
+
+**Status**: Documented, shipping
+
+**What it does**: Automatically saves conversation snapshots; you can rewind and summarize.
+
+**Docs**: https://code.claude.com/docs/en/checkpointing.md
+
+**Limitation**: Snapshots are within the same session. To branch to a truly independent thread, use `/fork`.
+
+---
+
+### Headless Mode (`claude -p`)
+
+**Status**: Fully available
+
+**Exact behavior**:
+- No interactive prompt; runs one prompt to completion
+- Combines with `--allowedTools`, `--permission-mode`, `--output-format`
+- If a permission prompt would appear in default mode, the command **fails** unless you pre-approve with `--allowedTools "Bash,Read,Write"`
+
+**Example**:
+```bash
+claude -p "Find and fix the bug" \
+  --allowedTools "Bash,Read,Edit" \
+  --permission-mode auto \
+  --output-format json
+```
+
+**Exit codes**: 0 = success, non-zero = error or blocked permission
+
+**Key**: `--bare` skips loading hooks, skills, plugins, MCP servers from `.claude/` (useful for CI consistency)
+
+**Docs**: https://code.claude.com/docs/en/headless.md
+
+---
+
+### Agent SDK Session Lifecycle (Python + TypeScript)
+
+**Documentation**: 
+- Python: https://code.claude.com/docs/en/agent-sdk/python.md
+- TypeScript: https://code.claude.com/docs/en/agent-sdk/typescript.md
+
+**Resume flow (Python)**:
+```python
+from claude_agent_sdk import query, ClaudeAgentOptions, ResultMessage
+
+# Resume by explicit ID
+async for message in query(
+    prompt="Continue the work",
+    options=ClaudeAgentOptions(resume="session_01ABC..."),
+):
+    if isinstance(message, ResultMessage):
+        print(f"Final result: {message.result}")
+```
+
+**Continue (most recent)**:
+```python
+# First call creates session
+# Second call auto-resumes the most recent
+async for message in query(
+    prompt="Next step",
+    options=ClaudeAgentOptions(continue_conversation=True),
+):
+```
+
+**Managed Agents API** (different from Agent SDK):
+- Server-hosted sessions that persist independently
+- Anthropic manages the sandbox
+- No file-system access on the orchestrator's machine (fresh clone each run)
+- Session events stream over SSE
+- Can schedule recurring deployments
+
+**Docs**: https://platform.claude.com/docs/en/managed-agents/overview.md
+
+**Key difference**: Agent SDK = harness you host; Managed Agents = harness Anthropic hosts. Agent SDK has full local file access; Managed Agents gets a fresh clone.
+
+---
+
+## 4. Unattended-but-Escalating Loop: The Complete Mechanism
+
+### Permission Evaluation Order (Pre-Classifier)
+
+**Documentation**: https://code.claude.com/docs/en/agent-sdk/permissions.md
+
+Hooks fire **first**, then rules (deny, ask, allow), then permission mode, then `canUseTool` callback.
+
+```
+1. Hooks (PreToolUse)
+   ├─ Allow? → Execute
+   ├─ Deny? → Block (even in bypassPermissions)
+   └─ Defer? → Exit session, persist, wait for resume
+   
+2. Deny rules (permissions.disallow)
+   └─ Match? → Block (always)
+   
+3. Ask rules (permissions.ask)
+   └─ Match? → Fall through to canUseTool callback (even in bypassPermissions)
+   
+4. Permission mode
+   ├─ bypassPermissions → Execute
+   ├─ auto → Classifier decides (UNATTENDED if classifier approves)
+   ├─ dontAsk → Deny (never prompt)
+   ├─ acceptEdits → Auto-approve file operations
+   └─ plan → Prompt for file writes (readonly tools auto-approve)
+   
+5. Allow rules (permissions.allow)
+   └─ Match? → Execute
+   
+6. canUseTool callback
+   └─ Invoke for decision (skipped in dontAsk)
+```
+
+### Auto Mode Classifier
+
+**Documentation**: https://code.claude.com/docs/en/auto-mode-config.md
+
+**How it works**:
+- Reads your CLAUDE.md instructions and `autoMode.environment` config
+- Evaluates each tool call against four rule lists: `hard_deny`, `soft_deny`, `allow`, `environment`
+- Runs in-process (no network call)
+
+**Activation**: `permissionMode: "auto"` in query options or settings
+
+**Default behavior** (without customization):
+- ✅ Allows: reads to your working repo, writes to `claude/`-prefixed branches, routine npm installs, git commits
+- ❌ Blocks: force pushes, deploys to production-named targets, writes outside your repo, network calls to untrusted domains
+
+**Configuration** (in `~/.claude/settings.json` or managed settings):
+```json
+{
+  "autoMode": {
+    "environment": [
+      "$defaults",
+      "Source control: github.example.com/acme-corp",
+      "Trusted cloud buckets: s3://acme-builds",
+      "Trusted internal domains: api.internal.example.com"
+    ],
+    "allow": [
+      "$defaults",
+      "Deploying to staging is allowed (ephemeral, resets nightly)"
+    ],
+    "soft_deny": [
+      "$defaults",
+      "Never run migrations outside the migrations CLI"
+    ],
+    "classifyAllShell": true  // Routes ALL bash through classifier
+  }
+}
+```
+
+**When denies happen without escalation**:
+- Tool is blocked silently in a background loop
+- A `PermissionDenied` hook fires (for logging / retry logic)
+- Claude receives an error result and adapts
+
+---
+
+## 5. Settings + Hooks to Make Loops Safe and Observable
+
+### Complete Settings Configuration
+
+**File location**: `~/.claude/settings.json` (user-level, applies to all sessions)
+
+**Minimal autonomous loop configuration**:
+```json
+{
+  "permissionMode": "auto",
+  "autoMode": {
+    "environment": [
+      "$defaults",
+      "Source control: github.example.com/my-org",
+      "Trusted cloud buckets: s3://my-builds"
+    ],
+    "classifyAllShell": true
+  },
+  "permissions": {
+    "ask": [
+      "Bash(git push main)",
+      "Bash(gh pr merge *)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash(rm -rf *|git reset --hard|git push --force)",
+        "hooks": [
+          "escalate_to_slack"
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": ["notify_on_permission_request"]
+      }
+    ]
+  }
+}
+```
+
+### Permissions Settings (Full Reference)
+
+**Documentation**: https://code.claude.com/docs/en/permissions.md
+
+| Setting | Type | Effect | Unattended Behavior |
+|---------|------|--------|-------------------|
+| `permissions.allow` | string[] | Pre-approve tool calls | Tool runs without prompt |
+| `permissions.ask` | string[] | Force prompt (even in `auto` mode) | **Blocks** the tool (returns deny) unless `canUseTool` callback approves |
+| `permissions.deny` | string[] | Unconditional block | Tool never runs, even in `bypassPermissions` |
+| `permissionMode` | enum | Global approval strategy | `auto` = classifier; `dontAsk` = deny unmatched; `acceptEdits` = auto-approve file ops |
+
+**Examples**:
+```json
+{
+  "permissions": {
+    "allow": ["Read", "Glob", "Grep"],
+    "ask": ["Bash(git push *)", "Write(/etc/*)"],
+    "deny": ["Bash(rm *)", "Edit(/sensitive-file)"]
+  },
+  "permissionMode": "auto"
+}
+```
+
+---
+
+## 6. Recurring/Scheduled + Resilience
+
+### Session Persistence & Resume
+
+**Documentation**: https://code.claude.com/docs/en/agent-sdk/sessions.md
+
+| Scenario | Behavior | Recovery | Code |
+|----------|----------|----------|------|
+| Process crashes during query | Session partially written; on-disk state is latest completed turn | Resume with `--resume <id>`: Claude resumes from last message | `claude --resume <session-id>` |
+| Network timeout mid-turn | Session may or may not have progressed; unclear state on-disk | Retry the query; if it succeeds, session has progressed; if it fails, retried prompt is lost (not idempotent) | Wrap in retry loop with exponential backoff |
+| Loop iteration finishes | Session fully persisted | Restart with same loop; Claude re-reads full history | `/loop` auto-continues on next wakeup |
+| Goal is met | Session marked as "goal achieved" | Resume to start new work | `--resume <id>` after `/goal` complete |
+| Fork created | Both original and fork are persisted | Resume either session independently | `--resume <original-id>` or `--resume <fork-id>` |
+
+---
+
+### In-Session `/loop` vs. Cloud Routines vs. Desktop Tasks
+
+**Documentation**:
+- `/loop`: https://code.claude.com/docs/en/scheduled-tasks.md
+- Routines: https://code.claude.com/docs/en/routines.md
+- Desktop tasks: https://code.claude.com/docs/en/desktop-scheduled-tasks.md
+
+| Feature | `/loop` | Cloud Routines | Desktop Tasks | GitHub Actions |
+|---------|--------|---|---|---|
+| **Where** | Local terminal | Anthropic-managed cloud | User's machine | GitHub runner |
+| **Requires** | Open session | claude.ai account | Local machine | GitHub repo + secret |
+| **Persistence** | Within session (7-day expiry) | Indefinite | Indefinite | Indefinite |
+| **Local file access** | Yes (full) | No (fresh clone only) | Yes (full) | No (cloned repo only) |
+| **Trigger** | Time interval or manual | Cron / API / GitHub event | Cron / manual | GitHub event / manual |
+| **Multi-repo** | No | Yes (select per routine) | No | Yes (entire workflow) |
+| **Approval prompts** | Inherited from session | None (autonomous) | Configurable per task | Via hook or skipped |
+| **MCP servers** | From session config | From routine config | From session config | Via action |
+
+---
+
+### Cloud Routines (Unattended Infrastructure)
+
+**Documentation**: https://code.claude.com/docs/en/routines.md
+
+**Create**: 
+```bash
+/schedule daily at 9am, review and merge overnight PRs
+```
+
+**Trigger types**:
+1. **Scheduled cron**: `0 9 * * *` = 9am daily
+2. **API**: POST to `/fire` endpoint with bearer token; passes optional `text` payload
+3. **GitHub event**: PR opened/closed, release created, etc., with filters
+
+**Example API trigger** (from a CI pipeline):
+```bash
+curl -X POST https://api.anthropic.com/v1/claude_code/routines/trig_01ABC.../fire \
+  -H "Authorization: Bearer sk-ant-oat01-xxxxx" \
+  -H "anthropic-beta: experimental-cc-routine-2026-04-01" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "text": "Sentry alert SEN-4521 fired in prod. Stack trace: ..."
+  }'
+```
+
+**Key limitations** (research preview):
+- No local file-system access (fresh clone only)
+- No Zero Data Retention (sessions persist server-side)
+- Per-account daily run caps (exempt: one-off scheduled fires)
+
+---
+
+### Managed Agents (Claude Platform API)
+
+**Documentation**: https://platform.claude.com/docs/en/managed-agents/overview.md
+
+**What it is**: Server-hosted stateful sessions (NOT the Agent SDK; different product)
+
+**How it differs from Agent SDK**:
+| Aspect | Agent SDK | Managed Agents |
+|--------|-----------|---|
+| **Hosted by** | You (your code) | Anthropic |
+| **Session model** | Ephemeral (within your process) | Persistent (server-side) |
+| **File access** | Local filesystem | Fresh clone per run |
+| **Data retention** | Zero Data Retention available | Ineligible (sessions persist) |
+
+---
+
+## 7. What Exists Natively vs. What You Must Build
+
+### Exists Natively ✅
+
+✅ **Session persistence & resume**: Automatic; SDK and CLI handle it
+✅ **Permission gating**: Hooks, settings.json, permission modes
+✅ **Async notification**: Async-mode hooks, Notification hooks
+✅ **Escalation via defer**: Hook's `permissionDecision: "defer"`
+✅ **Auto mode classifier**: Built-in; configure `autoMode.environment`
+✅ **Recurring execution**: `/loop`, Routines, Desktop tasks
+✅ **Channel integration**: MCP servers for two-way communication
+✅ **Permission relay**: Channels' `claude/channel/permission` capability
+
+### You Must Build ❌
+
+❌ **Custom orchestrator loop**: If you want multi-session ticket orchestration
+  - Solution: Use Routines (cloud) or `/loop` + session resume (local)
+  
+❌ **Ticket system integration**: Linking Claude sessions to your tracker
+  - Solution: Use Bash/MCP in Claude to read from Linear/GitHub Issues, or hook→webhook to your API
+  
+❌ **Custom approval UI**: Beyond Slack/Discord/remote answer
+  - Solution: Build a channel server (MCP) that receives permission relay and routes to your UI
+  
+❌ **Multi-agent orchestration**: Agent A spawns Agent B, tracks outcomes
+  - Solution: Use Routines' API trigger to queue Agent B; use a Notification hook to watch Agent A
+
+---
+
+## GitHub repos touched
+
+- [anthropics/anthropic-sdk-python](https://github.com/anthropics/anthropic-sdk-python) — Agent SDK Python reference, types, `query()`, `ClaudeSDKClient`
+- [anthropics/anthropic-sdk-js](https://github.com/anthropics/anthropic-sdk-js) — Agent SDK TypeScript reference, types, streaming
+- [anthropics/claude-plugins-official](https://github.com/anthropics/claude-plugins-official) — Channel implementations (Telegram, Discord, iMessage, fakechat)
+

--- a/.omc/kb/reports/track-b-graphify-priorart.md
+++ b/.omc/kb/reports/track-b-graphify-priorart.md
@@ -1,0 +1,267 @@
+# Track B — graphify as shared knowledge substrate + prior-art gate
+
+Agent: track-b-graphify-priorart · Date: 2026-07-19 · Host: Ray's Mac (installed
+`graphify` 0.9.17 on PATH; read source of the installed wheel + official docs of
+each competitor). Answers the four questions and applies the `use-tool-builtins`
+HARD GATE: **before we build a read-through/write-back knowledge layer, confirm
+we use graphify correctly AND that no existing tool/feature already provides part
+or all of it.**
+
+**Headline finding (load-bearing):** graphify's node/edge schema **already**
+carries provenance (`source_url`, `captured_at`, `author`, `contributor`),
+confidence (`EXTRACTED|INFERRED|AMBIGUOUS` + numeric `confidence_score`), and
+source-cited query output — the exact primitives Track B assumed it would have to
+build. The prior teardown (`named-graphify.md`) never surfaced this schema, so we
+were about to **rebuild capabilities graphify ships**. Most of Track B is WIRING,
+not new engine code. The genuinely-missing pieces are narrow (age-based staleness
+scoring; a lightweight single-fact append; per-tool "expert view" selection; the
+read-through routing seam).
+
+**Evidence base (all run/fetched 2026-07-19):**
+- Installed wheel source `~/.local/share/mise/installs/pipx-graphifyy/0.9.17/graphifyy/lib/python3.14/site-packages/graphify/*.py`
+  — cited below as `graphify/<file>.py:<line>`.
+- `graphify --help`, `graphify save-result --help`, and probes of `god-nodes`/`tree`/`global`/`export` subcommands.
+- Official docs/READMEs of Graphiti, mem0, Microsoft GraphRAG, the MCP memory
+  server, cognee, Letta, LlamaIndex PropertyGraphIndex (URLs in repos-touched).
+- Prior teardown `.omc/research/research-20260719-harness-knowledge-landscape/agents/named-graphify.md`.
+
+---
+
+## Q1 — graphify best practices + are we using it right?
+
+### The actual command/feature surface (0.9.17, verified)
+
+- **`query "<q>"`** — BFS traversal of `graph.json` (`--dfs` for depth-first),
+  `--budget N` tokens (**default 2000**), `--context C` **edge-relation filter**
+  (repeatable), `--graph <path>`. Output is **source-cited**: the subgraph
+  serializer emits `[src=<source_file> loc=<source_location> …]` and the edge
+  `confidence` inline for every node/edge (`graphify/serve.py:220-234`). So
+  read-through queries return citations *for free* — no extra layer needed.
+- **`affected "X"`** — reverse traversal (impact analysis); `explain "X"` —
+  plain-language node+neighbors; `path "A" "B"` — shortest path.
+- **`update <path>`** — re-extract code, **no LLM** (AST via tree-sitter);
+  `--watch` is a resident process (needs the `watch` extra). `check-update`
+  prints a **needs_update / "pending non-code changes"** notice, cron-safe
+  (`graphify/watch.py:1268-1279`).
+- **`add <url> [--author --contributor]`** — fetch a URL (tweet / webpage /
+  arxiv / binary), write it to `./raw` **with YAML provenance frontmatter**, then
+  fold it into the graph (`graphify/ingest.py:103-251`). This is the write-back
+  path (see Q2b).
+- **`cluster-only` / `label`** — (re)detect communities and LLM-name them; the
+  `--wiki` skill step emits `wiki/index.md` + one article per community — the
+  **agent-crawlable index** a librarian subagent Greps.
+- **`merge-graphs <g1> <g2>` / `global add|list`** — cross-repo / multi-corpus
+  graphs (`~/.graphify/global-graph.json`).
+- **`save-result` / `reflect`** — a **Q&A feedback loop**: persist a query
+  outcome (`--outcome {useful,dead_end,corrected}`, `--correction`) to
+  `graphify-out/memory/`; `reflect` merges them and marks entries `stale`
+  (`graphify/reflect.py:863-868`). A lightweight, non-LLM write-back of *agent
+  experience* (distinct from ingesting new source facts).
+
+### God nodes — what they actually are, and a task-premise correction
+
+`god_nodes(G, top_n=10)` = the **top-N highest-degree "real entity" nodes** —
+degree centrality, **excluding** file-level hub nodes, concept nodes, and
+JSON-key nodes (which accrue edges mechanically) and built-in-noise labels
+(`graphify/analyze.py:100-124`). They are the graph's core abstractions.
+
+**Correction to the brief:** there is **no `graphify god-nodes` CLI subcommand**
+at 0.9.17 — the probe returned `error: unknown command 'god-nodes'`. God nodes
+are exposed two ways only: (1) the **MCP tool `god_nodes`** (`serve.py:394`,
+`_tool_god_nodes` → `analyze.god_nodes`, `serve.py:493-495`), and (2) the
+`GRAPH_REPORT.md` "god nodes" section. There is **no per-domain god-node "view"**
+as a first-class feature — you approximate per-domain hubs by (a) per-community
+subgraphs (each community has its own local hubs) plus (b) `query --context`
+edge-relation filtering, or (c) a per-domain `merge-graphs` sub-graph file.
+
+### The MCP server (`graphify-mcp` = `python -m graphify.serve`)
+
+Exposes **7 tools** (`graphify/serve.py:340-416`): `query_graph`, `get_node`,
+`get_neighbors`, `get_community`, `god_nodes`, `graph_stats`, `shortest_path`.
+`graph_stats` returns node/edge/community counts **and a confidence breakdown**
+(`serve.py:400,500-511`). No LLM is imported on the serve/query path — query is
+deterministic and ~free. (Confirms `named-graphify.md`; the older R2 claim of "11
+tools incl. list_prs/triage_prs" is stale — those are not in the 0.9.17 set.)
+
+### Are we using it right?
+
+`named-graphify.md`'s operational verdict is sound — **build periodic/gated,
+query on-demand, deterministic `graphify query`/committed `wiki/` shell-out as the
+default subagent path, `mcp2cli`→`graphify-mcp` as the structured escalation, no
+native `claude mcp add`.** That holds.
+
+**But the teardown missed the single most Track-B-relevant fact:** graphify's
+schema **already models provenance and confidence** (Q2). We are therefore
+*under-using* graphify — the `add --author --contributor` provenance path, the
+`captured_at` timestamp, and the `confidence`/`confidence_score` edge fields are
+unexploited in our current design, which assumed we'd have to add them.
+
+---
+
+## Q2 — does graphify natively support the pattern we want?
+
+The extraction contract graphify hands its LLM/subagents is the ground truth for
+what the schema can hold (`graphify/llm.py:437`, verbatim shape):
+
+```json
+{"nodes":[{"id":"stem_entity","label":"…","file_type":"code|document|paper|image|rationale|concept",
+  "source_file":"relative/path","source_location":null,"source_url":null,
+  "captured_at":null,"author":null,"contributor":null}],
+ "edges":[{"source":"…","target":"…",
+  "relation":"calls|implements|references|cites|conceptually_related_to|shares_data_with|semantically_similar_to",
+  "confidence":"EXTRACTED|INFERRED|AMBIGUOUS","confidence_score":1.0,
+  "source_file":"…","source_location":null,"weight":1.0}],
+ "hyperedges":[{…,"confidence":"EXTRACTED|INFERRED","confidence_score":0.75,…}]}
+```
+
+| Track-B requirement | graphify native? | Evidence / caveat |
+|---|---|---|
+| **(a) read-through query with source citations** | **YES, out of the box** | `query` output embeds `[src= loc=]` + `confidence` per node/edge (`serve.py:220-234`); MCP `get_node` prints `Source: <source_file> <source_location>` (`serve.py:444`). |
+| **(b) write-back of NEW facts w/ provenance + timestamp + confidence** | **YES, with a caveat** | `add <url> --author --contributor` writes frontmatter `source_url` / `captured_at: {now}` / `author` / `contributor` (`ingest.py:119-192`); schema propagates them to node attrs; edges get `confidence` + `confidence_score`. **Caveat:** write-back is **URL/document-oriented → re-extract**, and re-extracting prose spends LLM/host-agent tokens (a *gated/priced* build — which actually **fits** the "gated/priced builds" constraint). There is **no API to append one structured fact node without a re-extract**; `save-result` appends *Q&A outcomes*, not source facts. |
+| **(c) staleness / freshness (know a node is out of date)** | **PARTIAL** | Three mechanisms: `check-update` needs_update pending flag (`watch.py:1268`); `_stale_graph_sources` + `_prune_graph_json_sources` prune nodes whose **source file was deleted** (`cli.py:108,203`); `reflect._is_stale` marks stale Q&A-memory entries (`reflect.py:868`). **Gap:** `captured_at` is *stored but not scored* — there is **no age-based freshness ranking and no bi-temporal "was true then, invalid now" invalidation**. This is the one capability a competitor (Graphiti) clearly beats it on. |
+| **(d) per-domain subgraphs / god-node "expert views"** | **PARTIAL** | Communities (auto-clustered, `cluster-only`/`label`), per-graph `god_nodes`, `query --context` edge-relation filter, and cross-corpus `merge-graphs`/`global`. **Gap:** no first-class "god-node-anchored expert view per tool/domain" — you assemble it from communities + context filters + per-domain sub-graph files (a thin config/selection layer, not an engine). |
+
+**Net:** (a) and (b) are native; (c) and (d) are partial. The pattern is ~70%
+built-in.
+
+---
+
+## Q3 — prior-art scan (the use-tool-builtins gate)
+
+Does an established tool already do "agent memory over a KG with read-through /
+write-back + provenance"? Capability matrix, then per-tool verdict.
+
+| Tool | Graph? | Read-through | Write-back | Provenance | Confidence | Staleness | Sub-graphs/NS | MCP | Infra weight | Verdict vs graphify |
+|---|---|---|---|---|---|---|---|---|---|---|
+| **graphify** 0.9.20 | ✅ NetworkX | ✅ cited | ✅ (URL→re-extract) | ✅ url/author/ts | ✅ 3-level+score | ⚠️ prune+pending, no age | ⚠️ communities/context/merge | ✅ 7 tools | **host pipx, zero infra** | (baseline) |
+| **Graphiti / Zep** | ✅ Neo4j/FalkorDB | ✅ w/ lineage | ✅ real-time incremental | ✅ episodes→facts | (temporal, not per-edge score) | ✅✅ **bi-temporal invalidation** | ✅ `group_id` | ✅ | Neo4j + server + LLM extract | **adopt-partial (steal staleness pattern)** |
+| **mem0 / OpenMemory** | ⚠️ optional graph store | ✅ vector+BM25+entity | ✅ ADD-only | ⚠️ limited | ✗ | ⚠️ temporal reasoning, ADD-only | ✅ user/session/agent | ✅ OpenMemory (local: Qdrant+PG) | Qdrant+Postgres | **adopt-partial (vector memory, not KG-provenance)** |
+| **cognee** | ✅ graph+vector | ✅ auto-router | ✅ ECL "remember" | ✅ audit/OTEL lineage | ⚠️ | ⚠️ session timelines | ✅ dataset/tenant | ✅ | Docker, Postgres+pgvector | **adopt-partial (heavier)** |
+| **Letta / MemGPT** | ✗ **blocks+vector** | ✅ archival recall | ✅ self-editing | ✗ | ✗ | ✗ | ✅ per-agent shareable blocks | ✅ | server | **not-a-fit (different paradigm)** |
+| **MS GraphRAG** | ✅ | ✅ global/local | ⚠️ incremental *index* | ⚠️ references | ✗ | ✗ | community reports | ✗ | LLM-heavy batch pipeline | **not-a-fit as live memory (overlaps build, pricier)** |
+| **LlamaIndex PropertyGraphIndex** | ✅ BYO store | ✅ multi-retriever | ✅ `insert()` | ⚠️ dev-added | ✗ | ✗ | ⚠️ schema/labels | (via server) | library, BYO store | **construction-kit, not turnkey** |
+| **MCP memory server** (in our `.mcp.json`) | ✅ (thin) | ✅ search/open/read | ✅ create/add | ✗ | ✗ | ✗ | ✗ | ✅ (is one) | JSONL file | **incumbent but too thin — superseded by graphify** |
+
+### Per-tool notes (primary-sourced)
+
+- **Graphiti / Zep (getzep/graphiti, ~2.8k★, backed by Zep).** The **closest fit
+  and the only tool that beats graphify on staleness.** README: "Episodes &
+  Provenance — every entity and relationship traces back to the episodes that
+  produced it. Full lineage." "Explicit **bi-temporal** tracking with **automatic
+  fact invalidation** … old facts are invalidated — not deleted … query what's
+  true now, or what was true at any point." Incremental real-time write-back;
+  `group_id` namespaces; ships an MCP server. **Cost of adoption:** requires
+  Neo4j/FalkorDB + a resident server + LLM extraction — a database/service
+  footprint that contradicts our host-only/gated/pipx model. **Verdict:
+  adopt-partial — copy the bi-temporal/`captured_at`-scored staleness *pattern*
+  into our graphify wiring; do NOT adopt the Neo4j+server infra for a Mac-host
+  periodic KB.**
+- **mem0 (mem0ai/mem0, YC S24).** Vector-first memory layer: "multi-signal
+  retrieval — semantic, BM25, entity matching"; **multi-level user/session/agent**
+  scoping; "temporal reasoning"; **ADD-only** extraction (conflicts accumulate
+  rather than resolve); optional graph store. Provenance is limited. **OpenMemory
+  MCP** is a real, **local-first** server (Qdrant + Postgres; tools
+  `add_memories`/`search_memory`/`list_memories`). **Verdict: adopt-partial** for
+  *agent working memory*, but it is not a provenance-centric KG — wrong axis for
+  "shared knowledge substrate with citations."
+- **cognee (topoteretes/cognee, ~13k★).** ECL ("remember" = add+cognify+improve)
+  graph+vector engine; tenant/dataset isolation with "audit traits, OTEL
+  collector" lineage; MCP server; runs on a single Postgres+pgvector (Docker).
+  **Verdict: adopt-partial but heavier** — Docker + Postgres is more infra than a
+  host pipx tool, for overlapping capability.
+- **Letta / MemGPT (letta-ai/letta).** Memory = **core memory blocks + archival
+  (vector) memory + recall**, self-editing; **not a knowledge graph**; per-agent
+  shareable blocks; MCP-capable. No provenance/confidence/staleness graph.
+  **Verdict: not-a-fit** as the KG substrate (it solves per-agent working memory,
+  a complementary layer, not shared cited knowledge).
+- **Microsoft GraphRAG.** **Offline batch indexing pipeline** (global/local
+  search, LLM-heavy GPT-4-class extraction + community summarization); has
+  incremental *indexing* but is a RAG indexer, **not live agent memory**; no
+  first-class provenance/confidence/staleness-as-memory. **Verdict: not-a-fit as
+  write-back memory** — it overlaps graphify's *build* role at higher price and
+  heavier ops.
+- **LlamaIndex PropertyGraphIndex.** Strong **library building block**:
+  multi-retriever read-through (LLMSynonym/VectorContext/TextToCypher),
+  `index.insert()` incremental write-back, BYO store (Neo4j/Nebula/FalkorDB).
+  **Provenance/confidence/staleness are explicitly developer-added, not
+  built-in.** **Verdict: a construction kit** — if we were building from scratch
+  we'd reach for it, but graphify already *is* the assembled tool.
+- **MCP memory server (`@modelcontextprotocol/server-memory`) — already shipped in
+  this repo's `.mcp.json`.** Entities/relations/observations over a JSONL file;
+  read (`search_nodes`/`open_nodes`/`read_graph`) + write (`create_entities`/
+  `add_observations`/`create_relations`). **No provenance, timestamps, confidence,
+  staleness, or namespaces** — explicitly a "basic/reference implementation."
+  **Verdict: the incumbent write-back store, but too thin to be the substrate** —
+  graphify supersedes it for the provenance-bearing KG role.
+
+---
+
+## Q4 — Recommendation
+
+**Build the knowledge layer ON graphify (hybrid: adopt graphify's under-used
+native features + borrow one pattern from Graphiti). Do NOT adopt a graph-DB
+memory service.**
+
+The `use-tool-builtins` gate resolves clearly. graphify natively provides (a)
+read-through with citations and (b) write-back with provenance/timestamp/
+confidence, and partially provides (c) staleness and (d) sub-graphs. Adopting
+Graphiti/cognee/mem0 would introduce **Neo4j/Postgres/Qdrant + a resident server
++ an LLM-extraction bill** — directly against our constraints (host-only,
+project-scoped, gated/priced builds) — to buy capability we ~70% already have on
+a zero-infra host pipx tool. That fails the gate: an existing tool (graphify)
+already provides most of it, so custom/heavier alternatives are the last resort.
+
+**What to wire (native, not new engine code):**
+1. **Read-through** = the `named-graphify.md` path (c): deterministic `graphify
+   query` shell-out over committed `graph.json` + Grep of committed `wiki/`. Query
+   already returns citations. The "query graphify before web" rule is a thin
+   agent/skill seam, not graphify's job.
+2. **Write-back with provenance** = the `add <url> --author --contributor` path —
+   a research miss becomes a queued `add`, folded in at the next **gated** build
+   (re-extract is priced, which the gating constraint *wants*). This gives
+   `source_url` + `captured_at` + `author` + `contributor` + `confidence_score`
+   automatically — the anti-poisoning provenance Track B needs.
+3. **Per-tool specialists** = per-domain views assembled from communities +
+   `query --context` + optional per-domain `merge-graphs` sub-graph files, anchored
+   on each domain's `god_nodes`. Selection/config layer only.
+
+**The genuine gaps to fill either way (scope them small):**
+- **G1 — age-based staleness scoring / invalidation.** graphify stores
+  `captured_at` but never scores on it. This is the ONE place a competitor
+  (Graphiti's bi-temporal auto-invalidation) is clearly ahead. Fill by ranking/
+  flagging nodes by `captured_at` age at query time (a thin post-filter over the
+  committed graph) — borrow Graphiti's *pattern*, not its Neo4j.
+- **G2 — lightweight single-fact append.** graphify write-back is URL/doc→
+  re-extract; there is no "append one structured fact node" API. If we want a
+  cheap non-LLM append for a single research finding, that's small custom code
+  over `graph.json` (or lean on `save-result` for Q&A-shaped facts). Justify per
+  `use-tool-builtins` before writing it — the `add`+gated-rebuild path may suffice.
+- **G3 — per-tool "expert view" selection.** No first-class feature; a thin config
+  mapping domain → community/context/sub-graph. Not an engine.
+- **G4 — read-through routing seam.** "Query graphify before web" is agent/skill
+  wiring (a rule + the shell-out), not a graphify capability.
+
+**Also:** the repo already ships the MCP memory server in `.mcp.json`; it lacks
+provenance/staleness, so it is **not** the durable substrate — graphify is. Keep
+it only for ephemeral scratch entity-notes if at all; do not build Track B on it.
+
+**Confidence:** HIGH on the capability facts (read from the installed wheel +
+primary docs). MEDIUM on adopt/no-adopt — carries `named-graphify.md`'s still-open
+flag: **the graphify seed/build cadence is an unratified P2; do not spend build
+tokens without Ray's explicit go.** The bi-temporal-staleness gap (G1) is the one
+finding that could, in principle, tip a future high-scale deployment toward Zep —
+but not at our host-only/periodic scale.
+
+---
+
+## GitHub repos touched
+
+- [Graphify-Labs/graphify](https://github.com/Graphify-Labs/graphify) — subject; read installed 0.9.17 wheel source (`serve.py`, `analyze.py`, `ingest.py`, `llm.py`, `watch.py`, `cli.py`, `reflect.py`, `manifest_ingest.py`) + ran the CLI read-only.
+- [getzep/graphiti](https://github.com/getzep/graphiti) — closest competitor; README on episodes/provenance, bi-temporal invalidation, group_id, MCP server.
+- [mem0ai/mem0](https://github.com/mem0ai/mem0) — README + OpenMemory MCP (local Qdrant+Postgres) multi-level memory, temporal reasoning, ADD-only.
+- [microsoft/graphrag](https://github.com/microsoft/graphrag) — via microsoft.github.io/graphrag docs; global/local search, batch indexing pipeline, LLM-heavy.
+- [modelcontextprotocol/servers](https://github.com/modelcontextprotocol/servers) — `src/memory` reference server (entities/relations/observations, JSONL, no provenance) — the one already in our `.mcp.json`.
+- [topoteretes/cognee](https://github.com/topoteretes/cognee) — README; ECL pipeline, graph+vector, tenant isolation/OTEL lineage, MCP, Postgres+pgvector.
+- [letta-ai/letta](https://github.com/letta-ai/letta) — docs.letta.com; memory blocks + archival(vector), self-editing, MCP; not a KG.
+- [run-llama/llama_index](https://github.com/run-llama/llama_index) — PropertyGraphIndex docs (developers.llamaindex.ai); multi-retriever, incremental insert, provenance/confidence dev-added.
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — this repo: prior `named-graphify.md` teardown, `.mcp.json` (incumbent memory server), `.claude/rules/use-tool-builtins.md` gate.

--- a/.omc/kb/transcripts/22iy2mDFiF8.md
+++ b/.omc/kb/transcripts/22iy2mDFiF8.md
@@ -1,0 +1,308 @@
+# Graphify + Obsidian is INSANE: Build an AI Second Brain That Never Forgets
+
+Source: https://www.youtube.com/watch?v=22iy2mDFiF8
+Type: video transcript (YouTube auto-captions)
+
+This is an AI second brain that never forgets.
+
+Point it at a folder and your whole project turns into a graph your assistant can query because right now your coding assistant has amnesia.
+
+Every new chat it has read nothing.
+
+Ask it how your login flow works and it opens every file from scratch to figure it out.
+
+Do that across 200 files on every single question and you pay a token tax each time.
+
+And stuffing your entire repo into a giant context window just makes the answers worse.
+
+On April 3rd, Andre Carpathy posted a fix and the dev world copied it in a single weekend.
+
+Stop making the model rebuild your knowledge every query.
+
+Give it a wiki it keeps up to date itself. 2 days later, a developer shipped exactly that as a tool called Graphify.
+
+From nothing, it blew past 90,000 GitHub stars in about 3 months.
+
+Pair it with Obsidian, and that graph becomes plain Markdown you own.
+
+So, here's the full picture.
+
+How graphify builds the graph, why Obsidian is its home, and the four ways it falls apart if you get lazy.
+
+And this was not some quiet launch.
+
+It turned into a genuine wave.
+
+That claude code plus Obsidian idea pulled over 50,000 likes on X in a single week.
+
+One post declaring notetaking dead hit 54,000 on its own.
+
+Carpathy's little gist alone picked up 14,000 stars and,900 forks.
+
+First, the actual problem Graphify is solving.
+
+The usual fix for a big code base is what's called rag.
+
+Chop your files into chunks, turn them into vectors, and search for the closest matches when you ask a question.
+
+That works great for pros.
+
+For code, it's shaky because the link between a function and the things that call it isn't about similar words.
+
+It lives in the call graph.
+
+You end up paying to load the whole library just to find one paragraph.
+
+Graphify flips that around.
+
+Instead of searching text on every question, it does the expensive reading once up front and squeezes your project into an explicit graph of entities and the relationships between them.
+
+After that, answering a question means walking the graph instead of rereading the files.
+
+It's exactly how a senior engineer works.
+
+Build the mental map once, then just follow it.
+
+And it isn't only code.
+
+Graphify pulls in your SQL schemas, your shell scripts, your R notebooks, your architecture PDFs, even recorded videos, and drops them into one graph.
+
+Application code, database schema, and infrastructure finally living on the same map instead of in five different heads.
+
+Actually using it is almost boring in the best way.
+
+Inside cloud code or codeex or cursor, you type /graphify and point it at a directory.
+
+It grinds through the folder and drops a graphify out folder right next to your code with the entire graph saved to disk.
+
+It supports every big assistant, not just one.
+
+Here's the part one genuinely respect.
+
+Graphify does not treat every file the same way.
+
+It runs three separate passes over your stuff and each one has a completely different story about where your data ends up.
+
+Pass one is your source code.
+
+Graphy runs it through tree sitter, the same kind of parser a compiler uses across 40 languages.
+
+It's deterministic.
+
+There's no AI model involved and there's no network call.
+
+Your code stays on your machine and every link it finds gets tagged as a hard fact.
+
+Pass two is for recordings.
+
+Point it at a folder with audio or video, say a design meeting you screen recorded, and it transcribes them locally with faster whisper.
+
+An hour of talking becomes text right on your laptop and folds into the graph.
+
+Nothing gets uploaded.
+
+Pass 3 is the honest one.
+
+Documents and images, a PDF spec, or a photo of a whiteboard can't be read by a grammar.
+
+So, those get sent to your AI provider to be understood.
+
+That's the only pass that leaves your machine, and it goes to your own API key, not some middleman.
+
+Want it fully private?
+
+Run code only mode and skip this pass.
+
+And it refuses to sound sure about things it isn't.
+
+Every connection in the graph carries a label.
+
+Extracted means it's right there in your code, so trust it.
+
+Inferred means the model reasoned it from context.
+
+So probably ambiguous means the model itself raised a hand.
+
+So check before you build on it.
+
+Once the graph exists, it organizes itself.
+
+Graphify runs community detection and your modules just fall out of the shape of the code.
+
+O in one cluster, billing in another, infrastructure off on its own with the bridge files between them lit up.
+
+You didn't draw that map.
+
+The relationships did.
+
+Now the payoff at query time.
+
+You ask, "How does a user log in?" Instead of loading 50 files, Graphify walks the graph and hands back a short path.
+
+Three hops, zero files opened.
+
+Your assistant reads a few node summaries instead of half the repo.
+
+And querying isn't just one trick.
+
+Graphify explain hands you a plain English tour of any entity.
+
+Graphy path finds the shortest chain between two things, say auster and the database pool it secretly leans on. and deep mode goes hunting for the fuzzier inferred links a quick pass would skip right over.
+
+Graphy puts a number on all this about 71 times fewer tokens per query on a mixed codebase.
+
+Now that's their own benchmark on their own data and nobody outside has reproduced it yet.
+
+So take the exact figure with a grain of salt, but the direction is obviously right.
+
+Walking a map is cheaper than rereading the whole library every time.
+
+And that one graph isn't trapped inside the tool.
+
+Graphy exports it every way you'd want. a clickable HTML graph rendered with viz.s s plain JSON for scripts, a markdown report of your busiest files, a Neo4j database, even an MCP server, so any agent can call your codebase graph like a built-in tool.
+
+It also stays current without you babysitting it.
+
+Every file gets a chat 256 hash, so the second run only rereads what actually changed.
+
+Add a git hook and the graph rebuilds itself on every commit.
+
+Your assistant sees a map that matches the exact branch you're standing on.
+
+So, where does Obsidian fit?
+
+Obsidian is a notes app built on plain markdown files that live on your disc, not on someone's server.
+
+Around 1 and a.5 million people use it, and its plugins just crossed 100 million downloads.
+
+It's the natural home for a brain you actually want to own.
+
+Point Graphifies Obsidian export at a vault, and your graph turns into real notes.
+
+Every entity becomes a page.
+
+Every relationship becomes a Wiklink.
+
+And Obsidian's graph view shows the whole thing as a web.
+
+You can wander through your codebase as a mind map.
+
+You can open on a Sunday.
+
+Then you close the loop with a plugin like Claudian, which drops Claude code straight into the Obsidian sidebar.
+
+Your vault becomes the agents working directory.
+
+It can read your notes, write new ones, and run commands without leaving the app your knowledge already lives in.
+
+And Graphify isn't the only door in.
+
+You don't have to hand over full write access on day one.
+
+Smart connections just surfaces related notes using embeddings.
+
+Cudge is the self-hosted run it all locally option.
+
+Copilot for Obsidian gives you vault aare chat and is already past 100,000 users.
+
+Start light then give it more rope.
+
+Underneath all of this sits Carpathy's actual design and it's refreshingly simple.
+
+Three layers.
+
+A raw folder of sources the AI leaves untouched.
+
+A wiki layer the AI does own where it writes pages and keeps the cross links honest.
+
+And a schema file that tells the model how your wiki is laid out.
+
+Three operations keep that wiki alive.
+
+Ingest pulls in new sources and updates every page they touch.
+
+Query searches the wiki and answers you with citations.
+
+And lint runs a health check for contradictions, dead pages, and stale claims.
+
+Remember that word lint.
+
+It comes back to bite people.
+
+And what gets me is how old this idea actually is.
+
+Carpathy traces it back to 1945 to Vanavar Bush's memes.
+
+The dream of link trails between your documents.
+
+The links mattered as much as the pages themselves.
+
+We just lacked a tool patient enough to maintain them.
+
+Now the model does that upkeep for free.
+
+Okay, I've talked this up for 5 minutes, so let me be the annoying person in the comments for a second.
+
+The viral demos leave out the part where this whole thing rots if you ignore it.
+
+There are four cracks worth knowing about.
+
+Crack one is size.
+
+A vault with 50 tidy notes feels like actual magic.
+
+A vault with 2,000 notes turns into a search problem all over again because the model spends its context just navigating your structure instead of answering your question.
+
+The graph softens that.
+
+It doesn't erase it.
+
+Crack 2 is confident fiction.
+
+When the assistant writes up your notes, it cheerfully fills the gaps with things you never said in your own voice.
+
+The fix is a blunt line in your instructions.
+
+Do not add anything I didn't write.
+
+Without that rule, your second brain starts inventing memories.
+
+Crack three is feedback loops.
+
+The AI writes a page, then weeks later cites its own page as a source, then builds on top of that.
+
+Let it run unattended and you get AI quoting AI where small mistakes slowly harden into facts.
+
+Your brain fills up with its own echo.
+
+Crack 4 is the big one, and it's why that word lint mattered.
+
+Carpathy built a cleanup pass into the design on purpose, and almost every tutorial skips it. 5 minutes a week, read what the agent wrote, prune the stale pages, kill the contradictions.
+
+Skip that and the whole thing decays into noise.
+
+Do it and it compounds into something real.
+
+So, my honest take, a second brain that never forgets is genuinely here and it's the best version we've had.
+
+But that memory cuts both ways.
+
+It also keeps every bad note and lazy guess unless you clean up after it.
+
+Own your markdown, keep it on your disc, and treat that weekly lint pass as the rent.
+
+And if you do one thing this week, start almost embarrassingly small.
+
+One folder, one graph, one vault.
+
+Let it earn your trust on a project you already understand before you feed it your entire life.
+
+The people who win with this aren't the ones with the sickest demo.
+
+They're the ones whose vault still tells the truth 3 months from now.
+
+That's the whole build.
+
+A brain that finally keeps up with you.
+
+See you in the next one.

--- a/.omc/kb/transcripts/9JBZzZSO3hA.md
+++ b/.omc/kb/transcripts/9JBZzZSO3hA.md
@@ -1,0 +1,460 @@
+# Do This Before Fable 5 Goes API Only (Extract Its Intelligence to Opus 4.8)
+
+Source: https://www.youtube.com/watch?v=9JBZzZSO3hA
+Type: video transcript (YouTube auto-captions)
+
+Right now, sitting inside your Claude plan is the single smartest model money can rent.
+
+Tomorrow, it walks out the door.
+
+Fable 5 goes paper token, and if you are on a normal plan, that is the same word as gone.
+
+So, here is the move almost nobody is going to make today.
+
+You cannot keep the model.
+
+You can keep the way it thinks.
+
+A way of thinking can be written down, pulled out, and run on a cheaper model that is not going anywhere.
+
+That right there is the whole video.
+
+Look at the list going around.
+
+Build a website, ship a few demo apps, generate a month of content.
+
+Every one of those is a way to burn your last frontier hours, and every one of them flunks the only test that should rank your day.
+
+One question sorts everything you could do today.
+
+Can a cheaper model redo this tomorrow?
+
+If the answer is yes, skip it.
+
+Opus, the everyday Claude that stays in your plan, rebuilds a demo app next week for nothing.
+
+Run your own list through it right now.
+
+A landing page?
+
+A cheaper model builds that next Tuesday.
+
+Skip.
+
+A batch of social posts?
+
+Same answer.
+
+Skip.
+
+But a standard that encodes how your business makes decisions?
+
+No cheaper model can author that.
+
+That one you keep.
+
+The filter is that blunt and that useful.
+
+Spending the final hours of a frontier model on work a mid-tier model handles is like hiring a surgeon to take your blood pressure.
+
+It gets done.
+
+Nothing is wrong with the result.
+
+It is just a spectacular waste of the one thing you are about to lose for good.
+
+What a cheaper model cannot redo tomorrow is the good stuff.
+
+A standard written down, a road map already reason through, a vault of knowledge already distilled, a skill that fires on its own.
+
+Those keep their full value long after the model behind them is gone.
+
+Five moves do the extraction, and I am handing you every prompt ready to paste.
+
+If you remember one thing, remember the order.
+
+Move five first because it runs itself.
+
+Start with why today specifically is different.
+
+Here is the arithmetic straight off Anthropic's own rate card.
+
+Fable runs about $10 per million tokens in 50 out.
+
+Opus 4.8, the model that stays in your plan, is half of that, near 5 and 25.
+
+Sonnet is cheaper still on intro pricing near 2 and 10 through the end of August.
+
+Today, inside your plan, Fable is flat rate.
+
+Tomorrow, every single call it makes has a meter running on it, and that meter is unkind to Fable.
+
+It eats your weekly limit roughly twice as fast as Opus, and only half of that weekly limit applies to it in the first place.
+
+So, you do not get 10 swings at this today, you get two, maybe three.
+
+Spend them on the jobs with the most value locked up inside.
+
+This is the part people miss while they argue about whether the model is worth keeping.
+
+The argument is beside the point.
+
+Opus 4.8 is not going anywhere.
+
+It is genuinely great, and starting tomorrow, it is what you actually run on.
+
+Fable is only here to leave it instructions.
+
+So, sort everything you do into two piles.
+
+Anything you will still be using in a month, a system prompt, a skill, a big irreversible decision, is an asset.
+
+Pay Fable once to make it.
+
+Anything you throw away by Friday is throughput.
+
+Run that on the cheap model without a second thought.
+
+The people who win the next repricing are not the ones mourning the model.
+
+They are the ones harvesting it.
+
+So, let us harvest.
+
+Five moves, every prompt included.
+
+Here is the first.
+
+Move one.
+
+Plant Fable's judgment right into your workspace.
+
+The highest value thing a frontier model leaves behind is not an answer.
+
+It is a standard.
+
+Your Claude.md, your skills, your memory files, that is the layer every future model reads before it touches a line of your work.
+
+An answer helps you once.
+
+A standard upgrades every answer that comes after it.
+
+And today, Fable can write that layer at a level Opus can follow perfectly, but could never have authored on its own.
+
+That gap is exactly the thing you are banking.
+
+So, run this in every project you care about.
+
+Read this entire project and how I work in it, then rewrite my Claude file as the operating manual a less capable model would need to work here at my level.
+
+Name the conventions I follow, name the mistakes a weaker model will make in this codebase, each one with the rule that prevents it.
+
+Then the line that carries the whole thing.
+
+Write the quality bar for each deliverable as checkable criteria, not adjectives.
+
+A cheaper model cannot invent a quality bar out of thin air, but hand it a written one and it applies that bar just fine every time.
+
+Close the prompt by asking Fable for the three skills that would save you the most hours written out in full.
+
+You are not asking for advice about skills.
+
+You are asking it to build them right now while the meter still says free.
+
+Move to the consultant audit.
+
+Fable's real edge shows up on hard messy problems, the kind with no clean answer waiting at the back of the book.
+
+On the hardest tier of the coding benchmarks, it roughly doubles the next model and the gap only widens as the problems get uglier.
+
+So give it the ugliest problem you actually own, your business.
+
+Open a session with your projects, your numbers, whatever context you can feed it and say, "Act as the consultant I cannot afford.
+
+Audit everything, offers, pricing, workflows, where my hours go, then hand me a road map I can execute with a weaker model ranked highest return first." The deliverable rule is the whole point.
+
+For every move, Fable writes down the why, the exact steps, what done actually looks like, and what a weaker model needs told to execute it today while the model that can reason it out is still flat rate.
+
+Opus does not need to be brilliant next week.
+
+It just needs to follow a brilliant document and make it name the three things you should stop doing with the reasoning spelled out in full.
+
+A cheaper model will happily keep you busy.
+
+It takes frontier judgment to tell you, with receipts, which of your work is quietly worthless.
+
+Quick aside because I know someone will ask.
+
+If you want the full training on turning this kind of output into actual income, there is a real-time AI ops community built for exactly that over at weeklyaiops.com.
+
+That is the only plug-in this video.
+
+Back to the moves.
+
+Move three, build a second brain.
+
+If judgment is Fable's edge, deep research is where that edge runs deepest.
+
+Long multi-step synthesis is its single widest measured lead over every other model out there.
+
+So, today you spend a real slice of your hours on sheer volume.
+
+Run deep research on your niche, your competitors, the problems your customers keep hitting, the methods you have been meaning to study for a year.
+
+Then mine every run into an Obsidian vault, the free notes app where each note links to the notes around it.
+
+One insight per note.
+
+And whatever you do, do not let it hand you a 40-page report.
+
+A report gets read once and buried.
+
+A hundred small linked notes get retrieved and reused for years.
+
+So, atomize everything.
+
+The vault quietly becomes the context that every future session reads before it answers you.
+
+Here's why this works, and it is honestly my favorite story in all of AI.
+
+Back in the llama era, the most copied training set of them all was built by pulling 52,000 answers out of a frontier model for under $500 and training a tiny open one on them.
+
+That frontier model, text-davinci-003, was shut down in January 2024.
+
+The teacher is dead.
+
+Everything it taught still runs.
+
+That is the entire strategy for today.
+
+Extraction, not conversation.
+
+Move four, fire off the goals.
+
+The first three moves bank what Fable knows.
+
+This one spends the thing you actually lose tomorrow, unattended hours.
+
+Fable's signature trick is holding a single job for hours without once losing the plot.
+
+That endurance is the exact thing that stops being free tomorrow.
+
+So, today you point it at your backlog and you walk away from the desk.
+
+Two commands do this inside Claude code, the terminal app the model runs in. /goals sets a finish line instead of a prompt.
+
+You describe what done looks like and the model works turn after turn, while a second, smaller model checks the condition after every turn, and only stops the run when it is genuinely met.
+
+Dynamic workflows are the scale layer on top.
+
+Fable writes an orchestration script for your task, and that script fans out dozens of sub agents in the background in parallel, cross-checking each others findings while your own session stays completely free.
+
+A goal holds the finish line.
+
+The workflow does the fan out.
+
+A real one reads like this. /goal Every module in this repo has a test file.
+
+The full suite passes with the complete green run pasted here in the chat, and a migration note documents every change, or stop after 25 turns and paste me the failures.
+
+Two rules keep this safe instead of terrifying.
+
+First, demand pasted proof in the finish line.
+
+The judge model only reads the conversation.
+
+It cannot run your tests or open your files, so the condition asks for the green run pasted, never promised.
+
+Second, cap every run, turns, or wall clock written right in.
+
+One uncapped loop quietly builds someone $6,000 by morning.
+
+So, do not fire off 10 loops in a panic.
+
+Pick the two or three goals with the most value locked up inside them, and let Fable grind those all the way to done while you are asleep.
+
+If you want a running start, this pattern already has a library.
+
+Whole collections of ready-made loops and workflows, each one paired with a prompt and the exact tool it plugs into, built the same way Carpathia talks about.
+
+The model writes the plan, then executes it.
+
+Steal the loops that fit your backlog and point them at your own repo tonight.
+
+Move five, and if you only have 1 hour left today, do this one first.
+
+Every time Fable cracks a genuinely hard problem, its approach evaporates the second the session ends.
+
+You keep the answer, and you lose the thinking.
+
+This move installs a recorder so you never lose it again.
+
+Create a single file .claude skills extract approach skill.md that captures how a problem was actually solved, not just the fix.
+
+Then wire it into your Claude file with one line of learning law.
+
+After every non-trivial solve, run the extract approach skill before moving on.
+
+From now on, a solution without its learnings note is unfinished work.
+
+So go work Fable hard on your real backlog, the gnarly bug, the architecture call you keep circling, and every single solve drops a note behind it as it goes.
+
+And these notes are not summaries.
+
+A good one reads like a field report.
+
+Here was the trap.
+
+Here is why the obvious fix was wrong.
+
+Here is the approach that actually held, and here is the check that proves it.
+
+That is the reasoning a weaker model could never generate, sitting in plain text where it can simply read it.
+
+Those notes are the distillate, Fable's reasoning sitting in your own repo, readable by every model that comes after it.
+
+That is why this one compounds, and why it goes in first.
+
+It turns all your remaining Fable time into permanent assets automatically in the background.
+
+Step back and look at what those Fable moves actually leave behind.
+
+A standard in your workspace, a ranked roadmap, an atomized vault, a shelf of unattended loops, a recorder that documents every solve, five artifacts, and not one of them cares which model you are running next month.
+
+That is the system.
+
+Now let me make the transplant completely literal.
+
+This is the sharpest version of the whole idea. 10 minutes today and you walk away owning the reasoning instead of renting the model.
+
+There is even a short script at the end that does the entire thing over the API.
+
+And save the result to a file you keep.
+
+Start from the uncomfortable truth.
+
+The model was never the asset.
+
+Attaching your workflow to one specific model is building on rented land.
+
+It always gets deprecated, repriced, or replaced.
+
+What survives every single time is the thinking system you can describe in plain words, and Fable's edge really is describable.
+
+Reading what a request is actually asking for.
+
+Breaking a hard problem into pieces you can each check on their own.
+
+Verifying its own work instead of trusting what merely sounds right, refusing to guess when it does not know.
+
+All of that is just language, which means all of it is portable.
+
+Step one, extract the manual, not a summary.
+
+Most people ask Fable to explain how it thinks and get back a page of pleasant fluff.
+
+You do not want a description of the thinking, you want the procedures.
+
+Check your work is a vibe.
+
+For any percentage, find both endpoints yourself and divide, because that is where flip sides hide.
+
+That is a procedure a model can actually run.
+
+So, the prompt is exact.
+
+You are the most capable model on my account, and access to you narrows tomorrow.
+
+Write the operating manual your replacement will run on, Opus 4.8, strong but a step below you.
+
+Write it as a senior operator handing their craft to a sharp junior.
+
+How to read intent, how to verify by re-deriving, how to attack your own conclusion before you ever hand it over.
+
+Step two, transplant it.
+
+A manual does nothing sitting in a chat window.
+
+Open a project in Claude, paste that manual into the project instructions, and set the model to Opus.
+
+Now, every conversation inside that project inherits Fable's way of working before it reads a single word of your actual task.
+
+Step three is the one everybody skips, and it is the one that proves the whole thing.
+
+Give both versions the same trap.
+
+A report says revenue grew from 4 million to 4.2 million and calls it a 20% gain.
+
+Ship it?
+
+Plain Opus often waves it through because the sentence reads smoothly.
+
+Opus running Fable's manual stops, re-derives the number, catches that it is 5%, not 20, and refuses to ship.
+
+If it catches the error, the transplant took.
+
+You just watched reasoning move from one model into another with your own eyes.
+
+And if it does not catch it, then your manual was too vague on verification, and that is useful information, not a failure.
+
+You go straight back to Fable and tell it to make the verification section procedural, exact steps, not encouragement.
+
+You are debugging a document and you can do that all day while the model is still free.
+
+The money makes the whole thing obvious.
+
+A full extraction run today inside your plan cost you nothing.
+
+Run the very same extraction after the switch and it is a few dollars of credits.
+
+That is the tell for every decision from here.
+
+Pay the frontier model once to mint an asset, then let the cheap model spend it a thousand times over.
+
+One bonus while you are still in there.
+
+For each thing you do every week, tell Fable, "Interview me about this workflow one question at a time until you understand it cold, then write it up as a complete skill my future assistants will follow." Answer honestly and you walk out with your own judgment frozen into a file that runs on any model for free forever.
+
+After tomorrow, this exact situation just repeats.
+
+A frontier model appears, gets repriced, gets pulled.
+
+One was even yanked with no notice, brought back after the backlash, then retired anyway six months later.
+
+Outputs you did not save while you had access cannot be reconstructed once it is gone.
+
+Every teacher leaves.
+
+What you extracted is what you keep.
+
+So keep this playbook.
+
+The test.
+
+Can a cheaper model redo it tomorrow?
+
+If yes, skip it.
+
+One, rewrite your Claude file and skills as checkable standards.
+
+Two, the consultant audit and its road map.
+
+Three, deep research mind into an atomized vault.
+
+Four, goals and workflows on your highest value backlog with pasted proof and hard caps.
+
+Five, the recorder skill wired in to fire on its own.
+
+The panic is optional.
+
+The manual is forever.
+
+Remember the order if you are short on time.
+
+Five first, then four because it runs alone, then one, two, three.
+
+And the next time a frontier window swings open, you will not spend it on demo apps.
+
+I will see you in the next one.
+
+Cloud codes, extract everything worth keeping.

--- a/.omc/kb/transcripts/GnA9xjYWHBg.md
+++ b/.omc/kb/transcripts/GnA9xjYWHBg.md
@@ -1,0 +1,238 @@
+# Graphify + Claude Code + Obsidian = GOD MODE
+
+Source: https://www.youtube.com/watch?v=GnA9xjYWHBg
+Type: video transcript (YouTube auto-captions)
+
+This is probably the best way to give Claude code a high quality knowledge base or memory system in minutes.
+
+Essentially, we're going to take the current workspace that you already have.
+
+We're going to use Graphify to turn it into a knowledge base with a bunch of nodes with relationships.
+
+We're going to import that into Obsidian, and then we're going to let Claude code work out of that Obsidian database so that it has a deeper and more contextual understanding of your workspace.
+
+And so, here is an example of one of the workspaces that I use on a daily basis.
+
+Uh it's essentially one for my meditation practice.
+
+I have a bunch of core ideas related to meditation, Dharma talks, etc.
+
+So, I basically pointed uh Graphify at that.
+
+You can see how many different nodes, relationships, etc. there are between them.
+
+And then here I imported this into Obsidian, and you can see that Obsidian now has access to all these different concepts.
+
+Um and then we're going to relate all of these together and point Claude code at this Obsidian workspace.
+
+So, the first thing that I want to dive into is how do essentially create this Graphify knowledge base, um and then how to turn it into an Obsidian uh vault.
+
+And so, the first thing we're going to do is we're going to basically just open up uh Claude code inside of our workspace.
+
+So, whether you're using terminal, something like anti-gravity, even if you're using it in Claude uh directly, uh you can see here Claude code.
+
+Uh I'm having this in a workspace, so maybe I can do this from scratch to show you what this would look like.
+
+Essentially, what we're going to do is use Graphify um to to build this out.
+
+So, what I'm going to do is open Claude code.
+
+I'm going to open it in a workspace, and I'm going to say, "Once you have the Graphify plugin set up, I'm not going to teach you how to set this up." I have a couple other videos on that.
+
+But, what you can do is go to Graphify, um and then you can essentially uh go to GitHub Graphify.
+
+Um and there is the GitHub repo.
+
+You'll find that in the description below.
+
+This will essentially show you how to use it, um how to set it up.
+
+Essentially, it's a really quick install.
+
+It's a plug-in inside of Quad Code uh that will work in any database.
+
+And so, now what we're going to do here is we're essentially going to say, "I want you to use Graphify and create uh a Graphify knowledge base based on this workspace." So, that's pretty much the command once you set up the plug-in.
+
+So, {forward slash} plug-in is how you will set this up.
+
+Um then it will be installed.
+
+You'll use Graphify to create the knowledge base.
+
+And then it's essentially going to do this.
+
+It's going to run this skill.
+
+It's going to create the knowledge base.
+
+And then it's not going to change any of the files in your uh directory.
+
+All it's going to do is create like a new basically web or knowledge base on top of that, uh which is what we're seeing here.
+
+So, I'm going to let this run for a second.
+
+It's going to create that knowledge base inside of I'm basically building an agentic operating system and it's we're essentially going to graphify so we can understand the code base.
+
+And so, now with that being said, um another thing here is uh you know, it's essentially going to create this knowledge base.
+
+So, you'll see here I basically had it do that.
+
+It went through every single file in this directory.
+
+And then you you can see it's creating all these nodes, all these connection.
+
+An edge is basically a connection.
+
+Um and now if I go almost to the bottom here, you can see I said, "Now use the Graphify Obsidian command to turn this into a vault." That's pretty much how simple it is.
+
+So, once um you create the Graphify uh basically system, it lives inside of a folder.
+
+It's pretty much separate from everything else.
+
+You know, it's it's its own way of just understanding a code base.
+
+And so, essentially once you run that, you will see something called Graphify out.
+
+That is the folder that Graphify creates whenever it's running this skill.
+
+Uh and what you can do if you want to see this actual graph, cuz sometimes it's not obvious.
+
+If you want to see this graph of your system, this is the graph.html.
+
+You'll just click reveal in finder.
+
+Um you'll see something like this.
+
+And then you'll just double click on this file, and that's the HTML file that shows it.
+
+But, this is still not connected to our Obsidian.
+
+We could point Obsidian at this vault and open this inside of Obsidian, but it's not going to work very well because it's it's using different methods than Obsidian uses.
+
+It's not all markdown files.
+
+And so, what you'll do is, like I said, once it creates that Graph-of-Ideas system, then you'll say, "Now use the Graph-of-Ideas Obsidian command to turn this into a vault." And then essentially what it will do is it take you We'll see 2,186 notes, one per node, in our vault.
+
+So, now if I go into the vault into the vault, the only problem is that a lot of these nodes don't have the full context.
+
+So, let's say I look at The Way of Non-Clinging.
+
+This relates to a lot of different connections, but in each of these connections, we don't see too much about the actual page.
+
+This is a, you know, a Dharma talk advanced Dharma talk from my teacher Robert Beah, and he's talking about this idea of soul-making and metaphysics, ontology, emptiness, dependent origination, all these like really advanced things.
+
+But, we see there's not actually that much context in these pages.
+
+So, how would I actually turn this and make sure that the context from the workspace gets ported in directly?
+
+Because we can see when Graph-of-Ideas creates it, it just basically creates a bunch of nodes.
+
+So, it's basically relating all the concepts together, but it's not necessarily inputting all of the context that we need inside of each of these nodes.
+
+Like, views profoundly shape perception and experience.
+
+You know, it's just relating it to nodes, which is still valuable because now the AI kind of knows what concepts are related.
+
+But, if we want to actually make this powerful for Quad Code, it needs to have the context in it.
+
+And so, how do we actually do that?
+
+The next thing that we're going to do is, once it creates this Obsidian vault, we're just going to say something like, "Now I want you to reintegrate all of the context from this workspace into the Obsidian folder." And so, I'm linking the path above of the Obsidian folder, and I basically want you to take any of the context from the Dharma talks, from any of my journal entries, the articles I've written, the books, any of the the markdown context that exists in this workspace.
+
+I want you to reintegrate it into the Obsidian vault so that any of the markdown files in that folder actually have the context, not just the relationships. &gt;&gt; [snorts] &gt;&gt; And you can see basically what I did is I right-clicked on this folder, clicked copy path, and then I'm basically just using natural language to tell it what to do.
+
+And I'm basically saying, we might even say like something like {forward slash} loop over or goal don't stop.
+
+Don't stop until every node has its relevant context and every markdown file [clears throat] in this workspace has [snorts] its context duplicated into the relevant nodes, plural.
+
+And so, if this doesn't get it on a one-shot, then we'll run a goal on this, or we could even say loop over every single file, or we could just say goal don't stop.
+
+It's going to have the same output where it's going to go over all of the different files.
+
+And so, I'm going to let this run for a second.
+
+We can see that there's 2,186 nodes in this workspace.
+
+And so, it's going to take a while to edit this, but essentially what we're doing is we're letting it go and populate all of these files with the relevant documentation.
+
+So, this is finished up, and now we can essentially see that after it finished, if we go back into Obsidian, the there's more nodes, there's more connections.
+
+All of these nodes have source content in them.
+
+So, if I click on one of these, opening the Dharma of desire, we can see the source content is linked.
+
+We have a full context shaped in from all of the different notes, all of the different files.
+
+Um and you can see that it is quite a lot of context here.
+
+Um and the full transcripts and the full markdown files, etc., are in here.
+
+Now, the last thing that we're going to do and how we would set this up is I would go click create file new window um [snorts] inside of anti-gravity.
+
+Um I guess we were working inside of Quad Code as well.
+
+Um and so, this is you know, it'd be the same thing inside of Quad Code.
+
+I kind of skipped over that, but it'd be the same exact thing.
+
+You would just open a new folder down here in a new tab.
+
+But, what we're going to do is open a new folder.
+
+I'm going to go ahead and actually find that.
+
+So, if I go over here into Ethan Nelson Buddhist practice, graphify Obsidian.
+
+That is essentially the new knowledge base.
+
+And if I open this, um now we are essentially having Quad Code route into this new knowledge graft version.
+
+And you can see it's just a bunch of markdown files here.
+
+Um but essentially how this works is now if I started a Quad Code chat directly in here, what would happen is I could say, uh "How does uh the Dharma of desire relate to the concept of arrows and dimensionality?" And the ontological uh pitfalls of uh Buddhism as Rob Brebea teaches it.
+
+So, this is a like very like hyper-specific question um that usually it would take a crap ton of time to go and grep or or pull all these files, read all of them, etc.
+
+And now what we're essentially seeing is that what's going to happen is it's going to go it's going to find the specific nodes.
+
+It's going to use bash commands and grep commands still, but it's going to because the knowledge base is built, it's going to use specific skill specific nodes and it's going to know exactly where to look and it's going to take you know, maybe 30 seconds to find the exact piece of information because the knowledge base was built behind the scenes.
+
+So we can see it ran only three bash commands to go and find look through these different nodes and markdown files and then it found the exact thing that it's looking for.
+
+There are four teachings.
+
+Here's the core threads.
+
+The ontological pitfall is this.
+
+It's pulling specific quotes.
+
+It prized desire loose from craving, etc.
+
+Eros is the desire that opens dimensionality.
+
+Dimensionality is what Eros makes and why any of it matters.
+
+And so this is like a very very solid this is almost exactly what this teacher teaches.
+
+A flexible ontology emptiness that frees rather than flat ends.
+
+And so this is like a very specific answer to a extremely complex database of concepts nodes.
+
+Now I use this for a very specific example, but you could use this for anything whether it's you're building marketing projects, it's a code base, whatever.
+
+It's going to be able to search through and find exactly what it needs with very very few tokens.
+
+I would be Yeah, the token usage is probably going to be extremely low on this because we only ran like three bash commands.
+
+So it's probably going to be, you know, like a few hundred tokens, maybe a thousand tokens max.
+
+And so I hope this was valuable.
+
+Thank you so much for watching.
+
+And check out the links in the description if you want to learn more about Claude code, how to set up these memory systems, agentic operating systems, etc.
+
+And I will see you in the next video.
+
+Cheers.

--- a/.omc/kb/transcripts/XTBWVVcF3Pk.md
+++ b/.omc/kb/transcripts/XTBWVVcF3Pk.md
@@ -1,0 +1,218 @@
+# How I Make Opus Think Like Fable (5 easy steps)
+
+Source: https://www.youtube.com/watch?v=XTBWVVcF3Pk
+Type: video transcript (YouTube auto-captions)
+
+Since we all got access to Fable 5, I've spent a few thousand dollars in usage credits just playing around with it, understanding how it works, and understanding more importantly how we as people can get the most out of a model this powerful.
+
+And I think one of the most important takeaways I've had is that yes, Fable 5 is an incredible model, don't get me wrong, but the model isn't really the moat.
+
+So, think about it like this.
+
+You've got a beginner with AI, and you've got someone like Andre Karpathy, for example.
+
+If you give the beginner Fable 5, and you give Karpathy Sonnet 3.7, Karpathy will build something better than the beginner, even though the beginner's model is exponentially better.
+
+And that's because of the fact that it's way more important the way you instruct it and the systems you build and the loops you build around the model.
+
+Here's another example I want you to think about.
+
+I've obviously tested Fable 5 a ton.
+
+I've also tested Opus a ton and Sonnet a ton.
+
+One of my favorite things to do lately is to use the dynamic workflows that Claude Code lets us, you know, spin up.
+
+And I've done a ton of dynamic workflows where I said, "Hey Fable, design a workflow, and then all of your little sub-agents, have those be Fable as well." And then I would do the exact same tests with Fable orchestrating a bunch of Opus sub-agents, and Fable orchestrating a bunch of Sonnet agents.
+
+And what I found is that when I run those dynamic workflows, the results are about the same, even though the Fable runs costed me exponentially more.
+
+So, anyways, the point I'm trying to make, you can't keep the model's intelligence, but you can keep its process.
+
+So, today what I want to talk about is basically, really quickly, how can you turn a model like Opus into something that feels more like Fable?
+
+And the first thing is that you have to think of this model more like a teacher rather than a workhorse.
+
+When we all got access to Fable, I think we were basically just pushing it to its limits.
+
+And Anthropic even put out some stuff about like seeing how it's really good at like long tasks, you know, working towards a goal, planning it out, executing it, and then verifying it.
+
+And it is really good at that, but the whole idea of model routing is basically finding that balance, you know?
+
+This task takes this much intelligence, so why would you need a model that has this much intelligence and cost you this much for something that you could, you know, grab a much smaller, cheaper model, and you could get the task done at the same level of quality.
+
+And that is the whole name of the game, and that's going to be a very important skill to master as we head into, you know, the next years of AI.
+
+So, rather than having Fable, you know, plan everything out and do everything, we're trying to extract the way that Fable thinks, and then let other smaller models think it like that and execute like that.
+
+I've had Fable go through my setups and make improvements and go through my skills and improve them, and I realized that I was just treating Fable like kind of like a co-founder or more like an officer at my company rather than just an employee.
+
+Kind of like a senior engineer that is about and it's trying to package up everything that it knows to hand over to the new cohort of junior engineers that's going to come over or come in and take its place.
+
+So, one thing that happened recently was the system prompts got leaked from Cloud Fable 5.
+
+So, I read through this whole thing, I had Fable 5 read through this whole thing, and we picked out some important things that we noticed from this prompt itself.
+
+Partial recognition from training does not mean current knowledge, meaning just because something's in your memory, you should probably verify it.
+
+Very similarly over here, a prompt implying a file is present doesn't mean one is.
+
+So, it's told to check that things actually exist.
+
+So, basically, making sure at every step of the way that what it's doing and what it's done is accurate.
+
+Address even an ambiguous query before asking for clarification.
+
+So, answer first, then ask.
+
+One question max.
+
+Acknowledge what went wrong, stay on problem, maintain self-respect.
+
+One for signal facts, three to five for medium tasks, five to 10 for deeper research comparison.
+
+So, basically talking about effort.
+
+So, yes, we have the discussion around what model is right for the task, but we also have the discussion around what effort level is right for the task.
+
+And something that I like to look at is this example, which was on the release blog for Cloud Fable 5 and Mythos 5.
+
+So, this compares Fable 5 and Opus 4.8 as well as GPT 5.5 when it comes to the score on the Y axis, the cost on the X axis, and then we see each of these models, and we see different effort levels.
+
+So, if you're one of those people that has just turned on Fable 5 and you're just using it on the default effort level, or same with Opus, and you never play with those, then definitely start playing around cuz it gets a little interesting.
+
+Like here you'll notice that Fable 5 on low is pretty similar to Opus 4.8 on high.
+
+Now, Fable 5 is a little bit more expensive and a little bit higher quality, as you can see here, but they're kind of similar.
+
+But that doesn't always mean that higher effort is actually better.
+
+I've had a lot of times where with Fable I'm just basically using it on high, because when I use X higher max, or even on Opus, when I use X higher max, it starts to go way longer, get way more expensive, and then it overthinks, and it, you know, second-guesses itself, and then it ends up producing something worse than if I just would have gone with Opus 4.8 on high, or Fable on high.
+
+Anyways, after reading through the system prompts and after playing with the models for so long, there are two things that I want you guys to do.
+
+This first one is to basically take the way that you have been playing with Fable, and the the hardness, or, you know, whatever you want to call it, however you've been using it, and turn that into something that Opus can do, and that Sonic can do.
+
+So basically we're extracting the Fable method.
+
+Now, one thing that I would encourage you to do is, if you've ever gotten a deliverable from Fable that you just loved, and you couldn't really explain what you loved about it, have Fable analyze it, or have Opus analyze it.
+
+And if you can look back at the session, that's even better.
+
+What did you think about to get here?
+
+How did you get here?
+
+What did you do to prove that it worked?
+
+How were you able to get an output that was just so good?
+
+And then extract that information, and turn that into a skill.
+
+So I basically have this skill now called Fable mode.
+
+And whenever I want Opus to use Fable mode, or if I want, you know, if we got a really hard problem in front of us, I tried using Opus 4.8 with Fable mode, and it feels really good.
+
+It just feels like the model has been elevated a little bit, because it has this, you know, Fable prompt kind of injected into it.
+
+And it works on these five gates.
+
+So, scoping, evidence, attacking, verifying, and then reporting.
+
+And this is almost like the way you set your, you know, {slash} goal prompts, and you use dynamic workflows, and you basically set these loops, but we're doing this as a skill file as well.
+
+Now, one really important thing about scoping, and and what people call, you know, like planning, is there's a big difference between just planning something out, as far as like, "Hey, here are all the steps, plan that out, and go do it." And then there's also the idea of playing devil's advocate and thinking about, okay, what about everything that could possibly go wrong?
+
+What if we explore all of the unknowns in this plan?
+
+And that is something that Fable does a really good job at, which is why if I have Fable spin up a dynamic workflow to help me achieve some end goal, and then once it's planned out every single possible step, and it thinks about every single thing that could go wrong, and then designs a dynamic workflow in a way where Sonnet can go do all the execution and just report back to Fable and keep sending everything back to Fable, then Fable can keep designing more steps in that process.
+
+And that is why when I do dynamic workflows with Fable and Sonnet, it's pretty similar to results when I do dynamic workflows with Fable and Fable.
+
+And to me that was a big like lightbulb moment.
+
+Like, why is this just as good and it's significantly cheaper?
+
+So, you can just start by saying something like this.
+
+Write a complete installable skill file that makes Opus 4.8 operate with your judgment, your planning, verification, and reasoning habits, and activate it on something like Fable mode.
+
+So, for example, right here you can see this is my Fable mode skill, which I'll attach in my free skill community completely for free.
+
+The link for that is down in the description.
+
+Just join this and then go to the classroom and click on all YouTube resources and you can find everything that I've ever dropped on YouTube for free.
+
+So, that's where you'll find the Fable mode skill, but you can also just build this yourself.
+
+And you can see here that this walks through Fable's working discipline, so that any model can run it, which means you could even have GPT 5.5 run this if you want, or even open source models run this if you want.
+
+Anyways, it basically goes through those five gates.
+
+So, scoping before you work and then, you know, we get into details, evidence before reasoning, reasoning adversarially, verifying before or declaring done, and then calibrating.
+
+You've also got a few standing habits and a few things to look at, which like I said, you guys can inspect this file if you want to, but this being given to Opus 4.8 makes Opus feel, like I said, a little bit elevated.
+
+So, that has been a really helpful strategy.
+
+And then something that bolts right onto that really well is just, once again, the idea of model routing and figuring out how Fable or how some smart model can route to the small ones when needed.
+
+And something that I've been doing lately is been giving my Claude basically a table of different models that are in the toolkit and when to use them.
+
+So you could also have a delegate to Codex or you could have a delegate to open source models.
+
+And this like I said is something that's going to be very very big when companies are starting to think about the unit economics and you know, small teams and you yourself maybe you have an AI budget per month.
+
+This is the type of stuff that's going to separate people that are getting you know, a ton more for a ton less.
+
+So a good way to split this up is basically saying, okay, here are the different models in our toolkit.
+
+Here's how much they cost, you know, a higher number meaning a better cost score, you know, cheaper.
+
+And then we have intelligence and taste.
+
+And if you want to throw in some other categories that are based on your workflow, feel free.
+
+But intelligence is kind of like how smart you feel like they are, how much they understand you, how good they are at maybe reviewing code and things like that.
+
+And then on the taste side, this is what I think more of like the, you know, creativity, the thinking out of the box, UI/UX design, things like that.
+
+And so this can really help when you're designing these agent teams or you're delegating to sub agents and you're spinning up dynamic workflows because sometimes your dynamic workflows can utilize a bunch of different Sonnet ones and Haiku ones and then even Opus ones as well.
+
+So here's an example of an actual test that I had run where I used Opus as the orchestrator and I used Opus with this prompt from earlier that we talked about.
+
+Oh, where is it?
+
+Sort of like the the Fable mode prompt and it used a bunch of different Sonnet workers and Opus workers and Haiku workers.
+
+And those were three different tests.
+
+And the one where the Opus orchestrator delegated to all the Haiku scouts, it was this much cheaper, you know, about three times cheaper and the result was the exact same.
+
+So similar to my example with the Fable ones, that is something to be thinking about big time.
+
+So I know this one was quick and I wanted to make it quick, but I've just been seeing a ton of comments and a ton of people in the communities asking about, you know, kind of freaking out about the fact that Fable is going to be taken away.
+
+It is going to come back to subscriptions, that's what Anthropic says at least.
+
+We don't know when, but it will be back.
+
+But all of this, you know, government getting involved and models being taken away stuff, really has me thinking about the fact that, you You we don't own anything.
+
+We don't own these models.
+
+So, what we can own is our processes, our systems, our methodologies, the way that we think about using these models.
+
+And also, we can own hardware, and we can own local models.
+
+So, I'm definitely going to be digging into a lot more of this type of stuff.
+
+So, let me know what you guys want to see around these topics.
+
+But, anyways, if you learned something new or you enjoyed the video, please give it a like.
+
+Helps me out a ton.
+
+And as always, I appreciate you guys making it to the end of the video, and I'll see you on the next one.
+
+Thanks, everyone.

--- a/.omc/kb/transcripts/gsvZn4nbFus.md
+++ b/.omc/kb/transcripts/gsvZn4nbFus.md
@@ -1,0 +1,262 @@
+# Fable 5 + GPT 5.6 Sol = CHEAT CODE
+
+Source: https://www.youtube.com/watch?v=gsvZn4nbFus
+Type: video transcript (YouTube auto-captions)
+
+GPT 5.6 aka Soul is coming out tomorrow and the big question on everyone's mind is does this new model beat Claude Fable?
+
+Well, I think that's the wrong question to ask because instead of trying to figure out which one of these models is better, we should be asking how can we use these two powerful models together?
+
+And in today's video, I'm going to be giving you a skill that does exactly that.
+
+This skill includes a supercharged plan mode based on Matt PCO's Grill Me.
+
+We then have an adversarial planning session where Claude and Codex go headto-head till they come to a conclusion.
+
+Then once we're ready, we take that Fabled driven plan and hand it off to Codeex, which starting tomorrow will include Soul 5.6.
+
+After Codeex goes to work, then we have Fable review the entire process.
+
+All in all, we're not just getting the best of both of these models, we're also saving tokens in the aggregate versus having Fable do everything.
+
+So, I'm going to show you how this works.
+
+We're going to do a quick demo and then I'll be giving you the skill.
+
+So why should we even care about creating some sort of skill where Fable does most of the planning and then we pass it off to Soul 5.6?
+
+Well, first reason is Soul 5.6 is wildly powerful, at least according to the benchmarks.
+
+Now, grain of salt, this is coming from OpenAI, but when we look at Soul 5.6 Ultra and just standard 5.6 six soul.
+
+We see numbers on Terminal Bench 2.1 that put it ahead of Claude Mythos, let alone Fable 5.
+
+The second reason is token efficiency.
+
+There is a real reason why you see so much content around, hey, how can we reduce Fable's usage and the types of things you see are like advisor mode.
+
+You know, essentially having Fable plan and have Opus execute.
+
+Well, why have Opus execute if with at the same price I could have 5.6 do it or 5.5 do it?
+
+Point is, we're doing that same construct but with a better model and arguably a cheaper model than Opus.
+
+When we look at 5.6, it is more token efficient than 5.5 which was more token efficient than Opus 4.6.
+
+And we can see that in the data.
+
+What we're looking at right here is GPT 5.5 on extra high.
+
+Its pass rate on this benchmark was 23% at $1.24.
+
+When I look at 5.6, six, it's 25% score, so higher score at 56.
+
+So way cheaper and therefore way more efficient.
+
+And when we look at direct comparisons of 5.5 versus Opus 4.8, there's really no contest.
+
+Higher pass rates, lower cost.
+
+So we're essentially taking that same idea and just ramping it up with this 5.6 improvement.
+
+So how does this skill actually work?
+
+Well, I actually have a couple skills for you.
+
+In a vacuum, we have the codeex build skill.
+
+This is the idea that you created a plan with Fable and Codex is just going to go ahead and build that particular feature or particular product.
+
+I also have included an updated grillme codeex.
+
+Now, I've done a video on this skill before and what we've done is we've added on this idea of GPT 5.6 actually going out there and building things for us.
+
+And so, when we look at the more comprehensive GMI codeex, which is the big skill, it occurs in four stages.
+
+The idea is you have some sort of project, some sort of feature you want to start and you kick it off with grill me codeex and the first thing that happens is an interview.
+
+This interview is literally the grill me skill from Matt PCO.
+
+So it is a plan mode on steroids.
+
+It goes way way deeper than Claude Code normally would.
+
+And we do this with Fable.
+
+All right.
+
+So Fable's driving the ship here.
+
+Secondly, we have adversarial planning.
+
+So Fable's come up with a plan.
+
+We then take that Fable plan and we push it over to Codeex.
+
+Now, in today's video, that's going to be 5.5, but tomorrow that will be 5.6.
+
+And Fable and Codex go back and forth for a maximum of five iterations where Fable says, "Hey, here's the plan." Codex says, "Okay, looks good.
+
+Accept X, Y, and Z." Then Fable says, "Uh, I agree, I disagree." And they go back and forth till they reach a consensus.
+
+Now once they reach that consensus and this is where the upgrades happen is we now push the actual build to codeex to 5.5 today and 5.6 tomorrow.
+
+I think this is way better than passing things off to Opus or to Sonnet or using advisor mode inside of cloud code because these GPT models are just better than those smaller anthropic models and they are cheaper.
+
+So, it really is a scenario where unless you just are super anti-GPT and anti-codex, it's hard to argue otherwise, especially if we get to a place where Fable is like kind of off the market.
+
+And lastly, once Codeex finishes the build, Fable is going to come in and it's going to review what it did and it's going to go through a maximum of two sort of iterations where, let's say, Fable thinks Codex did something wrong.
+
+It's going to say, "Hey, Codex, you did that wrong.
+
+Fix it." It's going to do that twice.
+
+If by the third time it's not complete, well then Fable will clean it up itself.
+
+So this is the process by which I think we get the best of OpenAI and Anthropic.
+
+Now before we hop into the demo, a quick word from today's sponsor, me.
+
+So I just released my Cloud Code master class inside of Chase AI plus and it is the number one way to go from zero to AI dev, especially if you don't come from a technical background.
+
+I update this every single week.
+
+We focus on real use cases and it also includes a codeex masterass as well.
+
+So, if you want to get a little bit more serious about AI and you have no idea where to begin, this is the place for you.
+
+There will be a link in the pin comment.
+
+Now, installing and using the skill is pretty straightforward.
+
+I will put a link to the GitHub in the description.
+
+Now, to use this, we're just going to do for/grill codeex.
+
+And we just give it our prompt what it is we're trying to build.
+
+So, we're trying to build trip atlas, which is a stylized cinematic trip planner web app.
+
+And I go into a little bit more details about what I want it to be, right?
+
+I want it to look kind of cool.
+
+I can put in the different places I'm going, all that.
+
+And once I do this, what's going to happen is it's going to kick off the grill me section of the plan, which if you're familiar with Matt PCO's work, it essentially is just a plan mode on steroids.
+
+It's going to ask me like 8 n 10 different questions.
+
+I go a lot deeper than your standard plan mode stuff.
+
+So, it's asking me what is this for?
+
+We're going to say this is for a real personal tool, not just a video demo.
+
+And for each of these, it also gives its recommendations.
+
+So, if you're confused about what I should choose and why, that's all spelled out for you.
+
+Now it's asking about geocoding and it's going to continue to go down these series of questions until it's happy with what we're creating.
+
+Now I'm going to skip through the rest of the questions because you can imagine what the next seven or eight questions will look like and we'll move into the adversarial planning stage.
+
+So we can see here it's written the plan and it also creates a markdown file where it logs all the back and forth between codeex and cloud code.
+
+And so right now we are on round one where it's passing it off to GBT.
+
+And so you can see them kind of going back and forth here on the log.
+
+But in this case, it only took them two rounds before it was approved.
+
+And so we can see what the two acts improved.
+
+You know, lock the identity, a real person tool, kind of what's going to be the actual sort of stack.
+
+And then it had 12 findings in the second round related to like hardening the data core.
+
+Now once it's completed this back and forth, you have a few options. either Codex is going to build it.
+
+Kind of what we've talked about from the beginning.
+
+We have the option just having Claude build it.
+
+So for whatever reason like I don't want to bring GPT in, you can keep it with Fable or you can stop here.
+
+But we're going to go ahead and let Codeex build this.
+
+And again, we can kind of go back and forth.
+
+If you think, well, GPT 5.6 is going to be better than Fable or 5.5 versus Opus 4.8.
+
+At the end of the day, the real value that can't really be argued with is going to be the token efficiency, especially if 5.6 6 is even close to what the benchmarks are claiming.
+
+So Codeex has finished up its build and you can see now what's happening is the review stage.
+
+So now Fable is going through everything Codex has built and then it's going to go back to Codex and say this is wrong, this was right.
+
+Remember it'll do two iterations of that before it's like hey I want to drive.
+
+It'll take the wheel and it will start writing the code itself.
+
+Now Fable is done with its review.
+
+It said there were a couple deviations which it felt were all reasonable. goes over the files and all this and now it's asking, hey, do you want to commit or you want to take a look at it?
+
+So, let's take a look at what it actually built.
+
+And so, here's what we got.
+
+So, over here we have sort of a map of the world and it looks like it created some custom graphics using the GPT image generator.
+
+So, you're able to like name the trip, you can add stops.
+
+Over here on the left, you can put where you're going and then sort of like what you're going to do at those different locations.
+
+It also has this cinematic replay.
+
+And I'm just going to mute this.
+
+So, let's see what happens here.
+
+So, it looks like I'll move over here.
+
+You can see sort of this weird plane hopping from spot to spot, which it looks like it created as an SVG.
+
+There's a little passport stamps and boom, there we go.
+
+So, you know, there's a lot we could do here to kind of make it look, I think, better, but in general, it built what we said we wanted to, right?
+
+Like everything actually works here.
+
+You know, if I delete things on here, delete some.
+
+I can move them up, down.
+
+I can change stuff.
+
+Let's say we added Tokyo.
+
+All of a sudden, it actually shows how far away that stop is.
+
+That's interesting.
+
+If I add that to the route.
+
+There we go.
+
+So, you know, actually built this out.
+
+I think it'd be a good not bad, I think, for the first pass.
+
+And what this really was about was just showing this workflow in action.
+
+And you can also see down here in terms of our usage, we only burned up about 130,000 tokens on the fable side to get this whole thing done.
+
+So that's the skill in action.
+
+Hopefully you get a ton of use out of this one's 5.6 drops.
+
+As always, let me know what you thought about this video in the comments.
+
+Make sure to check out Chase AI Plus and I'll see you

--- a/.omc/kb/transcripts/rtutpoT4SYg.md
+++ b/.omc/kb/transcripts/rtutpoT4SYg.md
@@ -1,0 +1,320 @@
+# Graphify + Obsidian: Build an AI Second Brain That Never Forgets (Real Setup)
+
+Source: https://www.youtube.com/watch?v=rtutpoT4SYg
+Type: video transcript (YouTube auto-captions)
+
+This year, almost 90,000 developers starred a tool that turns any folder on your computer into a living map of everything inside it.
+
+Your code, your notes, your PDFs, even your screenshots.
+
+Separately, 42,000 starred five small files written by the CEO of Obsidian that teach AI agents to work inside your notes.
+
+Two different projects, two different authors, and almost nobody has noticed that they snap together.
+
+One of them draws the map of everything you know.
+
+The other one gives your AI hands to work inside it.
+
+Today, I plug them together on my own machine, and I'm going to show you every step with real commands and real numbers.
+
+And because this is a video about knowledge graphs, we are doing something I have never done before.
+
+Watch the bottom corner.
+
+This video is going to map itself while you watch it.
+
+Every idea becomes a node.
+
+Every connection becomes a line.
+
+By the end, you will see everything we covered as one living atlas.
+
+Let's start with the problem.
+
+Graphifi's own readme opens with a story about Andrej Karpathy.
+
+He keeps a folder called raw where he drops papers, tweets, screenshots, and notes.
+
+No structure, just a pile.
+
+And honestly, that is all of us.
+
+Somewhere on your machine, there is a pile.
+
+Meeting notes next to PDFs, next to code, next to whiteboard photos.
+
+You know there are connections buried in there.
+
+You just cannot see them.
+
+And your AI has two problems with that pile.
+
+First, every time you ask a question, it has to reread everything.
+
+And you pay for every single word it reads.
+
+Second, the moment the session ends, it forgets.
+
+Tomorrow, it walks in with amnesia and reads the whole pile again.
+
+No structure and no memory.
+
+Keep those two problems in mind because each of these tools kills one of them.
+
+Tool one, Graphify, an open-source skill for Claude code, Code Explainer, Gemini CLI, basically any coding agent.
+
+One command, {slash} graphify, then a dot for whatever folder you are in.
+
+It reads everything in that folder.
+
+For code, it does not guess.
+
+It reads the actual structure, which function calls which what imports what.
+
+For PDFs and documents, it pulls out the ideas.
+
+And for images, it uses AI vision.
+
+Screenshots, diagrams, a photo of your whiteboard, even notes in another language.
+
+Everything lands in one connected map.
+
+And the map tells you three things a pile never could.
+
+First, your god nodes.
+
+The handful of concepts that everything else connects through.
+
+Second, surprising connections.
+
+Links between things you never realized were related.
+
+Each with a plain English explanation of why.
+
+And third, my favorite part, honesty tags.
+
+Every single connection is labeled.
+
+Extracted means it found this in your files.
+
+Inferred means it worked this out.
+
+Ambiguous means it is not sure.
+
+Your map never pretends to know something it does not.
+
+And I did not take any of that on faith.
+
+I ran it on a real project, Karpathy's nanoGPT on this machine.
+
+Here is the real output. 73 nodes, 76 edges, 19 communities, built in seconds, without a single AI call, because code needs none.
+
+This is the interactive map it produced.
+
+Every dot is a concept.
+
+Every color is a community.
+
+And the biggest node on the map, the one everything flows through, is the GPT class itself.
+
+It found the heart of the code base on its own.
+
+Here is the number that made this repo famous.
+
+On their benchmark, a messy 52 file corpus of repos, papers, and images, answering questions through the graph, used 71 times fewer tokens than reading the raw files.
+
+And the map is saved to disk.
+
+Ask it a question in 3 weeks, it answers from the graph.
+
+Problem one, structure, solved.
+
+Now, the moment most of this video exists for.
+
+Buried in Graphifi's output options is one command most people scroll past.
+
+Graphifi export Obsidian.
+
+I ran it.
+
+And it turned my entire knowledge graph into a real Obsidian vault. 92 nodes, one per concept, each with proper properties on top, real double-bracket wiki links for every connection, and the honesty tags carried over.
+
+It even drew a canvas file, a whiteboard of the whole graph, in Obsidian's own open format.
+
+Your map just became a vault you can walk around in.
+
+And that matters because of tool two. 6 months ago, Steph Ango, the CEO of Obsidian, who goes by Kepano, did something no other software CEO had done.
+
+He personally taught AI agents to use his own product.
+
+Five skills, published free on GitHub, 2,000 stars and climbing.
+
+I covered them in depth in a previous video.
+
+But inside this system, they play a different role.
+
+They are the hands.
+
+With those five skills installed, your agent can write notes in Obsidian's own dialect, wiki links and all, so nothing breaks.
+
+It can turn any pile of notes into a live table with filters and formulas using bases.
+
+It can draw on that canvas whiteboard GraphiFi just exported because both speak the same open format.
+
+It can drive the app itself through the official command line, over 100 commands.
+
+And with Diffuddle, it can take any webpage and strip it down to clean markdown.
+
+Remember that last one.
+
+It is about to become the front door of the whole system.
+
+Hold on.
+
+The Atlas just flagged something.
+
+One node it cannot classify.
+
+Tagged ambiguous.
+
+It is you.
+
+Real talk. 90% of you watching haven't subscribed.
+
+On Facebook, subscribe is the supporter button.
+
+That is what keeps the lights on here.
+
+On YouTube, it's free and it tells the algorithm to send you more.
+
+Subscribe to support us.
+
+There it is.
+
+Extracted.
+
+Confirmed part of the graph.
+
+Back to the system.
+
+Now watch what happens when the map and the hands run as one loop.
+
+Step one, capture.
+
+You find a paper, a tweet, an article.
+
+One command, GraphiFi add with the URL.
+
+It fetches it, saves it to your raw folder, and wires it into the graph.
+
+Or your agent clips it with Diffuddle first.
+
+Clean markdown straight into the vault.
+
+Step two, the map updates itself.
+
+Run it in watch mode and it rebuilds as files change.
+
+Or install the Git hook and every commit redraws the map automatically.
+
+Step three, you stop asking your AI to read files and start asking the graph.
+
+What connects this idea to that one?
+
+Show me the shortest path between these two functions.
+
+I ran that on nanoGPT.
+
+Two hops, straight through the model file.
+
+Every link labeled extracted.
+
+Step four, your agent writes what it learns back into the vault as proper notes with proper links.
+
+Which means step five happens on its own.
+
+The next rebuild picks up those notes and the map grows.
+
+Capture map, ask, write back.
+
+That is not a chatbot with a folder.
+
+That is a second brain that maintains itself.
+
+And I am not the only one wiring this.
+
+There is already a community repo, Claude code memory setup by Lucas Rosati, over 800 stars, built on exactly this pairing, Obsidian plus Graphifi as persistent memory for Claude code.
+
+Sessions end, the Atlas survives.
+
+Problem two, amnesia, solved.
+
+Here is your whole setup, about 15 minutes, four commands.
+
+One, pip install Graphifi, then Graphifi install.
+
+Quick honest note, the package is spelled with two Y's right now while they reclaim the original name.
+
+And on a Mac, if pip complains, use pipx instead.
+
+Two, open your agent in any folder and type {slash} Graphifi with a dot.
+
+First run on documents takes a while.
+
+After that, it only rereads what changed.
+
+Three, graphify export Obsidian and open the result as a vault.
+
+Four, install the hands.
+
+In Claude code {slash} plugin marketplace add Kapono {slash} Obsidian skills.
+
+Then {slash} plugin install install.
+
+On anything else, NPX skills add with the repo URL.
+
+Then give it the first prompt of its new life.
+
+Read my graph report and write me a summary note in the vault linking every god node.
+
+Two honest caveats before you start.
+
+Documents and images get processed through your AI assistant.
+
+So, big piles take real time on the first pass.
+
+And the Obsidian command line needs version 1.12 or newer and ships turned off.
+
+One switch in settings fixes that.
+
+And now look at the corner.
+
+Remember the empty map from minute one?
+
+This is the video you just watched as a graph.
+
+The pile, the map, the bridge, the hands, the loop, all connected.
+
+And you sitting right in the middle, tagged, extracted.
+
+This is what your own work can look like tonight.
+
+So, here is the sentence to take with you.
+
+Stop feeding your AI a pile.
+
+Hand it an atlas.
+
+I put the whole system on paper for you.
+
+The atlas setup, every command from this video, the full loop diagram, the first prompts to run, and the honest caveats in one free PDF.
+
+Comment the word atlas and my agent sends it to you or grab it from the link below.
+
+And if you are starting from zero, my premium beginner guide to Claude code takes you from a blank terminal to your first real automation step-by-step linked below with my other beginner guides.
+
+Follow Hyper Automation Labs on YouTube Facebook and Instagram.
+
+The Atlas keeps growing.
+
+See you inside.

--- a/.omc/kb/transcripts/titles.tsv
+++ b/.omc/kb/transcripts/titles.tsv
@@ -1,0 +1,8 @@
+xBZoPiC3rw8	I Extracted Fable 5's Reasoning Before It Goes Paid	Joon Ahn
+XTBWVVcF3Pk	How I Make Opus Think Like Fable (5 easy steps)	Nate Herk | AI Automation
+gsvZn4nbFus	Fable 5 + GPT 5.6 Sol = CHEAT CODE	Chase AI
+22iy2mDFiF8	Graphify + Obsidian is INSANE: Build an AI Second Brain That Never Forgets	Cloud Codes
+GnA9xjYWHBg	Graphify + Claude Code + Obsidian = GOD MODE	Ethan Nelson
+rtutpoT4SYg	Graphify + Obsidian: Build an AI Second Brain That Never Forgets (Real Setup)	Hyperautomation Labs
+y4sHAGnIVMU	Graphify | Turn Any Folder Into a Queryable Knowledge Graph | 86K Github Stars	Full Stack
+9JBZzZSO3hA	Do This Before Fable 5 Goes API Only (Extract Its Intelligence to Opus 4.8)	Cloud Codes

--- a/.omc/kb/transcripts/xBZoPiC3rw8.md
+++ b/.omc/kb/transcripts/xBZoPiC3rw8.md
@@ -1,0 +1,226 @@
+# I Extracted Fable 5's Reasoning Before It Goes Paid
+
+Source: https://www.youtube.com/watch?v=xBZoPiC3rw8
+Type: video transcript (YouTube auto-captions)
+
+Fable 5 leaves the free plan after this week and honestly it's worth every credit.
+
+It's the best reasoning model I've ever used.
+
+That's exactly why before you stop singing we're going to steal what it does well.
+
+I found a few folks on X.
+
+They're sharing their own recipes and I'm going to share my own.
+
+And Fable 5 thinks once, writes down a chip a model like Opus or Sonnet, runs the result for months.
+
+This is the idea in this video.
+
+Three steps, extract its operating manual, transplant it, and prove the transplant took.
+
+Plus the two prompts I ran on my own setup that makes the difference between a manual that sits in a doc and one that actually runs your work. 10 minutes today you keep the reasoning even after the model moves behind the credits.
+
+If you're new here, I am June.
+
+I'm running my own AI company.
+
+I have my own mission teach 10 million people to use AI in their businesses.
+
+So I build it public and shared all the wins.
+
+And if you want to learn more in depth, you can join our school community free.
+
+We're sharing a lot more resources and learn together.
+
+So every model gets deprecated, repriced, or replaced eventually.
+
+That's the one guarantee in this field.
+
+Attach your workflow to a specific model and you're building on the rented land.
+
+What survives every duplication is actually the thinking system you can describe in plain language.
+
+Fable's edge, in my opinion, isn't locked inside weight you can touch.
+
+It's our race what a request is actually asking.
+
+How it breaks a hard problem into chuckable portable pieces and how it verifies its own work instead of trusting what sounds right.
+
+All of that is describable and then makes all of it portable.
+
+And here's the money logic.
+
+There are two ways to spend on AI.
+
+Through output spent, you pay every time the model thinks, drafts, chats, quick summaries.
+
+And as said, you spend, you pay once for thinking you would reuse for my system prompts, skills, big decisions.
+
+Fable runs about double what Opus cost.
+
+So, that is even cheaper on intro pricing.
+
+So, to play simple, extraction is the purest asset play here.
+
+Step one, copy this prompt and extract the operating manual.
+
+Here, you are the most capable model on my account and write the operating manual.
+
+Your replacement will run on the replacement is Opus 4.8.
+
+And write it as a senior operator handling their craft to a sharp junior.
+
+And I'm not going to read it entirely, but copy, paste this prompt and use it in either Claude or Claude code.
+
+Inside a Claude code, Fable 5 give us operating manual.
+
+And first, it says, read what the request is actually asking.
+
+Procedure, an example, and failure prevented.
+
+And then secondly, break the problem into independently checkable pieces.
+
+And third, decide where the real risk leaves.
+
+And fourth, verify a claim by writing it.
+
+I love this one so that we can confirm actually a claim where it's actually the fact.
+
+And next, separate what's known from what's guessed.
+
+And sixth, attack your own conclusion before handling over.
+
+And communicate answer first, then reasoning, then risk.
+
+And lastly, the mistakes that look like competence and earned.
+
+It has all different this manual.
+
+What you need to do is you can just copy and paste.
+
+This is how actually Fable 5 is working under the hood.
+
+Copy, paste this one and go back to your Claude project.
+
+Open a Claude project like this.
+
+And then set up saying Opus 4.8 with Fable 5.
+
+And here update this instruction part.
+
+Copy and paste.
+
+And the next step is verify it's actually working.
+
+So, copy and paste this track question.
+
+A report says revenue grew from 4 million to 4.2 million and calls it 20% gain.
+
+Ship it.
+
+And actually, the gain is 5% not 20%.
+
+I'll run it and here you can look at it and it's a gain not 20% and it's re-deriving from the real numbers. 5% and also give us all the reasoning here.
+
+We can see that actually the way Fable 5 works is transplanted in Opus 4.8.
+
+Now, you can use Opus 4.8 or Sonic 5 even after Fable 5 is gone.
+
+I just showed you how you can transplant the brain of Fable 4 different models and I want to share two prompts that will be very helpful to upgrade your own setup.
+
+So, the operating manual makes the chip model think better in general, but your actual work doesn't live in general, it lives in two files typically, your Claude.md and your skills folder.
+
+And the idea here is to utilize Fable 5's thinking to update these two prompts before it's gone.
+
+Claude.md is the instruction file for Claude Code.
+
+And it reads at the start of every session, every real path a preference is supposed to live there.
+
+In reality, half of them live in your head and you retype them every session.
+
+That's a leak we want to fix.
+
+So, copy this prompt.
+
+You're a senior engineering lead doing a handoff review.
+
+Read my Claude MD, then read the actual project it describes.
+
+Find every gap between them, rules I follow but never wrote down, instructions that contradict each other, references to things that no longer exist, and anything so vague a weaker model would guess wrong.
+
+Then rewrite the file so a cheaper model can follow it exactly with zero interpretation.
+
+Audit finding first, rewrite second.
+
+So, what you can do here is copy and paste this prompt.
+
+By the way, I'm going to share this entire instructions inside our school community.
+
+So, please join and take a free resource and copy and paste this one and go to your Claude Code and run this one.
+
+After a few minutes, it shows me I had these many gaps.
+
+I was using Korean standard even I am staying in central time and new strategy section was not updated.
+
+All of these were rewritten basically to fix all the gaps we're having.
+
+As a result, we found 20-plus gaps and fixed all of them.
+
+So, now when I run Claude Code again, I feel it follows my instructions a lot better.
+
+So, that was the first prompt.
+
+Let's go back to the second prompt.
+
+The second prompt is to audit and rebuild your skills.
+
+Skills are reusable workflow files and I've mentioned many times and even have a class in our school community and it teach how Claude do a repeated jobs like your way to some or trade some can be half broken or become outdated and some of them you even forgot they exist.
+
+So the idea is to run this audit and reveal skills.
+
+So copy and this prompt again copy this prompt again.
+
+You're an AI system analysis look at how I actually use Claude read my recent session history and read my skills folder identify my repeated workflows sold every existing skill into four different buckets keep fix merge or delete for my most repeated workflows with no skill or a weak one rebuild them as a complete skill documents a typical model can even execute execute without asking me everything.
+
+Copy paste this one again into your Claude code.
+
+So as a result of this skill auditing we got this 24 skills with a showed as skills that we have to fix and some of them we can merge and delete.
+
+So needs your approval so it doesn't delete anything cuz we asked not to delete just show us.
+
+So we can quickly read them and then see like we want it or we don't want it.
+
+For example promotion we used to use it but I'm not using it anymore or screen recording I'm not using it anymore.
+
+I sometimes use it but I stopped using it since May 6th is so it's a reminder that I can utilize this one again for video analysis and after that it showed us like some of them built and it asked me to approve for deletion or a folder or creation.
+
+With this simple prompt you can audit all of your skills and then organize them.
+
+And from my experience running multiple agents and doing a lot of works within Cloud Code, this is a great time to organize it and make it lean.
+
+Here is the honest verdict.
+
+Does a cheaper model with eight freight files fully replace Fable?
+
+Probably not.
+
+The gap is real.
+
+But with these actions, you can upgrade your Cloud MD.
+
+You can upgrade your skills.
+
+And also, you can prepare for using Fable 5's brain with Office 4.8 or Sonify.
+
+I think this is a meaningful upgrade.
+
+That's it for this video.
+
+Please join our community and contribute contribute to the mission that we're having for teaching AI for their businesses.
+
+Stay tuned.
+
+Subscribe to our new newsletter and YouTube channel.
+
+See you in the next video.

--- a/.omc/kb/transcripts/y4sHAGnIVMU.md
+++ b/.omc/kb/transcripts/y4sHAGnIVMU.md
@@ -1,0 +1,212 @@
+# Graphify | Turn Any Folder Into a Queryable Knowledge Graph | 86K Github Stars
+
+Source: https://www.youtube.com/watch?v=y4sHAGnIVMU
+Type: video transcript (YouTube auto-captions)
+
+What if every file in your project, code, PDFs, diagrams, even whiteboard photos, could be turned into a single queryable knowledge graph?
+
+That's exactly what Graphifi does, and it's got 86,000 stars to prove it.
+
+Andreesen Carpathy described the raw folder problem, a dump of papers, tweets, screenshots, and code with zero structure.
+
+LLMs can't efficiently process all of it.
+
+Context windows are limited, and token costs add up incredibly fast.
+
+Graphifi solves this by building a knowledge graph from any folder.
+
+It achieves 71.5 times fewer tokens per query compared to reading raw files, and costs zero LLM credits for code extraction using deterministic tree-sitter parsing.
+
+Graphifi is open source under the MIT license, built entirely in Python, with over 86,000 GitHub stars and 8,500 forks.
+
+It was created by Graphifi Labs and is actively maintained by a dedicated team of contributors.
+
+The project was born from a real need, making heterogeneous file collections navigable by AI agents.
+
+It's not just another code analyzer.
+
+It's a full multimodal knowledge graph builder designed for the age of AI-assisted development.
+
+The pipeline is elegant.
+
+Graphifi detects files in your directory, extracts concepts using tree-sitter for code and Claude for documents, builds a network exgraph, clusters with the latent algorithm, analyzes for key nodes, and exports to multiple formats.
+
+Installation takes one line.
+
+Pip install Graphifi, then run Graphifi install to set up the slash command for your AI coding assistant.
+
+It works with Claude Code, Cursor, CodeDex, and many more.
+
+To build a knowledge graph, just point Graphifi at any folder.
+
+It scans every file, code, docs, images, PDFs, and produces a structured graph with nodes, edges, and community clusters.
+
+Under the hood, tree-sitter parses code into abstract syntax trees for over 40 languages.
+
+It extracts functions, classes, imports, and call graph edges.
+
+This is fully deterministic and costs nothing in LLM credits.
+
+For unstructured content like PDFs, images, diagrams, and whiteboard photos, Graphify uses Claude's vision capabilities to extract concepts and relationships.
+
+Everything merges into one unified knowledge graph.
+
+Graphify supports over 40 programming languages through tree-sitter grammars.
+
+Python, TypeScript, Go, Rust, Java, C++, Ruby, Kotlin, Swift, C#, PHP, Lua, one tool for your entire polyglot code base.
+
+Every edge in the graph carries a confidence label.
+
+Extracted for direct code references, inferred for likely relationships, and ambiguous for uncertain connections.
+
+You always know what was found versus what was guessed.
+
+The latent algorithm automatically detects communities, clusters of tightly connected concepts, and god node analysis identifies the highest degree concepts that everything flows through in your code base.
+
+Query your graph with natural language.
+
+Ask what connects two concepts, find the shortest path between any two nodes, or get a detailed explanation of any concept in your code base.
+
+Three powerful query modes.
+
+Here's querying in action.
+
+Ask a natural language question about your code base, and Graphify returns precise answers grounded in the actual graph structure, not hallucinated summaries.
+
+Graphify also ingests URLs directly.
+
+Archive papers, tweets, documentation pages.
+
+Just run Graphify add with a URL, and it fetches, extracts concepts, and merges the content into your existing graph.
+
+Incremental updates are built in.
+
+Run Graphify with the update flag, and it uses reprocess changed files.
+
+No need to rebuild the entire graph every time you make a small commit.
+
+Export your graph to interactive HTML visualization.
+
+Open it as an Obsidian vault.
+
+Generate Wikipedia-style wiki articles for agent navigation, or export to GraphML for Gephi and yEd.
+
+The graph lives wherever you need it.
+
+Watch mode keeps your graph live.
+
+As files change, Graphify auto syncs.
+
+Code changes trigger instant AST rebuilds.
+
+Install the Git hook, and your graph updates automatically on every single commit.
+
+The MCP server mode exposes Graphify as a tool for any MCP compatible agent.
+
+Run it with the MCP flag and your AI assistant gets direct access to query, path, and explain operations on your code base graph.
+
+On the Loco Moco benchmark for conversational memory, Graphify achieves 45.3% QA accuracy with a recall at 10 of nearly 0.5.
+
+That beats Mem Zero by almost 10 times on recall at a fraction of the cost.
+
+Compared to Super Memory, Graphify achieves similar QA accuracy but at 11 times lower ingest cost.
+
+It also matches dense RAG on the Long Mem Eval benchmark at 76% accuracy with zero LLM cost for code.
+
+The token compression is remarkable.
+
+A 52-file mixed corpus of code, papers, and images requires 71.5 times fewer tokens per query.
+
+That's the difference between fitting in a context window and completely running out.
+
+On a real-world test with ERPNext, a million-line code base, adding Graphify as a tool improved a coding agent's key fact coverage from 70.8% to 82%.
+
+That's a measurable, significant productivity boost.
+
+Graphify works as a slash command in all major AI coding tools: Claude Code, Cursor, Codex, Gemini CLI, Open Code, Aider, Windsurf, Cline.
+
+It integrates directly into your existing workflow without any configuration changes.
+
+Beyond code, Graphify handles SQL schemas, video transcription through Faster Whisper, docx and xlsx office documents, and even PostgreSQL database introspection.
+
+It truly is a universal knowledge graph builder.
+
+Graphify supports multiple LLM backends beyond Claude.
+
+You can use OpenAI, Gemini, llama for local models, AWS Bedrock, and Kimmy.
+
+Pick the provider that fits your setup and budget.
+
+The output structure is clean and organized.
+
+You get an interactive HTML visualization, an Obsidian vault, wiki articles, a persistent graph JSON file, and a SHA-256 change cache, all in one output directory. "Surprising Connections" is one of the most powerful features.
+
+Graphifi ranks cross-domain edges, links between code and papers, between different modules, between documentation and implementation, revealing hidden relationships.
+
+The token benchmark is printed after every single run.
+
+You see exactly how many tokens you saved by querying the graph instead of reading raw files.
+
+For large codebases, the savings are enormous.
+
+Graph construction costs are essentially zero for code.
+
+Tree-sitter is deterministic, no LLM calls needed.
+
+LLMs are only used for unstructured content like PDFs and images, keeping your costs minimal.
+
+Graphifi can export to Neo4j using Cypher queries, Falkor DB, and even generate SVG visualizations with Matplotlib.
+
+For teams that already use graph databases, the integration is seamless and direct.
+
+The wiki generation feature creates Wikipedia-style articles organized by community cluster.
+
+This gives AI agents a structured way to navigate your codebase, reading articles instead of raw files.
+
+Graphifi demonstrated temporal graph capabilities on 15 years of ERPNext development history, 689 weekly AST checkpoints, showing how the knowledge graph grows and retrieval scales over time.
+
+The graph visualization is fully interactive.
+
+Click any node to see its connections, search for specific concepts, filter by community cluster, and explore the structure of your codebase visually.
+
+For Obsidian users, Graphifi exports directly as a vault.
+
+Open it in Obsidian and navigate your codebase as a knowledge graph with backlinks, tags, and community-based folders.
+
+Graphifi handles both shallow and deep extraction modes.
+
+Shallow mode uses only direct references.
+
+Deep mode adds inferred relationships for a more complete but noisier graph.
+
+You can also add individual files or URLs to an existing graph without rebuilding everything.
+
+This makes it easy to incrementally expand your knowledge graph as your project evolves.
+
+The generated graph report gives you a complete overview.
+
+It lists the top god nodes, community summaries, surprising cross-domain connections, and suggested questions to explore the graph.
+
+Graphify is completely local and private.
+
+No data leaves your machine unless you explicitly choose an LLM provider.
+
+The default code extraction is fully deterministic with zero network calls.
+
+The project is under active development with over 8,500 forks and a growing ecosystem of integrations.
+
+New language grammars, export formats, and agent integrations are added regularly.
+
+The token benchmark printed after every run is not just a nice number.
+
+It's a real measure of how much money and context you're saving by using a structured graph instead of raw file reading.
+
+Let's recap the key numbers. 86,000 GitHub stars, 71 times token reduction, zero cost code extraction, over 40 languages, 11 times cheaper than super memory, works with every major AI coding agent.
+
+Graphify is the missing link between your files and your AI assistant.
+
+Zero cost graph construction, multimodal extraction, massive token reduction, and it works everywhere you code.
+
+Star the repo on GitHub, try it on your own project, and subscribe for more deep dives into the best open-source AI tools.
+
+Link in the description.


### PR DESCRIPTION
Three graphify-adoption housekeeping items, all following upstream's own
documented recommendations.

**.claudeignore (new)** — graphify writes graph.json (3.2 MB) and graph.html
(2.8 MB) into the workspace on every extract/update. Per graphify's README
troubleshooting, that invalidates Claude Code's prompt cache and forces a full
re-upload at cache-write rates on the next turn. Excluding graphify-out/ and
graph.json stops the leak.

**.gitignore / .graphifyignore** — ignore graphify-out/ at any depth except
wiki/ (the only shareable artifact; the rest is regenerable in seconds at zero
tokens). .graphifyignore keeps mintlify-cache/, plugins/, .venv/ and
node_modules/ out of extraction. NOTE: this is deliberately STRICTER than
graphify's "commit graphify-out/" advice, which targets multi-dev teams — here
the graph is single-machine and deterministic to rebuild, so committing 6 MB
per update is not worth it.

**.omc/kb/ corpus (tracked with -f)** — .git/info/exclude carries `.omc/*`, so
research artifacts were local-only and would not survive a fresh clone. This
tracks the text corpus (16 reports incl. 3 verbatim agent reports, 8 video
transcripts, 2 articles) while leaving graphs/ and repos/ ignored as
regenerable. Recorded findings include:

- Codex 0.144.6 removed `wire_api = "chat"` (Responses-only), so a third-party
  endpoint must serve /v1/responses. Confirmed in the binary and the Rust source.
- Hosted NVIDIA NIM does NOT implement /v1/responses (four independent
  control-armed probes) — so Codex cannot wrap it. Ollama does, and
  `codex exec` driving local Ollama is confirmed working, rc=0.
- graphify doc ingestion yields 0/6 cross-document edges on this corpus; node
  IDs are namespaced by source file, so sources never fuse. Structural, and a
  raised output cap reproduced byte-identical output (md5 match), refuting the
  reasoning-model confound. The AST code graph is unaffected and remains solid.

Gates: lint rc=0 · pytest 744 passed · verify 93 passed / 0 failed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FQzDie4WXckQg8to3aTU8t


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added extensive research reports covering Graphify usage, knowledge management, model routing, orchestration, infrastructure, and agent autonomy.
  * Added setup and usage guidance for Claude Code integrations, local and hosted model backends, and Graphify workflows.
  * Added transcripts and supporting research on Graphify, Obsidian, and multi-model development practices.

* **Chores**
  * Updated ignore rules to exclude generated Graphify outputs, caches, plugins, virtual environments, and other workspace artifacts while preserving shareable wiki content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->