### PR TITLE
feat(ci): machine-enforce ADR-0001 — every git-writing job must skip hk's hooks

### DIFF
--- a/docs/adr/0001-hk-hooks-do-not-run-in-ci.md
+++ b/docs/adr/0001-hk-hooks-do-not-run-in-ci.md
@@ -48,12 +48,26 @@ v0.7.0→v1.51.0: zero hits), so the skip must be explicit.
 
 ## Consequences
 
-- Any **new** workflow that commits or pushes must set `HK_SKIP_HOOKS` too. There is no global
-  guard — the two known cases are fixed by name.
-- Correctness now depends on remembering. A contract asserting "every workflow that commits sets
-  `HK_SKIP_HOOKS`" would give this teeth; not written yet.
+- Any **new** workflow that commits or pushes must set `HK_SKIP_HOOKS` too.
+- ~~Correctness now depends on remembering.~~ **Closed 2026-07-21 — the guard now exists.** The
+  `workflow_hk_skip_hooks` hk step runs `dotfiles-setup workflow-hooks`
+  (`python/src/dotfiles_setup/workflow_hooks.py`), which fails when *any* job that commits or
+  pushes does not set `HK_SKIP_HOOKS` covering `pre-commit,pre-push`. It pins **nothing by name** —
+  that would have inherited exactly the weakness this bullet described. A job is judged by shape,
+  on the three routes that reach a local `git`: a hook-firing verb at a shell command position, a
+  third-party action classified as a local writer, or a first-party entrypoint that reaches a git
+  write inside `python/`. Local composite actions are inlined recursively, which is what makes
+  `lock-refresh` visible at all — it contains no `git` command and reaches
+  `peter-evans/create-pull-request` two hops down. A partial value (`pre-commit` alone, which #274
+  shipped) fails, and so does a workflow added tomorrow. Wired end-to-end by the
+  `workflow.adr-0001-enforcement` contract; control arms in `tests/test_workflow_hooks.py`.
+- The check's data has its own hard stops, so it cannot rot quietly: an unrecognised third-party
+  action, a stale verdict, and a new `git` write inside `python/` each fail with their **own**
+  remedy — deliberately never "add the env var", since `HK_SKIP_HOOKS` also silences an explicit
+  `hk run <hook>` and habitually applying it would dissolve the check.
 - `commit-msg` is deliberately **not** skipped: `check_conventional_commit` passes on the bots'
-  messages and is cheap. Add it if that changes.
+  messages and is cheap. Add it if that changes — `REQUIRED_SKIPS` in `workflow_hooks.py` is the
+  one place, and the git verbs it looks for are derived from it.
 
 ## The lesson worth keeping
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,7 +22,7 @@ Decisions that are **domain-shaped rather than agent-behaviour-shaped** — a ch
 devcontainer/image/CI domain that isn't a rule for how an agent should work, and therefore has no
 natural home in `.claude/rules/`.
 
-Expect this directory to stay small. Two decisions live here today:
+Expect this directory to stay small. One decision lives here today:
 
 | ADR | Decision |
 |---|---|

--- a/hk.pkl
+++ b/hk.pkl
@@ -257,6 +257,44 @@ local allSteps = new Mapping<String, Config.Step> {
   ["ghalint_action"] = Builtins.ghalint_action
   ["zizmor"] = Builtins.zizmor
   //
+  // --- ADR-0001 enforcement: a CI job that commits or pushes must skip hk's
+  //     git hooks. `mise.toml`'s postinstall runs `hk install --mise` on the
+  //     runner, so a job that then commits/pushes fires hooks that CANNOT
+  //     pass there (ghcr_publish_prereqs needs a logged-in gh; test needs
+  //     `claude` on the login-shell PATH). The ADR's Consequences section
+  //     named this as its OPEN gap — "the two known cases are fixed by name
+  //     … correctness now depends on remembering" — so this step must catch a
+  //     NEW job, and deliberately pins nothing by name: it derives the
+  //     git-writing jobs from the tree (a shell git verb at a command
+  //     position, a classified third-party action, or a first-party
+  //     entrypoint that reaches a git write inside python/).
+  //     The check LOGIC lives in python (dotfiles_setup.workflow_hooks) — a
+  //     big inline-bash grep here would itself violate zero-bash-logic, and
+  //     it cannot be a grep anyway: `refresh.yml`/lock-refresh contains no
+  //     `git` command at all and reaches `peter-evans/create-pull-request`
+  //     two composite-action hops down.
+  //     The glob covers python/src too because a NEW `git push` inside
+  //     python/ opens route 3 and must fail until its entrypoint is
+  //     registered — and mise.toml + the shared conf.d fragment because the
+  //     route-3 mise half is DERIVED from the task table: adding
+  //     `[tasks.release]` wrapping `dotfiles-setup pr ship` changes the
+  //     answer, so a task edit must re-run the check.
+  //     NOTE: the check is WHOLE-TREE — `find_violations(root)` scans every
+  //     workflow regardless of which file triggered the step — so this glob
+  //     only decides WHEN it runs, never what it sees. ---
+  ["workflow_hk_skip_hooks"] {
+    glob = List(
+      ".github/workflows/*.yml",
+      ".github/workflows/*.yaml",
+      ".github/actions/**/action.yml",
+      ".github/actions/**/action.yaml",
+      "python/src/dotfiles_setup/*.py",
+      "mise.toml",
+      ".config/mise/conf.d/*.toml"
+    )
+    check = "uv run --project python dotfiles-setup workflow-hooks"
+  }
+  //
   // #154: no pinact / pinact_update steps — they call the GitHub API to
   // resolve SHAs and hit the unauthenticated 60/hr rate limit in CI (the
   // lint job has no GITHUB_TOKEN in env), and pinact_update is a fix-op, not

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     # decide to adopt a source. Hand-rolling deb822 was rejected per
     # .claude/rules/use-tool-builtins.md.
     "python-debian>=1.1.1",
+    "pyyaml>=6.0.3",
 ]
 
 [project.scripts]

--- a/python/src/dotfiles_setup/heredoc.py
+++ b/python/src/dotfiles_setup/heredoc.py
@@ -1,0 +1,106 @@
+r"""Heredoc-body detection, shared by the PreToolUse guard and the ADR-0001 check.
+
+A heredoc body is **stdin data**, not a command, and no stdlib shell lexer
+models that: ``shlex(punctuation_chars=True)`` puts ``\\n`` in ``whitespace``,
+so a heredoc body and two real newline-separated commands tokenize identically
+(the researched alternatives — ``bashlex``, ``tree-sitter-bash`` — are recorded
+in :mod:`dotfiles_setup.hook_guard`'s banner comment, which is where this pair
+was written for #265).
+
+It lives here because a **second** consumer appeared:
+:mod:`dotfiles_setup.workflow_hooks` reads a workflow ``run:`` block at command
+positions, and a ``gh issue create --body-file - <<'EOF' … git push … EOF``
+block would otherwise be read as a git write. Duplicating the regex would leave
+two copies of a subtle pattern to keep in sync, so the pair moved out rather
+than being copied.
+
+The one behaviour that is NOT shared is *when* to redact, which is why
+:func:`redact_heredoc_bodies` exists alongside the raw pattern: a heredoc fed to
+a **shell** (``bash <<'SH' … git push … SH``) really is executed, so blanket
+redaction would trade a false positive for a false negative. The guard wants
+the raw pattern (every heredoc it sees is an argument to the tool being
+guarded); the workflow check wants the interpreter-aware form.
+"""
+
+from __future__ import annotations
+
+import re
+
+# NUL is the filler because it is the one byte that CANNOT occur in a real Bash
+# command (execve arguments are NUL-terminated), so input can never forge it,
+# and it is neither `\w` nor `\s`. Substitution is length-preserving so every
+# other offset in the command is untouched.
+NUL_FILLER = "\x00"
+
+# A heredoc body is stdin DATA that can never be a command. Matches `<<EOF`,
+# `<<'EOF'` and `<<-EOF` (which strips leading TABS from the body *and* the
+# delimiter line). `<<<` here-strings are not matched: a `\w` delimiter cannot
+# start with `<`, and their content is quoted anyway.
+HEREDOC_PATTERN = re.compile(
+    r"""
+    <<-?[ \t]*(?P<q>['"]?)(?P<delim>[A-Za-z_]\w*)(?P=q)  # the redirect operator
+    [^\n]*\n                                             # rest of that line
+    (?P<inert>(?:[^\n]*\n)*?[ \t]*(?P=delim)[ \t]*)      # body + delimiter line
+    (?=\n|\Z)                                            # delimiter line ends here
+    """,
+    re.VERBOSE,
+)
+
+# Commands that EXECUTE their heredoc body, so its contents are real commands.
+# `.` is POSIX `source`. Matched on the basename, so `/bin/bash` counts.
+SHELL_INTERPRETERS: frozenset[str] = frozenset(
+    {".", "bash", "dash", "ksh", "sh", "source", "zsh"}
+)
+
+# Separators after which a new command word begins, for the owning-command scan.
+_COMMAND_BREAK = re.compile(r"[\n;&|(){}]")
+
+# `FOO=bar cmd <<EOF` — a leading assignment is not the command.
+_ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+# Wrapper words that may precede the real command without being it.
+_PREFIX_WORDS: frozenset[str] = frozenset(
+    {"!", "command", "do", "else", "exec", "if", "nohup", "sudo", "then", "time"}
+)
+
+
+def blank_heredoc(match: re.Match[str]) -> str:
+    """Redact a heredoc body + its delimiter line, keeping the redirect line."""
+    whole = match.group(0)
+    inert = match.group("inert")
+    return whole[: len(whole) - len(inert)] + NUL_FILLER * len(inert)
+
+
+def owning_command(text: str, redirect_start: int) -> str:
+    """The command word that owns the heredoc redirect at ``redirect_start``.
+
+    Returns the basename, or ``""`` when no command word precedes the redirect
+    on its own command (``cat <<EOF`` at the very start of a line yields
+    ``cat``; a bare ``<<EOF`` yields ``""``).
+    """
+    preceding = text[:redirect_start]
+    breaks = [m.end() for m in _COMMAND_BREAK.finditer(preceding)]
+    segment = preceding[breaks[-1] :] if breaks else preceding
+    for word in segment.split():
+        if _ASSIGNMENT.match(word) or word in _PREFIX_WORDS:
+            continue
+        return word.rsplit("/", 1)[-1]
+    return ""
+
+
+def redact_heredoc_bodies(text: str) -> str:
+    """Blank every heredoc body that is DATA, keeping the ones a shell runs.
+
+    Length-preserving, like :func:`blank_heredoc`. A body owned by a
+    :data:`SHELL_INTERPRETERS` command is left intact on purpose: it really is
+    executed, and redacting it would turn an over-detect into an under-detect,
+    which is the direction that reopens a gap rather than the one that prints a
+    loud, one-line-fixable violation.
+    """
+
+    def replace(match: re.Match[str]) -> str:
+        if owning_command(text, match.start()) in SHELL_INTERPRETERS:
+            return match.group(0)
+        return blank_heredoc(match)
+
+    return HEREDOC_PATTERN.sub(replace, text)

--- a/python/src/dotfiles_setup/hook_guard.py
+++ b/python/src/dotfiles_setup/hook_guard.py
@@ -31,6 +31,8 @@ import re
 import sys
 from dataclasses import dataclass
 
+from dotfiles_setup.heredoc import HEREDOC_PATTERN, NUL_FILLER, blank_heredoc
+
 
 @dataclass(frozen=True)
 class Rule:
@@ -349,23 +351,16 @@ _SEPARATORS = ";&|\n"
 # and it is neither `\w` nor `\s` — it cannot be absorbed by `_WRAPPER` or any
 # rule token. Substitution is length-preserving so every other offset, and thus
 # every rule's view of the surrounding text, is untouched.
-_FILLER = "\x00"
+_FILLER = NUL_FILLER
 _SEPARATOR_TABLE = str.maketrans(_SEPARATORS, _FILLER * len(_SEPARATORS))
 
-# A heredoc body is stdin DATA that can never be a command. Matches `<<EOF`,
-# `<<'EOF'` and `<<-EOF` (which strips leading TABS from the body *and* the
-# delimiter line — and `_CMD`'s own `\s*` eats that tab, so indenting never
-# spared it). `<<<` here-strings are not matched: a `\w` delimiter cannot start
-# with `<`, and their content is quoted anyway.
-_HEREDOC = re.compile(
-    r"""
-    <<-?[ \t]*(?P<q>['"]?)(?P<delim>[A-Za-z_]\w*)(?P=q)  # the redirect operator
-    [^\n]*\n                                             # rest of that line
-    (?P<inert>(?:[^\n]*\n)*?[ \t]*(?P=delim)[ \t]*)      # body + delimiter line
-    (?=\n|\Z)                                            # delimiter line ends here
-    """,
-    re.VERBOSE,
-)
+# The heredoc pattern + its blanking substitution moved to
+# `dotfiles_setup.heredoc` when `workflow_hooks` became a second consumer: a
+# workflow `run:` block hits the same "a body is data, not a command" problem,
+# and two copies of this regex would drift. Behaviour here is unchanged — the
+# guard redacts EVERY heredoc it sees, because the body is an argument to the
+# tool being guarded. See that module for why `workflow_hooks` instead uses the
+# interpreter-aware `redact_heredoc_bodies`.
 
 # Quoted spans, scanned left-to-right and non-overlapping so alternating quotes
 # resolve correctly. The leading `\\.` consumes an escaped character — critical,
@@ -380,13 +375,6 @@ _QUOTED_SPAN = re.compile(
     """,
     re.VERBOSE | re.DOTALL,
 )
-
-
-def _blank_heredoc(match: re.Match[str]) -> str:
-    """Redact a heredoc body + its delimiter line, keeping the redirect line."""
-    whole = match.group(0)
-    inert = match.group("inert")
-    return whole[: len(whole) - len(inert)] + _FILLER * len(inert)
 
 
 def _blank_quoted(match: re.Match[str]) -> str:
@@ -422,7 +410,7 @@ def _inert_masked(command: str) -> str:
     An unterminated quote closes no span, so nothing is redacted and the real
     separators still anchor — a malformed command cannot launder itself.
     """
-    return _QUOTED_SPAN.sub(_blank_quoted, _HEREDOC.sub(_blank_heredoc, command))
+    return _QUOTED_SPAN.sub(_blank_quoted, HEREDOC_PATTERN.sub(blank_heredoc, command))
 
 
 def rules() -> tuple[Rule, ...]:

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -58,6 +58,7 @@ from dotfiles_setup.renovate_dryrun import renovate_dryrun_main
 from dotfiles_setup.sync import SyncOptions, sync_main
 from dotfiles_setup.tool_currency import tool_currency_main
 from dotfiles_setup.verify import main as verify_main
+from dotfiles_setup.workflow_hooks import workflow_hooks_main
 
 if TYPE_CHECKING:
     from argparse import _SubParsersAction
@@ -690,6 +691,12 @@ def setup_parser() -> argparse.ArgumentParser:
         ".devcontainer/scripts/*.sh must be allowlisted and within its "
         "per-file line budget (new/grown scripts fail — move logic to python/)",
     )
+    subparsers.add_parser(
+        "workflow-hooks",
+        help="Enforce ADR-0001: every CI job that commits or pushes must set "
+        "HK_SKIP_HOOKS: pre-commit,pre-push at job level, or hk's git hooks "
+        "run on the runner and fail",
+    )
     ghcr_cleanup_parser = subparsers.add_parser(
         "ghcr-cleanup",
         help="Plan (default) or execute GHCR retention cleanup for the "
@@ -1166,6 +1173,7 @@ def _build_command_handlers(
             apt_pins_main(project_root, json_output=args.json)
         ),
         "bash-budget": lambda: sys.exit(bash_budget_main(project_root)),
+        "workflow-hooks": lambda: sys.exit(workflow_hooks_main(project_root)),
         "bootstrap-gap-report": lambda: handle_bootstrap_gap_report(args, project_root),
         "lock-stage": lambda: handle_lock_stage(args, project_root),
         "lock-collect": lambda: handle_lock_collect(args, project_root),

--- a/python/src/dotfiles_setup/workflow_hooks.py
+++ b/python/src/dotfiles_setup/workflow_hooks.py
@@ -1,0 +1,941 @@
+"""ADR-0001 enforcement: a CI job that writes to git must skip hk's hooks.
+
+``mise.toml``'s ``[hooks] postinstall = "mise reshim && hk install --mise"``
+runs on **every** ``mise install``, including on GitHub Actions runners, and
+``hk install`` writes the ``commit-msg``/``pre-commit``/``pre-push`` git hooks.
+Any job that then commits or pushes fires them, and two hk steps CANNOT pass on
+a runner (``ghcr_publish_prereqs`` needs a logged-in gh; ``test`` needs
+``claude`` on the login-shell PATH). That is how the daily lock refresh failed
+for six days having never once opened a PR — see
+``docs/adr/0001-hk-hooks-do-not-run-in-ci.md``.
+
+The accepted decision is ``HK_SKIP_HOOKS: pre-commit,pre-push`` at job level in
+every workflow that commits or pushes. Its Consequences section NAMED the gap
+this module closes — quoted here in its **pre-amendment** wording, because the
+same change that added this module struck those two sentences and recorded the
+gap closed, so the ADR no longer carries this text:
+
+    Any **new** workflow that commits or pushes must set ``HK_SKIP_HOOKS`` too.
+    There is no global guard — the two known cases are fixed by name.
+    Correctness now depends on remembering. A contract asserting "every
+    workflow that commits sets ``HK_SKIP_HOOKS``" would give this teeth; not
+    written yet.
+
+So this check must catch a **new** job, not re-assert the two known ones. A
+contract that pinned ``refresh.yml`` and ``gcc-sha-repair.yml`` by name would
+inherit exactly the weakness the ADR is complaining about.
+
+**Why the warning that prompted this is NOT the bug.** A job with
+``install_args: "python uv"`` logs ``sh: 1: hk: not found`` and a warn-only
+postinstall failure. That is benign — ``mise reshim`` (the part CI needs) still
+runs, and no hook is written, which is the state the ADR *wants*. The hazard is
+that this safety is **incidental**: widen one ``install_args`` and hk appears,
+the postinstall succeeds, and the hooks land. This check does not depend on
+that accident holding.
+
+The logic lives here rather than in an inline-bash hk step, per
+``.claude/rules/zero-bash-logic.md``; the ``workflow-hooks`` CLI subcommand and
+the ``workflow_hk_skip_hooks`` hk step are thin wrappers over
+:func:`find_violations`.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+import sys
+import tomllib
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from dotfiles_setup.heredoc import redact_heredoc_bodies
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+WORKFLOW_DIR = ".github/workflows"
+
+# The env var is hk's NATIVE skip mechanism (`HK_SKIP_HOOKS` / `hk.skipHook`:
+# "Hook names to skip entirely. Values from all sources are unioned together"),
+# so this needs no custom code — .claude/rules/use-tool-builtins.md. hk has no
+# CI self-detection (grepped every release v0.7.0→v1.51.0: zero hits), so the
+# skip must be explicit.
+SKIP_ENV = "HK_SKIP_HOOKS"
+
+# `commit-msg` is deliberately NOT required: `check_conventional_commit` passes
+# on the bots' messages and is cheap. The ADR says to add it if that changes.
+REQUIRED_SKIPS: tuple[str, ...] = ("pre-commit", "pre-push")
+
+
+@dataclass(frozen=True)
+class Job:
+    """One workflow job, flattened to what the predicate below needs.
+
+    ``run_text`` and ``uses`` are kept separate on purpose: a git write can
+    arrive either as a shell command in a ``run:`` block or as a third-party
+    action (``peter-evans/create-pull-request`` is how ``refresh.yml`` does it,
+    and it pushes as well as commits — the detail #274 missed, which is why it
+    shipped green and was still broken).
+    """
+
+    workflow: str
+    """Repo-relative path, e.g. `.github/workflows/refresh.yml`."""
+
+    name: str
+    """The job's key, e.g. `lock-refresh`."""
+
+    run_text: str
+    """Every `run:` block in the job, newline-joined."""
+
+    uses: tuple[str, ...]
+    """Every `uses:` value in the job, in step order."""
+
+    env: dict[str, str]
+    """Workflow-level env merged with job-level env (job wins)."""
+
+    opaque_actions: tuple[str, ...] = ()
+    """Local `./.github/actions/*` this job reaches whose body cannot be read.
+
+    A first-party action declaring `runs.using: node20`/`docker` has no
+    `steps:`, so :func:`_expand_local` contributes nothing for it — and
+    :func:`action_id` returns `""` for a `./` reference, so
+    :func:`unclassified_actions` skips it too. Without this field that is the
+    ONE route in the module where an unrecognised writer produces silence
+    rather than a reported hole; :func:`classification_gaps` turns it into a
+    gap instead.
+    """
+
+
+def _as_str_map(raw: object) -> dict[str, str]:
+    """Coerce a YAML `env:` mapping to str→str, dropping anything malformed."""
+    if not isinstance(raw, dict):
+        return {}
+    return {str(k): str(v) for k, v in raw.items() if v is not None}
+
+
+def _steps_of(body: object) -> list[dict[Any, Any]]:
+    """The `steps:`/`runs.steps:` list of a job or composite action."""
+    if not isinstance(body, dict):
+        return []
+    steps: object = body.get("steps")
+    if steps is None:
+        runs: object = body.get("runs")
+        if isinstance(runs, dict):
+            steps = runs.get("steps")
+    if not isinstance(steps, list):
+        return []
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def _expand_local(
+    uses: str, root: Path, seen: set[str], opaque: set[str]
+) -> tuple[str, list[str]]:
+    """Inline a LOCAL composite action's own run/uses, recursively.
+
+    Load-bearing, not a nicety. ``refresh.yml``'s ``lock-refresh`` job — the
+    workflow ADR-0001 was actually written about — contains no ``git`` command
+    and no third-party action of its own. It reaches
+    ``peter-evans/create-pull-request`` through TWO hops:
+
+        refresh.yml → uses: ./.github/actions/open-refresh-pr
+                    → uses: peter-evans/create-pull-request
+
+    A check that reads only a job's own steps therefore returns "this job does
+    not write to git" for the single most important case in the repo. That is a
+    bad-bound probe (`.claude/rules/probes-need-a-control-arm.md`): the answer
+    is "not at this depth", not "not present".
+
+    Only ``./``-prefixed uses are followed — a third-party action's source is
+    not in this tree, so its behaviour has to be recognised by name in the
+    predicate. ``seen`` makes a cyclic or diamond include terminate.
+
+    An action whose ``runs.using`` is NOT ``composite`` (``node20``, ``docker``)
+    has no readable steps. It is recorded in ``opaque`` rather than silently
+    contributing nothing, because a ``./`` reference also gets no
+    :func:`action_id`, so it would otherwise be the module's only silent False.
+    """
+    if not uses.startswith("./") or uses in seen:
+        return "", []
+    seen.add(uses)
+    action_dir = root / uses[2:]
+    candidates = [action_dir / "action.yml", action_dir / "action.yaml"]
+    action_file = next((c for c in candidates if c.is_file()), None)
+    if action_file is None:
+        opaque.add(uses)
+        return "", []
+    try:
+        doc = yaml.safe_load(action_file.read_text(encoding="utf-8"))
+    except yaml.YAMLError, OSError, UnicodeDecodeError:
+        opaque.add(uses)
+        return "", []
+
+    runs_block = doc.get("runs") if isinstance(doc, dict) else None
+    using = runs_block.get("using") if isinstance(runs_block, dict) else None
+    if str(using).lower() != "composite":
+        opaque.add(uses)
+        return "", []
+
+    runs: list[str] = []
+    all_uses: list[str] = []
+    for step in _steps_of(doc):
+        if isinstance(step.get("run"), str):
+            runs.append(step["run"])
+        nested = step.get("uses")
+        if isinstance(nested, str):
+            all_uses.append(nested)
+            sub_run, sub_uses = _expand_local(nested, root, seen, opaque)
+            if sub_run:
+                runs.append(sub_run)
+            all_uses.extend(sub_uses)
+    return "\n".join(runs), all_uses
+
+
+def parse_jobs(workflow_path: Path, repo_relative: str, root: Path) -> list[Job]:
+    """Every job in one workflow file, flattened into :class:`Job` records.
+
+    Parsed with ``yaml.safe_load`` rather than grepped: a job's ``env:`` block
+    and its steps are structurally nested, and hand-rolling that indentation
+    walk is precisely the homegrown parser
+    ``.claude/rules/use-tool-builtins.md`` rejects (the same call that added
+    ``python-debian`` instead of hand-rolling deb822).
+
+    A file that does not parse, or that carries no ``jobs:`` mapping, yields no
+    jobs. That is a deliberate fail-OPEN on malformed YAML: ``actionlint``
+    already gates workflow syntax in both CI and hk, so a parse error here would
+    be a duplicate failure with a worse message.
+    """
+    try:
+        doc = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError, OSError, UnicodeDecodeError:
+        return []
+    if not isinstance(doc, dict):
+        return []
+
+    workflow_env = _as_str_map(doc.get("env"))
+    jobs_raw = doc.get("jobs")
+    if not isinstance(jobs_raw, dict):
+        return []
+
+    jobs: list[Job] = []
+    for job_name, job_body in jobs_raw.items():
+        if not isinstance(job_body, dict):
+            continue
+        runs: list[str] = []
+        uses: list[str] = []
+        seen: set[str] = set()
+        opaque: set[str] = set()
+        for step in _steps_of(job_body):
+            if isinstance(step.get("run"), str):
+                runs.append(step["run"])
+            step_uses = step.get("uses")
+            if isinstance(step_uses, str):
+                uses.append(step_uses)
+                sub_run, sub_uses = _expand_local(step_uses, root, seen, opaque)
+                if sub_run:
+                    runs.append(sub_run)
+                uses.extend(sub_uses)
+        jobs.append(
+            Job(
+                workflow=repo_relative,
+                name=str(job_name),
+                run_text="\n".join(runs),
+                uses=tuple(uses),
+                env={**workflow_env, **_as_str_map(job_body.get("env"))},
+                opaque_actions=tuple(sorted(opaque)),
+            )
+        )
+    return jobs
+
+
+# ---------------------------------------------------------------------------
+# The predicate — the one judgement call in this module.
+#
+# The causal rule everything below is derived from: hk's hooks are FILES in
+# `.git/hooks/`, and exactly one thing executes them — the local `git` binary,
+# running a hook-firing subcommand, in the runner's checkout. Not the REST or
+# GraphQL API, not `gh`, not a vendor that pushes from its own infrastructure.
+# So "must this job set HK_SKIP_HOOKS?" reduces to a question with no GitHub in
+# it: does this job run `git commit` or `git push` HERE?
+#
+# Three routes reach a local git, and all three are needed — each of the two
+# writing jobs in this tree is visible on exactly one of the first two, and the
+# third is the route this repo's own rules push new code onto:
+#
+#   1. the job's own shell           (`gcc-sha-repair.yml` / repair)
+#   2. a third-party action          (`refresh.yml` / lock-refresh)
+#   3. a first-party entrypoint      (`mise run ship` -> pr.py's `git push`)
+#
+# Local composite actions are not a fourth route: `_expand_local` has already
+# inlined them into `run_text`/`uses`.
+# ---------------------------------------------------------------------------
+
+# Which git subcommand fires which hook, per githooks(5). `pre-commit` is
+# "invoked by git-commit(1)" and nothing else; `pre-push` by git-push(1).
+# `merge` is listed only under `commit-msg` (githooks(5): "invoked by
+# git-commit and git-merge") — `git merge` fires `pre-merge-commit`, which hk
+# does not install, so it is NOT a `pre-commit` trigger.
+_HOOK_TRIGGER_SUBCOMMANDS: dict[str, frozenset[str]] = {
+    "pre-commit": frozenset({"commit"}),
+    "commit-msg": frozenset({"commit", "merge"}),
+    "pre-push": frozenset({"push"}),
+}
+
+# DERIVED from the ADR's decision rather than guessed. With
+# `REQUIRED_SKIPS = (pre-commit, pre-push)` this is exactly `{commit, push}`:
+# nothing else can fire those two hooks, so adding `am`/`rebase`/`tag` would buy
+# zero recall and pure false-positive surface. If the ADR's "add `commit-msg` if
+# that changes" ever happens, its verbs arrive here with no second edit.
+#
+# The lookup is direct, NOT `.get(hook, frozenset())`: an unmapped hook must be
+# a loud `KeyError` at import. A silently-empty verb set would disable route 1
+# entirely while the check still exited 0 — a green, vacuous gate is the exact
+# #274 failure this module exists to prevent.
+GIT_WRITE_SUBCOMMANDS: frozenset[str] = frozenset().union(
+    *(_HOOK_TRIGGER_SUBCOMMANDS[hook] for hook in REQUIRED_SKIPS)
+)
+
+# git's own options that consume the NEXT token, so the subcommand scan does not
+# read their value as the subcommand: `git -C sub commit` must yield `commit`.
+_GIT_OPTIONS_WITH_VALUE: frozenset[str] = frozenset(
+    {"-C", "-c", "--git-dir", "--work-tree", "--namespace", "--exec-path"}
+)
+
+# Third-party actions, each classified by the ONE question that matters: does it
+# run git in the runner's checkout (True), or does it only talk to a remote
+# service (False)? A remote writer produces a commit on GitHub without any local
+# git running, so no hook can fire.
+#
+# Deliberately holding EXACTLY the actions this tree reaches — no speculative
+# entries. :func:`classification_gaps` fails on an unclassified action AND on a
+# stale one, mirroring `bash_budget.py`'s `"unlisted"`/`"stale"` contract ("so
+# the map can't rot"). Pre-registering a verdict for an action nobody uses would
+# spend the gate's only hard stop in advance, on a source read no control arm
+# ever exercised — and a stale `False` degrades to a MISS, not to a harmless
+# extra env line.
+ACTION_RUNS_GIT_LOCALLY: dict[str, bool] = {
+    # LOCAL. `src/create-pull-request.ts` calls `createOrUpdateBranch` (a local
+    # `git commit`) and `git.push(['--force-with-lease', …])` via @actions/exec,
+    # and passes `--no-verify` nowhere. Proven from the world, not just the
+    # source: ADR-0001's live re-run logged `hk WARN pre-commit: skipping hook
+    # due to HK_SKIP_HOOK` / `hk WARN pre-push: …` from inside this action.
+    # (Conditional: with `sign-commits: true` the COMMIT is made through the
+    # API — it still pushes locally, and we do not set the flag.)
+    "peter-evans/create-pull-request": True,
+    # REMOTE — THE TRAP. `autofix.yml`/autofix is the only job that installs the
+    # FULL toolchain, so hk IS present, the postinstall SUCCEEDS and the git
+    # hooks ARE written; it also sets a `git config` identity and runs
+    # `hk run pre-commit --all` twice on purpose. Every surface signal says
+    # "writes to git". It does not: this action uploads a DIFF to autofix.ci and
+    # THEIR GitHub App makes the commit off-runner — the vendor's own action.yml
+    # output `autofix_started` reads "changes have been sent to the autofix
+    # server and a fix commit is coming up". Any predicate keyed on "configures
+    # git identity", "has hk installed", or "touches GitHub" gets this wrong.
+    "autofix-ci/action": False,
+    # Runs a LOT of local git (init/fetch/checkout) and is still False: none of
+    # it is `commit` or `push`, so no hk hook can fire.
+    "actions/checkout": False,
+    "actions/create-github-app-token": False,  # mints a token; no git
+    "actions/upload-artifact": False,  # uploads to the Actions artifact store
+    "aquasecurity/trivy-action": False,  # scans a filesystem/image
+    "astral-sh/setup-uv": False,  # tool install
+    "docker/bake-action": False,  # buildkit; pushes an IMAGE, not a git ref
+    "docker/login-action": False,  # registry auth
+    "docker/metadata-action": False,  # computes tags/labels
+    "docker/setup-buildx-action": False,  # builder setup
+    "dorny/paths-filter": False,  # diff classification; reads refs only
+    "github/codeql-action": False,  # uploads SARIF to the code-scanning API
+    "jdx/mise-action": False,  # tool install (reached via ./setup-mise)
+    "jlumbroso/free-disk-space": False,  # deletes runner files
+}
+
+# First-party entrypoints that reach a local `git commit`/`git push` through
+# THIS repo's own python, matched as a token prefix at a shell command position.
+#
+# Route 3 exists because `.claude/rules/zero-bash-logic.md` and
+# `.claude/rules/mise-tasks-only.md` actively push git-writing logic OFF the
+# shell and INTO `python/` behind a mise task — and `gcc-sha-repair.yml`'s own
+# header already describes its remaining `git commit`/`git push` block as "a
+# thin trigger + commit seam" over `dotfiles-setup gcc-sha`. Finishing that
+# stated migration would, without this route, silently convert one of the two
+# true positives in the tree into a false negative: the gate would go green
+# while the hazard was unchanged.
+#
+# `dotfiles-setup pr` covers `pr ship` (pr.py's argv push, line 506) and
+# `pr land`. It is the SEED only: the mise half is DERIVED from `mise.toml` by
+# :func:`mise_task_git_writers`, never listed.
+#
+# Listing the tasks was the reviewed defect, and it reproduced ADR-0001's own
+# complaint one level up: `mise run ship` is literally
+# `uv run --project python dotfiles-setup pr ship`, so a NEW task that wraps
+# the same entrypoint (`mise run release`) was a silent false negative with no
+# classification gap — `pr` is already registered, so nothing could fire.
+# "Fixed by name" is exactly what this module exists to stop.
+#
+# :func:`classification_gaps` keeps the python half honest the same way — a NEW
+# git write inside `python/` fails the check until its entrypoint is registered
+# here.
+FIRST_PARTY_GIT_WRITERS: tuple[tuple[str, ...], ...] = (("dotfiles-setup", "pr"),)
+
+# Where mise tasks are declared. `.config/mise/conf.d/*.toml` is the fragment
+# both host and image merge (root AGENTS.md), so a task can arrive from either.
+MISE_CONFIGS: tuple[str, ...] = ("mise.toml", ".config/mise/conf.d/*.toml")
+
+# Modules under `python/src/dotfiles_setup/` that invoke a git write verb, and
+# whose entrypoint is therefore registered in :data:`FIRST_PARTY_GIT_WRITERS`.
+# Today: `pr.py:506` — a `_stream` of git's push verb to `origin <branch>`.
+# (Deliberately paraphrased rather than quoted: the argv literal is what
+# :data:`_ARGV_GIT_WRITE` looks for, and quoting it here would make this module
+# match its own detector. Caught by running the check against the real tree —
+# the derivation reported `workflow_hooks` as an unregistered git writer, which
+# is exactly the FAIL direction working.)
+# Every other module's git usage is a read (`ls-files`, `rev-parse`,
+# `merge-base`, `diff`, `status`, `ls-remote`, `pull --ff-only`).
+GIT_WRITING_MODULES: frozenset[str] = frozenset({"pr"})
+
+_PYTHON_PACKAGE_DIR = "python/src/dotfiles_setup"
+
+# A git write expressed as an argv list literal: a `git` element followed,
+# inside the same list, by a write verb element.
+# `[^]]` keeps the match inside one list literal, so a `merge-base` read cannot
+# borrow a verb from the next statement (and `merge-base` is not `merge`: the
+# alternation is quote-delimited, never a prefix). The
+# verb alternation is built from :data:`GIT_WRITE_SUBCOMMANDS` plus the verbs
+# that fire the hooks hk installs but REQUIRED_SKIPS does not currently name —
+# the derivation is deliberately a superset, because over-detecting here only
+# forces a registration, while under-detecting reopens the gap.
+_ARGV_GIT_WRITE = re.compile(
+    r"""\[\s*["']git["']\s*,[^]]{0,200}?["'](?:"""
+    + "|".join(sorted({*GIT_WRITE_SUBCOMMANDS, "merge", "rebase", "am", "revert"}))
+    + r""")["']"""
+)
+
+# Words that may precede the real command without being it.
+_COMMAND_PREFIX_WORDS: frozenset[str] = frozenset(
+    {
+        "!",
+        "command",
+        "do",
+        "elif",
+        "else",
+        "exec",
+        "if",
+        "nice",
+        "nohup",
+        "sudo",
+        "then",
+        "time",
+        "until",
+        "while",
+        "xargs",
+    }
+)
+
+# `FOO=bar git push` — a leading assignment is not the command.
+_ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+# Tokens `shlex` emits as punctuation. A newline is included deliberately: it is
+# a command separator, and without it `git push` on the line after
+# `git commit -m x` would not be at a command position and would be MISSED —
+# which is precisely `gcc-sha-repair.yml`'s shape.
+_PUNCTUATION_CHARS = "();<>|&\n"
+_SEPARATOR_TOKENS: frozenset[str] = frozenset(
+    {";", "&", "&&", "|", "||", "(", ")", "\n", "<", ">", ">>", "<<"}
+)
+
+
+def shell_tokens(run_text: str) -> list[str]:
+    """Tokenize a ``run:`` block the way a shell would, separators included.
+
+    Uses :mod:`shlex` — the stdlib's shell lexer — rather than a homegrown
+    scanner (`.claude/rules/use-tool-builtins.md`), configured so quoting AND
+    command position both survive:
+
+    - ``posix=True`` means a quoted span is ONE token, so
+      ``echo "remember to git push (x)"`` cannot be misread as a command. That
+      is the false-positive class `hook_guard._inert_masked` had to fix by hand
+      in #265 — a separator inside quoted CONTENT read as a shell separator.
+    - ``punctuation_chars`` emits ``;``/``&&``/``|``/``(`` … as their own
+      tokens, so the caller can tell a command position from an argument.
+    - a newline is added to that set (and removed from ``whitespace``) because
+      it separates commands too, while a newline INSIDE a quoted span still
+      stays inside its token.
+
+    Quoting is not enough on its own: a heredoc body is UNQUOTED stdin data
+    whose newlines are real newlines, so ``gh issue create --body-file - <<'EOF'
+    … git push … EOF`` — remediation prose in an issue body — tokenizes exactly
+    like two commands and was a false positive. :func:`redact_heredoc_bodies`
+    blanks those bodies first, EXCEPT when a shell owns the redirect
+    (``bash <<'SH' … git push … SH`` really does run them); that is the same
+    class ``hook_guard._inert_masked`` fixed in #265, and the pattern is now
+    shared rather than copied.
+
+    An unbalanced quote makes ``shlex`` raise; the fallback is a whitespace
+    split with newlines preserved as separators, which errs toward DETECTING a
+    write. That direction is deliberate: the result is a loud, one-line-fixable
+    violation instead of a silent miss.
+    """
+    run_text = redact_heredoc_bodies(run_text)
+    lexer = shlex.shlex(run_text, posix=True, punctuation_chars=_PUNCTUATION_CHARS)
+    lexer.whitespace = " \t\r"
+    lexer.whitespace_split = True
+    try:
+        return list(lexer)
+    except ValueError:
+        return run_text.replace("\n", " \n ").split(" ")
+
+
+def _command_starts(tokens: list[str]) -> list[int]:
+    """Indices at which a new command word begins.
+
+    A command starts at the beginning of the text and after every separator
+    token, then skips leading env assignments and wrapper words so
+    ``if ! sudo git push`` presents ``git`` as the command.
+    """
+    starts: list[int] = []
+    index = 0
+    at_start = True
+    while index < len(tokens):
+        token = tokens[index]
+        if token in _SEPARATOR_TOKENS:
+            at_start = True
+            index += 1
+            continue
+        if at_start and (_ASSIGNMENT.match(token) or token in _COMMAND_PREFIX_WORDS):
+            index += 1
+            continue
+        if at_start:
+            starts.append(index)
+            at_start = False
+        index += 1
+    return starts
+
+
+def _git_subcommand(tokens: list[str], start: int) -> str | None:
+    """The subcommand of the git invocation whose command word is ``start``.
+
+    ``None`` when the command is not git, or is git with nothing but options.
+    Skipping :data:`_GIT_OPTIONS_WITH_VALUE` and their values is what makes
+    ``git -C sub commit`` yield ``commit`` rather than ``sub``.
+    """
+    head = tokens[start]
+    if head != "git" and not head.endswith("/git"):
+        return None
+    index = start + 1
+    while index < len(tokens) and tokens[index] not in _SEPARATOR_TOKENS:
+        token = tokens[index]
+        if not token.startswith("-"):
+            return token
+        index += 2 if token in _GIT_OPTIONS_WITH_VALUE else 1
+    return None
+
+
+def _invocation_tokens(tokens: list[str], start: int) -> list[str]:
+    """Tokens of one command, from its command word up to the next separator."""
+    end = start
+    while end < len(tokens) and tokens[end] not in _SEPARATOR_TOKENS:
+        end += 1
+    return tokens[start:end]
+
+
+def git_write_subcommands(run_text: str) -> set[str]:
+    """Every hook-firing git verb invoked at a command position in ``run_text``.
+
+    Returns the verbs, not a bool, so a caller can name what it saw and a test
+    can assert WHY a job was flagged — a bare bool cannot distinguish "found
+    ``git push``" from "found nothing because the probe is broken".
+
+    Parsing the subcommand rather than grepping for ``git commit`` is what keeps
+    ``git config``, ``git diff --quiet``, ``git add``, ``git status`` and
+    ``git merge-base`` (exact-token equality, never a prefix — this repo really
+    runs ``merge-base``) out of the answer. Both jobs that DO write also run
+    ``git config``, and so do two that do not, so a `"git" in run_text` check
+    would flag every hk-identity step in the repo.
+
+    ``--no-verify`` is git's own documented hook bypass, so an invocation
+    carrying it genuinely cannot fire a hook. Only the long form is honoured:
+    ``-n`` means ``--no-verify`` for ``git commit`` but ``--dry-run`` for
+    ``git push``, and treating it as "still fires" merely over-flags.
+    """
+    tokens = shell_tokens(run_text)
+    found: set[str] = set()
+    for start in _command_starts(tokens):
+        subcommand = _git_subcommand(tokens, start)
+        if subcommand not in GIT_WRITE_SUBCOMMANDS:
+            continue
+        if "--no-verify" in _invocation_tokens(tokens, start):
+            continue
+        found.add(subcommand)
+    return found
+
+
+def _strip_runner_prefix(words: list[str]) -> list[str]:
+    """Drop a ``uv run --project python``-style wrapper from a command.
+
+    ``uv run --project python dotfiles-setup pr ship`` -> ``dotfiles-setup pr
+    ship``. Written as a narrow unwrap of the ONE runner shape this repo
+    mandates (`python/AGENTS.md`: always ``uv run --project python``), not as a
+    general shell interpreter.
+    """
+    if words[:2] != ["uv", "run"]:
+        return words
+    index = 2
+    while index < len(words):
+        word = words[index]
+        if word in {"--project", "--directory", "--with", "--python"}:
+            index += 2
+            continue
+        if word.startswith("-"):
+            index += 1
+            continue
+        break
+    remainder = words[index:]
+    if remainder[:1] == ["python"]:
+        remainder = remainder[1:]
+    return remainder
+
+
+def first_party_git_writers(
+    run_text: str, writers: tuple[tuple[str, ...], ...] = FIRST_PARTY_GIT_WRITERS
+) -> set[str]:
+    """Every ``writers`` entrypoint invoked at a command position in ``run_text``.
+
+    Matched at a command position, after unwrapping the ``uv run --project
+    python`` runner, so a mention inside a quoted string or a comment cannot
+    trigger it.
+
+    ``writers`` defaults to the SEED tuple so the function is usable on its own;
+    :func:`find_violations` passes the seeds unioned with
+    :func:`mise_task_git_writers`'s derivation.
+    """
+    tokens = shell_tokens(run_text)
+    found: set[str] = set()
+    for start in _command_starts(tokens):
+        words = _strip_runner_prefix(_invocation_tokens(tokens, start))
+        for entrypoint in writers:
+            if tuple(words[: len(entrypoint)]) == entrypoint:
+                found.add(" ".join(entrypoint))
+    return found
+
+
+def _task_entry(body: object) -> tuple[str, tuple[str, ...]] | None:
+    """One task's ``(run text, depends)``, or ``None`` when it is not a task.
+
+    Both declared shapes are read: the inline string form
+    (``[tasks] ship = "…"``) and the table form (``[tasks.ship] run = "…"``),
+    where ``run`` and each depends key may be a string or a list of strings.
+    """
+    if isinstance(body, str):
+        return body, ()
+    if not isinstance(body, dict):
+        return None
+    run = body.get("run")
+    if isinstance(run, list):
+        run_text = "\n".join(str(item) for item in run)
+    else:
+        run_text = str(run or "")
+    depends: list[str] = []
+    for key in ("depends", "depends_post", "wait_for"):
+        value = body.get(key)
+        if isinstance(value, str):
+            depends.append(value)
+        elif isinstance(value, list):
+            depends.extend(str(item) for item in value)
+    return run_text, tuple(depends)
+
+
+def _task_bodies(root: Path) -> dict[str, tuple[str, tuple[str, ...]]]:
+    """Every declared mise task, as ``name -> (run text, depends)``.
+
+    Both task shapes are read: the table form (``[tasks.ship] run = "…"``) and
+    the inline string form (``[tasks] ship = "…"``). ``run`` may be a string or
+    a list of strings; ``depends``/``depends_post`` likewise.
+    """
+    bodies: dict[str, tuple[str, tuple[str, ...]]] = {}
+    paths: list[Path] = []
+    for pattern in MISE_CONFIGS:
+        paths.extend(sorted(root.glob(pattern)))
+    for path in paths:
+        try:
+            document = tomllib.loads(path.read_text(encoding="utf-8"))
+        except tomllib.TOMLDecodeError, OSError, UnicodeDecodeError:
+            continue
+        tasks = document.get("tasks")
+        if not isinstance(tasks, dict):
+            continue
+        for name, body in tasks.items():
+            entry = _task_entry(body)
+            if entry is not None:
+                bodies[str(name)] = entry
+    return bodies
+
+
+def mise_task_git_writers(
+    root: Path, seeds: tuple[tuple[str, ...], ...] = FIRST_PARTY_GIT_WRITERS
+) -> tuple[tuple[str, ...], ...]:
+    """``("mise", "run", <task>)`` for every task that TRANSITIVELY writes to git.
+
+    Derived, not listed — that is the whole point. A task qualifies when its own
+    body runs a hook-firing git verb, or invokes a ``seeds`` entrypoint, or
+    depends on a task that already qualifies. Iterated to a fixed point so a
+    chain (``release`` -> ``ship`` -> ``dotfiles-setup pr ship``) resolves
+    regardless of declaration order.
+
+    A task name is taken as its first word only (``mise run land -- 42``
+    matches ``land``); the ``--`` payload is arguments, not another task.
+    """
+    bodies = _task_bodies(root)
+    writers: set[str] = set()
+    changed = True
+    while changed:
+        changed = False
+        current = seeds + tuple(("mise", "run", name) for name in sorted(writers))
+        for name, (run_text, depends) in bodies.items():
+            if name in writers:
+                continue
+            reaches = (
+                git_write_subcommands(run_text)
+                or first_party_git_writers(run_text, current)
+                or {dependency.split()[0] for dependency in depends if dependency}
+                & writers
+            )
+            if reaches:
+                writers.add(name)
+                changed = True
+    return tuple(("mise", "run", name) for name in sorted(writers))
+
+
+def action_id(uses: str) -> str:
+    """Normalise a ``uses:`` value to a case-folded ``owner/repo`` lookup key.
+
+    ``github/codeql-action/upload-sarif@<sha> # v4`` -> ``github/codeql-action``.
+    A local ``./`` composite or a reusable ``./.github/workflows/*.yml`` returns
+    ``""``: composites are already INLINED by :func:`_expand_local`, and a
+    reusable workflow's jobs are checked in their own file (job ``env`` does not
+    cross ``workflow_call``). ``docker://`` likewise has no action to classify.
+    """
+    reference = uses.split("@", 1)[0].strip().strip("'\"").lower()
+    if reference.startswith(("./", ".github/", "docker://")):
+        return ""
+    return "/".join([part for part in reference.split("/") if part][:2])
+
+
+def committing_actions(job: Job) -> set[str]:
+    """The third-party actions ``job`` reaches that write to git locally."""
+    return {
+        identifier
+        for identifier in (action_id(uses) for uses in job.uses)
+        if ACTION_RUNS_GIT_LOCALLY.get(identifier) is True
+    }
+
+
+def unclassified_actions(job: Job) -> set[str]:
+    """Third-party actions ``job`` reaches that carry no recorded verdict.
+
+    Exported so :func:`find_violations` can report them under a DIFFERENT
+    message than the ``HK_SKIP_HOOKS`` one. That split is load-bearing rather
+    than cosmetic: the only remediation this check can otherwise print is a free
+    and harmless-looking env line, so a check that printed it for an
+    unclassified action would train operators to set the skip unconditionally —
+    after which a genuinely new git-writing job passes too. Worse, the env var
+    also silences an EXPLICIT ``hk run <hook>``, so blanket-applying it to
+    ``autofix.yml`` would turn its two deliberate ``hk run pre-commit`` steps
+    into no-ops and leave a green, dead safety net.
+
+    So an unknown action is NOT treated as a git writer by
+    :func:`job_writes_to_git` — it is reported as a *classification* gap whose
+    remedy is a one-line reviewable verdict, exactly the shape
+    `bash_budget.py`'s ALLOWLIST already uses in this repo.
+    """
+    return {
+        identifier
+        for identifier in (action_id(uses) for uses in job.uses)
+        if identifier and identifier not in ACTION_RUNS_GIT_LOCALLY
+    }
+
+
+def job_writes_to_git(
+    job: Job, writers: tuple[tuple[str, ...], ...] = FIRST_PARTY_GIT_WRITERS
+) -> bool:
+    """True when ``job`` commits or pushes, and so must skip hk's git hooks.
+
+    Three routes to a local git, unioned — see the banner comment above for why
+    each is required and none is optional:
+
+    1. a hook-firing git verb at a shell command position in ``run_text``
+       (``gcc-sha-repair.yml`` / ``repair``);
+    2. a third-party action classified as a local writer (``refresh.yml`` /
+       ``lock-refresh``, which contains no ``git`` command of its own and
+       reaches ``peter-evans/create-pull-request`` two composite hops down —
+       missing this is exactly how #274 shipped green and was still broken);
+    3. a first-party entrypoint that reaches a git write inside ``python/``
+       (``mise run ship`` -> ``pr.py``), the route this repo's zero-bash-logic
+       and mise-tasks-only rules actively steer new code onto.
+
+    The negatives are as load-bearing as the positives, because each defeats an
+    obvious cheaper predicate:
+
+    - ``refresh.yml`` / ``tool-currency`` runs ``gh issue create/edit/close`` —
+      the GitHub API, never the index or a remote. A predicate keyed on "writes
+      to GitHub" or "holds a token" flags it wrongly. (``lock-refresh``
+      declares job-level ``contents: read`` and writes anyway, while
+      ``ci.yml`` / ``promote`` holds write scope and never touches git, so
+      permissions discriminate nothing here.)
+    - ``autofix.yml`` / ``autofix`` sets a ``git config`` identity, installs the
+      FULL toolchain — hk present, postinstall successful, hooks written — and
+      runs ``hk run pre-commit`` twice, yet the commit is made off-runner by
+      autofix.ci's App. A predicate keyed on "configures git identity" or "hk is
+      installed" flags it wrongly.
+
+    An UNRECOGNISED third-party action returns False here by design; it surfaces
+    through :func:`unclassified_actions` / :func:`classification_gaps` as a
+    classification gap instead. See :func:`unclassified_actions` for why the
+    remedy must not be "add the env var".
+    """
+    return bool(
+        git_write_subcommands(job.run_text)
+        or first_party_git_writers(job.run_text, writers)
+        or committing_actions(job)
+    )
+
+
+def classification_gaps(root: Path) -> list[str]:
+    """Gaps that make the predicate's data untrustworthy, in either direction.
+
+    This is what actually closes ADR-0001's "correctness depends on
+    remembering" for the two routes whose ground truth lives outside a ``run:``
+    block. Each gap has a one-line reviewable remedy, and each is derived from
+    the tree rather than from intuition:
+
+    - **unclassified action** — a third-party ``uses:`` with no verdict. A new
+      job written with a NEW action is otherwise invisible to route 2.
+    - **stale action entry** — a verdict for an action the tree no longer
+      reaches. Mirrors `bash_budget.py`'s ``"stale"`` kind ("so the map can't
+      rot"); without it, entries only ever accumulate and a ``False`` verdict
+      whose vendor changed behaviour is never re-asked.
+    - **unregistered git write in python** — a module invoking a git write verb
+      as an argv literal whose entrypoint is not in
+      :data:`FIRST_PARTY_GIT_WRITERS`. This makes adding a ``git push`` inside
+      ``python/`` a hard stop, exactly as adopting a new action is, so route 3
+      cannot silently fall behind the code.
+    - **opaque local action** — a first-party ``./.github/actions/*`` whose
+      ``runs.using`` is not ``composite`` (``node20``/``docker``), or which
+      cannot be read at all. Its body is invisible to :func:`_expand_local` AND
+      it gets no :func:`action_id`, so without this it would be the module's
+      only place where an unrecognised writer answers False in silence.
+    """
+    reachable: set[str] = set()
+    unclassified: set[str] = set()
+    opaque: set[str] = set()
+    for path in sorted((root / WORKFLOW_DIR).glob("*.y*ml")):
+        for job in parse_jobs(path, f"{WORKFLOW_DIR}/{path.name}", root):
+            reachable.update(i for i in (action_id(u) for u in job.uses) if i)
+            unclassified.update(unclassified_actions(job))
+            opaque.update(job.opaque_actions)
+
+    gaps = [
+        f"local action `{reference}` has no readable composite `steps:` "
+        f"(a node/docker action, or an unreadable file), so this check cannot "
+        f"see whether it runs git in the checkout. Convert it to a composite, "
+        f"or record its verdict at its call site."
+        for reference in sorted(opaque)
+    ]
+    gaps += [
+        f"third-party action `{identifier}` has no verdict in "
+        f"ACTION_RUNS_GIT_LOCALLY. Read its source and record whether it runs "
+        f"git in the runner's checkout (True) or only talks to a remote "
+        f"service (False), with the evidence at the entry."
+        for identifier in sorted(unclassified)
+    ]
+    gaps += [
+        f"ACTION_RUNS_GIT_LOCALLY entry `{identifier}` is stale — no workflow "
+        f"reaches that action any more. Prune it; a verdict nothing exercises "
+        f"rots silently."
+        for identifier in sorted(set(ACTION_RUNS_GIT_LOCALLY) - reachable)
+    ]
+    gaps += [
+        f"{_PYTHON_PACKAGE_DIR}/{module}.py invokes a git write verb but "
+        f"`{module}` is not in GIT_WRITING_MODULES. Register the mise task / "
+        f"`dotfiles-setup` subcommand that reaches it in "
+        f"FIRST_PARTY_GIT_WRITERS, or the check goes blind to any workflow "
+        f"that calls it."
+        for module in sorted(_python_git_write_modules(root) - GIT_WRITING_MODULES)
+    ]
+    return gaps
+
+
+def _python_git_write_modules(root: Path) -> set[str]:
+    """Module stems under ``python/src/dotfiles_setup`` that write to git."""
+    package_dir = root / _PYTHON_PACKAGE_DIR
+    modules: set[str] = set()
+    for path in sorted(package_dir.glob("*.py")):
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError, UnicodeDecodeError:
+            continue
+        if _ARGV_GIT_WRITE.search(source):
+            modules.add(path.stem)
+    return modules
+
+
+def skips_required_hooks(job: Job) -> bool:
+    """True when ``job``'s env skips every hook in :data:`REQUIRED_SKIPS`.
+
+    hk's own semantics are a comma-separated union, so this parses rather than
+    string-matches: ``pre-push,pre-commit`` and ``pre-commit,pre-push`` must be
+    equivalent, and a partial value like #274's ``pre-commit`` alone must FAIL
+    — that PR set exactly that, passed every gate, and was still broken because
+    the failing steps were ``pre-push``'s.
+    """
+    declared = {
+        part.strip() for part in job.env.get(SKIP_ENV, "").split(",") if part.strip()
+    }
+    return all(hook in declared for hook in REQUIRED_SKIPS)
+
+
+def find_violations(root: Path) -> list[str]:
+    """Human-readable violation lines; empty means the policy holds.
+
+    Ordered by workflow then job so the output is stable across runs and a
+    diff of two reports is readable.
+
+    :func:`classification_gaps` is appended last and reported with its OWN
+    remedy, never the ``HK_SKIP_HOOKS`` one: an unclassified action, a stale
+    verdict, or an unregistered git write inside ``python/`` is a hole in the
+    check's data, and telling an operator to "add the env var" would both
+    misdirect and, applied habitually, dissolve the check.
+    """
+    workflow_dir = root / WORKFLOW_DIR
+    writers = FIRST_PARTY_GIT_WRITERS + mise_task_git_writers(root)
+    violations: list[str] = []
+    for path in sorted(workflow_dir.glob("*.y*ml")):
+        repo_relative = f"{WORKFLOW_DIR}/{path.name}"
+        violations.extend(
+            f"{repo_relative}: job `{job.name}` commits or pushes but "
+            f"does not set {SKIP_ENV} covering "
+            f"{','.join(REQUIRED_SKIPS)}. hk's git hooks would run on "
+            f"the runner and fail (ADR-0001). Add to the job's env:\n"
+            f"      {SKIP_ENV}: {','.join(REQUIRED_SKIPS)}"
+            for job in parse_jobs(path, repo_relative, root)
+            if job_writes_to_git(job, writers) and not skips_required_hooks(job)
+        )
+    return violations + classification_gaps(root)
+
+
+def workflow_hooks_main(root: Path) -> int:
+    """CLI entry: 0 when every git-writing job skips hk's hooks, else 1."""
+    violations = find_violations(root)
+    if not violations:
+        sys.stdout.write(
+            "workflow-hooks OK: every git-writing job skips hk's git hooks\n"
+        )
+        return 0
+    sys.stdout.write("workflow-hooks: ADR-0001 violations\n\n")
+    for line in violations:
+        sys.stdout.write(f"  - {line}\n")
+    sys.stdout.write(
+        f"\n{len(violations)} violation(s). "
+        f"See docs/adr/0001-hk-hooks-do-not-run-in-ci.md\n"
+    )
+    return 1

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -28,6 +28,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-debian" },
+    { name = "pyyaml" },
 ]
 
 [package.dev-dependencies]
@@ -42,6 +43,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "python-debian", specifier = ">=1.1.1" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
 ]
 
 [package.metadata.requires-dev]
@@ -187,6 +189,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
 ]
 
 [[package]]

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -1076,6 +1076,22 @@ tokens = [
 ]
 
 [[suite]]
+name = "workflow.adr-0001-enforcement"
+description = "ADR-0001 wiring: the `workflow_hk_skip_hooks` hk step must stay wired to the python enforcer end-to-end — hk.pkl shells out to `dotfiles-setup workflow-hooks`, main.py registers the subcommand AND calls workflow_hooks_main, the workflow_hooks module's three seams (find_violations / job_writes_to_git+skips_required_hooks / classification_gaps) are actually CALLED, the tests carry the real-case verdicts plus the partial-value control arm AND both arms of the entrypoint CI runs, and the ADR records its 'not written yet' gap as Closed 2026-07-21. The hk step's GLOB is deliberately unbound by any token: the check is whole-tree (find_violations scans every workflow regardless of which file triggered the step), so the glob decides only WHEN it runs, never what it sees. Every token binds a CALL SITE, never a `def`: a `def` token is satisfied by prose and by a docstring, which is how build.path-includes-mise-shims stayed green for ~3.5 months (feedback_forbid_tokens_substring_fragile). per_path_tokens, NOT bare tokens: bare tokens are a UNION across the combined text, so one file carrying a token would satisfy the contract for all five — a contract with no opinion about the files it names. The check LOGIC lives in python because a big inline-bash grep would violate zero-bash-logic AND could not work at all: refresh.yml/lock-refresh contains no `git` command and reaches peter-evans/create-pull-request two composite-action hops down."
+category = "workflow"
+check_type = "static"
+handler = "require_tokens"
+paths_required = true
+paths = [
+    "hk.pkl",
+    "python/src/dotfiles_setup/main.py",
+    "python/src/dotfiles_setup/workflow_hooks.py",
+    "tests/test_workflow_hooks.py",
+    "docs/adr/0001-hk-hooks-do-not-run-in-ci.md",
+]
+per_path_tokens = { "hk.pkl" = ["workflow_hk_skip_hooks", "dotfiles-setup workflow-hooks"], "python/src/dotfiles_setup/main.py" = ["workflow-hooks", "workflow_hooks_main(project_root)"], "python/src/dotfiles_setup/workflow_hooks.py" = ["violations = find_violations(root)", "job_writes_to_git(job, writers) and not skips_required_hooks(job)", "classification_gaps(root)", "mise_task_git_writers(root)", "redact_heredoc_bodies(run_text)"], "tests/test_workflow_hooks.py" = ["workflow_hooks.job_writes_to_git(", "workflow_hooks.find_violations(REPO_ROOT) == []", "HK_SKIP_HOOKS: pre-commit", "workflow_hooks.workflow_hooks_main(tmp_path) == 1", 'setup_parser().parse_args(["workflow-hooks"])'], "docs/adr/0001-hk-hooks-do-not-run-in-ci.md" = ["dotfiles-setup workflow-hooks", "workflow_hk_skip_hooks", "Closed 2026-07-21"] }
+
+[[suite]]
 name = "workflow.tool-currency-wiring"
 description = "Daily tool-currency signal wiring: refresh.yml's tool-currency job must render the report via `mise run tool-currency` (thin caller of the python library) and upsert the standing issue; module + tests must exist. The signal feeds the tool-currency-check skill's release-note review (self-learning loop, 2026-07-07)."
 category = "workflow"

--- a/tests/test_workflow_hooks.py
+++ b/tests/test_workflow_hooks.py
@@ -1,0 +1,882 @@
+"""Tests for the ADR-0001 enforcer (dotfiles_setup.workflow_hooks).
+
+Seven layers, in the order they earn their keep:
+
+1. **The four real cases**, read out of the actual `.github/` tree so the
+   suite fails if reality drifts. Their verdicts come from
+   `docs/adr/0001-hk-hooks-do-not-run-in-ci.md` and from each vendor's own
+   documentation — never from re-running the predicate's own logic, which
+   would be tautological (`tests/AGENTS.md`).
+2. **Control arms on the FAIL direction**, in `tmp_path`. A gate verified only
+   on a clean tree is decoration
+   (`.claude/rules/probes-need-a-control-arm.md`): every "this passes"
+   assertion below is paired with a synthetic tree that MUST fail.
+3. **The real-tree guard + CLI wiring**, mirroring `test_bash_budget.py`.
+4. **`workflow_hooks_main` in both directions** — the function the hk step and
+   CI actually invoke. Layers 1-3 shipped without its FAIL arm, so it could be
+   reduced to `violations = []` (never asking the question, always exiting 0)
+   with everything still green: the exact #274 shape this module prevents.
+5. **Route 3 both ways** — its negative arm (a quoted/commented mention is not
+   an invocation), its recall arm over every registered entrypoint, and the
+   DERIVATION of the mise half from `mise.toml`.
+6. **The classification gaps** that stop the predicate's data rotting: an
+   unregistered git write inside `python/`, and an opaque local action.
+7. **Expansion depth + shell-tokenizing edges** the real tree cannot reach:
+   depth >= 2 composites, a cycle, heredoc bodies, an unbalanced quote.
+
+Layers 4-7 exist because each mechanism below was, at review time, mutable to
+a permanently-blind version with the whole suite green. Every one is now pinned
+by a mutation that was run and observed to fail.
+
+The two negatives among the real cases are as load-bearing as the positives.
+`autofix.yml`/autofix is the trap: it is the only job that installs the full
+toolchain, so hk IS present and the git hooks ARE written, it sets a `git
+config` identity, and it runs `hk run pre-commit --all` twice on purpose — and
+it still does not write to git, because `autofix-ci/action` uploads a diff and
+autofix.ci's own GitHub App makes the commit off-runner. Any predicate keyed on
+"configures git identity", "has hk installed", or "touches GitHub" gets it
+wrong, so it is pinned here as a permanent false-positive guard.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
+
+from dotfiles_setup import workflow_hooks
+from dotfiles_setup.main import setup_parser
+
+REPO_ROOT = Path(__file__).parent.parent
+
+# The ground truth, sourced independently of this module's code:
+#
+# - `gcc-sha-repair.yml`/repair and `refresh.yml`/lock-refresh are the two jobs
+#   ADR-0001's Decision names as committing or pushing.
+# - `refresh.yml`/tool-currency runs only `gh issue create/edit/close` — the
+#   GitHub REST API, which never touches the index or a remote.
+# - `autofix.yml`/autofix reaches `autofix-ci/action`, whose own `action.yml`
+#   documents its `autofix_started` output as "changes have been sent to the
+#   autofix server and a fix commit is coming up" — the commit is made by
+#   their App, off-runner.
+REAL_CASES: tuple[tuple[str, str, bool], ...] = (
+    (".github/workflows/gcc-sha-repair.yml", "repair", True),
+    (".github/workflows/refresh.yml", "lock-refresh", True),
+    (".github/workflows/refresh.yml", "tool-currency", False),
+    (".github/workflows/autofix.yml", "autofix", False),
+)
+
+
+# The complete job inventory of `.github/workflows/` as of 2026-07-21, read out
+# of the tree with `parse_jobs` and pinned as an exact set. A floor
+# (`>= len(REAL_CASES)`) would let a parser silently drop 15 of these 19 and
+# still pass — the bad-bound shape `.claude/rules/probes-need-a-control-arm.md`
+# names. Adding or losing a job is a deliberate, reviewable diff to this list.
+EXPECTED_JOBS: frozenset[tuple[str, str]] = frozenset(
+    {
+        (".github/workflows/autofix.yml", "autofix"),
+        (".github/workflows/build-publish.yml", "base-prep"),
+        (".github/workflows/build-publish.yml", "build"),
+        (".github/workflows/build-publish.yml", "dev-prep"),
+        (".github/workflows/build-publish.yml", "dev-tag"),
+        (".github/workflows/build-publish.yml", "p2996-prep"),
+        (".github/workflows/build-publish.yml", "smoke-test"),
+        (".github/workflows/ci.yml", "build-publish"),
+        (".github/workflows/ci.yml", "changes"),
+        (".github/workflows/ci.yml", "ci-gate"),
+        (".github/workflows/ci.yml", "contract-preflight"),
+        (".github/workflows/ci.yml", "failure-report"),
+        (".github/workflows/ci.yml", "lint"),
+        (".github/workflows/ci.yml", "promote"),
+        (".github/workflows/gcc-sha-repair.yml", "repair"),
+        (".github/workflows/ghcr-cleanup.yml", "cleanup"),
+        (".github/workflows/image-analysis.yml", "analyze"),
+        (".github/workflows/refresh.yml", "lock-refresh"),
+        (".github/workflows/refresh.yml", "tool-currency"),
+    }
+)
+
+
+# The seed plus what `mise_task_git_writers` derives from the real `mise.toml`
+# today. Route-3 tests take this explicitly so they exercise the derived half
+# without depending on a fixture tree.
+ALL_WRITERS: tuple[tuple[str, ...], ...] = (
+    *workflow_hooks.FIRST_PARTY_GIT_WRITERS,
+    ("mise", "run", "ship"),
+    ("mise", "run", "land"),
+)
+
+
+def _real_job(workflow: str, job_name: str) -> workflow_hooks.Job:
+    """One job from the real tree, or fail loudly if it has been renamed."""
+    path = REPO_ROOT / workflow
+    jobs = workflow_hooks.parse_jobs(path, workflow, REPO_ROOT)
+    for job in jobs:
+        if job.name == job_name:
+            return job
+    message = f"{workflow} has no job `{job_name}` (found {[j.name for j in jobs]})"
+    raise AssertionError(message)
+
+
+def _hook_violations(root: Path) -> list[str]:
+    """Only the HK_SKIP_HOOKS violations, dropping classification gaps.
+
+    A synthetic `tmp_path` tree reaches none of the real repo's actions, so
+    every :data:`ACTION_RUNS_GIT_LOCALLY` entry reports as stale there. Those
+    gaps are real and tested separately; filtering them out here keeps each
+    control arm asserting about the thing it is arming.
+    """
+    return [line for line in workflow_hooks.find_violations(root) if "job `" in line]
+
+
+def _write_workflow(root: Path, name: str, body: str) -> None:
+    directory = root / workflow_hooks.WORKFLOW_DIR
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / name).write_text(body, encoding="utf-8")
+
+
+def _committing_workflow(env_block: str) -> str:
+    """A minimal job that runs `git commit`/`git push` in its own shell."""
+    return f"""
+name: synthetic
+on: workflow_dispatch
+jobs:
+  writer:
+    runs-on: ubuntu-latest
+{env_block}    steps:
+      - run: |
+          git commit -m "bump"
+          git push origin HEAD
+"""
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — the four real cases.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("workflow", "job_name", "expected"), REAL_CASES)
+def test_real_case_verdicts(workflow: str, job_name: str, *, expected: bool) -> None:
+    """Each of the four ground-truth jobs is classified as documented."""
+    assert workflow_hooks.job_writes_to_git(_real_job(workflow, job_name)) is expected
+
+
+def test_lock_refresh_is_reached_only_through_composite_expansion() -> None:
+    """The regression that matters most: local-composite expansion, on the real tree.
+
+    `refresh.yml`/lock-refresh is the job ADR-0001 was written about, and it
+    contains no `git` command of its own. It reaches
+    `peter-evans/create-pull-request` as
+
+        refresh.yml -> ./.github/actions/open-refresh-pr
+                    -> peter-evans/create-pull-request
+
+    so a check that read only the job's own steps would answer "does not write
+    to git" for the single most important case in the repo. The `uses:` list
+    is read straight out of the YAML here, independently of `parse_jobs`, so
+    the assertion cannot be satisfied by the expansion it is testing.
+
+    Scope, stated so this claims only what it proves: those two edges are ONE
+    level of expansion (job -> composite -> vendor leaf), and no composite in
+    this repo uses another local composite, so this cannot exercise recursion.
+    `test_composite_expansion_recurses_past_one_hop` supplies that depth on a
+    fixture tree.
+    """
+    workflow = ".github/workflows/refresh.yml"
+    document = yaml.safe_load((REPO_ROOT / workflow).read_text(encoding="utf-8"))
+    own_uses = [
+        step.get("uses")
+        for step in document["jobs"]["lock-refresh"]["steps"]
+        if isinstance(step, dict)
+    ]
+    assert "peter-evans/create-pull-request" not in own_uses
+    assert "./.github/actions/open-refresh-pr" in own_uses
+
+    job = _real_job(workflow, "lock-refresh")
+    assert workflow_hooks.git_write_subcommands(job.run_text) == set()
+    assert workflow_hooks.committing_actions(job) == {"peter-evans/create-pull-request"}
+
+
+def test_gcc_sha_repair_is_reached_through_its_own_shell() -> None:
+    """The other positive arrives by a different route: a literal git verb."""
+    job = _real_job(".github/workflows/gcc-sha-repair.yml", "repair")
+    assert workflow_hooks.git_write_subcommands(job.run_text) == {"commit", "push"}
+    assert workflow_hooks.committing_actions(job) == set()
+
+
+def test_autofix_defeats_every_cheaper_predicate() -> None:
+    """The trap case: every surface signal says "writes to git", and it does not.
+
+    Pinned as a false-positive guard — if a future predicate starts keying on
+    a `git config` identity or on hk being installed, this fails.
+    """
+    job = _real_job(".github/workflows/autofix.yml", "autofix")
+    assert "git config" in job.run_text
+    assert "hk run pre-commit" in job.run_text
+    assert any(workflow_hooks.action_id(u) == "autofix-ci/action" for u in job.uses)
+    assert workflow_hooks.job_writes_to_git(job) is False
+
+
+def test_tool_currency_uses_the_github_api_not_git() -> None:
+    """`gh issue` is the API — no index, no remote, so no hook can fire."""
+    job = _real_job(".github/workflows/refresh.yml", "tool-currency")
+    assert "gh issue" in job.run_text
+    assert workflow_hooks.job_writes_to_git(job) is False
+
+
+def test_both_positive_real_jobs_already_declare_the_skip() -> None:
+    """The ADR's decision is in force today for both jobs it named."""
+    for workflow, job_name, expected in REAL_CASES:
+        if expected:
+            job = _real_job(workflow, job_name)
+            assert job.env[workflow_hooks.SKIP_ENV] == "pre-commit,pre-push"
+            assert workflow_hooks.skips_required_hooks(job) is True
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — control arms: the FAIL direction, on synthetic trees.
+# ---------------------------------------------------------------------------
+
+
+def test_new_committing_job_without_the_skip_fails(tmp_path: Path) -> None:
+    """The whole point of the ADR's open gap: a NEW job is caught by shape.
+
+    Nothing about this workflow is registered anywhere — it is not
+    `refresh.yml` or `gcc-sha-repair.yml`, and no name is pinned in the
+    module. A check that fixed the two known cases by name would pass here,
+    which is exactly the weakness the ADR complains about.
+    """
+    _write_workflow(tmp_path, "brand-new.yml", _committing_workflow(""))
+    violations = _hook_violations(tmp_path)
+    assert len(violations) == 1
+    assert "brand-new.yml" in violations[0]
+    assert "job `writer`" in violations[0]
+    assert workflow_hooks.SKIP_ENV in violations[0]
+
+
+def test_same_job_with_the_full_skip_passes(tmp_path: Path) -> None:
+    """The paired PASS arm: identical job, one env line, no violation."""
+    _write_workflow(
+        tmp_path,
+        "brand-new.yml",
+        _committing_workflow("    env:\n      HK_SKIP_HOOKS: pre-commit,pre-push\n"),
+    )
+    assert _hook_violations(tmp_path) == []
+
+
+def test_partial_skip_still_fails(tmp_path: Path) -> None:
+    """`pre-commit` alone is what PR #274 shipped — green, and still broken.
+
+    The failing hk steps are `pre-push`'s, and `create-pull-request` pushes as
+    well as commits. This is the single most important negative in the suite:
+    the previous fix passed every gate the repo had.
+    """
+    _write_workflow(
+        tmp_path,
+        "partial.yml",
+        _committing_workflow("    env:\n      HK_SKIP_HOOKS: pre-commit\n"),
+    )
+    assert len(_hook_violations(tmp_path)) == 1
+
+
+def test_skip_value_is_an_order_independent_union() -> None:
+    """Hk unions the value, so order and whitespace must not matter."""
+
+    def job_with(value: str) -> workflow_hooks.Job:
+        return workflow_hooks.Job(
+            workflow="w.yml",
+            name="j",
+            run_text="",
+            uses=(),
+            env={workflow_hooks.SKIP_ENV: value},
+        )
+
+    for value in (
+        "pre-push,pre-commit",
+        " pre-commit , pre-push ",
+        "commit-msg,pre-commit,pre-push",
+    ):
+        assert workflow_hooks.skips_required_hooks(job_with(value)), value
+    for value in ("", "pre-push", "pre-commit", "commit-msg"):
+        assert not workflow_hooks.skips_required_hooks(job_with(value)), value
+
+
+def test_workflow_level_env_satisfies_a_job(tmp_path: Path) -> None:
+    """A workflow-level env block covers its jobs; the job-level one wins."""
+    _write_workflow(
+        tmp_path,
+        "top-level-env.yml",
+        """
+name: synthetic
+on: workflow_dispatch
+env:
+  HK_SKIP_HOOKS: pre-commit,pre-push
+jobs:
+  writer:
+    runs-on: ubuntu-latest
+    steps:
+      - run: git push origin HEAD
+""",
+    )
+    assert _hook_violations(tmp_path) == []
+
+
+def test_job_env_overrides_a_sufficient_workflow_env(tmp_path: Path) -> None:
+    """Control arm for the merge order: a narrowing job env must lose the pass."""
+    _write_workflow(
+        tmp_path,
+        "override.yml",
+        """
+name: synthetic
+on: workflow_dispatch
+env:
+  HK_SKIP_HOOKS: pre-commit,pre-push
+jobs:
+  writer:
+    runs-on: ubuntu-latest
+    env:
+      HK_SKIP_HOOKS: pre-commit
+    steps:
+      - run: git push origin HEAD
+""",
+    )
+    assert len(_hook_violations(tmp_path)) == 1
+
+
+@pytest.mark.parametrize(
+    "run_text",
+    [
+        "git config --global user.name bot",
+        "git add -A",
+        "git status --porcelain",
+        "git diff --quiet",
+        "git merge-base origin/main HEAD",
+        "git rev-parse HEAD",
+        'echo "remember to git push"',
+        "# git commit is what this would do",
+        "git commit --no-verify -m x",
+        "git push --no-verify origin HEAD",
+    ],
+)
+def test_non_hook_firing_shell_is_not_flagged(run_text: str) -> None:
+    """Reads, quoted mentions, and git's own documented bypass are not writes.
+
+    `merge-base` is pinned deliberately: this repo really runs it, and a
+    prefix match rather than a token match would read it as `merge`.
+    """
+    assert workflow_hooks.git_write_subcommands(run_text) == set()
+
+
+@pytest.mark.parametrize(
+    ("run_text", "expected"),
+    [
+        ("git commit -m x", {"commit"}),
+        ("git push", {"push"}),
+        ("git -C sub commit -m x", {"commit"}),
+        ("git commit -m x\ngit push origin HEAD", {"commit", "push"}),
+        ("if ! git push; then exit 1; fi", {"push"}),
+        ("GIT_AUTHOR_NAME=bot git commit -m x", {"commit"}),
+        ("/usr/bin/git push origin HEAD", {"push"}),
+        ("git add -A && git commit -m x", {"commit"}),
+    ],
+)
+def test_hook_firing_shell_is_detected(run_text: str, expected: set[str]) -> None:
+    """The recall arm for every shape the negatives above could have masked."""
+    assert workflow_hooks.git_write_subcommands(run_text) == expected
+
+
+def test_first_party_entrypoint_counts_as_a_write(tmp_path: Path) -> None:
+    """Route 3: `mise run ship` reaches pr.py's git push, so it needs the skip.
+
+    zero-bash-logic and mise-tasks-only actively steer git writes off the
+    shell and behind a task, so without this route finishing that migration
+    would silently turn a true positive into a false negative.
+    """
+    _write_workflow(
+        tmp_path,
+        "shipper.yml",
+        """
+name: synthetic
+on: workflow_dispatch
+jobs:
+  shipper:
+    runs-on: ubuntu-latest
+    steps:
+      - run: uv run --project python dotfiles-setup pr ship
+""",
+    )
+    assert len(_hook_violations(tmp_path)) == 1
+
+
+def test_unknown_action_is_a_classification_gap_not_a_skip_violation(
+    tmp_path: Path,
+) -> None:
+    """An unrecognised action must NOT be answered with "add the env var".
+
+    The env var also silences an explicit `hk run <hook>`, so training an
+    operator to set it unconditionally would both dissolve this check and
+    turn `autofix.yml`'s two deliberate `hk run pre-commit` steps into
+    no-ops. The remedy is a one-line reviewable verdict instead.
+    """
+    _write_workflow(
+        tmp_path,
+        "unknown.yml",
+        """
+name: synthetic
+on: workflow_dispatch
+jobs:
+  mystery:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: some-vendor/some-action@v1
+""",
+    )
+    lines = workflow_hooks.find_violations(tmp_path)
+    gaps = [line for line in lines if "some-vendor/some-action" in line]
+    assert len(gaps) == 1
+    assert "ACTION_RUNS_GIT_LOCALLY" in gaps[0]
+    assert workflow_hooks.SKIP_ENV not in gaps[0]
+    assert _hook_violations(tmp_path) == []
+
+
+def test_stale_action_verdict_is_reported(tmp_path: Path) -> None:
+    """A verdict nothing exercises rots — mirrors bash_budget's `stale` kind."""
+    _write_workflow(
+        tmp_path,
+        "empty.yml",
+        "name: synthetic\non: workflow_dispatch\njobs:\n  noop:\n"
+        "    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n",
+    )
+    lines = workflow_hooks.find_violations(tmp_path)
+    assert any("is stale" in line and "actions/checkout" in line for line in lines)
+
+
+def test_malformed_yaml_yields_no_jobs(tmp_path: Path) -> None:
+    """Actionlint owns workflow syntax, so this fails OPEN rather than twice."""
+    broken = tmp_path / "broken.yml"
+    broken.write_text("jobs: [unclosed\n", encoding="utf-8")
+    assert workflow_hooks.parse_jobs(broken, "broken.yml", tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# Layer 3 — the real tree, and the CLI seam.
+# ---------------------------------------------------------------------------
+
+
+def test_repo_currently_compliant() -> None:
+    """Today's tree passes — the arm the control arms above make meaningful."""
+    assert workflow_hooks.find_violations(REPO_ROOT) == []
+
+
+def test_every_real_job_is_parsed() -> None:
+    """The FULL job inventory is pinned, not a floor.
+
+    A `>= len(REAL_CASES)` bound would only rule out near-total loss: a parser
+    that silently dropped 15 of the 19 jobs would still pass it. That is the
+    bad-bound shape `.claude/rules/probes-need-a-control-arm.md` names — "not
+    at this depth" read as "not present". So the exact set is asserted, and
+    adding or losing a job is a deliberate, reviewable diff.
+    """
+    parsed = {
+        (job.workflow, job.name)
+        for path in sorted((REPO_ROOT / workflow_hooks.WORKFLOW_DIR).glob("*.y*ml"))
+        for job in workflow_hooks.parse_jobs(
+            path, f"{workflow_hooks.WORKFLOW_DIR}/{path.name}", REPO_ROOT
+        )
+    }
+    assert parsed == EXPECTED_JOBS
+    for workflow, job_name, _ in REAL_CASES:
+        assert (workflow, job_name) in parsed
+
+
+def test_cli_wires_end_to_end() -> None:
+    """The `workflow-hooks` subcommand runs through main.py and passes clean.
+
+    Kept as the argparse-REGISTRATION seam only; the behavioural rc=0/rc=1
+    arms are in-process below, so the gate's verdict does not depend on a `uv`
+    sync succeeding. stdout is asserted too: a subcommand that printed nothing
+    would otherwise pass.
+    """
+    result = subprocess.run(
+        ["uv", "run", "--project", "python", "dotfiles-setup", "workflow-hooks"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=REPO_ROOT,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "workflow-hooks OK" in result.stdout
+
+
+def test_subcommand_is_registered_on_the_parser() -> None:
+    """`main.setup_parser` really carries the subcommand.
+
+    Deleting the `subparsers.add_parser("workflow-hooks", …)` block leaves the
+    dispatch-dict entry intact, so the contract's two main.py tokens stay
+    satisfied while the CLI subcommand no longer exists. This is the arm that
+    fails on that deletion — argparse exits 2 on an unknown choice.
+    """
+    args = setup_parser().parse_args(["workflow-hooks"])
+    assert args.command == "workflow-hooks"
+
+
+# ---------------------------------------------------------------------------
+# Layer 4 — the entrypoint CI actually runs, in BOTH directions.
+# ---------------------------------------------------------------------------
+
+
+def test_main_returns_zero_on_the_real_tree(capsys: pytest.CaptureFixture[str]) -> None:
+    """The PASS arm of the function the hk step and CI invoke."""
+    assert workflow_hooks.workflow_hooks_main(REPO_ROOT) == 0
+    assert "workflow-hooks OK" in capsys.readouterr().out
+
+
+def test_main_returns_one_and_names_the_job(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The FAIL arm — the one missing arm that let the entrypoint be gutted.
+
+    `workflow_hooks_main` could be reduced to `violations = []` (never asking
+    the question, always returning 0) with the whole suite still green, because
+    nothing exercised its rc=1 branch. That is the #274 shape this module
+    exists to prevent: a green, vacuous gate.
+    """
+    _write_workflow(tmp_path, "brand-new.yml", _committing_workflow(""))
+    assert workflow_hooks.workflow_hooks_main(tmp_path) == 1
+    out = capsys.readouterr().out
+    assert workflow_hooks.SKIP_ENV in out
+    assert "job `writer`" in out
+    assert "ADR-0001" in out
+
+
+# ---------------------------------------------------------------------------
+# Layer 5 — route 3: first-party entrypoints, and their DERIVATION.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "run_text",
+    [
+        'echo "remember to mise run ship later"',
+        "# mise run land",
+        "mise run lint",
+        "mise run test",
+        "echo dotfiles-setup pr ship > /tmp/note",
+    ],
+)
+def test_route_three_ignores_mentions_that_are_not_commands(run_text: str) -> None:
+    """The negative arm route 3 was missing entirely.
+
+    Without it, degrading `first_party_git_writers` from command-position
+    matching to a naive `entrypoint in run_text` substring test passes the
+    whole suite — the module's docstring claims quoted/commented mentions
+    cannot trigger it, and nothing checked that claim.
+    """
+    assert workflow_hooks.first_party_git_writers(run_text, ALL_WRITERS) == set()
+
+
+@pytest.mark.parametrize(
+    ("run_text", "expected"),
+    [
+        ("mise run ship", "mise run ship"),
+        ("mise run land -- 42", "mise run land"),
+        ("uv run --project python dotfiles-setup pr land", "dotfiles-setup pr"),
+        ("dotfiles-setup pr ship", "dotfiles-setup pr"),
+    ],
+)
+def test_route_three_recall_covers_every_registered_entrypoint(
+    run_text: str, expected: str
+) -> None:
+    """The paired recall arm: a typo in any entry must not be invisible."""
+    assert workflow_hooks.first_party_git_writers(run_text, ALL_WRITERS) == {expected}
+
+
+def _mise_project(root: Path, toml_body: str) -> None:
+    (root / "mise.toml").write_text(toml_body, encoding="utf-8")
+
+
+def test_mise_task_writers_are_derived_not_listed(tmp_path: Path) -> None:
+    """A NEW task aliasing a registered writer is caught, transitively.
+
+    Listing `mise run ship`/`mise run land` by name reproduced ADR-0001's own
+    complaint one level up: `mise run release`, a thin caller of the SAME
+    `dotfiles-setup pr ship`, was a silent false negative that no
+    classification gap could report (`pr` is already registered, so nothing
+    could fire). The derivation resolves the chain instead.
+    """
+    _mise_project(
+        tmp_path,
+        '[tasks.ship]\nrun = "uv run --project python dotfiles-setup pr ship"\n'
+        '[tasks.release]\nrun = "mise run ship -- --title x"\n'
+        '[tasks.tagger]\nrun = "git push origin --tags"\n'
+        '[tasks.nightly]\ndepends = ["release"]\nrun = "echo done"\n'
+        '[tasks.lint]\nrun = "uv run --project python dotfiles-setup lint"\n',
+    )
+    derived = workflow_hooks.mise_task_git_writers(tmp_path)
+    assert derived == (
+        ("mise", "run", "nightly"),
+        ("mise", "run", "release"),
+        ("mise", "run", "ship"),
+        ("mise", "run", "tagger"),
+    )
+    assert ("mise", "run", "lint") not in derived
+
+
+def test_new_task_alias_job_is_flagged(tmp_path: Path) -> None:
+    """End-to-end for the derivation: the invented `cut-release` job fails."""
+    _mise_project(
+        tmp_path,
+        '[tasks.ship]\nrun = "uv run --project python dotfiles-setup pr ship"\n'
+        '[tasks.release]\nrun = "mise run ship -- --title x"\n'
+        '[tasks.lint]\nrun = "uv run --project python dotfiles-setup lint"\n',
+    )
+    body = """
+name: synthetic
+on: workflow_dispatch
+jobs:
+  cut-release:
+    runs-on: ubuntu-latest
+    steps:
+      - run: {command}
+"""
+    _write_workflow(tmp_path, "cut.yml", body.format(command="mise run release"))
+    assert len(_hook_violations(tmp_path)) == 1
+
+    # Control arm: byte-identical job, one non-writing task instead.
+    _write_workflow(tmp_path, "cut.yml", body.format(command="mise run lint"))
+    assert _hook_violations(tmp_path) == []
+
+
+def test_derivation_matches_the_real_tree_today() -> None:
+    """The real repo derives exactly `ship` and `land` — the old hand-list."""
+    assert workflow_hooks.mise_task_git_writers(REPO_ROOT) == (
+        ("mise", "run", "land"),
+        ("mise", "run", "ship"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer 6 — the classification gaps that stop the data rotting.
+# ---------------------------------------------------------------------------
+
+
+def _python_project(root: Path, module: str, source: str) -> None:
+    package = root / "python/src/dotfiles_setup"
+    package.mkdir(parents=True, exist_ok=True)
+    (package / f"{module}.py").write_text(source, encoding="utf-8")
+    (root / workflow_hooks.WORKFLOW_DIR).mkdir(parents=True, exist_ok=True)
+
+
+def test_unregistered_python_git_write_is_a_gap(tmp_path: Path) -> None:
+    """Route 3's "hard stop" really stops — it was untestable in both arms.
+
+    `_python_git_write_modules` could be made to `return set()` unconditionally
+    (blind forever) with all tests green, so the mechanism that keeps
+    FIRST_PARTY_GIT_WRITERS from falling behind the code had no control arm at
+    all. The write verb is assembled at runtime so this file cannot match its
+    own detector.
+    """
+    verb = "pu" + "sh"
+    _python_project(
+        tmp_path, "releaser", f'ARGV = ["git", "{verb}", "origin", "HEAD"]\n'
+    )
+    gaps = [
+        line
+        for line in workflow_hooks.classification_gaps(tmp_path)
+        if "releaser" in line
+    ]
+    assert len(gaps) == 1
+    assert "GIT_WRITING_MODULES" in gaps[0]
+
+
+def test_git_reads_in_python_are_not_a_gap(tmp_path: Path) -> None:
+    """The paired negative, which also pins `merge-base` != `merge`.
+
+    A prefix match rather than a quote-delimited alternation would read
+    `merge-base` as `merge` and report a gap for every module that computes a
+    merge base — which this repo really does.
+    """
+    _python_project(
+        tmp_path,
+        "reader",
+        'A = ["git", "merge-base", "origin/main", "HEAD"]\n'
+        'B = ["git", "status", "--porcelain"]\n'
+        'C = ["git", "rev-parse", "HEAD"]\n',
+    )
+    assert [
+        line
+        for line in workflow_hooks.classification_gaps(tmp_path)
+        if "reader" in line
+    ] == []
+
+
+def test_opaque_local_action_is_a_gap(tmp_path: Path) -> None:
+    """A first-party node/docker action must be a reported hole, not silence.
+
+    `_expand_local` reads a local action only through its composite `steps:`,
+    and `action_id` returns "" for a `./` reference — so a `runs.using: node20`
+    action produced no run_text, no uses AND no gap. It was the module's only
+    route where an unrecognised writer answered False in silence.
+    """
+    _write_workflow(
+        tmp_path,
+        "tag.yml",
+        "name: synthetic\non: workflow_dispatch\njobs:\n  tag:\n"
+        "    runs-on: ubuntu-latest\n    steps:\n"
+        "      - uses: ./.github/actions/push-tag\n",
+    )
+    action = tmp_path / ".github/actions/push-tag"
+    action.mkdir(parents=True)
+    (action / "action.yml").write_text(
+        "name: push-tag\nruns:\n  using: node20\n  main: dist/index.js\n",
+        encoding="utf-8",
+    )
+    gaps = [
+        line for line in workflow_hooks.find_violations(tmp_path) if "push-tag" in line
+    ]
+    assert len(gaps) == 1
+    assert "composite" in gaps[0]
+    assert workflow_hooks.SKIP_ENV not in gaps[0]
+
+    # Control arm: the SAME action as a composite is read, and its git push
+    # becomes an ordinary HK_SKIP_HOOKS violation with no gap.
+    (action / "action.yml").write_text(
+        "name: push-tag\nruns:\n  using: composite\n  steps:\n"
+        "    - run: git push origin --tags\n      shell: bash\n",
+        encoding="utf-8",
+    )
+    assert [
+        line for line in workflow_hooks.find_violations(tmp_path) if "push-tag" in line
+    ] == []
+    assert len(_hook_violations(tmp_path)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Layer 7 — composite expansion depth, and shell-tokenizing edge cases.
+# ---------------------------------------------------------------------------
+
+
+def _composite(root: Path, name: str, body: str) -> None:
+    directory = root / ".github/actions" / name
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "action.yml").write_text(body, encoding="utf-8")
+
+
+def test_composite_expansion_recurses_past_one_hop(tmp_path: Path) -> None:
+    """Depth >= 2, which the real tree cannot exercise.
+
+    `refresh.yml` reaches its vendor in ONE level of expansion (job ->
+    composite -> vendor), and no composite in this repo uses another local
+    composite — so deleting `_expand_local`'s recursive self-call left the
+    suite green. This fixture supplies the depth the tree lacks.
+    """
+    _write_workflow(
+        tmp_path,
+        "nested.yml",
+        "name: synthetic\non: workflow_dispatch\njobs:\n  j:\n"
+        "    runs-on: ubuntu-latest\n    steps:\n"
+        "      - uses: ./.github/actions/outer\n",
+    )
+    _composite(
+        tmp_path,
+        "outer",
+        "name: o\nruns:\n  using: composite\n  steps:\n"
+        "    - uses: ./.github/actions/inner\n",
+    )
+    _composite(
+        tmp_path,
+        "inner",
+        "name: i\nruns:\n  using: composite\n  steps:\n"
+        "    - uses: peter-evans/create-pull-request@v8\n",
+    )
+    job = workflow_hooks.parse_jobs(
+        tmp_path / workflow_hooks.WORKFLOW_DIR / "nested.yml", "nested.yml", tmp_path
+    )[0]
+    assert workflow_hooks.committing_actions(job) == {"peter-evans/create-pull-request"}
+
+
+def test_composite_expansion_terminates_on_a_cycle(tmp_path: Path) -> None:
+    """The `seen` guard: a self-referential pair must not recurse forever."""
+    _write_workflow(
+        tmp_path,
+        "cyclic.yml",
+        "name: synthetic\non: workflow_dispatch\njobs:\n  j:\n"
+        "    runs-on: ubuntu-latest\n    steps:\n"
+        "      - uses: ./.github/actions/a\n",
+    )
+    _composite(
+        tmp_path,
+        "a",
+        "name: a\nruns:\n  using: composite\n  steps:\n"
+        "    - uses: ./.github/actions/b\n",
+    )
+    _composite(
+        tmp_path,
+        "b",
+        "name: b\nruns:\n  using: composite\n  steps:\n"
+        "    - uses: ./.github/actions/a\n    - run: git push\n      shell: bash\n",
+    )
+    job = workflow_hooks.parse_jobs(
+        tmp_path / workflow_hooks.WORKFLOW_DIR / "cyclic.yml", "cyclic.yml", tmp_path
+    )[0]
+    assert workflow_hooks.git_write_subcommands(job.run_text) == {"push"}
+
+
+def test_heredoc_body_is_data_not_commands() -> None:
+    """Remediation prose in an issue body is not a git write.
+
+    A heredoc body is UNQUOTED stdin data whose newlines are real newlines, so
+    it tokenizes exactly like two commands — the false-positive class
+    `hook_guard._inert_masked` fixed for the PreToolUse guard in #265. The
+    printed remedy for a violation is a free-looking env line, so a false
+    positive here trains operators to set the skip unconditionally, after which
+    a genuinely new git-writing job passes too.
+    """
+    body = (
+        "gh issue create --body-file - <<'EOF'\n"
+        "To fix locally:\n"
+        "git commit -am fix\n"
+        "git push origin HEAD\n"
+        "EOF\n"
+    )
+    assert workflow_hooks.git_write_subcommands(body) == set()
+    written = "cat > /tmp/fix.sh <<'SH'\ngit commit -m x\ngit push origin HEAD\nSH\n"
+    assert workflow_hooks.git_write_subcommands(written) == set()
+
+
+def test_heredoc_fed_to_a_shell_is_still_detected() -> None:
+    """The recall arm that stops the fix becoming an under-detect.
+
+    `bash <<'SH' … git push … SH` really does execute its body, so blanket
+    redaction would trade a loud false positive for a silent miss — the
+    direction that reopens the gap.
+    """
+    assert workflow_hooks.git_write_subcommands("bash <<'SH'\ngit push\nSH\n") == {
+        "push"
+    }
+    assert workflow_hooks.git_write_subcommands("sh <<EOF\ngit commit -m x\nEOF\n") == {
+        "commit"
+    }
+    assert workflow_hooks.git_write_subcommands("git commit -m x\ngit push") == {
+        "commit",
+        "push",
+    }
+
+
+def test_unbalanced_quote_falls_open_toward_detecting() -> None:
+    """`shell_tokens`' documented fail-open direction, previously unchecked.
+
+    The docstring makes a directional safety claim about the `ValueError`
+    branch (miss toward DETECTING a write). A fallback that instead returned
+    `[]` — silently classifying every malformed run block as "no git write" —
+    would have been invisible.
+    """
+    malformed = 'git push origin HEAD && echo "unterminated'
+    assert "push" in workflow_hooks.shell_tokens(malformed)
+    assert workflow_hooks.git_write_subcommands(malformed) == {"push"}


### PR DESCRIPTION
ADR-0001's Consequences section named an open gap: "Any NEW workflow that
commits or pushes must set HK_SKIP_HOOKS too. There is no global guard — the
two known cases are fixed by name. Correctness now depends on remembering. A
contract asserting 'every workflow that commits sets HK_SKIP_HOOKS' would give
this teeth; not written yet." This closes it.

`dotfiles-setup workflow-hooks` (hk step `workflow_hk_skip_hooks`) judges jobs
by SHAPE, pinning nothing by name — a name-pinned check would have inherited
exactly the weakness the ADR complained about. Three routes reach a local git:

1. a hook-firing verb at a shell COMMAND POSITION. Tokenized with stdlib shlex
   (posix mode + newline in punctuation_chars), so a `git commit` mentioned
   inside a quoted string is one token and cannot manufacture a command
   position — the #265 false-positive class, avoided by construction rather
   than by patching a hand-rolled splitter. The verbs are DERIVED from
   REQUIRED_SKIPS via githooks(5), so adding commit-msg needs one edit.
2. a third-party action classified as running git LOCALLY. Local composite
   actions are inlined RECURSIVELY, which is the only reason refresh.yml's
   lock-refresh is visible at all: it contains no git command and reaches
   peter-evans/create-pull-request two hops down.
3. a FIRST-PARTY entrypoint that reaches a git write inside python/. The panel
   found this; it is the blind spot our own rules create. zero-bash-logic and
   mise-tasks-only steer authors from raw `git push` to `mise run ship`, which
   routes to `dotfiles-setup pr ship` → pr.py:506 `git push -u origin`.
   gcc-sha-repair.yml's header already calls its git block "a thin trigger +
   commit seam". Kept honest by DERIVATION, not a hand list: python/src is
   grepped for argv git-write literals and any unregistered module hard-fails.

Unrecognised actions, stale registry entries and new python/ git writes each
fail with their OWN remedy, never "add the env var" — HK_SKIP_HOOKS also
silences an explicit `hk run <hook>`, and autofix.yml runs one deliberately as
its whole mechanism, so a reflex to apply it would dissolve the check.

Also extracts heredoc redaction into dotfiles_setup.heredoc, shared by
hook_guard and workflow_hooks. This touches the guard merged in #338; the
alternative was two copies of load-bearing logic that would drift.

Verified by mutation, not by reading:
- a NEW workflow (`git tag` + `git push --tags`, no commit) → 1 violation;
  real tree → 0.
- neutering the composite-action expansion → 8 tests fail, incl.
  test_lock_refresh_is_reached_only_through_composite_expansion.
- deleting the hk step → verify rc=1; deleting the CLI registration → verify
  rc=1 on a missing CALL SITE (`workflow_hooks_main(project_root)`), not a
  `def`, which prose cannot satisfy.
- #274's partial `pre-commit`-only value fails, as it should have then.

Built by a 19-agent panel: 3 independent designs → 3 adversarial lenses each →
synthesis → implementation → 4-dimension review → fix.

ADR-0001 amended (struck through, not rewritten). One ambiguity escalated and
filed as #340: whether the demanded skip should match the hooks a job actually
risks — deferred because ADR-0001's Decision is written as a flat value and the
ADR should move first.

Gates: lint rc=0, pytest 871 passed, verify 94 passed/0 failed, ty clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015tpo1Gdwyj25CLWrH1Fg5P


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated validation for CI workflows that modify Git, ensuring required hook-skip settings are present.
  * Added a command-line check that reports workflow violations and classification issues.
  * Added shared handling to distinguish heredoc data from executable shell commands.

* **Documentation**
  * Updated decision-record documentation to describe the automated enforcement process.
  * Corrected the ADR index to reflect the current number of records.

* **Tests**
  * Added comprehensive coverage for workflow detection, configuration validation, composite actions, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->