### PR TITLE
feat/eval runner tier1

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -885,6 +885,17 @@ description = "Assert the declared cross-repo shared set (parity.toml) holds in 
 # python/src/dotfiles_setup/parity.py for why that asymmetry is the point.
 run = "uv run --project python dotfiles-setup parity"
 
+[tasks.eval]
+description = "Tier-1 eval: does what we DECLARE actually RESOLVE? (offline, gated; `-- --live` adds the lane doctor)"
+# Tier 0 is suites.toml (`orchestration.*` / `eval.*`) — is it DECLARED? This is
+# tier 1 — does it RESOLVE? Different questions: a lane can be named in doctrine,
+# in both repos, with a passing contract, while its CLI is absent (#354).
+# Offline by default so it joins the ship gates for free. `--live` shells out to
+# the fable-orchestrator plugin's doctor.sh, which has NO offline mode and spends
+# one real API call per installed lane. Runner is the SHARED kb_setup.evals;
+# this repo's cases are dotfiles_setup.eval_cases.
+run = "uv run --project python dotfiles-setup eval"
+
 [tasks.lint-docs]
 description = "Validate agent documentation"
 # --strict: warnings-as-errors (#250) — parity with ci.yml + the hk agnix step.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     # neither repo has tags, so a SHA is the only stable pin. Renovate's git-refs
     # datasource bumps this the same way it bumps CLANG_P2996_REF. Dependency
     # direction is dotfiles → KB only; the KB never learns about its consumers.
-    "kb-setup @ git+https://github.com/ray-manaloto/knowledge-base@aa57cfa5d659de9a1f22146abd7b3eac14c71bd3",
+    "kb-setup @ git+https://github.com/ray-manaloto/knowledge-base@bc69caa769fde443542e6893f8a5075beb5ae55b",
 ]
 
 [project.scripts]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,13 +17,16 @@ dependencies = [
     "pyyaml>=6.0.3",
     # The SHARED engines (D2/G4: one implementation, never a second copy that
     # drifts). Two live here now: tool-currency (dotfiles' tool_currency.py was
-    # deleted) and md_budget (dotfiles' md_budget.py + tests deleted 2026-07-25;
-    # the `md_size_budget` hk step shells out to `kb-setup md-budget`).
+    # deleted), md_budget (dotfiles' md_budget.py + tests deleted 2026-07-25; the
+    # `md_size_budget` hk step shells out to `kb-setup md-budget`), and the tier-1
+    # eval runner (`kb_setup.evals`; this repo declares its own cases in
+    # dotfiles_setup.eval_cases). THREE gates now ride this pin, which is why
+    # tier1.shared-engine-resolves probes that it actually imports.
     # SHA-PINNED (D3) so it is reproducible on a clean CI runner and via uv.lock;
     # neither repo has tags, so a SHA is the only stable pin. Renovate's git-refs
     # datasource bumps this the same way it bumps CLANG_P2996_REF. Dependency
     # direction is dotfiles → KB only; the KB never learns about its consumers.
-    "kb-setup @ git+https://github.com/ray-manaloto/knowledge-base@3bb49a8cdecc972ceed73e8926b92d48e3f60b7f",
+    "kb-setup @ git+https://github.com/ray-manaloto/knowledge-base@aa57cfa5d659de9a1f22146abd7b3eac14c71bd3",
 ]
 
 [project.scripts]

--- a/python/src/dotfiles_setup/eval_cases.py
+++ b/python/src/dotfiles_setup/eval_cases.py
@@ -21,6 +21,7 @@ genuinely broken fixture and drive the same code path against it.
 from __future__ import annotations
 
 import importlib
+import shutil
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -86,6 +87,28 @@ def _broken_doctor() -> evals.Outcome:
         return evals.doctor_health(script, timeout=30)
 
 
+def _graphify_installed() -> evals.Outcome | None:
+    """Environment gate: graphify is HOST-ONLY, so the canary cannot run in-container.
+
+    Found by `sync-full` (the devcontainer smoke): inside the container this
+    case failed with `rc=-2, No such file or directory: 'graphify'` and took
+    the whole postCreate run with it. That is "does not apply here", not "the
+    graph is broken".
+
+    It must be a PRECONDITION, not a SKIP inside the probe: the control arm
+    drives the same code path, so it would skip too, and the runner would
+    correctly mark the case UNARMED and turn the run red. The precondition is
+    evaluated BEFORE the control-arm rule for exactly this reason.
+    """
+    if shutil.which("graphify") is None:
+        return evals.skip(
+            "graphify is not installed in this environment — it is host-only in "
+            "this repo (mise.toml), so the canary cannot look, which is not the "
+            "same as the graph having nothing to say"
+        )
+    return None
+
+
 def cases(repo_root: Path, *, doctor_script: Path | None = None) -> list[evals.Case]:
     """Build this repo's tier-1 cases."""
     doctor = doctor_script if doctor_script is not None else DOCTOR_SCRIPT
@@ -130,6 +153,7 @@ def cases(repo_root: Path, *, doctor_script: Path | None = None) -> list[evals.C
             ),
             probe=lambda: evals.graphify_canary(repo_root, CANARY_QUESTION),
             control=_broken_graph_canary,
+            precondition=_graphify_installed,
         ),
         evals.Case(
             name="tier1.lane-health",

--- a/python/src/dotfiles_setup/eval_cases.py
+++ b/python/src/dotfiles_setup/eval_cases.py
@@ -1,0 +1,182 @@
+"""This repo's tier-1 eval cases (#354 PR 2).
+
+The RUNNER is :mod:`kb_setup.evals`, shared with knowledge-base and consumed
+here as the SHA-pinned ``kb-setup`` dependency — the ``kb_setup.currency`` /
+``kb_setup.md_budget`` precedent (D2/G4: one implementation, never a second copy
+that drifts). Only the CASES are per-repo, because what "resolves" means differs.
+
+Tier 0 (``suites.toml`` ``orchestration.*`` / ``eval.*``) asks *is it declared?*
+These ask the next question: **does it resolve?** The two are genuinely
+different, and #354 is what the gap costs — a lane can be named in doctrine, in
+both repos, with a passing contract, while its CLI is not installed and nothing
+says what happens instead.
+
+Every gated case carries a ``control`` that must come back FAIL, and the runner
+refuses to count a gated case whose control does not fail. Note the trap the KB
+side hit first: **a control that returns SKIP is not armed.** Pointing a probe
+at something absent usually yields SKIP by design, so the controls below build a
+genuinely broken fixture and drive the same code path against it.
+"""
+
+from __future__ import annotations
+
+import importlib
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from kb_setup import evals
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+#: Lane CLIs the orchestration doctrine names in `.claude/CLAUDE.md`. `grok` is
+#: deliberately included and is NOT installed (control-armed: `codex`, `agy`,
+#: `claude`, `graphify` all resolve; `grok` does not). The doctrine's position is
+#: that availability is discovered at run time, so the case asserts the
+#: DEGRADATION PATH IS DECLARED — not that grok exists.
+DECLARED_LANES = ("codex", "agy", "grok")
+
+#: Tokens whose presence in the doctrine doc constitutes a declared degradation
+#: path. `.claude/CLAUDE.md` says grok "is NOT installed, so `codex` is the only
+#: viable fixed mode and cross-family review falls to antigravity or Claude".
+FALLBACK_TOKENS = ("NOT installed", "fall")
+
+#: The fable-orchestrator plugin's own lane doctor. Version-pinned inside the
+#: plugin cache, so it can vanish on plugin GC — hence a LOUD skip, never silent.
+DOCTOR_SCRIPT = Path.home().joinpath(
+    ".claude/plugins/cache/fable-orchestrator/fable-orchestrator/1.14.0/scripts/doctor.sh"
+)
+
+#: A liveness question for the local graph. Deliberately not phrased by echoing
+#: node labels — that grades lexical overlap and reports a win that isn't there.
+CANARY_QUESTION = "how does the devcontainer get built?"
+
+_MISSING_BINARY = "definitely-not-a-real-binary-xyz"
+
+
+def _broken_graph_canary() -> evals.Outcome:
+    """Control arm: drive the canary against a graph that cannot answer.
+
+    A directory holding a present-but-meaningless ``graph.json`` passes the
+    existence gate — so this is NOT a skip — and then makes the real
+    ``graphify query`` fail, which is the branch the canary must be shown to
+    reach.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        graph = root / "graphify-out" / "graph.json"
+        graph.parent.mkdir(parents=True)
+        graph.write_text("not a graph")
+        return evals.graphify_canary(root, CANARY_QUESTION, timeout=30)
+
+
+def _broken_doctor() -> evals.Outcome:
+    """Control arm: a doctor script that reports a failing lane.
+
+    Deliberately distinct from the absent-script case. "We could not look"
+    (SKIP) and "we looked and a lane is broken" (FAIL) must never collapse into
+    each other — the first is the inert declaration wearing a green badge.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        script = Path(tmp) / "doctor.sh"
+        script.write_text(
+            "#!/usr/bin/env bash\necho '0 ok, 0 warnings, 1 failures'\nexit 1\n"
+        )
+        return evals.doctor_health(script, timeout=30)
+
+
+def cases(repo_root: Path, *, doctor_script: Path | None = None) -> list[evals.Case]:
+    """Build this repo's tier-1 cases."""
+    doctor = doctor_script if doctor_script is not None else DOCTOR_SCRIPT
+    fallback_doc = repo_root / ".claude" / "CLAUDE.md"
+
+    return [
+        evals.Case(
+            name="tier1.lanes-declared-or-degraded",
+            description=(
+                "every lane the doctrine names either resolves on PATH, or its "
+                "degradation path is written down"
+            ),
+            probe=lambda: evals.declared_lanes_reconcile(
+                DECLARED_LANES,
+                fallback_doc=fallback_doc,
+                fallback_tokens=FALLBACK_TOKENS,
+            ),
+            # The fallback doc pointed at a file that does not exist: "we cannot
+            # read the fallback" must never resolve to "the fallback is declared".
+            control=lambda: evals.declared_lanes_reconcile(
+                (_MISSING_BINARY,),
+                fallback_doc=repo_root / ".claude" / "does-not-exist.md",
+                fallback_tokens=FALLBACK_TOKENS,
+            ),
+        ),
+        evals.Case(
+            name="tier1.shared-engine-resolves",
+            description=(
+                "the SHARED kb_setup engine this repo depends on is importable — "
+                "md_budget and the eval runner both come from it, so a broken pin "
+                "silently disarms two gates at once"
+            ),
+            probe=_kb_setup_importable,
+            control=_kb_setup_import_control,
+        ),
+        evals.Case(
+            name="tier1.graph-answers",
+            description=(
+                "the local graph does not merely exist — it returns a non-empty "
+                "answer (rc=0 with empty output is a graph that reads as healthy "
+                "and knows nothing)"
+            ),
+            probe=lambda: evals.graphify_canary(repo_root, CANARY_QUESTION),
+            control=_broken_graph_canary,
+        ),
+        evals.Case(
+            name="tier1.lane-health",
+            description=(
+                "the plugin's own doctor.sh reports every installed lane "
+                "authenticated with model access"
+            ),
+            probe=lambda: evals.doctor_health(doctor),
+            control=_broken_doctor,
+            # doctor.sh has NO offline mode: whenever a lane's CLI is present it
+            # fires a real API call, and it exits `[ FAIL -eq 0 ]` so warnings
+            # pass. It is the live half ENTIRELY and can never join the free
+            # gated tier — the offline probes above are that tier.
+            live=True,
+        ),
+    ]
+
+
+#: The shared entry points this repo consumes from the pinned kb_setup package.
+#: Both gates depend on them: `md_size_budget` shells out to `kb-setup
+#: md-budget`, and `mise run eval` imports the runner.
+SHARED_MODULES = ("kb_setup.evals", "kb_setup.md_budget")
+
+
+def _importable(names: Sequence[str]) -> evals.Outcome:
+    """FAIL naming every module in ``names`` that cannot be imported."""
+    missing = []
+    for name in names:
+        try:
+            importlib.import_module(name)
+        except ImportError:
+            missing.append(name)
+    if missing:
+        return evals.fail(f"kb_setup module(s) not importable: {', '.join(missing)}")
+    return evals.ok(f"{len(names)} shared module(s) import: {', '.join(names)}")
+
+
+def _kb_setup_importable() -> evals.Outcome:
+    """Both shared entry points must actually be reachable, not just pinned.
+
+    Asserting the pin exists is tier 0's job and is not the same question: a pin
+    can name a commit that predates the module, and then `md_size_budget` and
+    `mise run eval` both fail at the seam rather than at the declaration.
+    """
+    return _importable(SHARED_MODULES)
+
+
+def _kb_setup_import_control() -> evals.Outcome:
+    """Control arm: the same probe against a module that cannot exist."""
+    return _importable(("kb_setup.definitely_not_a_module",))

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -11,6 +11,8 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
+from kb_setup import evals
+
 from dotfiles_setup.ai import AIOrchestrator
 from dotfiles_setup.apt_pins import apt_pins_main
 from dotfiles_setup.apt_repo import LLVM_DEV, RepoQuery, apt_repo_main
@@ -27,6 +29,7 @@ from dotfiles_setup.doc_refs import (
     find_unresolved_task_refs,
 )
 from dotfiles_setup.docker import DevContainerManager
+from dotfiles_setup.eval_cases import cases as eval_cases_for
 from dotfiles_setup.gcc_sha import gcc_sha_main
 from dotfiles_setup.ghcr import validate_ghcr_prereqs
 from dotfiles_setup.ghcr_cleanup import plan_cleanup
@@ -168,6 +171,19 @@ def _add_consistency_subcommands(subparsers: _SubParsers) -> None:
         default=None,
         help="knowledge-base repo root; defaults to $KB_REPO_PATH, then the "
         "sibling directory beside this repo",
+    )
+    eval_parser = subparsers.add_parser(
+        "eval",
+        help="Tier-1 eval (#354 PR 2): tier 0 asks whether a thing is DECLARED, "
+        "this asks whether it RESOLVES — lanes, the shared engine, and the "
+        "graph. Offline and gated; every gated case must carry a control arm "
+        "that fails, or the runner refuses to count it",
+    )
+    eval_parser.add_argument(
+        "--live",
+        action="store_true",
+        help="also run the fable-orchestrator plugin's doctor.sh, which has no "
+        "offline mode and spends one real API call per installed lane CLI",
     )
 
 
@@ -1073,6 +1089,17 @@ def handle_parity(args: argparse.Namespace, project_root: Path) -> None:
     sys.exit(rc)
 
 
+def handle_eval(args: argparse.Namespace, project_root: Path) -> None:
+    """Handle eval: run this repo's tier-1 cases through the SHARED runner.
+
+    The runner is ``kb_setup.evals`` — one implementation, both repos, consumed
+    as the SHA-pinned ``kb-setup`` dependency. Only the cases are ours.
+    """
+    rc, report = evals.run(eval_cases_for(project_root), live=args.live)
+    sys.stdout.write(report + "\n")
+    sys.exit(rc)
+
+
 def handle_ghcr_cleanup(args: argparse.Namespace) -> None:
     """Handle ghcr-cleanup: print the retention plan (never deletes itself).
 
@@ -1215,6 +1242,7 @@ def _build_command_handlers(
         "ghcr-cleanup": lambda: handle_ghcr_cleanup(args),
         "check-doc-refs": lambda: handle_check_doc_refs(project_root),
         "parity": lambda: handle_parity(args, project_root),
+        "eval": lambda: handle_eval(args, project_root),
         "gcc-sha": lambda: sys.exit(gcc_sha_main(project_root, check=args.check)),
         "apt-repo": lambda: sys.exit(handle_apt_repo(args)),
         "apt-pins": lambda: sys.exit(

--- a/python/src/dotfiles_setup/pr.py
+++ b/python/src/dotfiles_setup/pr.py
@@ -287,6 +287,11 @@ def gate_matrix(paths: list[str]) -> list[Gate]:
             "hook-selfcheck",
             ("uv", "run", "--project", "python", "dotfiles-setup", "hook", "selfcheck"),
         ),
+        # Tier-1 reachability (#354 PR 2). Always-run and free: the offline set
+        # spends no API calls, and it catches the class tier 0 structurally
+        # cannot — a declaration that is present and does not resolve. Its live
+        # half stays on demand (`mise run eval -- --live`).
+        Gate("eval", ("mise", "run", "eval")),
     ]
     if any(_matches_any(p, _GHA_PATTERNS) for p in paths):
         gates.append(Gate("pin-actions", ("mise", "run", "pin-actions")))

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -41,7 +41,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "kb-setup", git = "https://github.com/ray-manaloto/knowledge-base?rev=aa57cfa5d659de9a1f22146abd7b3eac14c71bd3" },
+    { name = "kb-setup", git = "https://github.com/ray-manaloto/knowledge-base?rev=bc69caa769fde443542e6893f8a5075beb5ae55b" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "python-debian", specifier = ">=1.1.1" },
@@ -67,7 +67,7 @@ wheels = [
 [[package]]
 name = "kb-setup"
 version = "0.1.0"
-source = { git = "https://github.com/ray-manaloto/knowledge-base?rev=aa57cfa5d659de9a1f22146abd7b3eac14c71bd3#aa57cfa5d659de9a1f22146abd7b3eac14c71bd3" }
+source = { git = "https://github.com/ray-manaloto/knowledge-base?rev=bc69caa769fde443542e6893f8a5075beb5ae55b#bc69caa769fde443542e6893f8a5075beb5ae55b" }
 
 [[package]]
 name = "packaging"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -41,7 +41,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "kb-setup", git = "https://github.com/ray-manaloto/knowledge-base?rev=3bb49a8cdecc972ceed73e8926b92d48e3f60b7f" },
+    { name = "kb-setup", git = "https://github.com/ray-manaloto/knowledge-base?rev=aa57cfa5d659de9a1f22146abd7b3eac14c71bd3" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "python-debian", specifier = ">=1.1.1" },
@@ -67,7 +67,7 @@ wheels = [
 [[package]]
 name = "kb-setup"
 version = "0.1.0"
-source = { git = "https://github.com/ray-manaloto/knowledge-base?rev=3bb49a8cdecc972ceed73e8926b92d48e3f60b7f#3bb49a8cdecc972ceed73e8926b92d48e3f60b7f" }
+source = { git = "https://github.com/ray-manaloto/knowledge-base?rev=aa57cfa5d659de9a1f22146abd7b3eac14c71bd3#aa57cfa5d659de9a1f22146abd7b3eac14c71bd3" }
 
 [[package]]
 name = "packaging"

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -1049,6 +1049,26 @@ tokens = [
 ]
 
 [[suite]]
+name = "eval.tier1-runner-wiring"
+description = "Tier-1 eval wiring (#354 PR 2). Tier 0 asks whether a thing is DECLARED; tier 1 asks whether it RESOLVES, and the gap between those is exactly what #354 cost — a lane named in doctrine, in both repos, with a passing contract, whose CLI is not installed. This contract asserts the whole chain exists so tier 1 cannot silently stop running: the `eval` mise task, the CLI subcommand, this repo's cases module, its tests, and the `Gate(\"eval\")` entry that puts it in the ship gates. The RUNNER is deliberately NOT bound here — it is `kb_setup.evals`, lives in the knowledge-base repo, and is covered by ITS tests; naming a path outside this tree could only ever fail (`paths_required` is strict, #299). What binds it instead is the SHA-pinned kb-setup dependency plus the `tier1.shared-engine-resolves` case, which imports it at run time. Same shape as `workflow.md-budget-enforcement`: bind the seam that survives here."
+category = "eval"
+check_type = "static"
+handler = "require_tokens"
+paths_required = true
+paths = [
+    "mise.toml",
+    "python/src/dotfiles_setup/main.py",
+    "python/src/dotfiles_setup/eval_cases.py",
+    "python/src/dotfiles_setup/pr.py",
+    "python/pyproject.toml",
+    "tests/test_eval_cases.py",
+]
+per_path_tokens = { "mise.toml" = ["[tasks.eval]", "dotfiles-setup eval"], "python/src/dotfiles_setup/main.py" = ["def handle_eval", "\"eval\": lambda"], "python/src/dotfiles_setup/eval_cases.py" = ["def cases", "DECLARED_LANES", "control="], "python/src/dotfiles_setup/pr.py" = ["Gate(\"eval\"", "\"mise\", \"run\", \"eval\""], "python/pyproject.toml" = ["kb-setup @ git+https://github.com/ray-manaloto/knowledge-base@"], "tests/test_eval_cases.py" = ["test_every_control_arm_actually_fails"] }
+tokens = [
+    "dotfiles-setup eval",
+]
+
+[[suite]]
 name = "workflow.bash-logic-enforcement"
 description = "Zero-bash-logic policy wiring: the `bash_logic_budget` hk step must stay wired to the python enforcer end-to-end — hk.pkl shells out to `dotfiles-setup bash-budget`, main.py registers the subcommand, the bash_budget module (allowlist + per-file growth budget) + its tests exist, and the rule doc records the policy. The check LOGIC lives in python so the enforcer does not itself violate the policy it enforces; this contract asserts the whole chain so it can't drift out."
 category = "workflow"

--- a/tests/test_eval_cases.py
+++ b/tests/test_eval_cases.py
@@ -14,6 +14,10 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
 
@@ -111,6 +115,39 @@ def test_the_shared_engine_probe_names_what_is_missing() -> None:
     outcome = case.control()
     assert outcome.verdict is evals.Verdict.FAIL
     assert "kb_setup.definitely_not_a_module" in outcome.detail
+
+
+def test_the_graph_case_declares_an_environment_precondition() -> None:
+    """Graphify is HOST-ONLY here, so the canary cannot run in the devcontainer.
+
+    Without this the case failed in-container with `rc=-2, No such file or
+    directory: 'graphify'` and took the whole postCreate smoke down — caught by
+    `sync-full`, which is the reason this test exists rather than a comment.
+    """
+    case = next(c for c in _cases() if c.name == "tier1.graph-answers")
+    assert case.precondition is not None
+
+
+def test_the_precondition_skips_when_graphify_is_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both arms of the environment gate, since it decides whether a gate runs.
+
+    A precondition that could only ever return None would silently reintroduce
+    the in-container failure; one that could only ever skip would disable the
+    case everywhere, which is worse than not having it.
+    """
+    case = next(c for c in _cases() if c.name == "tier1.graph-answers")
+    assert case.precondition is not None
+
+    monkeypatch.setattr(eval_cases.shutil, "which", lambda _name: None)
+    gate = case.precondition()
+    assert gate is not None
+    assert gate.verdict is evals.Verdict.SKIP
+    assert "host-only" in gate.detail
+
+    monkeypatch.setattr(eval_cases.shutil, "which", lambda _name: "/usr/bin/graphify")
+    assert case.precondition() is None
 
 
 def test_the_real_offline_run_is_green_on_this_tree() -> None:

--- a/tests/test_eval_cases.py
+++ b/tests/test_eval_cases.py
@@ -1,0 +1,123 @@
+"""Tests for this repo's tier-1 eval cases (dotfiles_setup.eval_cases, #354 PR 2).
+
+The runner (`kb_setup.evals`) is tested in the knowledge-base repo, where it
+lives. What is ours to test is the CASES — and specifically that every gated one
+carries a control arm that really fails, because that is the property the whole
+harness rests on and the one an author adding a case will forget.
+
+Catching it here rather than only at `mise run eval` time matters: the runner
+reports UNARMED at run time, but a test says so at commit time, which is the
+difference between a red gate and a red gate you understand.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
+
+from dotfiles_setup import eval_cases
+from kb_setup import evals
+
+_ROOT = Path(__file__).parent.parent.absolute()
+
+
+def _cases() -> list[evals.Case]:
+    return eval_cases.cases(_ROOT)
+
+
+def test_every_gated_case_declares_a_control_arm() -> None:
+    """Design principle 1, checked statically."""
+    naked = [c.name for c in _cases() if c.gated and c.control is None]
+    assert naked == [], f"gated cases with no control arm: {naked}"
+
+
+def test_every_control_arm_actually_fails() -> None:
+    """The load-bearing half — and the one that is easy to get wrong.
+
+    A case can carry a control arm that is simply pointed at the wrong thing and
+    comes back SKIP or PASS; then the case LOOKS armed and is still a coin with
+    one face. This ran red on the first attempt in the sibling repo, because the
+    obvious control for the graph canary (a graph path that does not exist)
+    returns SKIP by design.
+    """
+    for case in _cases():
+        if not case.gated or case.control is None:
+            continue
+        outcome = case.control()
+        assert outcome.verdict is evals.Verdict.FAIL, (
+            f"{case.name}: control arm returned {outcome.verdict.name}, not FAIL "
+            f"— the probe cannot be shown to discriminate ({outcome.detail})"
+        )
+
+
+def test_the_expected_cases_are_declared() -> None:
+    """A case silently disappearing is the inert declaration one level up."""
+    assert {c.name for c in _cases()} == {
+        "tier1.lanes-declared-or-degraded",
+        "tier1.shared-engine-resolves",
+        "tier1.graph-answers",
+        "tier1.lane-health",
+    }
+
+
+def test_only_the_doctor_case_is_live() -> None:
+    """`doctor.sh` has NO offline mode — it is the live half, entirely.
+
+    It takes no flags and fires a real API call per installed CLI, so it can
+    never join the free gated tier. If another case is ever marked live, the
+    offline gate gets cheaper by doing less, which is the wrong direction.
+    """
+    assert [c.name for c in _cases() if c.live] == ["tier1.lane-health"]
+
+
+def test_grok_is_declared_and_the_case_still_passes() -> None:
+    """`grok` is named in the doctrine and is NOT installed. That is correct.
+
+    "Availability is discovered at run time, not declared" — so the case must
+    assert the DEGRADATION PATH is written down, not that grok exists. A case
+    that failed here would be pressure to either install a CLI we do not want or
+    delete a lane the doctrine legitimately names.
+    """
+    assert "grok" in eval_cases.DECLARED_LANES
+    outcome = evals.declared_lanes_reconcile(
+        eval_cases.DECLARED_LANES,
+        fallback_doc=_ROOT / ".claude" / "CLAUDE.md",
+        fallback_tokens=eval_cases.FALLBACK_TOKENS,
+    )
+    assert outcome.verdict is evals.Verdict.PASS
+
+
+def test_the_fallback_tokens_are_actually_present_in_the_doctrine_doc() -> None:
+    """Independent source of truth: the real `.claude/CLAUDE.md` on disk.
+
+    Without this the case above could pass on tokens chosen to match whatever
+    the doc happens to say — a tautology. Read the file directly.
+    """
+    text = (_ROOT / ".claude" / "CLAUDE.md").read_text()
+    for token in eval_cases.FALLBACK_TOKENS:
+        assert token in text, token
+
+
+def test_the_shared_engine_probe_names_what_is_missing() -> None:
+    """Principle 8: report the status seen, not a prose summary.
+
+    Reached through the case's own declared control arm rather than the private
+    helper, so this test exercises exactly what the runner will call.
+    """
+    case = next(c for c in _cases() if c.name == "tier1.shared-engine-resolves")
+    assert case.control is not None
+    outcome = case.control()
+    assert outcome.verdict is evals.Verdict.FAIL
+    assert "kb_setup.definitely_not_a_module" in outcome.detail
+
+
+def test_the_real_offline_run_is_green_on_this_tree() -> None:
+    """The live gate: this repo's own offline cases must pass here.
+
+    Skips nothing and hides nothing — a SKIP would be visible in the report, and
+    an all-SKIP run exits non-zero by construction.
+    """
+    rc, report = evals.run(_cases(), live=False)
+    assert rc == 0, report


### PR DESCRIPTION
- **feat(eval): tier-1 eval cases + `mise run eval`, joined to the ship gates (#354 PR 2)**
- **fix(eval): the graphify canary is host-only — declare it as an environment gate**
