### PR TITLE
feat(pr): `mise run automerge -- <PR#>` — the missing verb for bot PRs (#369)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,7 +17,9 @@ are its output, already adapted.
 ### Issue tracker
 
 GitHub Issues on `ray-manaloto/dotfiles`, via `gh`. See `docs/issue-tracker.md`.
-**`gh pr create`/`merge` are guard-denied — use `mise run ship` / `mise run land`.**
+**`gh pr create`/`merge` are guard-denied. One verb per PR provenance: `mise run ship`
+(your branch), `mise run automerge -- <PR#>` (bot PR, #369), `mise run land -- <PR#>`
+(post-merge).**
 
 ### Triage labels
 

--- a/.claude/rules/mise-tasks-only.md
+++ b/.claude/rules/mise-tasks-only.md
@@ -14,7 +14,8 @@ task (wrapping the python library, zero-bash-logic) in the same change.
 | `devcontainer up` / `devcontainer build` | `mise run up` / `mise run dev-rebuild` (env + workspace-hash guard) |
 | `docker pull …dotfiles-devcontainer…` | `mise run sync` (buildkit, digest-aware, verifying; classic pull wedges on ~38GB) |
 | `gh pr create` (+ push + gates by hand) | `mise run ship` |
-| `gh pr merge` (+ watch + validate by hand) | `mise run land -- <PR#>` |
+| `gh pr merge` (+ watch + validate by hand) | `mise run land -- <PR#>` (post-merge) |
+| `gh pr merge --auto` on a BOT-opened PR (Renovate / refresh bot) | `mise run automerge -- <PR#>` — arms and exits; a human PR is refused (use `ship`) |
 | `gh pr create -R …/knowledge-base` | `mise run kb-ship` (in the KB repo) |
 | `gh pr merge -R …/knowledge-base` | `mise run kb-land -- <PR#>` (in the KB repo) |
 | `nohup … mise run <task>` / `mise run <task> &` (hand-detaching a task) | the harness background run — stays tracked, one clean completion (no orphaned process, no hand-rolled log monitor); a `&`-detached Mac-side task gets REAPED when the turn goes idle |
@@ -42,6 +43,14 @@ main CI and re-validates the dotfiles devcontainer. The guard blocked the only
 working command and named a task that could not do the job; KB PRs #1 and #2
 were merged by hand as a result. A guard whose redirect target cannot perform
 the redirected action is not enforcement, it is an outage.
+
+**It recurred along a second axis — PR PROVENANCE (#369, 2026-07-27).** Only
+`ship` arms auto-merge and a bot PR never runs it; `land` refuses an OPEN PR;
+`gh pr merge` redirected to `land`. #138/#236/#386 sat green, unmergeable.
+`automerge` is the missing verb: **bot-authored PRs ONLY**, armed and exited
+(the required checks run against the merge RESULT, so a branch behind main is
+fine). `ship` gates the tree before arming and `automerge` does not, so one
+verb per provenance means no judgement call at the call site.
 
 ## Enforcement layers (deep-research verified, 2026-07-07)
 
@@ -157,16 +166,12 @@ If a deny ever does look wrong, the workaround remains: write the script
 with the Write tool and run `python3 <file>` — and after ANY deny,
 re-check that the command's intended side effects actually happened.
 
-**Evasion was never the defect — false positives were** (issue #265, now
-closed). The audit's `blocked` bucket measured it: 2 of the 3 denials ever
-recorded were false positives, both from a `|` INSIDE a quoted regex (`grep -iE
-"…|devcontainer up|…"`) reading as a shell separator. The surviving denial —
-an `npx` reached through a real `||` fallback — was correct all along, which is
-why the fix targets 3 → 1 and not 3 → 0.
-
-Twice now a predicted risk has been refuted by probing and the real one turned
-out to be its mirror image (#264's cd-prefix "evasion"; #265's quoting). When
-this guard next looks wrong, measure before believing the prediction.
+**Evasion was never the defect — false positives were** (#265, now closed):
+2 of the 3 denials ever recorded were the quoted-regex shape above, and the
+survivor (an `npx` reached through a real `||` fallback) was correct all along
+— which is why the fix targets 3 → 1, not 3 → 0. Twice now a predicted risk has
+been refuted by probing and the real one turned out to be its mirror image
+(#264's cd-prefix "evasion"; #265's quoting): measure before believing.
 
 ## Extending
 

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -1,22 +1,28 @@
 ---
 name: pr-workflow
-description: Ship and land PRs via `mise run ship` / `mise run land` — the full gated loop from committed work to merged-and-locally-validated main. Use whenever committing work that should become a PR, when asked to merge a green PR, or when validating that the ship/land wiring is intact. Never hand-roll commit→push→PR→merge sequences.
+description: Ship, automerge and land PRs via `mise run ship` / `mise run automerge -- <PR#>` / `mise run land -- <PR#>` — the full gated loop from committed work to merged-and-locally-validated main. Use whenever committing work that should become a PR, when asked to merge a green PR, when a bot-opened PR (Renovate / the refresh bot / a dependency bump) needs merging, or when validating that the ship/land wiring is intact. Never hand-roll commit→push→PR→merge sequences.
 user-invocable: true
 ---
 
-# PR Workflow: ship / land
+# PR Workflow: ship / automerge / land
 
 The full PR loop lives in `python/src/dotfiles_setup/pr.py`
-(zero-bash-logic); `mise run ship` and `mise run land` are thin callers.
-These tasks ARE the canonical workflow — do not hand-roll
+(zero-bash-logic); `mise run ship`, `mise run automerge` and `mise run land`
+are thin callers. These tasks ARE the canonical workflow — do not hand-roll
 `git push` + `gh pr create` + `gh pr merge` sequences when they apply
 (mise-tasks-only policy).
+
+**One verb per PR provenance.** Merging is *armed*, never performed by hand:
+`ship` arms your own branch (after gating it), `automerge` arms a **bot-opened**
+PR (which never runs ship), and `land` is the post-merge validation for either.
+Picking between them is a lookup, not a judgement call.
 
 ## Commands
 
 ```bash
 mise run ship                      # gates → push → PR open/update → enable native auto-merge, return
 mise run ship -- --title "..."     # override the PR title (default: gh --fill)
+mise run automerge -- <PR#>        # BOT PR only: arm native auto-merge and exit (no local gates)
 mise run land -- <PR#>             # (after it auto-merges) confirm merged → main CI → local verify
 ```
 
@@ -55,6 +61,34 @@ mise run land -- <PR#>             # (after it auto-merges) confirm merged → m
    March-2026 422 enable regression. ship prints the `mise run land`
    follow-up for post-merge Mac validation.
 
+## What automerge does (#369)
+
+`mise run automerge -- <PR#>` is the missing verb for a **bot-opened** PR. Only
+ship armed auto-merge, and a bot PR never runs ship; `land` refuses an OPEN PR;
+`gh pr merge` is guard-denied. So #138, #236 and #386 sat green with no
+sanctioned way to merge — *a guard whose redirect target cannot perform the
+redirected action is not enforcement, it is an outage.*
+
+1. Reads `state`, `author`, `isDraft`, `baseRefName`, `headRefOid` and refuses
+   unless the PR is **OPEN**, **non-draft**, **main-based**, and authored by one
+   of `BOT_PR_AUTHORS` (`app/renovate`, `app/dotfiles-refresh-bot-org`). A
+   **human PR is refused** and pointed at `ship`: ship gates the tree before
+   arming and automerge does not, so the split keeps that from being a call the
+   operator has to make.
+2. Arms through the **same** `enable_auto_merge` ship uses — squash,
+   `--delete-branch`, pinned with `--match-head-commit` to the head SHA it just
+   read — then **prints the `land` follow-up and exits**. It does not wait:
+   waiting would turn a seconds-long verb into a 20-40min Mac-side op that gets
+   reaped when the turn goes idle.
+3. **Staleness is deliberately not checked.** Renovate branches sit behind main,
+   but `ci-gate` and the other required checks run against the **merge result**
+   and auto-merge waits for them. A local freshness gate would be a second,
+   weaker opinion about a question GitHub has already answered (and pushes
+   against #257, rebase churn).
+
+Per-PR by construction — nothing is armed unless it is named, which is what
+keeps a deliberately HELD bot PR (e.g. #386) held.
+
 ## What land does
 
 land is the **post-merge validation** step (ship's auto-merge does the merge):
@@ -85,14 +119,18 @@ scopes it to the SHA the local gates validated.
 | CI check failed (PR never auto-merges) | A required check went red, so auto-merge never fires | Triage the run; autofix "✅ Autofix task started" means the bot pushed a fix → new checks run → auto-merges when green |
 | land failed AFTER the merge (CI watch / sync) | Merged-but-unvalidated PR | `mise run land -- <PR#> --resume` replays the idempotent post-merge steps |
 | `land: no main ci.yml run appeared` | A merge that SHOULD trigger a run didn't register (~10 min) | Check Actions; land only expects a run when the diff matches `CI_PUSH_PATHS` (ci.yml on.push.paths) — a merge matching none passes without one (#179) |
+| `automerge: PR #N was opened by '<login>', which is not one of the bots…` | A human/ship-able PR (or a bot not on the allowlist) | Use `mise run ship` from the branch — it gates the tree before arming. Adding a bot means editing `BOT_PR_AUTHORS` + its test, deliberately |
+| `automerge: PR #N is MERGED, not OPEN` | Already merged (auto-merge fired, or it was hand-merged) | `mise run land -- <PR#>` for the post-merge Mac validation |
+| `automerge: could not enable auto-merge` | Same 422 regression / auto-merge-not-configured cause as ship's | Check the repo's auto-merge setting + branch protection, then re-run; if the bot force-pushed a rebase since, re-run anyway (the arming is pinned to the SHA it read) |
 
 ## Wiring audit (meta-validation)
 
-Machine-enforced by `workflow.ship-land-wiring` in
-`python/verification/suites.toml`. By hand: `[tasks.ship]`/`[tasks.land]`
-delegate to `dotfiles-setup pr ...`; `tests/test_pr.py` passes; the
-surface list in `pr.py` covers every path class whose change demands
-full local verification (extend it when new validation code lands).
+Machine-enforced by `workflow.ship-land-wiring` and
+`workflow.automerge-wiring` in `python/verification/suites.toml`. By hand:
+`[tasks.ship]`/`[tasks.automerge]`/`[tasks.land]` delegate to
+`dotfiles-setup pr ...`; `tests/test_pr.py` passes; the surface list in `pr.py`
+covers every path class whose change demands full local verification (extend it
+when new validation code lands).
 
 ## See also
 

--- a/mise.toml
+++ b/mise.toml
@@ -646,6 +646,17 @@ description = "Verify PR green → pinned squash-merge → watch main CI → loc
 #   mise run land -- 172
 run = 'uv run --project python dotfiles-setup pr land'
 
+[tasks.automerge]
+description = "Arm GitHub-native auto-merge on a BOT-opened PR (Renovate / refresh bot), then exit"
+# Thin caller; see pr.py `automerge_main`. The missing verb (#369): a bot PR
+# never runs ship, so nothing armed auto-merge on it, and land refuses an OPEN
+# PR — the guard denied the only working command and redirected to a task that
+# could not do it. Bot-authored PRs ONLY (a human PR is refused → use ship,
+# which gates the tree before arming). Arms and exits; CI's required checks run
+# against the merge result, so a branch behind main is fine:
+#   mise run automerge -- 236
+run = 'uv run --project python dotfiles-setup pr automerge'
+
 [tasks.sync]
 description = "Converge the devcontainer onto the latest CI image + verify (digest fast-path)"
 # Thin caller per zero-bash-logic; the orchestration (registry-vs-local-tag

--- a/python/src/dotfiles_setup/eval_cases.py
+++ b/python/src/dotfiles_setup/eval_cases.py
@@ -116,6 +116,13 @@ GUARD_FIXTURES: tuple[evals.GuardFixture, ...] = (
     _D("gh pr create --fill", _DENY, "dotfiles PR — `mise run ship`"),
     _D("gh pr merge 123 --squash", _DENY, "dotfiles PR — `mise run land`"),
     _D(
+        "gh pr merge 236 --auto --squash",
+        _DENY,
+        "the ARMING shape (#369) — must redirect to `mise run automerge`, the "
+        "one thing `land` cannot do; until that verb existed this redirect "
+        "pointed at a task that refuses an OPEN PR",
+    ),
+    _D(
         "gh pr create -R ray-manaloto/knowledge-base --fill",
         _DENY,
         "KB PR — must redirect to kb-ship, NOT ship (the #349 defect)",

--- a/python/src/dotfiles_setup/hook_guard.py
+++ b/python/src/dotfiles_setup/hook_guard.py
@@ -107,6 +107,12 @@ _V3 = "2026-07-21"
 # The repo-aware gh-pr rules landed 2026-07-23, once the knowledge-base repo
 # grew its own kb-ship/kb-land to redirect to.
 _V4 = "2026-07-23"
+# The bot-PR arming rule landed 2026-07-27 with `mise run automerge` (#369) —
+# the same "the redirect target must be able to do the job" fix as _V4, along
+# the PR-provenance axis instead of the target-repo one. Until the verb
+# existed, `gh pr merge --auto` on a Renovate PR could only be redirected to
+# `land`, which refuses an OPEN PR.
+_V5 = "2026-07-27"
 
 # `gh` names a target repo with `-R owner/repo` / `--repo owner/repo` (or
 # `--repo=owner/repo`); with none, it infers from cwd — which, for a guard
@@ -240,12 +246,32 @@ _RULES: tuple[Rule, ...] = (
         ".claude/skills/pr-workflow/SKILL.md.",
         _V1,
     ),
+    # `--auto` names the intent exactly — ARM auto-merge — and that is the one
+    # thing `land` cannot do, which is how #369 became an outage: a Renovate PR
+    # never runs ship, so nothing armed it, and the only sanctioned redirect
+    # pointed at a task that refuses an OPEN PR. Ordered BEFORE the generic
+    # merge rule (first match wins) so the precise shape gets the precise
+    # redirect. The repo lookahead sits at the same position as the other
+    # gh-pr rules, so a `-R` naming a foreign repo is seen wherever it appears.
+    Rule(
+        "gh pr merge --auto",
+        re.compile(
+            _CMD + r"gh\s+pr\s+merge\b" + _GH_REPO_NOT_FOREIGN + r"[^;&|\n]*--auto\b"
+        ),
+        "Use `mise run automerge -- <PR#>` for a BOT-opened PR (Renovate / the "
+        "refresh bot) — it checks provenance, then arms auto-merge pinned to "
+        "the head SHA and exits. For your OWN branch use `mise run ship`, which "
+        "gates the tree before arming. See .claude/skills/pr-workflow/SKILL.md.",
+        _V5,
+    ),
     Rule(
         "gh pr merge",
         re.compile(_CMD + r"gh\s+pr\s+merge\b" + _GH_REPO_NOT_FOREIGN),
-        "Use `mise run land -- <PR#>` — it verifies check buckets, pins the "
-        "merge to the verified head SHA, watches main CI, and validates "
-        "locally. See .claude/skills/pr-workflow/SKILL.md.",
+        "Merging is armed, not performed, in this repo — one verb per PR "
+        "provenance: `mise run ship` for your own branch (gates, then arms), "
+        "`mise run automerge -- <PR#>` for a bot-opened PR (#369). Once GitHub "
+        "has merged it, `mise run land -- <PR#>` runs the post-merge main-CI "
+        "check + local validation. See .claude/skills/pr-workflow/SKILL.md.",
         _V1,
     ),
     # `nohup`/manual detachment of a mise task orphans it from the harness

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -59,7 +59,7 @@ from dotfiles_setup.p2996_hash import (
 )
 from dotfiles_setup.p2996_refresh import refresh as refresh_p2996_ref
 from dotfiles_setup.parity import run as parity_run
-from dotfiles_setup.pr import land_main, ship_main
+from dotfiles_setup.pr import automerge_main, land_main, ship_main
 from dotfiles_setup.renovate import renovate_status_main
 from dotfiles_setup.renovate_dryrun import renovate_dryrun_main
 from dotfiles_setup.sync import SyncOptions, sync_main
@@ -498,6 +498,17 @@ def _add_pr_subcommands(
         help="Replay the post-merge steps (main-CI watch, local validation) "
         "for an already-MERGED PR that failed after its merge",
     )
+    # #369: bot-opened PRs never run ship, so nothing ever armed auto-merge on
+    # them and land refuses an OPEN PR — the guard denied the only working
+    # command and redirected to a task that could not do the job.
+    automerge_parser = pr_sub.add_parser(
+        "automerge",
+        help="Arm GitHub-native auto-merge on a BOT-opened PR and exit "
+        "(Renovate / refresh bot); a human PR is refused → use ship",
+    )
+    automerge_parser.add_argument(
+        "number", type=int, help="Bot-opened PR number to arm auto-merge on"
+    )
 
 
 def _add_hook_subcommands(
@@ -842,6 +853,8 @@ def handle_pr(args: argparse.Namespace, project_root: Path) -> None:
         sys.exit(ship_main(project_root, title=args.title))
     elif args.pr_command == "land":
         sys.exit(land_main(project_root, args.number, resume=args.resume))
+    elif args.pr_command == "automerge":
+        sys.exit(automerge_main(project_root, args.number))
 
 
 def handle_hook(args: argparse.Namespace, project_root: Path) -> None:

--- a/python/src/dotfiles_setup/pr.py
+++ b/python/src/dotfiles_setup/pr.py
@@ -1,4 +1,4 @@
-"""Ship/land: the full PR loop as library code (zero-bash-logic).
+"""Ship/land/automerge: the full PR loop as library code (zero-bash-logic).
 
 ``dotfiles-setup pr ship`` (wrapped by ``mise run ship``) takes the
 current feature branch from "work is committed/staged" to "PR open with
@@ -6,6 +6,16 @@ checks watched"; ``dotfiles-setup pr land <n>`` (wrapped by
 ``mise run land``) takes a green PR through squash-merge, main-CI watch,
 and post-merge LOCAL validation on this Mac. Together they encode the
 verify-before-advancing rule as code instead of discipline.
+
+``dotfiles-setup pr automerge <n>`` (wrapped by ``mise run automerge``) is
+the third verb, and it exists because the first two left a hole (#369): a
+**bot-opened** PR never runs ship, so nothing ever armed auto-merge on it,
+land refuses an OPEN PR, and ``gh pr merge`` is guard-denied — the guard
+denied the only working command and redirected to a task that could not do
+the job. *A guard whose redirect target cannot perform the redirected action
+is not enforcement, it is an outage* — the same shape fixed for
+knowledge-base PRs in #349/#350, here along a different axis (PR provenance
+rather than target repo). See :func:`automerge_main`.
 
 Design notes (deep-research verified, 2026-07-07 —
 ``docs/research/runs/research-20260707-gha-shipland-enforcement/report.md``):
@@ -170,6 +180,24 @@ _DOCS_PATTERNS = (
 )
 
 _GREEN_BUCKETS = frozenset({"pass", "skipping"})
+
+# The GitHub Apps whose PRs `automerge` will arm (#369, scope locked by Ray
+# 2026-07-27). Re-derived, not assumed: `gh pr list --state all --limit 60
+# --json number,author` over this repo returns exactly two non-human logins,
+# and they own all three stuck PRs (#138, #236, #386).
+#
+# A login ALLOWLIST, deliberately, not `author.is_bot`: is_bot would admit any
+# app that ever opens a PR here, whereas the point of the ship/automerge split
+# is that a NAMED set of bots gets the verb that skips the local gates. A user
+# login cannot contain `/`, so an `app/…` login is not spoofable by a human
+# account. Control arm for the discriminator: `sortakool` -> is_bot=false and
+# is absent from this set, so a human PR takes the refusal path.
+BOT_PR_AUTHORS: frozenset[str] = frozenset(
+    {
+        "app/renovate",
+        "app/dotfiles-refresh-bot-org",
+    }
+)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -378,7 +406,9 @@ _AUTOMERGE_ENABLE_ATTEMPTS = 5
 _AUTOMERGE_ENABLE_BACKOFF_S = 20
 
 
-def enable_auto_merge(workspace: Path, pr_number: int, head: str) -> bool:
+def enable_auto_merge(
+    workspace: Path, pr_number: int, head: str, *, verb: str = "ship"
+) -> bool:
     """Enable GitHub-native auto-merge (squash), pinned to the verified head.
 
     GitHub then merges the PR server-side the instant the required ``ci-gate``
@@ -387,6 +417,10 @@ def enable_auto_merge(workspace: Path, pr_number: int, head: str) -> bool:
     GitHub auto-disables auto-merge if new commits are pushed), closing the
     verify-then-merge race. Runs as a subprocess, so it is not a hand-rolled
     watch — GitHub owns the wait.
+
+    ``verb`` only labels the failure line: both ``ship`` and ``automerge``
+    (#369) arm through this one function, so the arming semantics cannot drift
+    apart between the two entrypoints.
     """
     cmd = [
         "gh",
@@ -412,7 +446,7 @@ def enable_auto_merge(workspace: Path, pr_number: int, head: str) -> bool:
     if res.returncode == 0:
         return True
     sys.stdout.write(
-        f"FAIL  ship: could not enable auto-merge on PR #{pr_number}: "
+        f"FAIL  {verb}: could not enable auto-merge on PR #{pr_number}: "
         f"{res.stderr.strip()}\n"
     )
     return False
@@ -552,6 +586,128 @@ def ship_main(workspace: Path, *, title: str | None = None) -> int:
         f"GitHub merges it the instant ci-gate goes green (no poll; a base build "
         f"can take hours). After it merges, run `mise run land -- {number}` for "
         "the post-merge Mac validation (or `mise run sync` on next bring-up).\n"
+    )
+    return 0
+
+
+def _automerge_refusal(pr_number: int, info: dict[str, object]) -> str | None:
+    """The reason `automerge` will not arm this PR, or None when it will.
+
+    Split out from :func:`automerge_main` so every refusal is testable without
+    a subprocess, and so the precondition ORDER is visible in one place. Order
+    is by what the operator most likely got wrong: wrong state, then wrong
+    provenance (the split this verb exists to encode), then draft, then base.
+    """
+    state = info.get("state")
+    if state != "OPEN":
+        follow_up = (
+            f" It is already merged — run `mise run land -- {pr_number}` for the "
+            "post-merge Mac validation."
+            if state == "MERGED"
+            else ""
+        )
+        return (
+            f"FAIL  automerge: PR #{pr_number} is {state}, not OPEN — there is "
+            f"nothing to arm.{follow_up}"
+        )
+    author = info.get("author")
+    login = author.get("login", "") if isinstance(author, dict) else ""
+    if login not in BOT_PR_AUTHORS:
+        return (
+            f"FAIL  automerge: PR #{pr_number} was opened by {login!r}, which is "
+            f"not one of the bots this verb serves "
+            f"({', '.join(sorted(BOT_PR_AUTHORS))}). Use `mise run ship` from the "
+            "branch instead — ship gates the tree BEFORE arming auto-merge and "
+            "automerge does not gate anything, so one verb per provenance means "
+            "no judgement call at the call site."
+        )
+    if info.get("isDraft"):
+        return (
+            f"FAIL  automerge: PR #{pr_number} is a draft — GitHub refuses to "
+            "enable auto-merge on a draft. Mark it ready for review first."
+        )
+    base = info.get("baseRefName")
+    if base != "main":
+        return (
+            f"FAIL  automerge: PR #{pr_number} targets {base!r}, not main. The "
+            "post-merge validation this verb points at (`mise run land`) only "
+            "validates main-based PRs."
+        )
+    if not info.get("headRefOid"):
+        return (
+            f"FAIL  automerge: PR #{pr_number} has no headRefOid — cannot pin the "
+            "arming to a SHA."
+        )
+    return None
+
+
+def automerge_main(workspace: Path, pr_number: int) -> int:
+    """Arm GitHub-native auto-merge on a BOT-opened PR, then exit (#369).
+
+    The missing verb. ship arms auto-merge for work you shipped; a bot-opened
+    PR (Renovate, the refresh bot) never runs ship, so nothing armed it, and
+    land — post-merge validation — refuses an OPEN PR. This closes that hole
+    WITHOUT re-entangling land with merging (the ship/land split deliberately
+    undid that).
+
+    Four properties, all decisions rather than preferences (Ray, 2026-07-27,
+    recorded verbatim on #369):
+
+    - **Bot-authored PRs only** (:data:`BOT_PR_AUTHORS`). A human PR is refused
+      and pointed at ship, because ship gates the tree before arming and this
+      verb does not. One verb per provenance = no judgement call at the call
+      site.
+    - **Arm and exit** — it prints the ``mise run land`` follow-up rather than
+      waiting. Waiting would turn a seconds-long local verb into a 20-40min
+      Mac-side op that gets reaped when the turn goes idle
+      (``feedback_long_mac_ops_keep_turn_engaged``).
+    - **Arm even when the branch is behind main.** Renovate branches sit behind
+      (#369 records #342's base as ``66579dc``), but ``ci-gate`` and the other
+      required checks run against the MERGE RESULT and auto-merge waits for
+      them. A local freshness gate would be a second, weaker opinion about a
+      question GitHub has already answered — and would push against #257
+      (rebase churn).
+    - **Per-PR, never a sweep.** Nothing is armed unless it is named, which is
+      what keeps a HELD PR (#386, pending the corpus re-baseline) held.
+
+    It arms through :func:`enable_auto_merge`, the same call ship uses, pinned
+    with ``--match-head-commit`` to the head SHA read here. If the bot
+    force-pushes a rebase afterwards, the arming no longer matches its head —
+    re-run the verb.
+    """
+    view = _run(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(pr_number),
+            "--json",
+            "state,isDraft,baseRefName,headRefOid,author",
+        ],
+        timeout=_PROBE_TIMEOUT_S,
+        cwd=workspace,
+    )
+    if view.returncode != 0 or not view.stdout.strip():
+        # Report the status we SAW, never a prose summary of it (#358).
+        sys.stdout.write(
+            f"FAIL  automerge: gh pr view rc={view.returncode}: {view.stderr.strip()}\n"
+        )
+        return 1
+    info = json.loads(view.stdout)
+    refusal = _automerge_refusal(pr_number, info)
+    if refusal is not None:
+        sys.stdout.write(f"{refusal}\n")
+        return 1
+    head = str(info["headRefOid"])
+    if not enable_auto_merge(workspace, pr_number, head, verb="automerge"):
+        return 1
+    sys.stdout.write(
+        f"\nautomerge: OK — PR #{pr_number} armed (squash, pinned to "
+        f"{head[:7]}).\nGitHub merges it the instant ci-gate goes green; the "
+        "required checks run against the merge result, so a branch behind main "
+        "is fine.\nNothing was gated locally — that is CI's job here. After it "
+        f"merges, run `mise run land -- {pr_number}` for the post-merge Mac "
+        "validation.\n"
     )
     return 0
 

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -989,6 +989,57 @@ tokens = [
 ]
 
 [[suite]]
+name = "workflow.automerge-wiring"
+description = "#369 bot-PR merge path: `mise run automerge -- <PR#>` must stay wired end-to-end — the mise task shells out to `dotfiles-setup pr automerge`, main.py dispatches it, pr.py's `automerge_main` arms through the SAME `enable_auto_merge` ship uses, the bot allowlist names both real app logins, and the guard's `gh pr merge --auto` rule redirects there. It exists because ship/land left a hole: a bot-opened PR never runs ship so nothing armed auto-merge on it, land refuses an OPEN PR, and `gh pr merge` was denied and redirected to land — a guard whose redirect target cannot perform the redirected action is not enforcement, it is an outage (#138/#236/#386 sat green and unmergeable). Second instance of the #349/#350 shape, along the PR-provenance axis instead of the target-repo one. EVERY token below is anchored PAST its renamable identifier (#394): `dotfiles-setup pr automerge'` carries the closing quote and `verb=\"automerge\")` the closing paren, because renaming the subcommand to `automergeX` leaves the bare prefix intact and a contract that survives its own regression is decoration. Tokens bind CALL SITES (the dispatch line, the arming call, the guard rule literal), not definitions — #299 proved an existence token stays green while its wiring line is deleted, since the name survives in a comment."
+category = "workflow"
+check_type = "static"
+handler = "require_tokens"
+paths_required = true
+paths = [
+    "mise.toml",
+    "python/src/dotfiles_setup/main.py",
+    "python/src/dotfiles_setup/pr.py",
+    "python/src/dotfiles_setup/hook_guard.py",
+    "python/src/dotfiles_setup/eval_cases.py",
+    "tests/test_pr.py",
+    "tests/test_hook_guard.py",
+    ".claude/rules/mise-tasks-only.md",
+]
+per_path_tokens = { "mise.toml" = [
+    "[tasks.automerge]",
+    "dotfiles-setup pr automerge'",
+], "python/src/dotfiles_setup/main.py" = [
+    "args.pr_command == \"automerge\"",
+    "automerge_main(project_root, args.number)",
+], "python/src/dotfiles_setup/pr.py" = [
+    "def automerge_main(",
+    "BOT_PR_AUTHORS: frozenset[str]",
+    "\"app/renovate\"",
+    "\"app/dotfiles-refresh-bot-org\"",
+    "verb=\"automerge\")",
+], "python/src/dotfiles_setup/hook_guard.py" = [
+    "\"gh pr merge --auto\",",
+    "mise run automerge -- <PR#>",
+], "python/src/dotfiles_setup/eval_cases.py" = [
+    "gh pr merge 236 --auto --squash",
+], "tests/test_pr.py" = [
+    "def test_automerge_refuses_and_never_arms(",
+    "def test_automerge_never_asks_github_about_branch_freshness(",
+    "def test_automerge_authors_are_the_two_real_bot_logins(",
+], "tests/test_hook_guard.py" = [
+    "def test_gh_pr_merge_auto_routes_to_automerge(",
+    "def test_automerge_arming_control_arm(",
+], ".claude/rules/mise-tasks-only.md" = [
+    "mise run automerge -- <PR#>",
+] }
+tokens = [
+    "[tasks.automerge]",
+    "dotfiles-setup pr automerge'",
+    "def automerge_main(",
+    "verb=\"automerge\")",
+]
+
+[[suite]]
 name = "workflow.mise-tasks-enforcement"
 description = "mise-tasks-only policy wiring: the PreToolUse Bash guard must stay wired end-to-end — .claude/settings.json invokes `bash scripts/pretooluse-guard.sh`, that fail-open wrapper execs `dotfiles-setup hook pretooluse`, the guard module + its tests exist, and the rule doc names the canonical task map. The wrapper adds one hop of indirection (web-brick fix: fail open when the Python>=3.14 interpreter is absent) — this contract asserts BOTH hops so neither drifts out of the chain. Also pins the #265 precision fix: rules run against `_inert_masked(command)`, never the raw string, so a separator inside a quoted span or a heredoc body cannot fake a command position. That masking is the guard's ONLY measured defect class — evasion has been 0 for its whole lifetime while 2 of its 3 denials were quoting false positives, and a deny cancels the WHOLE compound command, so a wrong one silently skips the rest. Pinned here because the masking lives one call away from the rules and a refactor that dropped it would restore every false positive while every rule test still passed."
 category = "workflow"

--- a/tests/test_hook_guard.py
+++ b/tests/test_hook_guard.py
@@ -261,6 +261,75 @@ def test_gh_pr_allowed_for_other_repos(command: str) -> None:
     assert hook_guard.decide(command) is None, f"expected ALLOW for {command!r}"
 
 
+# --- #369: `gh pr merge --auto` routes by PR PROVENANCE ---------------------
+#
+# Same defect shape as the repo-aware split above, one axis over. A bot-opened
+# PR never runs ship, so nothing armed auto-merge on it; `land` refuses an OPEN
+# PR; `gh pr merge` was denied and redirected to `land`. The guard denied the
+# only working command and named a task that cannot do the job — #138, #236 and
+# #386 sat green and unmergeable. `--auto` names the ARMING intent exactly, so
+# it gets the precise redirect; the generic merge rule still has to name a verb
+# for each provenance.
+@pytest.mark.parametrize(
+    ("command", "rule_name"),
+    [
+        ("gh pr merge 236 --auto --squash", "gh pr merge --auto"),
+        ("gh pr merge 236 --squash --auto", "gh pr merge --auto"),
+        ("gh pr merge 236 -R ray-manaloto/dotfiles --auto", "gh pr merge --auto"),
+        # The KB rule is ordered first, so a KB `--auto` still routes to kb-land
+        # rather than to a dotfiles task that has no repo parameter (#349).
+        (
+            "gh pr merge 3 --auto -R ray-manaloto/knowledge-base",
+            "gh pr merge (knowledge-base)",
+        ),
+    ],
+)
+def test_gh_pr_merge_auto_routes_to_automerge(command: str, rule_name: str) -> None:
+    """Bound to the RULE, not to a substring of its reason.
+
+    A reason-substring assertion could not see this rule being deleted: the
+    generic merge rule names `mise run automerge` too, so it would match the
+    command and satisfy the substring. Matching on rule identity is what makes
+    deletion (the realistic regression) fail here.
+    """
+    rule = hook_guard.match(command)
+    assert rule is not None, f"expected a deny for {command!r}"
+    assert rule.name == rule_name
+    assert "mise run automerge" in rule.reason or "kb-land" in rule.reason
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # CONTROL ARM: the arming shape is only guarded where a canonical verb
+        # exists. A sibling repo has none, in either flag order.
+        "gh pr merge 5 --auto -R some-other/repo",
+        "gh pr merge -R some-other/repo 5 --auto",
+        # The redirect TARGETS must not be denied — that is the outage this
+        # whole rule exists to end.
+        "mise run automerge -- 236",
+        "uv run --project python dotfiles-setup pr automerge 236",
+        # Prose describing the ban stays allowed (the #265 class).
+        'echo "gh pr merge 1 --auto is denied"',
+    ],
+)
+def test_automerge_arming_control_arm(command: str) -> None:
+    assert hook_guard.decide(command) is None, f"expected ALLOW for {command!r}"
+
+
+def test_generic_merge_rule_still_names_every_provenance() -> None:
+    """A bare `gh pr merge` must name ship, automerge AND land.
+
+    Before #369 it named only `land`, which cannot merge — the redirect had no
+    working target for a bot PR. The three verbs are the whole dispatch table,
+    so losing any one of them re-opens the outage for that provenance.
+    """
+    reason = hook_guard.decide("gh pr merge 42 --squash")
+    assert reason is not None
+    for verb in ("mise run ship", "mise run automerge", "mise run land"):
+        assert verb in reason, f"{verb!r} missing from the generic merge redirect"
+
+
 def test_foreign_repo_lookahead_does_not_span_separators() -> None:
     r"""A later command's `-R` must not license an earlier dotfiles `gh pr`.
 

--- a/tests/test_pr.py
+++ b/tests/test_pr.py
@@ -347,6 +347,144 @@ def test_ship_fails_if_auto_merge_enable_fails(
     assert pr.ship_main(_WORKSPACE) == 1
 
 
+# --------------------------------------------------- automerge (#369)
+#
+# The verb exists because ship/land left a hole: a bot PR never runs ship, so
+# nothing armed auto-merge on it, and land refuses an OPEN PR. Every refusal
+# below is a real shape that reached the maintainer, and each is paired with
+# the arming case — a dispatch table tested in one direction proves nothing.
+
+
+def _pr_view(
+    *,
+    state: str = "OPEN",
+    login: str = "app/renovate",
+    base: str = "main",
+    draft: bool = False,
+    head: str = "a" * 40,
+) -> dict[str, object]:
+    return {
+        "state": state,
+        "isDraft": draft,
+        "baseRefName": base,
+        "headRefOid": head,
+        "author": {"login": login, "is_bot": login.startswith("app/")},
+    }
+
+
+def test_automerge_arms_a_bot_pr_and_exits(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The whole point: a Renovate PR gets armed, pinned to its head SHA."""
+    armed: dict[str, object] = {}
+    monkeypatch.setattr(pr, "_run", lambda *_a, **_k: _cp(json.dumps(_pr_view())))
+
+    def fake_enable(_w: Path, n: int, head: str, *, verb: str = "ship") -> bool:
+        armed.update({"pr": n, "head": head, "verb": verb})
+        return True
+
+    monkeypatch.setattr(pr, "enable_auto_merge", fake_enable)
+    assert pr.automerge_main(_WORKSPACE, 236) == 0
+    assert armed == {"pr": 236, "head": "a" * 40, "verb": "automerge"}
+
+
+def test_automerge_arms_the_refresh_bot_too(monkeypatch: pytest.MonkeyPatch) -> None:
+    """#138's author. Both allowlist entries must actually work, not just one."""
+    monkeypatch.setattr(
+        pr,
+        "_run",
+        lambda *_a, **_k: _cp(
+            json.dumps(_pr_view(login="app/dotfiles-refresh-bot-org"))
+        ),
+    )
+    monkeypatch.setattr(pr, "enable_auto_merge", lambda *_a, **_k: True)
+    assert pr.automerge_main(_WORKSPACE, 138) == 0
+
+
+@pytest.mark.parametrize(
+    ("view", "hint"),
+    [
+        # A human PR: ship gates the tree before arming and automerge does not,
+        # so the refusal must point at ship rather than quietly skip the gates.
+        (_pr_view(login="sortakool"), "mise run ship"),
+        # `is_bot` is NOT the discriminator — a NAMED allowlist is.
+        (_pr_view(login="app/some-other-bot"), "mise run ship"),
+        (_pr_view(state="MERGED"), "mise run land"),
+        (_pr_view(state="CLOSED"), "nothing to arm"),
+        (_pr_view(draft=True), "draft"),
+        (_pr_view(base="develop"), "not main"),
+        (_pr_view(head=""), "headRefOid"),
+    ],
+)
+def test_automerge_refuses_and_never_arms(
+    view: dict[str, object],
+    hint: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Each refusal exits 1, says why, and — the load-bearing half — never arms.
+
+    Asserting only the rc would pass a version that armed the PR and *then*
+    printed a complaint.
+    """
+    armed: list[int] = []
+
+    def fake_enable(_w: Path, n: int, _h: str, **_k: object) -> bool:
+        armed.append(n)
+        return True
+
+    monkeypatch.setattr(pr, "_run", lambda *_a, **_k: _cp(json.dumps(view)))
+    monkeypatch.setattr(pr, "enable_auto_merge", fake_enable)
+    assert pr.automerge_main(_WORKSPACE, 7) == 1
+    assert armed == [], "a refused PR must never reach the arming call"
+    assert hint in capsys.readouterr().out
+
+
+def test_automerge_never_asks_github_about_branch_freshness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Staleness is deliberately NOT a precondition (locked decision 4).
+
+    Renovate branches sit behind main, but ci-gate and the other required
+    checks run against the MERGE RESULT and auto-merge waits for them. A local
+    freshness gate would be a second, weaker opinion about a question GitHub
+    has already answered — and pushes against #257 (rebase churn). Pinned by
+    inspecting the fields the verb actually requests, because "just add a
+    staleness check" is the obvious-looking wrong fix and would start here.
+    """
+    seen: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_k: object) -> subprocess.CompletedProcess[str]:
+        seen.append(cmd)
+        return _cp(json.dumps(_pr_view()))
+
+    monkeypatch.setattr(pr, "_run", fake_run)
+    monkeypatch.setattr(pr, "enable_auto_merge", lambda *_a, **_k: True)
+    assert pr.automerge_main(_WORKSPACE, 342) == 0
+    fields = seen[0][seen[0].index("--json") + 1]
+    for freshness_field in ("mergeStateStatus", "mergeable", "commits", "baseRefOid"):
+        assert freshness_field not in fields
+
+
+def test_automerge_fails_when_gh_view_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pr, "_run", lambda *_a, **_k: _cp("", returncode=1))
+    assert pr.automerge_main(_WORKSPACE, 236) == 1
+
+
+def test_automerge_fails_when_arming_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pr, "_run", lambda *_a, **_k: _cp(json.dumps(_pr_view())))
+    monkeypatch.setattr(pr, "enable_auto_merge", lambda *_a, **_k: False)
+    assert pr.automerge_main(_WORKSPACE, 236) == 1
+
+
+def test_automerge_authors_are_the_two_real_bot_logins() -> None:
+    """Re-derived from `gh pr list --json author`, not invented.
+
+    A user login cannot contain `/`, so every entry must be an `app/…` login —
+    that is what makes the allowlist unspoofable by a human account.
+    """
+    assert {"app/renovate", "app/dotfiles-refresh-bot-org"} == pr.BOT_PR_AUTHORS
+    assert all(login.startswith("app/") for login in pr.BOT_PR_AUTHORS)
+
+
 def test_land_requires_merged(monkeypatch: pytest.MonkeyPatch) -> None:
     """A still-OPEN PR means auto-merge is pending ci-gate — land exits 1."""
     view = {"state": "OPEN", "baseRefName": "main"}

--- a/tests/test_workflow_hooks.py
+++ b/tests/test_workflow_hooks.py
@@ -654,8 +654,18 @@ jobs:
 
 
 def test_derivation_matches_the_real_tree_today() -> None:
-    """The real repo derives exactly `ship` and `land` — the old hand-list."""
+    """The real repo derives `automerge`, `land` and `ship`.
+
+    It was `ship`/`land` — the old hand-list — until #369 added `automerge`,
+    and the derivation picked the new task up with no edit here. That is the
+    mechanism working: `[tasks.automerge]` is a thin caller of
+    `dotfiles-setup pr`, an already-registered git-write module, so the chain
+    resolves without anyone remembering to extend a list. The classification is
+    also correct on the merits — arming auto-merge makes GitHub squash-merge
+    and delete the head branch, so it must not be reachable from a workflow.
+    """
     assert workflow_hooks.mise_task_git_writers(REPO_ROOT) == (
+        ("mise", "run", "automerge"),
         ("mise", "run", "land"),
         ("mise", "run", "ship"),
     )


### PR DESCRIPTION
Only `ship` armed GitHub-native auto-merge, and a bot-opened PR never runs
ship. `land` refuses an OPEN PR. `gh pr merge` is guard-denied and redirected
to `land`. So #138, #236 and #386 sat green, CLEAN/MERGEABLE, with no
sanctioned way to merge — the guard denied the only working command and named
a task that could not do the job.

*A guard whose redirect target cannot perform the redirected action is not
enforcement, it is an outage.* Second instance of the shape fixed for
knowledge-base PRs in #349/#350, along a different axis: PR **provenance**
rather than target repo.

Scope locked by Ray on the issue; all four decisions encoded and tested:

- **Option 1, a new verb** — `land` is NOT taught to arm; that would
  re-entangle land with merging, which the ship/land split deliberately undid.
- **Bot-authored PRs ONLY** (`BOT_PR_AUTHORS`). A human PR is refused and
  pointed at `ship`: ship gates the tree before arming and automerge does not,
  so one verb per provenance means no judgement call at the call site. A login
  allowlist, not `author.is_bot` — re-derived from `gh pr list --json author`
  (exactly two non-human logins, owning all three stuck PRs), and a user login
  cannot contain `/` so `app/…` is unspoofable.
- **Arm and exit**, printing the `land` follow-up. Waiting would turn a
  seconds-long verb into a 20-40min Mac-side op that gets reaped on idle.
- **Arm even when behind main.** `ci-gate` and the other required checks run
  against the merge RESULT and auto-merge waits for them; a local freshness
  gate would be a second, weaker opinion about a question GitHub has already
  answered, and pushes against #257 (rebase churn).

Arming goes through the SAME `enable_auto_merge` ship uses (pinned
`--match-head-commit`), so the semantics cannot drift between entrypoints.
Per-PR by construction — nothing is armed unless it is named, which is what
keeps #386 held.

Wiring, in the ship/land shape: a `hook_guard` rule for `gh pr merge --auto`
(`since = 2026-07-27`; ordered before the generic merge rule, after the KB
ones) plus a reworded generic reason naming all three verbs; the
`workflow.automerge-wiring` contract; a tier-2 eval fixture row; the task-map
row; the pr-workflow skill.

Every contract token is anchored PAST its renamable identifier (#394) —
`dotfiles-setup pr automerge'` carries the closing quote, `verb="automerge")`
the closing paren — and tokens bind CALL SITES, not definitions. The guard
tests bind `match(...).name` rather than a reason substring, because the
generic rule now names `mise run automerge` too and a substring assertion
could not see this rule being deleted.

Control-armed by 12 realistic mutations, every one detected and restored:
subcommand renamed to `automergeX`; the main.py dispatch line deleted with the
`def` surviving; `verb=` dropped from the arming call; the mise task renamed;
the guard rule renamed; a bot dropped from the allowlist; the rule doc losing
the invocation form; the provenance check disabled; "arm first, complain
later"; a freshness field added to the `--json` list.

`test_derivation_matches_the_real_tree_today` now expects `automerge` as well:
the ADR-0001 derivation resolved `[tasks.automerge]` -> `dotfiles-setup pr` on
its own, and the classification is right on the merits — arming auto-merge
makes GitHub squash-merge and delete the head branch.

`mise-tasks-only.md` was at 194/200 lines, so the new row + paragraph were paid
for by compressing the #265 block, which restated a measurement already given
above it. Now 199/200.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CzPdn3iHw6uhMWEdVPADfW

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787786304&installation_model_id=429246&pr_number=396&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F396&signature=be78c8296f4a1903080129e7e837b5dbed62fadba7ee69e3bb95a5c7733229d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->