### PR TITLE
chore(claude): enable the skill-creator plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -71,7 +71,7 @@
     "typescript-lsp@claude-plugins-official": false,
     "claude-md-management@claude-plugins-official": false,
     "commit-commands@claude-plugins-official": true,
-    "skill-creator@claude-plugins-official": false,
+    "skill-creator@claude-plugins-official": true,
     "claude-code-setup@claude-plugins-official": false,
     "pyright-lsp@claude-plugins-official": false,
     "pyright@claude-code-lsps": false,
@@ -106,10 +106,16 @@
   },
   "extraKnownMarketplaces": {
     "fable-orchestrator": {
-      "source": { "source": "github", "repo": "mar3co/fable-orchestrator" }
+      "source": {
+        "source": "github",
+        "repo": "mar3co/fable-orchestrator"
+      }
     },
     "antigravity-for-claude-code": {
-      "source": { "source": "github", "repo": "yuting0624/antigravity-for-claude-code" }
+      "source": {
+        "source": "github",
+        "repo": "yuting0624/antigravity-for-claude-code"
+      }
     }
   },
   "prefersReducedMotion": true


### PR DESCRIPTION
Ray enabled `skill-creator@claude-plugins-official` this session. It is needed
for #354's eval target (d) -- "skills fire when they should" -- whose measurement
loop is the skill-creator eval flow that `.claude/skills/kb-curator/SKILL.md`
already references but that we have never run.

The `extraKnownMarketplaces` hunk is Claude Code re-serialising the two
single-line `source` objects across multiple lines; no semantic change (same
two GitHub marketplaces, same repos).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XrjcvNq2VLuq5NhB6pdUaz
