### PR TITLE
docs(kb): 9-source review — corrects a wrong backend fact, resizes the roster

### DIFF
--- a/.omc/kb/raw/src-augmentcode-graphify-knowledge-graphs.md
+++ b/.omc/kb/raw/src-augmentcode-graphify-knowledge-graphs.md
@@ -1,0 +1,138 @@
+Graphify hits 58.3K stars: knowledge graphs for AI coding assistants | Augment Code 
+ Skip to content 
+ Product 
+ Solutions 
+ Context Engine Pricing Docs Blog Resources 
+
+ Sign in Book demo 
+
+ Product Cosmos CLI Changelog 
+
+ Solutions Code Review Review every PR with agents Test Coverage Coverage that climbs, suites that stay green Incident Management Investigate alerts before humans arrive Ticket to PR Assign a ticket, merge a reviewed PR Large Projects From design doc to shipped feature Automations Recurring work as repeatable workflows Security Remediation From CVE alert to a reviewed fix Migrations Modernization as a program, not a project Onboarding Ramp every engineer in days Team Standards at Scale Your best workflow, everyone's default 
+
+ Context Engine Pricing Docs Blog Resources Workflows Podcast Customers Status Page Trust Center Security 
+
+ Talk to Sales Sign in 
+
+ Book demo 
+
+ Back to Learn Graphify hits 58.3K stars: knowledge graphs for AI coding assistants
+ Jun 2, 2026 Last updated: Jun 18, 2026 • 
+
+ Paula Hingel 
+
+ Three things worth knowing 
+ Graphify is an open-source, YC-backed tool that converts entire projects into queryable knowledge graphs, now at 58.3K stars and 6.1K forks.
+ It works across 20 AI coding assistant platforms, parses 33 programming languages locally via tree-sitter with zero API calls, and stores results as three files your whole team can query.
+ If your AI assistant keeps giving shallow answers about how your codebase fits together, this is the structured context layer I'd evaluate first.
+
+ Ask any AI coding assistant how the login form connects to the users table in a large codebase. Nine times out of ten, it greps through files, misses relationships that aren't obvious from file contents, and gives you a partial answer.
+ The problem is structural. AI coding assistants operate on flat-file context. They read files, sometimes many at once, but they have no map of how concepts relate across your codebase. Functions, classes, database tables, API handlers, architecture docs: all of that is context the model has to reconstruct from scratch on every query.
+ Graphify pre-computes that map. The YC S26-backed tool converts code, docs, PDFs, images, and videos into a queryable knowledge graph and works across 20 AI assistant platforms. At 58.3K stars, 6.1K forks, and 1.2M PyPI downloads, it's the most widely adopted solution to this problem I've seen in the open-source space.
+
+ What Happened 
+ Developer Safi Shamsi released Graphify v0.8.28 as the latest in a rapid series of 123 releases. The project has 71 contributors and releases roughly every other day. It installs as a Python package ( graphifyy on PyPI, double-y) and registers itself as a skill in your AI coding assistant.
+ Type /graphify . and it maps your project into a knowledge graph stored as three files: an interactive HTML visualization, a markdown report, and a JSON graph you can query at any time. The graph persists in graphify-out/ and can be committed to your repo, so every teammate's assistant has immediate access.
+ The release cadence tells me this is a project with real production usage. Roughly every other day for 123 releases means the team is finding and fixing real issues, not shipping features into a vacuum.
+ Key Features 
+ Feature Description 
+ One-command setup graphify install registers the skill with your assistant. /graphify . builds the graph. Three output files land in graphify-out/. 
+ 33-language AST extraction Python, TypeScript, Go, Rust, Java, C/C++, and 27 more languages parsed locally via tree-sitter with zero API calls. LLM-powered extraction handles docs, PDFs, and images. 
+ Queryable graph from the CLI graphify query "what connects auth to the database?" returns answers from the graph without re-reading files. graphify path and graphify explain provide targeted lookups. 
+ Git-commit auto-rebuild graphify hook install adds post-commit hooks that rebuild the AST graph after each commit, with a merge driver that union-merges graph.json when two developers commit in parallel. 
+ PR impact analysis graphify prs --triage uses AI to rank your review queue by graph impact. graphify prs --conflicts flags PRs that share graph communities, a proxy for merge-order risk. 
+ Multiple LLM backends Supports Gemini, Claude, OpenAI, DeepSeek, Ollama (fully local), AWS Bedrock, and Kimi for semantic extraction. Auto-detects which API key is available. 
+
+ Why It Matters 
+ Graphify sits on top of AI coding assistants rather than replacing them. Cursor provides AI-assisted editing inside an IDE. Claude Code gives you an agentic coding assistant in the terminal. Graphify gives each of them a pre-built map of your project.
+ The confidence tagging system is the part I find most practically useful. Every relationship gets tagged as EXTRACTED , INFERRED , or AMBIGUOUS , so developers know which connections came from code versus model inference. That's the kind of signal that changes how much you trust the assistant's answers.
+ SQL schemas, shell scripts, architecture docs, and video walkthroughs all end up as nodes in the same graph. A single query can trace a path from a database table through an API handler to a frontend component. For teams onboarding new developers or reviewing unfamiliar parts of a codebase, that's a meaningful reduction in the time it takes to understand what a change actually touches.
+ Example Use Case 
+ A team maintains a Python/TypeScript monorepo with a PostgreSQL database, a FastAPI backend, and a Next.js frontend. A new developer joins and needs to understand how user authentication flows from the React login form through the API to the database.
+ They run graphify query "what connects the login form to the users table?" in Claude Code. The graph returns the path: LoginForm → /api/auth/login → AuthService.authenticate() → UserRepository.find_by_email() → users table , with confidence tags on each edge. They follow up with graphify export callflow-html to get a Mermaid diagram of the full call flow, viewable in any browser.
+ This is the workflow I'd walk through with a team spending hours on onboarding. The map is already built. You just query it.
+ Competitive Context 
+ Cursor ships built-in codebase indexing, but it's optimized for file content retrieval. Graphify captures relationships between entities, not just file contents, and works identically across 20 platforms.
+
+ Open source
+ augmentcode/auggie ★ 259 
+
+ Star on GitHub 
+
+ Manual RAG setups give teams similar query capabilities, but they require custom embedding pipelines, chunking strategies, and retrieval logic. Graphify's AST-based local extraction means that code relationships are parsed without LLM calls, keeping setup fast and costs low.
+ The 20-platform support is worth calling out specifically. One developer builds the graph and commits graphify-out/ to the repo. Every teammate's assistant, whether they use Claude Code, Cursor, Gemini CLI, or something else, can query the same graph without any additional setup.
+ My Take 
+ If your team uses AI coding assistants on a codebase larger than a few services, Graphify is worth five minutes of setup time. The 1.2M PyPI downloads tell me plenty of teams have already made that call.
+ I'm curious whether the confidence tagging actually changes how developers use the assistant's answers in practice, or whether most developers skip the metadata and just trust the output. Worth testing on a real team.
+ [ Free report ] 
+
+ The Agentic SDLC
+ How teams like Stripe, Ramp, and Uber move from solo coding agents to a coordinated, team-level system.
+
+ Download the guide 
+
+ Written by
+ Paula Hingel
+ Technical Writer
+ Paula writes about the patterns that make AI coding agents actually work — spec-driven development, multi-agent orchestration, and the context engineering layer most teams skip. Her guides draw on real build examples and focus on what changes when you move from a single AI assistant to a full agentic codebase. 
+
+ Drowning in agent-generated PRs? 
+ See Cosmos for your team 
+
+ Get Started
+ Give your codebase the agents it deserves
+ Install Augment to get started. Works with codebases of any size, from side projects to enterprise monorepos.
+ Install Augment Contact Sales 
+
+ PRODUCT
+ Cosmos 
+ CLI 
+ Pricing 
+
+ SOLUTIONS
+ Code Review 
+ Test Coverage 
+ Incident Management 
+ Ticket to PR 
+ Large Projects 
+ Automations 
+ Security Remediation 
+ Migrations 
+ Onboarding 
+ Team Standards at Scale 
+
+ RESOURCES
+ Customers 
+ Docs 
+ Blog 
+ Guides 
+ Learn 
+ Tools 
+ AI Engineering Playbook 
+ The Agentic SDLC 
+ State of AI-Native Engineering 2026 
+
+ COMPANY
+ Careers 
+ Press Inquiries 
+ Press Kit 
+ Contact Sales 
+ Contact Support 
+ Changelog 
+ Privacy & Security 
+ Trust Center 
+ Status Page 
+
+ LEGAL
+ Cookie Policy 
+ Privacy Policy 
+ SLA and Support Policy 
+ Terms of Service 
+
+ © 2026 Augment Code. All rights reserved.
+
+ DARK 
+
+ LIGHT 
+
+ SYSTEM

--- a/.omc/kb/raw/src-codersera-local-ai-model-picker.md
+++ b/.omc/kb/raw/src-codersera-local-ai-model-picker.md
@@ -1,0 +1,234 @@
+Local AI Model Picker — find the best open-source LLM for your machine | Codersera 
+ Codersera 
+ About Services Contact Blog Tools Guides 
+
+ Hire Developers 
+
+ Free tool · No signup · 100% browser-side · Last updated 2026-06-16
+ Pick the best local AI model for your machine
+ Open-source LLMs are now competitive with GPT-4 / Claude / Gemini — if you run the right one. Tell us your chip (Apple M1 / M2 / M3 / M4 / M5, NVIDIA, AMD, CPU), RAM, and use case. We surface 3 ranked picks with verified HuggingFace links, install commands, and quotes from credible engineers running them.
+ Quick answer
+ Codersera's free Local AI Model Picker recommends the best open-source LLM to run on your own machine based on your chip family (Apple Silicon M-series, NVIDIA / AMD GPU, or CPU-only), available RAM or VRAM, primary use case (general chat, coding, creative writing, vision, uncensored / role-play, or reasoning), and your preferred runtime (Ollama, LM Studio, llama.cpp, MLX, vLLM). The tool covers state-of-the-art June 2026 models — Llama 4, DeepSeek V4 + Coder, Qwen 3.5 + Coder, Gemma 4, Phi-4, Mistral Small 3, Kimi K2.6, vision models, and uncensored Dolphin / Hermes fine-tunes. Ranked top 3 with the Ollama install command included.
+
+ On this page Picker How to read the recommendations Best Macs to buy Covered models Runtimes explained How much RAM do I need? Censored vs uncensored FAQ Find your model
+
+ How to read the recommendations
+ Four inputs, four design tradeoffs you might want to know about.
+ 01
+ Pick your hardware
+ Apple Silicon (M1 / M2 / M3 / M4) uses unified memory, so RAM = VRAM. NVIDIA / AMD GPUs use discrete VRAM, so pick the VRAM size, not system RAM. CPU-only setups should stick to ≤8B models.
+
+ 02
+ Pick the use case
+ General chat, coding, creative writing, reasoning, vision (image / screenshot understanding), or uncensored / role-play. Each model has per-use-case quality scores; the picker weights them with hardware fit.
+
+ 03
+ Pick a runtime (or leave it on No preference)
+ Ollama is the easiest entry point. LM Studio is the polished GUI. llama.cpp is the lowest-level path. MLX is fastest on Apple Silicon. vLLM is the production server for NVIDIA boxes.
+
+ 04
+ Read the top 3 picks
+ We rank by use-case score + memory fit + runtime fit, and surface 3 strong options so you can A/B them. Each card shows active params, working-set memory, license, and an Ollama install command.
+
+ Quick picks for buying a new Mac
+ Already know you want a Mac? Here are three citation-backed picks by budget. Sources are the gold-standard local-LLM benchmark posts (Sean Kim's M4 Max benchmarks, MacRumors / Wccftech on M3 Ultra running DeepSeek V3, PopularAI's Mac mini guide).
+ Best $1k–$1.5k
+ Mac mini M4 Pro, 48 GB, 512 GB SSD
+ $1,399–$1,799
+ The M4 Pro Mac mini hits the M-Pro memory-bandwidth tier (273 GB/s) where 8B and 30B models run at conversational speed. The 48 GB upgrade fits Qwen 3.6 27B + Qwen 3.6 35B-A3B comfortably.
+ PopularAI — Best Mac mini for local LLMs 2026 ↗ 
+
+ Best $2k–$3k
+ M5 Pro 14" MacBook Pro 48 GB
+ $2,499–$2,899
+ Per Jun Song's hardware shortlist (351 likes), the M5 Pro is one of three picks worth recommending for serious local LLM use. 307 GB/s bandwidth, 4× AI uplift on Apple's metric vs M4. Runs Qwen 3.6 27B at ~63 tok/s.
+ Jun Song hardware shortlist ↗ 
+
+ Workstation
+ Mac Studio M3 Ultra 256 GB / 512 GB
+ $5,499–$9,499
+ The only consumer machine that runs DeepSeek V3 671B in unified RAM under 200 W. ~17-18 tok/s. Per Jun Song: M3 Ultra at 546-819 GB/s bandwidth crushes DGX Spark's 273 GB/s — "people know what's up."
+ MacRumors — M3 Ultra runs DeepSeek V3 ↗ 
+
+ Models in the catalog — verified as of 2026-06-16
+ Every Hugging Face URL below has been verified to return 200. When a forward-projected name doesn't have a real HuggingFace page yet, we point to the closest currently-shipping model and label it honestly. We refresh the catalog whenever a new generation lands.
+ Llama (3.1 / 3.2 / 3.3 / 4)
+ Llama 3.3 70B is the strongest dense open model. Llama 4 ships as Maverick 400B / Scout 109B MoE for workstations.
+
+ DeepSeek V3 / V4
+ V4-Flash 284B is the local-feasible frontier. V3 671B runs only on M3 Ultra 512 GB. MIT licensed.
+
+ DeepSeek Coder
+ Dense 33B + 6.7B for the V1 line; V2-Lite 16B MoE for the modern small-model slot. (No V4 Coder yet.)
+
+ Qwen 2.5 / 3.5 / 3.6
+ Qwen 3.6-35B-A3B is the 2026 frontier (beats Claude Opus 4.7 on Simon Willison's pelican benchmark). 2.5 Coder 32B is still the SOTA open coder.
+
+ Gemma 2 / 3
+ Gemma 3 27B is the current dense flagship. Gemma 2 9B + 2B fill the gaps the Gemma 3 ladder skips.
+
+ Phi-4
+ 14B + Phi-4-mini 3.8B. Microsoft's reasoning-tuned line, MIT licensed.
+
+ Mistral Small 3.1
+ 24B Apache-2.0. The polished open competitor to Qwen 3.5 27B.
+
+ Kimi K2.6
+ 1T MoE. Local feasibility only on workstation-class machines (~600 GB Q4).
+
+ Vision
+ Llama 3.2 Vision 11B, Qwen 2.5-VL 7B / 72B, InternVL 2.5 8B, MiniCPM-V 2.6.
+
+ Uncensored
+ Dolphin 3.0 Llama 3.1 8B, Dolphin 3.0 Mistral 24B, Hermes 4 70B, Tiger-Gemma 9B.
+
+ Creative / RAG
+ Command R+ 104B (CC-BY-NC), Mistral Nemo 12B.
+
+ Runtimes — what to install
+ A runtime is the program that loads the model weights and actually generates tokens. You only need one to start.
+ Ollama 
+ The default. Install with `curl -fsSL https://ollama.com/install.sh | sh` (Linux) or download the macOS / Windows app. One-line model pulls (`ollama pull llama4:8b`). Exposes an OpenAI-compatible REST API on localhost:11434 — point your IDE assistant or chatbot at it.
+
+ LM Studio 
+ Polished desktop GUI. Drag-drop .gguf model files, browse Hugging Face from inside the app, switch between models instantly, chat in a built-in UI. Also exposes an OpenAI-compatible server. Best entry point for non-CLI users.
+
+ llama.cpp 
+ The C++ inference engine that powers most of the others. Pick this if you want fine-grained control: custom KV cache size, speculative decoding, multi-GPU layer splitting, embedded into your own binary. No GUI; you build and call it directly.
+
+ MLX 
+ Apple's native ML framework. Fastest inference on M-series Macs because it uses unified memory + Metal directly without copies. Use mlx-lm (`pip install mlx-lm`) to load Hugging Face models; expect 2-3× the throughput of llama.cpp on the same hardware.
+
+ vLLM 
+ Production inference server for NVIDIA GPUs. PagedAttention scheduler, continuous batching, multi-GPU tensor parallelism. Pick this if you are serving many concurrent users — not for desktop chat.
+
+ How much RAM do I actually need?
+ Rule of thumb at Q4_K_M quantization: working-set memory ≈ 0.6 GB per billion parameters, plus 2-4 GB for KV cache + overhead. Add 4-8 GB for OS / apps when sizing.
+ Available RAM / VRAM Best models Notes 
+ 8 GB Gemma 4 2B · Phi-4-mini 3.8B Tight. Stick to ≤4B models. Quality drops fast. 
+ 16 GB Llama 4 8B · Qwen 3.5 7B · DeepSeek Coder V4 6.7B Sweet spot for laptops. 7-9B models run comfortably. 
+ 24-32 GB Qwen 3.5 32B · Gemma 4 27B · Mistral Small 3 (24B) Real workstation territory. Frontier-class single-machine performance. 
+ 48-64 GB Llama 4 70B · Kimi K2.6 70B · Hermes 4 70B Mac Studio M3 Ultra / dual RTX 4090 territory. Approaches GPT-4-class quality. 
+ 96 GB+ Command R+ (104B) · DeepSeek V4 MoE 670B Server / workstation. You can run almost any open model. 
+
+ Censored vs uncensored — what's the practical difference?
+ Base open models (Llama 4, DeepSeek V4, Qwen 3.5, Gemma 4, Phi-4) ship with safety / RLHF tuning that refuses certain prompts — graphic content, security-relevant content, role-play that crosses internal policies. For most users that's fine: it matches the ChatGPT / Claude UX.
+ Fine-tunes like Dolphin (Cognitive Computations) and Hermes (Nous Research) strip those refusals via additional DPO training. They're used by security researchers, fiction writers, role-play communities, and red-teamers. The picker exposes the Show uncensored models only toggle so you can route to those when you need them.
+ Same legal status as the base models — both Dolphin and Hermes are publicly hosted on Hugging Face under the base model's license. You are responsible for how you use the output.
+
+ Frequently asked questions
+ Why local AI instead of ChatGPT / Claude / Gemini?
+ Privacy (data never leaves your machine), zero per-token cost after the model is downloaded, works offline, no rate limits, and full control over the system prompt + sampling. Frontier-class open models like Llama 4 70B and DeepSeek V4 now approach proprietary quality.
+
+ What does Q4_K_M mean?
+ A 4-bit quantization scheme used by llama.cpp and Ollama. It reduces a 16-bit fp model to roughly 25% of its weight size with negligible quality loss for the majority of tasks. Our memory estimates assume Q4_K_M unless noted otherwise.
+
+ What is the difference between MoE and dense models?
+ Mixture-of-Experts models (e.g., DeepSeek V4: 670B total / 37B active) only route through a fraction of parameters per token. The full weights still need to live in memory, but inference speed is closer to the active parameter count — important when comparing throughput.
+
+ Which runtime should I install first?
+ Ollama. It is the lowest-friction path — one-line install, model registry with one-line pulls, OpenAI-compatible REST API on port 11434. Once you have a few models locally, look at LM Studio for the GUI or MLX for raw speed on Apple Silicon.
+
+ Are uncensored models illegal?
+ No. The Dolphin and Hermes fine-tunes are publicly hosted on Hugging Face under the base model license. They are widely used by security researchers, creative writers, and roleplay communities. Treat them like any other tool — you are responsible for how you use them.
+
+ What about API keys for OpenAI / Anthropic?
+ Not needed. This tool covers local-only models that run entirely on your hardware. You download the weights once and run them with Ollama / llama.cpp / MLX / vLLM. Zero API keys, zero per-token cost.
+
+ Does the tool send my hardware spec to a server?
+ No. The recommender runs 100% in your browser. Codersera does not log your chip, RAM, use case, or any picks. The model catalog is bundled into the page as a static dataset.
+
+ How often is the model catalog refreshed?
+ Whenever a major model lands (a new Llama / DeepSeek / Qwen / Gemma generation, or a notable fine-tune). Each model card carries a lastReviewed date so you can see how current the recommendation is.
+
+ Related Codersera resources
+ Self-hosting LLMs — complete guide 
+ AI coding agents — complete guide 
+ Cursor IDE — complete guide 
+ Llama 4 — complete guide 
+ DeepSeek V4 — complete guide 
+ Qwen 3.5 — complete guide 
+ Gemma 4 — complete guide 
+ Kimi K2.6 — complete guide 
+ Apple Silicon LLMs — complete guide 
+
+ Codersera
+
+ 4.9 /5 
+ Based on 1095 Ratings
+
+ Hire a Developer Apply as a developer 
+
+ Company
+ About
+ Why Us
+ FAQs
+ Contact Us
+ Partner with Us
+ Blog
+
+ Hire
+ Hire Node.JS Developer 
+ Hire React Developer 
+ Hire React Native Developer 
+ Hire Express.JS Developer 
+ Hire Javascript Developer 
+ Hire Angular Developer 
+ Hire Typescript Developer 
+
+ Looking for Job
+ Java Developers 
+ React Developers 
+ Node Developers 
+ IOS Developers 
+ Python Developers 
+ Angular Developers 
+ React-native Developers 
+
+ Support
+ Terms of Services 
+ Risk-Free Trial Policy 
+ Privacy Policy 
+
+ Tools
+ Free Invoice Generator 
+ Task Tracker: Kanban + List + Matrix 
+ Impact-Effort Matrix 
+ AI Agent Task Manager 
+ Startup Directory Submission List 
+ Free Domain Rating Checker 
+ Free IP Lookup 
+ Local AI Model Picker 
+ Focus Timer: task list + timer 
+ InterviewLab: AI mock interviewer 
+ Wingman: AI interview copilot 
+ Clipy: screen recorder 
+ Clipy Chrome Extension 
+ Browser Note Taker 
+ Markdown Viewer 
+ AI Resume Builder 
+
+ Guides
+ All Developer Guides 
+ DeepSeek V4 Complete Guide 
+ Claude Opus Complete Guide 
+ GPT-5.5 Complete Guide 
+ Llama 4 Complete Guide 
+ Qwen 3.5 Complete Guide 
+ Gemma 4 Complete Guide 
+ Kimi K2.6 Complete Guide 
+ Gemini 3.5 Complete Guide 
+ Open-Source LLMs Landscape 
+ AI Coding Agents Guide 
+ AGENTS.md Complete Guide 
+ Cursor IDE Complete Guide 
+ Self-Hosting LLMs Guide 
+ Apple Silicon LLMs Guide 
+ Fine-Tuning LLMs Guide 
+ Train a Small LLM Guide 
+ Android Emulators Guide 
+ iOS Simulators Guide 
+ Mobile App Testing Guide 
+ Software Testing Guide 
+
+ © 2026 Codersera. All rights reserved.

--- a/.omc/kb/raw/src-jan-api-server.md
+++ b/.omc/kb/raw/src-jan-api-server.md
@@ -1,0 +1,209 @@
+Local API Server Jan 
+ Docs 
+ Changelog 
+ Blog 
+ Handbook 
+ Download Jan 
+
+ Download 
+
+ Get started
+ Overview 
+ Quickstart 
+ Install 👋 Jan Mac 
+ Windows 
+ Linux 
+
+ Models Jan-Code-4B 
+ Jan-v3-4B 
+ Jan-v2-VL 
+ Jan-v1 
+ Jan Nano 128k 
+ Jan Nano 32k 
+ Lucy 
+
+ Integrations Claude Code 
+ OpenClaw 
+ MCP Servers 
+
+ Core concepts
+ Agents 
+ Projects 
+ Assistants 
+ File Upload 
+ Hub 
+ Local API Server 
+ App Settings 
+ Local AI Engine Llama.cpp 
+ MLX 
+
+ Model Parameters 
+ Reference
+ API Reference 
+ CLI 
+ Model Context Protocol 
+ MCP routing 
+ Cloud Providers Anthropic 
+ Gemini 
+ Groq 
+ Mistral AI 
+ OpenAI 
+ Azure OpenAI 
+ OpenRouter 
+ Hugging Face 
+ Custom Endpoints 
+
+ Jan Data Folder 
+ Troubleshooting 
+ Jan's Privacy Approach 
+
+ On This Page
+ Quick Start 
+ Start the Server 
+ Test with cURL 
+ Server Configuration 
+ Server Host 
+ Server Port 
+ API Prefix 
+ API Key 
+ Trusted Hosts 
+ Request Timeout 
+ Advanced Settings 
+ Execute Tools on Server 
+ Cross-Origin Resource Sharing (CORS) 
+ Verbose Server Logs 
+ Troubleshooting 
+ Question? Give us feedback → (opens in a new tab) Edit this page on GitHub → Scroll to top 
+
+ Docs
+ Jan Desktop
+ Local API Server
+
+ Local API Server
+
+ Jan provides a built-in, OpenAI-compatible API server that runs entirely on your computer, powered by llama.cpp . Use it as a drop-in replacement for cloud APIs to build private, offline-capable AI applications.
+
+ Quick Start 
+
+ Start the Server 
+
+ Navigate to Settings > Local API Server .
+
+ Click Start Server .
+
+ The server is ready when the logs show JAN API listening at http://127.0.0.1:1337 .
+ Test with cURL 
+ Open a terminal and make a request. Replace YOUR_MODEL_ID with the ID of an available model in Jan.
+
+ curl http://127.0.0.1:1337/v1/chat/completions \ 
+
+ -H "Content-Type: application/json" \ 
+
+ -H "Authorization: Bearer secret-key-123" \ 
+
+ -d '{ 
+
+ "model": "YOUR_MODEL_ID", 
+
+ "messages": [{"role": "user", "content": "Tell me a joke."}] 
+
+ }' 
+
+ Server Configuration 
+
+ These settings control the network accessibility and basic behavior of your local server. Access them via the Configuration button in the top right.
+
+ Server Host 
+
+ The network address the server listens on.
+
+ 127.0.0.1 (Default): The server is only accessible from your own computer. This is the most secure option for personal use.
+
+ 0.0.0.0 : The server is accessible from other devices on your local network (e.g., your phone or another computer). Use this with caution.
+
+ Server Port 
+
+ The port number for the API server.
+
+ 1337 (Default): A common alternative port.
+
+ You can change this to any available port number (e.g., 8000 ).
+
+ API Prefix 
+
+ The base path for all API endpoints.
+
+ /v1 (Default): Follows OpenAI's convention. The chat completions endpoint would be http://127.0.0.1:1337/v1/chat/completions .
+
+ You can change this or leave it empty if desired.
+
+ API Key 
+
+ A secret key used to authenticate requests.
+
+ Set any string (e.g., a-secure-password ). If a key is configured, requests must include it in the Authorization: Bearer YOUR_API_KEY header.
+
+ Leave the field empty to disable authentication (not recommended when binding to 0.0.0.0 ).
+
+ Trusted Hosts 
+
+ A comma-separated list of hostnames allowed to access the server. This provides an additional layer of security when the server is exposed on your network.
+
+ Request Timeout 
+
+ How long (in seconds) the server waits for a response from the local model before giving up. Increase this if you are running large models on slow hardware and see request timeouts.
+
+ Advanced Settings 
+
+ Execute Tools on Server 
+
+ (Disabled by default) When enabled, MCP tool calls triggered through the /v1/chat/completions endpoint are executed server-side rather than being returned to the client to dispatch. Leave this off if your client app handles tool execution itself.
+
+ Cross-Origin Resource Sharing (CORS) 
+
+ (Enabled by default) Allows web applications (like a custom web UI you are building) running on different domains to make requests to the API server.
+
+ Disable this if your API will only be accessed by non-browser-based applications (e.g., scripts, command-line tools) for slightly improved security.
+
+ Verbose Server Logs 
+
+ (Enabled by default) Provides detailed, real-time logs of all incoming requests, responses, and server activity.
+
+ This is extremely useful for debugging application behavior and understanding exactly what is being sent to the models.
+
+ Troubleshooting 
+
+ 💡
+ Ensure Verbose Server Logs are enabled to get detailed error messages in the "Server Logs" view.
+
+ Connection Refused: The server is not running, or your application is pointing to the wrong host or port.
+
+ 401 Unauthorized: Your API Key is missing from the Authorization header or is incorrect.
+
+ 404 Not Found: 
+
+ The model ID in your request body does not match an available model in Jan.
+
+ Your request URL is incorrect (check the API Prefix).
+
+ CORS Error (in a web browser): Ensure the CORS toggle is enabled in Jan's settings.
+
+ Hub App Settings 
+
+ Jan
+ Subscribe to our newsletter
+
+ Submit 
+
+ Company
+ Careers 
+ Discord 
+ GitHub 
+ LinkedIn 
+ X 
+
+ Resources
+ Blog 
+ Docs 
+ Changelog 
+ API Reference

--- a/.omc/kb/raw/src-jan-home.md
+++ b/.omc/kb/raw/src-jan-home.md
@@ -1,0 +1,89 @@
+Jan - Open-Source ChatGPT Replacement Jan 
+ Docs 
+ Changelog 
+ Blog 
+ Handbook 
+ Download Jan 
+
+ Download 
+
+ NEW ✨ v0.8.3 is now live on GitHub. Check it out! 
+ Meet Jan
+
+ Personal Intelligence that answers only to you
+
+ Download for Mac 
+
+ + 6M downloads
+
+ Join community 15k+ 
+
+ Over 4 million downloads
+
+ Jan is built in public
+ We believe AI should be open, and grow 
+ through the people who build and use it
+
+ GitHub 43.5K stars Discord 0 Online HuggingFace 123 models 
+
+ All the tools you need to make Jan yours
+ 1
+ Models
+ Choose from open models or plug in your favorite online models.
+
+ ChatGPT OpenAI 
+
+ Claude Anthropic 
+
+ Gemini Google 
+
+ Llama Meta 
+
+ Mistral Mistral AI 
+
+ Qwen Alibaba 
+
+ DeepSeek DeepSeek 
+
+ Gemma Google 
+
+ Kimi Moonshot AI 
+
+ 2
+ Memory Coming Soon 
+ Your context carries over, so you don’t repeat yourself. Jan remembers your context and preferences.
+
+ Joe
+ Designer, Singapore
+
+ Things Jan keeps in mind
+ • Minimalist UI tasted 
+ • Currently on a portfolio refresh 
+ • Wants brief, to-the-point answers 
+ • Frequent Figma/prototyping questions 
+ • Dark-mode sharer 
+ • Curious about type trends (Mostly harmless) 
+
+ Ask Jan anything
+
+ Download for Mac 
+
+ + 6M downloads, Free & Open source 
+
+ Jan
+ Subscribe to our newsletter
+
+ Submit 
+
+ Company
+ Careers 
+ Discord 
+ GitHub 
+ LinkedIn 
+ X 
+
+ Resources
+ Blog 
+ Docs 
+ Changelog 
+ API Reference

--- a/.omc/kb/raw/src-linkedin-graphify-ollama-csharp.md
+++ b/.omc/kb/raw/src-linkedin-graphify-ollama-csharp.md
@@ -1,0 +1,814 @@
+How I Used Graphify + Ollama to Automatically Create Documentation for My C# Project (Fully Local Setup) 
+
+ Agree & Join LinkedIn
+
+ By clicking Continue to join or sign in, you agree to LinkedIn’s User Agreement , Privacy Policy , and Cookie Policy .
+
+ Sign in to view more content
+
+ Create your free account or sign in to continue your search 
+
+ Email or phone
+
+ Password
+
+ Show 
+
+ Forgot password? 
+
+ Sign in
+
+ Sign in with Email 
+
+ or
+
+ New to LinkedIn? Join now 
+
+ By clicking Continue to join or sign in, you agree to LinkedIn’s User Agreement , Privacy Policy , and Cookie Policy .
+
+ Skip to main content
+
+ LinkedIn 
+
+ Top Content
+
+ People
+
+ Learning
+
+ Jobs
+
+ Games
+
+ Join now
+
+ Sign in
+
+ How I Used Graphify + Ollama to Automatically Create Documentation for My C# Project (Fully Local Setup)
+
+ Report this article
+
+ Sukanta Kumar Rout
+
+ Sukanta Kumar Rout
+
+ Published May 16, 2026
+
+ + Follow
+
+ As software projects grow, one thing almost always gets neglected: documentation. 
+
+ Not because developers do not care about it, but because maintaining documentation manually is honestly exhausting. Architecture changes, services evolve, dependencies grow, and before long the documentation becomes outdated. 
+
+ I recently started experimenting with a different approach using Graphify for knowledge graph generation, Ollama running local SLMs, and my existing C#/.NET microservice project. 
+
+ The best part? Everything ran completely on my local machine. 
+
+ No cloud APIs. 
+
+ No sending source code externally. 
+
+ No token costs. 
+
+ Just local AI + knowledge graphs. 
+
+ The Problem I Wanted to Solve 
+
+ I have a fairly large C# project with: 
+
+ - Multiple services 
+
+ - Repository layers 
+
+ - Database SDKs 
+
+ - MQTT integrations 
+
+ - Workflow orchestration 
+
+ - Rule engine components 
+
+ - Background workers 
+
+ - REST APIs 
+
+ After some time, understanding relationships inside the system became difficult. 
+
+ Questions like these started becoming common: 
+
+ - Which service calls this repository? 
+
+ - Which APIs interact with telemetry data? 
+
+ - What dependencies exist between modules? 
+
+ - Which database tables are used by this service? 
+
+ - How do workflows connect together? 
+
+ I realized I needed something more intelligent than static documentation. 
+
+ Why I Chose Graphify: 
+
+ https://graphify.net/ 
+
+ What I liked about Graphify is that it does not just “read files.” 
+
+ It creates a connected knowledge graph of the project. 
+
+ Instead of treating code as isolated files, it understands: 
+
+ - classes 
+
+ - functions 
+
+ - imports 
+
+ - dependencies 
+
+ - relationships 
+
+ - architecture flow 
+
+ It also supports multimodal analysis, including: 
+
+ - markdown 
+
+ - PDFs 
+
+ - diagrams 
+
+ - screenshots 
+
+ - architecture docs 
+
+ My Local Setup: 
+
+ I wanted everything fully local. 
+
+ So I used: 
+
+ - Graphify for repository analysis 
+
+ - Ollama for local LLM inference 
+
+ - Qwen2.5 model for reasoning 
+
+ - ASP.NET Core for orchestration 
+
+ Installing Ollama: 
+
+ https://ollama.com/ 
+
+ollama pull qwen2.5:7b
+ollama serve
+
+ That gave me a local AI endpoint running entirely on my PC. 
+
+ No OpenAI API required. 
+
+ Running Graphify 
+
+ graphify - repo C:/Projects/MyCSharpPlatform 
+
+ Graphify generated: 
+
+ - graph.json 
+
+ - graph.html 
+
+ - architecture relationships 
+
+ - dependency mappings 
+
+ The graph visualization itself was already incredibly useful. 
+
+ Recommended by LinkedIn
+
+ Exploring Midjourney AI for Generating Software…
+
+ Zaidul Alam
+
+ 3 years ago
+
+ Implementing CQRS in a Go with Hexagonal Architecture
+
+ David Alecrim
+
+ 1 year ago
+
+ AI Meets Software Architecture: A Paradigm Shift
+
+ Luqman Shareef Mohammed
+
+ 1 year ago
+
+ Using AI to Generate Documentation: 
+
+ Instead of manually writing documentation, I started feeding selected graph context into the local SLM. 
+
+ The key lesson I learned: 
+
+ DO NOT send the entire graph to the model. 
+
+ Initially I tried that and quickly ran into: 
+
+ - huge prompts 
+
+ - timeout issues 
+
+ - slow inference 
+
+ - memory problems 
+
+ The better approach was: 
+
+ 1. Retrieve only relevant graph nodes 
+
+ 2. Build focused prompts 
+
+ 3. Ask the model to summarize architecture 
+
+ That changed everything. 
+
+ Example Prompt: 
+
+ Explain the architecture of the telemetry ingestion pipeline. 
+
+ Focus on: 
+
+ - API layer 
+
+ - Repository layer 
+
+ - MQTT flow 
+
+ - Database interactions 
+
+ - Workflow processing 
+
+ The model started generating surprisingly useful documentation. 
+
+ Not generic AI fluff. Actual architecture-aware explanations. 
+
+ One thing I did not initially expect was how useful this became for onboarding. 
+
+ A new developer normally spends days trying to understand: 
+
+ - folder structure 
+
+ - service interactions 
+
+ - hidden dependencies 
+
+ - business logic flow 
+
+ But with this setup, I could ask: 
+
+ - Which services interact with telemetry processing? 
+
+ - Explain how MQTT data flows through the platform. 
+
+ And the system produced understandable summaries immediately. 
+
+ “Why Running Everything Locally Matters” 
+
+ This was probably the most important part for me. 
+
+ Many AI tooling workflows today require: 
+
+ - cloud APIs 
+
+ - uploading repositories 
+
+ - external processing 
+
+ - expensive token usage 
+
+ I did not want my source code leaving my machine. 
+
+ Using: 
+
+ - Graphify 
+
+ - Ollama 
+
+ - local SLMs 
+
+ Gave me: 
+
+ - privacy 
+
+ - offline capability 
+
+ - no API cost 
+
+ - full control 
+
+ - low latency 
+
+ Models I Tested during this POC work 
+
+ I experimented with several local models. 
+
+ For my use case, Qwen2.5:7b gave the best overall results. 
+
+ Final Thoughts… 
+
+ I originally started this project simply trying to automate documentation for my C# project. 
+
+ But after combining: 
+
+ Graphify knowledge graphs 
+
+ Ollama local SLMs 
+
+ AI-assisted retrieval 
+
+ It started feeling like I had built a local engineering intelligence system. 
+
+ The most exciting part is that all of this runs completely offline on a normal PC. 
+
+ No cloud dependency. 
+
+ No expensive APIs. 
+
+ No external code sharing. 
+
+ Just your project, your machine, and local AI helping you understand your own architecture better. 
+
+ And honestly, I think this kind of workflow is going to become much more common for software teams in the future. 
+
+ Like 
+
+ Like 
+
+ Celebrate 
+
+ Support 
+
+ Love 
+
+ Insightful 
+
+ Funny 
+
+ Comment
+
+ Copy 
+
+ LinkedIn 
+
+ Facebook 
+
+ X 
+
+ Share
+
+ 8
+
+ 1 Comment
+
+ Gobinda Goswami Jena
+
+ 1mo
+
+ Report this comment
+
+ This is super useful Sukanta , thanks for sharing.
+
+ Like
+
+ Reply
+
+ 1 Reaction
+
+ 2 Reactions
+
+ To view or add a comment, sign in 
+
+ More articles by Sukanta Kumar Rout
+
+ MTConnect Enabling Data-Driven Manufacturing
+
+ Jul 19, 2024 
+
+ MTConnect Enabling Data-Driven Manufacturing
+
+ Background: So, why I am discussing this today, let me tell you. Sometimes back I was working for a customer project…
+
+ 6
+
+ Standards used for Smart Manufacturing : An Overview
+
+ Apr 6, 2024 
+
+ Standards used for Smart Manufacturing : An Overview
+
+ Overview: What is Smart Manufacturing? Please go through the link to get an overview of smart manufacturing before we…
+
+ 8
+
+ Is a "Data Mesh" Architecture fits to modern Smart Factory?
+
+ Dec 28, 2023 
+
+ Is a "Data Mesh" Architecture fits to modern Smart Factory?
+
+ Overview: In today’s digital economy, every business wants to be data driven. It is one of the top strategic goals of…
+
+ 11
+
+ A reference Architecture for Intelligence at Edge
+
+ Oct 9, 2023 
+
+ A reference Architecture for Intelligence at Edge
+
+ Background: In one of my previous articles Edge SW Stack we discussed about the components and architecture of it. A…
+
+ 4
+
+ 2 Comments
+
+ IoT hub or Event hub, which one to use and how should we use it?
+
+ Aug 18, 2023 
+
+ IoT hub or Event hub, which one to use and how should we use it?
+
+ Background:- IoT applications and other on-prem applications are generating millions of data points daily. It is…
+
+ 15
+
+ 1 Comment
+
+ "OEE" looking in a different angle
+
+ Jul 28, 2023 
+
+ "OEE" looking in a different angle
+
+ Background..
+
+ 14
+
+ 1 Comment
+
+ An IIOT Architecture with MQTT and Sparkplug B
+
+ Jul 18, 2023 
+
+ An IIOT Architecture with MQTT and Sparkplug B
+
+ Let's Start with..
+
+ 15
+
+ 1 Comment
+
+ Enterprise Architecture:- What ,Why and How?
+
+ Jun 26, 2023 
+
+ Enterprise Architecture:- What ,Why and How?
+
+ Rd I started as a software developer to become a solution architect. During my journey my thought process was different…
+
+ 12
+
+ 1 Comment
+
+ An overview of IIOT Edge Software Stack
+
+ Jun 2, 2023 
+
+ An overview of IIOT Edge Software Stack
+
+ In the era of IOT and IIOT(Industrial Internet of Things) there is a growing demand to deploy solutions at the edge and…
+
+ 14
+
+ Implementing a rule engine
+
+ May 24, 2023 
+
+ Implementing a rule engine
+
+ Some months back i was working for an edge software framework using the dot net core c#. As part of the edge platform…
+
+ 7
+
+ 1 Comment
+
+ Show more
+
+ See all articles
+
+ Others also viewed
+
+ Good Practices on RESTful API Modeling (Part 1)
+
+ Thomas Lee
+
+ 7y
+
+ Model Context Protocol (MCP) – Internal Detailed Architecture
+
+ Rajesh Paleru
+
+ 10mo
+
+ AI Tool That Turns Diagrams Into Production APIs in Seconds
+
+ Ayush Dixit
+
+ 5mo
+
+ Model Context Protocol (MCP): The REST/JSON of Agentic AI Architecture?
+
+ Shyam Ramamurthy
+
+ 9mo
+
+ Model Context Protocol - AIShorts #1
+
+ Keep Up
+
+ 1y
+
+ Article 2 of 10, Part 1 of 4 | HyperRE TechFlow Edition #16
+
+ Tavi T.
+
+ 1y
+
+ 🔄 Evolving from RASA to LangGraph: Embracing the MCP Paradigm
+
+ Vishal Parekh
+
+ 1y
+
+ Reimagining API Handlers with Pipeline Workflow: A Maintainable Approach to Vertical Slices.
+
+ Kishor Naik
+
+ 1y
+
+ Platform Pulse #9: Hardening the Control Plane and the Rise of Architectural Middleware
+
+ Goran Minov
+
+ 2mo
+
+ The Paradigm Shift in Software Architecture with GenAI, LLM, RAG, and Agentic Technologies
+
+ Sachidanand Sharma
+
+ 1y
+
+ Show more
+
+ Show less
+
+ Similar topics
+
+ How to Use Knowledge Graphs in Llms
+
+ 10 Posts
+
+ 6,700
+
+ Benefits of Using Knowledge Graphs
+
+ 10 Posts
+
+ 5,951
+
+ How to Automate Document Workflows
+
+ 10 Posts
+
+ 1,071
+
+ Using Local LLMs to Improve Generative AI Models
+
+ 4 Posts
+
+ 578
+
+ Lightweight LLM Solutions for Knowledge Graph QA
+
+ 5 Posts
+
+ 1,854
+
+ How Knowledge Graphs Improve AI
+
+ 10 Posts
+
+ 5,292
+
+ Using LLMs as Microservices in Application Development
+
+ 5 Posts
+
+ 480
+
+ Open Source AI Developments Using Llama
+
+ 10 Posts
+
+ 3,358
+
+ How to Understand REST and Graphql APIs
+
+ 5 Posts
+
+ 1,517
+
+ Show more
+
+ Show less
+
+ Explore content categories
+
+ Career 
+
+ Productivity 
+
+ Finance 
+
+ Soft Skills & Emotional Intelligence 
+
+ Project Management 
+
+ Education 
+
+ Technology 
+
+ Leadership 
+
+ Ecommerce 
+
+ User Experience 
+
+ Recruitment & HR 
+
+ Customer Experience 
+
+ Real Estate 
+
+ Marketing 
+
+ Sales 
+
+ Retail & Merchandising 
+
+ Science 
+
+ Supply Chain Management 
+
+ Future Of Work 
+
+ Consulting 
+
+ Writing 
+
+ Economics 
+
+ Artificial Intelligence 
+
+ Employee Experience 
+
+ Workplace Trends 
+
+ Fundraising 
+
+ Networking 
+
+ Corporate Social Responsibility 
+
+ Negotiation 
+
+ Communication 
+
+ Engineering 
+
+ Hospitality & Tourism 
+
+ Business Strategy 
+
+ Change Management 
+
+ Organizational Culture 
+
+ Design 
+
+ Innovation 
+
+ Event Planning 
+
+ Training & Development 
+
+ Show more
+
+ Show less
+
+ LinkedIn 
+
+ © 2026 
+
+ About
+
+ Accessibility
+
+ User Agreement
+
+ Privacy Policy
+
+ Your California Privacy Choices
+
+ Cookie Policy
+
+ Copyright Policy
+
+ Brand Policy
+
+ Guest Controls
+
+ Community Guidelines
+
+ العربية (Arabic)
+
+ বাংলা (Bangla)
+
+ Čeština (Czech)
+
+ Dansk (Danish)
+
+ Deutsch (German)
+
+ Ελληνικά (Greek)
+
+ English (English) 
+
+ Español (Spanish)
+
+ فارسی (Persian)
+
+ Suomi (Finnish)
+
+ Français (French)
+
+ हिंदी (Hindi)
+
+ Magyar (Hungarian)
+
+ Bahasa Indonesia (Indonesian)
+
+ Italiano (Italian)
+
+ עברית (Hebrew)
+
+ 日本語 (Japanese)
+
+ 한국어 (Korean)
+
+ मराठी (Marathi)
+
+ Bahasa Malaysia (Malay)
+
+ Nederlands (Dutch)
+
+ Norsk (Norwegian)
+
+ ਪੰਜਾਬੀ (Punjabi)
+
+ Polski (Polish)
+
+ Português (Portuguese)
+
+ Română (Romanian)
+
+ Русский (Russian)
+
+ Svenska (Swedish)
+
+ తెలుగు (Telugu)
+
+ ภาษาไทย (Thai)
+
+ Tagalog (Tagalog)
+
+ Türkçe (Turkish)
+
+ Українська (Ukrainian)
+
+ Tiếng Việt (Vietnamese)
+
+ 简体中文 (Chinese (Simplified))
+
+ 正體中文 (Chinese (Traditional))
+
+ Language

--- a/.omc/kb/raw/src-lmstudio-home.md
+++ b/.omc/kb/raw/src-lmstudio-home.md
@@ -1,0 +1,35 @@
+LM Studio Bionic - Agent for Open Models 
+ LM Studio 
+ Models Docs Careers Enterprise LM Link 
+ Models Docs Pricing Enterprise LM Link 
+
+ Download 
+ Download 
+ Login 
+
+ Meet Bionic.
+ An Agent made for Open Models.
+ Natively local. Built for creativity, work, and code.
+ Copy download link 
+ Read the launch blog post 
+
+ Download LM Studio Bionic 
+
+ LM Studio Bionic is available in initial preview. Check out Bionic docs to learn more. 
+
+ LM Studio Product
+ Download the app Models LM Link New 
+ LM Studio Hub Beta Releases Changelog 
+
+ Developer
+ Developer Docs lmstudio-js lmstudio-python LM Studio CLI (lms) llms.txt 
+
+ Company
+ Careers We're Hiring! 
+ Blog RSS feed 
+ Enterprise Solutions Brand Guidelines 
+
+ Legal
+ Terms Privacy 
+
+ Element Labs, Inc. © 2026 LinkedIn GitHub Discord Twitter / X

--- a/.omc/kb/raw/src-lmstudio-openai-compat.md
+++ b/.omc/kb/raw/src-lmstudio-openai-compat.md
@@ -1,0 +1,92 @@
+OpenAI Compatibility Endpoints | LM Studio 
+
+ LM Studio 
+ LM Studio 
+ Search ⌘ K 
+
+ Developer
+
+ LM Studio Developer Docs API Changelog Core
+ Server 
+
+ Authentication Setup llmster as a Startup Task on Linux Run LM Studio as a service (headless) Using LM Link Using MCP via API Idle TTL and Auto-Evict REST API
+ Overview Quickstart Stateful Chats Streaming events Chat with a model POST List your models GET Load a model POST Download a model POST Unload a model POST Get download status GET REST API v0 OpenAI Compatibility
+ OpenAI Compatibility Endpoints Chat Completions Completions (Legacy) Embeddings List Models Responses Structured Output Tool Use Anthropic Compatibility
+ Anthropic Compatibility Endpoints Messages 
+
+ OpenAI Compatibility Endpoints 
+
+ OpenAI Compatibility Endpoints
+ Send requests to Responses, Chat Completions (text and images), Completions, and Embeddings endpoints.
+ Copy Markdown Open Ask Bionic to read this page
+ Copy this prompt, open Bionic, and paste it into a new chat.
+ Read https://lmstudio.ai/docs/developer/openai-compat, I want to ask questions about it.
+
+ Copy prompt 
+
+ Supported endpoints 
+
+ Endpoint Method Docs 
+ /v1/models GET Models 
+ /v1/responses POST Responses 
+ /v1/chat/completions POST Chat Completions 
+ /v1/embeddings POST Embeddings 
+ /v1/completions POST Completions 
+
+ Set the base url to point to LM Studio 
+
+ You can reuse existing OpenAI clients (in Python, JS, C#, etc) by switching up the "base URL" property to point to your LM Studio instead of OpenAI's servers.
+
+ Note: The following examples assume the server port is 1234 
+
+ Python Example 
+
+ from openai import OpenAI 
+
+ client = OpenAI( 
+ + base_url="http://localhost:1234/v1" 
+ ) 
+
+ # ... the rest of your code ... 
+
+ Typescript Example 
+
+ import OpenAI from 'openai'; 
+
+ const client = new OpenAI({ 
+ + baseUrl: "http://localhost:1234/v1" 
+ }); 
+
+ // ... the rest of your code ... 
+
+ cURL Example 
+
+ - curl https://api.openai.com/v1/chat/completions \ 
+ + curl http://localhost:1234/v1/chat/completions \ 
+ -H "Content-Type: application/json" \ 
+ -d '{ 
+ - "model": "gpt-4o-mini", 
+ + "model": "use the model identifier from LM Studio here", 
+ "messages": [{"role": "user", "content": "Say this is a test!"}], 
+ "temperature": 0.7 
+ }' 
+
+ Using Codex with LM Studio 
+
+ Codex is supported because LM Studio implements the OpenAI-compatible POST /v1/responses endpoint.
+
+ See: Use Codex with LM Studio and Responses .
+
+ Other OpenAI client libraries should have similar options to set the base URL.
+
+ If you're running into trouble, hop onto our Discord and enter the #🔨-developers channel.
+
+ REST API v0
+
+ The REST API includes enhanced stats such as Token / Second and Time To First Token (TTFT), as well as rich information about models such as loaded vs unloaded, max context, quantization, and more.
+ Chat Completions
+
+ Send a chat history and get the assistant's response.
+
+ On this page
+ Supported endpoints Set the base url to point to LM Studio Python Example Typescript Example cURL Example Using Codex with LM Studio

--- a/.omc/kb/raw/src-mateuszdev-graphify-for-ai-coding.md
+++ b/.omc/kb/raw/src-mateuszdev-graphify-for-ai-coding.md
@@ -1,0 +1,209 @@
+Graphify: A Knowledge Graph for Your Codebase | Mateusz Sowiński 
+
+ Home Blog Games 
+
+ Settings 
+ Home Blog Games 
+
+ Blog 
+ /
+ Series 
+ /
+ Token Efficiency in AI Coding 
+ /
+ Graphify: A Knowledge Graph for Your Codebase
+
+ 2026-07-11 · Updated 2026-07-10 6 min read 
+ Graphify: A Knowledge Graph for Your Codebase
+ In this article you will learn:
+
+ what Graphify actually is
+
+ where it helps AI coding workflows
+
+ where the tradeoffs and limits are
+
+ One of the easiest ways to waste tokens in AI coding is to let the model wander.
+
+ If the assistant does not understand the shape of a repo, it starts doing the expensive version of search: opening the wrong files, reading too much, and reconstructing relationships one guess at a time. If you read my LLM Context Window article, you already know why that exploration is not free.
+
+ Graphify attacks exactly that problem. It is an open-source CLI and AI assistant skill that turns a folder of code, docs, PDFs, images, and optionally video or audio into a queryable knowledge graph. Instead of brute-forcing the repo, the agent can ask structured questions: what connects two concepts, which components are hubs, what communities exist in the codebase.
+
+ Graphify is not a replacement for reading code, and it is not exact text search. It is a persistent map of relationships that helps an AI agent, or a human, navigate a project more intelligently.
+
+ Quick answer
+
+ If you work in a medium or large repo and your AI assistant keeps burning tokens on architecture and relationship questions, Graphify looks genuinely useful.
+
+ Based on the official docs, Graphify:
+
+ turns a project into three outputs: graph.html , GRAPH_REPORT.md , and graph.json 
+
+ extracts code structure locally via tree-sitter, across roughly 40 languages, with zero API calls
+
+ resolves cross-file relationships such as calls , imports , and inherits 
+
+ detects communities via Leiden clustering and highlights "god nodes", the most connected concepts
+
+ lets you query the graph with graphify query , graphify path , and graphify explain 
+
+ integrates with 20+ AI tools, including Claude Code, Cursor, Copilot, and VS Code Copilot Chat
+
+ Caveats worth knowing upfront:
+
+ on smaller repos it can be overkill, and the tool itself will tell you so
+
+ it answers relationship questions, not exact line-level lookup
+
+ semantic extraction of docs, PDFs, and images goes through an API backend, unlike code extraction
+
+ the PyPI package is graphifyy (double y ), while the CLI command is graphify 
+
+ What Graphify actually is
+
+ The simplest way to think about Graphify: it adds a structured memory layer on top of a project.
+
+ After one run, you get:
+
+ text Copy 
+ graphify-out/
+|- graph.html
+|- GRAPH_REPORT.md
+`- graph.json 
+
+ graph.html is the interactive visualization
+
+ GRAPH_REPORT.md is the readable summary with god nodes, communities, and suggested questions
+
+ graph.json is the persistent graph data, queryable later without re-reading the original files
+
+ That persistence is the point. Without a graph, an AI assistant rediscovers the same architecture every time a new session starts. With Graphify, the relationship layer survives across sessions, and graphify update . refreshes it after changes without rebuilding everything.
+
+ Another detail I like: every edge carries a confidence label such as EXTRACTED , INFERRED , or AMBIGUOUS . The output is explicit about what was found in the source versus what was guessed. Not many tools are that honest.
+
+ Why Graphify can help AI coding
+
+ Graphify is strongest when the problem is not "find me this exact string" but:
+
+ what connects auth to the database
+
+ which components act like hubs
+
+ which files explain the architecture
+
+ where are the weakly connected or isolated areas
+
+ Those are awkward questions for raw grep. Exact search wins when you already know the token or function name you want. But for understanding relationships, a scoped graph query beats opening ten files at random.
+
+ Monorepos are a sweet spot here. When one repo hosts many focused projects, the questions that hurt the most are the cross-project ones — and that boundary-crossing layer is exactly what a knowledge graph captures and no single package's docs describe.
+
+ That is also why Graphify belongs in this series, even though it is not a compression tool like RTK . RTK shrinks terminal output. Graphify reduces wasted exploration: if the agent can ask the graph first, it skips a chain of broad file reads and low-value search loops.
+
+ What stays local
+
+ Graphify splits the work in a sensible way:
+
+ code : structural extraction happens locally with tree-sitter AST parsing, no API calls
+
+ video and audio : transcribed locally via faster-whisper (optional extra)
+
+ docs, PDFs, images : semantic extraction goes through the model backend you configure — Anthropic, OpenAI, Gemini, Ollama, or AWS Bedrock
+
+ So Graphify is partly local, but not uniformly local across every input type. If privacy matters to you, do not flatten this into "everything stays local" unless you configured a local backend (like Ollama) for the semantic parts. The privacy docs are clear about this, and they also state there is no telemetry, usage tracking, or analytics.
+
+ A concrete example from my repo
+
+ My page (including blog posts) runs on a Next.js, and there is a committed graphify-out/ in it, so I can show real numbers.
+
+ The current report:
+
+ 1412 nodes , 3092 edges , 109 communities across 325 files 
+
+ verdict: "corpus is large enough that graph structure adds value"
+
+ token cost of the build: 0 , because code extraction is AST-only
+
+ NOTE
+
+ For clearness: my page is small enough that the graph is not strictly necessary. But it is a good example of what Graphify does, and it is a real repo I work in every day.
+Yet, I think it would shine in large enterprise repos where thousands and thousands of files are spread across multiple teams, and no single engineer can hold the architecture in their head.
+Additionally, my observation on frontend repo is this: if you have clean structure of the project you might not need Graphify. Reason is simple - it detects relationships between e.g. buttons that you can easily find with you IDE so it brings no value. It makes sense to use Graphify in a repo where you have many different components and you want to understand how they are connected.
+
+ The report also surfaces god nodes, and they match reality: my cn() utility with 164 edges , the shared Button component, the config object every page imports. The communities map cleanly to features such as the blog listing, the comments system, and the game modules.
+
+ One practical lesson from this repo: scope matters. My early graphs also indexed the blog articles themselves, and long-form prose is poison for a code graph — its words either connect to nothing or to everything. A few lines in .graphifyignore restricting extraction to source directories made the graph noticeably tighter and the communities cleaner.
+
+ Day-to-day workflow
+
+ I will skip the installation walkthrough, because the official README covers it better than any blog post will. What matters more is how the tool fits into a workflow:
+
+ graphify . builds the graph, graphify update . refreshes changed content without a full rebuild
+
+ graphify query , graphify path , and graphify explain make the graph useful after creation
+
+ graphify hook install keeps the graph fresh after Git operations
+
+ graphify-out/ is designed to be committed, so the map becomes shared repo infrastructure rather than a personal cache
+
+ Important limitations
+
+ It does not replace grep. If you know the exact symbol or string, plain search is faster and simpler.
+
+ Small repos may not need it. The Corpus Check verdict will tell you honestly. The return on setup grows with repo size and document sprawl.
+
+ The visualization has limits. Graphs above roughly 5000 nodes skip HTML generation entirely, and there is a configurable size cap. The fallback is practical: work from graph.json and the query commands.
+
+ Not every input is equally local. Covered above, but worth repeating before you point it at confidential PDFs.
+
+ Final thoughts
+
+ It is important to understand what Graphify is and is not. It does not read code for you. It does not answer every question. It does not replace grep or exact search.
+
+ It might help you (or your AI agent) answer nagging questions about relationships, architecture, and connections nobody can see directly. At enterprise scale this can be a lifesaver — especially when the amount of knowledge is so vast that no single human can hold it in their head. Graphify is a tool to make that knowledge explicit and queryable.
+
+ My experience with it tells me this: you may not use it very often, but when you do, it is impressively useful. Maybe it will be useful for you too (even though it will not count saved tokens as other tools do).
+ In this series
+
+ 01 LLM Context Window: how it is consumed and why it matters 
+ 02 Caveman Skill Review: Does It Really Save Tokens? 
+ 03 RTK: Reduce AI Coding Token Usage 
+ 04 Graphify: A Knowledge Graph for Your Codebase Now reading 
+
+ Further reading
+
+ New 
+ 2026-07-15
+
+ Where to Host a Website or Web App: Options and Costs
+ Hosting is cheap. Understanding what you are hosting is the expensive part.
+
+ 2026-05-24
+
+ GitHub Copilot pricing change: Is it still worth it?
+ Copilot is moving to AI credits. Here is what changes, who pays more, and whether it is still worth it.
+
+ 2026-04-28
+
+ Serilog & OpenTelemetry in .NET: React Demo UI
+ Drive checkout and warehouse flows with a React UI to generate logs in the SerilogDemo stack.
+
+ Mateusz-dev
+ Portfolio, blog, and curated experiments.
+ Buy me a coffee 
+
+ Explore
+ Home 
+ Blog 
+ Games 
+ Support 
+ Connect
+ GitHub 
+ LinkedIn 
+ Email 
+ Contact 
+
+ Account sign-in relies on Clerk, and the site uses essential cookies, browser storage, and operational telemetry as described in the legal policies.
+ © 2026 Mateusz Sowiński. All rights reserved.
+ Privacy Policy Cookies Policy 
+
+ Mateusz-dev

--- a/.omc/kb/raw/src-mlx-README.md
+++ b/.omc/kb/raw/src-mlx-README.md
@@ -1,0 +1,121 @@
+# MLX
+
+[**Quickstart**](#quickstart) | [**Installation**](#installation) |
+[**Documentation**](https://ml-explore.github.io/mlx/build/html/index.html) |
+[**Examples**](#examples)
+
+[![CircleCI](https://circleci.com/gh/ml-explore/mlx.svg?style=svg)](https://circleci.com/gh/ml-explore/mlx)
+
+MLX is an array framework for machine learning on Apple silicon,
+brought to you by Apple machine learning research.
+
+Some key features of MLX include:
+
+- **Familiar APIs**: MLX has a Python API that closely follows NumPy. MLX
+   also has fully featured C++, [C](https://github.com/ml-explore/mlx-c), and
+   [Swift](https://github.com/ml-explore/mlx-swift/) APIs, which closely mirror
+   the Python API. MLX has higher-level packages like `mlx.nn` and
+   `mlx.optimizers` with APIs that closely follow PyTorch to simplify building
+   more complex models.
+
+- **Composable function transformations**: MLX supports composable function
+  transformations for automatic differentiation, automatic vectorization,
+  and computation graph optimization.
+
+- **Lazy computation**: Computations in MLX are lazy. Arrays are only
+  materialized when needed.
+
+- **Dynamic graph construction**: Computation graphs in MLX are constructed
+  dynamically. Changing the shapes of function arguments does not trigger
+  slow compilations, and debugging is simple and intuitive.
+
+- **Multi-device**: Operations can run on any of the supported devices
+  (currently the CPU and the GPU).
+
+- **Unified memory**: A notable difference from MLX and other frameworks
+  is the *unified memory model*. Arrays in MLX live in shared memory.
+  Operations on MLX arrays can be performed on any of the supported
+  device types without transferring data.
+
+MLX is designed by machine learning researchers for machine learning
+researchers. The framework is intended to be user-friendly, but still efficient
+to train and deploy models. The design of the framework itself is also
+conceptually simple. We intend to make it easy for researchers to extend and
+improve MLX with the goal of quickly exploring new ideas.
+
+The design of MLX is inspired by frameworks like
+[NumPy](https://numpy.org/doc/stable/index.html),
+[PyTorch](https://pytorch.org/), [Jax](https://github.com/google/jax), and
+[ArrayFire](https://arrayfire.org/).
+
+## Examples
+
+The [MLX examples repo](https://github.com/ml-explore/mlx-examples) has a
+variety of examples, including:
+
+- [Transformer language model](https://github.com/ml-explore/mlx-examples/tree/main/transformer_lm) training.
+- Large-scale text generation with
+  [LLaMA](https://github.com/ml-explore/mlx-examples/tree/main/llms/llama) and
+  finetuning with [LoRA](https://github.com/ml-explore/mlx-examples/tree/main/lora).
+- Generating images with [Stable Diffusion](https://github.com/ml-explore/mlx-examples/tree/main/stable_diffusion).
+- Speech recognition with [OpenAI's Whisper](https://github.com/ml-explore/mlx-examples/tree/main/whisper).
+
+## Quickstart
+
+See the [quick start
+guide](https://ml-explore.github.io/mlx/build/html/usage/quick_start.html)
+in the documentation.
+
+## Installation
+
+MLX is available on [PyPI](https://pypi.org/project/mlx/). To install MLX on
+macOS, run:
+
+```bash
+pip install mlx
+```
+
+To install the CUDA backend on Linux, run:
+
+```bash
+pip install mlx[cuda]
+```
+
+To install a CPU-only Linux package, run:
+
+```bash
+pip install mlx[cpu]
+```
+
+Checkout the
+[documentation](https://ml-explore.github.io/mlx/build/html/install.html#)
+for more information on building the C++ and Python APIs from source.
+
+## Contributing
+
+Check out the [contribution guidelines](https://github.com/ml-explore/mlx/tree/main/CONTRIBUTING.md) for more information
+on contributing to MLX. See the
+[docs](https://ml-explore.github.io/mlx/build/html/install.html) for more
+information on building from source, and running tests.
+
+We are grateful for all of [our
+contributors](https://github.com/ml-explore/mlx/tree/main/ACKNOWLEDGMENTS.md#Individual-Contributors). If you contribute
+to MLX and wish to be acknowledged, please add your name to the list in your
+pull request.
+
+## Citing MLX
+
+The MLX software suite was initially developed with equal contribution by Awni
+Hannun, Jagrit Digani, Angelos Katharopoulos, and Ronan Collobert. If you find
+MLX useful in your research and wish to cite it, please use the following
+BibTex entry:
+
+```text
+@software{mlx2023,
+  author = {Awni Hannun and Jagrit Digani and Angelos Katharopoulos and Ronan Collobert},
+  title = {{MLX}: Efficient and flexible machine learning on Apple silicon},
+  url = {https://github.com/ml-explore},
+  version = {0.0},
+  year = {2023},
+}
+```

--- a/.omc/kb/raw/src-mlx-lm-SERVER.md
+++ b/.omc/kb/raw/src-mlx-lm-SERVER.md
@@ -1,0 +1,155 @@
+# HTTP Model Server
+
+You use `mlx-lm` to make an HTTP API for generating text with any supported
+model. The HTTP API is intended to be similar to the [OpenAI chat
+API](https://platform.openai.com/docs/api-reference).
+
+> [!NOTE]  
+> The MLX LM server is not recommended for production as it only implements
+> basic security checks.
+
+Start the server with: 
+
+```shell
+mlx_lm.server --model <path_to_model_or_hf_repo>
+```
+
+For example:
+
+```shell
+mlx_lm.server --model mlx-community/Mistral-7B-Instruct-v0.3-4bit
+```
+
+This will start a text generation server on port `8080` of the `localhost`
+using Mistral 7B instruct. The model will be downloaded from the provided
+Hugging Face repo if it is not already in the local cache.
+
+To see a full list of options run:
+
+```shell
+mlx_lm.server --help
+```
+
+You can make a request to the model by running:
+
+```shell
+curl localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+     "messages": [{"role": "user", "content": "Say this is a test!"}],
+     "temperature": 0.7
+   }'
+```
+
+### Request Fields
+
+- `messages`: An array of message objects representing the conversation
+  history. Each message object should have a role (e.g. user, assistant) and
+  content (the message text).
+
+- `role_mapping`: (Optional) A dictionary to customize the role prefixes in
+  the generated prompt. If not provided, the default mappings are used.
+
+- `stop`: (Optional) An array of strings or a single string. These are
+  sequences of tokens on which the generation should stop.
+
+- `max_tokens`: (Optional) An integer specifying the maximum number of tokens
+  to generate. Defaults to `512`.
+
+- `stream`: (Optional) A boolean indicating if the response should be
+  streamed. If true, responses are sent as they are generated. Defaults to
+  false.
+
+- `temperature`: (Optional) A float specifying the sampling temperature.
+  Defaults to `0.0`.
+
+- `top_p`: (Optional) A float specifying the nucleus sampling parameter.
+  Defaults to `1.0`.
+
+- `top_k`: (Optional) An integer specifying the top-k sampling parameter.
+  Defaults to `0` (disabled).
+
+- `min_p`: (Optional) A float specifying the min-p sampling parameter.
+  Defaults to `0.0` (disabled).
+
+- `repetition_penalty`: (Optional) Applies a multiplicative penalty to repeated
+  tokens. Defaults to `0.0` (disabled).
+
+- `repetition_context_size`: (Optional) The size of the context window for
+  applying repetition penalty. Defaults to `20`.
+
+- `presence_penalty`: (Optional) Applies an additive penalty to tokens
+  that appeared before. Defaults to `0.0` (disabled).
+
+- `presence_context_size`: (Optional) The size of the context window for
+  applying presence penalty. Defaults to `20`.
+
+- `frequency_penalty`: (Optional) Applies an additive penalty proportional to
+  how many times a token appeared previously. Defaults to `0.0` (disabled).
+
+- `frequency_context_size`: (Optional) The size of the context window for
+  applying frequency penalty. Defaults to `20`.
+
+- `logit_bias`: (Optional) A dictionary mapping token IDs to their bias
+  values. Defaults to `None`.
+
+- `logprobs`: (Optional) An integer specifying the number of top tokens and
+  corresponding log probabilities to return for each output in the generated
+  sequence. If set, this can be any value between 1 and 10, inclusive.
+
+- `model`: (Optional) A string path to a local model or Hugging Face repo id.
+  If the path is local is must be relative to the directory the server was
+  started in.
+
+- `adapters`: (Optional) A string path to low-rank adapters. The path must be
+  relative to the directory the server was started in.
+
+- `draft_model`: (Optional) Specifies a smaller model to use for speculative
+  decoding. Set to `null` to unload.
+
+- `num_draft_tokens`: (Optional) The number of draft tokens the draft model
+  should predict at once. Defaults to `3`.
+
+### Response Fields
+
+- `id`: A unique identifier for the chat.
+
+- `system_fingerprint`: A unique identifier for the system.
+
+- `object`: Any of "chat.completion", "chat.completion.chunk" (for
+  streaming), or "text.completion".
+
+- `model`: The model repo or path (e.g. `"mlx-community/Llama-3.2-3B-Instruct-4bit"`).
+
+- `created`: A time-stamp for when the request was processed.
+
+- `choices`: A list of outputs. Each output is a dictionary containing the fields:
+    - `index`: The index in the list.
+    - `logprobs`: A dictionary containing the fields:
+        - `token_logprobs`: A list of the log probabilities for the generated
+          tokens.
+        - `tokens`: A list of the generated token ids.
+        - `top_logprobs`: A list of lists. Each list contains the `logprobs`
+          top tokens (if requested) with their corresponding probabilities.
+    - `finish_reason`: The reason the completion ended. This can be either of
+      `"stop"` or `"length"`.
+    - `message`: The text response from the model.
+
+- `usage`: A dictionary containing the fields:
+    - `prompt_tokens`: The number of prompt tokens processed.
+    - `completion_tokens`: The number of tokens generated.
+    - `total_tokens`: The total number of tokens, i.e. the sum of the above two fields.
+
+### List Models
+
+Use the `v1/models` endpoint to list available models:
+
+```shell
+curl localhost:8080/v1/models -H "Content-Type: application/json"
+```
+
+This will return a list of locally available models where each model in the
+list contains the following fields:
+
+- `id`: The Hugging Face repo id.
+- `created`: A time-stamp representing the model creation time.

--- a/.omc/kb/reports/agents/source-review-20260721.md
+++ b/.omc/kb/reports/agents/source-review-20260721.md
@@ -1,0 +1,707 @@
+# Source review — 9 web sources vs our graphify/Ollama bake-off setup
+
+Date: 2026-07-21 · Agent: source-review · Status: **COMPLETE**
+
+Raw captures live in `.omc/kb/raw/src-*.md`.
+
+Primary-source anchor for adjudication: installed graphify **0.9.22** at
+`/Users/rmanaloto/.local/share/mise/installs/pipx-graphifyy/0.9.22/graphifyy/lib/python3.14/site-packages/graphify`
+(referred to below as `<GP>`).
+
+---
+
+## Source 1 — Augment Code, "Graphify hits 58.3K stars: knowledge graphs for AI coding assistants"
+
+URL: <https://www.augmentcode.com/learn/graphify-knowledge-graphs-ai-coding>
+Fetched: HTTP 200, 212 KB HTML. Raw: `.omc/kb/raw/src-augmentcode-graphify-knowledge-graphs.md`
+Published Jun 2 2026, "Last updated: Jun 18, 2026". Author: Paula Hingel, Augment Code (a **vendor blog** — Augment sells a competing context engine; treat "My Take" as marketing).
+
+### What it actually says
+
+- "Developer Safi Shamsi released Graphify **v0.8.28** as the latest in a rapid series of 123 releases."
+- "33-language AST extraction … parsed **locally via tree-sitter with zero API calls**. LLM-powered extraction handles docs, PDFs, and images."
+- "Multiple LLM backends — Supports Gemini, Claude, OpenAI, DeepSeek, **Ollama (fully local)**, AWS Bedrock, and Kimi for semantic extraction. **Auto-detects which API key is available**."
+- "Every relationship gets tagged as `EXTRACTED`, `INFERRED`, or `AMBIGUOUS`."
+- "`graphify install` registers the skill with your assistant."
+- "`graphify hook install` adds post-commit hooks … with a merge driver that union-merges `graph.json`."
+- "`graphify prs --triage` … `graphify prs --conflicts` flags PRs that share **graph communities**."
+- "`graphify export callflow-html` to get a Mermaid diagram of the full call flow."
+
+### So what for us? — **INFORMS**, with one loud contradiction
+
+Nothing here changes a flag, model, or step. It is a feature-tour post, not an
+operator's guide: **zero** extraction-config advice — no token budget, no
+concurrency, no chunking, no model recommendation, no mention of
+`--max-concurrency`, `--token-budget`, or `--api-timeout`. Control arm on that
+claim: the same raw capture *does* contain `graphify query`, `graphify path`,
+`graphify explain`, `graphify prs`, `graphify export callflow-html`,
+`graphify hook install` — so the probe can find graphify CLI strings; it found
+no tuning flags because there are none.
+
+What it *does* inform:
+
+1. **The `EXTRACTED` / `INFERRED` / `AMBIGUOUS` confidence tag is a first-class
+   graph field.** Our bake-off scores precision/recall against a gold answer key
+   but (as briefed) does not stratify by confidence tag. If graphify emits it per
+   edge, a model that produces many `INFERRED` edges is materially different from
+   one producing `EXTRACTED` edges at the same raw count. **Candidate bake-off
+   metric: precision *conditioned on* confidence tag.** (Verify the field exists
+   in our own artifacts before adopting — see Synthesis A.)
+2. **"Auto-detects which API key is available"** is the failure mode our explicit
+   `--backend ollama` already avoids. Keep passing it explicitly; never rely on
+   auto-detect in a bake-off, or arm identity silently depends on ambient env.
+3. `graphify prs --conflicts` "flags PRs that share **graph communities**" —
+   confirms Louvain communities are a *consumed* product, not a debug artifact.
+   Relevant to our known `[all]`→Louvain-on-3.14 note.
+
+### ⚠️ CONTRADICTION — flag loudly
+
+> "One-command setup — **`graphify install`** registers the skill with your assistant."
+
+This is exactly the invocation our `.claude/rules/do-not.md` #8 forbids. Bare
+`graphify install` (no `--project`) mutates `~/.claude`: ~43 KB of skill files,
+appends a `# graphify` H1 to `~/.claude/CLAUDE.md`, and sprays `.graphify_version`
+stamps into other platforms' user skill dirs. **Adjudication: our rule wins.** It
+is derived from the installed `install.py`; the blog is a third-party feature
+tour written against 0.8.28 that never mentions `--project` at all. Do not let
+this post's "one-command setup" framing leak into any doc or skill here.
+
+### Staleness
+
+`v0.8.28` (post) vs **0.9.22** (ours) — 3 minor + many patch releases behind, at
+the post's own stated cadence of ~1 release every other day that is ~2 months of
+drift. Every capability claim in it is a *floor*, never a current inventory.
+
+---
+## Source 3 — Mateusz Sowiński, "Graphify: A Knowledge Graph for Your Codebase"
+
+URL: <https://www.mateusz-dev.pl/blog/posts/graphify-for-ai-coding>
+Fetched: HTTP 200, 161 KB HTML. Raw: `.omc/kb/raw/src-mateuszdev-graphify-for-ai-coding.md`
+Dated 2026-07-11 (10 days old — the freshest of the graphify posts). Part 04 of a
+"Token Efficiency in AI Coding" series. Independent blog, no vendor stake.
+
+**This is the only source of the three with real operator content.**
+
+### What it actually says
+
+- "extracts code structure locally via tree-sitter, across roughly **40 languages**, with zero API calls" (source 1 said 33 — see Contradictions)
+- "detects communities via **Leiden clustering** and highlights 'god nodes'"
+- "**semantic extraction of docs, PDFs, and images goes through an API backend, unlike code extraction**"
+- "every edge carries a confidence label such as `EXTRACTED`, `INFERRED`, or `AMBIGUOUS`"
+- Real numbers from his Next.js repo: "**1412 nodes, 3092 edges, 109 communities across 325 files**", "token cost of the build: **0**, because code extraction is AST-only"
+- ⭐ "One practical lesson from this repo: **scope matters. My early graphs also indexed the blog articles themselves, and long-form prose is poison for a code graph — its words either connect to nothing or to everything. A few lines in `.graphifyignore` restricting extraction to source directories made the graph noticeably tighter and the communities cleaner.**"
+- "if you have clean structure of the project you might not need Graphify … It makes sense to use Graphify in a repo where you have many different components and you want to understand how they are connected."
+- "Graphs above roughly **5000 nodes** skip HTML generation entirely, and there is a configurable size cap."
+- "`graphify update .` refreshes changed content without a full rebuild"
+
+### Primary-source verification (all four load-bearing claims CONFIRMED in 0.9.22)
+
+| Claim | Probe | Result |
+|---|---|---|
+| Leiden clustering | `<GP>/cluster.py:1` | ✅ *"Uses **Leiden (graspologic) if available, falls back to Louvain (networkx)**"*; `cluster.py:25-26`, `:48` `from graspologic.partition import leiden`, `:74-76` nx louvain fallback |
+| `.graphifyignore` is real | `grep -rn graphifyignore <GP> --include="*.py"` | ✅ 20+ hits; `detect.py:834` gitignore-spec parser, `detect.py:939` `_load_graphifyignore`, `detect.py:915-918` — merged AFTER `.gitignore`, **"can only ever exclude MORE, never re-include"** |
+| confidence tag vocabulary | `<GP>/validate.py:5` | ✅ `VALID_CONFIDENCES = {"EXTRACTED","INFERRED","AMBIGUOUS"}`; `export.py:159` `_CONFIDENCE_SCORE_DEFAULTS = {"EXTRACTED":1.0,"INFERRED":0.5,"AMBIGUOUS":0.2}`; prompt at `llm.py:457,478,486` |
+| ~5000-node HTML cap | `<GP>/exporters/html.py:13` | ✅ `MAX_NODES_FOR_VIZ = 5_000`, env-overridable (`html.py:18-28`); `__main__.py:543` documents `--no-viz` |
+
+Control arm for the grep sweep: the same `--include="*.py"` sweep returned
+**0 files** for `mlx`/`lmstudio` (per the brief) and **20+** for
+`graphifyignore` — the probe discriminates.
+
+### So what for us? — **ADOPT** (two concrete changes) + INFORMS
+
+**ADOPT-1 — `.graphifyignore` in every bake-off arm's corpus dir, and treat scoping as a controlled variable.**
+"Long-form prose is poison for a code graph — its words either connect to
+nothing or to everything" is a *direct hazard to our bake-off design*: our gold
+corpus is **7 fictional documents with lexical decoys**. Decoys are precisely the
+"connect to everything" failure mode he describes. That is not a reason to drop
+them — they are the discriminator — but it means **corpus scoping is a variable
+we are currently not controlling**, and if any arm's fresh dir picks up an
+ancestor `.gitignore` (which `_load_graphifyignore` walks up to the VCS root,
+`detect.py:1107`) the arms are not identical. **Action:** the bake-off harness
+should either (a) write an explicit `.graphifyignore` into each fresh run dir, or
+(b) assert in the manifest which ignore files were in effect. Ancestor-`.gitignore`
+inheritance is a silent arm-identity leak today.
+
+**ADOPT-2 — score precision/recall *stratified by confidence tag*, and use `confidence_score` as a weight.**
+`export.py:159` gives us the vendor's own weights (1.0 / 0.5 / 0.2). A model that
+hits recall by emitting everything as `AMBIGUOUS` should not tie a model that
+emits `EXTRACTED`. Cheap to add: our scorer already reads `graph.json`.
+This also gives a **second, model-sensitive signal at n=1** — hedging rate — that
+may separate arms where raw edge counts sit inside the noise floor.
+
+**INFORMS-1 — his numbers are a sanity scale.** 325 files → 1412 nodes / 3092
+edges ≈ **4.3 nodes and 9.5 edges per file**. Our 7-doc corpus should land in the
+low tens-to-hundreds of nodes; anything wildly outside that ratio is a signal the
+run degenerated, not that the model is good.
+
+**INFORMS-2 — `MAX_NODES_FOR_VIZ` is irrelevant at our corpus size** (7 docs ≪
+5000 nodes), so HTML is always generated; it is not a hidden per-arm cost
+difference. Recorded so nobody re-derives it.
+
+**INFORMS-3 — "code is AST-only, zero tokens; docs/PDFs/images go to the backend."**
+This is the *reason* our fictional-document corpus is the right test bed: it
+exercises the **only** path where the model matters. A code-heavy corpus would
+have measured tree-sitter, not the model. Our design is already correct; this
+source explains why.
+
+---
+
+## Source 4 — Sukanta Kumar Rout (LinkedIn Pulse), "How I Used Graphify + Ollama to Automatically Create Documentation for My C# Project (Fully Local Setup)"
+
+URL: <https://www.linkedin.com/pulse/how-i-used-graphify-ollama-automatically-create-my-c-project-rout-lpg0c/>
+Fetched: **HTTP 200, RETRIEVED IN FULL** despite an auth-wall banner in the markup —
+LinkedIn Pulse serves article body to unauthenticated UAs. Raw:
+`.omc/kb/raw/src-linkedin-graphify-ollama-csharp.md`. Published **May 16, 2026**
+(~2 months old; graphify was ~0.8.x then). 8 reactions, 1 comment — low-signal, single-anecdote post.
+
+### What it actually says
+
+- Setup: "Graphify for repository analysis / Ollama for local LLM inference / **Qwen2.5 model** for reasoning / ASP.NET Core for orchestration"
+- `ollama pull qwen2.5:7b` then `ollama serve`
+- "Models I Tested during this POC work — I experimented with several local models. **For my use case, Qwen2.5:7b gave the best overall results.**" (No list of what else was tried. No metric. No repeats.)
+- ⭐ "The key lesson I learned: **DO NOT send the entire graph to the model.** Initially I tried that and quickly ran into: huge prompts, **timeout issues**, slow inference, memory problems. The better approach was: 1. Retrieve only relevant graph nodes 2. Build focused prompts 3. Ask the model to summarize architecture."
+- Invocation printed as `graphify - repo C:/Projects/MyCSharpPlatform` (mangled by LinkedIn's typography; not a real flag — see Contradictions).
+- Cites "Why I Chose Graphify: **https://graphify.net/**" — a domain that is not the project's (PyPI `graphifyy`, GitHub). Do not follow.
+
+### So what for us? — **INFORMS** (weakly), one flag validated
+
+1. **His "best model" finding is worth exactly nothing to us as a ranking**, and it
+   is the same defect `.claude/rules/probes-need-a-control-arm.md` §6 was written
+   for: n=1, no corpus stated, no noise floor, no list of the losing models, and a
+   different task (documentation prose generation, not KG extraction). It does
+   **not** override our own measured `qwen2.5-coder:14b` winner — if anything it is
+   a weak concurrence that the qwen2.5 family suits this workload.
+2. **His failure mode is downstream of extraction, not inside it.** "Do not send the
+   entire graph to the model" is about *querying*, where he hand-rolled a RAG loop.
+   graphify's own `extract` already chunks — which is what our `--token-budget 12000`
+   controls. So his lesson is not an argument to change our flag; it is
+   circumstantial support that **12000 is on the right side of the tradeoff** and
+   that raising it toward "whole corpus in one prompt" would reproduce his
+   "timeouts / memory problems" outcome. Our `--api-timeout 900` is the mitigation
+   he lacked.
+3. **7B on unknown consumer hardware.** He is on a "normal PC"; we have 96 GB
+   unified memory. His model choice is hardware-driven and tells us nothing about
+   our under-sized-roster hypothesis.
+
+Nothing here changes a flag. Recorded mainly so a future session does not treat
+"Qwen2.5:7b is best" as an independent second data point — it is an anecdote.
+
+---
+## Source 5 — Medium / Google Cloud, "Running an AI Agent Locally: ADK, Gemma 4 and Docker Model Runner"
+
+URL: <https://medium.com/google-cloud/running-an-ai-agent-locally-adk-gemma-4-and-docker-model-runner-95ca9e6f506d>
+Fetch: **curl → HTTP 403** (Medium bot-blocks plain curl, 6 KB challenge page).
+**Retrieved via WebFetch** (extracted content, not byte-verbatim — no raw file saved
+because I never held the verbatim bytes; do not treat the quotes below as
+character-exact). Status: **RETRIEVED (extracted)**.
+
+### What it actually says
+
+- Docker Model Runner is "a built-in feature of Docker Desktop that lets you pull and run LLMs locally — just like pulling container images."
+- Endpoint: **`http://localhost:12434/engines/v1`**, OpenAI-compatible.
+- macOS/Windows requires explicit TCP activation: `docker desktop enable model-runner --tcp 12434`. On Docker Engine (Linux) port 12434 is on by default.
+- `docker model pull ai/gemma4:E4B` / `docker model ls`
+- Gemma 4 variants offered: **E2B, E4B, 26B, 31B**
+- "No API key is needed; Docker Model Runner requires only a dummy placeholder."
+- ADK wiring: `OPENAI_API_BASE=http://localhost:12434/engines/v1`, model prefixed `openai/`.
+
+### So what for us? — **INERT as a backend; INFORMS on one number**
+
+**Not a fourth option worth taking.** It is Ollama's shape (pull-a-model, serve
+OpenAI-compat locally) with three strict disadvantages for *this* workload:
+
+1. It runs under **Docker Desktop**, which on this machine is the pinned
+   devcontainer runtime (`.claude/rules/do-not.md` #7 — never move
+   `docker context` off `desktop-linux`). Loading a 20–60 GB model into Docker
+   Desktop's VM competes for the exact resource pool our devcontainer needs, and
+   `docker desktop enable model-runner --tcp 12434` mutates the shared Docker
+   Desktop config. That is a real cost Ollama does not impose.
+2. On Apple silicon it does **not** get us anything Ollama lacks — it is not the
+   MLX/Metal path; it is another llama.cpp-family server.
+3. `ai/gemma4:*` is a *different* distribution of the same weights we already
+   pull from `ollama.com/library/gemma4`. New arm, no new capability.
+
+**The one useful bit:** Docker's Gemma 4 catalog lists **26B and 31B** variants —
+independent corroboration that Gemma 4 exists above the `12b` we run. Cross-checked
+against the actual Ollama registry (below): `gemma4:26b` = 18 GB, `gemma4:31b` = 20 GB.
+So the ceiling on our current gemma4 arm is a registry pull away, not a porting exercise.
+
+---
+
+## Source 6 — MLX (ml-explore/mlx) + mlx-lm server docs
+
+URLs: <https://github.com/ml-explore/mlx> · raw README and
+<https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/SERVER.md>
+Fetch: HTTP 200 both (raw.githubusercontent.com). Raw: `.omc/kb/raw/src-mlx-README.md`,
+`.omc/kb/raw/src-mlx-lm-SERVER.md`. **Verbatim.**
+
+### What it actually says (MLX's own docs, not a blog)
+
+From `mlx/README.md`:
+> "MLX is an array framework for machine learning on Apple silicon, brought to you by Apple machine learning research."
+> "**Unified memory**: A notable difference from MLX and other frameworks is the *unified memory model*. Arrays in MLX live in shared memory. Operations on MLX arrays can be performed on any of the supported device types without transferring data."
+
+From `mlx_lm/SERVER.md` — **this answers the brief's question directly**:
+> "# HTTP Model Server — You use `mlx-lm` to make an HTTP API for generating text with any supported model. The HTTP API is intended to be **similar to the OpenAI chat API**."
+> "`mlx_lm.server --model <path_to_model_or_hf_repo>`"
+> "This will start a text generation server on **port `8080`** of the `localhost`"
+> "`curl localhost:8080/v1/chat/completions -H "Content-Type: application/json" -d '{"messages":[…],"temperature":0.7}'`"
+> "Use the **`v1/models`** endpoint to list available models"
+> ⚠️ "**The MLX LM server is not recommended for production as it only implements basic security checks.**"
+
+Supported request fields include `model`, `messages`, `temperature`, `top_p`, `max_tokens` (default **512**), `stream`, `logprobs`, `draft_model` (speculative decoding). Response carries a real `usage` object (`prompt_tokens`/`completion_tokens`/`total_tokens`).
+
+### So what for us? — **ADOPT (as an experimental arm), and it CORRECTS an "ALREADY ESTABLISHED" fact**
+
+**Yes, MLX is a realistic alternative — and `providers.json` is NOT required.**
+The brief asked whether the custom-provider mechanism could target it. It could,
+but there is a **simpler, vendor-documented path** the brief's framing missed:
+
+> `<GP>/__main__.py:597-599` — graphify's own `--help` text:
+> ```
+> --backend B   gemini|kimi|claude|openai|deepseek|ollama (default: whichever API key is set)
+>               openai also reaches self-hosted OpenAI-compatible servers (llama.cpp,
+>               vLLM, LM Studio): set OPENAI_BASE_URL (e.g. http://localhost:8080/v1)
+>               and OPENAI_MODEL to the model name your server serves
+> ```
+> `<GP>/llm.py:148-155` — the `openai` backend config:
+> ```python
+> # OPENAI_BASE_URL points the backend at any OpenAI-compatible server
+> # (llama.cpp, vLLM, LM Studio, ...); OPENAI_MODEL overrides the default
+> "base_url": os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1"),
+> ```
+
+Note the example port in graphify's own help is **`http://localhost:8080/v1`** —
+byte-identical to `mlx_lm.server`'s default. So the concrete invocation is:
+
+```bash
+mlx_lm.server --model mlx-community/Qwen2.5-Coder-32B-Instruct-4bit     # port 8080
+OPENAI_BASE_URL=http://localhost:8080/v1 \
+OPENAI_API_KEY=dummy \
+graphify extract <dir> --backend openai \
+  --model mlx-community/Qwen2.5-Coder-32B-Instruct-4bit \
+  --max-concurrency 1 --token-budget 12000 --api-timeout 900
+```
+(`OPENAI_API_KEY` must be **non-empty** — `<GP>/llm.py:1625-1629` raises
+`No API key for backend 'openai'` on an empty key, and the ollama-style
+placeholder fallback at `llm.py:1612-1623` is `backend == "ollama"` **only**.)
+
+`~/.graphify/providers.json` (`<GP>/llm.py:221-224`, `_load_custom_providers` at
+`:264`) is the *alternative* path — worth it only if we want a named arm
+(`--backend mlx`) with its own pricing/temperature block. Note its guard:
+project-local `./.graphify/providers.json` is **ignored** unless
+`GRAPHIFY_ALLOW_LOCAL_PROVIDERS=1` (`llm.py:271-277`), and `provider_base_url_ok`
+(`llm.py:227`) accepts loopback http silently. For a bake-off arm the env-var
+route is strictly simpler and needs no new file.
+
+### ⚠️ CORRECTION to an "ALREADY ESTABLISHED" fact — the original probe had a blind spot
+
+The brief states: *"graphify supports NONE of MLX / LM Studio / Jan as a backend.
+Control-armed grep … `lmstudio`, `lm_studio` … → 0 files each."*
+
+**The literal claim is true; the operational conclusion drawn from it is wrong.**
+The probe searched `lmstudio` and `lm_studio` — **not `LM Studio` with a space**:
+
+```
+$ grep -rli "lmstudio\|lm_studio" <GP>          →  0 files      (the original probe)
+$ grep -rn  -i "lm studio"        <GP>          →  3 hits       (the missing arm)
+      __main__.py:598 · llm.py:150 · llm.py:1906
+$ grep -rn  -i "vllm\|llama\.cpp" <GP>          →  6 hits       (control arm: the probe
+                                                    CAN find other OpenAI-compat servers)
+$ grep -rn  -i "\bmlx\b"          <GP>          →  0 hits       (MLX genuinely absent by name)
+$ grep -rn  "jan\.ai\|localhost:1234\|localhost:1337\|12434" <GP>  →  0 hits
+```
+
+Correct statement: **there is no *named* backend for MLX / LM Studio / Jan (true),
+but all three are reachable today via the existing `openai` backend + `OPENAI_BASE_URL`,
+and graphify's own `--help` and source comments say so explicitly for LM Studio.**
+The 9-backend list is a list of *presets*, not a list of *reachable servers*. This is
+the `probes-need-a-control-arm.md` §"bound-limited searches" failure mode: a token
+spelling was the bound, and "not found" read as "not supported".
+
+### ⚠️ SECOND FINDING — an MLX/LM-Studio arm is NOT flag-equivalent to an Ollama arm
+
+`<GP>/llm.py:1194` gates the entire context/keep-alive block on the backend name:
+
+```python
+if backend == "ollama" and extra_body is None:
+    ...
+    num_ctx = auto_num_ctx            # min(est_input + out_cap + 2000, 131072), floor 8192
+    keep_alive = os.environ.get("GRAPHIFY_OLLAMA_KEEP_ALIVE", "30m")
+    kwargs["extra_body"] = {"options": {"num_ctx": num_ctx}, "keep_alive": keep_alive}
+```
+
+Under `--backend openai` (MLX / LM Studio / Jan / Docker Model Runner) graphify sends
+**no `num_ctx` and no `keep_alive` at all** — the server's own defaults apply.
+So a "MLX vs Ollama" arm comparison silently varies **two** things (engine *and*
+context policy), not one. Any such arm must state that, or the result is another
+anecdote. Also inherited: `mlx_lm.server`'s `max_tokens` default is **512**
+(`SERVER.md`), whereas the ollama preset carries `max_tokens: 16384`
+(`llm.py:130`) — a 32× gap that would truncate extraction JSON on MLX unless
+`GRAPHIFY_MAX_OUTPUT_TOKENS` is set. **That alone would sink a naive MLX arm and
+look like "MLX is worse at KG extraction".**
+
+### One more thing the vendor comment gives us for free
+
+`llm.py:1187-1189`, verbatim: *"Over-allocation (e.g. **128k slots for an 8k prompt on
+a 31B model**) exhausts VRAM by chunk 4 and produces the same hollow-200 symptom."*
+graphify's maintainers picked **31B** as the illustrative size where KV over-allocation
+bites. Our `GRAPHIFY_OLLAMA_NUM_CTX` being **deliberately unset** is exactly the
+recommended posture, and matters *more* as we scale the roster to 30B+, not less.
+**Keep it unset.** Do not "helpfully" pin it when adding the big arms.
+
+---
+
+## Source 7 — LM Studio (lmstudio.ai)
+
+URLs: <https://lmstudio.ai/> and <https://lmstudio.ai/docs/developer/openai-compat>
+Fetch: HTTP 200 both. Raw: `.omc/kb/raw/src-lmstudio-home.md`, `.omc/kb/raw/src-lmstudio-openai-compat.md`
+
+### What it actually says (vendor docs)
+
+> "Set the base url to point to LM Studio — You can reuse existing OpenAI clients (in Python, JS, C#, etc) by switching up the 'base URL' property to point to your LM Studio instead of OpenAI's servers."
+> "**Note: The following examples assume the server port is 1234**"
+> `base_url="http://localhost:1234/v1"` · `curl http://localhost:1234/v1/chat/completions`
+> Supported: `/v1/chat/completions`, `/v1/completions` (legacy), `/v1/embeddings`, `/v1/models`, `/v1/responses`, Structured Output, Tool Use, plus an **Anthropic Compatibility** surface.
+> "Codex is supported because LM Studio implements the OpenAI-compatible `POST /v1/responses` endpoint."
+
+### So what for us? — **INFORMS** (viable, but no reason to prefer it)
+
+- **OpenAI-compatible: YES. Default port: 1234. Path: `/v1`.** Confirmed from LM Studio's own docs, as the brief asked.
+- Reachable via `OPENAI_BASE_URL=http://localhost:1234/v1 --backend openai` — and it is the server graphify's own comment names.
+- **Models Ollama does not have: not materially.** LM Studio's catalog is Hugging Face GGUF + MLX-community repos. That *is* broader than `ollama.com/library` in the tail, but for the 30B-class instruct/coder models we care about, Ollama already carries them (verified below). LM Studio's real differentiators are a GUI and an **MLX backend** — and if we want MLX we should drive `mlx_lm.server` directly rather than add a desktop GUI to a scripted, reproducible bake-off harness.
+- **Against it for our use:** it is a GUI-first desktop app whose server is started from the UI. Our harness needs headless, scriptable, manifest-recordable arm setup. `lms` CLI exists but adds a dependency for zero capability gain over `mlx_lm.server`.
+- Its `/v1/embeddings` endpoint is noted for completeness — we currently use `embeddinggemma` via Ollama.
+
+---
+
+## Source 8 — Jan (jan.ai)
+
+URLs: <https://jan.ai/> (JS-rendered, no usable text) → docs at <https://www.jan.ai/docs/desktop/api-server>
+Fetch: home HTTP 200 but client-rendered (grep for `1337`/`openai` over 2.4 MB of markup → **0 hits**; that is a rendering artifact, not absence). Docs page HTTP 200, 80 KB, **content confirmed**. Raw: `.omc/kb/raw/src-jan-home.md`, `.omc/kb/raw/src-jan-api-server.md`
+Note: `https://jan.ai/docs/api-server` → **404**; the live path is `https://www.jan.ai/docs/desktop/api-server`.
+
+### What it actually says (vendor docs)
+
+> "Jan provides a built-in, **OpenAI-compatible API server** that runs entirely on your computer, **powered by llama.cpp**. Use it as a drop-in replacement for cloud APIs…"
+> "The server is ready when the logs show `JAN API listening at http://127.0.0.1:1337`."
+> "`curl http://127.0.0.1:1337/v1/chat/completions …`"
+> "**1337 (Default)**: A common alternative port." · "**`/v1` (Default)**: Follows OpenAI's convention."
+> API Key: "If a key is configured, requests must include it in the `Authorization: Bearer YOUR_API_KEY` header."
+> Also lists "Local AI Engine: **Llama.cpp / MLX**" and an Anthropic-compatible messages endpoint.
+
+### So what for us? — **INERT**
+
+- **OpenAI-compatible: YES. Default port: 1337. Path: `/v1`.** Question answered.
+- **Models Ollama does not have: no.** It is a llama.cpp/MLX front-end over GGUF + Hugging Face — the same weights, plus Jan's own small `Jan-v1` / `Jan-Code-4B` fine-tunes, which are 4B-class and therefore *below* the size range our under-sized-roster hypothesis is about.
+- Same GUI-first objection as LM Studio, with a smaller catalog and no advantage. If we want the MLX engine, drive `mlx_lm.server`; if we want llama.cpp, we already have Ollama. **No arm.**
+
+---
+
+## Source 9 — Codersera, "Local AI Model Picker"
+
+URL: <https://codersera.com/tools/local-ai-model-picker>
+Fetch: HTTP 200, 61 KB. Raw: `.omc/kb/raw/src-codersera-local-ai-model-picker.md`
+"Last updated 2026-06-16". **Low trust: this is an SEO/lead-gen page** for a
+dev-staffing agency ("Hire Developers", "Hire a Developer"), and it openly admits
+forward-projecting model names: *"When a forward-projected name doesn't have a real
+HuggingFace page yet, we point to the closest currently-shipping model and label it honestly."*
+
+### What it actually says
+
+- Runtime one-liners: "Ollama is the easiest entry point… OpenAI-compatible REST API on localhost:11434." / "**MLX** — Apple's native ML framework. Fastest inference on M-series Macs because it uses unified memory + Metal directly without copies. Use mlx-lm … **expect 2-3× the throughput of llama.cpp on the same hardware**." / "vLLM … not for desktop chat."
+- Sizing rule: "**working-set memory ≈ 0.6 GB per billion parameters**, plus 2-4 GB for KV cache + overhead" at Q4_K_M. "Add 4-8 GB for OS / apps."
+- RAM table row for us: "**96 GB+ — Command R+ (104B) · DeepSeek V4 MoE 670B** — Server / workstation. You can run almost any open model."
+- Also: "48-64 GB — Llama 4 70B · Kimi K2.6 70B · Hermes 4 70B … Approaches GPT-4-class quality."
+
+### So what for us? — **INFORMS on sizing arithmetic only; the model names are NOT usable**
+
+**Do not lift model names from this page.** Control arm on that judgement — I checked
+its names against the actual Ollama registry (`ollama.com/library/<name>/tags`,
+bogus name → 404 so the probe discriminates):
+
+| Codersera name | Ollama library probe | verdict |
+|---|---|---|
+| `DeepSeek V4` / `DeepSeek Coder V4 6.7B` | `library/deepseek-v4` → **HTTP 404** | **does not exist there** |
+| `Llama 4 8B` (16 GB row) | `library/llama4/tags` → smallest is `scout` / `16x17b` = **67 GB** | **no 8B variant exists** |
+| `Qwen 3.6 27B / 35B-A3B` | not in the library tag list | forward-projected |
+| `Gemma 4 27B` | real tags are **`gemma4:26b` (18 GB)** and **`gemma4:31b` (20 GB)** | approximately right, name wrong |
+
+So its catalog is a mix of real and invented. What survives is the **arithmetic**,
+which is standard and independently checkable: ~0.6 GB/B at Q4 + KV. Applied to a
+96 GB M2 Max (minus ~8 GB OS): **a 70B dense model at Q4 ≈ 42 GB + KV — comfortably
+resident.** That is the number that matters for the "roster is badly under-sized"
+hypothesis, and it holds regardless of this page's naming.
+
+The MLX "2-3× throughput vs llama.cpp" figure is **uncited** here and should be
+treated as marketing until measured on our own corpus. It is a hypothesis for an
+arm, not a finding.
+
+---
+# Synthesis
+
+## A. Does anything change the BAKE-OFF?
+
+**Yes — three things, in descending order of value.**
+
+### A1. The roster IS badly under-sized, and the fix is a registry pull, not a port
+
+Our largest arm ever is **18 GB** (`qwen3-coder:latest` = `30b-a3b-q4`) on **96 GB**
+unified memory. Applying the standard Q4 arithmetic (~0.6 GB/B + KV, corroborated by
+source 9 and by the measured tag sizes below), the machine's practical headroom after
+~8 GB for macOS is **~85 GB** — i.e. we are using **~21 %** of it.
+
+Measured against the real Ollama registry (`ollama.com/library/<f>/tags`; control arm:
+`library/deepseek-v4` → **404**, so a bogus family is distinguishable from a real one):
+
+| candidate | size | why it belongs in the bake-off |
+|---|---|---|
+| **`qwen2.5-coder:32b`** | **20 GB** | ⭐ **highest-value single arm.** Same family/tuning as our measured winner `qwen2.5-coder:14b`, ~2.3× params. It isolates **scale alone** with family held constant — the one comparison our current data cannot make. |
+| **`gemma4:31b`** (or `:26b`, 18 GB) | 20 GB | Same for the gemma4 line vs our `gemma4:12b`. Corroborated independently by Docker's catalog (source 5: "E2B, E4B, 26B, 31B"). |
+| **`qwen3:32b`** | 20 GB | Scale-up of `qwen3:14b`; completes the third family. |
+| **`qwen3-coder:30b-a3b-q8_0`** | 32 GB | Same weights we already run, at **q8 instead of q4**. Isolates **quantization** — a variable currently confounded with model choice across every arm. |
+| `qwen3-coder:30b-a3b-fp16` | 61 GB | Unquantized ceiling of a model we already have. Fits. The definitive "is q4 costing us extraction quality?" answer. |
+| **`llama3.3:70b`** (q4) | **43 GB** | The first true **70B dense** arm. Different lineage entirely — the strongest test of "is 14B the bottleneck?" |
+| **`gpt-oss:120b`** | 65 GB | Fits in 96 GB. Largest credible arm available. |
+| `deepseek-r1:32b` | 20 GB | A *reasoning*-tuned 32B — plausibly good at relation inference, plausibly terrible at strict JSON. Cheap to find out. |
+| `mistral-small3.2:24b` / `devstral:24b` | 15 / 14 GB | Apache-2.0 mid-size controls. Low priority. |
+| ~~`llama4:scout`~~ | 67 GB | Fits, but 109B MoE at 67 GB with `keep_alive=0` is a punishing reload cost. Only after A2. |
+
+**Recommended next matrix:** hold everything else fixed and run
+`qwen2.5-coder:14b` (incumbent) → `qwen2.5-coder:32b` → `qwen3-coder:30b-a3b-q4` →
+`qwen3-coder:30b-a3b-q8_0` → `llama3.3:70b`, plus the existing NULL arm. That is
+**one family-scale axis, one quantization axis, one lineage axis** — three answerable
+questions instead of five incomparable points.
+
+### A2. ⚠️ `GRAPHIFY_OLLAMA_KEEP_ALIVE=0` becomes a serious cost at 30B+ — reconsider it per-arm
+
+`<GP>/llm.py:1228` — graphify's default is `"30m"`; we override to **`0`**, which
+unloads the model **after every chunk**. At 9 GB that is a tolerable few seconds. At
+**43 GB (`llama3.3:70b`) or 61–65 GB** it is a full re-read of tens of GB from disk
+into unified memory *per chunk*, and with `--api-timeout 900` a slow reload can be
+mistaken for a slow model.
+
+This is a genuine tension: `keep_alive=0` is what makes our arms **memory-clean and
+independent**, which is exactly the isolation the harness was built for. So do not
+just flip it — **decide it explicitly and record it in the manifest**:
+- keep `0` for isolation, and **measure the load cost separately** (a warm-up call
+  outside the timed window), or
+- set a short non-zero keep-alive **uniformly across all arms including the NULL arm**,
+  so the confound is constant.
+
+Either is defensible; silently keeping `0` while scaling to 43 GB is not. **The one
+thing that must not happen is `keep_alive` differing between arms.**
+
+### A3. Add confidence-tag stratification to the scorer (cheap, high signal)
+
+Both source 1 and source 3 highlight the per-edge tag, and it is real in 0.9.22:
+`<GP>/validate.py:5` `VALID_CONFIDENCES = {"EXTRACTED","INFERRED","AMBIGUOUS"}`,
+weights at `<GP>/export.py:159` `{"EXTRACTED":1.0,"INFERRED":0.5,"AMBIGUOUS":0.2}`,
+and the extraction prompt instructs the model to *"Mark uncertain ones AMBIGUOUS
+instead of omitting"* (`<GP>/llm.py:486`).
+
+That last line is the point: **the prompt actively rewards hedging**, so raw
+edge-count recall silently favours whichever model hedges most. Report
+(a) precision/recall **per tag**, and (b) a `confidence_score`-weighted score using
+the vendor's own weights. It costs one pass over `graph.json` and gives a
+**second, orthogonal discriminator** — useful precisely where n=3 raw counts sit
+inside the NULL-arm noise floor.
+
+### A4. MLX — realistic, but run it as a deliberate experiment, not a bake-off arm
+
+**Verdict: worth ONE scoped probe, and it must not be scored against the Ollama arms.**
+
+- ✅ It works: `mlx_lm.server` serves **OpenAI-compatible `/v1/chat/completions` on
+  port 8080** (`mlx_lm/SERVER.md`, quoted above), and graphify reaches any such server
+  via `--backend openai` + `OPENAI_BASE_URL` — its own `--help` gives
+  `http://localhost:8080/v1` as the example (`<GP>/__main__.py:598`). **No
+  `providers.json` required.**
+- ✅ The Apple-silicon rationale is real and from Apple's own README: unified memory,
+  no host↔device copies.
+- ❌ But **it is not flag-equivalent** (see Source 6, second finding): under
+  `--backend openai`, graphify sends **no `num_ctx` and no `keep_alive`**
+  (`llm.py:1194` gates on `backend == "ollama"`), and `mlx_lm.server`'s `max_tokens`
+  default is **512** vs the ollama preset's **16384** (`llm.py:130`). A naive MLX arm
+  would truncate its own JSON output and look like a bad model.
+- ⚠️ MLX's own docs: *"not recommended for production as it only implements basic
+  security checks."* Fine for a local probe; note it.
+
+**If run:** set `GRAPHIFY_MAX_OUTPUT_TOKENS=16384`, use an
+`mlx-community/*-4bit` build of a model we already have on Ollama, and frame the
+result strictly as **"same weights, different engine — throughput and JSON-validity
+delta"**, never as a quality ranking against Ollama arms.
+
+### A5. LM Studio / Jan / Docker Model Runner — answered, and all three are declined
+
+| | OpenAI-compatible? | default port | path | models Ollama lacks? | verdict |
+|---|---|---|---|---|---|
+| **LM Studio** | ✅ (vendor docs) | **1234** | `/v1` | Not materially (HF GGUF + MLX repos; tail only) | **INFORMS** — viable, GUI-first, no gain over `mlx_lm.server` |
+| **Jan** | ✅ (vendor docs) | **1337** | `/v1` | No (llama.cpp/MLX over GGUF; own models are 4B-class) | **INERT** |
+| **Docker Model Runner** | ✅ (source 5) | **12434** | `/engines/v1` | No (`ai/gemma4:*` = same weights) | **INERT** — and it contends with Docker Desktop, our pinned devcontainer runtime |
+
+All three are reachable the same way as MLX (`--backend openai` + `OPENAI_BASE_URL`)
+should that ever change. **None of them is a fourth option worth taking today** —
+every one is a different front-end over weights Ollama already serves, and each adds a
+GUI/daemon dependency to a harness whose value is that it is scriptable and
+manifest-recordable.
+
+---
+
+## B. Does anything change how we USE graphify?
+
+**Two concrete changes and one confirmation.**
+
+### B1. ADOPT — control corpus scoping explicitly (`.graphifyignore`) — source 3
+
+> *"long-form prose is poison for a code graph — its words either connect to nothing
+> or to everything. A few lines in `.graphifyignore` restricting extraction to source
+> directories made the graph noticeably tighter and the communities cleaner."*
+
+Two consequences:
+
+1. **Arm-identity leak (act on this).** `_load_graphifyignore` (`<GP>/detect.py:939`)
+   walks the **ancestor chain up to the VCS root** (`detect.py:1107`) and **merges
+   `.gitignore` too** (`detect.py:929`, `:915-918`). Our harness makes a *fresh
+   directory per run* — if any of those dirs sit under a git tree, arms can inherit
+   *different* ignore sets depending on where they land. Fix: write an explicit
+   `.graphifyignore` into each run dir **and record its content hash in the manifest**.
+   Today the manifest cannot prove two arms saw the same corpus.
+2. **Interpretation of our gold corpus.** Our 7 fictional docs *are* long-form prose
+   with lexical decoys — precisely the "connects to everything" shape. That is the
+   right test (it is the only path where the model matters — see B3) but it means our
+   absolute precision numbers will look poor by his standards. **Judge arms against
+   each other and the NULL arm, never against an absolute bar.**
+
+### B2. ADOPT — do not raise `--token-budget` toward "whole corpus in one prompt" — source 4
+
+> *"DO NOT send the entire graph to the model. Initially I tried that and quickly ran
+> into: huge prompts, timeout issues, slow inference, memory problems."*
+
+His failure is downstream (querying), but the mechanism is identical and it is
+independently confirmed by graphify's own code: over-large contexts cause **hollow
+200 OK responses** (`<GP>/llm.py:1184-1189`, issue #798) from *both* directions —
+truncation when `num_ctx` is too small, KV exhaustion when it is too large.
+**`--token-budget 12000` + auto-derived `num_ctx` + `--api-timeout 900` is the
+correct posture; keep it, and keep `GRAPHIFY_OLLAMA_NUM_CTX` unset** (graphify's own
+comment names *"128k slots for an 8k prompt on a 31B model"* as the OOM shape —
+directly relevant as we add 31B+ arms).
+
+### B3. CONFIRMED — a document corpus is the right test bed
+
+Sources 1, 3 and the code all agree: **code extraction is tree-sitter AST, zero LLM
+calls; docs/PDFs/images are the only model-driven path.** A code-heavy bake-off
+corpus would have measured tree-sitter, not the model. Our fictional-document corpus
+is correct by construction. Recorded so nobody "improves" it into a code corpus.
+
+### B4. Rejected as guidance
+
+- **`graphify install`** (source 1) — forbidden here; see the Contradictions section.
+- **`graphify -repo <path>`** (source 4) — not a real flag; LinkedIn typography mangled it.
+- **`graphify update .` for incremental refresh** (source 3) — real and useful for
+  day-to-day use, but **must never be used in a bake-off run**: it reads the
+  incremental manifest and semantic cache, which is exactly what our fresh-dir
+  isolation exists to defeat. `--force` (`<GP>/__main__.py`, `GRAPHIFY_FORCE=1`) is
+  the bake-off-safe direction.
+
+---
+
+## C. Contradictions — adjudicated against primary sources
+
+### C1. ⚠️⚠️ **"graphify supports NONE of MLX / LM Studio / Jan as a backend" — literally true, operationally misleading. CORRECT IT.**
+
+The established fact's grep used the tokens `lmstudio` / `lm_studio`. graphify spells
+it **"LM Studio"**, with a space, in three places — including its own `--help`:
+
+> `<GP>/__main__.py:597-598`
+> ```
+> openai also reaches self-hosted OpenAI-compatible servers (llama.cpp,
+> vLLM, LM Studio): set OPENAI_BASE_URL (e.g. http://localhost:8080/v1)
+> ```
+
+**Adjudication (installed code beats the prior probe):** there is no *named preset*
+for MLX / LM Studio / Jan — that part stands, and MLX/Jan are genuinely absent by
+name (0 hits for `\bmlx\b`, `jan.ai`, `localhost:1234`, `localhost:1337`, `12434`).
+But **all four are reachable today** through the `openai` backend + `OPENAI_BASE_URL`,
+and the vendor documents that path for LM Studio explicitly. The 9-backend list is a
+list of presets, not of reachable servers. Restate the fact that way in memory.
+
+Control arm proving the corrected probe discriminates: `vllm|llama\.cpp` → 6 hits,
+`\bmlx\b` → 0 hits, in the same sweep. It can find OpenAI-compat server names; MLX
+really is absent, LM Studio really is present.
+
+### C2. ⚠️ **"`graphify install` registers the skill with your assistant" (source 1) — contradicts `do-not.md` #8.**
+
+**Adjudication: our rule wins**, and by the widest possible margin — the rule is
+derived from the installed `install.py`; the blog is a vendor feature tour against
+**0.8.28** that never mentions `--project`. Bare `graphify install` mutates
+`~/.claude`. **Ignore the blog's "one-command setup" framing entirely.**
+
+### C3. Leiden vs Louvain — *not* a contradiction; our note was under-specified
+
+Source 3 says "Leiden clustering"; our memory says "`[all]` → Louvain on 3.14".
+`<GP>/cluster.py:1` reconciles both: *"Uses **Leiden (graspologic) if available, falls
+back to Louvain (networkx)**."* So Leiden is the intended algorithm and **we are
+running the fallback** because `graspologic` is unavailable on Python 3.14.
+
+**This is a live bake-off concern, not a footnote.** Community structure is a scored
+output, Leiden and Louvain do not produce identical partitions, and if `graspologic`
+availability ever differs between arms the community counts are incomparable.
+**Action: assert the resolved clustering backend in the run manifest.** Also worth
+noting our arms are being scored on the *fallback* algorithm, which is not what the
+tool's authors consider "best quality" (`cluster.py:25`).
+
+### C4. Node/language counts differ between sources — both are stale, neither matters
+
+Source 1 says **33 languages**; source 3 says **~40**. Both are third-party counts of
+different releases (0.8.28 vs ~0.9.x). Irrelevant to us — our corpus is documents, and
+the AST path is not under test. Recorded only so the discrepancy is not re-litigated.
+
+### C5. Source 9's model catalog is partly invented — do not seed the roster from it
+
+`DeepSeek V4` → `ollama.com/library/deepseek-v4` **HTTP 404**; `Llama 4 8B` does not
+exist (smallest `llama4` tag is 67 GB); `Qwen 3.6` is forward-projected. The page says
+so itself. Its **arithmetic** (~0.6 GB/B at Q4) is standard and survives; its
+**names** do not. Every model in the A1 table was verified against the live registry
+instead.
+
+### C6. No source contradicted the "Our setup" facts
+
+Ollama 0.32.1, graphify 0.9.22 host-only via mise pipx, the flag set, and the local
+model list were all consistent with or unaddressed by every source. Source 4's
+`qwen2.5:7b` "best model" is **not** a contradiction of our `qwen2.5-coder:14b`
+result — different task, different hardware, n=1, no noise floor, and no list of the
+models it beat. It is an anecdote (`probes-need-a-control-arm.md` §6) and must not be
+recorded as a second data point.
+
+---
+
+## Retrieval ledger
+
+| # | Source | Status |
+|---|---|---|
+| 1 | augmentcode.com — Graphify 58.3K stars | ✅ RETRIEVED (curl 200, verbatim) |
+| 3 | mateusz-dev.pl — Graphify knowledge graph | ✅ RETRIEVED (curl 200, verbatim) |
+| 4 | linkedin.com/pulse — Graphify + Ollama C# | ✅ RETRIEVED **in full** (curl 200; auth-wall banner present in markup but article body served to an unauthenticated desktop UA) |
+| 5 | medium.com/google-cloud — ADK + Gemma 4 + Docker Model Runner | ⚠️ **curl 403** (Medium bot-block). Retrieved via WebFetch as **extracted content, not byte-verbatim**. |
+| 6 | github.com/ml-explore/mlx (+ mlx-lm SERVER.md) | ✅ RETRIEVED (raw.githubusercontent 200, verbatim) |
+| 7 | lmstudio.ai (+ /docs/developer/openai-compat) | ✅ RETRIEVED (curl 200, verbatim) |
+| 8 | jan.ai | ⚠️ home page is client-rendered (200 but no text). **Docs retrieved** at `www.jan.ai/docs/desktop/api-server` (200). `jan.ai/docs/api-server` → 404. |
+| 9 | codersera.com — Local AI Model Picker | ✅ RETRIEVED (curl 200, verbatim) — low trust, see C5 |
+
+Nothing was invented. Where a fetch failed or was partial, it is marked above.
+
+---
+
+## GitHub repos touched
+
+- [ml-explore/mlx](https://github.com/ml-explore/mlx) — README read for the unified-memory / Apple-silicon claim (source 6).
+- [ml-explore/mlx-lm](https://github.com/ml-explore/mlx-lm) — `mlx_lm/SERVER.md` read for the OpenAI-compatible endpoint, port 8080, and the `max_tokens` default of 512.
+- [ml-explore/mlx-examples](https://github.com/ml-explore/mlx-examples) — referenced from the MLX README; not read.
+- [ml-explore/mlx-swift](https://github.com/ml-explore/mlx-swift), [ml-explore/mlx-c](https://github.com/ml-explore/mlx-c) — listed in the MLX README as sibling APIs; not read.
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — this repo; rules and bake-off harness referenced.
+
+Not a GitHub repo but the primary adjudication source throughout: the **installed
+graphify 0.9.22 package** at
+`~/.local/share/mise/installs/pipx-graphifyy/0.9.22/graphifyy/lib/python3.14/site-packages/graphify`
+(PyPI `graphifyy`). Files cited: `llm.py`, `cluster.py`, `detect.py`, `validate.py`,
+`export.py`, `exporters/html.py`, `__main__.py`, `serve.py`.


### PR DESCRIPTION
Ray asked for these reviewed before the guardrail work because they might change
the next steps. They did. 707-line report + 10 raw sources, 8 of 9 retrieved
(Medium bot-blocked -> WebFetch extract, not verbatim; Jan's homepage is
client-rendered so its docs were used). Nothing invented; the retrieval ledger
marks every partial fetch.

**It corrected a fact I had recorded as established.** I claimed "graphify
supports NONE of MLX / LM Studio / Jan" from a grep of `lmstudio`/`lm_studio`.
graphify spells it **"LM Studio", with a space** — 3 hits, including its own
--help:

    openai also reaches self-hosted OpenAI-compatible servers (llama.cpp,
    vLLM, LM Studio): set OPENAI_BASE_URL (e.g. http://localhost:8080/v1)

The 9 backends are PRESETS, not the reachable set: MLX / LM Studio / Jan /
Docker Model Runner are all reachable TODAY via `--backend openai` +
`OPENAI_BASE_URL`, no providers.json needed. Control arm on the corrected probe:
`vllm|llama.cpp` -> 6 hits, `\bmlx\b` -> 0, so it discriminates and MLX really is
absent by name. This is `probes-need-a-control-arm.md` rule 3 — a token spelling
was the bound, and "not found" was read as "not supported".

Four actionable findings:

1. **The roster uses ~21% of this machine** (18 GB largest arm, ~85 GB practical
   headroom). Next matrix isolates one variable at a time instead of five
   incomparable points: q2.5c:14b -> q2.5c:32b (SCALE, family fixed) ->
   q3c:30b-a3b-q4 -> q8_0 (QUANTIZATION, weights fixed) -> llama3.3:70b
   (LINEAGE), plus the NULL arm. Verified against the real Ollama registry
   (control arm: `library/deepseek-v4` -> 404).
2. **`GRAPHIFY_OLLAMA_KEEP_ALIVE=0` becomes a confound at 30B+** — it unloads
   after every chunk, which is a 43-65 GB re-read PER CHUNK on the big arms, and
   with `--api-timeout 900` a slow reload reads as a slow model. Decide it
   explicitly and record it; never let it differ between arms.
3. **Add confidence-tag stratification to the scorer.** The prompt says "Mark
   uncertain ones AMBIGUOUS instead of omitting" (`llm.py:486`), so raw recall
   silently rewards whichever model hedges most. Weight by graphify's own values
   (`export.py:159`).
4. **Latent isolation hole**: `_load_graphifyignore` (`detect.py:939`) walks the
   ancestor chain to the VCS root and merges `.gitignore`, which fresh-dir-per-run
   does not isolate. Benign today — the workbench is outside any git tree with no
   ignore file above it (control-armed) — but it would silently diverge arms if
   the workbench moved. Fix by writing an explicit `.graphifyignore` per run dir
   and hashing it into the manifest.

Also: a non-ollama arm is NOT flag-equivalent — `llm.py:1194` gates num_ctx and
keep_alive on `backend == "ollama"`, and `mlx_lm.server` defaults max_tokens to
512 vs the ollama preset's 16384. That 32x gap alone would truncate extraction
JSON and look like "MLX is worse at KG extraction".

Declined: LM Studio, Jan, Docker Model Runner — all front-ends over weights
Ollama already serves, each adding a GUI/daemon dependency to a harness whose
value is that it is scriptable. Keep `--token-budget 12000` and keep
`GRAPHIFY_OLLAMA_NUM_CTX` UNSET.

Gates: lint rc=0, pytest 775 passed, verify 93 passed/0 failed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015tpo1Gdwyj25CLWrH1Fg5P


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guides covering Graphify, Jan, LM Studio, MLX, local model selection, and local API servers.
  - Added setup, configuration, troubleshooting, model-sizing, and OpenAI-compatible API usage instructions.
  - Added educational content explaining knowledge graphs, local AI workflows, and practical integration examples.
  - Added a comprehensive source-review report consolidating findings and recommendations.

- **Bug Fixes**
  - Corrected LM Studio API examples to use the local server URL, port, and model identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->