### PR TITLE
fix/doc ref coverage and stale rule

### DIFF
--- a/.claude/rules/tool-currency-and-native-first.md
+++ b/.claude/rules/tool-currency-and-native-first.md
@@ -28,9 +28,12 @@ in the devcontainer build-input program:
   lockfile tier**, and native conda locking remains open upstream
   (`jdx/mise#7700`). This is itself a case of "docs/assumption lag code": the
   assumption that conda had reached lockfile parity did not survive probing.
-  **Do NOT retire `mise_snapshot.py` / the snapshot machinery on the conda-lock
-  basis** — until `#7700` closes and a probe confirms `sha256` in the lockfile,
-  the snapshot is the only sha-verified capture we have.
+  **The snapshot machinery is nonetheless GONE** — `mise_snapshot.py` was
+  deleted in `352063a` (#160 T4–T13). This rule told readers "do NOT retire" it
+  for ~2 weeks after it had already been retired, while the
+  `tool-currency-check` skill said "RETIRED in #160 T1" — two docs, opposite
+  claims, neither checked. Corrected 2026-07-24; the durable fact is the conda
+  gap, not the file.
 - **`minimum_release_age` / `lockfile` / `lockfile_platforms`** are native — no
   custom cooldown or platform-scoping machinery needed.
 - **Renovate's native `mise` manager + the `github>jdx/renovate-config` preset**

--- a/.claude/skills/clear-prep/SKILL.md
+++ b/.claude/skills/clear-prep/SKILL.md
@@ -97,20 +97,30 @@ reflected in docs), find and update every affected doc. Walk these in order:
    (`.claude/rules/research-repo-enumeration.md`).
 4. **Issue / epic checklists** on GitHub — tick boxes, file follow-ups,
    cross-link (`gh issue edit`, `gh issue comment`).
-5. **Doc-ref integrity — repo-wide, NOT just this session's diff.** Stale
-   refs predating the session escape the diff-scoped greps above (a deleted
-   file's mentions can linger for months — the `home/AGENTS.md` case,
-   deleted in PR #80, found 2026-07-05). Verify every backtick path ref in
-   the agent docs resolves:
-   ```bash
-   git grep -hoE '`[A-Za-z0-9_./-]+\.(md|sh|py|toml|pkl|yml|yaml|json|hcl|lock)`' \
-     -- 'AGENTS.md' 'CLAUDE.md' '*/AGENTS.md' '.claude/rules' '.claude/skills' \
-     | tr -d '`' | sort -u | while read -r p; do [ -e "$p" ] || echo "MISSING: $p"; done
-   ```
-   Judge each MISSING hit: fix the ref, or confirm it is intentionally
-   absent (container path, gitignored, planned file) and make the citing
-   doc say so. Machine gate: `dotfiles-setup check-doc-refs` + hk step
-   (validation-addition J, epic #160 T13) supersedes this loop once landed.
+5. **Doc-ref integrity — machine-gated; do NOT hand-roll a grep sweep.**
+   Stale refs predating the session escape the diff-scoped greps above (a
+   deleted file's mentions can linger for months — the `home/AGENTS.md` case,
+   deleted in PR #80, found 2026-07-05). That sweep is now the **`doc_refs`
+   hk step** (`dotfiles-setup check-doc-refs`, logic in
+   `python/src/dotfiles_setup/doc_refs.py`, pinned by `tests/test_doc_refs.py`),
+   so `mise run lint` already covers it — nothing extra to run here.
+
+   **This step used to print an ad-hoc `git grep | while read` loop, and it
+   was retired 2026-07-24 because it was actively misleading**: it matched
+   bare basenames and reported **~120 false MISSING hits** in one run (a
+   `.claude/rules/*.md` "see also" cites `do-not.md`, which resolves at
+   `.claude/rules/do-not.md`). Filtering by "does this basename exist anywhere
+   in `git ls-files`" still left 58, nearly all legitimately external —
+   container paths, gitignored artifacts, memory files living outside the
+   repo, illustrative examples. Exactly one was real. The checker encodes all
+   of that as `_ALLOWED_ABSENT`, each entry justified; the loop encoded none
+   of it. A sweep whose output is ~99% noise does not get read.
+
+   So: if `mise run lint` is green, doc refs are clean. When the gate DOES
+   fire, judge the hit — fix the ref, or add a justified `_ALLOWED_ABSENT`
+   entry (prefer fixing). Widening the checker's scope is a `DOC_PATHSPECS`
+   change plus a coverage assertion in `tests/test_doc_refs.py`; do not
+   re-add a manual loop.
 
 **Constraints (machine-enforced — respect or the gate fails):**
 - Markdown size is **class-aware** — see `.claude/rules/md-size-budgets.md`

--- a/python/src/dotfiles_setup/doc_refs.py
+++ b/python/src/dotfiles_setup/doc_refs.py
@@ -64,6 +64,14 @@ _NON_PATH_CHARS = re.compile(r"[\s*{}<>$()|\"'=@!,;]")
 DOC_PATHSPECS = (
     "AGENTS.md",
     "**/AGENTS.md",
+    # The ONLY CLAUDE.md carrying real content: the root one is locked
+    # byte-exactly to `@AGENTS.md` (claude_md_import_stub) and every subdir
+    # CLAUDE.md is the same one-line stub, so `**/CLAUDE.md` would add only
+    # stubs. `.claude/CLAUDE.md` is stub-EXEMPT precisely so Claude-specific
+    # config can live there — including the fable-orchestrator trigger whose
+    # absence went undetected for an unknown number of sessions (#354). An
+    # uncovered file is exactly where the next stale ref hides.
+    ".claude/CLAUDE.md",
     ".claude/rules/*.md",
     ".claude/skills/*/SKILL.md",
     # graphify's vendored SKILL.md cites its own runtime files

--- a/python/src/dotfiles_setup/doc_refs.py
+++ b/python/src/dotfiles_setup/doc_refs.py
@@ -130,6 +130,12 @@ _ALLOWED_ABSENT = frozenset(
         # refuted the stale issue #959. Neither is ours to track.
         "install.py",
         "llm.py",
+        # graphify's generated graph, cited by `.claude/CLAUDE.md` as the thing
+        # to query before grepping. `graphify-out/` is gitignored and rebuilt
+        # per-clone, so it exists locally and never in CI — the divergence that
+        # failed PR #359's first run. Same rationale as the vendored graphify
+        # SKILL.md exclusion in DOC_PATHSPECS.
+        "graphify-out/graph.json",
         # Documented-retired files (docs narrate the retirement).
         "install.sh",
         "mise-system-resolved.json",
@@ -216,6 +222,47 @@ def _is_allowlisted(ref: str) -> bool:
     if ref in _ALLOWED_ABSENT:
         return True
     return any(ref.startswith(prefix) for prefix in _ALLOWED_PREFIXES)
+
+
+def find_local_only_refs(repo_root: Path) -> list[UnresolvedRef]:
+    """Return refs that resolve ONLY because the file exists on THIS machine.
+
+    :func:`find_unresolved_refs` accepts a ref when ``(repo_root / ref).exists()``,
+    which is a filesystem stat — so a **gitignored** artifact present locally
+    resolves here and vanishes in a fresh CI checkout. That is a silent
+    local/CI divergence of exactly the shape `.claude/rules/clean-git-state.md`
+    exists to prevent, and it shipped one: adding `.claude/CLAUDE.md` to
+    :data:`DOC_PATHSPECS` passed locally and failed CI on its
+    ``graphify-out/graph.json`` citation (PR #359).
+
+    A ref is local-only when it exists on disk but is neither a tracked file nor
+    a directory containing one. Callers should require every such ref to be
+    allowlisted; the test suite pins that, so the divergence fails locally
+    instead of in CI.
+    """
+    all_tracked = _tracked_files(repo_root, ("*",))
+    tracked = set(all_tracked)
+    local_only: list[UnresolvedRef] = []
+    top_level = frozenset(p.split("/", 1)[0] for p in all_tracked)
+    for doc in _tracked_files(repo_root, DOC_PATHSPECS):
+        text = (repo_root / doc).read_text()
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            for span in _SPAN_RE.findall(line):
+                if not _is_path_candidate(span, top_level):
+                    continue
+                ref = _LINE_SUFFIX_RE.sub("", span)
+                if _is_allowlisted(ref) or not (repo_root / ref).exists():
+                    continue
+                # `git ls-files` never emits a leading "./", but docs write it
+                # (do-not.md contrasts `./CLAUDE.md` with `~/.claude/CLAUDE.md`).
+                # Without this, three tracked files read as local-only.
+                bare = ref.removeprefix("./")
+                if bare in tracked:
+                    continue
+                if any(p.startswith(bare + "/") for p in all_tracked):
+                    continue
+                local_only.append(UnresolvedRef(doc=doc, line=lineno, ref=ref))
+    return local_only
 
 
 def find_unresolved_refs(repo_root: Path) -> list[UnresolvedRef]:

--- a/tests/test_doc_refs.py
+++ b/tests/test_doc_refs.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from dotfiles_setup.doc_refs import _is_path_candidate, find_unresolved_refs
+from dotfiles_setup.doc_refs import (
+    DOC_PATHSPECS,
+    _is_path_candidate,
+    _tracked_files,
+    find_unresolved_refs,
+)
 
 _TOP = frozenset({".devcontainer", ".claude", "python", "tests", "docs", "home"})
 
@@ -39,3 +44,27 @@ def test_real_tree_has_zero_unresolved_refs() -> None:
     """The repo's own docs must stay reference-clean — this is the gate."""
     unresolved = find_unresolved_refs(Path(__file__).parent.parent)
     assert unresolved == [], [f"{r.doc}:{r.line}: {r.ref}" for r in unresolved]
+
+
+def test_scope_covers_every_doc_with_real_content() -> None:
+    """Pin WHICH files the gate reads, not just that they are clean.
+
+    The zero-unresolved test above passes just as happily when a file is
+    silently out of scope, so it cannot detect a coverage hole on its own —
+    the control arm this suite's own `tests/AGENTS.md` demands.
+
+    `.claude/CLAUDE.md` is the case that matters: it is the only `CLAUDE.md`
+    with real content (the root one is locked byte-exactly to `@AGENTS.md` by
+    `claude_md_import_stub`, and every subdir one is that same stub), it is
+    stub-EXEMPT so Claude-specific config lives there, and it is where the
+    fable-orchestrator trigger sits — the declaration whose absence went
+    undetected and opened #354. It was outside `DOC_PATHSPECS` until
+    2026-07-24.
+    """
+    scanned = set(_tracked_files(Path(__file__).parent.parent, DOC_PATHSPECS))
+    assert ".claude/CLAUDE.md" in scanned
+    assert "AGENTS.md" in scanned
+    assert "python/AGENTS.md" in scanned
+    # The vendored graphify skill is excluded on purpose (it cites its own
+    # generated runtime files); keep that exclusion honest.
+    assert ".claude/skills/graphify/SKILL.md" not in scanned

--- a/tests/test_doc_refs.py
+++ b/tests/test_doc_refs.py
@@ -8,6 +8,7 @@ from dotfiles_setup.doc_refs import (
     DOC_PATHSPECS,
     _is_path_candidate,
     _tracked_files,
+    find_local_only_refs,
     find_unresolved_refs,
 )
 
@@ -68,3 +69,20 @@ def test_scope_covers_every_doc_with_real_content() -> None:
     # The vendored graphify skill is excluded on purpose (it cites its own
     # generated runtime files); keep that exclusion honest.
     assert ".claude/skills/graphify/SKILL.md" not in scanned
+
+
+def test_no_doc_ref_resolves_only_on_this_machine() -> None:
+    """Fail HERE when a doc cites a gitignored file, not in CI.
+
+    `find_unresolved_refs` accepts a ref via a filesystem stat, so an artifact
+    that is present locally and gitignored resolves on a dev box and vanishes
+    in a fresh checkout. That is not hypothetical: adding `.claude/CLAUDE.md`
+    to `DOC_PATHSPECS` passed every local gate and then failed CI on its
+    `graphify-out/graph.json` citation (PR #359) — the exact local/CI
+    divergence `.claude/rules/clean-git-state.md` exists to prevent.
+
+    Every such ref must be a justified `_ALLOWED_ABSENT` entry, which is a
+    reviewable diff, rather than an accident of one machine's working tree.
+    """
+    local_only = find_local_only_refs(Path(__file__).parent.parent)
+    assert local_only == [], [f"{r.doc}:{r.line}: {r.ref}" for r in local_only]


### PR DESCRIPTION
- **fix(rules): tool-currency rule told readers not to retire a deleted file**
- **fix(doc-refs): cover .claude/CLAUDE.md and retire clear-prep's manual sweep**
