### PR TITLE
fix(tooling): `raw = true` on the cc task — without it tmux can never attach

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -922,6 +922,12 @@ run = "uv run --project python dotfiles-setup p2996-refresh"
 
 [tasks.cc]
 description = "Launch Claude Code rooted in THIS repo with a VERIFIED environment (tmux, --add-dir knowledge-base, auto mode)"
+# raw: mise normally CAPTURES a task's output so it can prefix each line with
+# `[cc]`, which leaves the child with NO TTY — tmux then dies with "open terminal
+# failed: not a terminal", and the buffering even prints that error BEFORE the
+# preflight lines. `raw` connects stdin/stdout/stderr straight through, which an
+# interactive session requires. Without it this task can never attach.
+raw = true
 # Thin BY DESIGN. Every decision — PATH hygiene, the tmux env injection, and a
 # preflight that can REFUSE — lives in `kb_setup.launch`, shared by both repos so
 # the two launchers cannot drift. That module's docstring carries the


### PR DESCRIPTION
Mirrors knowledge-base#39. Reported from a real terminal: `mise run cc` died
with "open terminal failed: not a terminal" despite a clean preflight.

mise CAPTURES a task's output to prefix each line with `[cc]`, leaving the child
with no TTY; tmux needs one to attach. The capture also reorders the evidence —
the tmux error printed BEFORE the preflight lines, since those were still
buffered — so the failure reads as though the preflight blew up when it had
passed. `raw = true` connects stdin/stdout/stderr straight through;
`mise run --raw cc` is the escape hatch on an older checkout.

How it was missed: the same string appeared in my own probes earlier and was
dismissed as "a tool call is not a terminal" — plausible, and wrong, for a
failure that would hit any terminal identically. The distinguishing probe
(`--raw` versus not) takes seconds and was never run.

Gates: `mise run lint` rc=0.

Refs #354, knowledge-base#39.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CzPdn3iHw6uhMWEdVPADfW

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787764324&installation_model_id=429246&pr_number=390&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F390&signature=11112c33966c0ebc2f705596f5fd422ae09b787f3c58ad4b1f47733952e30700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the interactive Claude Code task so terminal input and output work correctly without non-TTY or tmux-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->