### PR TITLE
feat(tooling): `mise run cc` calls the verified launcher

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -921,49 +921,25 @@ description = "Bump CLANG_P2996_REF in docker-bake.hcl to the latest bloomberg/c
 run = "uv run --project python dotfiles-setup p2996-refresh"
 
 [tasks.cc]
-description = "Launch Claude Code rooted in THIS repo (so its hooks load), sibling repo via --add-dir, inside a tmux session, auto mode on"
-# WHY EVERY PIECE — verified against the docs on 2026-07-27, Claude Code 2.1.220.
-# The sibling repo carries the mirror of this task; keep the two in sync.
+description = "Launch Claude Code rooted in THIS repo with a VERIFIED environment (tmux, --add-dir knowledge-base, auto mode)"
+# Thin BY DESIGN. Every decision — PATH hygiene, the tmux env injection, and a
+# preflight that can REFUSE — lives in `kb_setup.launch`, shared by both repos so
+# the two launchers cannot drift. That module's docstring carries the
+# measurements; the short version:
 #
-# * ROOTED IN THIS REPO. Hooks and most `.claude/settings.json` keys load from
-#   "the current working directory's `.claude/` folder with NO parent-directory
-#   fallback", and hooks are NOT among the `--add-dir` exceptions. So the
-#   PreToolUse guard only fires for the repo the session is rooted in — which is
-#   why each repo gets its own launcher instead of one combined entrypoint.
-# * `--add-dir`, NOT `permissions.additionalDirectories`. The settings key grants
-#   "file access only and doesn't load any of the configuration"; the FLAG also
-#   loads the sibling's `.claude/skills/` and `.claude/agents/`.
-# * WHAT IS *NOT* HERE, ON PURPOSE. Everything expressible as configuration now
-#   lives in this repo's `.claude/settings.json` instead of a flag (Ray,
-#   2026-07-27 — project-level settings only, never user/global):
-#     - `permissions.defaultMode: "auto"` replaces `--permission-mode auto`
-#       ("a goal doesn't change permissions", so unattended turns need it).
-#     - `env.CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: "1"` makes the
-#       sibling's `CLAUDE.md`, `.claude/CLAUDE.md`, `.claude/rules/*.md` and
-#       `CLAUDE.local.md` load; without it they are silently absent.
-#   `--add-dir` CANNOT move to settings: `permissions.additionalDirectories`
-#   grants "file access only and doesn't load any of the configuration", so the
-#   flag is the only form that also brings the sibling's skills and agents.
-#   UNVERIFIED: the docs do not state whether settings `env` is applied before
-#   memory files load at session start. If the sibling's rules turn out not to be
-#   loaded, move that one var back into this task's environment.
-# * tmux — split-pane teammates require tmux (or iTerm2 + `it2`). Without it
-#   `teammateMode` falls back to in-process, and in-process teammates cannot be
-#   resumed and cannot spawn background subagents. `new-session -A` attaches if
-#   the session exists and creates it otherwise; when already inside tmux we exec
-#   claude directly rather than nesting.
-# * `$MISE_PROJECT_ROOT`, never `$PWD` — measured 2026-07-27: inside a mise task
-#   `$PWD` is wherever mise was invoked from (`/Users/rmanaloto`), NOT the repo.
-run = '''
-set -euo pipefail
-root="$MISE_PROJECT_ROOT"
-sibling="$root/../knowledge-base"
-[ -d "$sibling" ] || { echo "[cc] no sibling repo at $sibling" >&2; exit 2; }
-sibling="$(cd "$sibling" && pwd)"
-if [ -n "${TMUX:-}" ]; then
-  cd "$root"
-  exec claude --add-dir "$sibling"
-fi
-exec tmux new-session -A -s "${CC_TMUX_SESSION:-dotfiles}" -c "$root" \
-  "claude --add-dir '$sibling'"
-'''
+#   * a stale `mise/installs/<tool>/<ver>/bin` entry can shadow the shims and
+#     does NOT follow the pin (MISE_ENV_CACHE freezes it), so the whole CLASS is
+#     stripped rather than a named version — naming one is how the previous
+#     guard went inert;
+#   * tmux hands a NEW session the SERVER's environment, not the caller's, so
+#     the verified PATH is injected explicitly via `new-session -e PATH=...`;
+#   * it REFUSES to launch unless graphify resolves through the shims AT this
+#     repo's pinned version. A corpus rebuilt by one version and stamped with
+#     another is unfalsifiable afterwards, and that is the one failure this
+#     queue cannot absorb.
+#
+# `--root "$MISE_PROJECT_ROOT"` is NOT optional: the CLI otherwise derives the
+# root from the CWD, and inside a mise task the CWD is wherever mise was invoked
+# from, not the repo (measured). Session name: CC_TMUX_SESSION, default the repo.
+# Single-quoted TOML so the inner double quotes need no escaping.
+run = 'uv run --project python kb-setup cc --root "$MISE_PROJECT_ROOT" --sibling "$MISE_PROJECT_ROOT/../knowledge-base"'


### PR DESCRIPTION
Mirrors knowledge-base#37. The task body is now one line into
`kb_setup.launch`, shared by both repos so the two launchers cannot drift; all
the reasoning and every measurement lives in that module's docstring.

What the launcher adds over the shell version it replaces: it can REFUSE. It
strips the whole class of stale `mise/installs/<tool>/<ver>/bin` entries rather
than a named version (naming one is exactly how the previous doc snippet went
inert — it stripped 0.9.26 while 0.9.25 was the entry actually present), injects
the verified PATH into tmux explicitly because tmux hands a new session the
SERVER's environment rather than the caller's, and refuses to launch unless
graphify resolves through the shims AT this repo's pin.

`--root "$MISE_PROJECT_ROOT"` is required, not decorative: the CLI otherwise
derives the root from the CWD, and inside a mise task the CWD is wherever mise
was invoked from, not the repo. A wrong root would find no pin, skip the version
check and launch — passing for the reason that should refuse hardest.

Single-quoted TOML for the run body: the first attempt used double quotes inside
a double-quoted string, which broke mise.toml badly enough that `git` stopped
working (it is a mise shim), needing `/usr/bin/git` to recover.

Gates: `mise run lint` rc=0, 922 passed.

Refs #354, #380, knowledge-base#37.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CzPdn3iHw6uhMWEdVPADfW
