### PR TITLE
docs(queue): §6 — cold review and refutation are not substitutes

### DIFF
--- a/docs/specs/graphify-autonomous-queue.md
+++ b/docs/specs/graphify-autonomous-queue.md
@@ -267,6 +267,25 @@ Per issue, inside one workflow:
 4. **Ship** — `cd <repo> && mise run kb-ship`, then `kb-land`. Never `gh pr
    create`/`merge`: guard-denied, and correctly so.
 
+**Steps 2 and 3 are BOTH mandatory and neither subsumes the other** (measured,
+knowledge-base #41, 2026-07-27). They find *disjoint* defect classes:
+
+- The **refuters**, each told to attack a named claim, found **semantic**
+  divergences — build vs stamp reading different binaries, `mise where`
+  cwd-sensitivity.
+- The **cold reviewer**, given only the diff, found **structural** ones no
+  refuter looked at: a destructive step ordered before its own validation, a
+  missing branch, and the missing regression test itself.
+
+#41 shipped with a destructive bug (`tmux kill-server` ahead of preflight, so
+any preflight failure destroyed every tmux session on the host and launched
+nothing) because the session judged the refuters had covered the reviewer's
+brief. They had not, and a majority-pass on step 3 does not discharge step 2.
+
+The mechanism is decorrelation, and it is the same reason §4 keeps the two
+repos in one session rather than two: **an agent told what to attack cannot
+report what nobody thought to ask about.** A refuter's brief is its blind spot.
+
 **Gates before any ship** (knowledge-base): `mise run lint` rc=0, `pytest`,
 `kb-setup eval` (and `--slow` for any retrieval change), `brain-audit`.
 


### PR DESCRIPTION
The 2026-07-27-c handoff recorded that §6 "currently specifies adversarial
refuters only". It does not: step 2 has been "an independent agent that
did not write the code" all along, with the refuters at step 3. Correcting
the premise narrows the real gap — §6 named both modes but never said what
the KB session learned the expensive way, that they find DISJOINT defect
classes and neither discharges the other.

Measured, knowledge-base #41: refuters each told to attack a named claim
found semantic divergences (build vs stamp reading different binaries,
`mise where` cwd-sensitivity). The cold reviewer, given only the diff,
found structural ones none of them looked at — a destructive step ordered
before its own validation, a missing branch, and the missing regression
test itself. #41 shipped with `tmux kill-server` ahead of preflight, so
any preflight failure would have destroyed every tmux session on the host
and launched nothing, because the session judged the refuters had covered
the reviewer's brief.

Names the mechanism rather than only the rule, so it generalises: an agent
told what to attack cannot report what nobody thought to ask about. A
refuter's brief is its blind spot — the same decorrelation argument §4
already makes for keeping both repos in one session.

Gates: lint rc=0 (0 failures), pytest 924 passed, verify 105 passed / 0 failed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CzPdn3iHw6uhMWEdVPADfW

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787772465&installation_model_id=429246&pr_number=393&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F393&signature=c6e6480bc5196972f2eac67694eee3a703e6f142092dd2b76ed74180efff80df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->