### PR TITLE
feat(bakeoff): matrix runner, significance-aware report, and `mise run bakeoff`

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -493,6 +493,31 @@ description = "Deterministically query the project knowledge graph (host-only, #
 # Pass flags through: mise run graphify-query -- "how does lint work?" --budget 3000
 run = 'uv run --project python dotfiles-setup graphify query'
 
+[tasks.bakeoff]
+description = "Run the graphify extraction bake-off (writes OUTSIDE the repo)"
+# Thin caller (zero-bash-logic); logic in
+# python/src/dotfiles_setup/graph_bakeoff.py.
+#
+# Every artifact lands in the WORKBENCH (~/dev/graphify-bakeoff), never in this
+# repo: bake-off output is result data, not source. The one exception is the
+# gold corpus at tests/fixtures/graphify-gold, which is an INPUT and is
+# versioned so a score is reproducible across machines.
+#
+# Each (corpus, arm, repeat) gets a FRESH directory. That is not tidiness — it
+# is the cache-isolation guarantee. graphify's semantic cache is keyed by file
+# content + relative path and carries NO model identity, so two arms sharing an
+# output tree would silently serve one model's results to the other.
+#
+# The arm list includes a NULL ARM: the reference model run twice under
+# identical conditions. The spread between the twins is the noise floor, and a
+# cross-arm gap smaller than it is reported as "indistinguishable" rather than
+# as a finding. Without it, no gap in the report means anything.
+#
+#   mise run bakeoff                          # gold corpus, 3 repeats, null arm
+#   mise run bakeoff -- --repeats 5
+#   mise run bakeoff -- --corpus .omc/kb/raw --run-id full-corpus
+run = 'uv run --project python dotfiles-setup graphify bakeoff'
+
 [tasks.verify-apt-pins]
 description = "Prove every pinned [bootstrap.packages] version still resolves (~60s, no image build)"
 # Thin caller per zero-bash-logic; the probe container, the Dockerfile-ARG

--- a/python/src/dotfiles_setup/graph_bakeoff.py
+++ b/python/src/dotfiles_setup/graph_bakeoff.py
@@ -540,3 +540,312 @@ def load_answer_key(corpus_dir: Path) -> dict[str, Any] | None:
     if not path.is_file():
         return None
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def gather_versions() -> dict[str, str]:
+    """Record the tool versions a run depended on.
+
+    graphify writes none of this into its own output, which is why the previous
+    comparison could not be attributed after the fact.
+    """
+    versions: dict[str, str] = {}
+    for label, argv in (
+        ("graphify", ["graphify", "--version"]),
+        ("ollama", ["ollama", "--version"]),
+        ("git_sha", ["git", "rev-parse", "HEAD"]),
+    ):
+        try:
+            proc = subprocess.run(
+                argv, capture_output=True, text=True, check=False, timeout=30
+            )
+            versions[label] = proc.stdout.strip() or proc.stderr.strip() or "unknown"
+        except OSError, subprocess.SubprocessError:
+            versions[label] = "unavailable"
+    return versions
+
+
+def build_arms(*, include_null: bool = True) -> list[Arm]:
+    """The default arm list, with a null twin for the reference model.
+
+    Only backends that WORK today are here. Deliberately absent:
+
+    * ``claude-cli`` — the model does the extraction and then returns an agentic
+      summary instead of JSON, so graphify reads truncation and converges on an
+      empty graph. Diagnosed to graphify's prompt construction (a clean room
+      outside the repo fails identically, and ``claude -p --output-format json``
+      returns raw JSON when asked directly).
+    * ``nim`` — reachable only through a custom provider; see
+      :func:`nim_provider_config`.
+    """
+    arms = [
+        Arm("q25c-14b", "ollama", "qwen2.5-coder:14b"),
+        Arm("gemma4-12b", "ollama", "gemma4:12b"),
+        Arm("q3c-30b", "ollama", "qwen3-coder"),
+        Arm("gemini-flash-lite", "gemini", "gemini-3.1-flash-lite"),
+    ]
+    if include_null:
+        # The null twin clones the REFERENCE arm — the one every other arm is
+        # compared against — so the noise floor is measured where it is used.
+        arms.append(make_null_arm(arms[0]))
+    return arms
+
+
+def nim_provider_config() -> dict[str, Any]:
+    """The ``~/.graphify/providers.json`` entry that makes NIM reachable.
+
+    NIM is not one of graphify's nine built-in backends; it is an
+    OpenAI-compatible endpoint reached through the custom-provider mechanism
+    (``llm.py:264`` ``_load_custom_providers``). Written to the GLOBAL path on
+    purpose: a project-local ``./.graphify/providers.json`` is ignored unless
+    ``GRAPHIFY_ALLOW_LOCAL_PROVIDERS=1``, because a provider config controls
+    where your corpus and API key are sent and travels with a cloned repo.
+
+    Not written automatically, and not with a key in it — this returns the shape
+    so the config can be reviewed before it exists.
+
+    One thing that changed: NVIDIA's API Trial ToS §3.3(iv) permits training on
+    submitted content, which is why NIM was vetted and NOT adopted for the real
+    corpus. The gold corpus is **fictional**, so there is nothing confidential
+    to leak — NIM is safe to benchmark on the gold set specifically, and still
+    wrong for ``.omc/kb/raw``.
+    """
+    return {
+        "nim": {
+            "base_url": "https://integrate.api.nvidia.com/v1",
+            "env_key": "NVIDIA_API_KEY",
+            "default_model": "meta/llama-3.3-70b-instruct",
+            "pricing": {"input": 0.0, "output": 0.0},
+            "temperature": 0,
+            "max_tokens": 16384,
+        }
+    }
+
+
+def execute_matrix(
+    workbench: Path,
+    run_id: str,
+    corpora: Sequence[Path],
+    arms: Sequence[Arm],
+    repeats: int = DEFAULT_REPEATS,
+) -> list[RunResult]:
+    """Run every (corpus, arm, repeat) combination sequentially.
+
+    Sequential on purpose. These arms share one machine and one Ollama server,
+    so running them concurrently would make the ``seconds`` column measure
+    contention rather than the model — and ``--max-concurrency 1`` inside each
+    run would be pointless if the runs themselves overlapped.
+    """
+    versions = gather_versions()
+    results: list[RunResult] = []
+    for corpus_dir in corpora:
+        if not corpus_dir.is_dir():
+            msg = f"corpus directory not found: {corpus_dir}"
+            raise BakeoffError(msg)
+        for arm in arms:
+            for repeat in range(1, repeats + 1):
+                spec = RunSpec(workbench, run_id, corpus_dir, arm, repeat, versions)
+                result = execute_run(spec)
+                results.append(result)
+                logger.info(
+                    "%s/%s r%d: rc=%d nodes=%d edges=%d x-doc=%d %.1fs",
+                    corpus_dir.name,
+                    arm.name,
+                    repeat,
+                    result.rc,
+                    result.nodes,
+                    result.edges,
+                    result.cross_doc,
+                    result.seconds,
+                )
+    return results
+
+
+def _score_arm(results: Sequence[RunResult], key: dict[str, Any]) -> Score | None:
+    """Score an arm's BEST run against the answer key.
+
+    Best rather than median: recall is a set, not a scalar, so there is no
+    meaningful median of five link-id lists. The spread lives in the raw metrics
+    beside it, and every run's graph is on disk for inspection.
+    """
+    graphs = [g for r in results if (g := load_graph(r.run_dir)) is not None]
+    if not graphs:
+        return None
+    return max((score_graph(g, key) for g in graphs), key=lambda s: s.recall)
+
+
+def _render_floor(floors: dict[str, float]) -> list[str]:
+    """The noise-floor table, or a loud warning when there is no null arm."""
+    if not floors:
+        return [
+            "> ⚠️ **No null arm in this run — no noise floor.** Every gap below",
+            "> is uninterpretable: nothing distinguishes a real difference from",
+            "> run-to-run variance. Re-run with `build_arms(include_null=True)`.",
+            "",
+        ]
+    return [
+        "## Noise floor (same model, two arms, nothing changed)",
+        "",
+        "| metric | floor |",
+        "|---|---:|",
+        *[f"| {m} | {v:g} |" for m, v in floors.items()],
+        "",
+        "**A cross-arm gap smaller than the floor is not a finding.**",
+        "",
+    ]
+
+
+def _render_metrics(by_arm: dict[str, list[RunResult]]) -> list[str]:
+    """Per-arm medians, each carried with its spread."""
+    lines = [
+        "## Metrics (median ± spread over repeats)",
+        "",
+        "| arm | ok | nodes | edges | x-doc | out tok | secs |",
+        "|---|---:|---:|---:|---:|---:|---:|",
+    ]
+    for arm, runs in by_arm.items():
+        agg = aggregate(runs)
+        cells = " | ".join(
+            f"{agg[m]['median']:g} ±{agg[m]['spread']:g}"
+            for m in ("nodes", "edges", "cross_doc", "out_tokens", "seconds")
+        )
+        lines.append(f"| {arm} | {agg['ok']}/{agg['n']} | {cells} |")
+    return lines
+
+
+def _render_significance(
+    by_arm: dict[str, list[RunResult]], reference: str, floors: dict[str, float]
+) -> list[str]:
+    """Every gap adjudicated against the floor before it is called a difference."""
+    lines = [
+        "",
+        "## Significance vs the reference arm",
+        "",
+        f"Reference: `{reference}`",
+        "",
+        "| arm | metric | gap | floor | verdict |",
+        "|---|---|---:|---:|---|",
+    ]
+    ref_agg = aggregate(by_arm[reference])
+    for arm, runs in by_arm.items():
+        if arm == reference or arm.endswith(NULL_ARM_SUFFIX):
+            continue
+        agg = aggregate(runs)
+        for metric, floor in floors.items():
+            gap = abs(agg[metric]["median"] - ref_agg[metric]["median"])
+            verdict = (
+                "**differs**" if is_significant(gap, floor) else "indistinguishable"
+            )
+            lines.append(f"| {arm} | {metric} | {gap:g} | {floor:g} | {verdict} |")
+    return lines
+
+
+def _render_scores(
+    by_arm: dict[str, list[RunResult]], key: dict[str, Any]
+) -> list[str]:
+    """Answer-key recall and decoy resistance, best run per arm."""
+    lines = [
+        "",
+        "## Answer-key score (best run per arm)",
+        "",
+        "| arm | recall | decoy resistance | missed | asserted decoys |",
+        "|---|---:|---:|---|---|",
+    ]
+    for arm, runs in by_arm.items():
+        score = _score_arm(runs, key)
+        if score is None:
+            lines.append(f"| {arm} | — | — | (no graph produced) | — |")
+            continue
+        lines.append(
+            f"| {arm} | {score.recall:.2f} | {score.decoy_resistance:.2f} "
+            f"| {', '.join(score.recall_misses) or '—'} "
+            f"| {', '.join(score.forbidden_hits) or '—'} |"
+        )
+    return lines
+
+
+def render_report(
+    results: Sequence[RunResult],
+    key: dict[str, Any] | None = None,
+) -> str:
+    """Render the comparison as markdown, with significance against the floor.
+
+    Every number carries its spread, and every cross-arm gap is checked against
+    the same-model noise floor before it is called a difference. An arm whose
+    lead does not clear the floor is reported as *indistinguishable* — the
+    honest reading, and the one the previous bake-off skipped.
+    """
+    by_arm: dict[str, list[RunResult]] = {}
+    for r in results:
+        by_arm.setdefault(r.arm, []).append(r)
+
+    reference = next((a for a in by_arm if f"{a}{NULL_ARM_SUFFIX}" in by_arm), None)
+    floors: dict[str, float] = {}
+    if reference:
+        twin = by_arm[f"{reference}{NULL_ARM_SUFFIX}"]
+        floors = {
+            m: noise_floor(by_arm[reference], twin, m)
+            for m in ("nodes", "edges", "cross_doc")
+        }
+
+    lines = [
+        "# graphify extraction bake-off",
+        "",
+        f"Runs: {len(results)} · arms: {len(by_arm)}",
+        "",
+        *_render_floor(floors),
+        *_render_metrics(by_arm),
+    ]
+    if reference and floors:
+        lines += _render_significance(by_arm, reference, floors)
+    if key:
+        lines += _render_scores(by_arm, key)
+    return "\n".join(lines) + "\n"
+
+
+def bakeoff_main(
+    *,
+    corpus: Path,
+    workbench: Path = DEFAULT_WORKBENCH,
+    repeats: int = DEFAULT_REPEATS,
+    run_id: str = "manual",
+    no_null: bool = False,
+) -> int:
+    """Run the matrix and write the report. Returns a process exit code.
+
+    The report goes to the WORKBENCH, never into the repo — it is result data.
+    """
+    if not corpus.is_dir():
+        logger.error("bakeoff: corpus directory not found: %s", corpus)
+        return 1
+
+    arms = build_arms(include_null=not no_null)
+    logger.info(
+        "bakeoff: %d arms x %d repeats over %s", len(arms), repeats, corpus.name
+    )
+    results = execute_matrix(workbench, run_id, [corpus], arms, repeats)
+
+    key = load_answer_key(corpus)
+    if key is None:
+        logger.warning(
+            "bakeoff: %s has no %s — reporting raw metrics only, no recall or "
+            "decoy scoring. Counts alone cannot rank models.",
+            corpus.name,
+            _ANSWER_KEY,
+        )
+
+    report = render_report(results, key)
+    out = workbench / "reports" / f"{run_id}.md"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(report, encoding="utf-8")
+    logger.info("bakeoff: report written to %s", out)
+
+    failed = [r for r in results if not r.ok]
+    if failed:
+        logger.error(
+            "bakeoff: %d/%d runs produced no graph: %s",
+            len(failed),
+            len(results),
+            ", ".join(sorted({f"{r.arm}" for r in failed})),
+        )
+        return 1
+    return 0

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -26,6 +26,12 @@ from dotfiles_setup.docker import DevContainerManager
 from dotfiles_setup.gcc_sha import gcc_sha_main
 from dotfiles_setup.ghcr import validate_ghcr_prereqs
 from dotfiles_setup.ghcr_cleanup import plan_cleanup
+from dotfiles_setup.graph_bakeoff import (
+    DEFAULT_REPEATS,
+    DEFAULT_WORKBENCH,
+    GOLD_CORPUS_RELPATH,
+    bakeoff_main,
+)
 from dotfiles_setup.graphify import graphify_main
 from dotfiles_setup.hook_guard import pretooluse_main
 from dotfiles_setup.hook_selfcheck import hook_selfcheck_main
@@ -253,6 +259,35 @@ def _add_graphify_subcommands(
     )
     query_parser.add_argument(
         "--dfs", action="store_true", help="Traverse depth-first instead of BFS"
+    )
+    bakeoff_parser = graphify_sub.add_parser(
+        "bakeoff",
+        help="Run the extraction bake-off (writes OUTSIDE the repo, to the workbench)",
+    )
+    bakeoff_parser.add_argument(
+        "--corpus",
+        default=None,
+        help=f"Corpus dir (default: the versioned gold fixture, {GOLD_CORPUS_RELPATH})",
+    )
+    bakeoff_parser.add_argument(
+        "--workbench",
+        default=str(DEFAULT_WORKBENCH),
+        help=f"Where runs and reports land (default: {DEFAULT_WORKBENCH})",
+    )
+    bakeoff_parser.add_argument(
+        "--repeats",
+        type=int,
+        default=DEFAULT_REPEATS,
+        help=f"Runs per arm (default: {DEFAULT_REPEATS}); variance needs >1",
+    )
+    bakeoff_parser.add_argument(
+        "--run-id", default="manual", dest="run_id", help="Names the run subtree"
+    )
+    bakeoff_parser.add_argument(
+        "--no-null",
+        action="store_true",
+        dest="no_null",
+        help="Drop the null arm. Removes the noise floor, so no gap is interpretable",
     )
 
 
@@ -792,6 +827,19 @@ def handle_graphify(args: argparse.Namespace, project_root: Path) -> None:
                 budget=args.budget,
                 context=args.context,
                 dfs=args.dfs,
+            )
+        )
+    if getattr(args, "graphify_command", None) == "bakeoff":
+        corpus = (
+            Path(args.corpus) if args.corpus else project_root / GOLD_CORPUS_RELPATH
+        )
+        sys.exit(
+            bakeoff_main(
+                corpus=corpus,
+                workbench=Path(args.workbench),
+                repeats=args.repeats,
+                run_id=args.run_id,
+                no_null=args.no_null,
             )
         )
 

--- a/tests/test_graph_bakeoff.py
+++ b/tests/test_graph_bakeoff.py
@@ -11,6 +11,8 @@ not a test.
 
 from __future__ import annotations
 
+import json
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -19,8 +21,10 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
 
+from dotfiles_setup import graph_bakeoff
 from dotfiles_setup.graph_bakeoff import (
     FIXED_FLAGS,
+    GOLD_CORPUS_RELPATH,
     NULL_ARM_SUFFIX,
     Arm,
     RunResult,
@@ -406,3 +410,130 @@ def test_answer_key_shape_is_validated_before_scoring() -> None:
     }
     with pytest.raises(KeyError):
         score_graph(_graph([], []), broken)
+
+
+# ---------------------------------------------------------------------------
+# The matrix runner and report. The graphify subprocess is faked at the module
+# boundary (`_run`), so these exercise the real orchestration without a model.
+# ---------------------------------------------------------------------------
+
+
+def _fake_proc(stdout: str = "", rc: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=rc, stdout=stdout, stderr="")
+
+
+def test_execute_matrix_runs_every_combination(
+    tmp_path: Path, corpus: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Corpora x arms x repeats, each in its own directory."""
+    calls: list[tuple[list[str], Path, dict[str, str]]] = []
+
+    def fake_run(
+        args: list[str], *, cwd: Path, env: dict[str, str]
+    ) -> subprocess.CompletedProcess[str]:
+        """Stands in for the graphify subprocess; signature mirrors `_run`."""
+        calls.append((list(args), cwd, dict(env)))
+        return _fake_proc("[graphify extract] tokens: 1 in / 5 out")
+
+    monkeypatch.setattr(graph_bakeoff, "_run", fake_run)
+    monkeypatch.setattr(graph_bakeoff, "gather_versions", dict)
+
+    arms = [Arm("a", "ollama", "m1"), Arm("b", "ollama", "m2")]
+    results = graph_bakeoff.execute_matrix(tmp_path, "t", [corpus], arms, repeats=3)
+
+    assert len(results) == 6
+    assert len(calls) == 6
+    # Control arm: the runs are genuinely distinct on disk, not overwriting.
+    assert len({r.run_dir for r in results}) == 6
+    # Each run executes in its OWN directory, and every ollama arm carries the
+    # serialisation env — graphify never sets OLLAMA_NUM_PARALLEL itself, and
+    # Ollama's default of 4 is the multiplier behind graphify #798.
+    assert len({cwd for _, cwd, _ in calls}) == 6
+    for _, _, env in calls:
+        assert env["OLLAMA_NUM_PARALLEL"] == "1"
+        assert env["GRAPHIFY_OLLAMA_KEEP_ALIVE"] == "0"
+
+
+def test_every_run_gets_its_own_corpus_copy_and_manifest(
+    tmp_path: Path, corpus: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The manifest is what makes a graph attributable after the fact."""
+
+    def stub(
+        args: list[str], *, cwd: Path, env: dict[str, str]
+    ) -> subprocess.CompletedProcess[str]:
+        """Asserts the boundary is called sanely; the test checks the manifest."""
+        assert args[0] == "graphify"
+        assert cwd.is_dir()
+        assert "OLLAMA_NUM_PARALLEL" in env
+        return _fake_proc()
+
+    monkeypatch.setattr(graph_bakeoff, "_run", stub)
+    monkeypatch.setattr(graph_bakeoff, "gather_versions", dict)
+
+    results = graph_bakeoff.execute_matrix(
+        tmp_path, "t", [corpus], [Arm("a", "ollama", "qwen2.5-coder:14b")], repeats=1
+    )
+    manifest = json.loads(
+        (results[0].run_dir / "manifest.json").read_text(encoding="utf-8")
+    )
+
+    assert manifest["backend"] == "ollama"
+    assert manifest["model"] == "qwen2.5-coder:14b"
+    assert set(manifest["corpus_sha256"]) == {"a.md", "b.md"}
+    assert manifest["fixed_flags"] == list(FIXED_FLAGS)
+    # The corpus really was copied in, so the run is self-contained.
+    assert (results[0].run_dir / "corpus" / "a.md").is_file()
+
+
+def test_report_without_a_null_arm_says_gaps_are_uninterpretable() -> None:
+    """No null arm must produce a loud warning, not a confident table.
+
+    A report that ranks arms with no noise floor is exactly the artifact the
+    audit rejected, so the absence has to be visible in the output.
+    """
+    results = [_res("a", 1), _res("b", 9)]
+    report = graph_bakeoff.render_report(results)
+    assert "No null arm" in report
+    assert "uninterpretable" in report
+
+
+def test_report_marks_a_sub_floor_gap_as_indistinguishable() -> None:
+    """The end-to-end expression of the rule, in the rendered table."""
+    results = [
+        _res("ref", 1),
+        _res("ref", 4),  # reference wanders 1..4
+        _res("ref-null", 2),
+        _res("ref-null", 3),
+        _res("other", 2),
+        _res("other", 2),  # median gap well inside the floor
+    ]
+    report = graph_bakeoff.render_report(results)
+    assert "Noise floor" in report
+    assert "indistinguishable" in report
+
+
+def test_report_scores_against_the_answer_key_when_one_exists() -> None:
+    """Recall and decoy columns appear only when a key is supplied."""
+    results = [_res("a", 1)]
+    assert "Answer-key score" not in graph_bakeoff.render_report(results)
+    # Control arm: with a key, the section IS rendered.
+    assert "Answer-key score" in graph_bakeoff.render_report(results, KEY)
+
+
+def test_gold_fixture_key_is_internally_consistent() -> None:
+    """Every link in the shipped gold key names a declared entity.
+
+    Runs against the VERSIONED fixture rather than the workbench copy, so it
+    executes everywhere instead of skipping in CI.
+    """
+    key_path = Path(__file__).parent.parent / GOLD_CORPUS_RELPATH / "ANSWER_KEY.json"
+    key = json.loads(key_path.read_text(encoding="utf-8"))
+    names = set(key["entities"])
+    for link in key["expected_links"] + key["forbidden_links"]:
+        assert link["a"] in names, link["id"]
+        assert link["b"] in names, link["id"]
+    # Every entity's documents must exist in the fixture directory.
+    for name, spec in key["entities"].items():
+        for doc in spec["docs"]:
+            assert (key_path.parent / doc).is_file(), f"{name} -> {doc}"


### PR DESCRIPTION
Completes the harness. `execute_matrix` runs corpora x arms x repeats
sequentially (concurrency would make the `seconds` column measure contention,
and would defeat the `--max-concurrency 1` inside each run), `render_report`
renders it, and `dotfiles-setup graphify bakeoff` / `mise run bakeoff` drive it.

**The report refuses to rank without a noise floor.** With a null arm it prints
the floor and adjudicates every cross-arm gap against it — `**differs**` or
`indistinguishable`. Without one it prints a warning saying every gap is
uninterpretable, rather than a confident table. That absence had to be visible
in the output, since a floorless ranking is the artifact the audit rejected.

**Verified end-to-end** on the gold corpus, 2 arms x 1 repeat, real ollama:

    q25c-14b       r1: rc=0 nodes=13 edges=10 x-doc=8  202.5s
    q25c-14b-null  r1: rc=0 nodes=13 edges=10 x-doc=8  207.2s

    | arm      | recall | decoy resistance | missed |
    | q25c-14b | 0.60   | 1.00             | L1, L4 |

Three things that result establishes:

1. **The gold corpus has the structure it was built to have** — 8 cross-doc
   edges, against 1 on the old probe corpus whose two documents were topically
   disjoint. The metric now has dynamic range.
2. **The score is diagnostic, not just a number.** qwen2.5-coder got L2/L3/L5
   and missed exactly **L1 and L4** — the two genuinely semantic links (one
   concept under three names; a causal claim restated in different vocabulary)
   — while resisting both lexical decoys. That is a specific, actionable
   weakness, which raw node counts could never have surfaced.
3. **Cache isolation demonstrably works.** The null twin took 207s, not ~0s. A
   leaked cache would have made the second arm instant; it genuinely re-ran.

Also added: `build_arms` (only backends that work today — `claude-cli` is
excluded with its diagnosis in the docstring), `gather_versions`, and
`nim_provider_config`, which returns the custom-provider shape WITHOUT writing
it or embedding a key. Its docstring records why NIM is now safe on this corpus
specifically: NVIDIA's trial ToS permits training on submitted content, and the
gold corpus is fictional, so there is nothing confidential to leak.

Tests: 6 more (31 total), with the graphify subprocess faked at the `_run`
boundary so orchestration is exercised without a model. The fake asserts every
ollama arm carries `OLLAMA_NUM_PARALLEL=1` and its own cwd.

Gates: lint rc=0, pytest 775 passed, verify 93 passed/0 failed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FQzDie4WXckQg8to3aTU8t


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `graphify bakeoff` command for comparing graph extraction configurations across corpora and repeated runs.
  - Added options to select the corpus, output location, repeat count, run name, and optional reference arm.
  - Each run is isolated to prevent cache or result reuse between configurations.
  - Generates Markdown reports with performance metrics, noise-floor comparisons, significance results, and optional answer-key scoring.
  - Added a `mise bakeoff` task for convenient execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->