### PR TITLE
fix(deps): bump the kb-setup pin past launch.py and gate `mise run cc` (#391)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -20,14 +20,21 @@ dependencies = [
     # deleted), md_budget (dotfiles' md_budget.py + tests deleted 2026-07-25; the
     # `md_size_budget` hk step shells out to `kb-setup md-budget`), and the eval
     # runner (`kb_setup.evals` — tier-1 probes plus the tier-2 guard fixture
-    # engine; this repo declares its own cases in dotfiles_setup.eval_cases).
-    # THREE gates now ride this pin, which is why tier1.shared-engine-resolves
-    # probes that it actually imports.
+    # engine; this repo declares its own cases in dotfiles_setup.eval_cases),
+    # and `kb_setup.launch` (the `mise run cc` launcher).
+    # FOUR gates/entry points now ride this pin, which is why
+    # tier1.shared-engine-resolves probes that it actually imports.
+    #
+    # BUMPING IS NOT A DRIVE-BY (#391): this pin sat at 23e4a724 — a revision
+    # that PREDATES `kb_setup/launch.py` — so `mise run cc` had never once
+    # worked in this repo, while every gate stayed green because no gate
+    # invoked it. A pin is a DECLARATION; only a probe that runs the thing is
+    # RESOLUTION. `tier1.cc-subcommand-dispatches` is that probe.
     # SHA-PINNED (D3) so it is reproducible on a clean CI runner and via uv.lock;
     # neither repo has tags, so a SHA is the only stable pin. Renovate's git-refs
     # datasource bumps this the same way it bumps CLANG_P2996_REF. Dependency
     # direction is dotfiles → KB only; the KB never learns about its consumers.
-    "kb-setup @ git+https://github.com/ray-manaloto/knowledge-base@23e4a724a6ad034fab204a8cd3c827a386d19516",
+    "kb-setup @ git+https://github.com/ray-manaloto/knowledge-base@737ff6e3b745c096c886ff4a732befc033efb75e",
 ]
 
 [project.scripts]

--- a/python/src/dotfiles_setup/eval_cases.py
+++ b/python/src/dotfiles_setup/eval_cases.py
@@ -60,7 +60,19 @@ DOCTOR_SCRIPT = Path.home().joinpath(
 #: node labels — that grades lexical overlap and reports a win that isn't there.
 CANARY_QUESTION = "how does the devcontainer get built?"
 
+#: The launcher subcommands the `cc` / `cc-doctor` mise tasks dispatch to. Both
+#: live in `kb_setup.launch` and are reached through the pinned CLI's own
+#: dispatch chain, which is the thing #391 found broken.
+LAUNCHER_SUBCOMMANDS = ("cc", "cc-doctor")
+
+#: What a launcher subcommand prints when dispatch REACHED it and the required
+#: argument is absent. Both refuse on a missing `--sibling` before preflight
+#: runs, so driving them this way exercises real dispatch and launches nothing,
+#: kills no tmux server, and touches no repo.
+LAUNCHER_REACHED_MARKER = "--sibling <path> is required"
+
 _MISSING_BINARY = "definitely-not-a-real-binary-xyz"
+_MISSING_SUBCOMMAND = "definitely-not-a-subcommand"
 
 _D = evals.GuardFixture
 _DENY = evals.Decision.DENY
@@ -226,6 +238,50 @@ def _broken_doctor() -> evals.Outcome:
         return evals.doctor_health(script, timeout=30)
 
 
+def _launcher_dispatches(subcommands: Sequence[str]) -> evals.Outcome:
+    """Does the pinned ``kb-setup`` CLI actually route each subcommand?
+
+    #391: this repo's pin named a revision that predates ``kb_setup/launch.py``,
+    so ``mise run cc`` had never once worked — while every gate stayed green,
+    because a pin is a DECLARATION and no gate ever invoked the thing.
+
+    The rc is **2 in both directions** — the handler's missing-argument refusal
+    and the CLI's own ``unknown command`` both exit 2 — so grading rc here would
+    be a probe that cannot fail. :data:`LAUNCHER_REACHED_MARKER` is the only
+    discriminator, and it is printed by the handler itself.
+    """
+    exe = shutil.which("kb-setup")
+    if exe is None:
+        return evals.fail(
+            "kb-setup does not resolve — the `cc` task runs it through "
+            "`uv run --project python`, so this is the launcher being dead"
+        )
+    unreachable = []
+    for sub in subcommands:
+        rc, out = evals.run_command([exe, sub])
+        if LAUNCHER_REACHED_MARKER not in out:
+            first = next(iter(out.strip().splitlines()), "(no output)")
+            unreachable.append(f"{sub} (rc={rc}): {first}")
+    if unreachable:
+        return evals.fail(
+            "the pinned kb-setup CLI does not dispatch: " + "; ".join(unreachable)
+        )
+    return evals.ok(
+        f"{len(subcommands)} launcher subcommand(s) dispatch through {exe}: "
+        + ", ".join(subcommands)
+    )
+
+
+def _launcher_dispatch_control() -> evals.Outcome:
+    """Control arm: the same probe against a subcommand that cannot exist.
+
+    This is #391's measured failure verbatim — ``kb-setup: unknown command`` —
+    so the control reproduces the real regression rather than a mutation that
+    could not happen.
+    """
+    return _launcher_dispatches((_MISSING_SUBCOMMAND,))
+
+
 def _graphify_installed() -> evals.Outcome | None:
     """Environment gate: graphify is HOST-ONLY, so the canary cannot run in-container.
 
@@ -282,6 +338,17 @@ def cases(repo_root: Path, *, doctor_script: Path | None = None) -> list[evals.C
             ),
             probe=_kb_setup_importable,
             control=_kb_setup_import_control,
+        ),
+        evals.Case(
+            name="tier1.cc-subcommand-dispatches",
+            description=(
+                "the `cc` / `cc-doctor` mise tasks reach a real handler in the "
+                "PINNED kb-setup — #391: the pin predated `launch.py`, so the "
+                "launcher was dead for its whole life and no gate noticed, "
+                "because every gate graded the declaration"
+            ),
+            probe=lambda: _launcher_dispatches(LAUNCHER_SUBCOMMANDS),
+            control=_launcher_dispatch_control,
         ),
         evals.Case(
             name="tier1.graph-answers",

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -41,7 +41,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "kb-setup", git = "https://github.com/ray-manaloto/knowledge-base?rev=23e4a724a6ad034fab204a8cd3c827a386d19516" },
+    { name = "kb-setup", git = "https://github.com/ray-manaloto/knowledge-base?rev=737ff6e3b745c096c886ff4a732befc033efb75e" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "python-debian", specifier = ">=1.1.1" },
@@ -67,7 +67,7 @@ wheels = [
 [[package]]
 name = "kb-setup"
 version = "0.1.0"
-source = { git = "https://github.com/ray-manaloto/knowledge-base?rev=23e4a724a6ad034fab204a8cd3c827a386d19516#23e4a724a6ad034fab204a8cd3c827a386d19516" }
+source = { git = "https://github.com/ray-manaloto/knowledge-base?rev=737ff6e3b745c096c886ff4a732befc033efb75e#737ff6e3b745c096c886ff4a732befc033efb75e" }
 
 [[package]]
 name = "packaging"

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -1086,6 +1086,24 @@ tokens = [
 ]
 
 [[suite]]
+name = "eval.cc-launcher-wiring"
+description = "The `cc` launcher chain, declaration half (#391). `mise run cc` dispatches to `kb-setup cc`, whose handler lives in `kb_setup.launch` — supplied by the SHA-pinned kb-setup dependency. That pin sat at a revision PREDATING `launch.py`, so the task had never worked in this repo across two PRs (#379, #390), while every gate stayed green: lint checks the TOML, not that the subcommand exists at the pinned revision, and nothing else invoked it. This contract binds the declaration side — the task, the argv it runs, the pin that supplies the handler — and `tier1.cc-subcommand-dispatches` binds the RESOLUTION side by really running it. Both halves are needed and neither substitutes: a pin can name a commit and a task can name a subcommand while the two do not meet, which IS the #354 defect class. The handler itself is deliberately not bound — `kb_setup/launch.py` lives in the knowledge-base repo, is covered by ITS tests, and naming a path outside this tree could only ever fail (`paths_required` is strict, #299). Note `raw = true` on the task is bound too: without it mise captures the task's output, the child gets no TTY, and tmux dies with \"open terminal failed\" (#390) — a launcher that cannot attach is as dead as one that cannot dispatch. The mise token is anchored to `kb-setup cc --root` because it was CONTROL-ARMED and the unanchored form failed: renaming the subcommand to `ccX` still contains `kb-setup cc`, so the first draft of this contract passed on the very break it exists to catch."
+category = "eval"
+check_type = "static"
+handler = "require_tokens"
+paths_required = true
+paths = [
+    "mise.toml",
+    "python/pyproject.toml",
+    "python/src/dotfiles_setup/eval_cases.py",
+    "tests/test_eval_cases.py",
+]
+per_path_tokens = { "mise.toml" = ["[tasks.cc]", "kb-setup cc --root", "raw = true"], "python/pyproject.toml" = ["kb-setup @ git+https://github.com/ray-manaloto/knowledge-base@"], "python/src/dotfiles_setup/eval_cases.py" = ["LAUNCHER_SUBCOMMANDS", "LAUNCHER_REACHED_MARKER", "tier1.cc-subcommand-dispatches"], "tests/test_eval_cases.py" = ["test_the_launcher_marker_is_what_the_pinned_cli_really_prints", "test_rc_alone_cannot_discriminate_the_launcher_probe"] }
+tokens = [
+    "tier1.cc-subcommand-dispatches",
+]
+
+[[suite]]
 name = "workflow.bash-logic-enforcement"
 description = "Zero-bash-logic policy wiring: the `bash_logic_budget` hk step must stay wired to the python enforcer end-to-end — hk.pkl shells out to `dotfiles-setup bash-budget`, main.py registers the subcommand, the bash_budget module (allowlist + per-file growth budget) + its tests exist, and the rule doc records the policy. The check LOGIC lives in python so the enforcer does not itself violate the policy it enforces; this contract asserts the whole chain so it can't drift out."
 category = "workflow"

--- a/tests/test_eval_cases.py
+++ b/tests/test_eval_cases.py
@@ -12,6 +12,7 @@ difference between a red gate and a red gate you understand.
 
 from __future__ import annotations
 
+import shutil
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -61,6 +62,7 @@ def test_the_expected_cases_are_declared() -> None:
     assert {c.name for c in _cases()} == {
         "tier1.lanes-declared-or-degraded",
         "tier1.shared-engine-resolves",
+        "tier1.cc-subcommand-dispatches",
         "tier1.graph-answers",
         "tier1.lane-health",
         "tier2.guard-fixtures",
@@ -116,6 +118,37 @@ def test_the_shared_engine_probe_names_what_is_missing() -> None:
     outcome = case.control()
     assert outcome.verdict is evals.Verdict.FAIL
     assert "kb_setup.definitely_not_a_module" in outcome.detail
+
+
+def test_the_launcher_marker_is_what_the_pinned_cli_really_prints() -> None:
+    """Independent source of truth: drive the real pinned CLI and read it.
+
+    A marker constant chosen to match the probe's own expectation is a
+    tautology. This runs `kb-setup cc` — the exact command `mise run cc` runs,
+    minus its arguments — and asserts the marker appears in the real output. If
+    the launcher's refusal wording changes upstream, this goes red here rather
+    than the case quietly going inert.
+    """
+    exe = shutil.which("kb-setup")
+    assert exe is not None, "kb-setup must resolve — `mise run cc` invokes it"
+    rc, out = evals.run_command([exe, "cc"])
+    assert eval_cases.LAUNCHER_REACHED_MARKER in out, f"rc={rc}: {out}"
+
+
+def test_rc_alone_cannot_discriminate_the_launcher_probe() -> None:
+    """Both directions exit 2 — which is *why* the probe grades the marker.
+
+    #391's failure (`unknown command 'cc'`) and the handler's own
+    missing-argument refusal are indistinguishable by exit code. A later edit
+    that "simplified" the probe to `rc == 2` would pass in both directions — a
+    coin with one face. Pinning the equality here makes that visibly wrong.
+    """
+    exe = shutil.which("kb-setup")
+    assert exe is not None
+    reached_rc, _ = evals.run_command([exe, "cc"])
+    unknown_rc, unknown_out = evals.run_command([exe, "no-such-subcommand-xyz"])
+    assert reached_rc == unknown_rc
+    assert eval_cases.LAUNCHER_REACHED_MARKER not in unknown_out
 
 
 def test_the_graph_case_declares_an_environment_precondition() -> None:


### PR DESCRIPTION
`mise run cc` had never worked in this repo. The task dispatches to
`uv run --project python kb-setup cc`, but the pin sat at 23e4a724 — a
revision that PREDATES `kb_setup/launch.py` — so every invocation would
have died with `kb-setup: unknown command 'cc'`. It shipped twice (#379,
#390) and both PRs' gates passed correctly: no gate ran it. A declaration
nothing observed, in the repo that hosts #354.

Bump to 737ff6e (knowledge-base main): `launch.py` settled there in #43,
which repaired the four defects its cold review found — including a
`tmux kill-server` ordered BEFORE its own preflight, i.e. any preflight
failure destroyed every tmux session on the host and launched nothing.
Ray's condition for the bump ("after KB #40's follow-up merges") is met:
#41-#44 merged, #40 closed.

Both halves of the gap now have a gate, because they are different
questions and neither substitutes for the other:

* `tier1.cc-subcommand-dispatches` (RESOLUTION) really runs `kb-setup cc`
  and `cc-doctor` with no `--sibling`. That is the handler's own earliest
  refusal — reached after dispatch, before preflight — so it launches
  nothing, kills no tmux server and touches no repo. The control arm is
  #391's literal output (`unknown command`), not an invented mutation.
  Note the rc is 2 in BOTH directions, so the probe grades the handler's
  marker; grading rc would be a probe that cannot fail, and a test pins
  that equality so the "simplification" is visibly wrong.

* `eval.cc-launcher-wiring` (DECLARATION) binds `[tasks.cc]` -> argv ->
  pin -> case -> tests.

The contract's first draft PASSED its own control arm: renaming the
subcommand to `ccX` still contains the substring `kb-setup cc`, so it
graded green on exactly the break it exists to catch. Anchored to
`kb-setup cc --root`; it now fails on both a renamed subcommand and a
removed `raw = true`, and passes restored.

Gates: lint rc=0 (48 steps, 0 failures), pytest 924 passed,
verify 105 passed / 0 failed, eval 5 passed / 0 unarmed.

Closes #391. Refs #354, knowledge-base#40.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CzPdn3iHw6uhMWEdVPADfW

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787770560&installation_model_id=429246&pr_number=392&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F392&signature=1da22cc4e21a6b8924c842d2f37a259a49f2e9cb97bfaa59861f356960ea4eb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added verification for correct `cc` and `cc-doctor` command dispatch.
  * Added a new tier-1 validation case for launcher wiring and runtime resolution.

* **Bug Fixes**
  * Updated the pinned setup tool version to ensure launcher commands resolve correctly.

* **Tests**
  * Added coverage confirming successful launcher dispatch and distinguishing it from unknown commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->