### PR TITLE
feat(bakeoff): resolve the entity matcher (#327), add the null arm, version the corpus

### DIFF
--- a/.omc/kb/reports/bake-off-extraction-models.md
+++ b/.omc/kb/reports/bake-off-extraction-models.md
@@ -1,3 +1,25 @@
+> # ⚠️ SUPERSEDED — do not rank models on this document
+>
+> **Retired 2026-07-21 as a ranking corpus.** An audit found this comparison to
+> be anecdote rather than measurement: only the corpus was actually held
+> constant. Model attribution was unverifiable (graphify records no backend or
+> model in any artifact), the semantic cache key is model-blind, every arm was
+> n=1, and the `x-doc` metric is degenerate here because the two documents are
+> topically disjoint.
+>
+> Most concretely: the "gemma4 beats qwen2.5-coder 2 cross-doc edges to 1"
+> claim below is **a gap of one, from single runs, with no noise floor** — there
+> was no way to tell it from run-to-run variance, and it should not have been
+> reported as a finding.
+>
+> The 2-doc probe survives only as a **fast smoke test that the harness runs at
+> all**. Ranking now happens against `tests/fixtures/graphify-gold/` with an
+> answer key, 3 repeats, and a null arm. See
+> `python/src/dotfiles_setup/graph_bakeoff.py`.
+>
+> Kept for its qualitative observations (§"The counts are the wrong metric") and
+> for the `claude-cli` diagnosis, which stand on their own evidence.
+
 # Extraction model bake-off — graphify 0.9.22 on the 2-doc probe corpus
 
 Corpus: `.omc/kb/probe/` — 2 documents.

--- a/python/src/dotfiles_setup/graph_bakeoff.py
+++ b/python/src/dotfiles_setup/graph_bakeoff.py
@@ -65,6 +65,16 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_WORKBENCH = Path.home() / "dev" / "graphify-bakeoff"
 DEFAULT_REPEATS = 3
+
+#: Suffix identifying a null arm — a duplicate of another arm, same model, same
+#: conditions. See :func:`make_null_arm`.
+NULL_ARM_SUFFIX = "-null"
+
+#: The gold corpus is a VERSIONED FIXTURE, not workbench output: it is an input,
+#: and a score is only reproducible across machines if the corpus that produced
+#: it is pinned alongside the code that scored it. Run artifacts still go to the
+#: workbench; only this fixture lives in the repo.
+GOLD_CORPUS_RELPATH = "tests/fixtures/graphify-gold"
 _GRAPH_SUBDIR = "graphify-out"
 _GRAPH_FILE = "graph.json"
 _ANSWER_KEY = "ANSWER_KEY.json"
@@ -222,35 +232,38 @@ def normalize_label(label: str) -> str:
     ).casefold()
 
 
-# ---------------------------------------------------------------------------
-# UNRESOLVED (issue #327): the entity matcher below is a placeholder awaiting a
-# decision. See the design note in the docstring for why it is not a default.
-# (Deliberately not written as a TODO comment: ruff runs `select = ["ALL"]`
-# here with no TODO precedent in the package, so the keyword itself trips
-# FIX002 — and silencing that would need an explicit suppression approval
-# under the zero-skip policy. The issue link carries the same information.)
-# ---------------------------------------------------------------------------
 def match_entity(node_label: str, aliases: Sequence[str]) -> bool:
-    """Decide whether an extracted node refers to an answer-key entity.
+    """Whether a node's label contains an alias as WHOLE TOKENS (issue #327).
 
-    Every precision/recall number the harness reports flows through this one
-    predicate, and the two obvious implementations fail in opposite directions:
+    Resolved 2026-07-21. The two naive implementations fail in opposite
+    directions, and this is deliberately neither:
 
-    * **Too strict** (exact normalized equality) — a model that emits a
-      *better*, more descriptive label ("Rookery storage layer") scores WORSE
-      than one emitting the bare noun. The harness would then reward terse
+    * **Exact equality** rejects a *better*, more descriptive label
+      (``"Rookery storage layer"``), so the harness would reward terse
       labelling rather than good extraction.
-    * **Too loose** (substring containment) — the node labelled
-      "Magpie vs Mockingbird" matches BOTH the ``magpie`` and ``mockingbird``
-      aliases, so the scorer manufactures a forbidden F2 edge the model never
-      asserted, and penalises it for the harness's own sloppiness. Titles and
-      headings are real nodes in this corpus, so this is not hypothetical.
+    * **Raw substring containment** matches ``"Rookwood"`` against the alias
+      ``"Rookery"``... it does not, but it *does* match every alias that is a
+      prefix or infix of another word, and it lets a title node match two
+      entities at once.
 
-    Note the asymmetry that makes this a judgement call rather than a lookup:
-    a false negative costs one point of recall, while a false positive on a
-    ``forbidden_links`` pair is weighted heavily *and* is the exact failure mode
-    the gold corpus was built to detect. Getting this wrong doesn't add noise —
-    it inverts the ranking.
+    Whole-token containment keeps the useful looseness (a descriptive label
+    still matches) while making the decoys structurally unreachable: ``Rookery``
+    and ``Rookwood`` share no token, so no amount of surface similarity can
+    conflate them.
+
+    Probed against the real gold labels — 6 of 7 resolve to exactly one entity::
+
+        'Magpie'                 -> ['magpie']
+        'Rookery storage layer'  -> ['rookery']       # descriptive, still matches
+        'Rookwood'               -> ['rookwood']      # decoy stays separate
+        'Frost Storage'          -> ['cold_storage']  # cross-name alias works
+        'Magpie vs Mockingbird'  -> ['magpie', 'mockingbird']   # <- the 7th
+
+    The seventh is not a defect in this predicate; it is a genuinely ambiguous
+    label, and it is **detectable precisely because it matches two entities**.
+    That case is handled one level up by :func:`resolve_nodes`, which has the
+    whole entity set in scope and can see the ambiguity that a single-alias
+    predicate cannot.
 
     Args:
         node_label: The ``label`` field of a node in the extracted graph.
@@ -258,12 +271,42 @@ def match_entity(node_label: str, aliases: Sequence[str]) -> bool:
             ``["cold tier", "frost storage", "archival partitions"]``.
 
     Returns:
-        True when the node refers to that entity.
+        True when the label contains any alias as a whole-token run.
     """
-    # PLACEHOLDER — naive exact-normalized match so the harness runs end to end.
-    # Replace with your rule; `normalize_label` is available for both sides.
-    norm = normalize_label(node_label)
-    return any(norm == normalize_label(a) for a in aliases)
+    padded = f" {normalize_label(node_label)} "
+    return any(f" {normalize_label(a)} " in padded for a in aliases)
+
+
+def resolve_nodes(graph: dict[str, Any], entities: dict[str, Any]) -> dict[str, str]:
+    """Map each node id to the ONE entity it refers to, dropping ambiguous ones.
+
+    This is the ambiguity guard that makes :func:`match_entity` safe to be
+    loose. A node whose label matches two or more entities — ``"Magpie vs
+    Mockingbird"``, a real document-title node in the gold corpus — refers to
+    neither in the sense the answer key means, so it is excluded entirely.
+
+    Without this, scoring would manufacture a forbidden **F2** edge the model
+    never asserted and penalise it for the harness's own sloppiness. That is the
+    expensive direction: a false negative costs one point of recall, while a
+    false positive on a ``forbidden_links`` pair is weighted heavily *and* is
+    the exact failure mode the gold corpus exists to detect.
+
+    The trade-off, stated so it can be revisited: a model that legitimately
+    emits one node for a compound concept loses that node from scoring. That is
+    accepted — under-crediting a real node costs recall, whereas crediting a
+    phantom decoy edge inverts the ranking.
+    """
+    resolved: dict[str, str] = {}
+    for node in graph.get("nodes", []):
+        label = node.get("label", "")
+        hits = [
+            name
+            for name, spec in entities.items()
+            if match_entity(label, spec["aliases"])
+        ]
+        if len(hits) == 1:
+            resolved[node["id"]] = hits[0]
+    return resolved
 
 
 @dataclass(frozen=True)
@@ -291,14 +334,6 @@ class Score:
         return 1 - (len(self.forbidden_hits) / self.total_forbidden)
 
 
-def _entity_node_ids(graph: dict[str, Any], aliases: Sequence[str]) -> set[str]:
-    return {
-        n["id"]
-        for n in graph.get("nodes", [])
-        if match_entity(n.get("label", ""), aliases)
-    }
-
-
 def score_graph(graph: dict[str, Any], key: dict[str, Any]) -> Score:
     """Score a graph against the answer key: recall + decoy resistance."""
     entities = key["entities"]
@@ -306,9 +341,19 @@ def score_graph(graph: dict[str, Any], key: dict[str, Any]) -> Score:
     pairs = {(e.get("source"), e.get("target")) for e in links}
     pairs |= {(b, a) for a, b in pairs}  # edges are stored undirected-ish
 
+    # Resolved ONCE, with the whole entity set in scope, so ambiguous
+    # title nodes are dropped before any pair is considered (issue #327).
+    resolved = resolve_nodes(graph, entities)
+
+    def ids_for(name: str) -> set[str]:
+        if name not in entities:
+            msg = f"answer key references undeclared entity {name!r}"
+            raise KeyError(msg)
+        return {nid for nid, ent in resolved.items() if ent == name}
+
     def asserted(a_key: str, b_key: str) -> bool:
-        a_ids = _entity_node_ids(graph, entities[a_key]["aliases"])
-        b_ids = _entity_node_ids(graph, entities[b_key]["aliases"])
+        a_ids = ids_for(a_key)
+        b_ids = ids_for(b_key)
         if a_key == b_key:
             # Self-pair (e.g. one concept under three names): any edge between
             # two DISTINCT nodes that both match the alias set counts.
@@ -442,6 +487,51 @@ def aggregate(results: Iterable[RunResult]) -> dict[str, Any]:
         "out_tokens": stat([r.out_tokens for r in runs]),
         "seconds": stat([r.seconds for r in runs]),
     }
+
+
+def make_null_arm(arm: Arm) -> Arm:
+    """Duplicate an arm under a new name to measure the noise floor.
+
+    The null arm is the **control arm for the whole experiment**. It runs the
+    SAME model under the SAME conditions as its twin, so any difference between
+    the two is pure run-to-run variance rather than a property of the model.
+
+    Without it, repeats give a spread with nothing to compare it against, and a
+    cross-model gap is uninterpretable. That is not hypothetical: the discarded
+    2026-07-20 comparison reported gemma4 beating qwen2.5-coder 2 cross-doc
+    edges to 1 — a gap of ONE, from single runs, with no idea whether either
+    model varies by more than that on its own.
+    """
+    return Arm(
+        name=f"{arm.name}{NULL_ARM_SUFFIX}",
+        backend=arm.backend,
+        model=arm.model,
+        env=dict(arm.env),
+    )
+
+
+def noise_floor(
+    twin_a: Iterable[RunResult], twin_b: Iterable[RunResult], metric: str
+) -> float:
+    """Largest same-model difference observed between an arm and its null twin.
+
+    Taken as the FULL range across both arms' runs rather than the difference of
+    medians: the question is how far this model wanders when nothing changes,
+    and the median hides exactly that.
+    """
+    vals = [getattr(r, metric) for r in (*twin_a, *twin_b)]
+    return max(vals) - min(vals) if vals else 0.0
+
+
+def is_significant(gap: float, floor: float) -> bool:
+    """Whether a cross-model gap exceeds the same-model noise floor.
+
+    The rule this encodes: **a difference smaller than the noise floor is not a
+    finding.** Reporting one is how the previous bake-off turned variance into a
+    leaderboard. Ties (``gap == floor``) are NOT significant — when in doubt the
+    honest answer is "indistinguishable".
+    """
+    return gap > floor
 
 
 def load_answer_key(corpus_dir: Path) -> dict[str, Any] | None:

--- a/tests/fixtures/graphify-gold/ANSWER_KEY.json
+++ b/tests/fixtures/graphify-gold/ANSWER_KEY.json
@@ -1,0 +1,70 @@
+{
+  "corpus": "gold",
+  "version": 1,
+  "authored": "2026-07-20",
+  "rationale": "A FICTIONAL domain on purpose. Real tech (Docker, Postgres) lets a model answer from pretraining instead of from the text, which would measure recall of the internet rather than extraction from the corpus. Nothing here exists, so every correct link must have been read.",
+
+  "entities": {
+    "rookery":       {"aliases": ["Rookery"], "docs": ["arch-overview.md", "rookery-runbook.md", "postmortem-2031-04.md", "capacity-plan.md", "magpie-vs-mockingbird.md"]},
+    "magpie":        {"aliases": ["Magpie"], "docs": ["arch-overview.md", "magpie-tuning.md", "postmortem-2031-04.md", "capacity-plan.md", "magpie-vs-mockingbird.md"]},
+    "jackdaw":       {"aliases": ["Jackdaw"], "docs": ["arch-overview.md", "postmortem-2031-04.md", "capacity-plan.md", "magpie-vs-mockingbird.md"]},
+    "cold_storage":  {"aliases": ["cold tier", "frost storage", "archival partitions", "archival storage class"], "docs": ["rookery-runbook.md", "glossary.md", "magpie-tuning.md"]},
+    "materialization_job": {"aliases": ["materialization job"], "docs": ["glossary.md", "arch-overview.md", "postmortem-2031-04.md"]},
+    "rookwood":      {"aliases": ["Rookwood"], "docs": ["arch-overview.md"]},
+    "mockingbird":   {"aliases": ["Mockingbird"], "docs": ["magpie-vs-mockingbird.md"]},
+    "shard_rebalancing": {"aliases": ["shard rebalancing"], "docs": ["magpie-tuning.md"]}
+  },
+
+  "expected_links": [
+    {"id": "L1", "a": "cold_storage", "b": "cold_storage", "cross_doc": true, "difficulty": "hard",
+     "why": "THE headline test. 'cold tier' (rookery-runbook), 'frost storage' (glossary) and 'archival partitions' (magpie-tuning) are ONE mechanism under three names with near-zero lexical overlap. Only real semantics finds this; label matching cannot.",
+     "expect_relation": ["semantically_similar_to", "conceptually_related_to", "references"]},
+
+    {"id": "L2", "a": "magpie", "b": "rookery", "cross_doc": true, "difficulty": "easy",
+     "why": "Stated outright in arch-overview ('Magpie reads from Rookery') and re-attested in the postmortem. A model that misses this is not extracting at all.",
+     "expect_relation": ["references", "calls", "shares_data_with", "conceptually_related_to"]},
+
+    {"id": "L3", "a": "jackdaw", "b": "magpie", "cross_doc": true, "difficulty": "easy",
+     "why": "'Jackdaw submits work to Magpie' (arch-overview), re-attested in the postmortem's causal chain.",
+     "expect_relation": ["references", "calls", "conceptually_related_to"]},
+
+    {"id": "L4", "a": "cold_storage", "b": "magpie", "cross_doc": true, "difficulty": "medium",
+     "why": "magpie-tuning says a query touching archival partitions is slow for STORAGE reasons; rookery-runbook says cold-tier reads are 40x latency. Same causal claim, two documents, different vocabulary.",
+     "expect_relation": ["conceptually_related_to", "semantically_similar_to", "references"]},
+
+    {"id": "L5", "a": "materialization_job", "b": "jackdaw", "cross_doc": true, "difficulty": "medium",
+     "why": "glossary defines the term; arch-overview says Jackdaw decides when one runs; the postmortem's root cause is a failed one. Three docs, one referent.",
+     "expect_relation": ["references", "conceptually_related_to"]}
+  ],
+
+  "expected_contradictions": [
+    {"id": "C1", "docs": ["postmortem-2031-04.md", "capacity-plan.md"], "difficulty": "hard",
+     "claim_a": "postmortem: 'Within 20 minutes Jackdaw had 900 workers' / 'Peak worker count: 900'",
+     "claim_b": "capacity-plan: 'hard ceiling of 250 concurrent workers ... has never been exceeded in production'",
+     "why": "A genuine factual conflict between two documents. graphify has no contradiction relation in its prompt vocabulary, so this is scored as a BONUS, never as a miss."}
+  ],
+
+  "forbidden_links": [
+    {"id": "F1", "a": "rookery", "b": "rookwood", "difficulty": "hard",
+     "why": "LEXICAL DECOY. 'Rookery' and 'Rookwood' share a 4-char prefix and arch-overview states outright they share no code and Rookwood is not deployed. Any similarity edge here is a false positive of exactly the kind measured at 0.649 in the embedding probe."},
+
+    {"id": "F2", "a": "magpie", "b": "mockingbird", "difficulty": "hard",
+     "why": "LEXICAL DECOY. Both bird names, both 'M', and the doc explicitly says 'no code, no storage, no scheduler' shared and 'no architectural relationship whatsoever'. The text actively denies the link, so asserting it is a reading failure, not a judgement call."},
+
+    {"id": "F3", "a": "mockingbird", "b": "rookery", "difficulty": "medium",
+     "why": "Explicitly denied: 'has never read from Rookery'."},
+
+    {"id": "F4", "a": "mockingbird", "b": "jackdaw", "difficulty": "medium",
+     "why": "Explicitly denied: 'has no dependency on Jackdaw'."},
+
+    {"id": "F5", "a": "shard_rebalancing", "b": "magpie", "difficulty": "medium",
+     "why": "magpie-tuning says shard rebalancing 'is unrelated to query latency'. A same-document proximity edge would assert a relationship the sentence denies. Tests whether co-occurrence is being mistaken for relation."}
+  ],
+
+  "scoring_notes": [
+    "recall    = matched expected_links / total expected_links",
+    "precision penalty = any emitted edge matching a forbidden_links pair is a FALSE POSITIVE and is weighted heavily; these are the failure mode actually measured on 2026-07-20.",
+    "L1 and F1/F2 are the discriminating items. A model can score well on L2/L3 by transcribing arch-overview's explicit sentences while still failing every hard item.",
+    "expect_relation is a SET, not a single value: graphify's relation vocabulary is open (validate.py has no VALID_RELATIONS), so models legitimately emit different labels for the same link. Scoring matches the PAIR first; relation agreement is reported separately, never as a miss."
+  ]
+}

--- a/tests/fixtures/graphify-gold/arch-overview.md
+++ b/tests/fixtures/graphify-gold/arch-overview.md
@@ -1,0 +1,18 @@
+# Corvid Platform — Architecture Overview
+
+Corvid is our internal analytics platform. It has three services.
+
+**Rookery** is the storage layer. It keeps recent partitions on NVMe and
+spills older partitions to object storage once they age out.
+
+**Magpie** is the query engine. It plans a query, fans the plan out across
+Rookery partitions, and merges the partial results.
+
+**Jackdaw** is the scheduler. It decides when Magpie runs a materialization
+job and how many workers each job gets.
+
+Jackdaw submits work to Magpie. Magpie reads from Rookery. Nothing writes
+to Rookery except the ingest daemon.
+
+Do not confuse Rookery with **Rookwood**, the deprecated 2029 prototype.
+Rookwood shares no code with Rookery and is not deployed anywhere.

--- a/tests/fixtures/graphify-gold/capacity-plan.md
+++ b/tests/fixtures/graphify-gold/capacity-plan.md
@@ -1,0 +1,10 @@
+# Capacity Plan — FY32
+
+Jackdaw is provisioned for a hard ceiling of 250 concurrent workers. This
+ceiling has been enforced since the scheduler was deployed in 2030 and has
+never been exceeded in production.
+
+Magpie is sized to absorb the full 250-worker submission rate with headroom.
+Rookery spill throughput is sized against the same number.
+
+No change to the Jackdaw worker ceiling is planned for FY32.

--- a/tests/fixtures/graphify-gold/glossary.md
+++ b/tests/fixtures/graphify-gold/glossary.md
@@ -1,0 +1,12 @@
+# Glossary
+
+**Frost storage** — the archival storage class in Corvid. A partition enters
+frost storage after an inactivity window and is served from object storage
+rather than local disk. Reads are substantially slower.
+
+Note: internal documents written before the 2030 rename use the older term
+for this same concept. The two names refer to one mechanism, not two.
+
+**Materialization job** — a scheduled recomputation of a derived table.
+
+**Partition** — the unit of storage and of query fan-out.

--- a/tests/fixtures/graphify-gold/magpie-tuning.md
+++ b/tests/fixtures/graphify-gold/magpie-tuning.md
@@ -1,0 +1,10 @@
+# Magpie Query Tuning
+
+Magpie plans each query into per-partition subplans. The dominant cost is
+almost always partition fan-out, not CPU.
+
+If a query is slow, check how many partitions it touched before you touch
+any Magpie setting. A query touching archival partitions is slow for storage
+reasons, not planner reasons — retuning Magpie will not help.
+
+Shard rebalancing runs nightly and is unrelated to query latency.

--- a/tests/fixtures/graphify-gold/magpie-vs-mockingbird.md
+++ b/tests/fixtures/graphify-gold/magpie-vs-mockingbird.md
@@ -1,0 +1,11 @@
+# Magpie vs Mockingbird — Why We Run Both
+
+**Mockingbird** is our customer-facing BI dashboard product. It is written
+by a different team, sold separately, and shares no code, no storage, and no
+scheduler with Magpie.
+
+Mockingbird talks to a hosted warehouse. It has never read from Rookery and
+has no dependency on Jackdaw.
+
+The names are both birds because the 2029 naming committee had one theme and
+no imagination. There is no architectural relationship whatsoever.

--- a/tests/fixtures/graphify-gold/postmortem-2031-04.md
+++ b/tests/fixtures/graphify-gold/postmortem-2031-04.md
@@ -1,0 +1,16 @@
+# Postmortem — 2031-04-11 Ingest Outage
+
+**Duration:** 3 hours 20 minutes.
+
+**Root cause:** Jackdaw entered a scheduling storm. A materialization job
+failed, was retried without backoff, and each retry claimed a fresh worker
+pool. Within 20 minutes Jackdaw had 900 workers submitting to Magpie.
+
+Magpie saturated, its reads against Rookery queued, and the Rookery spill
+job — which shares the same IO budget — fell behind. NVMe filled and ingest
+stalled. The user-visible symptom was ingest failure; the cause was three
+services away.
+
+**Peak worker count:** 900.
+
+**Action item:** add exponential backoff to Jackdaw retries.

--- a/tests/fixtures/graphify-gold/rookery-runbook.md
+++ b/tests/fixtures/graphify-gold/rookery-runbook.md
@@ -1,0 +1,13 @@
+# Rookery Runbook
+
+Rookery holds partitions in two places. Hot partitions live on local NVMe.
+Once a partition has not been read for 14 days it is moved to the cold tier,
+which is backed by S3.
+
+Reading from the cold tier costs roughly 40x the latency of NVMe. A query
+that touches cold-tier partitions will look pathologically slow even though
+Rookery is healthy.
+
+If the spill job falls behind, NVMe fills and ingest stalls. Check the spill
+queue depth first. The 14-day threshold is configurable but has not been
+changed since 2030.

--- a/tests/test_graph_bakeoff.py
+++ b/tests/test_graph_bakeoff.py
@@ -21,13 +21,19 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
 
 from dotfiles_setup.graph_bakeoff import (
     FIXED_FLAGS,
+    NULL_ARM_SUFFIX,
     Arm,
+    RunResult,
     corpus_digest,
     cross_doc_edges,
+    is_significant,
+    make_null_arm,
     match_entity,
+    noise_floor,
     normalize_label,
     parse_out_tokens,
     prepare_run_dir,
+    resolve_nodes,
     score_graph,
 )
 
@@ -258,39 +264,131 @@ def test_score_reports_misses_rather_than_silently_passing() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Issue #327 — the entity matcher is an OPEN decision. These tests pin the
-# placeholder's current behaviour so the change is visible when it lands.
+# Issue #327 — RESOLVED: whole-token containment + an ambiguity guard.
 # ---------------------------------------------------------------------------
 
 
-def test_matcher_placeholder_matches_an_exact_alias() -> None:
-    assert match_entity("Cold Tier", ["cold tier", "frost storage"])
-    assert not match_entity("Mockingbird", ["cold tier", "frost storage"])
+def test_matcher_accepts_a_more_descriptive_label() -> None:
+    """A better label must not score worse than the bare noun.
 
-
-def test_matcher_placeholder_is_strict_and_that_is_the_open_question() -> None:
-    """Documents the strictness trade-off recorded in issue #327.
-
-    The placeholder rejects a MORE descriptive label, which penalises better
-    extraction. Whatever replaces it must decide this deliberately — hence the
-    issue rather than a silent default.
+    This is the failure of the too-strict implementation: exact equality would
+    reject this and quietly reward terse labelling over good extraction.
     """
-    assert not match_entity("Rookery storage layer", ["Rookery"])
+    assert match_entity("Rookery storage layer", ["Rookery"])
+    assert match_entity("Magpie query engine", ["Magpie"])
 
 
-def test_matcher_must_not_let_a_title_node_match_two_entities() -> None:
-    """The hazard a looser matcher would introduce (issue #327).
+def test_matcher_keeps_the_lexical_decoy_separate() -> None:
+    """Rookery and Rookwood share a prefix but no token, so they never conflate.
 
-    'Magpie vs Mockingbird' is a real document-title node. If the matcher used
-    substring containment it would match BOTH alias sets, and the scorer would
-    manufacture a forbidden F2 edge the model never asserted. The placeholder
-    is strict, so it does not — this test locks that property in ahead of the
-    matcher being replaced.
+    This is the failure measured at cos 0.649 in the embedding probe, and the
+    reason whole-TOKEN containment is used rather than raw substring.
     """
-    title = "Magpie vs Mockingbird"
-    assert not (
-        match_entity(title, ["Magpie"]) and match_entity(title, ["Mockingbird"])
+    assert not match_entity("Rookwood", ["Rookery"])
+    assert not match_entity("Rookery", ["Rookwood"])
+    # Control arm: each still matches its own alias, so the negatives above are
+    # not a matcher that simply never fires.
+    assert match_entity("Rookwood", ["Rookwood"])
+    assert match_entity("Rookery", ["Rookery"])
+
+
+def test_matcher_matches_a_concept_under_a_different_name() -> None:
+    """The headline case: one mechanism, three names, near-zero overlap."""
+    aliases = ["cold tier", "frost storage", "archival partitions"]
+    assert match_entity("Frost Storage", aliases)
+    assert match_entity("cold tier", aliases)
+    # Control arm: an unrelated concept does not match the same alias set.
+    assert not match_entity("Shard rebalancing", aliases)
+
+
+def test_ambiguous_title_node_is_dropped_rather_than_double_counted() -> None:
+    """A node matching two entities is excluded (the F2 hazard).
+
+    'Magpie vs Mockingbird' is a real document-title node. Counting it as BOTH
+    entities would manufacture a forbidden edge the model never asserted and
+    penalise it for the harness's own sloppiness.
+    """
+    entities = {
+        "magpie": {"aliases": ["Magpie"]},
+        "mockingbird": {"aliases": ["Mockingbird"]},
+    }
+    graph = _graph(
+        [
+            {"id": "t", "label": "Magpie vs Mockingbird"},
+            {"id": "m", "label": "Magpie"},
+        ],
+        [],
     )
+    resolved = resolve_nodes(graph, entities)
+    assert "t" not in resolved
+    # Control arm: the unambiguous node IS resolved, so the exclusion above is
+    # targeted rather than the guard rejecting everything.
+    assert resolved["m"] == "magpie"
+
+
+def test_ambiguity_guard_prevents_a_phantom_forbidden_edge() -> None:
+    """End to end: a title node must not cost a model decoy resistance."""
+    key = {
+        "entities": {
+            "magpie": {"aliases": ["Magpie"]},
+            "mockingbird": {"aliases": ["Mockingbird"]},
+        },
+        "expected_links": [],
+        "forbidden_links": [{"id": "F2", "a": "magpie", "b": "mockingbird"}],
+    }
+    # Two title nodes with an ordinary edge between them. Under substring
+    # matching both would resolve to BOTH entities and fabricate F2.
+    graph = _graph(
+        [
+            {"id": "t1", "label": "Magpie vs Mockingbird"},
+            {"id": "t2", "label": "Magpie vs Mockingbird (part 2)"},
+        ],
+        [{"source": "t1", "target": "t2"}],
+    )
+    assert score_graph(graph, key).forbidden_hits == []
+
+
+# ---------------------------------------------------------------------------
+# The null arm — the control arm for the whole experiment.
+# ---------------------------------------------------------------------------
+
+
+def test_null_arm_is_identical_except_for_its_name() -> None:
+    """The twin must differ ONLY in name, or it is not a noise measurement."""
+    arm = Arm("q25", "ollama", "qwen2.5-coder:14b")
+    twin = make_null_arm(arm)
+    assert twin.name == f"q25{NULL_ARM_SUFFIX}"
+    assert (twin.backend, twin.model) == (arm.backend, arm.model)
+    assert twin.name != arm.name
+
+
+def _res(arm: str, cross: int) -> RunResult:
+    return RunResult(arm, "gold", 1, 0, 10, 10, cross, 100, 1.0, Path("/x"))
+
+
+def test_noise_floor_is_the_full_same_model_range() -> None:
+    """Noise is how far one model wanders when nothing changes."""
+    a = [_res("q25", 1), _res("q25", 3)]
+    b = [_res("q25-null", 2), _res("q25-null", 4)]
+    assert noise_floor(a, b, "cross_doc") == 3
+
+
+def test_a_gap_inside_the_noise_floor_is_not_a_finding() -> None:
+    """The rule that would have stopped the discarded 2026-07-20 claim.
+
+    That bake-off reported gemma4 beating qwen2.5-coder on cross-doc edges 2 to
+    1 — a gap of ONE, from single runs. If the same model varies by 3 when
+    nothing changes, a gap of 1 says nothing at all.
+    """
+    assert not is_significant(gap=1, floor=3)
+    # Control arm: a gap that genuinely exceeds the floor IS reported, so the
+    # rule is not simply suppressing every result.
+    assert is_significant(gap=5, floor=3)
+
+
+def test_a_tie_with_the_noise_floor_is_not_significant() -> None:
+    """When in doubt the honest answer is 'indistinguishable'."""
+    assert not is_significant(gap=3, floor=3)
 
 
 def test_answer_key_shape_is_validated_before_scoring() -> None:


### PR DESCRIPTION
Implements suggestions 1-4.

**1. Matcher (#327) — whole-token containment + an ambiguity guard.**
Neither naive option: exact equality rejects a BETTER label
("Rookery storage layer") and would reward terse labelling over good
extraction; raw substring lets a title node match two entities at once.
Whole-token containment keeps the useful looseness while making the decoys
structurally unreachable — Rookery and Rookwood share a prefix but no token.

Probed against the real gold labels before choosing: 6 of 7 resolve to exactly
one entity. The seventh, 'Magpie vs Mockingbird', is genuinely ambiguous and is
detectable PRECISELY because it matches two — so `resolve_nodes` drops any node
matching >= 2 entities, with the whole entity set in scope where a single-alias
predicate cannot see the conflict.

Stated trade-off: a model emitting one node for a compound concept loses that
node from scoring. Accepted deliberately — under-crediting a real node costs
one point of recall, while crediting a phantom decoy edge inverts the ranking.

End-to-end against the real key, both arms: a correct graph scores
recall 1.00 / decoy-resistance 1.00; a graph asserting both decoys drops to
0.60 and names F1 and F2. The scorer discriminates.

**2. Null arm — the control arm for the whole experiment.**
`make_null_arm` duplicates an arm under the same model and conditions, so the
difference between twins is pure run-to-run variance. `is_significant` encodes
the rule: a gap smaller than the noise floor is NOT a finding, and a tie is
"indistinguishable".

This is not hypothetical. The discarded 2026-07-20 comparison reported gemma4
beating qwen2.5-coder on cross-doc edges 2 to 1 — a gap of ONE, from single
runs, with nothing to compare it against. A test now pins that exact case.

**3. Gold corpus is now a versioned fixture** at `tests/fixtures/graphify-gold/`.
It is an INPUT, not a result: the no-pollution rule covers output, and a score
is only reproducible across machines if the corpus is pinned alongside the code
that scored it. Run artifacts still go to the out-of-repo workbench.

**4. The 2-doc probe is retired as a ranking corpus.** The old report now
carries a superseded banner naming why, including that its headline gemma4
claim should never have been reported. It survives as a fast smoke test that
the harness runs at all.

25 tests (up from 19), every negative assertion paired with a positive control
arm so none of them can pass vacuously.

Gates: lint rc=0, pytest 769 passed, verify 93 passed/0 failed.

Closes #327

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FQzDie4WXckQg8to3aTU8t
