### PR TITLE
docs(spec): gate Phase 4 on a graphify version-skew re-baseline

### DIFF
--- a/docs/specs/graphify-autonomous-queue.md
+++ b/docs/specs/graphify-autonomous-queue.md
@@ -152,9 +152,44 @@ fixed-by-construction rather than writing redundant fixes.
 **Phase 3 — parallel lanes.** #16 (idempotency), #22 (hosts), #20 (API refs from
 source), #13, #14, #23, #34. Worktree-isolate any two that touch one file.
 
-**Phase 4 — retrieval, SERIAL.** P4 (1-hop context expansion), then P6 (age
-decay). One arm at a time, `uv run kb-setup eval --slow` between each. **Stop
-with a costed proposal for P3/P5.**
+**Phase 4 — retrieval, SERIAL. GATED on a re-baseline (see §5a).** P4 (1-hop
+context expansion), then P6 (age decay). One arm at a time, `uv run kb-setup
+eval --slow` between each. **Stop with a costed proposal for P3/P5.**
+
+### 5a. Version-skew gate — do this BEFORE measuring any new arm
+
+**graphify is 0.9.27 on PATH; the KB corpus was built by 0.9.26.** Measured
+2026-07-27 after dotfiles #372 merged: `mise which graphify` resolves
+`…/pipx-graphifyy/0.9.27/bin/graphify`, while
+`knowledge-base/graphify-out/.currency-stamp.json` records `"version":
+"0.9.26"` (built 2026-07-26, `artifact_commit 12c0fd3`). knowledge-base's
+`mise.toml` still pins **0.9.26**, so the repos have drifted.
+
+This is a gate, not a note: **0.9.26's prompt was unchanged but its AST
+extractor CHANGED, so a rebuild moves the graph.** Measuring a new arm against a
+corpus built by a different extractor version makes the delta unattributable,
+destroying the property that made P0/P1/P2 citable in the first place.
+
+Required order:
+
+1. Decide the KB pin — match 0.9.27, or hold at 0.9.26 **deliberately and record
+   why**.
+2. `cd <kb root> && mise run kb-build`, logging `graphify --version` as the first
+   line so the artifact proves its own provenance.
+3. `uv run kb-setup eval --slow` — **re-baseline all four arms** and record the
+   table. `RETRIEVAL_FLOOR = 4` is asserted on the best arm and may need
+   revisiting if the rebuild moves `prose+idf` off 5/8.
+4. Only then build P4, then P6.
+
+Treat the existing P2 table as the **0.9.26** record; do not compare a post-
+rebuild number against it without saying so.
+
+**The stale-install PATH hazard moved with the version** — strip `0.9.26`, not
+`0.9.25`, and re-apply it in every Bash call since it does not persist:
+
+```bash
+export PATH="$(echo "$PATH" | tr ':' '\n' | grep -v 'pipx-graphifyy/0.9.26/bin' | paste -sd: -)"
+```
 
 **Phase 5 — dotfiles.** #369 (bot-PR merge path), #375 (release-note review).
 


### PR DESCRIPTION
Merging #372 moved the host pin to graphify 0.9.27 while the knowledge-base
corpus is stamped as built by 0.9.26 (artifact_commit 12c0fd3) and KB's own
mise.toml still pins 0.9.26. So the next session would measure a new retrieval
arm against a corpus built by a DIFFERENT extractor version.

That is a correctness gate, not bookkeeping: last session established that
0.9.26's prompt was unchanged but its AST extractor CHANGED, so a rebuild moves
the graph. An arm measured across that boundary has an unattributable delta,
which destroys the exact property that made P0/P1/P2 citable.

Phase 4 now requires, in order: decide the KB pin (match or hold deliberately
and say why), rebuild the corpus logging `graphify --version` as the first line
so the artifact proves its own provenance, re-baseline ALL FOUR arms, and only
then build P4/P6. RETRIEVAL_FLOOR is asserted on the best arm and may need
revisiting if the rebuild moves prose+idf off 5/8. The existing P2 table is
labelled as the 0.9.26 record.

Also moved the stale-install PATH guard from 0.9.25 to 0.9.26 — the hazard
follows the version, and a bare `graphify` picking up a stale install dir would
silently rebuild the corpus with the wrong version and stamp it with the right
one.

Gates: `mise run lint` rc=0.

Refs #354, #375, knowledge-base#12.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CzPdn3iHw6uhMWEdVPADfW
