### PR TITLE
docs/correct false claims

### DIFF
--- a/.agnix.toml
+++ b/.agnix.toml
@@ -43,7 +43,7 @@ max_files_to_validate = 10000
 #  - AGM-006: the deliberate nested-AGENTS.md hierarchy (enforced by the
 #    claude_agents_md_pairs hk step).
 #  - AGM-004: these files carry project context without a literal
-#    "## Project Context" header, and are at the 200-line claude_md_size_limit.
+#    "## Project Context" header, and are at the 200-line md_size_budget cap.
 #  - PE-001: "critical keyword in the 40-60% lost-in-middle zone" is a prompt
 #    heuristic that misfires on reference docs.
 # CONTEXT.md joins them (2026-07-15): it is the domain glossary the mattpocock

--- a/.claude/rules/ai-cli-invocation.md
+++ b/.claude/rules/ai-cli-invocation.md
@@ -73,5 +73,16 @@ Codex or Gemini. For background tasks, use:
 
 ## Reference
 
-The octopus `orchestrate.sh` (lib/dispatch.sh + lib/spawn.sh) has the canonical
-invocation patterns. When in doubt, check `get_agent_command()` in dispatch.sh.
+**The patterns above ARE the reference — there is no script to consult.** This
+section used to point at the octopus `orchestrate.sh` / `get_agent_command()`.
+That file does not exist in this repo (control-armed: `find . -name
+orchestrate.sh` → 0, while `find . -maxdepth 1 -name hk-common.pkl` → 1, so the
+probe discriminates); it lives only inside the `octo@nyldn-plugins` plugin
+cache, which is `false` in BOTH `.claude/settings.json` and
+`~/.claude/settings.json` and may vanish on plugin GC. A reader could not act
+on it.
+
+When a pattern here looks wrong, **re-probe the CLI itself** (`codex exec
+--help`, `gemini --help`) rather than hunting for a canonical script — these
+flags change between releases, which is how the wrong forms above got
+documented in the first place.

--- a/.claude/rules/ci-local-parity.md
+++ b/.claude/rules/ci-local-parity.md
@@ -23,7 +23,7 @@ If the CI step has no local equivalent, add one to hk.pkl before committing.
 
 When adding a new hk step with a `check` command, verify the tool binary
 is listed in the repo's merged mise config — `mise.toml` [tools] OR the
-shared fragment `.config/mise/conf.d/shared.toml` (the 20 host↔image tools;
+shared fragment `.config/mise/conf.d/shared.toml` (the host↔image tools;
 epic #160 T5). mise merges `<repo>/.config/mise/conf.d/*.toml` into the
 project config, so CI's `mise install` (run with cwd at the repo root)
 installs both — parity holds. What must NOT be relied on is a tool present

--- a/.claude/rules/research-doc-sources.md
+++ b/.claude/rules/research-doc-sources.md
@@ -37,13 +37,26 @@ worked.
    chrome, no JS). Use this once step 1 has told you which page you
    want. This is the primary per-page fetch for mintlify content.
 
-3. **`ctx7` / `/context7-cli` skill** — for libraries whose docs live
-   outside mintlify, or for libraries where `llms.txt`/`.md` doesn't
-   cover what you need. Invoked via the `/context7-cli` skill. Note:
-   the `ctx7` binary itself is a skill-management CLI
-   (subcommands `skills`/`login`/`whoami`/`setup`), not a direct
-   doc-fetcher — the actual doc retrieval happens through the skill
-   wrapper. See `.claude/skills/context7-cli/SKILL.md`.
+3. **`ctx7`** — for libraries whose docs live outside mintlify, or where
+   `llms.txt`/`.md` doesn't cover what you need. It is a **direct
+   doc-fetcher**; call it straight, in two steps:
+
+   ```bash
+   ctx7 library <name> [query]        # resolve a name -> Context7 library ID
+   ctx7 docs <libraryId> <query>      # fetch the docs
+   ```
+
+   Corrected 2026-07-23: this step used to say `ctx7` was "a
+   skill-management CLI … **not** a direct doc-fetcher", routing every
+   lookup through a skill wrapper that adds nothing. Verified against
+   `ctx7 --help` (0.5.5, the `mise.toml` pin): the documented commands are
+   `login/logout/whoami/setup/remove/library/docs/upgrade`.
+
+   The `skills` subcommands still *run* (`ctx7 skills list` → rc=0) but are
+   **hidden from `--help` and deprecated** — "Skill commands are deprecated
+   and will stop working in the next major release." So do not build on
+   them, and do not treat their absence from `--help` as proof they are
+   gone. `.claude/skills/context7-cli/SKILL.md` remains the setup reference.
 
 4. **Raw HTML fetch** (`curl <url>` or `npx @teng-lin/agent-fetch <url>`) —
    **last resort only.** Pays the full HTML-parse cost in agent

--- a/.claude/rules/tool-currency-and-native-first.md
+++ b/.claude/rules/tool-currency-and-native-first.md
@@ -91,7 +91,7 @@ this natively now?" surface area.
 
 Partially machine-backed, not fully automatable (judgment is required):
 
-- **hk cross-file version-parity** (planned check-H): asserts `hk@<ver>` is
+- **hk cross-file version-parity** (`hk_version_parity` in `hk.pkl` — SHIPPED): asserts `hk@<ver>` is
   identical across `hk.pkl` / `hk-common.pkl` / `hk-image.pkl` and matches the
   `mise.toml` binary pin — catches pin drift that this rule would otherwise
   catch by hand.

--- a/.claude/rules/tool-currency-and-native-first.md
+++ b/.claude/rules/tool-currency-and-native-first.md
@@ -72,7 +72,7 @@ getting a *weaker* result (version-only vs sha256-verified) than the native path
    decoupling a cache tier, bumping a pinned version, or swapping custom→native
    goes stale in `P2996-CACHE.md`, the `AGENTS.md` files, isolation wikis, and
    skill files. Update them in the same commit — respecting
-   `claude_md_size_limit` / `claude_agents_md_pairs` / `claude_md_import_stub`.
+   `md_size_budget` / `claude_agents_md_pairs` / `claude_md_import_stub`.
 
 6. **Justify any custom code that survives the check, in writing.** If a native
    feature exists but is genuinely insufficient (rule 4's `get_env()` case),

--- a/.claude/skills/clear-prep/SKILL.md
+++ b/.claude/skills/clear-prep/SKILL.md
@@ -113,10 +113,14 @@ reflected in docs), find and update every affected doc. Walk these in order:
    (validation-addition J, epic #160 T13) supersedes this loop once landed.
 
 **Constraints (machine-enforced — respect or the gate fails):**
-- `CLAUDE.md` / `AGENTS.md` files have a **200-line / 12,000-char hard
-  limit** (`claude_md_size_limit` hk step; char half machine-enforced from
-  #160 T13). Check BOTH (`wc -l` and `wc -c`); when a file sits at or near
-  either limit, record in the handoff which future edit must trim. Any
+- Markdown size is **class-aware** — see `.claude/rules/md-size-budgets.md`
+  for the table (hk step **`md_size_budget`**, which replaced the retired
+  `claude_md_size_limit`). An `AGENTS.md` additionally carries agnix
+  AGM-003's 12,000-char cap — **Windsurf's rule, not Anthropic's** — which
+  binds first. Do NOT restate a flat "200-line / 12,000-char" limit: that
+  misattribution is exactly what `md-size-budgets.md` exists to kill.
+  Verify with `mise run lint` + `mise run lint-docs`; when a file sits near
+  a limit, record in the handoff which future edit must trim. Any
   addition needs an offsetting trim — prefer collapsing duplication to a
   pointer (rule files / `action.yml` / other docs are the authority) over
   deleting load-bearing facts. Long single-line table rows are more
@@ -225,8 +229,8 @@ resumes from the handoff."*
 - [ ] Session-INDEPENDENT autonomous processes (running GHA runs, Renovate PRs) inventoried in the handoff — NOT waited/blocked on; `main` noted as bot-advanced.
 - [ ] Every doc affected by this session's changes updated; cross-refs grep-clean.
 - [ ] Repo-wide doc-ref sweep run (step 2.5); every MISSING hit fixed or justified in place.
-- [ ] `CLAUDE.md`/`AGENTS.md` files ≤ 200 lines AND ≤ 12,000 chars; at-limit files flagged in the handoff.
-- [ ] Every findings-bearing agent report persisted verbatim under `.omc/research/`; coverage audited.
+- [ ] `mise run lint` + `mise run lint-docs` green (class-aware `md_size_budget` + agnix AGM-003); at-limit files flagged in the handoff.
+- [ ] Every findings-bearing agent report persisted verbatim under `.omc/kb/reports/agents/`; coverage audited.
 - [ ] Durable memory written + `MEMORY.md` pointer added.
 - [ ] Local handoff written under `.omc/plans/` and self-verified (paths, file:line, task names, gate rcs).
 - [ ] Relevant local gate green; doc commit made (if appropriate).

--- a/.claude/skills/context7-cli/SKILL.md
+++ b/.claude/skills/context7-cli/SKILL.md
@@ -5,19 +5,22 @@ description: Use when the user mentions "ctx7" or "context7", needs current docs
 
 # ctx7 CLI
 
-The Context7 CLI does three things: fetches up-to-date library documentation, manages AI coding skills, and sets up Context7 MCP for your editor.
+The Context7 CLI fetches up-to-date library documentation and sets up Context7 MCP for your editor. It also still carries **deprecated** skill-management commands (see the caveat below).
 
-Make sure the CLI is up to date before running commands:
-
-```bash
-npm install -g ctx7@latest
-```
-
-Or run directly without installing:
+**In this repo `ctx7` is mise-pinned — do NOT `npm install -g` or `npx` it.** The pin is `"npm:ctx7"` in `mise.toml`; `.claude/rules/ci-local-parity.md` rule 3 bans `npx` because it bypasses mise and can resolve a different version than CI. Just call the binary:
 
 ```bash
-npx ctx7@latest <command>
+ctx7 library <name> [query]     # resolve a name -> Context7 library ID
+ctx7 docs <libraryId> <query>   # fetch the docs
 ```
+
+To move the version, bump the `mise.toml` pin (Renovate does this) — not `@latest`.
+
+> ⚠️ **The `ctx7 skills …` commands are DEPRECATED.** They are hidden from
+> `--help` but still execute, printing *"Skill commands are deprecated and will
+> stop working in the next major release."* (verified on the pinned 0.5.5, rc=0).
+> Treat the sections below that use them as historical; do not build on them.
+> Note their absence from `--help` is NOT proof they are gone — they run.
 
 ## What this skill covers
 

--- a/.claude/skills/devcontainer-workflow/SKILL.md
+++ b/.claude/skills/devcontainer-workflow/SKILL.md
@@ -20,10 +20,10 @@ The user-facing workflow is `mise run up` → work inside → `mise run down`.
 
 ```bash
 mise run build   # docker buildx bake dev-load (build base image locally)
-mise run up      # devcontainer up --workspace-folder . (pinned @devcontainers/cli 0.85.0)
+mise run up      # devcontainer up --workspace-folder . (CLI pinned in mise.toml)
 mise run down    # alias of `mise run stop` — tears the container down
 mise run stop    # docker rm -f filtered on devcontainer.local_folder=$PWD
-                 # (devcontainer CLI v0.85.0 has no `down` verb)
+                 # (the devcontainer CLI has no `down` verb)
 mise run test          # uv run --project python pytest tests/ -x -q (HOST tests)
 mise run pre-commit    # hk run pre-commit --all
 ```

--- a/.devcontainer/mise-system.toml
+++ b/.devcontainer/mise-system.toml
@@ -29,7 +29,7 @@ java = "latest"
 deno = "latest"
 ruby = "latest"
 cargo-binstall = "latest"
-# The 20 tools shared with the host (hk, pkl, gitleaks, chezmoi, python, uv,
+# The tools shared with the host (hk, pkl, gitleaks, chezmoi, python, uv,
 # pixi, pinact, and the linters) come from .config/mise/conf.d/shared.toml,
 # COPYd to /usr/local/share/mise/conf.d/ and merged into this system config —
 # exact-pinned so host and image never drift. See epic #160 T5.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ the official `@devcontainers/cli` (pinned in `mise.toml`).
 
 | File | Purpose |
 |------|---------|
-| `mise.toml` + `.config/mise/conf.d/shared.toml` | Host tool versions + tasks; the 20 tools shared with the image (hk, pkl, linters, python, uv, chezmoi) live in the exact-pinned shared fragment both host and image merge (#160 T5) |
+| `mise.toml` + `.config/mise/conf.d/shared.toml` | Host tool versions + tasks; the tools shared with the image (hk, pkl, linters, python, uv, chezmoi, bun) live in the exact-pinned shared fragment both host and image merge (#160 T5) |
 | `mise.lock` | Locked tool versions for reproducible installs |
 | `mise.local.toml` | Gitignored per-clone overrides (e.g., `BASE_IMAGE`). See `mise.local.toml.example` |
 | `hk.pkl` | Project git hook config; imports `hk-common.pkl`; enforces `no_lint_skip`, `require_pipefail`, `bash_logic_budget`, `claude_md_import_stub`, `claude_agents_md_pairs` |
@@ -56,7 +56,7 @@ the official `@devcontainers/cli` (pinned in `mise.toml`).
 | `.claude/` | Claude-specific agents, skills, rules. Has its own `CLAUDE.md` (exempt from the stub check) |
 | `home/` | Chezmoi-managed dotfile templates (its AGENTS.md was removed in #80) |
 | `python/` | Python package `dotfiles_setup` — see `python/AGENTS.md` |
-| `tests/` | Pytest + Bats test suite (775 pytest tests) — see `tests/AGENTS.md` |
+| `tests/` | Pytest + Bats test suite — see `tests/AGENTS.md` |
 | `scripts/` | Utility scripts (`benchmark-docker.sh`, `devcontainer-smoke.sh`) |
 | `docs/` | Documentation, research findings, design specs |
 
@@ -86,7 +86,7 @@ content-hashed since hk 1.47 — no manual cache clearing after edits.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q               # All 775 tests
+uv run --project python pytest tests/ -x -q               # Run the test suite
 uv run --project python pytest tests/test_audit.py -x -q  # Single file
 mise run lint                                             # Lint checks only (hk under a hard timeout)
 mise run verify                                 # Verification contracts (suites.toml)

--- a/hk-common.pkl
+++ b/hk-common.pkl
@@ -17,13 +17,28 @@
 import "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Builtins.pkl"
 import "package://github.com/jdx/hk/releases/download/v1.52.0/hk@1.52.0#/Config.pkl"
 
-// #154: shared `exclude` list for ALL builtin linters — third-party cached
-// docs, generated research artifacts, and gitignored local tool caches (not
-// first-party source). Defined once here and referenced by BOTH hk.pkl (host)
-// and hk-image.pkl (in-image, used by the devcontainer smoke) so they can't
-// drift — a drift is exactly what broke the in-container smoke when hk.pkl had
-// the exclude but hk-image.pkl did not. `gitleaks dir` ignores .gitignore, so
-// the gitignored caches must be listed explicitly.
+// #154: shared `exclude` list for the builtin linters that CONSUME `{{files}}`
+// — third-party cached docs, generated research artifacts, and gitignored local
+// tool caches (not first-party source). Defined once here and referenced by BOTH
+// hk.pkl (host) and hk-image.pkl (in-image, used by the devcontainer smoke) so
+// they can't drift — a drift is exactly what broke the in-container smoke when
+// hk.pkl had the exclude but hk-image.pkl did not.
+//
+// ⚠️ THIS LIST DOES NOT CONSTRAIN `gitleaks`. Corrected 2026-07-23; the previous
+// comment ("`gitleaks dir` ignores .gitignore, so the gitignored caches must be
+// listed explicitly") was read as meaning an entry HERE stops gitleaks scanning
+// a path. It never did. The builtin runs `gitleaks dir … {{ files }}`, and
+// `gitleaks dir` takes only ONE positional path: measured on gitleaks 8.30.1,
+// one file scans that file (1.85 KB), while TWO OR MORE files are silently
+// discarded and it scans the whole cwd instead (45.87 MB) — gitignored dirs
+// included. So gitleaks never reads this list at all, and the other entries look
+// effective only because they happen to hold nothing it flags.
+//
+// gitleaks is scoped by its OWN config, `.gitleaks.toml` (whose header states
+// this correctly). The two lists are kept mirrored on purpose: add a path to
+// BOTH, and expect only the `.gitleaks.toml` half to affect secret scanning.
+// A path that is gitignored AND untracked (e.g. graphify-out/) is invisible to
+// the `{{files}}` builtins anyway — its entry here is for symmetry, not effect.
 excludePaths: List<String> = List(
   "docs/research/mintlify-cache/**",
   "docs/research/trail/findings/**",

--- a/mise.toml
+++ b/mise.toml
@@ -17,8 +17,8 @@ lima = "2.2.0"
 biome = "2.5.5"
 # Markdown + Claude-docs linters. Installed now; hk.pkl integration is
 # scheduled for post-devcontainer-work review (see GH issue tracking
-# follow-up). claude_md_size_limit (below in hk.pkl) provides the
-# immediate 200-line enforcement per Claude Code memory docs.
+# follow-up). md_size_budget (below in hk.pkl) provides the immediate,
+# class-aware enforcement — see .claude/rules/md-size-budgets.md.
 "npm:claude-code-lint" = "0.7.0"
 "npm:@contextlint/cli" = "1.1.1"
 "npm:markdownlint-cli2" = "0.23.1"

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 # These are Build Type 1 tools: run locally before commits
 
 [tools]
-# The 20 tools shared with the devcontainer image live in
+# The tools shared with the devcontainer image live in
 # .config/mise/conf.d/shared.toml — the single exact-pinned source both this
 # host config and .devcontainer/mise-system.toml merge, so they never drift
 # (Renovate bumps that one file). See epic #160 T5. Below: host-ONLY tools.

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -39,7 +39,7 @@ Requires **Python 3.14**.
 ## Testing
 
 ```bash
-uv run --project python pytest tests/ -x -q                # All 775 tests
+uv run --project python pytest tests/ -x -q                # Run the test suite
 uv run --project python pytest tests/test_audit.py -x -q   # Single file
 ```
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -22,7 +22,7 @@ It is referenced, NOT `@import`ed: agnix rejects `@import` in an `AGENTS.md`
 requires every non-`.claude/` `CLAUDE.md` be solely `@AGENTS.md`. So the index
 is on-demand reference — which is what it should be anyway.
 
-Total: **775 pytest tests** run by default (`pytest tests/` collects all
+Total: **893 pytest tests** run by default (`pytest tests/` collects all
 `test_*.py` files) plus **4 gated `image_exec`** exec tests (deselected by
 default; run via `mise run smoke-exec`) and Bats scenarios under `infra/`.
 


### PR DESCRIPTION
- **docs: correct false and stale claims in the instruction surface**
- **docs: drop drifted counts, fix stale pins, and remove an unreachable reference**
- **docs: correct the ctx7 doc-fetch chain (and mark its deprecated commands)**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project guidance for Markdown size budgets, shared tooling, local/CI parity, and test-suite instructions.
  * Clarified Context7 CLI usage, including pinned installation guidance and deprecated command behavior.
  * Documented devcontainer lifecycle commands and corrected related workflow references.
  * Updated test documentation to reflect the current suite size of 893 tests.
  * Corrected references to report locations and available tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->