### PR TITLE
docs(eval-harness): record the pin bump, and the hole it exposed in our own contract style

### DIFF
--- a/docs/specs/eval-harness-design.md
+++ b/docs/specs/eval-harness-design.md
@@ -790,6 +790,44 @@ the *measurement* cheaply before building the thing that changes it.
 never calls `retrieval_recall` — but PR 5 now inherits a `retrieval_recall` that
 has grown a `floor` keyword, so the bump is no longer purely cosmetic.
 
+### 2026-07-27-d revision (the pin is BUMPED — and it was never cosmetic)
+
+The four revision notes above each closed with "PR 5 should bump the pin
+deliberately or say why it did not." **The bump happened outside PR 5**, as
+dotfiles#392 (issue #391), because the gap turned out to be load-bearing in a
+way none of those notes saw: `23e4a72` predates `kb_setup/launch.py` entirely,
+so **`mise run cc` in this repo had never once worked**. Pin is now
+`737ff6e3b745c096c886ff4a732befc033efb75e` (knowledge-base `main`), which
+carries KB #41–#44 on top of #35. PR 5 inherits a current runner and owes this
+question nothing further.
+
+Two things this correct-but-incomplete note class is worth recording for:
+
+1. **"Nothing is broken" was measured against the wrong surface.** Each note
+   checked the one consumer it knew about (`dotfiles imports the runner and
+   never calls retrieval_recall`) and concluded the gap was inert. It was inert
+   *for the eval runner*. `md_budget` and then `launch` arrived on the same pin
+   without the note's scope widening, and the third one was dead on arrival.
+   A staleness note should name **every** consumer of the pinned artifact, or
+   say it did not enumerate them.
+2. **The gap was visible in this very file and still cost a shipped defect.**
+   #391's issue body cites the "SIX revisions behind" line above as prior
+   evidence. A written-down gap that no gate reads is the same inert
+   declaration this epic exists to catch — which is why the fix shipped a
+   *probe* (`tier1.cc-subcommand-dispatches`, which runs the launcher) and a
+   *contract* (`eval.cc-launcher-wiring`) rather than another revision note.
+
+**Also from #392, a defect in this epic's own contract style.** The new
+`eval.cc-launcher-wiring` contract **passed its own control arm on first
+draft**. It bound `kb-setup cc` — a genuine invocation, satisfying the
+"bind a call site, not a `def`" rule this epic established in #300 — and the
+realistic regression (renaming the subcommand to `ccX`) leaves `kb-setup cc`
+intact as a **prefix**. Anchored to `kb-setup cc --root`; re-probed: renamed
+subcommand → FAIL, `raw = true` removed → FAIL, restored → PASS. The rule needs
+its second half: **an invocation token must extend past the renamable
+identifier.** Every `per_path_tokens` entry in `suites.toml` whose token ends at
+an identifier boundary is a candidate for the same hole.
+
 ## GitHub repos touched
 
 - [wshobson/agents](https://github.com/wshobson/agents) — `plugins/plugin-eval` + `docs/plugin-eval.md`; the three-layer taxonomy and the triggering-F1 method.


### PR DESCRIPTION
Four revision notes in this file each closed with "PR 5 should bump the
kb-setup pin deliberately or say why it did not". The bump happened
outside PR 5 — as #392, for #391 — because the gap was load-bearing in a
way none of those notes saw: `23e4a72` predates `kb_setup/launch.py`
entirely, so `mise run cc` in this repo had never once worked.

Appended as a dated revision rather than rewriting the earlier notes;
they are point-in-time analysis and stay legible as baseline.

Two things worth recording beyond the fact:

* "Nothing is broken" was measured against the wrong surface. Each note
  checked the one consumer it knew about (dotfiles imports the runner and
  never calls retrieval_recall) and concluded the gap was inert. It was
  inert for the eval runner. md_budget and then launch arrived on the
  same pin without the note's scope widening, and the third was dead on
  arrival. A staleness note should name EVERY consumer, or say it did not
  enumerate them.

* The gap was written down in this very file and still cost a shipped
  defect — #391's body cites the "SIX revisions behind" line as prior
  evidence. A written-down gap no gate reads is the same inert
  declaration this epic exists to catch, which is why the fix shipped a
  probe and a contract rather than another revision note.

Also records a defect in this epic's own contract style, now #394: the
new `eval.cc-launcher-wiring` contract PASSED its own control arm on
first draft. It bound `kb-setup cc` — a genuine invocation, satisfying
the "bind a call site, not a def" rule this epic established in #300 —
and the realistic regression, renaming the subcommand to `ccX`, leaves
`kb-setup cc` intact as a prefix. The rule needs its second half: an
invocation token must extend past the renamable identifier.

Gates: lint rc=0 (0 failures), lint-docs rc=0 (agnix: no issues found).

Refs #354, #391, #392, #394.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CzPdn3iHw6uhMWEdVPADfW

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787783815&installation_model_id=429246&pr_number=395&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F395&signature=3b650166ca27b9ac94243149d490afc0b8fbae3a3def2faa85579d92a15041cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a revision note clarifying the timing and scope of the pin update.
  * Documented additional inherited knowledge-base content and follow-up corrections to validation claims.
  * Identified a contract-testing edge case involving invocation tokens ending at identifier boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->