### PR TITLE
test(lock): gate exact config pin ↔ lock version drift per-PR

### DIFF
--- a/python/src/dotfiles_setup/lock_refresh.py
+++ b/python/src/dotfiles_setup/lock_refresh.py
@@ -221,11 +221,23 @@ def _has_provenance_key(node: object) -> bool:
     return False
 
 
+def merged_system_config(repo_root: Path) -> dict[str, object]:
+    """Return the image's merged BASE config tools table (system + shared).
+
+    Name -> pin value (a version string or a `{version = ..., ...}` table).
+    `shared.toml` is spread last so a tool declared in both wins from the
+    shared fragment, matching how the image merges `conf.d/` over the system
+    `config.toml`. The name-only view (`merged_system_config_tools`) and the
+    version-drift gate both read from this one merge.
+    """
+    system = tomllib.loads((repo_root / _SYSTEM_TOML).read_text()).get("tools", {})
+    shared = tomllib.loads((repo_root / _SHARED_TOML).read_text()).get("tools", {})
+    return {**system, **shared}
+
+
 def merged_system_config_tools(repo_root: Path) -> set[str]:
     """Return the tool keys of the image's merged BASE config (system + shared)."""
-    system = tomllib.loads((repo_root / _SYSTEM_TOML).read_text())
-    shared = tomllib.loads((repo_root / _SHARED_TOML).read_text())
-    return set(system.get("tools", {})) | set(shared.get("tools", {}))
+    return set(merged_system_config(repo_root))
 
 
 def runtime_config_tools(repo_root: Path) -> set[str]:

--- a/tests/test_lock_coverage.py
+++ b/tests/test_lock_coverage.py
@@ -16,8 +16,13 @@ import json
 import re
 import tomllib
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 from dotfiles_setup.lock_refresh import (
+    merged_system_config,
     merged_system_config_tools,
     runtime_config_tools,
 )
@@ -25,6 +30,11 @@ from dotfiles_setup.lock_refresh import (
 _REPO_ROOT = Path(__file__).parent.parent
 _FEATURE_KEY_RE = re.compile(r'"(ghcr\.io/[^"]+/features/[^"]+)"\s*:')
 _EXTRAS_RE = re.compile(r"\[.*\]$")
+# A fully-specified pin (X.Y.Z, optional suffix). ONLY these are version-checked
+# against the lock: "latest", partial ("1.52"), and range ("^1.2") pins resolve
+# to a version mise picks and legitimately drifts between refreshes — asserting
+# those per-PR would false-fail, which is the daily lock-refresh job's domain.
+_EXACT_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+[\w.\-+]*$")
 
 
 def _strip_extras(tool: str) -> str:
@@ -41,6 +51,83 @@ def _strip_extras(tool: str) -> str:
 
 def _lock_tools(lock_path: Path) -> set[str]:
     return set(tomllib.loads(lock_path.read_text()).get("tools", {}))
+
+
+def _normalize_version(version: str) -> str:
+    """Strip a leading `v` so a pin (`v0.2.40`) matches a lock version (`0.2.40`)."""
+    return version.removeprefix("v")
+
+
+def _config_pin(value: object) -> str | None:
+    """Extract the pin from a mise tool value (a string or a `{version=...}` table)."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        pin = value.get("version")
+        return pin if isinstance(pin, str) else None
+    return None
+
+
+def _exact_config_pins(tools: Mapping[str, object]) -> dict[str, str]:
+    """Map each EXACTLY-pinned tool to its normalized version (name extras-stripped).
+
+    Only fully-specified pins (X.Y.Z) are returned; see `_EXACT_VERSION_RE`.
+    """
+    pins: dict[str, str] = {}
+    for name, value in tools.items():
+        pin = _config_pin(value)
+        if pin is None:
+            continue
+        normalized = _normalize_version(pin)
+        if _EXACT_VERSION_RE.match(normalized):
+            pins[_strip_extras(name)] = normalized
+    return pins
+
+
+def _lock_versions(lock_path: Path) -> dict[str, str]:
+    """Map each locked tool to its normalized version.
+
+    mise writes each tool as an array-of-tables (`[[tools.NAME]]`), so the
+    version lives at `tools[name][0]["version"]`.
+    """
+    tools = tomllib.loads(lock_path.read_text()).get("tools", {})
+    versions: dict[str, str] = {}
+    for name, entries in tools.items():
+        if isinstance(entries, list) and entries and isinstance(entries[0], dict):
+            version = entries[0].get("version")
+            if isinstance(version, str):
+                versions[name] = _normalize_version(version)
+    return versions
+
+
+def _version_drift(
+    tools: Mapping[str, object], lock_path: Path
+) -> dict[str, tuple[str, str]]:
+    """Return {tool: (config_pin, lock_version)} for exact pins that disagree.
+
+    Only tools present in BOTH the config pins and the lock are compared — name
+    coverage is the other tests' job; this one is purely about version match.
+    """
+    pins = _exact_config_pins(tools)
+    locked = _lock_versions(lock_path)
+    return {
+        name: (pins[name], locked[name])
+        for name in pins
+        if name in locked and pins[name] != locked[name]
+    }
+
+
+def _assert_no_version_drift(tools: dict[str, object], lock_path: Path) -> None:
+    drift = _version_drift(tools, lock_path)
+    assert not drift, (
+        f"{lock_path.name}: exact config pin != lock version — a tool was "
+        f"bumped in config without regenerating the lock (root/shared: "
+        f"`mise run lock`; image: lock-refresh on linux-x64). Drift: "
+        + "; ".join(
+            f"{name}: config {cfg} vs lock {lock}"
+            for name, (cfg, lock) in sorted(drift.items())
+        )
+    )
 
 
 def test_system_lock_covers_merged_config() -> None:
@@ -156,4 +243,103 @@ def test_devcontainer_lock_covers_features() -> None:
     assert referenced - locked == set(), (
         f"features missing from devcontainer-lock.json "
         f"(run `devcontainer upgrade`): {sorted(referenced - locked)}"
+    )
+
+
+# --- Version-drift gates (config exact pin must equal the locked version) ------
+# The coverage tests above check a tool NAME is present in its lock; these check
+# its exact-pinned VERSION matches. Version drift was the invisible gap that let
+# a manual tool bump (hk 1.50.0 -> 1.52.0) ship with a stale lock: name coverage
+# stayed green because hk was still present (at the old version), and CI's
+# `mise install --locked` only failed downstream in the base build. These gates
+# move that failure per-PR, where the fix (`mise run lock` / lock-refresh) is
+# cheap. "latest"/partial/range pins are excluded by design (see _EXACT_VERSION_RE).
+
+
+def _root_config_tools() -> dict[str, object]:
+    return tomllib.loads((_REPO_ROOT / "mise.toml").read_text()).get("tools", {})
+
+
+def _shared_config_tools() -> dict[str, object]:
+    return tomllib.loads(
+        (_REPO_ROOT / ".config" / "mise" / "conf.d" / "shared.toml").read_text()
+    ).get("tools", {})
+
+
+def _runtime_config_tools_table() -> dict[str, object]:
+    return tomllib.loads(
+        (_REPO_ROOT / ".devcontainer" / "mise-runtime.toml").read_text()
+    ).get("tools", {})
+
+
+def test_root_lock_versions_match_pins() -> None:
+    """mise.lock's versions must equal root mise.toml's exact pins (`mise run lock`)."""
+    _assert_no_version_drift(_root_config_tools(), _REPO_ROOT / "mise.lock")
+
+
+def test_shared_lock_versions_match_pins() -> None:
+    """.config/mise/mise.lock's versions must equal shared.toml's exact pins."""
+    _assert_no_version_drift(
+        _shared_config_tools(), _REPO_ROOT / ".config" / "mise" / "mise.lock"
+    )
+
+
+def test_system_lock_versions_match_pins() -> None:
+    """mise-system.lock's versions must equal the merged image config's exact pins.
+
+    This is the gate that would have caught the stale image lock: a shared.toml
+    bump that skipped the linux-x64 lock-refresh leaves mise-system.lock behind,
+    and the base build's `mise install --system --locked` rejects it.
+    """
+    _assert_no_version_drift(
+        merged_system_config(_REPO_ROOT),
+        _REPO_ROOT / ".devcontainer" / "mise-system.lock",
+    )
+
+
+def test_runtime_lock_versions_match_pins() -> None:
+    """mise-runtime.lock's versions must equal the runtime tier's exact pins."""
+    _assert_no_version_drift(
+        _runtime_config_tools_table(),
+        _REPO_ROOT / ".devcontainer" / "mise-runtime.lock",
+    )
+
+
+def test_version_drift_gate_discriminates(tmp_path: Path) -> None:
+    """Control arm: the gate must flag a stale lock AND pass a matching one.
+
+    A gate verified only on the (currently clean) real locks is a check that
+    can only pass. Reproduce the exact stale-lock failure realistically — an
+    exact config pin ahead of its lock entry — and confirm it is caught; then
+    align them and confirm it clears. See probes-need-a-control-arm.md.
+    """
+    config = {"hk": "1.52.0", "pixi": {"version": "0.73.0", "os": ["macos"]}}
+    stale_lock = tmp_path / "stale.lock"
+    stale_lock.write_text(
+        '[[tools.hk]]\nversion = "1.50.0"\nbackend = "aqua:jdx/hk"\n\n'
+        '[[tools.pixi]]\nversion = "0.73.0"\nbackend = "github:prefix-dev/pixi"\n'
+    )
+    drift = _version_drift(config, stale_lock)
+    assert drift == {"hk": ("1.52.0", "1.50.0")}, (
+        f"gate failed to flag the stale hk pin (or over-reported): {drift}"
+    )
+
+    fresh_lock = tmp_path / "fresh.lock"
+    fresh_lock.write_text('[[tools.hk]]\nversion = "1.52.0"\nbackend = "aqua:jdx/hk"\n')
+    assert _version_drift({"hk": "1.52.0"}, fresh_lock) == {}, (
+        "gate false-positived on a matching pin/lock pair"
+    )
+
+
+def test_version_drift_gate_skips_non_exact_pins(tmp_path: Path) -> None:
+    """`latest`/partial/range pins are not version-checked (they legitimately drift)."""
+    config = {"conda:cmake": "latest", "foo": "1.52", "bar": "^1.2.0"}
+    lock = tmp_path / "x.lock"
+    lock.write_text(
+        '[[tools."conda:cmake"]]\nversion = "3.31.0"\n\n'
+        '[[tools.foo]]\nversion = "1.52.9"\n\n'
+        '[[tools.bar]]\nversion = "1.5.0"\n'
+    )
+    assert _version_drift(config, lock) == {}, (
+        "gate must not check non-exact pins — those are the daily refresh's domain"
     )


### PR DESCRIPTION
Closes the gap that let a manual tool bump ship a stale lock (hk 1.50.0 in
the lockfiles while shared.toml pinned 1.52.0), passing every per-PR gate and
only failing downstream in the base build's `mise install --system --locked`.

test_lock_coverage.py checked tool-NAME presence but, by design, not version
match — version drift was delegated to the daily refresh.yml job, which a
manual bump bypasses. This adds a version-match check across all four
config<->lock pairs (root, shared, image-system, runtime) for EXACT (X.Y.Z)
pins only; "latest"/partial/range pins stay excluded (their resolution
legitimately drifts between refreshes — checking them per-PR would false-fail).

Rides the existing contract-preflight path (no new wiring). Refactored
merged_system_config_tools to expose merged_system_config (the pin table).

Control arm (test_version_drift_gate_discriminates): reproduces the exact
stale-lock shape and confirms the gate flags it, passes a matching pair, and
skips non-exact pins — a check verified in both directions.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A5qEkEL6fx1YEBaqR2HxPV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - System tool configuration now consistently applies shared settings when the same tool is defined in both locations.
  - Resolved potential discrepancies between configured tool versions and recorded lockfile versions.

- **Tests**
  - Added validation to detect version drift across system, shared, root, and runtime tool environments.
  - Added coverage for exact version pins while correctly excluding flexible versions such as `latest`, ranges, and partial versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->