### PR TITLE
docs: sync for the bake-off harness + widen the graphify-install hazard

### DIFF
--- a/.claude/rules/do-not.md
+++ b/.claude/rules/do-not.md
@@ -53,6 +53,19 @@ self-contained block). Each item's context is preserved verbatim.
    the machine-level expression of the PROJECT-ONLY invariant; also never run
    `graphify hook install` or `graphify --watch`.
 
+   **This generalises to EVERY platform, in two flavours (verified 2026-07-21,
+   0.9.22).** Run any `graphify <platform> install` in a **throwaway directory
+   outside this repo**, never here:
+   - ⚠️ **`graphify codex install` breaks our lint gate with OR without
+     `--project`.** Both paths call `_agents_install` (`install.py:1463`), which
+     appends a 13-line / 1,129-byte `## graphify` block to the root
+     `AGENTS.md` — a file at exactly **200/200 lines**. Result: 213 lines and a
+     failed `md_size_budget` step. `--project` only relocates the *skill* file.
+   - ⚠️ **`graphify antigravity install` without `--project` writes OUTSIDE the
+     project** — `~/.gemini/config/skills/graphify/SKILL.md`. With `--project`
+     it stays in-repo (control arm: `_project_install`'s body contains **zero**
+     `Path.home()` calls).
+
 9. **Do NOT commit onto the default branch — branch FIRST.** Create the branch
    *before* the commit, then `mise run ship`. On 2026-07-20 a session committed
    34 files straight onto `main` and had to move them afterwards

--- a/.claude/rules/probes-need-a-control-arm.md
+++ b/.claude/rules/probes-need-a-control-arm.md
@@ -111,7 +111,29 @@ before you believe it.
 5. **Say which arm you ran.** When reporting a probe result, state the control:
    "bogus-dist → 404 while resolute-22 → 200, so the probe discriminates." A
    result without its control is an opinion.
-6. **Cross-check a surprise before you report it.** A second route to the same
+6. **An INHERITED number is not a measurement — re-derive it or label it.** A
+   figure that arrives from a handoff, a prior session's table, or your own
+   earlier message has *no control arm attached*. Repeating it converts someone
+   else's unverified note into your finding, and the provenance is gone the
+   moment you restate it.
+
+   2026-07-21: a session inherited a 5-row model bake-off table from a handoff
+   and reported it as "same corpus, same flags, so it is comparable". Only the
+   corpus was ever actually constant. graphify records **no backend or model in
+   any artifact** (control arm: the corpus filename *is* recorded), three of the
+   directories were identical in shape, the semantic cache key is model-blind,
+   and every arm was n=1. The whole comparison had to be discarded — after a
+   claim from it ("gemma4 wins on cross-doc edges, 2 to 1") had already been
+   reported to the user as a finding. It was a gap of **one**, from single runs,
+   with no noise floor.
+
+   So: before repeating an inherited number, either (a) re-derive it and say you
+   did, or (b) mark it explicitly as unverified and inherited. And when the
+   number ranks things, ask what the **noise floor** is — a difference smaller
+   than the same-input variance is not a difference. If nothing establishes that
+   floor, the ranking is not reportable at any confidence.
+
+7. **Cross-check a surprise before you report it.** A second route to the same
    fact costs seconds and settles which side is broken. Disagreement is a
    finding, not noise — and the finding is usually your probe.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ the official `@devcontainers/cli` (pinned in `mise.toml`).
 | `.claude/` | Claude-specific agents, skills, rules. Has its own `CLAUDE.md` (exempt from the stub check) |
 | `home/` | Chezmoi-managed dotfile templates (its AGENTS.md was removed in #80) |
 | `python/` | Python package `dotfiles_setup` — see `python/AGENTS.md` |
-| `tests/` | Pytest + Bats test suite (697 pytest tests) — see `tests/AGENTS.md` |
+| `tests/` | Pytest + Bats test suite (775 pytest tests) — see `tests/AGENTS.md` |
 | `scripts/` | Utility scripts (`benchmark-docker.sh`, `devcontainer-smoke.sh`) |
 | `docs/` | Documentation, research findings, design specs |
 
@@ -86,7 +86,7 @@ content-hashed since hk 1.47 — no manual cache clearing after edits.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q               # All 697 tests
+uv run --project python pytest tests/ -x -q               # All 775 tests
 uv run --project python pytest tests/test_audit.py -x -q  # Single file
 mise run lint                                             # Lint checks only (hk under a hard timeout)
 mise run verify                                 # Verification contracts (suites.toml)

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -39,7 +39,7 @@ Requires **Python 3.14**.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q                # All 697 tests
+uv run --project python pytest tests/ -x -q                # All 775 tests
 uv run --project python pytest tests/test_audit.py -x -q   # Single file
 ```
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -22,7 +22,7 @@ It is referenced, NOT `@import`ed: agnix rejects `@import` in an `AGENTS.md`
 requires every non-`.claude/` `CLAUDE.md` be solely `@AGENTS.md`. So the index
 is on-demand reference — which is what it should be anyway.
 
-Total: **697 pytest tests** run by default (`pytest tests/` collects all
+Total: **775 pytest tests** run by default (`pytest tests/` collects all
 `test_*.py` files) plus **4 gated `image_exec`** exec tests (deselected by
 default; run via `mise run smoke-exec`) and Bats scenarios under `infra/`.
 

--- a/tests/TEST-INDEX.md
+++ b/tests/TEST-INDEX.md
@@ -46,6 +46,7 @@ derive instead.
 | `test_autofix.py` | pytest | autofix.ci artifact applier (`dotfiles_setup.autofix`) — additions, traversal/shape/deletion refusal |
 | `test_bash_budget.py` | pytest | Zero-bash-logic enforcer (`dotfiles_setup.bash_budget`) — allowlist/growth/shrink/stale logic, real-repo `allowlist == tracked` pin, end-to-end CLI |
 | `test_gcc_sha.py` | pytest | gcc-latest sha auto-repair (`dotfiles_setup.gcc_sha`, #249) — pin parse/rewrite (strict subn), injected-fetcher sha compute, drift/no-drift repair, check-mode dry-run, CLI rc |
+| `test_graph_bakeoff.py` | pytest | graphify extraction bake-off harness (`dotfiles_setup.graph_bakeoff`) — fixed-flag invariant, corpus digests, fresh-dir cache isolation, cross-doc by `source_file`, whole-token entity matching + ambiguity guard (#327), null-arm noise floor + significance, matrix runner with the graphify subprocess faked at `_run` |
 | `test_shell_integration.py` | pytest | Tool reachability in login shells (mise, chezmoi, uv, pixi, claude, gemini, codex) |
 | `infra/foundation.bats` | Bats | Bash-level foundation checks (shell script integration) |
 | `infra/runtimes.bats` | Bats | Runtime installation checks (bash) |


### PR DESCRIPTION
Doc sync for a session that shipped 8 PRs (#322-#330).

- Test counts 697 -> 775 across AGENTS.md, python/AGENTS.md, tests/AGENTS.md.
- tests/TEST-INDEX.md gains test_graph_bakeoff.py.

- **do-not.md #8 widened from `graphify install` to EVERY platform**, in two
  distinct flavours found by reading install.py rather than by running it:
  - `graphify codex install` appends a 13-line block to the root AGENTS.md via
    `_agents_install` (install.py:1463) with OR without `--project` — and that
    file sits at exactly 200/200 lines, so it lands at 213 and fails
    md_size_budget. `--project` only relocates the skill file.
  - `graphify antigravity install` without `--project` writes to
    `~/.gemini/config/skills/` (control arm: `_project_install`'s body has ZERO
    `Path.home()` calls, so the project path really is contained).

- **probes-need-a-control-arm.md gains rule 6: an inherited number is not a
  measurement.** This session restated a 5-row bake-off table from a handoff as
  "same corpus, same flags, comparable". Only the corpus was ever constant —
  graphify records no backend or model in any artifact, three directories were
  identical in shape, the cache key is model-blind, and every arm was n=1. The
  comparison was discarded, but only after a claim from it had been reported to
  the user as a finding: "gemma4 wins 2 cross-doc edges to 1" was a gap of ONE,
  from single runs, with no noise floor.

  Folded into the existing rule rather than given its own file: eager rule
  context is already ~107 KB per session, and this belongs to the same family
  the rule already governs.

AGENTS.md is at 200/200 lines, so `mise run bakeoff` is NOT listed in its Quick
Start — the task is documented in mise.toml's task comment instead. Adding it
needs an offsetting trim; recorded in the handoff.

Doc-ref integrity verified with the real gate (`dotfiles-setup check-doc-refs`
rc=0, hk-wired at hk.pkl:340), not the ad-hoc grep loop — that loop reports ~95
false positives because it cannot resolve a bare basename.

Gates: lint rc=0, lint-docs rc=0, pytest 775 passed, verify 93 passed/0 failed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FQzDie4WXckQg8to3aTU8t
