### PR TITLE
fix(guard): make the gh-pr redirects repo-aware instead of repo-blind

### DIFF
--- a/.claude/rules/mise-tasks-only.md
+++ b/.claude/rules/mise-tasks-only.md
@@ -15,6 +15,8 @@ task (wrapping the python library, zero-bash-logic) in the same change.
 | `docker pull …dotfiles-devcontainer…` | `mise run sync` (buildkit, digest-aware, verifying; classic pull wedges on ~38GB) |
 | `gh pr create` (+ push + gates by hand) | `mise run ship` |
 | `gh pr merge` (+ watch + validate by hand) | `mise run land -- <PR#>` |
+| `gh pr create -R …/knowledge-base` | `mise run kb-ship` (in the KB repo) |
+| `gh pr merge -R …/knowledge-base` | `mise run kb-land -- <PR#>` (in the KB repo) |
 | `nohup … mise run <task>` / `mise run <task> &` (hand-detaching a task) | the harness background run — stays tracked, one clean completion (no orphaned process, no hand-rolled log monitor); a `&`-detached Mac-side task gets REAPED when the turn goes idle |
 | `<gate> 2>&1 \| tail -40` (piping a gate command into a pager) | `<gate> > /tmp/out.log 2>&1; echo "rc=$?" >> /tmp/out.log`, then read the file — a pipe returns `tail`'s exit code, masking a failed or killed gate |
 | `gh run watch <id>` (hand-rolled CI wait) | `mise run land -- <PR#>` (watches main CI via --json buckets); one-shot: `gh run view <id> --json conclusion` |
@@ -26,6 +28,20 @@ task (wrapping the python library, zero-bash-logic) in the same change.
 
 Diagnostic/read-only commands (`docker ps`, `gh pr view`, `git status`,
 single-test `pytest path::test` via uv) are NOT wrapped and stay direct.
+
+**The `gh pr` redirects are REPO-AWARE (2026-07-23).** Dispatch is by the
+target repo, resolved from an explicit `-R`/`--repo`: dotfiles (or no `-R`,
+i.e. cwd) → `ship`/`land`; knowledge-base → `kb-ship`/`kb-land`; **any other
+repo → ALLOW**. Allowing the rest is deliberate — no canonical task exists for
+a sibling repo, so a deny would redirect to nothing and merely block real work.
+
+This was a real defect, not a hypothetical: the rules used to match `gh pr
+merge` unconditionally, so a knowledge-base PR was denied and pointed at `mise
+run land` — a *dotfiles* task with no repo parameter that watches dotfiles'
+main CI and re-validates the dotfiles devcontainer. The guard blocked the only
+working command and named a task that could not do the job; KB PRs #1 and #2
+were merged by hand as a result. A guard whose redirect target cannot perform
+the redirected action is not enforcement, it is an outage.
 
 ## Enforcement layers (deep-research verified, 2026-07-07)
 

--- a/python/src/dotfiles_setup/hook_guard.py
+++ b/python/src/dotfiles_setup/hook_guard.py
@@ -104,6 +104,23 @@ _V2 = "2026-07-14"
 # The two evidence-discipline rules (pipe-to-pager, `&`-detachment) landed
 # 2026-07-21 — guardrails 2 and 3 of the session-2026-07-21 handoff.
 _V3 = "2026-07-21"
+# The repo-aware gh-pr rules landed 2026-07-23, once the knowledge-base repo
+# grew its own kb-ship/kb-land to redirect to.
+_V4 = "2026-07-23"
+
+# `gh` names a target repo with `-R owner/repo` / `--repo owner/repo` (or
+# `--repo=owner/repo`); with none, it infers from cwd — which, for a guard
+# running in this repo, means dotfiles. Both fragments are SUFFIXES appended
+# after `gh pr create|merge`, and both scan only to the next shell separator so
+# they cannot read a flag belonging to a later command in a compound.
+_GH_REPO = r"(?:-R|--repo)[=\s]\s*"
+_REPO_RE = r"[\w.-]+/[\w.-]+"
+# "an explicit -R naming the knowledge-base repo appears in this command"
+_GH_REPO_IS_KB = rf"(?=[^;&|\n]*{_GH_REPO}ray-manaloto/knowledge-base\b)"
+# "no explicit -R naming a repo OTHER than dotfiles appears in this command" —
+# so a bare `gh pr create` (cwd = dotfiles) still denies, while a sibling repo's
+# is left alone.
+_GH_REPO_NOT_FOREIGN = rf"(?![^;&|\n]*{_GH_REPO}(?!ray-manaloto/dotfiles\b){_REPO_RE})"
 
 # A GATE command: one whose exit code is the answer you are about to act on.
 # Deliberately NOT every command — `git log | head` is fine, and a rule that
@@ -176,9 +193,47 @@ _RULES: tuple[Rule, ...] = (
         "verifies the result.",
         _V1,
     ),
+    # --- gh pr create/merge: REPO-AWARE (#349 follow-up, 2026-07-23) ---
+    #
+    # These rules used to match `gh pr create|merge` unconditionally, which was
+    # wrong the moment a second repo entered the picture: a knowledge-base PR was
+    # denied and redirected to `mise run land`, a DOTFILES task that has no repo
+    # parameter, watches dotfiles' main CI, and re-validates the dotfiles
+    # devcontainer. The guard blocked the only working command and pointed at a
+    # task that cannot do the job. Measured 2026-07-23 — it is why KB PRs #1 and
+    # #2 had to be merged by hand.
+    #
+    # Dispatch is by TARGET repo, resolved from an explicit `-R`/`--repo`:
+    #   dotfiles (or no -R, i.e. cwd)  -> ship / land
+    #   knowledge-base                 -> kb-ship / kb-land
+    #   any other repo                 -> ALLOW
+    # Allowing the rest is deliberate: no canonical task exists for a sibling
+    # repo, so a deny would redirect to nothing and merely block real work. This
+    # is a redirect guard, not a sandbox (it already fails open on `$(…)`,
+    # `sh -c`, and aliases) — see .claude/rules/mise-tasks-only.md.
+    #
+    # KB rules come FIRST because first match wins; the dotfiles rules carry a
+    # negative lookahead so they do not swallow another repo's `-R`.
+    Rule(
+        "gh pr create (knowledge-base)",
+        re.compile(_CMD + r"gh\s+pr\s+create\b" + _GH_REPO_IS_KB),
+        "Use `mise run kb-ship` (in the knowledge-base repo) — it runs that "
+        "repo's lint+test gates BEFORE pushing, so a red branch never becomes "
+        "a PR. `mise run ship` is a dotfiles task and cannot ship a KB PR.",
+        _V4,
+    ),
+    Rule(
+        "gh pr merge (knowledge-base)",
+        re.compile(_CMD + r"gh\s+pr\s+merge\b" + _GH_REPO_IS_KB),
+        "Use `mise run kb-land -- <PR#>` (in the knowledge-base repo) — it "
+        "verifies the checks, then pins the merge to that verified head SHA. "
+        "`mise run land` is a dotfiles task: no repo parameter, and it watches "
+        "dotfiles' main CI.",
+        _V4,
+    ),
     Rule(
         "gh pr create",
-        re.compile(_CMD + r"gh\s+pr\s+create\b"),
+        re.compile(_CMD + r"gh\s+pr\s+create\b" + _GH_REPO_NOT_FOREIGN),
         "Use `mise run ship` — it runs the path-aware gate matrix (incl. "
         "the hard full-sync gate on devcontainer-surface diffs) before the "
         "PR opens, then watches checks to bucket-verified green. See "
@@ -187,7 +242,7 @@ _RULES: tuple[Rule, ...] = (
     ),
     Rule(
         "gh pr merge",
-        re.compile(_CMD + r"gh\s+pr\s+merge\b"),
+        re.compile(_CMD + r"gh\s+pr\s+merge\b" + _GH_REPO_NOT_FOREIGN),
         "Use `mise run land -- <PR#>` — it verifies check buckets, pins the "
         "merge to the verified head SHA, watches main CI, and validates "
         "locally. See .claude/skills/pr-workflow/SKILL.md.",

--- a/tests/test_hook_guard.py
+++ b/tests/test_hook_guard.py
@@ -213,6 +213,66 @@ def test_pull_rule_does_not_span_separators() -> None:
     assert hook_guard.decide(cmd) is None
 
 
+# --- repo-aware gh pr create/merge (2026-07-23) -----------------------------
+#
+# Before this, `gh pr merge -R ray-manaloto/knowledge-base` was denied and
+# redirected to `mise run land` — a DOTFILES task with no repo parameter that
+# watches dotfiles' main CI. The guard blocked the only working command and
+# named a task that cannot do the job; KB PRs #1 and #2 were hand-merged
+# because of it. Each arm below is paired with its opposite: a dispatch table
+# tested in only one direction proves nothing about the others.
+@pytest.mark.parametrize(
+    ("command", "redirect_hint"),
+    [
+        # No -R at all => cwd => dotfiles. The pre-existing behaviour, pinned so
+        # the new lookahead cannot silently stop denying the common case.
+        ("gh pr create --fill", "mise run ship"),
+        ("gh pr merge 42 --squash", "mise run land"),
+        # Explicit dotfiles target routes the same way.
+        ("gh pr create -R ray-manaloto/dotfiles --fill", "mise run ship"),
+        ("gh pr merge 42 -R ray-manaloto/dotfiles --squash", "mise run land"),
+        ("gh pr merge 42 --repo ray-manaloto/dotfiles", "mise run land"),
+        # knowledge-base target routes to the KB tasks, in all flag spellings.
+        ("gh pr create -R ray-manaloto/knowledge-base --fill", "mise run kb-ship"),
+        ("gh pr merge 3 -R ray-manaloto/knowledge-base --squash", "mise run kb-land"),
+        ("gh pr merge 3 --repo ray-manaloto/knowledge-base", "mise run kb-land"),
+        ("gh pr merge 3 --repo=ray-manaloto/knowledge-base", "mise run kb-land"),
+    ],
+)
+def test_gh_pr_routes_by_target_repo(command: str, redirect_hint: str) -> None:
+    reason = hook_guard.decide(command)
+    assert reason is not None, f"expected a deny for {command!r}"
+    assert redirect_hint in reason
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A sibling repo has no canonical task to redirect to, so denying would
+        # block real work while pointing at nothing. CONTROL ARM for the table
+        # above: the same verbs, allowed purely because of the target repo.
+        "gh pr create -R ray-manaloto/symphony-cpp --fill",
+        "gh pr merge 7 -R ray-manaloto/symphony-cpp --squash",
+        "gh pr merge 7 --repo someone-else/their-repo",
+        "gh pr create --repo=octocat/hello-world --fill",
+    ],
+)
+def test_gh_pr_allowed_for_other_repos(command: str) -> None:
+    assert hook_guard.decide(command) is None, f"expected ALLOW for {command!r}"
+
+
+def test_foreign_repo_lookahead_does_not_span_separators() -> None:
+    r"""A later command's `-R` must not license an earlier dotfiles `gh pr`.
+
+    Without the `[^;&|\n]*` bound, the lookahead would scan past the separator,
+    see a foreign `-R`, and stop denying a genuine dotfiles `gh pr create`.
+    """
+    cmd = "gh pr create --fill && gh issue list -R octocat/hello-world"
+    reason = hook_guard.decide(cmd)
+    assert reason is not None
+    assert "mise run ship" in reason
+
+
 # --- #265: a separator inside an INERT span is not a separator --------------
 #
 # The two shapes below are the guard's ONLY measured false positives, recovered


### PR DESCRIPTION
`gh pr create|merge` matched unconditionally, so a knowledge-base PR was
denied and redirected to `mise run land` — a DOTFILES task with no repo
parameter, which watches dotfiles' main CI and re-validates the dotfiles
devcontainer. The guard blocked the only working command and named a task
that cannot do the job. Not hypothetical: KB PRs #1 and #2 were merged by
hand because of it.

A guard whose redirect target cannot perform the redirected action is not
enforcement, it is an outage.

Dispatch is now by TARGET repo, resolved from an explicit `-R`/`--repo`:

  dotfiles (or no -R, i.e. cwd)  ->  ship / land
  knowledge-base                 ->  kb-ship / kb-land
  any other repo                 ->  ALLOW

Allowing the rest is deliberate. No canonical task exists for a sibling repo,
so a deny would redirect to nothing and merely block real work — and this is a
redirect guard, not a sandbox (it already fails open on `$(…)`, `sh -c`, and
aliases). This preserves the dependency direction: dotfiles may know about the
knowledge-base, never the reverse.

The KB rules are ordered FIRST (first match wins) and the dotfiles rules carry
a negative lookahead so they do not swallow another repo's `-R`. That lookahead
is bounded to `[^;&|\n]*` so a LATER command's `-R` cannot license an earlier
dotfiles `gh pr` — pinned by its own test, since an unbounded version would
silently stop denying the common case.

16 new tests, each arm paired with its opposite: a dispatch table tested in
only one direction proves nothing about the others. Verified end-to-end
through the wired guard, not just the pure function — the exact command that
was wrongly denied now redirects to `kb-land`, dotfiles still redirects to
ship/land, a sibling repo is allowed, and an unrelated command stays allowed.

Gates: lint rc=0 · pytest 893 passed · verify 94 passed, 0 failed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A5qEkEL6fx1YEBaqR2HxPV
