### PR TITLE
chore(renovate): default minimumReleaseAge to 1 hour, timestamp-optional

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,12 @@
   "schedule": [
     "at any time"
   ],
-  "minimumReleaseAge": null,
+  "minimumReleaseAge": "1 hour",
+  "minimumReleaseAgeBehaviour": "timestamp-optional",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "minimumReleaseAge": "1 hour"
+  },
   "prConcurrentLimit": 20,
   "prHourlyLimit": 0,
   "packageRules": [


### PR DESCRIPTION
Ray's call: a light global soak instead of either extreme (we were at `null`
= no delay at all; the jdx preset we extend defaults to 7 days).

**`minimumReleaseAgeBehaviour: "timestamp-optional"` is load-bearing, not
decoration.** Renovate's default is `timestamp-required`
(config/options/index.js), and with that default a candidate release carrying
no `releaseTimestamp` is pushed onto `pendingReleases` and held FOREVER
(workers/repository/process/lookup/filter-checks.js:46-49). Swept every
datasource in the installed renovate 43.272.5 for `releaseTimestamp` support:

    deb 0 | pypi 1 | npm 2 | github-releases 1 | github-tags 1
    docker 1 | crate 1 | go 2 | custom 1 | galaxy 2 | nuget 3

`deb` is the ONLY one that emits none — so a bare 1-hour default would have
frozen all 66 [bootstrap.packages] apt pins permanently. This is the same trap
the `custom.gcc-latest` rule already documents for the html datasource; setting
it globally covers both and any future timestamp-less datasource.

None of this bit us before because filter-checks.js:34 short-circuits the whole
block when minimumReleaseAge is unset — `null` disabled the machinery entirely.
Turning it on is what activates the freeze risk.

Also synced `lockFileMaintenance.minimumReleaseAge` to 1 hour. The jdx preset
sets it to "7 days" as a nested value, which our top-level override does NOT
reach — so lockfile maintenance would otherwise have kept a 7-day hold while
everything else moved to 1 hour.

Verification note: `renovate-config-validator --strict --no-global` returns
rc=0, and DOES catch an unknown key (control arm: injected `bogusKeyAbc` ->
rc=1) — but it does NOT enforce this option's enum (injected
`not-a-real-value` -> rc=0). The value is therefore verified from source
instead: `allowedValues: ["timestamp-required", "timestamp-optional"]` in
config/options/index.js, and the `=== "timestamp-optional"` comparison at
filter-checks.js:50.

Gates: lint rc=0, pytest 744 passed, verify 93 passed/0 failed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FQzDie4WXckQg8to3aTU8t
