### PR TITLE
chore(graphify): upgrade 0.9.23 → 0.9.25 + scope gitleaks off graphify-out/

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -21,6 +21,7 @@ paths = [
   '''\.idea/''',
   '''\.logging/''',
   '''\.mise/''',
+  '''graphify-out/''',
   '''__pycache__/''',
   # Documentation with illustrative `token = "..."` examples, not real secrets.
   '''\.github/workflows/AGENTS\.md''',

--- a/hk-common.pkl
+++ b/hk-common.pkl
@@ -34,6 +34,7 @@ excludePaths: List<String> = List(
   ".logging/**",
   ".idea/**",
   ".mise/**",
+  "graphify-out/**",
   "**/__pycache__/**",
 )
 

--- a/mise.lock
+++ b/mise.lock
@@ -2955,7 +2955,7 @@ version = "0.2.2"
 backend = "pipx:deepagents-cli"
 
 [[tools."pipx:graphifyy"]]
-version = "0.9.23"
+version = "0.9.25"
 backend = "pipx:graphifyy"
 
 [tools."pipx:graphifyy".options]

--- a/mise.toml
+++ b/mise.toml
@@ -50,7 +50,7 @@ rtk = "0.43.0"                         # re-probed at #160 T12.5: mise #10703 (2
 # instead appended a SECOND, bare `"pipx:graphifyy" = "0.9.22"` entry, leaving
 # the real pin stranded at 0.9.20. The table form is what the bump path can
 # rewrite in place.
-"pipx:graphifyy" = { version = "0.9.23", extras = ["all"] }
+"pipx:graphifyy" = { version = "0.9.25", extras = ["all"] }
 # ffmpeg: system binary the graphify `video` extra (faster-whisper) needs to
 # extract audio before transcription — it is NOT a pip dep, so `graphifyy[all]`
 # cannot supply it. Host-only, same as graphify (root mise.toml is in the


### PR DESCRIPTION
Upgrade verified empirically before adopting, not on release notes alone.

0.9.25 is a MIT→Apache-2.0 relicense; 0.9.24 adds MCP `token_budget` and a
`claude-cli` structured-output fix (relevant to the #2076 labeling
workaround). Rebuilt the dotfiles graph on the new pin and diffed the
result against a 0.9.23 baseline:

  top-level graph.json keys   identical
  node schema (key union)     identical
  link schema (key union)     identical
  rebuild                     RC=0 (3597 nodes / 5442 edges / 273 communities)

No format break and no forced re-extract: the version-scoped cache holds
AST only (`cache/ast/v0.9.xx`), while LLM extraction lives in committed
`sources/extractions/*.json`, so an upgrade costs a free AST re-parse.

The zero-node warning surfaced by the rebuild is pre-existing, not a
regression — control-armed: the affected JSONC/data files yield 0 nodes on
0.9.23 and 0.9.25 alike. 0.9.25 merely stopped caching empties, so it now
reports what was always true.

gitleaks: add `graphify-out/` to the `.gitleaks.toml` allowlist. That file
is the mechanism that actually runs — its own header documents that the hk
`gitleaks` builtin invokes `gitleaks dir`, which scans the entire working
tree and ignores both the file list hk passes and .gitignore. Confirmed:
`gitleaks dir` accepts one positional path; given 2+ it silently discards
them and scans cwd (1 file → 1.85 KB; 2 files → 45.87 MB). So hk's
`exclude` can never constrain this step. `graphify-out/` was added to
.gitignore later and never propagated to either list; the mirroring entry
in hk-common.pkl keeps the two lists in sync for the builtins that do
consume {{ files }}.

Allowlist proven in both directions with the same synthetic token, varying
only the path: normal path → `leaks found: 1`; inside graphify-out/ → `no
leaks`. Path-scoped, not a blinded scanner.

Gates: lint RC=0 · pytest 877 passed · verify 94 passed, 0 failed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A5qEkEL6fx1YEBaqR2HxPV
