### PR TITLE
feat(config): declare the agent-team dependency in-repo

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -121,6 +121,8 @@
   },
   "prefersReducedMotion": true,
   "env": {
-    "CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD": "1"
-  }
+    "CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD": "1",
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "teammateMode": "auto"
 }


### PR DESCRIPTION
Mirrors knowledge-base#38. CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS and
teammateMode lived only in ~/.claude/settings.json, so the queue design's
teammates-in-split-panes assumption was declared in neither repo: on a fresh
clone agent teams would not exist, teammates would silently be in-process, and
nothing would say so. That is this epic's own defect class.

Project-level only — user config is not this repo's to change. `auto` rather
than `tmux` (Ray): the docs define it as split panes inside tmux or iTerm2+it2
and in-process otherwise, so it matches `mise run cc` (which guarantees tmux)
while degrading gracefully outside it.

`kb_setup.launch.teammate_note` reports the effective transport at launch, so a
session that quietly landed in-process no longer looks identical to one that
did not.

Gates: `mise run lint` rc=0.

Refs #354, knowledge-base#38.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CzPdn3iHw6uhMWEdVPADfW
