### PR TITLE
feat/graph bakeoff harness

### DIFF
--- a/.omc/kb/reports/agents/graphify-gemma-issues.md
+++ b/.omc/kb/reports/agents/graphify-gemma-issues.md
@@ -1,0 +1,242 @@
+# graphify "gemma" issue/PR sweep — assessment of our setup
+
+Date: 2026-07-20 · Agent: graphify-gemma-issues
+Query: <https://github.com/search?q=repo%3AGraphify-Labs%2Fgraphify+gemma&type=issues>
+
+## Probe methodology (and its control arms)
+
+`gh search issues --state all` is **invalid** — `gh` accepts only `open|closed`, so the
+command in the brief errors out. The authoritative probe was the plain REST search, which
+returns issues **and** PRs in one result set:
+
+```
+gh api -X GET search/issues -f q="repo:Graphify-Labs/graphify gemma" -f per_page=100
+→ total_count = 7
+```
+Split: **3 ISSUE + 4 PR**. `gh search issues` / `gh search prs` divide the same 7 across two
+commands (issues-only excludes PRs unless `--include-prs`) — that is the `gh`-vs-web-UI
+disagreement the brief warned about. The REST call is the union and is what this report uses.
+
+Source-verification target (all `file:line` below are from this tree, referred to as `$G`):
+`/Users/rmanaloto/.local/share/mise/installs/pipx-graphifyy/0.9.22/graphifyy/lib/python3.14/site-packages/graphify`
+
+**Control arms used throughout** (a probe that can only say "not found" is not evidence):
+
+| negative claim | probe | control arm (same command shape) |
+|---|---|---|
+| no `embed.py` | `ls $G/embed.py` → absent | `ls $G/file_slice.py` → **present, 6318 bytes** |
+| no gemma code | `grep -rni gemma $G --include='*.py'` → **0** | `grep -rn 'qwen2.5-coder'` → **2** (`llm.py:128`, `llm.py:1264`) |
+| no `--embeddings` flag | `grep -c -- '--embeddings' cli.py` → **0** | `grep -c -- '--token-budget' cli.py` → **5** |
+| no `stitch.py` | `grep -rn stitch $G --include='*.py'` → **0** | `grep -rn hollow` → **12** |
+| graphify never sets `OLLAMA_NUM_PARALLEL` | `grep -rn NUM_PARALLEL` → **0** | `grep -rn NUM_CTX` → **5** |
+| no user-settable sampling knobs | `grep -rn top_p` → **0** | `grep -rn temperature` → many |
+
+---
+
+## 1. Every gemma-matching issue/PR
+
+| # | type | state | last activity | title | one-line verdict |
+|---|---|---|---|---|---|
+| [#7](https://github.com/Graphify-Labs/graphify/issues/7) | ISSUE | **OPEN** | 2026-06-02 | v0.4.0: local embeddings via quantized Gemma 4 (no API cost) | **Confirmed unimplemented in 0.9.22** by source, not by ticket state. Our fact holds. |
+| [#798](https://github.com/Graphify-Labs/graphify/issues/798) | ISSUE | closed | 2026-05-09 | [Critical] Context Window Saturation / Missing Session Reset between Chunks (Ollama Backend) | **Most relevant to us.** Fixed 0.7.13; fix live in 0.9.22 at `llm.py:1193-1233`. Our unset-`NUM_CTX` choice is exactly right. Its *headline diagnosis is wrong* — see §4. |
+| [#792](https://github.com/Graphify-Labs/graphify/issues/792) | ISSUE | closed | 2026-05-09 | [Feature Request] Enhancing Local LLM Performance (Ollama) & High-Core CPU Scaling via graphify.yaml | Origin of `--max-workers` / `--token-budget` / `--max-concurrency` / `--api-timeout` — i.e. **three of the four flags we pass**. `graphify.yaml` + temperature/top_p/top_k/seed knobs were **declined**. |
+| [#1126](https://github.com/Graphify-Labs/graphify/pull/1126) | PR | closed, **NOT merged** | 2026-06-05 | feat: local embedding pass for exhaustive `semantically_similar_to` edges (#7) | The one serious attempt at #7. Rejected → embeddings still absent. Used **ONNX `embeddinggemma-300m`**, *not* Ollama. |
+| [#1326](https://github.com/Graphify-Labs/graphify/pull/1326) | PR | closed, **NOT merged** | 2026-06-17 | feat: intra-file slicing, incremental safety, and cross-file stitch | Slicing half **shipped anyway** (`file_slice.py`, wired `llm.py:2139`); the `stitch.py` half did **not**. |
+| [#1398](https://github.com/Graphify-Labs/graphify/pull/1398) | PR | closed, **NOT merged** | 2026-06-22 | fix: Fix for the slicer (0.8.42 #1369), regression from 0.8.43 (#1386) | `Path(FileSlice)` crash under a **lowered `--token-budget`**. Matches "gemma" only via a passing mention that local Gemma env vars broke the author's backend-detection tests. |
+| [#252](https://github.com/Graphify-Labs/graphify/pull/252) | PR | closed, **NOT merged** | 2026-04-15 | feat: Windows-native skill support and edge-model workflow optimizations for OpenClaw | Inert for us (PowerShell, Windows `python`, OpenClaw skill files). A `claw` platform does exist in 0.9.22 (`install.py:359`, `skill-claw.md`) but is unrelated to this PR's content. |
+
+**All four PRs are closed with `mergedAt: null`.** Where a feature they describe nevertheless
+exists in 0.9.22 (file slicing), the maintainer reimplemented it. So **PR merge status is not
+a reliable proxy for "shipped" in this repo, in either direction** — every verdict below is
+adjudicated against installed source.
+
+---
+
+## 2. Does this affect our setup?
+
+Our setup under assessment:
+`graphify extract <dir> --backend ollama --model <M> --max-concurrency 1 --token-budget 12000 --api-timeout 900`,
+`OLLAMA_NUM_PARALLEL=1`, `GRAPHIFY_OLLAMA_NUM_CTX` **unset**, graphify `0.9.22` pinned
+host-only at `mise.toml:53` as `"pipx:graphifyy" = { version = "0.9.22", extras = ["all"] }`.
+
+### #7 — local embeddings via Gemma 4 → **INERT, and our reading of it is correct**
+Verified unimplemented in 0.9.22:
+- `$G/embed.py` **does not exist** (control-armed against `file_slice.py`, which does).
+- `grep -c -- "--embeddings" $G/cli.py` → **0** (control arm `--token-budget` → 5).
+- `grep -rn "embed_threshold\|embeddings" $G --include='*.py'` → **0 hits**.
+- The shipped package METADATA markets the opposite:
+  `graphifyy-0.9.22.dist-info/METADATA:169` — *"**Not a vector index.** No embeddings, no
+  vector store: a real graph you traverse."*
+
+**Consequence:** `embeddinggemma` is currently **dead weight for graphify** — nothing in
+0.9.22 can call it. No flag, env var, model, or version change follows from #7. Note further
+that #1126 chose **ONNX Runtime + `onnx-community/embeddinggemma-300m-ONNX`**, i.e. *not* the
+Ollama `embeddinggemma` we pulled, and the #7 thread (2026-06-02, TPAteeq +
+FolatheDuckofDuckingburg) explicitly settles on "pull Gemma 4 from Hugging Face". If #7 ever
+lands it will most likely arrive as ONNX/HF, not as an Ollama pull.
+
+### #798 — Ollama context saturation → **DIRECTLY RELEVANT; our config is on the correct side**
+The fix is present in 0.9.22 at `llm.py:1193-1233`:
+```python
+if backend == "ollama" and extra_body is None:
+    num_ctx_raw = os.environ.get("GRAPHIFY_OLLAMA_NUM_CTX", "").strip()      # llm.py:1195
+    estimated_input = len(user_message) // _CHARS_PER_TOKEN + 400            # llm.py:1198
+    auto_num_ctx = min(estimated_input + max_completion_tokens + 2000, 131072)
+    auto_num_ctx = max(auto_num_ctx, 8192)                                   # llm.py:1199-1200
+    ...
+    kwargs["extra_body"] = {"options": {"num_ctx": num_ctx}, "keep_alive": keep_alive}  # llm.py:1229
+```
+With `_CHARS_PER_TOKEN = 4` (`llm.py:36`) and `max_completion_tokens = 8192` (`llm.py:1127`),
+our `--token-budget 12000` derives **num_ctx ≈ 12000 + 400 + 8192 + 2000 ≈ 22.6k** —
+comfortably inside the 131072 cap and above the 8192 floor. That is the intended regime.
+
+**Leaving `GRAPHIFY_OLLAMA_NUM_CTX` unset is correct and load-bearing.** The env var
+*overrides* the derivation entirely (`llm.py:1201-1203`); pinning it re-introduces #798's
+failure from one side or the other — too big → KV-slot VRAM blowout; too small → silent prompt
+truncation, which the code explicitly warns about at `llm.py:1216-1222`. **Do not set it.**
+
+`OLLAMA_NUM_PARALLEL=1` is also correct and is *only* achievable from our side: the
+maintainer's root-cause comment on #798 (2026-05-09 22:44) names Ollama's default
+`OLLAMA_NUM_PARALLEL=4` as the multiplier that turned an over-large `num_ctx` into chunk-4
+VRAM exhaustion, and **graphify never sets that variable itself** (`grep -rn NUM_PARALLEL` →
+0 hits; control arm `NUM_CTX` → 5). Keep it.
+
+`--max-concurrency 1` is the second half of the same protection: `llm.py:2223`
+`workers = max(1, min(max_concurrency, total))` forces strictly sequential LLM calls.
+
+### #792 — CLI flags for local LLMs → **ORIGIN OF OUR FLAGS; all present**
+- `--api-timeout` → `cli.py:2507` / `cli.py:2557` (sets `GRAPHIFY_API_TIMEOUT`), consumed by
+  `_resolve_api_timeout(default=600.0)` (`llm.py:403`), applied at `llm.py:1156`. Our `900`
+  overrides the 600s default upward — appropriate for a 12–14B model on Apple silicon.
+- `--max-concurrency` (`llm.py:2085`, `2173`), `--token-budget` (`cli.py`, ×5),
+  `--max-workers` — all present.
+- **Declined upstream, therefore unavailable to us:** `graphify.yaml`, and any
+  `temperature` / `top_p` / `top_k` / `seed` knob. `grep -rn 'top_p'` → **0 hits**; the
+  `temperature` hits are per-backend *defaults* in the `BACKENDS` table (e.g. `llm.py:131`
+  `"temperature": 0` for ollama), not user-settable per run. Maintainer's stated position:
+  *"set these server-side via Ollama Modelfile."*
+  **Real gap for us**: if extraction quality wobbles on gemma4/qwen, our only lever for
+  temperature/top_p/top_k is an Ollama `Modelfile` — there is no graphify flag.
+
+### #1126 — the embeddings PR → **INERT** (not merged; see #7).
+Useful intel if we ever revisit: at threshold 0.82 it added +169 similarity edges to a
+177-node / 246-edge graph. Its own "Deferred" note records that on a **pure-code corpus, 87%
+of edges at 0.82 were identical-label collisions** (different classes' `.__init__()` embedding
+identically). A known trap for any embedding pass we build over code.
+
+### #1326 / #1398 — the slicer → **RELEVANT; resolved in our favour**
+`file_slice.py` exists and `expand_oversized_files(files, _FILE_CHAR_CAP)` is wired into the
+real extraction path at `llm.py:2139` (imported `llm.py:22`). Oversized markdown docs *are*
+split at heading/paragraph boundaries before packing in 0.9.22. **This matters to us
+specifically**: #1398 notes its crash "only surfaces … with a **lowered `--token-budget`**",
+and 12000 is a heavily lowered budget on a markdown corpus — but the crashing code was
+reimplemented rather than merged, so the failure cannot be reproduced by construction.
+
+`stitch.py` did **not** ship (0 hits; control arm `hollow` → 12). **Actionable — see §3(e).**
+
+### #252 — OpenClaw / Windows → **INERT.** Not merged, and Windows/PowerShell-specific.
+
+---
+
+## 3. Known bugs / gotchas with gemma-under-Ollama we should guard against
+
+**(a) There is NO gemma-specific code path in graphify 0.9.22.**
+`grep -rni gemma $G --include='*.py'` → **0 hits**, control-armed by `grep -rn 'qwen2.5-coder'`
+→ 2 hits in the identical sweep. Every gemma-related behaviour is generic-Ollama behaviour.
+Corollary: graphify's own default Ollama model is **`qwen2.5-coder:7b`** (`llm.py:128`,
+`OLLAMA_MODEL` fallback), and its low-token warning recommends `qwen2.5-coder:14b`
+(`llm.py:1264`). The maintainer's implicit recommendation is the qwen-coder family, not gemma
+— independently corroborating our bake-off result (qwen2.5-coder:14b winning).
+
+**(b) Hollow-response handling — mitigated, but know the signature.**
+`_response_is_hollow()` (`llm.py:1047-1071`) treats HTTP-200 with empty content **or** zero
+nodes/edges as truncation and relabels `finish_reason = "length"` (`llm.py:1247-1256`) so
+adaptive bisection fires. **Measurement gotcha:** a chunk that *legitimately* yields zero nodes
+is indistinguishable from a choke and gets bisected and retried. If a gemma4:12b run looks
+slow, this is a likely reason — and it inflates the output-token count we measure.
+
+**(c) The "very few tokens" warning is now VRAM-first** (`llm.py:1258-1266`). If we see it on
+gemma4:12b, the prescribed order is: reduce `--token-budget`, then switch model — **not** raise
+`NUM_CTX`.
+
+**(d) `GRAPHIFY_OLLAMA_KEEP_ALIVE` defaults to `"30m"` and we are not setting it — for a
+bake-off we probably should.** `llm.py:1228`:
+`keep_alive = os.environ.get("GRAPHIFY_OLLAMA_KEEP_ALIVE", "30m")`, passed to Ollama at
+`llm.py:1229`. **After a gemma4:12b run finishes, that model stays resident for 30 minutes.**
+Back-to-back arms (gemma4:12b → qwen2.5-coder:14b → qwen3:14b) therefore stack resident models
+in unified memory and can make the *second* arm look slower than it is.
+**Recommendation: `GRAPHIFY_OLLAMA_KEEP_ALIVE=0` (or `ollama stop <model>`) between bake-off
+arms.** Measurement hygiene, not a correctness bug. (`RANGERVIII` in #798 reports this var was
+"completely ineffective" — true for *saturation*, which is not what it controls; it is
+effective for residency, which is our use.)
+
+**(e) `stitch.py` never shipped → incremental extracts can produce isolated subgraphs.**
+PR #1326's Problem 3 is unfixed in 0.9.22. If we run `graphify extract` **incrementally**
+(adding docs one at a time) rather than over the whole corpus, new nodes may not connect to the
+existing graph, and BFS/`query` will not reach them. **Guard: prefer full-corpus extracts, or
+verify connectivity after an incremental run.** Our `mise run graphify-query` path is a
+deterministic BFS over `graph.json` and inherits exactly this limitation.
+
+**(f) Ollama gets `max_retries = 0` by default (#1686).** `llm.py:1152-1155` sets the OpenAI
+SDK to zero transient retries for ollama specifically, so **`--api-timeout 900` is a hard
+per-call wall-clock bound**, not a 7×900s one. Good, and worth knowing when budgeting a run.
+
+---
+
+## 4. Contradictions with our established facts
+
+**No hard contradiction found.** Three near-misses, each adjudicated against source rather than
+issue text:
+
+1. **"#7 is open ⇒ embeddings unimplemented"** — the shape that most often lies (an open issue
+   outliving its fix). Here it is **corroborated by source**: no `embed.py`, `--embeddings`
+   count 0, and shipped METADATA advertising "No embeddings, no vector store". Our fact stands
+   on evidence, not on the ticket.
+
+2. **PRs #1326/#1398 closed-unmerged, yet `file_slice.py` exists** — the mirror-image trap:
+   *unmerged does not mean unshipped here*. Adjudicated by reading `llm.py:22` and
+   `llm.py:2139`. Anyone reasoning about this repo from PR status alone will be wrong in both
+   directions.
+
+3. **⚠️ #798's headline diagnosis is WRONG, and it is the more visible artifact.** The issue
+   title and body assert "Missing Session Reset between Chunks" / KV-cache leakage. The
+   maintainer refutes it in-thread and the source agrees: every call builds a fresh
+   `messages=[system, user]` array (`llm.py:1160-1166`), there is no conversation history, and
+   graphify uses `/v1/chat/completions` — not the native `/api/generate` endpoint where the
+   `context` array exists at all. Real cause: `num_ctx` over-allocation × Ollama's default
+   `OLLAMA_NUM_PARALLEL=4`. **Do not adopt the `ollama stop`-between-chunks workaround from
+   that thread** — it targets a mechanism that does not exist, and it would serialise our runs
+   for nothing. (Setting `KEEP_ALIVE=0` between *bake-off arms*, §3(d), is a different and
+   legitimate use of a superficially similar idea.)
+
+Nothing found contradicts: our 0.9.22 pin, the `--max-concurrency 1` / `--token-budget 12000` /
+`--api-timeout 900` flag set, `OLLAMA_NUM_PARALLEL=1`, leaving `GRAPHIFY_OLLAMA_NUM_CTX` unset,
+or the gemma4:12b-has-no-embedding-capability finding (graphify contains no gemma code at all,
+so it cannot and does not speak to it).
+
+---
+
+## Verdict on our setup
+
+**Correct as configured.** Every deliberate choice is either the directly-prescribed remedy for
+a closed gemma/Ollama issue (`NUM_CTX` unset → #798; `--max-concurrency 1` +
+`OLLAMA_NUM_PARALLEL=1` → #798 root cause; `--api-timeout 900` → #792 addendum) or is inert
+with respect to every finding. Two optional changes, neither a correctness fix:
+
+1. **Set `GRAPHIFY_OLLAMA_KEEP_ALIVE=0`** (or `ollama stop <model>`) between bake-off arms —
+   the 30m default (`llm.py:1228`) leaves prior models resident and biases comparisons.
+2. **Prefer full-corpus extracts over incremental ones** until `stitch.py` ships — incremental
+   runs can leave unreachable subgraphs (#1326 Problem 3, verified unimplemented).
+
+One expectation to drop: **`embeddinggemma` does nothing for graphify 0.9.22**, and if #7 ever
+lands it will most likely arrive as ONNX/HuggingFace, not as an Ollama pull.
+
+One gap with no workaround inside graphify: **no `temperature` / `top_p` / `top_k` / `seed`
+flags** (declined in #792). If gemma4:12b output quality needs tightening, that must be done in
+an Ollama `Modelfile`.
+
+---
+
+## GitHub repos touched
+
+- [Graphify-Labs/graphify](https://github.com/Graphify-Labs/graphify) — the sole subject: issues #7, #792, #798 and PRs #252, #1126, #1326, #1398 read via `gh`; the installed 0.9.22 package source read from disk to adjudicate every load-bearing claim.

--- a/.omc/kb/reports/bake-off-extraction-models.md
+++ b/.omc/kb/reports/bake-off-extraction-models.md
@@ -29,6 +29,7 @@ cross = sum(1 for e in d['links']
 | qwen3:14b (reasoning) | 9 | 6 | 0 | 2,013 |
 | **gemma4:12b** (2026-07-20) | 8 | 6 | **2** | 7,479 |
 | qwen3-coder (30B) | 5 | 4 | 0 | 999 |
+| **claude-cli** (Claude Code sub) | — | — | — | **FAILED, rc=1** |
 
 `gemma4:12b` capabilities: completion, vision, audio, tools, **thinking**
 (no embedding — see `docs/graphify-local-embedding-pass.md` §1.1).
@@ -76,6 +77,43 @@ both label-only and context-enriched. See
 
 **Do not choose a model on this corpus's `x-doc` column.** Re-run on the full
 137-document corpus in `.omc/kb/raw/` before treating cross-doc yield as signal.
+
+## The `claude-cli` backend is BROKEN on Claude Code 2.1.216
+
+graphify has a `claude-cli` backend (`llm.py:205-216`) that routes through the locally
+installed `claude` CLI and bills to a Pro/Max subscription rather than an
+`ANTHROPIC_API_KEY` — pricing declared as `{"input": 0.0, "output": 0.0}`.
+It **does not work**, and the extraction is lost *after* the model has done it:
+
+```
+[graphify] LLM returned invalid JSON, skipping chunk (first 200 chars:
+  'Knowledge graph extracted and delivered — 21 nodes, 20 edges, 3 hyperedges
+   from the Codex↔NIM probe document.')
+[graphify] claude-cli returned a hollow response; treating as truncation…
+[graphify extract] graph is empty — extraction produced no nodes.
+rc=1
+```
+
+Claude Code **did the work** — 21 nodes / 20 edges / 3 hyperedges would have beaten every
+model in the table — then replied with an agentic *summary* instead of the raw JSON
+payload. graphify's `_response_is_hollow` reads that as truncation, bisects, and converges
+on nothing. The two semantic cache entries written are `partial: True`, `nodes: 0`.
+
+### Diagnosis — four arms, cause isolated
+
+| # | hypothesis | probe | result |
+|---|---|---|---|
+| 1 | our repo's ~107 KB eager `CLAUDE.md`/`AGENTS.md` context makes it behave agentically | re-ran in a clean room outside the repo | **REFUTED** — fails identically (`'Graph fragment extracted and delivered.'`) |
+| 2 | user-level `~/.claude/CLAUDE.md` leaks in everywhere | `ls ~/.claude/CLAUDE.md` | **REFUTED** — does not exist, so the clean room really was clean |
+| 3 | `claude -p --output-format json` can't return raw JSON | direct minimal prompt | **REFUTED** — returns `result: '{"nodes":[{"id":"a","label":"A"}],"edges":[]}'` exactly |
+| 4 | graphify's own prompt construction triggers agentic behavior | ← by elimination, and see below | **CONFIRMED** |
+
+`llm.py:1376-1391` documents this exact failure class and claims a fix — deliver the schema
+in the **user turn** and drop `--system-prompt` — explicitly *"verified against Claude Code
+**2.1.197**"*. We run **2.1.216**. The workaround has regressed in the intervening releases.
+
+**Worth reporting upstream.** Until then, `claude-cli` is not a usable ingestion backend, and
+the $0-cost path it advertises is unavailable.
 
 ## Caveats
 

--- a/docs/graphify-local-embedding-pass.md
+++ b/docs/graphify-local-embedding-pass.md
@@ -83,6 +83,12 @@ the Gemma family, 621 MB, 768 dimensions, ~0 GPU pressure. It is almost
 certainly what #7 meant. Note it produces embeddings *only*; it cannot be
 reused for extraction.
 
+> **`embeddinggemma` is dead weight for graphify itself.** Nothing in 0.9.22 can
+> call it — no `embed.py`, `grep -c -- '--embeddings' cli.py` → 0 (control arm
+> `--token-budget` → 5), and the shipped `METADATA:169` markets the opposite:
+> *"**Not a vector index.** No embeddings, no vector store: a real graph you
+> traverse."* It is pulled for **our own** pass (§6), which runs outside graphify.
+
 *(Worth reporting on #7 — the maintainers are currently debating ONNX Runtime
 vs Ollama for a model that does not embed under either.)*
 
@@ -178,6 +184,23 @@ mention the label** (1,200-char cap). Same nodes, same model, same corpus:
 
 **Every lexical collision drops out of the top 20**, and real relations take the
 top slots. 5 of 16 nodes had no sentence match and fell back to label-only.
+
+### 2.3b Independent corroboration — upstream measured the same collapse
+
+**PR [#1126](https://github.com/Graphify-Labs/graphify/pull/1126)** was the one serious
+attempt to implement #7 (2026-06-05, **closed unmerged**). Its own "Deferred" note records
+that on a pure-code corpus, **87% of the edges it emitted at threshold 0.82 were
+identical-label collisions** — different classes' `.__init__()` embedding identically.
+
+That is the same failure this spec measured from the other end, on a document corpus, with a
+different embedding model, arrived at independently. Two measurements, two corpora, one
+conclusion: **`label` alone is not enough text.** It also means #7's 0.82 is not merely
+unvalidated — it has been measured and found wanting by the only person who tried to build it.
+
+Note #1126 used **ONNX Runtime + `onnx-community/embeddinggemma-300m-ONNX`**, not Ollama.
+Combined with the #7 thread settling on "pull Gemma 4 from Hugging Face", the likely shape of
+any upstream implementation is ONNX/HF rather than an Ollama pull — so §1.2's transport is a
+choice for *our* pass, not a prediction of theirs.
 
 **So the spec's answer to "what gets embedded" is: not what #7 says.** Three
 options, in order of cost:

--- a/python/src/dotfiles_setup/graph_bakeoff.py
+++ b/python/src/dotfiles_setup/graph_bakeoff.py
@@ -1,0 +1,452 @@
+r"""Repeatable graphify extraction bake-off — isolated runs, recorded provenance.
+
+Replaces the ad-hoc 2026-07-20 comparison, which a same-day audit found to be
+anecdote rather than measurement. Each defect below is answered by a specific
+mechanism here, and the mechanism is the reason the module exists:
+
+============================  ==================================================
+audit finding                 mechanism
+============================  ==================================================
+model attribution was         :func:`write_manifest` records backend, model,
+unverifiable — graphify       flags, graphify version, per-file corpus SHA256,
+records NOTHING about the     git SHA and timings NEXT TO every ``graph.json``.
+backend or model in any       Nothing is inferred from a directory name again.
+artifact (control arm: the
+corpus filename IS recorded)
+
+the semantic cache key is     :func:`prepare_run_dir` creates a FRESH directory
+MODEL-BLIND — it is           per (corpus, arm, repeat) and copies the corpus in,
+``SHA256(content \\0 relpath)``  so a cache written by one arm is unreachable by
+plus a *prompt* fingerprint   another **by construction** rather than by
+(``model`` appears once in    remembering to pass a different ``--out``.
+``cache.py``, in a comment;
+``prompt`` appears 81 times)
+
+n=1, so a single run was      :data:`DEFAULT_REPEATS` runs per arm; results are
+reported as a measurement     reported as median + spread, so a gap between two
+                              arms can be compared against each arm's own
+                              run-to-run variance.
+
+the metric was degenerate —   Scoring is precision/recall against an explicit
+raw node/edge counts on a     ``ANSWER_KEY.json``, including ``forbidden_links``
+2-doc corpus whose two docs   (lexical decoys) that count AGAINST a model. Raw
+are topically disjoint        counts are still reported, but never ranked on.
+============================  ==================================================
+
+**Nothing is written inside this repo.** Runs land under
+:data:`DEFAULT_WORKBENCH` (outside the project) because bake-off output is
+result data, not source — and because a platform skill install
+(``graphify codex install``) appends to ``AGENTS.md``, which sits at exactly
+its 200-line budget here and would fail the ``md_size_budget`` hk step.
+
+The single external boundary is :func:`_run` (the graphify subprocess),
+isolated at module scope so tests replace it by ``monkeypatch`` — mirroring
+:mod:`dotfiles_setup.graphify` and :mod:`dotfiles_setup.ghcr`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import shutil
+import statistics
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_WORKBENCH = Path.home() / "dev" / "graphify-bakeoff"
+DEFAULT_REPEATS = 3
+_GRAPH_SUBDIR = "graphify-out"
+_GRAPH_FILE = "graph.json"
+_ANSWER_KEY = "ANSWER_KEY.json"
+
+#: Flags held IDENTICAL across every arm. The whole point of the harness is
+#: that only (backend, model) varies, so these are not per-arm configurable —
+#: a flag that differs between arms silently turns a comparison into two
+#: unrelated experiments, which is what happened on 2026-07-20.
+FIXED_FLAGS: tuple[str, ...] = (
+    "--max-concurrency",
+    "1",  # sequential; #798 root cause is concurrency x num_ctx
+    "--token-budget",
+    "12000",
+    "--api-timeout",
+    "900",
+)
+
+#: Env applied to every ollama arm. ``OLLAMA_NUM_PARALLEL=1`` is ours to set —
+#: graphify never sets it (``grep NUM_PARALLEL`` -> 0; control arm ``NUM_CTX``
+#: -> 5) and Ollama's default of 4 is the multiplier behind graphify #798.
+#: ``KEEP_ALIVE=0`` stops a finished arm's model staying resident for the 30m
+#: default and biasing the NEXT arm's timings.
+OLLAMA_ENV = {"OLLAMA_NUM_PARALLEL": "1", "GRAPHIFY_OLLAMA_KEEP_ALIVE": "0"}
+
+
+class BakeoffError(RuntimeError):
+    """Raised when the harness cannot proceed (bad corpus, missing binary)."""
+
+
+@dataclass(frozen=True)
+class Arm:
+    """One (backend, model) combination under test."""
+
+    name: str
+    backend: str
+    model: str | None = None
+    env: dict[str, str] = field(default_factory=dict)
+
+    def extract_args(self, corpus_dir: Path, out_dir: Path) -> list[str]:
+        """Build the graphify argv for this arm. Only backend/model vary."""
+        args = ["graphify", "extract", str(corpus_dir), "--backend", self.backend]
+        if self.model:
+            args += ["--model", self.model]
+        return [*args, "--out", str(out_dir), *FIXED_FLAGS]
+
+
+@dataclass(frozen=True)
+class RunResult:
+    """Outcome of a single (corpus, arm, repeat) run."""
+
+    arm: str
+    corpus: str
+    repeat: int
+    rc: int
+    nodes: int
+    edges: int
+    cross_doc: int
+    out_tokens: int
+    seconds: float
+    run_dir: Path
+
+    @property
+    def ok(self) -> bool:
+        """True when the run exited clean AND produced a non-empty graph."""
+        return self.rc == 0 and self.nodes > 0
+
+
+def _run(
+    args: Sequence[str], *, cwd: Path, env: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    """Execute graphify. The module's only external boundary."""
+    merged = {**os.environ, **env}
+    # Wall-clock is bounded by graphify's own --api-timeout in FIXED_FLAGS.
+    return subprocess.run(
+        list(args), cwd=cwd, env=merged, capture_output=True, text=True, check=False
+    )
+
+
+def corpus_digest(corpus_dir: Path) -> dict[str, str]:
+    """SHA256 every corpus file, so 'same inputs' is proven rather than assumed.
+
+    This is the check that would have caught the 2026-07-20 comparison
+    inheriting four rows whose inputs were never verified.
+    """
+    return {
+        p.name: hashlib.sha256(p.read_bytes()).hexdigest()
+        for p in sorted(corpus_dir.glob("*.md"))
+    }
+
+
+def prepare_run_dir(
+    workbench: Path, run_id: str, corpus: str, arm: str, repeat: int
+) -> Path:
+    """Create an EMPTY run directory and copy the corpus into it.
+
+    Freshness is the cache-isolation guarantee: graphify's semantic cache is
+    keyed by file content + relative path and carries no model identity, so two
+    arms sharing an output tree would silently share results. A new tree per run
+    makes that impossible rather than merely unlikely.
+    """
+    run_dir = workbench / "runs" / run_id / corpus / arm / f"r{repeat}"
+    if run_dir.exists():
+        shutil.rmtree(run_dir)
+    (run_dir / "corpus").mkdir(parents=True)
+    return run_dir
+
+
+def parse_out_tokens(stdout: str) -> int:
+    """Pull the output-token count out of graphify's summary line.
+
+    Format: ``[graphify extract] tokens: 5,697 in / 7,479 out, est. cost ...``
+    Returns 0 when absent — a failed run has no summary, and 0 is honest.
+    """
+    for line in stdout.splitlines():
+        if "tokens:" in line and "out" in line:
+            try:
+                after = line.split("tokens:", 1)[1]
+                out_part = after.split("/", 1)[1]
+                return int(out_part.strip().split()[0].replace(",", ""))
+            except IndexError, ValueError:
+                return 0
+    return 0
+
+
+def load_graph(run_dir: Path) -> dict[str, Any] | None:
+    """Load a run's ``graph.json``, or None when the run produced no graph."""
+    path = run_dir / "out" / _GRAPH_SUBDIR / _GRAPH_FILE
+    if not path.is_file():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def cross_doc_edges(graph: dict[str, Any]) -> int:
+    """Count edges whose endpoints come from DIFFERENT source files.
+
+    Measured by real ``source_file``, never by splitting node ids on ``_``.
+    That heuristic reported a false 15/15 for qwen2.5-coder (true value: 1)
+    because models differ in whether they prefix ids with the source stem.
+    """
+    src = {n["id"]: n.get("source_file") for n in graph.get("nodes", [])}
+    links = graph.get("links", graph.get("edges", []))
+    return sum(
+        1
+        for e in links
+        if src.get(e.get("source"))
+        and src.get(e.get("target"))
+        and src[e["source"]] != src[e["target"]]
+    )
+
+
+def normalize_label(label: str) -> str:
+    """Casefold and collapse whitespace/punctuation for comparison."""
+    return " ".join(
+        "".join(c if c.isalnum() else " " for c in label).split()
+    ).casefold()
+
+
+# ---------------------------------------------------------------------------
+# UNRESOLVED (issue #327): the entity matcher below is a placeholder awaiting a
+# decision. See the design note in the docstring for why it is not a default.
+# (Deliberately not written as a TODO comment: ruff runs `select = ["ALL"]`
+# here with no TODO precedent in the package, so the keyword itself trips
+# FIX002 — and silencing that would need an explicit suppression approval
+# under the zero-skip policy. The issue link carries the same information.)
+# ---------------------------------------------------------------------------
+def match_entity(node_label: str, aliases: Sequence[str]) -> bool:
+    """Decide whether an extracted node refers to an answer-key entity.
+
+    Every precision/recall number the harness reports flows through this one
+    predicate, and the two obvious implementations fail in opposite directions:
+
+    * **Too strict** (exact normalized equality) — a model that emits a
+      *better*, more descriptive label ("Rookery storage layer") scores WORSE
+      than one emitting the bare noun. The harness would then reward terse
+      labelling rather than good extraction.
+    * **Too loose** (substring containment) — the node labelled
+      "Magpie vs Mockingbird" matches BOTH the ``magpie`` and ``mockingbird``
+      aliases, so the scorer manufactures a forbidden F2 edge the model never
+      asserted, and penalises it for the harness's own sloppiness. Titles and
+      headings are real nodes in this corpus, so this is not hypothetical.
+
+    Note the asymmetry that makes this a judgement call rather than a lookup:
+    a false negative costs one point of recall, while a false positive on a
+    ``forbidden_links`` pair is weighted heavily *and* is the exact failure mode
+    the gold corpus was built to detect. Getting this wrong doesn't add noise —
+    it inverts the ranking.
+
+    Args:
+        node_label: The ``label`` field of a node in the extracted graph.
+        aliases: The answer key's alias list for one entity, e.g.
+            ``["cold tier", "frost storage", "archival partitions"]``.
+
+    Returns:
+        True when the node refers to that entity.
+    """
+    # PLACEHOLDER — naive exact-normalized match so the harness runs end to end.
+    # Replace with your rule; `normalize_label` is available for both sides.
+    norm = normalize_label(node_label)
+    return any(norm == normalize_label(a) for a in aliases)
+
+
+@dataclass(frozen=True)
+class Score:
+    """Precision/recall of one graph against the gold answer key."""
+
+    recall_hits: list[str]
+    recall_misses: list[str]
+    forbidden_hits: list[str]
+    total_expected: int
+    total_forbidden: int
+
+    @property
+    def recall(self) -> float:
+        """Fraction of the answer key's expected links the model asserted."""
+        if not self.total_expected:
+            return 0.0
+        return len(self.recall_hits) / self.total_expected
+
+    @property
+    def decoy_resistance(self) -> float:
+        """Fraction of forbidden pairs the model correctly did NOT assert."""
+        if not self.total_forbidden:
+            return 1.0
+        return 1 - (len(self.forbidden_hits) / self.total_forbidden)
+
+
+def _entity_node_ids(graph: dict[str, Any], aliases: Sequence[str]) -> set[str]:
+    return {
+        n["id"]
+        for n in graph.get("nodes", [])
+        if match_entity(n.get("label", ""), aliases)
+    }
+
+
+def score_graph(graph: dict[str, Any], key: dict[str, Any]) -> Score:
+    """Score a graph against the answer key: recall + decoy resistance."""
+    entities = key["entities"]
+    links = graph.get("links", graph.get("edges", []))
+    pairs = {(e.get("source"), e.get("target")) for e in links}
+    pairs |= {(b, a) for a, b in pairs}  # edges are stored undirected-ish
+
+    def asserted(a_key: str, b_key: str) -> bool:
+        a_ids = _entity_node_ids(graph, entities[a_key]["aliases"])
+        b_ids = _entity_node_ids(graph, entities[b_key]["aliases"])
+        if a_key == b_key:
+            # Self-pair (e.g. one concept under three names): any edge between
+            # two DISTINCT nodes that both match the alias set counts.
+            return any(x != y and (x, y) in pairs for x in a_ids for y in a_ids)
+        return any((x, y) in pairs for x in a_ids for y in b_ids)
+
+    hits = [ln["id"] for ln in key["expected_links"] if asserted(ln["a"], ln["b"])]
+    misses = [ln["id"] for ln in key["expected_links"] if ln["id"] not in hits]
+    bad = [fl["id"] for fl in key["forbidden_links"] if asserted(fl["a"], fl["b"])]
+    return Score(
+        hits, misses, bad, len(key["expected_links"]), len(key["forbidden_links"])
+    )
+
+
+@dataclass(frozen=True)
+class RunSpec:
+    """Everything that identifies one run, before it is executed.
+
+    Bundled rather than passed positionally so :func:`execute_run` and
+    :func:`write_manifest` stay under the argument budget, and so the manifest
+    and the argv are built from exactly the same values.
+    """
+
+    workbench: Path
+    run_id: str
+    corpus_dir: Path
+    arm: Arm
+    repeat: int
+    versions: dict[str, str]
+
+    @property
+    def corpus(self) -> str:
+        """Corpus directory name, used as the run-tree path segment."""
+        return self.corpus_dir.name
+
+
+def write_manifest(
+    run_dir: Path,
+    spec: RunSpec,
+    digests: dict[str, str],
+    result: RunResult,
+    argv: Sequence[str],
+) -> None:
+    """Record everything needed to reproduce and attribute this run.
+
+    The audit's headline failure was that a graph could not be traced back to
+    the model that made it. This file is the fix.
+    """
+    arm = spec.arm
+    payload = {
+        "arm": arm.name,
+        "backend": arm.backend,
+        "model": arm.model,
+        "corpus": spec.corpus,
+        "corpus_sha256": digests,
+        "repeat": result.repeat,
+        "argv": list(argv),
+        "fixed_flags": list(FIXED_FLAGS),
+        "env": {**arm.env},
+        "versions": spec.versions,
+        "rc": result.rc,
+        "seconds": round(result.seconds, 2),
+        "metrics": {
+            "nodes": result.nodes,
+            "edges": result.edges,
+            "cross_doc": result.cross_doc,
+            "out_tokens": result.out_tokens,
+        },
+    }
+    (run_dir / "manifest.json").write_text(
+        json.dumps(payload, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def execute_run(spec: RunSpec) -> RunResult:
+    """Run one arm once, in a fresh directory, and record its manifest."""
+    arm, corpus = spec.arm, spec.corpus
+    run_dir = prepare_run_dir(
+        spec.workbench, spec.run_id, corpus, arm.name, spec.repeat
+    )
+    for src in sorted(spec.corpus_dir.glob("*.md")):
+        shutil.copy2(src, run_dir / "corpus" / src.name)
+
+    argv = arm.extract_args(run_dir / "corpus", run_dir / "out")
+    env = {**(OLLAMA_ENV if arm.backend == "ollama" else {}), **arm.env}
+
+    started = time.monotonic()
+    proc = _run(argv, cwd=run_dir, env=env)
+    elapsed = time.monotonic() - started
+
+    (run_dir / "stdout.log").write_text(proc.stdout, encoding="utf-8")
+    (run_dir / "stderr.log").write_text(proc.stderr, encoding="utf-8")
+
+    graph = load_graph(run_dir)
+    result = RunResult(
+        arm=arm.name,
+        corpus=corpus,
+        repeat=spec.repeat,
+        rc=proc.returncode,
+        nodes=len(graph.get("nodes", [])) if graph else 0,
+        edges=len(graph.get("links", graph.get("edges", []))) if graph else 0,
+        cross_doc=cross_doc_edges(graph) if graph else 0,
+        out_tokens=parse_out_tokens(proc.stdout),
+        seconds=elapsed,
+        run_dir=run_dir,
+    )
+    write_manifest(run_dir, spec, corpus_digest(spec.corpus_dir), result, argv)
+    return result
+
+
+def aggregate(results: Iterable[RunResult]) -> dict[str, Any]:
+    """Median + spread per metric. Spread is what makes a gap interpretable."""
+    runs = list(results)
+    if not runs:
+        return {}
+
+    def stat(vals: list[float]) -> dict[str, float]:
+        return {
+            "median": statistics.median(vals),
+            "min": min(vals),
+            "max": max(vals),
+            "spread": max(vals) - min(vals),
+        }
+
+    return {
+        "n": len(runs),
+        "ok": sum(1 for r in runs if r.ok),
+        "nodes": stat([r.nodes for r in runs]),
+        "edges": stat([r.edges for r in runs]),
+        "cross_doc": stat([r.cross_doc for r in runs]),
+        "out_tokens": stat([r.out_tokens for r in runs]),
+        "seconds": stat([r.seconds for r in runs]),
+    }
+
+
+def load_answer_key(corpus_dir: Path) -> dict[str, Any] | None:
+    """Load the corpus's answer key, when it has one (the gold corpus does)."""
+    path = corpus_dir / _ANSWER_KEY
+    if not path.is_file():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,12 @@
   "schedule": [
     "at any time"
   ],
-  "minimumReleaseAge": null,
+  "minimumReleaseAge": "1 hour",
+  "minimumReleaseAgeBehaviour": "timestamp-optional",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "minimumReleaseAge": "1 hour"
+  },
   "prConcurrentLimit": 20,
   "prHourlyLimit": 0,
   "packageRules": [

--- a/tests/test_graph_bakeoff.py
+++ b/tests/test_graph_bakeoff.py
@@ -1,0 +1,310 @@
+"""Tests for the graphify extraction bake-off harness.
+
+Each test maps to a specific finding from the 2026-07-20 audit that found the
+previous comparison unsound. The point is not coverage for its own sake — it is
+that the harness cannot regress into the same defects silently.
+
+Every negative assertion here is paired with a positive control arm, per
+``.claude/rules/probes-need-a-control-arm.md``: a test that can only pass is
+not a test.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
+
+from dotfiles_setup.graph_bakeoff import (
+    FIXED_FLAGS,
+    Arm,
+    corpus_digest,
+    cross_doc_edges,
+    match_entity,
+    normalize_label,
+    parse_out_tokens,
+    prepare_run_dir,
+    score_graph,
+)
+
+
+@pytest.fixture
+def corpus(tmp_path: Path) -> Path:
+    """A two-document corpus with one cross-document edge available."""
+    d = tmp_path / "gold"
+    d.mkdir()
+    (d / "a.md").write_text("# Alpha\nRookery stores partitions.\n", encoding="utf-8")
+    (d / "b.md").write_text("# Beta\nMagpie reads Rookery.\n", encoding="utf-8")
+    return d
+
+
+def _graph(nodes: list[dict[str, Any]], edges: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"nodes": nodes, "links": edges}
+
+
+# ---------------------------------------------------------------------------
+# The invariant the old bake-off violated: only (backend, model) may vary.
+# ---------------------------------------------------------------------------
+
+
+def test_every_arm_gets_byte_identical_fixed_flags(tmp_path: Path) -> None:
+    """Two different arms must differ ONLY in backend/model.
+
+    The audit's finding was that flags were unverified across the inherited
+    rows. A flag differing between arms turns one comparison into two unrelated
+    experiments, so this is the harness's core guarantee.
+    """
+    a = Arm("ollama-q25", "ollama", "qwen2.5-coder:14b")
+    b = Arm("gemini", "gemini", "gemini-3.1-flash-lite")
+
+    args_a = a.extract_args(tmp_path / "c", tmp_path / "o")
+    args_b = b.extract_args(tmp_path / "c", tmp_path / "o")
+
+    def tail(args: list[str]) -> list[str]:
+        return args[args.index("--out") :]
+
+    assert tail(args_a) == tail(args_b)
+    for flag in FIXED_FLAGS:
+        assert flag in args_a
+        assert flag in args_b
+
+    # Control arm: the parts that SHOULD differ actually do, so the equality
+    # above is not vacuous.
+    assert args_a != args_b
+    assert "qwen2.5-coder:14b" in args_a
+    assert "qwen2.5-coder:14b" not in args_b
+
+
+def test_arm_without_model_omits_the_flag(tmp_path: Path) -> None:
+    """A backend with no model override must not emit a bare --model."""
+    args = Arm("claude-cli", "claude-cli").extract_args(tmp_path / "c", tmp_path / "o")
+    assert "--model" not in args
+    # Control arm: it IS emitted when a model is given.
+    args_with = Arm("x", "ollama", "m:1b").extract_args(tmp_path / "c", tmp_path / "o")
+    assert "--model" in args_with
+
+
+# ---------------------------------------------------------------------------
+# "Same inputs" must be proven, not assumed.
+# ---------------------------------------------------------------------------
+
+
+def test_corpus_digest_detects_a_changed_document(corpus: Path) -> None:
+    """A one-byte corpus change must change the digest."""
+    before = corpus_digest(corpus)
+    assert set(before) == {"a.md", "b.md"}
+
+    (corpus / "a.md").write_text(
+        "# Alpha\nRookery stores PARTITIONS.\n", encoding="utf-8"
+    )
+    after = corpus_digest(corpus)
+
+    assert after["a.md"] != before["a.md"]
+    # Control arm: the untouched file's digest is stable, so the difference
+    # above is attributable to the edit rather than to nondeterminism.
+    assert after["b.md"] == before["b.md"]
+
+
+# ---------------------------------------------------------------------------
+# Cache isolation by construction (the model-blind cache).
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_run_dir_wipes_a_dirty_tree(tmp_path: Path) -> None:
+    """A pre-existing run dir must be destroyed, not reused.
+
+    graphify's semantic cache key carries no model identity, so a surviving
+    cache from a previous arm would be served to the next one silently.
+    """
+    first = prepare_run_dir(tmp_path, "run1", "gold", "armA", 1)
+    (first / "out").mkdir()
+    (first / "out" / "stale-cache.json").write_text("{}", encoding="utf-8")
+
+    second = prepare_run_dir(tmp_path, "run1", "gold", "armA", 1)
+
+    assert second == first
+    assert not (second / "out").exists()
+    assert (second / "corpus").is_dir()
+
+
+def test_each_arm_and_repeat_gets_a_distinct_path(tmp_path: Path) -> None:
+    """Distinct (arm, repeat) pairs must never collide on disk."""
+    paths = {
+        prepare_run_dir(tmp_path, "run1", "gold", arm, rep)
+        for arm in ("armA", "armB")
+        for rep in (1, 2, 3)
+    }
+    assert len(paths) == 6
+
+
+# ---------------------------------------------------------------------------
+# Metrics.
+# ---------------------------------------------------------------------------
+
+
+def test_cross_doc_edges_counts_by_source_file_not_by_id_shape() -> None:
+    """Cross-doc must be measured by source_file.
+
+    The id-splitting heuristic reported a false 15/15 for qwen2.5-coder (true
+    value 1) because models differ on whether ids carry a source-file prefix.
+    These nodes use BARE ids, which that heuristic could not have scored.
+    """
+    graph = _graph(
+        [
+            {"id": "rookery", "source_file": "a.md"},
+            {"id": "magpie", "source_file": "b.md"},
+            {"id": "partition", "source_file": "a.md"},
+        ],
+        [
+            {"source": "magpie", "target": "rookery"},  # cross-document
+            {"source": "rookery", "target": "partition"},  # same document
+        ],
+    )
+    assert cross_doc_edges(graph) == 1
+
+
+def test_cross_doc_edges_is_zero_for_a_single_document_graph() -> None:
+    """Control arm: a graph that cannot have cross-doc edges scores 0."""
+    graph = _graph(
+        [{"id": "x", "source_file": "a.md"}, {"id": "y", "source_file": "a.md"}],
+        [{"source": "x", "target": "y"}],
+    )
+    assert cross_doc_edges(graph) == 0
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        (
+            "[graphify extract] tokens: 5,697 in / 7,479 out, est. cost (~ollama): $0",
+            7479,
+        ),
+        ("[graphify extract] tokens: 1 in / 999 out", 999),
+        ("[graphify extract] graph is empty", 0),
+        ("", 0),
+    ],
+)
+def test_parse_out_tokens(line: str, expected: int) -> None:
+    """Token parsing, including the honest 0 for a run that never summarised."""
+    assert parse_out_tokens(line) == expected
+
+
+def test_normalize_label_folds_case_and_punctuation() -> None:
+    assert normalize_label("Cold-Tier!") == normalize_label("cold tier")
+    # Control arm: genuinely different labels stay different.
+    assert normalize_label("Rookery") != normalize_label("Rookwood")
+
+
+# ---------------------------------------------------------------------------
+# Scoring against the answer key.
+# ---------------------------------------------------------------------------
+
+
+KEY = {
+    "entities": {
+        "rookery": {"aliases": ["Rookery"]},
+        "magpie": {"aliases": ["Magpie"]},
+        "rookwood": {"aliases": ["Rookwood"]},
+    },
+    "expected_links": [{"id": "L2", "a": "magpie", "b": "rookery"}],
+    "forbidden_links": [{"id": "F1", "a": "rookery", "b": "rookwood"}],
+}
+
+
+def test_score_credits_an_expected_link_and_flags_a_decoy() -> None:
+    """A graph asserting both the real link and the decoy scores 1.0 / 0.0."""
+    graph = _graph(
+        [
+            {"id": "n1", "label": "Rookery", "source_file": "a.md"},
+            {"id": "n2", "label": "Magpie", "source_file": "b.md"},
+            {"id": "n3", "label": "Rookwood", "source_file": "a.md"},
+        ],
+        [
+            {"source": "n2", "target": "n1"},  # L2 — correct
+            {"source": "n1", "target": "n3"},  # F1 — lexical decoy
+        ],
+    )
+    score = score_graph(graph, KEY)
+    assert score.recall == 1.0
+    assert score.forbidden_hits == ["F1"]
+    assert score.decoy_resistance == 0.0
+
+
+def test_score_rewards_a_graph_that_avoids_the_decoy() -> None:
+    """Control arm: omitting the decoy edge yields full decoy resistance."""
+    graph = _graph(
+        [
+            {"id": "n1", "label": "Rookery", "source_file": "a.md"},
+            {"id": "n2", "label": "Magpie", "source_file": "b.md"},
+            {"id": "n3", "label": "Rookwood", "source_file": "a.md"},
+        ],
+        [{"source": "n2", "target": "n1"}],
+    )
+    score = score_graph(graph, KEY)
+    assert score.recall == 1.0
+    assert score.forbidden_hits == []
+    assert score.decoy_resistance == 1.0
+
+
+def test_score_reports_misses_rather_than_silently_passing() -> None:
+    """An empty graph must score 0 recall and name the missed link."""
+    score = score_graph(_graph([], []), KEY)
+    assert score.recall == 0.0
+    assert score.recall_misses == ["L2"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #327 — the entity matcher is an OPEN decision. These tests pin the
+# placeholder's current behaviour so the change is visible when it lands.
+# ---------------------------------------------------------------------------
+
+
+def test_matcher_placeholder_matches_an_exact_alias() -> None:
+    assert match_entity("Cold Tier", ["cold tier", "frost storage"])
+    assert not match_entity("Mockingbird", ["cold tier", "frost storage"])
+
+
+def test_matcher_placeholder_is_strict_and_that_is_the_open_question() -> None:
+    """Documents the strictness trade-off recorded in issue #327.
+
+    The placeholder rejects a MORE descriptive label, which penalises better
+    extraction. Whatever replaces it must decide this deliberately — hence the
+    issue rather than a silent default.
+    """
+    assert not match_entity("Rookery storage layer", ["Rookery"])
+
+
+def test_matcher_must_not_let_a_title_node_match_two_entities() -> None:
+    """The hazard a looser matcher would introduce (issue #327).
+
+    'Magpie vs Mockingbird' is a real document-title node. If the matcher used
+    substring containment it would match BOTH alias sets, and the scorer would
+    manufacture a forbidden F2 edge the model never asserted. The placeholder
+    is strict, so it does not — this test locks that property in ahead of the
+    matcher being replaced.
+    """
+    title = "Magpie vs Mockingbird"
+    assert not (
+        match_entity(title, ["Magpie"]) and match_entity(title, ["Mockingbird"])
+    )
+
+
+def test_answer_key_shape_is_validated_before_scoring() -> None:
+    """A key naming an undeclared entity must fail loudly, not score as 0.
+
+    Deliberately exercised against an inline fixture rather than the shipped
+    gold key: that file lives in the out-of-repo workbench by design, so a test
+    reading it would SKIP in CI — and a check that never executes is not a
+    check.
+    """
+    broken = {
+        "entities": {"rookery": {"aliases": ["Rookery"]}},
+        "expected_links": [{"id": "L9", "a": "magpie", "b": "rookery"}],
+        "forbidden_links": [],
+    }
+    with pytest.raises(KeyError):
+        score_graph(_graph([], []), broken)


### PR DESCRIPTION
- **chore(renovate): default minimumReleaseAge to 1 hour, timestamp-optional**
- **docs(graphify): gemma issue sweep + claude-cli backend is broken**
- **feat(bakeoff): repeatable graphify extraction harness — core + gold corpus**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a repeatable extraction bake-off harness for comparing backends and models.
  * Added graph scoring for expected links, missed links, and decoy resistance.
  * Added run manifests with corpus, configuration, metrics, and outcome details.

* **Documentation**
  * Added reports covering Gemma compatibility, Ollama behavior, extraction findings, and model bake-off results.
  * Documented limitations affecting local embedding and Claude CLI extraction workflows.

* **Tests**
  * Added regression coverage for bake-off setup, graph metrics, scoring, corpus changes, and validation.

* **Chores**
  * Added a one-hour minimum release age for dependency updates and lockfile maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->