### PR TITLE
fix(image): bump two stale apt pins that broke every base rebuild

### DIFF
--- a/.devcontainer/mise-system.toml
+++ b/.devcontainer/mise-system.toml
@@ -139,7 +139,7 @@ cargo-binstall = "latest"
 # `mise run verify-apt-pins` BEFORE spending a ~2.5h CI base rebuild
 # (`.claude/rules/local-devcontainer-first.md`).
 [bootstrap.packages]
-"apt:build-essential" = "12.12ubuntu2.26.04.1"
+"apt:build-essential" = "12.12ubuntu2.26.04.2"
 "apt:ca-certificates" = "20260601~26.04.1"
 "apt:curl" = "8.18.0-1ubuntu2.3"
 "apt:gnupg" = "2.4.8-4ubuntu3"
@@ -153,7 +153,7 @@ cargo-binstall = "latest"
 "apt:libatomic1" = "16-20260322-1ubuntu1"
 "apt:libbz2-dev" = "1.0.8-6build2"
 "apt:libreadline-dev" = "8.3-4"
-"apt:libsqlite3-dev" = "3.46.1-9ubuntu0.1"
+"apt:libsqlite3-dev" = "3.46.1-9ubuntu0.2"
 "apt:libssl-dev" = "3.5.5-1ubuntu3.2"
 "apt:zlib1g-dev" = "1:1.3.dfsg+really1.3.1-1ubuntu3"
 # LLVM-22 C++ toolchain (#222 PR-C) — Ubuntu 26.04's version-suffixed apt packages


### PR DESCRIPTION
Closes #332.

`build-essential` and `libsqlite3-dev` were pinned to versions Ubuntu has since
dropped from the archive, so `mise bootstrap packages apply` failed and took
`base-prep` -> `ci-gate` with it:

    E: Version '12.12ubuntu2.26.04.1' for 'build-essential' was not found
    E: Version '3.46.1-9ubuntu0.1'    for 'libsqlite3-dev'  was not found

Both had simply rolled forward one patch. Queried in a throwaway container on
the digest-pinned BASE_IMAGE (`ubuntu:26.04@sha256:b7f48…`):

    build-essential | 12.12ubuntu2.26.04.2 | resolute-updates + resolute-security
    libsqlite3-dev  | 3.46.1-9ubuntu0.2    | resolute-updates + resolute-security

This is exactly `feedback_ubuntu_release_pocket_pins_dont_install`: the LTS
release pocket is frozen at release day, so a pin must name the newest version
across resolute + -updates + -security — and a `.1` security update gets
superseded by `.2` and removed.

**Nobody noticed because `main` was green on a cache hit, not on correctness.**
Bot PR #331 (`chore/lock-refresh`) touches only the two `.devcontainer/*.lock`
files, but those are image build inputs, so it busted the base cache, forced a
genuine rebuild, and exposed this. Control arm: `main` CI is success at
`da6078e` while carrying the identical broken pins. Any change to
`.devcontainer/**`, `mise.toml`, `mise-system.toml`, the Dockerfile or
`docker-bake.hcl` would have failed the same way.

Verified with `mise run verify-apt-pins`, which simulates all 66 pins in ONE
transaction so a cross-package conflict cannot hide: rc=1 before (naming these
two), rc=0 after — so the gate discriminates rather than merely passing.

Found during clear-prep while triaging #331's failing CI, which had been about
to be handed off as "bot branch, unexamined".

Gates: lint rc=0, pytest 775 passed, verify 93 passed/0 failed,
verify-apt-pins rc=0.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FQzDie4WXckQg8to3aTU8t


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment package versions for improved maintenance and compatibility.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->