### PR TITLE
chore(mise): upgrade to 2026.7.12 + pin CI mise + drop superseded tools

### DIFF
--- a/.config/mise/conf.d/shared.toml
+++ b/.config/mise/conf.d/shared.toml
@@ -19,6 +19,11 @@
 # for the host hk step, not needed in the ~354MB-heavier image).
 [tools]
 actionlint = "1.7.12"
+# bun: the npm package_manager (npm.package_manager = "bun") both host/CI and the
+# image use under mise 2026.7.12 (aube default rejects our low-download npm
+# tools). Shared so both install the same bun; the setup-mise action installs it
+# before the npm: tools that need it.
+bun = "1.3.14"
 chezmoi = "2.71.1"
 ghalint = "1.5.6"
 gitleaks = "8.30.1"

--- a/.config/mise/mise.lock
+++ b/.config/mise/mise.lock
@@ -46,6 +46,54 @@ url = "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_
 url_api = "https://api.github.com/repos/rhysd/actionlint/releases/assets/384924919"
 provenance = "github-attestations"
 
+[[tools.bun]]
+version = "1.3.14"
+backend = "core:bun"
+
+[tools.bun."platforms.linux-arm64"]
+checksum = "sha256:a27ffb63a8310375836e0d6f668ae17fa8d8d18b88c37c821c65331973a19a3b"
+url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-aarch64.zip"
+
+[tools.bun."platforms.linux-arm64-musl"]
+checksum = "sha256:b98e0ad3625c5c00d1d5b5ff55605c7adddbfae151861e68ade57b2d3b8703bb"
+url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-aarch64-musl.zip"
+
+[tools.bun."platforms.linux-x64"]
+checksum = "sha256:951ee2aee855f08595aeec6225226a298d3fea83a3dcd6465c09cbccdf7e848f"
+url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-x64.zip"
+
+[tools.bun."platforms.linux-x64-baseline"]
+checksum = "sha256:a063908ae08b7852ca10939bbdc6ceed3ddabce8fb9402dce83d65d73b36e6c7"
+url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-x64-baseline.zip"
+
+[tools.bun."platforms.linux-x64-musl"]
+checksum = "sha256:14bd9aedeebf1dba67e8def9531c89bc989ecfdf1de42e5bfcaf1b8cd9294719"
+url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-x64-musl.zip"
+
+[tools.bun."platforms.linux-x64-musl-baseline"]
+checksum = "sha256:56a7d6806cf155536c0178f0ea5fbd098e684fa509ebdb4fc0a7e19fb65382dc"
+url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-x64-musl-baseline.zip"
+
+[tools.bun."platforms.macos-arm64"]
+checksum = "sha256:d8b96221828ad6f97ac7ac0ab7e95872341af763001e8803e8267652c2652620"
+url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-darwin-aarch64.zip"
+
+[tools.bun."platforms.macos-x64"]
+checksum = "sha256:4183df3374623e5bab315c547cfa0974533cd457d86b73b639f7a87974cd6633"
+url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-darwin-x64.zip"
+
+[tools.bun."platforms.macos-x64-baseline"]
+checksum = "sha256:3e35ad6f53971a9834bf9e6786e2adf72b5f1921cc9a9c5fde073d2972944076"
+url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-darwin-x64-baseline.zip"
+
+[tools.bun."platforms.windows-x64"]
+checksum = "sha256:0a0620930b6675d7ba440e81f4e0e00d3cfbe096c4b140d3fff02205e9e18922"
+url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-windows-x64.zip"
+
+[tools.bun."platforms.windows-x64-baseline"]
+checksum = "sha256:538f9c846355d9e847b2671bc00c47da4229a0befb24df3282b739770f3b475f"
+url = "https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-windows-x64-baseline.zip"
+
 [[tools.chezmoi]]
 version = "2.71.1"
 backend = "aqua:twpayne/chezmoi"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -112,7 +112,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 # mise.run installer already chmods the binary; the explicit chmod is a
 # belt-and-braces guard against permission drift on the cache mount.
 # renovate: datasource=github-releases depName=jdx/mise
-ARG MISE_VERSION=2026.7.5
+ARG MISE_VERSION=2026.7.12
 RUN curl https://mise.run | MISE_VERSION="v${MISE_VERSION}" sh && \
     chmod +x ${MISE_INSTALL_PATH} && \
     mise --version

--- a/.devcontainer/mise-runtime.lock
+++ b/.devcontainer/mise-runtime.lock
@@ -102,6 +102,7 @@ backend = "aqua:bats-core/bats-core"
 
 [tools.bats."platforms.linux-x64"]
 url = "https://github.com/bats-core/bats-core/archive/refs/tags/v1.13.0.tar.gz"
+url_api = "https://api.github.com/repos/bats-core/bats-core/tarball/v1.13.0"
 
 [[tools.claude-code]]
 version = "2.1.201"

--- a/.devcontainer/mise-system.toml
+++ b/.devcontainer/mise-system.toml
@@ -20,7 +20,8 @@
 [tools]
 # Core runtimes
 node = "latest"
-bun = "latest"
+# bun moved to .config/mise/conf.d/shared.toml (host↔image shared: it is the
+# npm package_manager both sides use; mise-parity forbids declaring it here too).
 go = "latest"
 rust = "latest"
 zig = "latest"

--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -21,7 +21,25 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install mise
+    # Two-phase install: bun FIRST, then the requested tools. mise 2026.7.12
+    # defaults npm installs to the embedded `aube` manager (supply-chain guards
+    # that reject this repo's low-download npm tools); we pin npm.package_manager
+    # = "bun" to match the image, but a bare runner has no bun, and mise does not
+    # guarantee bun installs before the `npm:` tools that need it in one pass
+    # (WARN "bun may be required but was not found"). Installing bun in its own
+    # mise-action call first removes that ordering hazard. Each call keeps
+    # mise-action's per-install_args caching, so subsets still cache independently.
+    - name: Install mise + bun
       uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
       with:
+        # Pin CI's mise to the version the image bakes (Dockerfile ARG
+        # MISE_VERSION). Unpinned, mise-action installs the latest release, so a
+        # mise release (e.g. 2026.7.12's aube default) can change install
+        # behavior mid-day and break CI with no repo change. Bump in lockstep.
+        version: "2026.7.12"
+        install_args: "bun"
+    - name: Install tools
+      uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      with:
+        version: "2026.7.12"
         install_args: ${{ inputs.install_args }}

--- a/mise.lock
+++ b/mise.lock
@@ -712,6 +712,362 @@ checksum = "sha256:6b6a57710192764d0538f72ea1ccecf2c6174a092e0bc76d790f8ca36bbe9
 url = "https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda"
 checksum = "sha256:47101a4055a70a4876ffc87b750ab2287b67eca793f21c8224be5e1ee6394d3f"
 
+[conda-packages.macos-x64-baseline."aom-3.14.1-pl5321h3d58d69_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/aom-3.14.1-pl5321h3d58d69_1.conda"
+checksum = "sha256:f4b61d6701205611c11e2dedaf398ebce30ecf05c193be98df9f7887e189129a"
+
+[conda-packages.macos-x64-baseline."bzip2-1.0.8-h500dc9f_9"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_9.conda"
+checksum = "sha256:9f242f13537ef1ce195f93f0cc162965d6cc79da578568d6d8e50f70dd025c42"
+
+[conda-packages.macos-x64-baseline."ca-certificates-2026.7.22-hbd8a1cb_0"]
+url = "https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda"
+checksum = "sha256:0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6"
+
+[conda-packages.macos-x64-baseline."cairo-1.18.4-h7656bdc_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.4-h7656bdc_1.conda"
+checksum = "sha256:88e7e1efb6a0f6b1477e617338e0ed3d27d4572a3283f8341ce6143b7118e31a"
+
+[conda-packages.macos-x64-baseline."dav1d-1.2.1-h0dc2134_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/dav1d-1.2.1-h0dc2134_0.conda"
+checksum = "sha256:ec71a835866b42e946cd2039a5f7a6458851a21890d315476f5e66790ac11c96"
+
+[conda-packages.macos-x64-baseline."dbus-1.16.2-h6e7f9a9_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/dbus-1.16.2-h6e7f9a9_1.conda"
+checksum = "sha256:80ea0a20236ecb7006f7a89235802a34851eaac2f7f4323ca7acc094bcf7f372"
+
+[conda-packages.macos-x64-baseline."font-ttf-dejavu-sans-mono-2.37-hab24e00_0"]
+url = "https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2"
+checksum = "sha256:58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b"
+
+[conda-packages.macos-x64-baseline."font-ttf-inconsolata-3.000-h77eed37_0"]
+url = "https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2"
+checksum = "sha256:c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c"
+
+[conda-packages.macos-x64-baseline."font-ttf-source-code-pro-2.038-h77eed37_0"]
+url = "https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2"
+checksum = "sha256:00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139"
+
+[conda-packages.macos-x64-baseline."font-ttf-ubuntu-0.83-h77eed37_3"]
+url = "https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda"
+checksum = "sha256:2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14"
+
+[conda-packages.macos-x64-baseline."fontconfig-2.18.1-h7a4440b_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.18.1-h7a4440b_0.conda"
+checksum = "sha256:134aed823beae85798607e32b78aa1368afbfbea145a43c974d88269f1013287"
+
+[conda-packages.macos-x64-baseline.fonts-conda-ecosystem-1-0]
+url = "https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2"
+checksum = "sha256:a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61"
+
+[conda-packages.macos-x64-baseline.fonts-conda-forge-1-hc364b38_1]
+url = "https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda"
+checksum = "sha256:54eea8469786bc2291cc40bca5f46438d3e062a399e8f53f013b6a9f50e98333"
+
+[conda-packages.macos-x64-baseline."freetype-2.14.3-h694c41f_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/freetype-2.14.3-h694c41f_1.conda"
+checksum = "sha256:c67130a919d3c7733fce056cc2ce8cec2935e295547d5d70bcbf35e4351d543b"
+
+[conda-packages.macos-x64-baseline."fribidi-1.0.16-h8616949_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/fribidi-1.0.16-h8616949_0.conda"
+checksum = "sha256:53dd0a6c561cf31038633aaa0d52be05da1f24e86947f06c4e324606c72c7413"
+
+[conda-packages.macos-x64-baseline."gdk-pixbuf-2.44.7-hae309b2_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/gdk-pixbuf-2.44.7-hae309b2_0.conda"
+checksum = "sha256:b936e714e8b449ea1fe3f9773392794795b3c3142666d56806ee3c4c9e8f70e4"
+
+[conda-packages.macos-x64-baseline."glslang-16.3.0-he78e680_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/glslang-16.3.0-he78e680_0.conda"
+checksum = "sha256:7daad6c8e66ab4ced78305c3c55cd8fdfd4f694b1912b94e8420ae3993acd2df"
+
+[conda-packages.macos-x64-baseline."gmp-6.3.0-hf036a51_2"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-hf036a51_2.conda"
+checksum = "sha256:75aa5e7a875afdcf4903b7dc98577672a3dc17b528ac217b915f9528f93c85fc"
+
+[conda-packages.macos-x64-baseline."graphite2-1.3.15-hcc62823_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/graphite2-1.3.15-hcc62823_0.conda"
+checksum = "sha256:aaebae3c0e713579e52de6fd4eec54a172e28c7f90d90da4583e91b1634a7fee"
+
+[conda-packages.macos-x64-baseline."harfbuzz-14.2.1-h694c41f_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-14.2.1-h694c41f_1.conda"
+checksum = "sha256:41949302a347146509cf3734123753b508abc5518b4e4285b2977039ede6db43"
+
+[conda-packages.macos-x64-baseline."icu-78.3-h25d91c4_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_1.conda"
+checksum = "sha256:4f86ab2f24714449b334c216f0fce0178c4b3e5638f945485222f06fc001eb1e"
+
+[conda-packages.macos-x64-baseline."lame-4.0-h6c71e33_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/lame-4.0-h6c71e33_0.conda"
+checksum = "sha256:b55357790e05d139e7be4470529ae5485d5c4237f2798fe4770a04bbe062d3fd"
+
+[conda-packages.macos-x64-baseline."lcms2-2.19.1-h5ea7634_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.19.1-h5ea7634_1.conda"
+checksum = "sha256:8bae1207dc7cf0e670ae920a549b1d55486514213ca808b8119067cbad0db43a"
+
+[conda-packages.macos-x64-baseline."lerc-4.1.0-h35c7297_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/lerc-4.1.0-h35c7297_0.conda"
+checksum = "sha256:f918716c71c8bebbc0c40e1050878aa512fea92c1d17c363ca35650bc60f6c35"
+
+[conda-packages.macos-x64-baseline."libabseil-20260526.0-cxx17_h1a06613_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libabseil-20260526.0-cxx17_h1a06613_1.conda"
+checksum = "sha256:97f67b176c3b686d40e2501bb06ebf28cfeaa0af19ce7d33ecc9a988f690d8dc"
+
+[conda-packages.macos-x64-baseline."libass-0.17.5-hf78704f_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libass-0.17.5-hf78704f_0.conda"
+checksum = "sha256:c34ab289380159fcc10234da036fbdc0be38925f42913a7e2c43b22ca7bd9125"
+
+[conda-packages.macos-x64-baseline."libbrotlicommon-1.2.0-h8616949_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.2.0-h8616949_1.conda"
+checksum = "sha256:4c19b211b3095f541426d5a9abac63e96a5045e509b3d11d4f9482de53efe43b"
+
+[conda-packages.macos-x64-baseline."libbrotlidec-1.2.0-h8616949_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.2.0-h8616949_1.conda"
+checksum = "sha256:729158be90ae655a4e0427fe4079767734af1f9b69ff58cf94ca6e8d4b3eb4b7"
+
+[conda-packages.macos-x64-baseline."libbrotlienc-1.2.0-h8616949_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.2.0-h8616949_1.conda"
+checksum = "sha256:8ece7b41b6548d6601ac2c2cd605cf2261268fc4443227cc284477ed23fbd401"
+
+[conda-packages.macos-x64-baseline."libcxx-22.1.8-h19cb2f5_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libcxx-22.1.8-h19cb2f5_0.conda"
+checksum = "sha256:57ee997f1f800cf38abc743c0f0a9ddfe6a101c697c35510452ce6f4ddf96361"
+
+[conda-packages.macos-x64-baseline."libdeflate-1.25-h517ebb2_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.25-h517ebb2_0.conda"
+checksum = "sha256:025f8b1e85dd8254e0ca65f011919fb1753070eb507f03bca317871a884d24de"
+
+[conda-packages.macos-x64-baseline."libdovi-3.4.0-h59a3c7f_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libdovi-3.4.0-h59a3c7f_0.conda"
+checksum = "sha256:405af0d2e61f51d575a4520b8be96138c43c69bcdcfc47b605bb29a5f87c5afd"
+
+[conda-packages.macos-x64-baseline."libexpat-2.8.1-hcc62823_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda"
+checksum = "sha256:9c96cc05e056e1bba5b545cbbd57b6e01db622dc2c82934caaaa25cfb22fe666"
+
+[conda-packages.macos-x64-baseline."libffi-3.5.2-hd1f9c09_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda"
+checksum = "sha256:951958d1792238006fdc6fce7f71f1b559534743b26cc1333497d46e5903a2d6"
+
+[conda-packages.macos-x64-baseline."libfreetype-2.14.3-h694c41f_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libfreetype-2.14.3-h694c41f_1.conda"
+checksum = "sha256:9029ed0c940be8161c86f5338eacfad1f61af216cdc508e386a648f6ef893a28"
+
+[conda-packages.macos-x64-baseline."libfreetype6-2.14.3-h58fbd8d_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libfreetype6-2.14.3-h58fbd8d_1.conda"
+checksum = "sha256:cc94862c51e68626fadddf68b523e5f752149186ccc498fa37976504e2e7ff55"
+
+[conda-packages.macos-x64-baseline."libglib-2.88.2-hf28f236_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libglib-2.88.2-hf28f236_0.conda"
+checksum = "sha256:445e6806480103c6411993e7c2fd5ad1c6cb14ef1fee9386b44adeb536834d07"
+
+[conda-packages.macos-x64-baseline."libharfbuzz-14.2.1-h97ceea7_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libharfbuzz-14.2.1-h97ceea7_1.conda"
+checksum = "sha256:33ec741f9f4bfe132c03e18c2a5822a9ad850c8813fa1a40b94f1f4df8fcde58"
+
+[conda-packages.macos-x64-baseline."libharfbuzz-devel-14.2.1-h97ceea7_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libharfbuzz-devel-14.2.1-h97ceea7_1.conda"
+checksum = "sha256:728387566192c8c57904256888edc71a95db68e3b07678046b39802d32a9ee3f"
+
+[conda-packages.macos-x64-baseline."libhwloc-2.13.0-default_h4e3125e_1000"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libhwloc-2.13.0-default_h4e3125e_1000.conda"
+checksum = "sha256:8e051b990da280ca6eca2f025640572459a0ddfa2b3b71a113e4d14b4277aa33"
+
+[conda-packages.macos-x64-baseline."libhwy-1.4.0-h7747b51_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libhwy-1.4.0-h7747b51_0.conda"
+checksum = "sha256:b028ef59ae5a84d40bbf5ad2d0dd2378808afd895ddd4b6a313c42aa7e850f90"
+
+[conda-packages.macos-x64-baseline."libiconv-1.18-h57a12c2_2"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h57a12c2_2.conda"
+checksum = "sha256:a1c8cecdf9966921e13f0ae921309a1f415dfbd2b791f2117cf7e8f5e61a48b6"
+
+[conda-packages.macos-x64-baseline."libintl-0.25.1-h3184127_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libintl-0.25.1-h3184127_1.conda"
+checksum = "sha256:8c352744517bc62d24539d1ecc813b9fdc8a785c780197c5f0b84ec5b0dfe122"
+
+[conda-packages.macos-x64-baseline."libjpeg-turbo-3.2.0-ha1e9b39_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.2.0-ha1e9b39_0.conda"
+checksum = "sha256:5c48ea89073ba28eb93df264587973d3905827e5b536a5320604ae3baaa73e13"
+
+[conda-packages.macos-x64-baseline."libjxl-0.12.0-h473410d_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libjxl-0.12.0-h473410d_1.conda"
+checksum = "sha256:c95d90d1bc89f8a2dde719a830afe83e1c3b46957e6981ebe0fa427bd18b9b0e"
+
+[conda-packages.macos-x64-baseline."liblzma-5.8.3-hbb4bfdb_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_0.conda"
+checksum = "sha256:d9e2006051529aec5578c6efeb13bb6a7200a014b2d5a77a579e83a8049d5f3c"
+
+[conda-packages.macos-x64-baseline."libogg-1.3.5-he3325bb_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libogg-1.3.5-he3325bb_1.conda"
+checksum = "sha256:26691d40c70e83d3955a8daaee713aa7d087aa351c5a1f43786bbb0e871f29da"
+
+[conda-packages.macos-x64-baseline."libopenvino-2026.2.1-h96313a9_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libopenvino-2026.2.1-h96313a9_1.conda"
+checksum = "sha256:8d9eb80a21338c3cfd064966336b0194c472b3187827d885a47ea9f04ef95976"
+
+[conda-packages.macos-x64-baseline."libopenvino-auto-batch-plugin-2026.2.1-h4a57bf7_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-batch-plugin-2026.2.1-h4a57bf7_1.conda"
+checksum = "sha256:b4cb9f1f1a9dd37730773b813d4cdd6d9fb58e60eab409c88b28e2703af54807"
+
+[conda-packages.macos-x64-baseline."libopenvino-auto-plugin-2026.2.1-h4a57bf7_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-plugin-2026.2.1-h4a57bf7_1.conda"
+checksum = "sha256:2ec56959873145aaf6046db82045b26a065e6bcc48f4bf1017b671f6c8688e16"
+
+[conda-packages.macos-x64-baseline."libopenvino-hetero-plugin-2026.2.1-h5d0de11_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libopenvino-hetero-plugin-2026.2.1-h5d0de11_1.conda"
+checksum = "sha256:898e78330d16104fb788d5eb1e1898a176ccb4120c62f3cff1cefc5e6e3bbad9"
+
+[conda-packages.macos-x64-baseline."libopenvino-intel-cpu-plugin-2026.2.1-h96313a9_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libopenvino-intel-cpu-plugin-2026.2.1-h96313a9_1.conda"
+checksum = "sha256:996beb5c8268a242a4ed85018c71a1d1563f361bc2935c53db5ba0a95d3961e6"
+
+[conda-packages.macos-x64-baseline."libopenvino-ir-frontend-2026.2.1-h5d0de11_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libopenvino-ir-frontend-2026.2.1-h5d0de11_1.conda"
+checksum = "sha256:2b4026f5c34086682197affd728e4d21e8f90ae82a7c71d06c7e032ef5711e09"
+
+[conda-packages.macos-x64-baseline."libopenvino-onnx-frontend-2026.2.1-h8456301_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libopenvino-onnx-frontend-2026.2.1-h8456301_1.conda"
+checksum = "sha256:d8a734ae0e21857ad73201e80957a1c19f392a2f666a050a36c73f46de4f562b"
+
+[conda-packages.macos-x64-baseline."libopenvino-paddle-frontend-2026.2.1-h8456301_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libopenvino-paddle-frontend-2026.2.1-h8456301_1.conda"
+checksum = "sha256:04338b752e0260893fa257e471d4dd7ed2c69aeebaf7407a3bb974eff86f977d"
+
+[conda-packages.macos-x64-baseline."libopenvino-pytorch-frontend-2026.2.1-h409306b_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libopenvino-pytorch-frontend-2026.2.1-h409306b_1.conda"
+checksum = "sha256:a657d15f95593389bad1761a4e429b9e855f73d5f0613faa4e26d5b4377e1e78"
+
+[conda-packages.macos-x64-baseline."libopenvino-tensorflow-frontend-2026.2.1-h10fe5cc_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-frontend-2026.2.1-h10fe5cc_1.conda"
+checksum = "sha256:91afa52b5c96b0f0b54bfd83b9886dc6474653382debb405ed1768f37bd82287"
+
+[conda-packages.macos-x64-baseline."libopenvino-tensorflow-lite-frontend-2026.2.1-h409306b_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-lite-frontend-2026.2.1-h409306b_1.conda"
+checksum = "sha256:1b52f62960f7f273177644aed63034380510de70dd96b0bffc93212dfb4608cc"
+
+[conda-packages.macos-x64-baseline."libopus-1.6.1-hc6ced15_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libopus-1.6.1-hc6ced15_0.conda"
+checksum = "sha256:14389effc1a614456cfe013e4b34e0431f28c5e0047bb6fc80b7dbdab3df4d25"
+
+[conda-packages.macos-x64-baseline."libplacebo-7.360.1-h1ed201f_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libplacebo-7.360.1-h1ed201f_1.conda"
+checksum = "sha256:498086d67adc639e28f36185db7310ac6f2900baf842c3229172ba97f3bf5bcf"
+
+[conda-packages.macos-x64-baseline."libpng-1.6.58-he930e7c_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.58-he930e7c_0.conda"
+checksum = "sha256:a669b22978e546484d18d99a210801b1823360a266d7035c713d8d1facd035f7"
+
+[conda-packages.macos-x64-baseline."libprotobuf-7.35.1-h087ac9f_2"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-7.35.1-h087ac9f_2.conda"
+checksum = "sha256:d9199b69128d4337d7b34ebbf37372844ce2d257a53d39f4a41886a95ec97136"
+
+[conda-packages.macos-x64-baseline."librsvg-2.62.3-h7321050_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/librsvg-2.62.3-h7321050_0.conda"
+checksum = "sha256:4e6ceb25dcc7b67d550e2b6ce98da585b49dd4590f21a709dd6ec626df3b8c19"
+
+[conda-packages.macos-x64-baseline."libtiff-4.7.2-h95d6d7f_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.7.2-h95d6d7f_0.conda"
+checksum = "sha256:8e43d2a3538f45848c61cdda4baa6728ce0a48bc665b306de5a31dd3464a30c1"
+
+[conda-packages.macos-x64-baseline."libusb-1.0.29-h2287256_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libusb-1.0.29-h2287256_0.conda"
+checksum = "sha256:b46c1c71d8be2d19615a10eaa997b3547848d1aee25a7e9486ad1ca8d61626a7"
+
+[conda-packages.macos-x64-baseline."libvorbis-1.3.7-ha059160_2"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libvorbis-1.3.7-ha059160_2.conda"
+checksum = "sha256:7b79c0e867db70c66e57ea0abf03ea940070ed8372289d6dc5db7ab59e30acc1"
+
+[conda-packages.macos-x64-baseline."libvpx-1.15.2-heffb93a_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libvpx-1.15.2-heffb93a_0.conda"
+checksum = "sha256:e82f4e3e40e1d31eaecda27970bace1f13037c39ff65c043fc451a07defeddce"
+
+[conda-packages.macos-x64-baseline."libvulkan-loader-1.4.341.0-ha6bc089_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libvulkan-loader-1.4.341.0-ha6bc089_0.conda"
+checksum = "sha256:ce9bc992ffffdefbde5f7977b0a3ad9036650f8323611e4024908755891674e0"
+
+[conda-packages.macos-x64-baseline."libwebp-base-1.6.0-hb807250_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.6.0-hb807250_0.conda"
+checksum = "sha256:00dbfe574b5d9b9b2b519acb07545380a6bc98d1f76a02695be4995d4ec91391"
+
+[conda-packages.macos-x64-baseline."libxml2-16-2.15.3-h7a90416_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_0.conda"
+checksum = "sha256:437f003e299d77403db42d17e532d686236f357ac5c3d6bf466558c697902597"
+
+[conda-packages.macos-x64-baseline."libxml2-2.15.3-h953d39d_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_0.conda"
+checksum = "sha256:24248928e63b5de45012c8ad3fd6b350ae1fe2fc355613bb89ee5f0a35835bea"
+
+[conda-packages.macos-x64-baseline."libzlib-1.3.2-hbb4bfdb_2"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda"
+checksum = "sha256:4c6da089952b2d70150c74234679d6f7ac04f4a98f9432dec724968f912691e7"
+
+[conda-packages.macos-x64-baseline."mpg123-1.32.9-h78e78a4_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/mpg123-1.32.9-h78e78a4_0.conda"
+checksum = "sha256:15e660430e9ed13c98c81c3f0333d6d8aaf1a40f703e2af68973d1c374842e60"
+
+[conda-packages.macos-x64-baseline."openh264-2.6.0-hd629203_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/openh264-2.6.0-hd629203_1.conda"
+checksum = "sha256:bf665eb898b6105fd87a3a908301b8216463d2ee963b8e719801d3b1032148fd"
+
+[conda-packages.macos-x64-baseline."openssl-3.6.3-hc881268_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.3-hc881268_0.conda"
+checksum = "sha256:819d4368d6b5b298fa40d4bc836c1250842489002cacf3fb918a13ee2033b7c6"
+
+[conda-packages.macos-x64-baseline."pango-1.56.4-hf280016_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/pango-1.56.4-hf280016_1.conda"
+checksum = "sha256:c1150e6a405985b25830c18f896d5e89b9777ef7e420bc0b1d88634f9a614769"
+
+[conda-packages.macos-x64-baseline."pcre2-10.47-h13923f0_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda"
+checksum = "sha256:8d64a9d36073346542e5ea042ef8207a45a0069a2e65ce3323ee3146db78134c"
+
+[conda-packages.macos-x64-baseline."pixman-0.46.4-h2fb4741_2"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/pixman-0.46.4-h2fb4741_2.conda"
+checksum = "sha256:24fd53956b359b0cb79152522aadc2c216531880736e146cac3acaf137c48867"
+
+[conda-packages.macos-x64-baseline."pugixml-1.15-h46091d4_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/pugixml-1.15-h46091d4_0.conda"
+checksum = "sha256:d22fd205d2db21c835e233c30e91e348735e18418c35327b0406d2d917e39a90"
+
+[conda-packages.macos-x64-baseline."sdl2-2.32.56-h2fb4741_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/sdl2-2.32.56-h2fb4741_0.conda"
+checksum = "sha256:22aacfc07fb6003992a281517514cbfc024fe52131bcb5645e7e13f3da28340b"
+
+[conda-packages.macos-x64-baseline."sdl3-3.4.12-hf9078ff_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/sdl3-3.4.12-hf9078ff_0.conda"
+checksum = "sha256:1341772ad10c042d2486c5b0d8c2fd412591dadb83b5921c1838231197f5c661"
+
+[conda-packages.macos-x64-baseline."shaderc-2026.3-h3d334e4_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/shaderc-2026.3-h3d334e4_0.conda"
+checksum = "sha256:f1d9235299de62beb0ea7e17c1dbf9de5cb339f344e10422684d69d32dab91e0"
+
+[conda-packages.macos-x64-baseline."snappy-1.2.2-h01f5ddf_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.2-h01f5ddf_1.conda"
+checksum = "sha256:1525e6d8e2edf32dabfe2a8e2fc8bf2df81c5ef9f0b5374a3d4ccfa672bfd949"
+
+[conda-packages.macos-x64-baseline."spirv-tools-2026.2-hc1436ee_1"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/spirv-tools-2026.2-hc1436ee_1.conda"
+checksum = "sha256:435d5cfe2a73f3711b925d159267bf26e0943459ec5d371a3ad973a60d056c94"
+
+[conda-packages.macos-x64-baseline."svt-av1-4.2.0-hcc62823_0"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/svt-av1-4.2.0-hcc62823_0.conda"
+checksum = "sha256:a213979ade4c9a46f3e96aa532a802d1aca1de60d61e30e665e338a601c18f4a"
+
+[conda-packages.macos-x64-baseline."tbb-2023.0.0-he3dc2fa_2"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/tbb-2023.0.0-he3dc2fa_2.conda"
+checksum = "sha256:f57b374fa5bbb1823a9e1b7e4a9db044c42964313c59d4c652b948f20b55d1a0"
+
+[conda-packages.macos-x64-baseline."x264-1!164.3095-h775f41a_2"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/x264-1!164.3095-h775f41a_2.tar.bz2"
+checksum = "sha256:de611da29f4ed0733a330402e163f9260218e6ba6eae593a5f945827d0ee1069"
+
+[conda-packages.macos-x64-baseline."x265-3.5-hbb4e6a2_3"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/x265-3.5-hbb4e6a2_3.tar.bz2"
+checksum = "sha256:6b6a57710192764d0538f72ea1ccecf2c6174a092e0bc76d790f8ca36bbe90e4"
+
+[conda-packages.macos-x64-baseline."zstd-1.5.7-h3eecb57_6"]
+url = "https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda"
+checksum = "sha256:47101a4055a70a4876ffc87b750ab2287b67eca793f21c8224be5e1ee6394d3f"
+
 [conda-packages.windows-x64."aom-3.14.1-pl5321h06fc181_1"]
 url = "https://conda.anaconda.org/conda-forge/win-64/aom-3.14.1-pl5321h06fc181_1.conda"
 checksum = "sha256:3033fa8953f7f0c1bb5b89b5af77253badc14a89ba94d743dde3c9159e10fd5e"
@@ -1032,6 +1388,326 @@ checksum = "sha256:ef408f85f664a4b9c9dac3cb2e36154d9baa15a88984ea800e11060e0f239
 url = "https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda"
 checksum = "sha256:368d8628424966fd8f9c8018326a9c779e06913dd39e646cf331226acc90e5b2"
 
+[conda-packages.windows-x64-baseline."aom-3.14.1-pl5321h06fc181_1"]
+url = "https://conda.anaconda.org/conda-forge/win-64/aom-3.14.1-pl5321h06fc181_1.conda"
+checksum = "sha256:3033fa8953f7f0c1bb5b89b5af77253badc14a89ba94d743dde3c9159e10fd5e"
+
+[conda-packages.windows-x64-baseline."bzip2-1.0.8-h0ad9c76_9"]
+url = "https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda"
+checksum = "sha256:76dfb71df5e8d1c4eded2dbb5ba15bb8fb2e2b0fe42d94145d5eed4c75c35902"
+
+[conda-packages.windows-x64-baseline."ca-certificates-2026.7.22-h4c7d964_0"]
+url = "https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-h4c7d964_0.conda"
+checksum = "sha256:95e8e74062a5fe5f870ac8c90302b6e89945165fdaed7810606e84ddee6aac12"
+
+[conda-packages.windows-x64-baseline."cairo-1.18.4-h477c42c_1"]
+url = "https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.4-h477c42c_1.conda"
+checksum = "sha256:9ee4ad706c5d3e1c6c469785d60e3c2b263eec569be0eac7be33fbaef978bccc"
+
+[conda-packages.windows-x64-baseline."dav1d-1.2.1-hcfcfb64_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda"
+checksum = "sha256:2aa2083c9c186da7d6f975ccfbef654ed54fff27f4bc321dbcd12cee932ec2c4"
+
+[conda-packages.windows-x64-baseline."font-ttf-dejavu-sans-mono-2.37-hab24e00_0"]
+url = "https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2"
+checksum = "sha256:58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b"
+
+[conda-packages.windows-x64-baseline."font-ttf-inconsolata-3.000-h77eed37_0"]
+url = "https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2"
+checksum = "sha256:c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c"
+
+[conda-packages.windows-x64-baseline."font-ttf-source-code-pro-2.038-h77eed37_0"]
+url = "https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2"
+checksum = "sha256:00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139"
+
+[conda-packages.windows-x64-baseline."font-ttf-ubuntu-0.83-h77eed37_3"]
+url = "https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda"
+checksum = "sha256:2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14"
+
+[conda-packages.windows-x64-baseline."fontconfig-2.18.2-hd47e2ca_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.18.2-hd47e2ca_0.conda"
+checksum = "sha256:3263ba9ad9e78a927964c76e0b2b4c745d279394928f4d381272b771ec816235"
+
+[conda-packages.windows-x64-baseline.fonts-conda-ecosystem-1-0]
+url = "https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2"
+checksum = "sha256:a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61"
+
+[conda-packages.windows-x64-baseline.fonts-conda-forge-1-hc364b38_1]
+url = "https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda"
+checksum = "sha256:54eea8469786bc2291cc40bca5f46438d3e062a399e8f53f013b6a9f50e98333"
+
+[conda-packages.windows-x64-baseline."freetype-2.14.3-h57928b3_1"]
+url = "https://conda.anaconda.org/conda-forge/win-64/freetype-2.14.3-h57928b3_1.conda"
+checksum = "sha256:a0e419e96146159f12344c870dca608d11bca36841f228092b986ffc2e1e0f02"
+
+[conda-packages.windows-x64-baseline."fribidi-1.0.16-hfd05255_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/fribidi-1.0.16-hfd05255_0.conda"
+checksum = "sha256:15011071ee56c216ffe276c8d734427f1f893f275ef733f728d13f610ed89e6e"
+
+[conda-packages.windows-x64-baseline."gdk-pixbuf-2.44.7-h1f5b9c4_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/gdk-pixbuf-2.44.7-h1f5b9c4_0.conda"
+checksum = "sha256:4965bf7c84c9b7c970f1f7bc475962e43441018cf9551682a4a22960c5090588"
+
+[conda-packages.windows-x64-baseline."glib-2.88.2-h395db07_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/glib-2.88.2-h395db07_0.conda"
+checksum = "sha256:b67107959a71dbf9f5c2e95511f18095d9ac6f0001f0de4a1b6e14282162989e"
+
+[conda-packages.windows-x64-baseline."glib-tools-2.88.2-h74ecf4c_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.88.2-h74ecf4c_0.conda"
+checksum = "sha256:c604b6ca42c6271f281b1c0616e0d50bd800f8fc913a91a2753c2551b3b6b16c"
+
+[conda-packages.windows-x64-baseline."glslang-16.3.0-h294ba9c_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/glslang-16.3.0-h294ba9c_0.conda"
+checksum = "sha256:d80276b89d8aeab6ff0d8d7d4b9af336b368fc0b8fa28ea8cde6f6f2aa07bacf"
+
+[conda-packages.windows-x64-baseline."graphite2-1.3.15-hac47afa_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.15-hac47afa_0.conda"
+checksum = "sha256:88b6601f8edae59834b59b521e293ff3b58361dc1603240f5a8328c24e6936ad"
+
+[conda-packages.windows-x64-baseline."harfbuzz-14.2.1-h57928b3_1"]
+url = "https://conda.anaconda.org/conda-forge/win-64/harfbuzz-14.2.1-h57928b3_1.conda"
+checksum = "sha256:c8bf564f2c415b82f056eff98b8967fb75c86821398998f20289397b5acf1ef7"
+
+[conda-packages.windows-x64-baseline."icu-78.3-h637d24d_1"]
+url = "https://conda.anaconda.org/conda-forge/win-64/icu-78.3-h637d24d_1.conda"
+checksum = "sha256:61f16ae57ee8956d5c1f69e703f7abaebb972d0def1edc5704d7198430398295"
+
+[conda-packages.windows-x64-baseline."lame-4.0-h4a41cd3_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/lame-4.0-h4a41cd3_0.conda"
+checksum = "sha256:ed10e660e52e7180cef2e2e90d912c21b8e84fed4f0bccf03dfd42a79b113846"
+
+[conda-packages.windows-x64-baseline."lerc-4.1.0-hd936e49_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/lerc-4.1.0-hd936e49_0.conda"
+checksum = "sha256:45df58fca800b552b17c3914cc9ab0d55a82c5172d72b5c44a59c710c06c5473"
+
+[conda-packages.windows-x64-baseline."libbrotlicommon-1.2.0-hfd05255_1"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.2.0-hfd05255_1.conda"
+checksum = "sha256:5097303c2fc8ebf9f9ea9731520aa5ce4847d0be41764edd7f6dee2100b82986"
+
+[conda-packages.windows-x64-baseline."libbrotlidec-1.2.0-hfd05255_1"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.2.0-hfd05255_1.conda"
+checksum = "sha256:3239ce545cf1c32af6fffb7fc7c75cb1ef5b6ea8221c66c85416bb2d46f5cccb"
+
+[conda-packages.windows-x64-baseline."libbrotlienc-1.2.0-hfd05255_1"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.2.0-hfd05255_1.conda"
+checksum = "sha256:3226df6b7df98734440739f75527d585d42ca2bfe912fbe8d1954c512f75341a"
+
+[conda-packages.windows-x64-baseline."libdeflate-1.25-h51727cc_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.25-h51727cc_0.conda"
+checksum = "sha256:834e4881a18b690d5ec36f44852facd38e13afe599e369be62d29bd675f107ee"
+
+[conda-packages.windows-x64-baseline."libexpat-2.8.1-hac47afa_1"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda"
+checksum = "sha256:1a54d874addda73b6f7164d5f3905821277a1831bcc05edd74b3085391688571"
+
+[conda-packages.windows-x64-baseline."libffi-3.5.2-h3d046cb_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda"
+checksum = "sha256:59d01f2dfa8b77491b5888a5ab88ff4e1574c9359f7e229da254cdfe27ddc190"
+
+[conda-packages.windows-x64-baseline."libfreetype-2.14.3-h57928b3_1"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libfreetype-2.14.3-h57928b3_1.conda"
+checksum = "sha256:035d0c67bf9f7a16f4a1764f420c120f1a995d071bb265fcc66ef688ef709d7b"
+
+[conda-packages.windows-x64-baseline."libfreetype6-2.14.3-hdbac1cb_1"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libfreetype6-2.14.3-hdbac1cb_1.conda"
+checksum = "sha256:0bbd19c9f7c4d0232b31892e6a4d1f82b8d19d1b84d89725f1f491b336447758"
+
+[conda-packages.windows-x64-baseline."libglib-2.88.2-h7ce1215_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libglib-2.88.2-h7ce1215_0.conda"
+checksum = "sha256:20d4a182b8aa1d71b331579fae281bb3ccb1a199257ce15fadc53786031a7408"
+
+[conda-packages.windows-x64-baseline."libharfbuzz-14.2.1-h03b5201_1"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libharfbuzz-14.2.1-h03b5201_1.conda"
+checksum = "sha256:634a64cf43f1ce5a4139334bcdbde54d6854ae33d881ae1774377965e21051a5"
+
+[conda-packages.windows-x64-baseline."libharfbuzz-devel-14.2.1-h03b5201_1"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libharfbuzz-devel-14.2.1-h03b5201_1.conda"
+checksum = "sha256:d04bac65245bf76ae23a18148b941d8215085d38a6d391971966ccda8a996b99"
+
+[conda-packages.windows-x64-baseline."libhwy-1.4.0-h2419aca_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libhwy-1.4.0-h2419aca_0.conda"
+checksum = "sha256:ade3e4e8e09051bad9c75ea9e96b09e3c635216c409c87c369e6f8566a528cb1"
+
+[conda-packages.windows-x64-baseline."libiconv-1.18-hc1393d2_2"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda"
+checksum = "sha256:0dcdb1a5f01863ac4e8ba006a8b0dc1a02d2221ec3319b5915a1863254d7efa7"
+
+[conda-packages.windows-x64-baseline."libintl-0.22.5-h5728263_3"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda"
+checksum = "sha256:c7e4600f28bcada8ea81456a6530c2329312519efcf0c886030ada38976b0511"
+
+[conda-packages.windows-x64-baseline."libintl-devel-0.22.5-h5728263_3"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libintl-devel-0.22.5-h5728263_3.conda"
+checksum = "sha256:be1f3c48bc750bca7e68955d57180dfd826d6f9fa7eb32994f6cb61b813f9a6a"
+
+[conda-packages.windows-x64-baseline."libjpeg-turbo-3.2.0-hfd05255_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.2.0-hfd05255_0.conda"
+checksum = "sha256:3d6635efa9497b9c5ba7957df8067c0a980d5cb10a6ea136931809eb410f8a99"
+
+[conda-packages.windows-x64-baseline."libjxl-0.12.0-h932607e_1"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libjxl-0.12.0-h932607e_1.conda"
+checksum = "sha256:141310ec747808be57ba9e7501fcfab75b260803233dd9ba818fb85f6080aad9"
+
+[conda-packages.windows-x64-baseline."liblzma-5.8.3-hfd05255_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.3-hfd05255_0.conda"
+checksum = "sha256:d636d1a25234063642f9c531a7bb58d84c1c496411280a36ea000bd122f078f1"
+
+[conda-packages.windows-x64-baseline."libmpdec-4.0.0-hfd05255_1"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libmpdec-4.0.0-hfd05255_1.conda"
+checksum = "sha256:40dcd0b9522a6e0af72a9db0ced619176e7cfdb114855c7a64f278e73f8a7514"
+
+[conda-packages.windows-x64-baseline."libogg-1.3.5-h2466b09_1"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.5-h2466b09_1.conda"
+checksum = "sha256:c63e5fb169dbd192aacdcee6e37235407f106b8ca9c9036942a25e0366cbc73c"
+
+[conda-packages.windows-x64-baseline."libopus-1.6.1-h6a83c73_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libopus-1.6.1-h6a83c73_0.conda"
+checksum = "sha256:c3678f111866235b44fa65265966abae7d90b6387178f1459afaedcee8b4a997"
+
+[conda-packages.windows-x64-baseline."libpng-1.6.58-h7351971_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.58-h7351971_0.conda"
+checksum = "sha256:218913aeee391460bd0e341b834dbd9c6fa6ae0a4276c0c300266cc99a816a28"
+
+[conda-packages.windows-x64-baseline."librsvg-2.62.3-h15cfe45_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/librsvg-2.62.3-h15cfe45_0.conda"
+checksum = "sha256:6f678be6074b79fe754660d16857a6edba73dd197ad92086250dc38c11b179ab"
+
+[conda-packages.windows-x64-baseline."libsqlite-3.53.3-hf5d6505_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.53.3-hf5d6505_0.conda"
+checksum = "sha256:692dfb73a22c873656d5e393b8f1e2b019a3c8a6486c97cb6900552e64e38c25"
+
+[conda-packages.windows-x64-baseline."libtiff-4.7.2-h8f73337_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.2-h8f73337_0.conda"
+checksum = "sha256:ec6d66308a6d6abaf3225f2f185113e6172e77eb0fa8622af982d7a5d6d47a2c"
+
+[conda-packages.windows-x64-baseline."libusb-1.0.29-h1839187_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libusb-1.0.29-h1839187_0.conda"
+checksum = "sha256:9837f8e8de20b6c9c033561cd33b4554cd551b217e3b8d2862b353ed2c23d8b8"
+
+[conda-packages.windows-x64-baseline."libvorbis-1.3.7-h5112557_2"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libvorbis-1.3.7-h5112557_2.conda"
+checksum = "sha256:429124709c73b2e8fae5570bdc6b42f5418a7551ba72e591bb960b752e87b365"
+
+[conda-packages.windows-x64-baseline."libvulkan-loader-1.4.341.0-h477610d_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libvulkan-loader-1.4.341.0-h477610d_0.conda"
+checksum = "sha256:0f0965edca8b255187604fc7712c53fe9064b31a1845a7dfb2b63bf660de84a7"
+
+[conda-packages.windows-x64-baseline."libwebp-base-1.6.0-h4d5522a_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.6.0-h4d5522a_0.conda"
+checksum = "sha256:7b6316abfea1007e100922760e9b8c820d6fc19df3f42fb5aca684cfacb31843"
+
+[conda-packages.windows-x64-baseline."libxml2-16-2.15.3-h3cfd58e_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libxml2-16-2.15.3-h3cfd58e_0.conda"
+checksum = "sha256:3b61ee3caba702d2ff432fa3920835db963026e5c99c4e6fdca0c6114f59e7ce"
+
+[conda-packages.windows-x64-baseline."libxml2-2.15.3-h8ef44ab_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libxml2-2.15.3-h8ef44ab_0.conda"
+checksum = "sha256:a4599c6bbbbdd7db570896e520c557eec8e66d94e839a59d17dc1f24a3d5f82b"
+
+[conda-packages.windows-x64-baseline."libzlib-1.3.2-hfd05255_2"]
+url = "https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.2-hfd05255_2.conda"
+checksum = "sha256:88609816e0cc7452bac637aaf65783e5edf4fee8a9f8e22bdc3a75882c536061"
+
+[conda-packages.windows-x64-baseline."mpg123-1.32.9-h01009b0_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/mpg123-1.32.9-h01009b0_0.conda"
+checksum = "sha256:a1d7d25f2c448f5c47d1678cca1f6ae5deadb38e176ea0c76ea5c688589dfd7a"
+
+[conda-packages.windows-x64-baseline."openh264-2.6.0-h1eab103_1"]
+url = "https://conda.anaconda.org/conda-forge/win-64/openh264-2.6.0-h1eab103_1.conda"
+checksum = "sha256:8d7e4a2dcd68afcc87c1e875a19600d980ca8f792f00105a622efd5faed6b05a"
+
+[conda-packages.windows-x64-baseline."openssl-3.6.3-hf411b9b_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.3-hf411b9b_0.conda"
+checksum = "sha256:cb6e7ba0d010ee0d3249ce9886de3d7613d26d9965d4c95666fa66b9c4c31001"
+
+[conda-packages.windows-x64-baseline."packaging-26.2-pyhc364b38_0"]
+url = "https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda"
+checksum = "sha256:3906abfb6511a3bb309e39b9b1b7bc38f50a723971de2395489fd1f379255890"
+
+[conda-packages.windows-x64-baseline."pango-1.56.4-h13911b6_1"]
+url = "https://conda.anaconda.org/conda-forge/win-64/pango-1.56.4-h13911b6_1.conda"
+checksum = "sha256:3d4e6e541e633f6fd22fc2c1d79ad5ec39503dea3ba04fc3e01d5be904ec7cea"
+
+[conda-packages.windows-x64-baseline."pcre2-10.47-hd2b5f0e_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/pcre2-10.47-hd2b5f0e_0.conda"
+checksum = "sha256:3e9e02174edf02cb4bcdd75668ad7b74b8061791a3bc8bdb8a52ae336761ba3e"
+
+[conda-packages.windows-x64-baseline."pixman-0.46.4-h5112557_2"]
+url = "https://conda.anaconda.org/conda-forge/win-64/pixman-0.46.4-h5112557_2.conda"
+checksum = "sha256:f37fb21952bd4297f8c7d78e2f256647da2b4ad4e1df097d49ebff8a40275cab"
+
+[conda-packages.windows-x64-baseline."python-3.14.6-h4b44e0e_100_cp314"]
+url = "https://conda.anaconda.org/conda-forge/win-64/python-3.14.6-h4b44e0e_100_cp314.conda"
+checksum = "sha256:f1acb89cb1a6bec9a94ae9f8e7411839de009cd64d3ac6a6aec4f3d8a481099a"
+
+[conda-packages.windows-x64-baseline."python_abi-3.14-8_cp314"]
+url = "https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda"
+checksum = "sha256:ad6d2e9ac39751cc0529dd1566a26751a0bf2542adb0c232533d32e176e21db5"
+
+[conda-packages.windows-x64-baseline."sdl2-2.32.56-h5112557_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/sdl2-2.32.56-h5112557_0.conda"
+checksum = "sha256:d17da21386bdbf32bce5daba5142916feb95eed63ef92b285808c765705bbfd2"
+
+[conda-packages.windows-x64-baseline."sdl3-3.4.12-h5112557_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/sdl3-3.4.12-h5112557_0.conda"
+checksum = "sha256:cd70a95559fdcaa9809d7c697b1d2e283c2d61eb184f91f7b03f8c2291e206a8"
+
+[conda-packages.windows-x64-baseline."shaderc-2026.3-hbcac29b_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/shaderc-2026.3-hbcac29b_0.conda"
+checksum = "sha256:ae69be2f9a0828e35397b4c0d25bad3eb9b395535bc635154e872a6fd5b440aa"
+
+[conda-packages.windows-x64-baseline."spirv-tools-2026.2-h49e36cd_1"]
+url = "https://conda.anaconda.org/conda-forge/win-64/spirv-tools-2026.2-h49e36cd_1.conda"
+checksum = "sha256:30a87a710c1deed93371e6ff365ebd3b578aeefad68cc89bedff85ffb2fea9d2"
+
+[conda-packages.windows-x64-baseline."svt-av1-4.2.0-hac47afa_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/svt-av1-4.2.0-hac47afa_0.conda"
+checksum = "sha256:6dc6ed0e651e99d03ae25b6a358064247c96b1cb436fdbf973ab25c1c6aedcd4"
+
+[conda-packages.windows-x64-baseline."tk-8.6.13-h967ab96_3"]
+url = "https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h967ab96_3.conda"
+checksum = "sha256:13fa29257d43f8e630a1e591ed77fae9bbbb236b011432f01e2034cf36e6bf03"
+
+[conda-packages.windows-x64-baseline.tzdata-2026c-h151e31d_0]
+url = "https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda"
+checksum = "sha256:b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8"
+
+[conda-packages.windows-x64-baseline."ucrt-10.0.26100.0-h57928b3_0"]
+url = "https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda"
+checksum = "sha256:3005729dce6f3d3f5ec91dfc49fc75a0095f9cd23bab49efb899657297ac91a5"
+
+[conda-packages.windows-x64-baseline."vc-14.5-h1b7c187_39"]
+url = "https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_39.conda"
+checksum = "sha256:17693b60cb54f80c60275f003f3bfc1b128af56dbfd65c4fae37c64eeb755ce1"
+
+[conda-packages.windows-x64-baseline."vc14_runtime-14.51.36231-h1b9f54f_39"]
+url = "https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_39.conda"
+checksum = "sha256:8153ed849c92e891eacac0f2f8d7ecb79f9b5fd7f7917fbb896f252a60a40390"
+
+[conda-packages.windows-x64-baseline."vcomp14-14.51.36231-h1b9f54f_39"]
+url = "https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_39.conda"
+checksum = "sha256:07fb14713c4bc62e2533a2e23a363abfb0e65650681fba0ae4c840e2219350f3"
+
+[conda-packages.windows-x64-baseline."vs2015_runtime-14.51.36231-h84cd919_39"]
+url = "https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_39.conda"
+checksum = "sha256:6de6c2cf008fc2dce61060b583f2d8494c83883106952b201381b6b0505f03d7"
+
+[conda-packages.windows-x64-baseline."x264-1!164.3095-h8ffe710_2"]
+url = "https://conda.anaconda.org/conda-forge/win-64/x264-1!164.3095-h8ffe710_2.tar.bz2"
+checksum = "sha256:97166b318f8c68ffe4d50b2f4bd36e415219eeaef233e7d41c54244dc6108249"
+
+[conda-packages.windows-x64-baseline."x265-3.5-h2d74725_3"]
+url = "https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2"
+checksum = "sha256:02b9874049112f2b7335c9a3e880ac05d99a08d9a98160c5a98898b2b3ac42b2"
+
+[conda-packages.windows-x64-baseline."zlib-1.3.2-hfd05255_2"]
+url = "https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda"
+checksum = "sha256:ef408f85f664a4b9c9dac3cb2e36154d9baa15a88984ea800e11060e0f2394a1"
+
+[conda-packages.windows-x64-baseline."zstd-1.5.7-h534d264_6"]
+url = "https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda"
+checksum = "sha256:368d8628424966fd8f9c8018326a9c779e06913dd39e646cf331226acc90e5b2"
+
 [[tools."aqua:jackchuka/mdschema"]]
 version = "0.13.4"
 backend = "aqua:jackchuka/mdschema"
@@ -1051,7 +1727,17 @@ checksum = "sha256:b4d86b3c273172aca0380f6c3e5a23f731cfc5576633b467f6c5f923e4818
 url = "https://github.com/jackchuka/mdschema/releases/download/v0.13.4/mdschema_0.13.4_linux_amd64.tar.gz"
 url_api = "https://api.github.com/repos/jackchuka/mdschema/releases/assets/484149103"
 
+[tools."aqua:jackchuka/mdschema"."platforms.linux-x64-baseline"]
+checksum = "sha256:b4d86b3c273172aca0380f6c3e5a23f731cfc5576633b467f6c5f923e48180e3"
+url = "https://github.com/jackchuka/mdschema/releases/download/v0.13.4/mdschema_0.13.4_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/jackchuka/mdschema/releases/assets/484149103"
+
 [tools."aqua:jackchuka/mdschema"."platforms.linux-x64-musl"]
+checksum = "sha256:b4d86b3c273172aca0380f6c3e5a23f731cfc5576633b467f6c5f923e48180e3"
+url = "https://github.com/jackchuka/mdschema/releases/download/v0.13.4/mdschema_0.13.4_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/jackchuka/mdschema/releases/assets/484149103"
+
+[tools."aqua:jackchuka/mdschema"."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:b4d86b3c273172aca0380f6c3e5a23f731cfc5576633b467f6c5f923e48180e3"
 url = "https://github.com/jackchuka/mdschema/releases/download/v0.13.4/mdschema_0.13.4_linux_amd64.tar.gz"
 url_api = "https://api.github.com/repos/jackchuka/mdschema/releases/assets/484149103"
@@ -1066,7 +1752,17 @@ checksum = "sha256:656f2cc6e0d59f06cccc3fa7a1f257e629da2e1ac7e8105bfe2fa5ec48847
 url = "https://github.com/jackchuka/mdschema/releases/download/v0.13.4/mdschema_0.13.4_darwin_amd64.tar.gz"
 url_api = "https://api.github.com/repos/jackchuka/mdschema/releases/assets/484149099"
 
+[tools."aqua:jackchuka/mdschema"."platforms.macos-x64-baseline"]
+checksum = "sha256:656f2cc6e0d59f06cccc3fa7a1f257e629da2e1ac7e8105bfe2fa5ec48847727"
+url = "https://github.com/jackchuka/mdschema/releases/download/v0.13.4/mdschema_0.13.4_darwin_amd64.tar.gz"
+url_api = "https://api.github.com/repos/jackchuka/mdschema/releases/assets/484149099"
+
 [tools."aqua:jackchuka/mdschema"."platforms.windows-x64"]
+checksum = "sha256:53143267a31c2030b025805e6c9aef3b6b5007548aeda5136d9b9a5cc355839d"
+url = "https://github.com/jackchuka/mdschema/releases/download/v0.13.4/mdschema_0.13.4_windows_amd64.zip"
+url_api = "https://api.github.com/repos/jackchuka/mdschema/releases/assets/484149098"
+
+[tools."aqua:jackchuka/mdschema"."platforms.windows-x64-baseline"]
 checksum = "sha256:53143267a31c2030b025805e6c9aef3b6b5007548aeda5136d9b9a5cc355839d"
 url = "https://github.com/jackchuka/mdschema/releases/download/v0.13.4/mdschema_0.13.4_windows_amd64.zip"
 url_api = "https://api.github.com/repos/jackchuka/mdschema/releases/assets/484149098"
@@ -1084,13 +1780,22 @@ url = "https://awscli.amazonaws.com/awscli-exe-linux-aarch64-2.36.5.zip"
 [tools.aws-cli."platforms.linux-x64"]
 url = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.36.5.zip"
 
+[tools.aws-cli."platforms.linux-x64-baseline"]
+url = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.36.5.zip"
+
 [tools.aws-cli."platforms.linux-x64-musl"]
+url = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.36.5.zip"
+
+[tools.aws-cli."platforms.linux-x64-musl-baseline"]
 url = "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.36.5.zip"
 
 [tools.aws-cli."platforms.macos-arm64"]
 url = "https://awscli.amazonaws.com/AWSCLIV2-2.36.5.pkg"
 
 [tools.aws-cli."platforms.macos-x64"]
+url = "https://awscli.amazonaws.com/AWSCLIV2-2.36.5.pkg"
+
+[tools.aws-cli."platforms.macos-x64-baseline"]
 url = "https://awscli.amazonaws.com/AWSCLIV2-2.36.5.pkg"
 
 [[tools.azure-cli]]
@@ -1122,7 +1827,19 @@ url = "https://github.com/biomejs/biome/releases/download/%40biomejs/biome%402.5
 url_api = "https://api.github.com/repos/biomejs/biome/releases/assets/484416085"
 provenance = "github-attestations"
 
+[tools.biome."platforms.linux-x64-baseline"]
+checksum = "sha256:12ecb833102c8bf8ab6ede7ecd5b6e6fc76e8af95b3ef356933a1f5330afc028"
+url = "https://github.com/biomejs/biome/releases/download/%40biomejs/biome%402.5.5/biome-linux-x64"
+url_api = "https://api.github.com/repos/biomejs/biome/releases/assets/484416085"
+provenance = "github-attestations"
+
 [tools.biome."platforms.linux-x64-musl"]
+checksum = "sha256:549fea27c74212aaeb2c737346028facbcca7a93f66cf4aa145388dd8b18d7bc"
+url = "https://github.com/biomejs/biome/releases/download/%40biomejs/biome%402.5.5/biome-linux-x64-musl"
+url_api = "https://api.github.com/repos/biomejs/biome/releases/assets/484416086"
+provenance = "github-attestations"
+
+[tools.biome."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:549fea27c74212aaeb2c737346028facbcca7a93f66cf4aa145388dd8b18d7bc"
 url = "https://github.com/biomejs/biome/releases/download/%40biomejs/biome%402.5.5/biome-linux-x64-musl"
 url_api = "https://api.github.com/repos/biomejs/biome/releases/assets/484416086"
@@ -1140,7 +1857,19 @@ url = "https://github.com/biomejs/biome/releases/download/%40biomejs/biome%402.5
 url_api = "https://api.github.com/repos/biomejs/biome/releases/assets/484416089"
 provenance = "github-attestations"
 
+[tools.biome."platforms.macos-x64-baseline"]
+checksum = "sha256:81f7f09a1ffacd225a65a29e2506ad02013b95964e684554cc5cc7ae9db005b4"
+url = "https://github.com/biomejs/biome/releases/download/%40biomejs/biome%402.5.5/biome-darwin-x64"
+url_api = "https://api.github.com/repos/biomejs/biome/releases/assets/484416089"
+provenance = "github-attestations"
+
 [tools.biome."platforms.windows-x64"]
+checksum = "sha256:f24c77f79d02dff42bfa4ee62e31b0522754d87eaaa3202435c7126cdb30ebd2"
+url = "https://github.com/biomejs/biome/releases/download/%40biomejs/biome%402.5.5/biome-win32-x64.exe"
+url_api = "https://api.github.com/repos/biomejs/biome/releases/assets/484416083"
+provenance = "github-attestations"
+
+[tools.biome."platforms.windows-x64-baseline"]
 checksum = "sha256:f24c77f79d02dff42bfa4ee62e31b0522754d87eaaa3202435c7126cdb30ebd2"
 url = "https://github.com/biomejs/biome/releases/download/%40biomejs/biome%402.5.5/biome-win32-x64.exe"
 url_api = "https://api.github.com/repos/biomejs/biome/releases/assets/484416083"
@@ -1165,7 +1894,17 @@ checksum = "sha256:54ea35f4847815d0a1445dbc2bc3dd6469518a38a9e960449e96b044d248d
 url = "https://github.com/abiosoft/colima/releases/download/v0.10.3/colima-Linux-x86_64"
 url_api = "https://api.github.com/repos/abiosoft/colima/releases/assets/438456720"
 
+[tools.colima."platforms.linux-x64-baseline"]
+checksum = "sha256:54ea35f4847815d0a1445dbc2bc3dd6469518a38a9e960449e96b044d248d00d"
+url = "https://github.com/abiosoft/colima/releases/download/v0.10.3/colima-Linux-x86_64"
+url_api = "https://api.github.com/repos/abiosoft/colima/releases/assets/438456720"
+
 [tools.colima."platforms.linux-x64-musl"]
+checksum = "sha256:54ea35f4847815d0a1445dbc2bc3dd6469518a38a9e960449e96b044d248d00d"
+url = "https://github.com/abiosoft/colima/releases/download/v0.10.3/colima-Linux-x86_64"
+url_api = "https://api.github.com/repos/abiosoft/colima/releases/assets/438456720"
+
+[tools.colima."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:54ea35f4847815d0a1445dbc2bc3dd6469518a38a9e960449e96b044d248d00d"
 url = "https://github.com/abiosoft/colima/releases/download/v0.10.3/colima-Linux-x86_64"
 url_api = "https://api.github.com/repos/abiosoft/colima/releases/assets/438456720"
@@ -1176,6 +1915,11 @@ url = "https://github.com/abiosoft/colima/releases/download/v0.10.3/colima-Darwi
 url_api = "https://api.github.com/repos/abiosoft/colima/releases/assets/438456725"
 
 [tools.colima."platforms.macos-x64"]
+checksum = "sha256:3082737fe8a98afda11cba7d9a20b6e56fe80c6153464beda04bec630758770b"
+url = "https://github.com/abiosoft/colima/releases/download/v0.10.3/colima-Darwin-x86_64"
+url_api = "https://api.github.com/repos/abiosoft/colima/releases/assets/438456722"
+
+[tools.colima."platforms.macos-x64-baseline"]
 checksum = "sha256:3082737fe8a98afda11cba7d9a20b6e56fe80c6153464beda04bec630758770b"
 url = "https://github.com/abiosoft/colima/releases/download/v0.10.3/colima-Darwin-x86_64"
 url_api = "https://api.github.com/repos/abiosoft/colima/releases/assets/438456722"
@@ -1377,7 +2121,188 @@ conda_deps = [
     "zstd-1.5.7-h3eecb57_6",
 ]
 
+[tools."conda:ffmpeg"."platforms.macos-x64-baseline"]
+checksum = "sha256:8aad3817c595824e95389e1def364b8fb0b1d84dd4e45ce41804971bb542d21a"
+url = "https://conda.anaconda.org/conda-forge/osx-64/ffmpeg-8.1.2-gpl_he601db1_104.conda"
+conda_deps = [
+    "svt-av1-4.2.0-hcc62823_0",
+    "shaderc-2026.3-h3d334e4_0",
+    "libzlib-1.3.2-hbb4bfdb_2",
+    "libwebp-base-1.6.0-hb807250_0",
+    "libvulkan-loader-1.4.341.0-ha6bc089_0",
+    "libvpx-1.15.2-heffb93a_0",
+    "librsvg-2.62.3-h7321050_0",
+    "libopus-1.6.1-hc6ced15_0",
+    "liblzma-5.8.3-hbb4bfdb_0",
+    "libharfbuzz-14.2.1-h97ceea7_1",
+    "libass-0.17.5-hf78704f_0",
+    "lame-4.0-h6c71e33_0",
+    "fonts-conda-ecosystem-1-0",
+    "fontconfig-2.18.1-h7a4440b_0",
+    "dav1d-1.2.1-h0dc2134_0",
+    "libpng-1.6.58-he930e7c_0",
+    "libglib-2.88.2-hf28f236_0",
+    "graphite2-1.3.15-hcc62823_0",
+    "fribidi-1.0.16-h8616949_0",
+    "mpg123-1.32.9-h78e78a4_0",
+    "pcre2-10.47-h13923f0_0",
+    "libplacebo-7.360.1-h1ed201f_1",
+    "libdovi-3.4.0-h59a3c7f_0",
+    "aom-3.14.1-pl5321h3d58d69_1",
+    "gmp-6.3.0-hf036a51_2",
+    "libexpat-2.8.1-hcc62823_1",
+    "libfreetype-2.14.3-h694c41f_1",
+    "libfreetype6-2.14.3-h58fbd8d_1",
+    "libiconv-1.18-h57a12c2_2",
+    "libjxl-0.12.0-h473410d_1",
+    "libopenvino-2026.2.1-h96313a9_1",
+    "pugixml-1.15-h46091d4_0",
+    "libopenvino-tensorflow-lite-frontend-2026.2.1-h409306b_1",
+    "libopenvino-tensorflow-frontend-2026.2.1-h10fe5cc_1",
+    "libopenvino-pytorch-frontend-2026.2.1-h409306b_1",
+    "libopenvino-paddle-frontend-2026.2.1-h8456301_1",
+    "libopenvino-onnx-frontend-2026.2.1-h8456301_1",
+    "libopenvino-ir-frontend-2026.2.1-h5d0de11_1",
+    "libopenvino-intel-cpu-plugin-2026.2.1-h96313a9_1",
+    "libopenvino-hetero-plugin-2026.2.1-h5d0de11_1",
+    "libopenvino-auto-plugin-2026.2.1-h4a57bf7_1",
+    "libopenvino-auto-batch-plugin-2026.2.1-h4a57bf7_1",
+    "libvorbis-1.3.7-ha059160_2",
+    "openh264-2.6.0-hd629203_1",
+    "sdl2-2.32.56-h2fb4741_0",
+    "sdl3-3.4.12-hf9078ff_0",
+    "libusb-1.0.29-h2287256_0",
+    "x264-1!164.3095-h775f41a_2",
+    "bzip2-1.0.8-h500dc9f_9",
+    "libcxx-22.1.8-h19cb2f5_0",
+    "libxml2-2.15.3-h953d39d_0",
+    "libxml2-16-2.15.3-h7a90416_0",
+    "openssl-3.6.3-hc881268_0",
+    "x265-3.5-hbb4e6a2_3",
+    "libintl-0.25.1-h3184127_1",
+    "fonts-conda-forge-1-hc364b38_1",
+    "font-ttf-dejavu-sans-mono-2.37-hab24e00_0",
+    "harfbuzz-14.2.1-h694c41f_1",
+    "libharfbuzz-devel-14.2.1-h97ceea7_1",
+    "freetype-2.14.3-h694c41f_1",
+    "cairo-1.18.4-h7656bdc_1",
+    "icu-78.3-h25d91c4_1",
+    "libbrotlienc-1.2.0-h8616949_1",
+    "libbrotlicommon-1.2.0-h8616949_1",
+    "libbrotlidec-1.2.0-h8616949_1",
+    "libhwy-1.4.0-h7747b51_0",
+    "tbb-2023.0.0-he3dc2fa_2",
+    "libhwloc-2.13.0-default_h4e3125e_1000",
+    "libabseil-20260526.0-cxx17_h1a06613_1",
+    "libprotobuf-7.35.1-h087ac9f_2",
+    "snappy-1.2.2-h01f5ddf_1",
+    "lcms2-2.19.1-h5ea7634_1",
+    "gdk-pixbuf-2.44.7-hae309b2_0",
+    "pango-1.56.4-hf280016_1",
+    "libogg-1.3.5-he3325bb_1",
+    "ca-certificates-2026.7.22-hbd8a1cb_0",
+    "spirv-tools-2026.2-hc1436ee_1",
+    "glslang-16.3.0-he78e680_0",
+    "font-ttf-ubuntu-0.83-h77eed37_3",
+    "font-ttf-inconsolata-3.000-h77eed37_0",
+    "font-ttf-source-code-pro-2.038-h77eed37_0",
+    "pixman-0.46.4-h2fb4741_2",
+    "libffi-3.5.2-hd1f9c09_0",
+    "libjpeg-turbo-3.2.0-ha1e9b39_0",
+    "libtiff-4.7.2-h95d6d7f_0",
+    "libdeflate-1.25-h517ebb2_0",
+    "lerc-4.1.0-h35c7297_0",
+    "dbus-1.16.2-h6e7f9a9_1",
+    "zstd-1.5.7-h3eecb57_6",
+]
+
 [tools."conda:ffmpeg"."platforms.windows-x64"]
+checksum = "sha256:a31772d389fa14ca3eec690a4f07b8308116302392a48f6affab01cbcaa97e23"
+url = "https://conda.anaconda.org/conda-forge/win-64/ffmpeg-8.1.2-gpl_he504192_904.conda"
+conda_deps = [
+    "x265-3.5-h2d74725_3",
+    "svt-av1-4.2.0-hac47afa_0",
+    "shaderc-2026.3-hbcac29b_0",
+    "sdl2-2.32.56-h5112557_0",
+    "libzlib-1.3.2-hfd05255_2",
+    "libwebp-base-1.6.0-h4d5522a_0",
+    "libvulkan-loader-1.4.341.0-h477610d_0",
+    "librsvg-2.62.3-h15cfe45_0",
+    "libopus-1.6.1-h6a83c73_0",
+    "liblzma-5.8.3-hfd05255_0",
+    "libharfbuzz-14.2.1-h03b5201_1",
+    "lame-4.0-h4a41cd3_0",
+    "fonts-conda-ecosystem-1-0",
+    "dav1d-1.2.1-hcfcfb64_0",
+    "libpng-1.6.58-h7351971_0",
+    "libglib-2.88.2-h7ce1215_0",
+    "graphite2-1.3.15-hac47afa_0",
+    "mpg123-1.32.9-h01009b0_0",
+    "pcre2-10.47-hd2b5f0e_0",
+    "aom-3.14.1-pl5321h06fc181_1",
+    "fontconfig-2.18.2-hd47e2ca_0",
+    "libexpat-2.8.1-hac47afa_1",
+    "libfreetype-2.14.3-h57928b3_1",
+    "libfreetype6-2.14.3-hdbac1cb_1",
+    "libiconv-1.18-hc1393d2_2",
+    "libjxl-0.12.0-h932607e_1",
+    "libvorbis-1.3.7-h5112557_2",
+    "openh264-2.6.0-h1eab103_1",
+    "x264-1!164.3095-h8ffe710_2",
+    "bzip2-1.0.8-h0ad9c76_9",
+    "libxml2-2.15.3-h8ef44ab_0",
+    "libxml2-16-2.15.3-h3cfd58e_0",
+    "openssl-3.6.3-hf411b9b_0",
+    "ucrt-10.0.26100.0-h57928b3_0",
+    "vc-14.5-h1b7c187_39",
+    "vc14_runtime-14.51.36231-h1b9f54f_39",
+    "vcomp14-14.51.36231-h1b9f54f_39",
+    "vs2015_runtime-14.51.36231-h84cd919_39",
+    "libintl-0.22.5-h5728263_3",
+    "fonts-conda-forge-1-hc364b38_1",
+    "font-ttf-dejavu-sans-mono-2.37-hab24e00_0",
+    "cairo-1.18.4-h477c42c_1",
+    "icu-78.3-h637d24d_1",
+    "libhwy-1.4.0-h2419aca_0",
+    "libbrotlienc-1.2.0-hfd05255_1",
+    "libbrotlicommon-1.2.0-hfd05255_1",
+    "libbrotlidec-1.2.0-hfd05255_1",
+    "gdk-pixbuf-2.44.7-h1f5b9c4_0",
+    "harfbuzz-14.2.1-h57928b3_1",
+    "libharfbuzz-devel-14.2.1-h03b5201_1",
+    "glib-2.88.2-h395db07_0",
+    "freetype-2.14.3-h57928b3_1",
+    "libintl-devel-0.22.5-h5728263_3",
+    "glib-tools-2.88.2-h74ecf4c_0",
+    "zlib-1.3.2-hfd05255_2",
+    "pango-1.56.4-h13911b6_1",
+    "fribidi-1.0.16-hfd05255_0",
+    "libogg-1.3.5-h2466b09_1",
+    "ca-certificates-2026.7.22-h4c7d964_0",
+    "sdl3-3.4.12-h5112557_0",
+    "libusb-1.0.29-h1839187_0",
+    "glslang-16.3.0-h294ba9c_0",
+    "spirv-tools-2026.2-h49e36cd_1",
+    "font-ttf-ubuntu-0.83-h77eed37_3",
+    "font-ttf-inconsolata-3.000-h77eed37_0",
+    "font-ttf-source-code-pro-2.038-h77eed37_0",
+    "pixman-0.46.4-h5112557_2",
+    "libffi-3.5.2-h3d046cb_0",
+    "libjpeg-turbo-3.2.0-hfd05255_0",
+    "libtiff-4.7.2-h8f73337_0",
+    "libdeflate-1.25-h51727cc_0",
+    "lerc-4.1.0-hd936e49_0",
+    "zstd-1.5.7-h534d264_6",
+    "python-3.14.6-h4b44e0e_100_cp314",
+    "python_abi-3.14-8_cp314",
+    "packaging-26.2-pyhc364b38_0",
+    "libmpdec-4.0.0-hfd05255_1",
+    "libsqlite-3.53.3-hf5d6505_0",
+    "tk-8.6.13-h967ab96_3",
+    "tzdata-2026c-h151e31d_0",
+]
+
+[tools."conda:ffmpeg"."platforms.windows-x64-baseline"]
 checksum = "sha256:a31772d389fa14ca3eec690a4f07b8308116302392a48f6affab01cbcaa97e23"
 url = "https://conda.anaconda.org/conda-forge/win-64/ffmpeg-8.1.2-gpl_he504192_904.conda"
 conda_deps = [
@@ -1476,7 +2401,13 @@ url = "https://download.docker.com/linux/static/stable/aarch64/docker-29.6.2.tgz
 [tools.docker-cli."platforms.linux-x64"]
 url = "https://download.docker.com/linux/static/stable/x86_64/docker-29.6.2.tgz"
 
+[tools.docker-cli."platforms.linux-x64-baseline"]
+url = "https://download.docker.com/linux/static/stable/x86_64/docker-29.6.2.tgz"
+
 [tools.docker-cli."platforms.linux-x64-musl"]
+url = "https://download.docker.com/linux/static/stable/x86_64/docker-29.6.2.tgz"
+
+[tools.docker-cli."platforms.linux-x64-musl-baseline"]
 url = "https://download.docker.com/linux/static/stable/x86_64/docker-29.6.2.tgz"
 
 [tools.docker-cli."platforms.macos-arm64"]
@@ -1485,7 +2416,13 @@ url = "https://download.docker.com/mac/static/stable/aarch64/docker-29.6.2.tgz"
 [tools.docker-cli."platforms.macos-x64"]
 url = "https://download.docker.com/mac/static/stable/x86_64/docker-29.6.2.tgz"
 
+[tools.docker-cli."platforms.macos-x64-baseline"]
+url = "https://download.docker.com/mac/static/stable/x86_64/docker-29.6.2.tgz"
+
 [tools.docker-cli."platforms.windows-x64"]
+url = "https://download.docker.com/win/static/stable/x86_64/docker-29.6.2.zip"
+
+[tools.docker-cli."platforms.windows-x64-baseline"]
 url = "https://download.docker.com/win/static/stable/x86_64/docker-29.6.2.zip"
 
 [[tools.editorconfig-checker]]
@@ -1507,7 +2444,17 @@ checksum = "sha256:613bd88f34165a334adcb6b7e92a123c9de0eada65846d31af63613b779ff
 url = "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v3.8.0/ec-linux-amd64.tar.gz"
 url_api = "https://api.github.com/repos/editorconfig-checker/editorconfig-checker/releases/assets/460248510"
 
+[tools.editorconfig-checker."platforms.linux-x64-baseline"]
+checksum = "sha256:613bd88f34165a334adcb6b7e92a123c9de0eada65846d31af63613b779ff3be"
+url = "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v3.8.0/ec-linux-amd64.tar.gz"
+url_api = "https://api.github.com/repos/editorconfig-checker/editorconfig-checker/releases/assets/460248510"
+
 [tools.editorconfig-checker."platforms.linux-x64-musl"]
+checksum = "sha256:613bd88f34165a334adcb6b7e92a123c9de0eada65846d31af63613b779ff3be"
+url = "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v3.8.0/ec-linux-amd64.tar.gz"
+url_api = "https://api.github.com/repos/editorconfig-checker/editorconfig-checker/releases/assets/460248510"
+
+[tools.editorconfig-checker."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:613bd88f34165a334adcb6b7e92a123c9de0eada65846d31af63613b779ff3be"
 url = "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v3.8.0/ec-linux-amd64.tar.gz"
 url_api = "https://api.github.com/repos/editorconfig-checker/editorconfig-checker/releases/assets/460248510"
@@ -1522,7 +2469,17 @@ checksum = "sha256:ee0d45c94b9808a5aa15e08f94333a81842b456f511f29f71a8fe589b82d7
 url = "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v3.8.0/ec-darwin-amd64.tar.gz"
 url_api = "https://api.github.com/repos/editorconfig-checker/editorconfig-checker/releases/assets/460248506"
 
+[tools.editorconfig-checker."platforms.macos-x64-baseline"]
+checksum = "sha256:ee0d45c94b9808a5aa15e08f94333a81842b456f511f29f71a8fe589b82d72a1"
+url = "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v3.8.0/ec-darwin-amd64.tar.gz"
+url_api = "https://api.github.com/repos/editorconfig-checker/editorconfig-checker/releases/assets/460248506"
+
 [tools.editorconfig-checker."platforms.windows-x64"]
+checksum = "sha256:7ec31e1a6a9983aa2a4942cb66dfd35e8b61e76263460413988438ae1426906a"
+url = "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v3.8.0/ec-windows-amd64.zip"
+url_api = "https://api.github.com/repos/editorconfig-checker/editorconfig-checker/releases/assets/460248513"
+
+[tools.editorconfig-checker."platforms.windows-x64-baseline"]
 checksum = "sha256:7ec31e1a6a9983aa2a4942cb66dfd35e8b61e76263460413988438ae1426906a"
 url = "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v3.8.0/ec-windows-amd64.zip"
 url_api = "https://api.github.com/repos/editorconfig-checker/editorconfig-checker/releases/assets/460248513"
@@ -1549,7 +2506,19 @@ url = "https://github.com/agent-sh/agnix/releases/download/v0.40.0/agnix-x86_64-
 url_api = "https://api.github.com/repos/agent-sh/agnix/releases/assets/479035416"
 provenance = "github-attestations"
 
+[tools."github:agent-sh/agnix"."platforms.linux-x64-baseline"]
+checksum = "sha256:9452e72f477c5f47917dd523c9510d4a013a8ee33afaa3e8d5d94fa3d1da7690"
+url = "https://github.com/agent-sh/agnix/releases/download/v0.40.0/agnix-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/agent-sh/agnix/releases/assets/479035416"
+provenance = "github-attestations"
+
 [tools."github:agent-sh/agnix"."platforms.linux-x64-musl"]
+checksum = "sha256:e5a99da40d653cfb979a4d1622a96989eee8d461b7971273579834d75ad683c0"
+url = "https://github.com/agent-sh/agnix/releases/download/v0.40.0/agnix-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/agent-sh/agnix/releases/assets/479035404"
+provenance = "github-attestations"
+
+[tools."github:agent-sh/agnix"."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:e5a99da40d653cfb979a4d1622a96989eee8d461b7971273579834d75ad683c0"
 url = "https://github.com/agent-sh/agnix/releases/download/v0.40.0/agnix-x86_64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/agent-sh/agnix/releases/assets/479035404"
@@ -1562,6 +2531,12 @@ url_api = "https://api.github.com/repos/agent-sh/agnix/releases/assets/479035432
 provenance = "github-attestations"
 
 [tools."github:agent-sh/agnix"."platforms.windows-x64"]
+checksum = "sha256:a42785e19797cb5a96b3e6f8b50fefb770167f0a215d6e3fed9418ca737508ed"
+url = "https://github.com/agent-sh/agnix/releases/download/v0.40.0/agnix-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/agent-sh/agnix/releases/assets/479035402"
+provenance = "github-attestations"
+
+[tools."github:agent-sh/agnix"."platforms.windows-x64-baseline"]
 checksum = "sha256:a42785e19797cb5a96b3e6f8b50fefb770167f0a215d6e3fed9418ca737508ed"
 url = "https://github.com/agent-sh/agnix/releases/download/v0.40.0/agnix-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/agent-sh/agnix/releases/assets/479035402"
@@ -1586,7 +2561,17 @@ checksum = "sha256:611f9e5e76f2611ecea1a35dd3468ceedf600641a11224b80341d79c6ee7b
 url = "https://github.com/ast-grep/ast-grep/releases/download/0.44.1/app-x86_64-unknown-linux-gnu.zip"
 url_api = "https://api.github.com/repos/ast-grep/ast-grep/releases/assets/466366790"
 
+[tools."github:ast-grep/ast-grep"."platforms.linux-x64-baseline"]
+checksum = "sha256:611f9e5e76f2611ecea1a35dd3468ceedf600641a11224b80341d79c6ee7b9dd"
+url = "https://github.com/ast-grep/ast-grep/releases/download/0.44.1/app-x86_64-unknown-linux-gnu.zip"
+url_api = "https://api.github.com/repos/ast-grep/ast-grep/releases/assets/466366790"
+
 [tools."github:ast-grep/ast-grep"."platforms.linux-x64-musl"]
+checksum = "sha256:611f9e5e76f2611ecea1a35dd3468ceedf600641a11224b80341d79c6ee7b9dd"
+url = "https://github.com/ast-grep/ast-grep/releases/download/0.44.1/app-x86_64-unknown-linux-gnu.zip"
+url_api = "https://api.github.com/repos/ast-grep/ast-grep/releases/assets/466366790"
+
+[tools."github:ast-grep/ast-grep"."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:611f9e5e76f2611ecea1a35dd3468ceedf600641a11224b80341d79c6ee7b9dd"
 url = "https://github.com/ast-grep/ast-grep/releases/download/0.44.1/app-x86_64-unknown-linux-gnu.zip"
 url_api = "https://api.github.com/repos/ast-grep/ast-grep/releases/assets/466366790"
@@ -1601,7 +2586,17 @@ checksum = "sha256:46584f3e4f67e9ae482de69e71e4e4aa88e68da322316fdd25ad73f2621dd
 url = "https://github.com/ast-grep/ast-grep/releases/download/0.44.1/app-x86_64-apple-darwin.zip"
 url_api = "https://api.github.com/repos/ast-grep/ast-grep/releases/assets/466366771"
 
+[tools."github:ast-grep/ast-grep"."platforms.macos-x64-baseline"]
+checksum = "sha256:46584f3e4f67e9ae482de69e71e4e4aa88e68da322316fdd25ad73f2621ddbc5"
+url = "https://github.com/ast-grep/ast-grep/releases/download/0.44.1/app-x86_64-apple-darwin.zip"
+url_api = "https://api.github.com/repos/ast-grep/ast-grep/releases/assets/466366771"
+
 [tools."github:ast-grep/ast-grep"."platforms.windows-x64"]
+checksum = "sha256:f122d5507e5206c3a9f030fc3a0d137070eb6c4f708e1b496df56795bc9858b9"
+url = "https://github.com/ast-grep/ast-grep/releases/download/0.44.1/app-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/ast-grep/ast-grep/releases/assets/466370609"
+
+[tools."github:ast-grep/ast-grep"."platforms.windows-x64-baseline"]
 checksum = "sha256:f122d5507e5206c3a9f030fc3a0d137070eb6c4f708e1b496df56795bc9858b9"
 url = "https://github.com/ast-grep/ast-grep/releases/download/0.44.1/app-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/ast-grep/ast-grep/releases/assets/466370609"
@@ -1628,7 +2623,19 @@ url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.10/leftho
 url_api = "https://api.github.com/repos/evilmartians/lefthook/releases/assets/470227493"
 provenance = "github-attestations"
 
+[tools.lefthook."platforms.linux-x64-baseline"]
+checksum = "sha256:0b14162a0bb2f0c64ae0759f6102f6e19c4d00981666a8ac73d4f5a6878ada4f"
+url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.10/lefthook_2.1.10_Linux_x86_64.gz"
+url_api = "https://api.github.com/repos/evilmartians/lefthook/releases/assets/470227493"
+provenance = "github-attestations"
+
 [tools.lefthook."platforms.linux-x64-musl"]
+checksum = "sha256:0b14162a0bb2f0c64ae0759f6102f6e19c4d00981666a8ac73d4f5a6878ada4f"
+url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.10/lefthook_2.1.10_Linux_x86_64.gz"
+url_api = "https://api.github.com/repos/evilmartians/lefthook/releases/assets/470227493"
+provenance = "github-attestations"
+
+[tools.lefthook."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:0b14162a0bb2f0c64ae0759f6102f6e19c4d00981666a8ac73d4f5a6878ada4f"
 url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.10/lefthook_2.1.10_Linux_x86_64.gz"
 url_api = "https://api.github.com/repos/evilmartians/lefthook/releases/assets/470227493"
@@ -1646,7 +2653,19 @@ url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.10/leftho
 url_api = "https://api.github.com/repos/evilmartians/lefthook/releases/assets/470227495"
 provenance = "github-attestations"
 
+[tools.lefthook."platforms.macos-x64-baseline"]
+checksum = "sha256:49d905f28ca46442cb236060058b252da650b5f7b864bd275b61aa46945e8c4a"
+url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.10/lefthook_2.1.10_MacOS_x86_64.gz"
+url_api = "https://api.github.com/repos/evilmartians/lefthook/releases/assets/470227495"
+provenance = "github-attestations"
+
 [tools.lefthook."platforms.windows-x64"]
+checksum = "sha256:beabbce824641ae71229ed11dd8634f47148921cb649d25c90441b737481494a"
+url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.10/lefthook_2.1.10_Windows_x86_64.gz"
+url_api = "https://api.github.com/repos/evilmartians/lefthook/releases/assets/470227505"
+provenance = "github-attestations"
+
+[tools.lefthook."platforms.windows-x64-baseline"]
 checksum = "sha256:beabbce824641ae71229ed11dd8634f47148921cb649d25c90441b737481494a"
 url = "https://github.com/evilmartians/lefthook/releases/download/v2.1.10/lefthook_2.1.10_Windows_x86_64.gz"
 url_api = "https://api.github.com/repos/evilmartians/lefthook/releases/assets/470227505"
@@ -1674,7 +2693,19 @@ url = "https://github.com/lima-vm/lima/releases/download/v2.2.0/lima-2.2.0-Linux
 url_api = "https://api.github.com/repos/lima-vm/lima/releases/assets/484813993"
 provenance = "github-attestations"
 
+[tools.lima."platforms.linux-x64-baseline"]
+checksum = "sha256:a0ea1ccf6b7335a900adb5f8d2b8384457965fecb1ba72f09b4e3e46d12f424a"
+url = "https://github.com/lima-vm/lima/releases/download/v2.2.0/lima-2.2.0-Linux-x86_64.tar.gz"
+url_api = "https://api.github.com/repos/lima-vm/lima/releases/assets/484813993"
+provenance = "github-attestations"
+
 [tools.lima."platforms.linux-x64-musl"]
+checksum = "sha256:a0ea1ccf6b7335a900adb5f8d2b8384457965fecb1ba72f09b4e3e46d12f424a"
+url = "https://github.com/lima-vm/lima/releases/download/v2.2.0/lima-2.2.0-Linux-x86_64.tar.gz"
+url_api = "https://api.github.com/repos/lima-vm/lima/releases/assets/484813993"
+provenance = "github-attestations"
+
+[tools.lima."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:a0ea1ccf6b7335a900adb5f8d2b8384457965fecb1ba72f09b4e3e46d12f424a"
 url = "https://github.com/lima-vm/lima/releases/download/v2.2.0/lima-2.2.0-Linux-x86_64.tar.gz"
 url_api = "https://api.github.com/repos/lima-vm/lima/releases/assets/484813993"
@@ -1692,9 +2723,11 @@ url = "https://github.com/lima-vm/lima/releases/download/v2.2.0/lima-2.2.0-Darwi
 url_api = "https://api.github.com/repos/lima-vm/lima/releases/assets/484813996"
 provenance = "github-attestations"
 
-[[tools."npm:@claude-flow/cli"]]
-version = "3.32.9"
-backend = "npm:@claude-flow/cli"
+[tools.lima."platforms.macos-x64-baseline"]
+checksum = "sha256:0d6f99c19f6e4bc3c92730c4c29d929e6927f0cb0a0ba1a84383367135a8ff31"
+url = "https://github.com/lima-vm/lima/releases/download/v2.2.0/lima-2.2.0-Darwin-x86_64.tar.gz"
+url_api = "https://api.github.com/repos/lima-vm/lima/releases/assets/484813996"
+provenance = "github-attestations"
 
 [[tools."npm:@contextlint/cli"]]
 version = "1.1.1"
@@ -1703,10 +2736,6 @@ backend = "npm:@contextlint/cli"
 [[tools."npm:@devcontainers/cli"]]
 version = "0.87.0"
 backend = "npm:@devcontainers/cli"
-
-[[tools."npm:@ralph-orchestrator/ralph-cli"]]
-version = "2.10.1"
-backend = "npm:@ralph-orchestrator/ralph-cli"
 
 [[tools."npm:agent-browser"]]
 version = "0.32.3"
@@ -1763,7 +2792,17 @@ checksum = "sha256:bab463c3fb3224d388bb7cfad63f38703df9cf0be2cfd2ce8cb49d886b53a
 url = "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-linux-x64.tar.gz"
 url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/483582201"
 
+[tools.opencode."platforms.linux-x64-baseline"]
+checksum = "sha256:bab463c3fb3224d388bb7cfad63f38703df9cf0be2cfd2ce8cb49d886b53a174"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-linux-x64.tar.gz"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/483582201"
+
 [tools.opencode."platforms.linux-x64-musl"]
+checksum = "sha256:b6cb242a989387cd79d5f9b742f24dccda2537e4938d413cbea5b3c88ac6085a"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-linux-x64-musl.tar.gz"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/483582194"
+
+[tools.opencode."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:b6cb242a989387cd79d5f9b742f24dccda2537e4938d413cbea5b3c88ac6085a"
 url = "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-linux-x64-musl.tar.gz"
 url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/483582194"
@@ -1778,7 +2817,17 @@ checksum = "sha256:e177c532654572079981db1dce464a78adbaed9654a142848b2e81beb8c9f
 url = "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-darwin-x64.zip"
 url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/483582097"
 
+[tools.opencode."platforms.macos-x64-baseline"]
+checksum = "sha256:e177c532654572079981db1dce464a78adbaed9654a142848b2e81beb8c9f5c6"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-darwin-x64.zip"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/483582097"
+
 [tools.opencode."platforms.windows-x64"]
+checksum = "sha256:814dae5724dfa396a43b6408703d0929625483e2fac135623f10f0fa8db04a96"
+url = "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-windows-x64.zip"
+url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/483585385"
+
+[tools.opencode."platforms.windows-x64-baseline"]
 checksum = "sha256:814dae5724dfa396a43b6408703d0929625483e2fac135623f10f0fa8db04a96"
 url = "https://github.com/anomalyco/opencode/releases/download/v1.18.4/opencode-windows-x64.zip"
 url_api = "https://api.github.com/repos/anomalyco/opencode/releases/assets/483585385"
@@ -1817,7 +2866,17 @@ checksum = "sha256:ff8a1e7766496e175291a85aeca1dc97c9ff6df33e51e5893d1fbc78fea2a
 url = "https://github.com/rtk-ai/rtk/releases/download/v0.43.0/rtk-x86_64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/rtk-ai/rtk/releases/assets/460115882"
 
+[tools.rtk."platforms.linux-x64-baseline"]
+checksum = "sha256:ff8a1e7766496e175291a85aeca1dc97c9ff6df33e51e5893d1fbc78fea2a609"
+url = "https://github.com/rtk-ai/rtk/releases/download/v0.43.0/rtk-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/rtk-ai/rtk/releases/assets/460115882"
+
 [tools.rtk."platforms.linux-x64-musl"]
+checksum = "sha256:ff8a1e7766496e175291a85aeca1dc97c9ff6df33e51e5893d1fbc78fea2a609"
+url = "https://github.com/rtk-ai/rtk/releases/download/v0.43.0/rtk-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/rtk-ai/rtk/releases/assets/460115882"
+
+[tools.rtk."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:ff8a1e7766496e175291a85aeca1dc97c9ff6df33e51e5893d1fbc78fea2a609"
 url = "https://github.com/rtk-ai/rtk/releases/download/v0.43.0/rtk-x86_64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/rtk-ai/rtk/releases/assets/460115882"
@@ -1832,7 +2891,17 @@ checksum = "sha256:a85f60e2637811be68366208b8d8b9c5ba1b748cb5df4477ab20cd73d3c5d
 url = "https://github.com/rtk-ai/rtk/releases/download/v0.43.0/rtk-x86_64-apple-darwin.tar.gz"
 url_api = "https://api.github.com/repos/rtk-ai/rtk/releases/assets/460115887"
 
+[tools.rtk."platforms.macos-x64-baseline"]
+checksum = "sha256:a85f60e2637811be68366208b8d8b9c5ba1b748cb5df4477ab20cd73d3c5d9f8"
+url = "https://github.com/rtk-ai/rtk/releases/download/v0.43.0/rtk-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/rtk-ai/rtk/releases/assets/460115887"
+
 [tools.rtk."platforms.windows-x64"]
+checksum = "sha256:7c5e4a2ef816a4d4ed947ddd74ca3df851fc39ea87d49a3ca2bf3abc515a016b"
+url = "https://github.com/rtk-ai/rtk/releases/download/v0.43.0/rtk-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/rtk-ai/rtk/releases/assets/460115883"
+
+[tools.rtk."platforms.windows-x64-baseline"]
 checksum = "sha256:7c5e4a2ef816a4d4ed947ddd74ca3df851fc39ea87d49a3ca2bf3abc515a016b"
 url = "https://github.com/rtk-ai/rtk/releases/download/v0.43.0/rtk-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/rtk-ai/rtk/releases/assets/460115883"
@@ -1859,7 +2928,19 @@ url = "https://github.com/rvben/rumdl/releases/download/v0.2.40/rumdl-v0.2.40-x8
 url_api = "https://api.github.com/repos/rvben/rumdl/releases/assets/485787533"
 provenance = "github-attestations"
 
+[tools.rumdl."platforms.linux-x64-baseline"]
+checksum = "sha256:959df95c5e5ebe47b2c6917f12248c4bee85ad42ac8506eb4cb7db1f0be1394e"
+url = "https://github.com/rvben/rumdl/releases/download/v0.2.40/rumdl-v0.2.40-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/rvben/rumdl/releases/assets/485787533"
+provenance = "github-attestations"
+
 [tools.rumdl."platforms.linux-x64-musl"]
+checksum = "sha256:959df95c5e5ebe47b2c6917f12248c4bee85ad42ac8506eb4cb7db1f0be1394e"
+url = "https://github.com/rvben/rumdl/releases/download/v0.2.40/rumdl-v0.2.40-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/rvben/rumdl/releases/assets/485787533"
+provenance = "github-attestations"
+
+[tools.rumdl."platforms.linux-x64-musl-baseline"]
 checksum = "sha256:959df95c5e5ebe47b2c6917f12248c4bee85ad42ac8506eb4cb7db1f0be1394e"
 url = "https://github.com/rvben/rumdl/releases/download/v0.2.40/rumdl-v0.2.40-x86_64-unknown-linux-musl.tar.gz"
 url_api = "https://api.github.com/repos/rvben/rumdl/releases/assets/485787533"
@@ -1877,7 +2958,19 @@ url = "https://github.com/rvben/rumdl/releases/download/v0.2.40/rumdl-v0.2.40-x8
 url_api = "https://api.github.com/repos/rvben/rumdl/releases/assets/485787536"
 provenance = "github-attestations"
 
+[tools.rumdl."platforms.macos-x64-baseline"]
+checksum = "sha256:b4def412e8126f49d3654ef4e9d71ab853b8a0f5c402533854d972382a7c531e"
+url = "https://github.com/rvben/rumdl/releases/download/v0.2.40/rumdl-v0.2.40-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/rvben/rumdl/releases/assets/485787536"
+provenance = "github-attestations"
+
 [tools.rumdl."platforms.windows-x64"]
+checksum = "sha256:920a35d71acd10903d2b7e1a7aed420aca9a0fabd34b05a5b4b2bbf8cb6b9201"
+url = "https://github.com/rvben/rumdl/releases/download/v0.2.40/rumdl-v0.2.40-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/rvben/rumdl/releases/assets/485787540"
+provenance = "github-attestations"
+
+[tools.rumdl."platforms.windows-x64-baseline"]
 checksum = "sha256:920a35d71acd10903d2b7e1a7aed420aca9a0fabd34b05a5b4b2bbf8cb6b9201"
 url = "https://github.com/rvben/rumdl/releases/download/v0.2.40/rumdl-v0.2.40-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/rvben/rumdl/releases/assets/485787540"
@@ -1902,7 +2995,16 @@ url = "https://github.com/zizmorcore/zizmor/releases/download/v1.28.0/zizmor-x86
 url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/485211657"
 provenance = "github-attestations"
 
+[tools.zizmor."platforms.linux-x64-baseline"]
+checksum = "sha256:e87b67160194884e375a46a12c57ccc904f762b53845f254fab7f17d98809c09"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.28.0/zizmor-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/485211657"
+provenance = "github-attestations"
+
 [tools.zizmor."platforms.linux-x64-musl"]
+provenance = "github-attestations"
+
+[tools.zizmor."platforms.linux-x64-musl-baseline"]
 provenance = "github-attestations"
 
 [tools.zizmor."platforms.macos-arm64"]
@@ -1917,7 +3019,19 @@ url = "https://github.com/zizmorcore/zizmor/releases/download/v1.28.0/zizmor-x86
 url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/485211652"
 provenance = "github-attestations"
 
+[tools.zizmor."platforms.macos-x64-baseline"]
+checksum = "sha256:40a58d8560d65c71357b3977d0da425773bf8f10bf1ffd38099d963d3afdf3aa"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.28.0/zizmor-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/485211652"
+provenance = "github-attestations"
+
 [tools.zizmor."platforms.windows-x64"]
+checksum = "sha256:06e5b2345323201ed4c55897651862fee3b43f79ddced799f1236f0f0d1c1c0f"
+url = "https://github.com/zizmorcore/zizmor/releases/download/v1.28.0/zizmor-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/485211651"
+provenance = "github-attestations"
+
+[tools.zizmor."platforms.windows-x64-baseline"]
 checksum = "sha256:06e5b2345323201ed4c55897651862fee3b43f79ddced799f1236f0f0d1c1c0f"
 url = "https://github.com/zizmorcore/zizmor/releases/download/v1.28.0/zizmor-x86_64-pc-windows-msvc.zip"
 url_api = "https://api.github.com/repos/zizmorcore/zizmor/releases/assets/485211651"

--- a/mise.toml
+++ b/mise.toml
@@ -70,13 +70,26 @@ aws-cli = { version = "2.36.5", symlink_bins = "true" }
 azure-cli = { version = "2.88.0", uvx_args = "--prerelease=allow" }
 docker-cli = "29.6.2"
 opencode = "1.18.4"
-"npm:@claude-flow/cli" = "3.32.9"
-"npm:@ralph-orchestrator/ralph-cli" = "2.10.1"
+# bun (the npm package_manager) is a host↔image SHARED tool → declared in
+# .config/mise/conf.d/shared.toml, not here (mise-parity: a tool used by both
+# sides lives only in the shared fragment).
+# claude-flow + ralph-cli removed 2026-07-23: superseded by the cross-vendor
+# orchestrator adoption (#346, fable-orchestrator + antigravity), and unused by
+# CI/hk/scripts. Re-add if needed for interactive use.
 
 [settings]
 experimental = true
 auto_install = true
 lockfile = true
+# npm.package_manager = "bun": mise 2026.7.12 made the embedded `aube` manager
+# the npm default, whose supply-chain guards (low-download threshold + stricter
+# dependency resolution) reject several of this repo's pinned npm tools
+# (contextlint 978/wk, agents-lint 714/wk; renovate dep-resolution). Keep the
+# same `bun` manager the image bakes (mise-system.toml) so host/CI/image agree.
+# `bun` is declared in [tools] below so CI installs it, and the setup-mise
+# action installs it BEFORE the npm tools that need it (bare runners have no
+# bun). Opt back into aube once its allow mechanism is a documented mise setting.
+npm.package_manager = "bun"
 # #160 T12.5 (decision 15): new tool requests get exact-pinned versions on
 # `mise use` instead of fuzzy ranges — pins are the repo's whole versioning
 # model. (task.timings from the decision does not exist as a setting in mise


### PR DESCRIPTION
mise 2026.7.12 (released 2026-07-23) made the embedded `aube` package manager
the npm default, whose supply-chain guards (low-download threshold + stricter
dep resolution) reject several of this repo's pinned npm tools. CI's mise was
UNPINNED, so it picked up 2026.7.12 the day it released and broke lint for every
PR + main — no repo change involved. This upgrade adopts 2026.7.12 deliberately
and closes the unpinned-CI gap:

- Pin CI mise to 2026.7.12 in the setup-mise action (jdx/mise-action `version`),
  in lockstep with the Dockerfile ARG. Unpinned CI is why a same-day release
  could break us.
- Dockerfile ARG MISE_VERSION 2026.7.5 -> 2026.7.12.
- npm.package_manager = "bun" in root [settings] — aligns host/CI to the npm
  manager the image already pins (mise-system.toml), sidestepping aube's guard
  for the kept tools (agents-lint, contextlint, renovate). Opt back into aube
  per-tool once its allow mechanism is a documented mise setting (today
  `lowDownloadThreshold`/`--allow-low-downloads` is not in `settings ls --all`).
- Removed npm:@claude-flow/cli + npm:@ralph-orchestrator/ralph-cli — superseded
  by the cross-vendor orchestrator adoption (#346), unused by CI/hk/scripts.
- Regenerated all lockfiles with 2026.7.12: host mise.lock (tools dropped),
  image mise-runtime.lock (latest tools re-resolved on the linux devcontainer,
  pinned mise via the lock-refresh stage/collect recipe). mise-system.lock is
  byte-identical (pinned system tools are format-stable across these versions).

Follow-up (separate PR): adopt `mise lock --bump` + `MISE_SAFE=1` in refresh.yml
to modernize the lock-refresh job (2026.7.12 shipped both). Kept out of this
cold-base-rebuild PR so a rebuild failure stays bisectable.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A5qEkEL6fx1YEBaqR2HxPV
