### PR TITLE
feat(security): gate committed env dumps, generate the hk audit, gate token uniqueness

### DIFF
--- a/.claude/rules/secrets-out-of-the-shell-env.md
+++ b/.claude/rules/secrets-out-of-the-shell-env.md
@@ -1,0 +1,129 @@
+# Secrets Stay Out of the Shell Environment
+
+A credential that lives in the interactive shell's environment is inherited by
+**every** child process — every agent, every CLI, every task — and travels in a
+form no secret scanner can read. Keep secrets out of the shell; inject them into
+the one process that needs them.
+
+## What happened (2026-07-27)
+
+`fnox activate` exported 49 variables into the login shell. mise records the
+whole environment delta in **`__MISE_DIFF`** (zlib-compressed, base64-encoded)
+so it can undo it on directory exit, and that variable is inherited by every
+child. Decoded, the live blob carried an AWS access key id and secret, several
+API tokens, an app password, and a Google client secret.
+
+**Nothing reached a public remote.** Verified by pickaxing the exact live values
+across the full history of both public repos: **0 commits** each, against a
+control term returning 339 (dotfiles) and 94 (knowledge-base), so the probe
+discriminates. The single `AKIA` in dotfiles history is a vendor example inside
+`docs/research/mintlify-cache/`.
+
+The exposure was real anyway: the blob sat in every child process, and one
+`env > notes.md` inside a tracked directory would have published all of it.
+
+## Why no scanner would have caught it
+
+Measured 2026-07-27 with synthetic, format-valid credentials — the same content
+in two forms:
+
+| scanner | plaintext env dump | the same content as a `__MISE_DIFF` blob |
+|---|---|---|
+| gitleaks 8.30.1 | **2 leaks** | **0** |
+| betterleaks 1.7.1 | **1 leak** | **0** |
+
+The control arm fires on the plaintext, so the zero is a real negative and not
+a blind probe. Both scanners are pattern matchers; compression destroys the
+patterns. This is the one gap that justifies custom code here at all
+(see [[use-tool-builtins]]) — and the custom code covers only the decode.
+
+## The source fix — fnox already ships it
+
+fnox **v1.30.0** (2026-07-09) added an exec-only env mode whose release notes
+name this exact threat: it keeps secrets out of the interactive shell *"where AI
+coding agents and other inherited processes would see them"*, while still
+injecting them into `fnox exec` subprocesses. fnox here is **1.31.1**, so it is
+available now.
+
+```toml
+# fnox.toml — one line flips the whole config to default-deny
+env = "exec"
+
+[secrets]
+AWS_SECRET_ACCESS_KEY = { provider = "…" }              # exec-only
+SOME_PROMPT_VAR       = { provider = "…", env = true }  # explicit opt-back-in
+```
+
+| `env` | shell / `fnox export` | `fnox exec` | `fnox get` |
+|---|:-:|:-:|:-:|
+| `true` (default) | yes | yes | yes |
+| `"exec"` | **no** | yes | yes |
+| `false` | no | no | yes |
+
+With `env = "exec"` there is no delta for mise to record, so `__MISE_DIFF`
+stops carrying credentials at the source. Everything below is the net under
+that, not a substitute for it.
+
+**This is a user-level file** (`~/.config/mise/config.toml` → fnox), outside
+this repo, so it is written up here rather than applied — the standing rule is
+to never touch a file outside the project unasked (memory
+`feedback_no_user_level_file_updates`).
+
+## The same setting fixes the `[redacted]` digit-masking
+
+mise redacts every occurrence of a redacted variable's **value** in task output.
+fnox marks all 49 of its variables redacted, and two of them —
+`GEMINI_TELEMETRY_ENABLED` and `GEMINI_TELEMETRY_LOG_PROMPTS` — hold
+**one-character, all-digit values**. So mise faithfully masks every digit in
+every `mise run` line, which is why a number read from `mise run` output cannot
+be trusted (memory `feedback_mise_run_masks_digits`). `LANGSMITH_WORKSPACE_ID`
+is worse: an **empty** value.
+
+Those are telemetry flags, not secrets. Moving them out of fnox — or marking
+them `redact = false` — restores readable task output. The digit-masking was
+never a mise bug; it was collateral from treating a non-secret as a secret.
+
+## The gates that now exist in this repo
+
+1. **`no_env_dump`** (`hk.pkl` → `dotfiles-setup env-blob-scan`) rejects a
+   committed environment dump: a `__MISE_DIFF` assignment, **any** base64 run
+   that decompresses to text naming two or more secret-bearing variables, or a
+   literal credential value. Deliberately **glob-less** — a dump can land in any
+   tracked file, and the directories most likely to receive one
+   (`docs/research/kb/`, `docs/research/runs/`) are both tracked *and*
+   allowlisted in `.gitleaks.toml`, so gitleaks is looking away from exactly
+   the wrong place. Only `docs/research/mintlify-cache/` is exempt (vendor docs
+   with documented example keys).
+2. **`betterleaks`** (`hk.pkl`, host-only) now really runs.
+   `docs/hk-builtins-audit.md` listed it as a "second scanner alongside
+   gitleaks" since that audit was written and it was never wired — 0 occurrences
+   in any `.pkl`, against a control of 1 for `Builtins.gitleaks`. A doc
+   asserting a security scanner runs when it does not is worse than not claiming
+   it. It sits in the project config rather than `hk-common.pkl`'s shared
+   `security` group because that group is spread into `hk-image.pkl`, which
+   would require pinning the tool in the shared mise fragment — a base image
+   build input, and a cold rebuild for no gain at the commit boundary.
+3. **`clean_env()`** (`python/src/dotfiles_setup/child_env.py`) strips
+   `__MISE_DIFF` and the credential-bearing names from processes this repo
+   spawns, so the blob stops travelling further than it must.
+
+## Rules
+
+1. **Never write an environment dump into a tracked file.** Not `env`, not
+   `printenv`, not `export -p`, not a debug log that includes them. If you need
+   one for diagnosis, write it to the scratchpad and delete it.
+2. **A secret belongs to a process, not to a shell.** Reach for `fnox exec --`
+   (or the tool's own credential flow) rather than exporting.
+3. **Do not mark a non-secret as a secret.** Redaction is value-based, so a
+   short or empty "secret" corrupts every log the tool writes.
+4. **When a scanner reports clean, ask what it can see.** Compression, encoding,
+   and a path allowlist each turn "no findings" into "never looked".
+
+## See also
+
+- `probes-need-a-control-arm.md` — every measurement above ran both arms.
+- `use-tool-builtins.md` — the gate that made this research-first; the fix was
+  a tool feature, and the custom code is only what no tool can do.
+- Memory `feedback_no_user_level_file_updates` — why the fnox change is
+  written up rather than applied.
+- `python/src/dotfiles_setup/env_blob_scan.py` — the scanner and its evidence.

--- a/docs/hk-builtins-audit.md
+++ b/docs/hk-builtins-audit.md
@@ -1,102 +1,150 @@
 # hk Builtins Audit
 
-> **STATUS (2026-07-02): superseded as an "active steps" reference by #154–#158.**
-> This is a point-in-time 2026-04-05 audit. At the time, hk builtins were
-> declared as bare `["name"] {}` blocks that hk **silently no-op'd** — so the
-> table below reflects *intended* steps, not steps that actually ran. #154
-> (PR #155) rewired them via `= Builtins.name` so they run for real, and
-> curated the set: **dropped** `jq`, `taplo_format`, `yamlfmt`, `pkl_format`,
-> `shfmt` (opinionated formatters), `hclfmt` (not in mise registry), `zizmor`
-> (`check=null` no-op), `markdown_lint`/`rumdl` (redundant), `no_commit_to_branch`
-> (fails CI detached-HEAD), `pinact`/`pinact_update` (GitHub API rate-limit).
-> The current authoritative set is `hk.pkl` + `hk-common.pkl` + `hk-image.pkl`.
-> See memory `feedback_hk_builtins_need_assignment`.
+<!-- GENERATED FILE — do not edit by hand.
+     Regenerate: mise run hk-audit
+     Gated by: workflow.hk-builtins-audit (suites.toml) + the hk_audit step.
+     Authored content lives in python/src/dotfiles_setup/hk_builtins_audit.py
+     (NOT_ADOPTED); everything else is read from `hk builtins` + the configs. -->
 
-- **Last checked:** 2026-04-05
-- **hk version:** v1.40.0
-- **Project:** dotfiles (ray-manaloto/dotfiles)
+- **hk version:** hk 1.52.0
+- **Builtins available:** 144
+- **Wired as builtins:** 27
+- **Steps defined in total:** 60 (33 custom, with their own check/fix commands)
 
-## Summary
+A *wired builtin* is referenced as `Builtins.<name>`. A *custom step* is a
+`["name"] { … }` block carrying its own commands — it may share a
+name with a builtin without being one, which is how the previous
+hand-written audit came to list `ruff_format` and `editorconfig-checker`
+as builtins in use.
 
-41 builtins used / 71 total builtins audited
+## Wired builtins (27)
 
-## Builtins Used
+| Builtin | Declared in |
+|---------|-------------|
+| `actionlint` | hk.pkl |
+| `betterleaks` | hk.pkl |
+| `byte_order_marker` | hk-common.pkl |
+| `check_added_large_files` | hk-common.pkl |
+| `check_case_conflict` | hk-common.pkl |
+| `check_conventional_commit` | hk.pkl |
+| `check_executables_have_shebangs` | hk-common.pkl |
+| `check_merge_conflict` | hk-common.pkl |
+| `check_symlinks` | hk-common.pkl |
+| `detect_private_key` | hk-common.pkl |
+| `fix_smart_quotes` | hk-common.pkl |
+| `ghalint_action` | hk.pkl |
+| `ghalint_workflow` | hk.pkl |
+| `gitleaks` | hk-common.pkl |
+| `hadolint` | hk.pkl |
+| `mise` | hk.pkl |
+| `mixed_line_ending` | hk-common.pkl |
+| `newlines` | hk-common.pkl |
+| `pkl` | hk.pkl |
+| `python_check_ast` | hk.pkl |
+| `python_debug_statements` | hk.pkl |
+| `shellcheck` | hk.pkl, hk-image.pkl |
+| `taplo` | hk.pkl |
+| `trailing_whitespace` | hk-common.pkl |
+| `typos` | hk-common.pkl |
+| `yamllint` | hk.pkl |
+| `zizmor` | hk.pkl |
 
-| Builtin | Category | Notes |
-|---------|----------|-------|
-| trailing_whitespace | File Hygiene | Auto-fix enabled |
-| newlines | File Hygiene | |
-| mixed_line_ending | File Hygiene | |
-| fix_smart_quotes | File Hygiene | |
-| detect_private_key | Safety | |
-| check_added_large_files | Safety | |
-| check_merge_conflict | Safety | |
-| check_case_conflict | Safety | |
-| check_symlinks | Safety | |
-| check_executables_have_shebangs | Safety | |
-| check_byte_order_marker | Safety | |
-| no_commit_to_branch | Safety | Enforces worktree PR workflow |
-| editorconfig-checker | Style | |
-| prettier | Formatter | batch mode |
-| gitleaks | Security | batch mode |
-| betterleaks | Security | batch mode; second scanner alongside gitleaks |
-| typos | Spelling | batch mode |
-| ruff_format | Python | Scoped to python/src + tests |
-| ruff | Python | check_first mode; scoped to python/src + tests |
-| python_check_ast | Python | Scoped to python/src + tests |
-| python_debug_statements | Python | Scoped to python/src + tests |
-| ty | Python | Type checker; scoped to python/src + tests |
-| hadolint | Docker | Scoped to .devcontainer/Dockerfile |
-| docker_bake_check | Docker | Custom check command (devcontainer read-configuration) |
-| taplo_format | TOML | batch mode |
-| taplo | TOML | batch mode; depends on taplo_format |
-| yamlfmt | YAML | batch mode |
-| yamllint | YAML | batch mode; depends on yamlfmt |
-| jq | JSON | batch mode |
-| pkl | Pkl | |
-| pkl_format | Pkl | |
-| shellcheck | Shell | batch mode |
-| shfmt | Shell | batch mode; check_first mode |
-| markdown_lint | Markdown | |
-| actionlint | GHA | Scoped to .github/workflows/*.yml |
-| ghalint_workflow | GHA | Scoped to .github/workflows/*.yml |
-| zizmor | GHA | Security scanner; scoped to .github/workflows/*.yml |
-| pinact | GHA | Verifies SHA-pinned actions; scoped to .github/workflows/*.yml |
-| hclfmt | HCL | Scoped to **/*.hcl |
-| mise | Config | Scoped to **/mise.toml |
-| check_conventional_commit | Commit | commit-msg hook |
+## Custom steps (33)
 
-## Builtins Not Used (with justification)
+Not builtins. Each carries its own `check`/`fix`, so `hk builtins` has no
+opinion about them, and neither does this table beyond recording them.
 
-| Builtin | Category | Reason |
-|---------|----------|--------|
-| dprint | Formatter | Redundant with prettier + taplo + yamlfmt |
-| flake8 | Python | Superseded by ruff |
-| mdschema | Markdown | No schema-validated markdown in project |
-| rumdl | Markdown | Redundant with markdown_lint |
-| ryl | YAML | Redundant with yamllint |
-| tombi | TOML | Redundant with taplo |
-| tombi-format | TOML | Redundant with taplo_format |
-| vale | Prose | No formal style guide; network dependency in hook |
-| xmllint | XML | No XML files in project |
-| yq (formatter mode) | YAML | Conflicts with yamlfmt |
-| autopep8 | Python | Superseded by ruff_format |
-| black | Python | Superseded by ruff_format |
-| isort | Python | Superseded by ruff (I sorting rules) |
-| mypy | Python | Using ty instead |
-| pylint | Python | Superseded by ruff |
-| pyright | Python | Using ty instead |
-| bandit | Python | Superseded by ruff (S rules) |
-| clang-format (standalone) | C++ | Using apt clang-format-22 in devcontainer only (#222 PR-C; was conda:clang-format) |
-| cmake-format | C++ | Using pipx:cmakelang in devcontainer only |
-| eslint | JavaScript | No JS source in project |
-| biome | JavaScript | No JS source in project |
-| rustfmt | Rust | No Rust source in project |
-| clippy | Rust | No Rust source in project |
-| gofmt | Go | No Go source in project |
-| golangci-lint | Go | No Go source in project |
-| terraform_fmt | Terraform | No Terraform files |
-| tflint | Terraform | No Terraform files |
-| rubocop | Ruby | No Ruby source in project |
-| stylelint | CSS | No CSS files |
-| htmlhint | HTML | No HTML files |
+| Step | Declared in |
+|------|-------------|
+| `agnix` | hk.pkl |
+| `bash_logic_budget` | hk.pkl |
+| `check` | hk.pkl |
+| `chezmoi_template_render` | hk.pkl |
+| `claude_agents_md_pairs` | hk.pkl |
+| `claude_md_import_stub` | hk.pkl |
+| `commit-msg` | hk.pkl |
+| `contract_token_uniqueness` | hk.pkl |
+| `devcontainer_json_validate` | hk.pkl |
+| `doc_refs` | hk.pkl |
+| `docker_bake_check` | hk.pkl |
+| `dockerfile_host_user_thin_overlay` | hk.pkl |
+| `editorconfig-checker` | hk.pkl |
+| `fix` | hk.pkl |
+| `ghcr_publish_prereqs` | hk.pkl |
+| `hk_audit` | hk.pkl |
+| `hk_version_parity` | hk.pkl |
+| `md_size_budget` | hk.pkl |
+| `no_env_dump` | hk.pkl |
+| `no_global_skill_leakage` | hk.pkl |
+| `no_grep_q_under_pipefail` | hk.pkl |
+| `no_hk_depends` | hk.pkl |
+| `no_lint_skip` | hk.pkl |
+| `pre-commit` | hk.pkl, hk-image.pkl |
+| `pre-push` | hk.pkl |
+| `py_ty` | hk.pkl |
+| `renovate_config_validate` | hk.pkl |
+| `require_pipefail` | hk.pkl |
+| `ruff` | hk.pkl |
+| `ruff_format` | hk.pkl |
+| `test` | hk.pkl |
+| `uv_lock_check` | hk.pkl |
+| `workflow_hk_skip_hooks` | hk.pkl |
+
+## Deliberately not adopted (25)
+
+The only authored section — a judgement no tool can recover. Edit it in
+`hk_builtins_audit.py`; an entry that stops naming a real builtin, or that
+names one now wired, fails the gate.
+
+| Builtin | Reason |
+|---------|--------|
+| `biome` | No JS source in project |
+| `black` | Superseded by ruff format |
+| `dprint` | Redundant with the taplo/yamlfmt/prettier set |
+| `eslint` | No JS source in project |
+| `flake8` | Superseded by ruff |
+| `go_fmt` | No Go source in project |
+| `golangci_lint` | No Go source in project |
+| `isort` | Superseded by ruff's I rules |
+| `markdown_lint` | Runs markdownlint v1; repo uses markdownlint-cli2 (#154) |
+| `mdschema` | Requires a schema file that does not exist yet (#160 T12) |
+| `mypy` | Using ty instead |
+| `no_commit_to_branch` | Fails on CI's detached HEAD; branch protection covers it |
+| `pinact` | GitHub API rate-limit in the hook; use `mise run pin-actions` |
+| `pylint` | Superseded by ruff |
+| `rubocop` | No Ruby source in project |
+| `rumdl` | 591 findings across 56 files — a burn-down project, deferred (#160 T12) |
+| `rustfmt` | No Rust source in project |
+| `ryl` | Redundant with yamllint |
+| `stylelint` | No CSS files |
+| `terraform` | No Terraform files |
+| `tf_lint` | No Terraform files |
+| `tombi` | Redundant with taplo |
+| `tombi_format` | Redundant with the taplo formatter |
+| `vale` | No formal style guide; network dependency in the hook |
+| `xmllint` | No XML files in project |
+
+## Not yet considered (92)
+
+Available in this hk version, neither wired nor explicitly declined.
+Listed so the unexamined remainder is visible rather than implied — the
+previous audit's biggest silent gap was 87 builtins it never mentioned.
+
+```
+alejandra, aqua_update_checksum, asciidoctor, astro, brakeman, buf_format
+buf_lint, buildifier_format, buildifier_lint, bundle_audit, cargo_check, cargo_clippy
+cargo_fmt, check_byte_order_marker, clang_format, cmake_format, cocogitto_commit_msg, contextlint
+cpp_lint, dclint, deadnix, deno, deno_check, editorconfig-checker
+erb, err_check, fasterer, fix_byte_order_marker, go_fumpt, go_imports
+go_lines, go_sec, go_vet, go_vuln_check, gomod_tidy, google_java_format
+harper, harper_commit_message, hclfmt, hk_test, jq, just_format
+knip, knip_strict, ktlint, luacheck, lychee, mix_compile
+mix_fmt, mix_test, nil, nix_fmt, nixf_diagnose, nixpkgs_format
+ox_lint, oxfmt, php_cs, pinact_update, pkl_format, prettier
+reek, revive, rubocop_server, ruff, ruff_format, rumdl_format
+ryl_markdown, selene, shellharden, sherif, shfmt, sorbet
+sort_package_json, sql_fluff, standard_js, standard_rb, staticcheck, stylua
+swiftlint, taplo_format, textlint, tofu, tsc, tsserver
+ty, vacuum, vp_check, vp_fmt, vp_lint, xo
+yamlfmt, yq
+```

--- a/hk-common.pkl
+++ b/hk-common.pkl
@@ -87,6 +87,13 @@ safety: Mapping<String, Config.Step> = new {
 }
 
 // Security scanning — secret detection via gitleaks.
+//
+// `betterleaks` is the SECOND scanner and lives in hk.pkl, not here: this group
+// is spread into hk-image.pkl, so a tool referenced here must also exist in the
+// image — which means pinning it in the shared mise fragment, which is a base
+// image build input and costs a cold rebuild. The scanning that matters happens
+// at the commit boundary (host + CI lint), so the project config is the right
+// home and the image config is left alone.
 security: Mapping<String, Config.Step> = new {
   ["gitleaks"] = (Builtins.gitleaks) {
     batch = true

--- a/hk.pkl
+++ b/hk.pkl
@@ -249,6 +249,47 @@ local allSteps = new Mapping<String, Config.Step> {
     check = "uv run --project python dotfiles-setup bash-budget"
   }
 
+  // Rejects a committed environment dump. Deliberately NOT scoped by glob:
+  // an `env` dump can land in any tracked file, and the paths most likely to
+  // receive one (the tracked agent-artifact trees) are exactly the ones
+  // `.gitleaks.toml` allowlists away. Covers only what gitleaks and
+  // betterleaks cannot — measured 2026-07-27, both score 0 on a compressed
+  // dump they both flag in plaintext. See env_blob_scan.py's module docstring
+  // and .claude/rules/secrets-out-of-the-shell-env.md.
+  ["no_env_dump"] {
+    check = "uv run --project python dotfiles-setup env-blob-scan"
+  }
+
+  // Second secret scanner, a SECOND OPINION rather than a replacement — on a
+  // synthetic plaintext dump gitleaks found 2 and betterleaks 1. It was listed
+  // as "used" in docs/hk-builtins-audit.md since that audit was written and was
+  // wired NOWHERE: 0 occurrences in any .pkl against a control of 1 for
+  // `Builtins.gitleaks`. Measured before adopting: 0 findings over the whole
+  // 31.5 MB tree in 199 ms. Lives here rather than in hk-common.pkl's `security`
+  // group because that group is spread into hk-image.pkl, which would require
+  // the shared mise fragment — a base image build input — and a cold rebuild.
+  // Neither scanner can see a compressed env dump; that is `no_env_dump`.
+  ["betterleaks"] = (Builtins.betterleaks) {
+    batch = true
+  }
+
+  // docs/hk-builtins-audit.md is GENERATED. The hand-written version drifted
+  // into claiming 15 builtins were "used" that were not wired — one of them
+  // `betterleaks`, described as a "second scanner alongside gitleaks" and
+  // present in no config at all. Regenerate with `mise run hk-audit`.
+  ["hk_audit"] {
+    check = "uv run --project python dotfiles-setup hk-builtins-audit --check"
+  }
+
+  // #394 step 4, as the audit recommended it. A `per_path_tokens` entry should
+  // match its target file exactly once: the three holes that were live in #394
+  // all survived their anchor because the token matched somewhere OTHER than
+  // the site it meant. Genuine multiplicity is allowlisted with a reason in
+  // token_audit.py; a NEW ambiguity, or a stale allowlist entry, fails.
+  ["contract_token_uniqueness"] {
+    check = "uv run --project python dotfiles-setup token-audit"
+  }
+
   // --- Markdown ---
   // #154: no markdown_lint step — its builtin runs `markdownlint` (cli v1),
   // but the repo standardizes on `markdownlint-cli2` (+ rumdl, mdschema).

--- a/mise.lock
+++ b/mise.lock
@@ -3907,6 +3907,76 @@ checksum = "sha256:0e37447c3d63284d5404e7e6679e099b7e8a6bdd800a56cee70d0283398ee
 url = "https://github.com/google-antigravity/antigravity-cli/releases/download/1.1.5/agy_cli_windows_x64.zip"
 url_api = "https://api.github.com/repos/google-antigravity/antigravity-cli/releases/assets/484140699"
 
+[[tools."aqua:betterleaks/betterleaks"]]
+version = "1.7.1"
+backend = "aqua:betterleaks/betterleaks"
+
+[tools."aqua:betterleaks/betterleaks"."platforms.linux-arm64"]
+checksum = "sha256:c350f1c94c7187f81a8900aa17b50ee868fdc72e89dac849d68d757754665721"
+url = "https://github.com/betterleaks/betterleaks/releases/download/v1.7.1/betterleaks_1.7.1_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/betterleaks/betterleaks/releases/assets/491711492"
+provenance = "cosign"
+
+[tools."aqua:betterleaks/betterleaks"."platforms.linux-arm64-musl"]
+checksum = "sha256:c350f1c94c7187f81a8900aa17b50ee868fdc72e89dac849d68d757754665721"
+url = "https://github.com/betterleaks/betterleaks/releases/download/v1.7.1/betterleaks_1.7.1_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/betterleaks/betterleaks/releases/assets/491711492"
+provenance = "cosign"
+
+[tools."aqua:betterleaks/betterleaks"."platforms.linux-x64"]
+checksum = "sha256:48d9ae267b46677c9943cf9291bed682ed7b37b5b2c6ffbdea47a155495e5dcc"
+url = "https://github.com/betterleaks/betterleaks/releases/download/v1.7.1/betterleaks_1.7.1_linux_x64.tar.gz"
+url_api = "https://api.github.com/repos/betterleaks/betterleaks/releases/assets/491711509"
+provenance = "cosign"
+
+[tools."aqua:betterleaks/betterleaks"."platforms.linux-x64-baseline"]
+checksum = "sha256:48d9ae267b46677c9943cf9291bed682ed7b37b5b2c6ffbdea47a155495e5dcc"
+url = "https://github.com/betterleaks/betterleaks/releases/download/v1.7.1/betterleaks_1.7.1_linux_x64.tar.gz"
+url_api = "https://api.github.com/repos/betterleaks/betterleaks/releases/assets/491711509"
+provenance = "cosign"
+
+[tools."aqua:betterleaks/betterleaks"."platforms.linux-x64-musl"]
+checksum = "sha256:48d9ae267b46677c9943cf9291bed682ed7b37b5b2c6ffbdea47a155495e5dcc"
+url = "https://github.com/betterleaks/betterleaks/releases/download/v1.7.1/betterleaks_1.7.1_linux_x64.tar.gz"
+url_api = "https://api.github.com/repos/betterleaks/betterleaks/releases/assets/491711509"
+provenance = "cosign"
+
+[tools."aqua:betterleaks/betterleaks"."platforms.linux-x64-musl-baseline"]
+checksum = "sha256:48d9ae267b46677c9943cf9291bed682ed7b37b5b2c6ffbdea47a155495e5dcc"
+url = "https://github.com/betterleaks/betterleaks/releases/download/v1.7.1/betterleaks_1.7.1_linux_x64.tar.gz"
+url_api = "https://api.github.com/repos/betterleaks/betterleaks/releases/assets/491711509"
+provenance = "cosign"
+
+[tools."aqua:betterleaks/betterleaks"."platforms.macos-arm64"]
+checksum = "sha256:2c75082322bacc78763a725326b1bf7f013a2e46ac5696786b2c0bf49e545a34"
+url = "https://github.com/betterleaks/betterleaks/releases/download/v1.7.1/betterleaks_1.7.1_darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/betterleaks/betterleaks/releases/assets/491711494"
+provenance = "cosign"
+
+[tools."aqua:betterleaks/betterleaks"."platforms.macos-x64"]
+checksum = "sha256:cdec2e001513019c4bb18dbb2982c472b5e7dc4fab053cf7b7814ef94aee7eea"
+url = "https://github.com/betterleaks/betterleaks/releases/download/v1.7.1/betterleaks_1.7.1_darwin_x64.tar.gz"
+url_api = "https://api.github.com/repos/betterleaks/betterleaks/releases/assets/491711503"
+provenance = "cosign"
+
+[tools."aqua:betterleaks/betterleaks"."platforms.macos-x64-baseline"]
+checksum = "sha256:cdec2e001513019c4bb18dbb2982c472b5e7dc4fab053cf7b7814ef94aee7eea"
+url = "https://github.com/betterleaks/betterleaks/releases/download/v1.7.1/betterleaks_1.7.1_darwin_x64.tar.gz"
+url_api = "https://api.github.com/repos/betterleaks/betterleaks/releases/assets/491711503"
+provenance = "cosign"
+
+[tools."aqua:betterleaks/betterleaks"."platforms.windows-x64"]
+checksum = "sha256:41696e5f4a2d3b01a4ba028512f061e6731588fb14de6529c2c2fefe8927a13e"
+url = "https://github.com/betterleaks/betterleaks/releases/download/v1.7.1/betterleaks_1.7.1_windows_x64.zip"
+url_api = "https://api.github.com/repos/betterleaks/betterleaks/releases/assets/491711493"
+provenance = "cosign"
+
+[tools."aqua:betterleaks/betterleaks"."platforms.windows-x64-baseline"]
+checksum = "sha256:41696e5f4a2d3b01a4ba028512f061e6731588fb14de6529c2c2fefe8927a13e"
+url = "https://github.com/betterleaks/betterleaks/releases/download/v1.7.1/betterleaks_1.7.1_windows_x64.zip"
+url_api = "https://api.github.com/repos/betterleaks/betterleaks/releases/assets/491711493"
+provenance = "cosign"
+
 [[tools."aqua:jackchuka/mdschema"]]
 version = "0.13.4"
 backend = "aqua:jackchuka/mdschema"

--- a/mise.toml
+++ b/mise.toml
@@ -6,9 +6,15 @@
 # .config/mise/conf.d/shared.toml — the single exact-pinned source both this
 # host config and .devcontainer/mise-system.toml merge, so they never drift
 # (Renovate bumps that one file). See epic #160 T5. Below: host-ONLY tools.
-editorconfig-checker = "3.8.0"      # provides `ec` — hk editorconfig_checker builtin (#154); host-only (image drops it in T6)
+editorconfig-checker = "3.8.0" # provides `ec` — hk editorconfig_checker builtin (#154); host-only (image drops it in T6)
+# Second secret scanner (hk `betterleaks` builtin, wired in hk.pkl). HOST-ONLY
+# on purpose: shared.toml is a base image build input, and putting a second
+# scanner in the image would cost a cold rebuild for no gain — the scanning that
+# matters happens at the commit boundary. Measured before adopting: 0 findings
+# over the whole 31.5 MB tree in 199 ms.
+"aqua:betterleaks/betterleaks" = "1.7.1"
 "npm:@devcontainers/cli" = "0.87.0"
-colima = "0.10.3"                   # Alternate Docker runtime (VZ + Rosetta); Docker Desktop is the CURRENT supported runtime — see AGENTS.md Docker Runtimes + docs/research/runs/research-20260409c-dockerdesktop-ssh/
+colima = "0.10.3"                        # Alternate Docker runtime (VZ + Rosetta); Docker Desktop is the CURRENT supported runtime — see AGENTS.md Docker Runtimes + docs/research/runs/research-20260409c-dockerdesktop-ssh/
 lima = "2.2.0"
 "github:agent-sh/agnix" = "0.40.0"
 "npm:agents-lint" = "0.5.0"
@@ -913,6 +919,10 @@ description = "Eval harness, tiers 1+2 (offline, gated; `-- --live` adds the lan
 # one real API call per installed lane. Runner is the SHARED kb_setup.evals;
 # this repo's cases are dotfiles_setup.eval_cases.
 run = "uv run --project python dotfiles-setup eval"
+
+[tasks.hk-audit]
+description = "Regenerate docs/hk-builtins-audit.md from `hk builtins` + the hk configs"
+run = "uv run --project python dotfiles-setup hk-builtins-audit"
 
 [tasks.lint-docs]
 description = "Validate agent documentation"

--- a/python/src/dotfiles_setup/child_env.py
+++ b/python/src/dotfiles_setup/child_env.py
@@ -1,0 +1,81 @@
+"""Strip credentials from the environment of processes this repo spawns.
+
+`fnox activate` exports real credentials into the interactive shell, and mise
+records the whole delta in ``__MISE_DIFF`` (zlib+base64) so it can undo it on
+directory exit. Both are inherited by every child process — including external
+tools that write artifacts we then commit.
+
+This is containment, not the fix. The fix is fnox's own ``env = "exec"``
+(v1.30.0+), which keeps the secrets out of the shell in the first place; see
+`.claude/rules/secrets-out-of-the-shell-env.md`. Until that is set, a tool this
+repo launches has no business inheriting an AWS secret key, so it does not.
+
+Two strengths, because they carry different risk:
+
+- :func:`without_env_diff` drops **only** ``__MISE_DIFF``. Nothing but mise
+  reads it, and mise re-derives it, so this is safe at every boundary and is
+  what the spawn sites use by default. It removes the whole blob — the single
+  variable that carries every other secret in one opaque field.
+- :func:`clean_env` additionally drops every credential-shaped NAME. That can
+  break a child that genuinely needs one, so it is opt-in per call site, with
+  an explicit ``keep`` for the exceptions.
+
+**Neither touches your shell.** Both build a copy handed to
+:func:`subprocess.run`; mise still gets its ``__MISE_DIFF`` for directory exit.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+# The compressed env delta. Its entire content is the leak, and no child reads
+# it — mise recomputes it from config.
+ENV_DIFF_NAME = "__MISE_DIFF"
+
+# Names that carry a credential. Matched on the NAME, so a provider we have
+# never heard of is covered as long as it follows the usual convention.
+CREDENTIAL_NAME = re.compile(
+    r"(?:^|_)(?:SECRET|PASSWORD|PASSWD|TOKEN|API_KEY|ACCESS_KEY|PRIVATE_KEY|"
+    r"CREDENTIAL|CREDENTIALS|APP_PASSWORD|CLIENT_SECRET)(?:_|$)"
+)
+
+
+def is_credential(name: str) -> bool:
+    """True when the variable NAME marks it as carrying a credential."""
+    return name == ENV_DIFF_NAME or bool(CREDENTIAL_NAME.search(name))
+
+
+def without_env_diff(base: dict[str, str] | None = None) -> dict[str, str]:
+    """A copy of the environment with ``__MISE_DIFF`` removed, nothing else.
+
+    The default strength for a spawn site: it cannot break a child, because no
+    child reads the variable, and it removes the one field that carries every
+    secret at once.
+    """
+    source = os.environ if base is None else base
+    return {k: v for k, v in source.items() if k != ENV_DIFF_NAME}
+
+
+def clean_env(
+    base: dict[str, str] | None = None, *, keep: frozenset[str] = frozenset()
+) -> dict[str, str]:
+    """A copy of the environment with every credential-bearing name removed.
+
+    Args:
+        base: Environment to filter. Defaults to the current process's.
+        keep: Names to preserve even though they look like credentials — for a
+            child that genuinely needs one. Pass it at the call site so the
+            exception is visible in review rather than buried in a constant.
+
+    Returns:
+        A new dict. The caller's environment is never modified.
+    """
+    source = os.environ if base is None else base
+    return {k: v for k, v in source.items() if k in keep or not is_credential(k)}
+
+
+def dropped_names(base: dict[str, str] | None = None) -> list[str]:
+    """The names :func:`clean_env` would remove — for logging. Never values."""
+    source = os.environ if base is None else base
+    return sorted(k for k in source if is_credential(k))

--- a/python/src/dotfiles_setup/env_blob_scan.py
+++ b/python/src/dotfiles_setup/env_blob_scan.py
@@ -1,0 +1,245 @@
+"""Env-dump detection — the one leak shape no secret scanner can see.
+
+## Why this exists (2026-07-27)
+
+`fnox activate` exports real credentials into the interactive shell, and mise
+then records the whole environment delta in **`__MISE_DIFF`** — zlib-compressed
+and base64-encoded — which every child process inherits. Decoded, the live blob
+on this machine carried an AWS access key id and secret, several API tokens, an
+app password, and a Google client secret. Nothing ever reached a public remote
+(verified by pickaxing the exact values across the full history of both repos,
+0 commits each against a control term returning 339 / 94), but the shape is one
+commit away: any tool that writes its environment into a file — an agent
+transcript, a research artifact, a CI log, a bug report — writes those
+credentials in a form that looks like opaque noise.
+
+**Measured, both arms, with synthetic secrets:**
+
+| scanner | plaintext env dump | the same content as a blob |
+|---|---|---|
+| gitleaks 8.30.1 | 2 leaks | **0** |
+| betterleaks 1.7.1 | 1 leak | **0** |
+
+The control arm fires on the plaintext, so the zero is a real negative, not a
+blind probe. That measurement is this module's justification under
+`.claude/rules/use-tool-builtins.md`: gitleaks and betterleaks both run in this
+repo and both stay — this covers only what neither can do, which is **decode**.
+
+## What it checks
+
+1. A `__MISE_DIFF` (or any env-var) assignment followed by a long opaque run.
+2. **Any** long base64 run that actually zlib/gzip-decompresses to text naming
+   two or more secret-bearing environment variables. Random base64 does not
+   decompress, so this is precise rather than noisy.
+3. High-confidence secret *values* in tracked files. gitleaks is configured
+   here with a path allowlist covering `docs/research/kb/` and
+   `docs/research/runs/` — both of which are **tracked** — so an env dump
+   landing there today is committed with the scanner deliberately looking away.
+   This check has no such exemption.
+
+The source-side fix is fnox's own `env = "exec"` (v1.30.0+, and fnox is already
+at 1.31.1 here), which keeps secrets out of the interactive shell entirely.
+See `.claude/rules/secrets-out-of-the-shell-env.md`. This module is the
+commit-boundary net under that, not a substitute for it.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import gzip
+import logging
+import re
+import subprocess
+import zlib
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Third-party documentation caches ship vendor EXAMPLE credentials (the single
+# `AKIA` in this repo's history is one). They are not ours, they are already
+# committed, and re-flagging them forever would train the reader to ignore this
+# gate. Nothing else is exempt — that is the point.
+EXEMPT_PREFIXES: tuple[str, ...] = ("docs/research/mintlify-cache/",)
+
+# How long a base64 run must be before decoding is attempted. The first draft
+# used 200 and the control arm caught it: a synthetic 157-byte dump compresses
+# to ~180 chars, so the probe's own fixture slipped under the floor. 120 keeps
+# the scan cheap while covering a dump far smaller than any real one (mise's
+# live `__MISE_DIFF` here is ~7 KB), and the decompress step — not the length —
+# is what keeps it precise.
+MIN_BLOB_CHARS = 120
+
+# A `__MISE_DIFF` assignment needs no decode and no length argument: mise sets
+# it to a compressed env delta and nothing else, so its presence in a tracked
+# file IS the finding.
+MIN_NAMED_BLOB_CHARS = 40
+
+_B64_RUN = re.compile(r"[A-Za-z0-9+/_-]{" + str(MIN_BLOB_CHARS) + r",}={0,2}")
+
+# An env-var assignment whose value is an opaque run — `__MISE_DIFF=eJx…` as it
+# appears in `env` output, an exported shell snippet, or a pasted log.
+_ENV_ASSIGNMENT = re.compile(
+    r"\b([A-Z_][A-Z0-9_]{2,})\s*[=:]\s*[\"']?"
+    r"([A-Za-z0-9+/_-]{" + str(MIN_NAMED_BLOB_CHARS) + r",}={0,2})"
+)
+
+# The variable whose very presence is the leak.
+ENV_DIFF_NAME = "__MISE_DIFF"
+
+# Names that mark decoded text as an environment dump carrying credentials.
+_SECRET_NAME = re.compile(
+    r"\b[A-Z][A-Z0-9_]*"
+    r"(?:SECRET|PASSWORD|PASSWD|TOKEN|API_KEY|ACCESS_KEY|PRIVATE_KEY|CREDENTIAL)"
+    r"[A-Z0-9_]*\b"
+)
+
+# How many distinct secret-bearing names a decoded blob must name before it is
+# called an env dump. One is a coincidence; two is a dump.
+MIN_DECODED_NAMES = 2
+
+# High-confidence secret VALUES. Deliberately few: gitleaks and betterleaks own
+# the general case, and every pattern here is one whose format is unambiguous,
+# so it cannot fire on prose.
+_VALUE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("aws-access-key-id", re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
+    ("google-client-secret", re.compile(r"\bGOCSPX-[A-Za-z0-9_-]{20,}\b")),
+    ("github-pat", re.compile(r"\bgh[pousr]_[A-Za-z0-9]{36,}\b")),
+    ("github-fine-grained-pat", re.compile(r"\bgithub_pat_[A-Za-z0-9_]{60,}\b")),
+    ("private-key-header", re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----")),
+)
+
+
+@dataclass(frozen=True)
+class Violation:
+    """One finding. Carries the SHAPE of the leak, never the value."""
+
+    path: str
+    line: int
+    kind: str
+    detail: str
+
+    def render(self) -> str:
+        """One line naming the file, the line, and the leak SHAPE."""
+        return f"{self.path}:{self.line}: {self.kind} — {self.detail}"
+
+
+def decode_blob(candidate: str) -> str | None:
+    """Decode a base64 run to text if it really is compressed data.
+
+    Returns None for anything that is not base64-of-compressed-text, which is
+    almost everything: random base64 fails the decompress step, so this is the
+    filter that keeps the scan precise.
+    """
+    padded = candidate.rstrip("=")
+    padded += "=" * (-len(padded) % 4)
+    for decoder in (base64.b64decode, base64.urlsafe_b64decode):
+        try:
+            raw = decoder(padded)
+        except binascii.Error, ValueError:
+            continue
+        for decompress in (zlib.decompress, gzip.decompress):
+            try:
+                return decompress(raw).decode("utf-8", errors="replace")
+            except zlib.error, gzip.BadGzipFile, EOFError, OSError:
+                continue
+    return None
+
+
+def _secret_names(text: str) -> set[str]:
+    return set(_SECRET_NAME.findall(text))
+
+
+def _scan_text(rel: str, text: str) -> list[Violation]:
+    violations: list[Violation] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for kind, pattern in _VALUE_PATTERNS:
+            if pattern.search(line):
+                violations.append(
+                    Violation(rel, lineno, kind, "a literal credential value")
+                )
+
+        assignment = _ENV_ASSIGNMENT.search(line)
+        if assignment:
+            name, blob = assignment.group(1), assignment.group(2)
+            names = _secret_names(decode_blob(blob) or "")
+            if name == ENV_DIFF_NAME or len(names) >= MIN_DECODED_NAMES:
+                violations.append(
+                    Violation(
+                        rel,
+                        lineno,
+                        "env-dump-blob",
+                        f"{name} assigned an opaque {len(blob)}-char run"
+                        + (
+                            f" that decodes to {len(names)} secret names"
+                            if names
+                            else ""
+                        ),
+                    )
+                )
+                continue
+
+        for run in _B64_RUN.findall(line):
+            names = _secret_names(decode_blob(run) or "")
+            if len(names) >= MIN_DECODED_NAMES:
+                violations.append(
+                    Violation(
+                        rel,
+                        lineno,
+                        "compressed-env-dump",
+                        f"a {len(run)}-char blob decompresses to text naming "
+                        f"{len(names)} secret-bearing variables",
+                    )
+                )
+    return violations
+
+
+def tracked_files(root: Path) -> list[str]:
+    """Every file git tracks — i.e. everything a push would carry."""
+    result = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "-z"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        logger.error("git ls-files failed: %s", result.stderr.strip())
+        return []
+    return [p for p in result.stdout.split("\0") if p]
+
+
+def find_violations(root: Path, paths: list[str] | None = None) -> list[Violation]:
+    """Scan the given paths (default: every tracked file) for env dumps."""
+    candidates = paths if paths is not None else tracked_files(root)
+    violations: list[Violation] = []
+    for rel in candidates:
+        if rel.startswith(EXEMPT_PREFIXES):
+            continue
+        target = root / rel
+        if not target.is_file():
+            continue
+        try:
+            text = target.read_text(encoding="utf-8")
+        except UnicodeDecodeError, OSError:
+            continue  # binary or unreadable — no env dump lives there
+        violations.extend(_scan_text(rel, text))
+    return violations
+
+
+def env_blob_scan_main(root: Path, paths: list[str] | None = None) -> int:
+    """CLI entrypoint: report every env-dump finding; 1 if any."""
+    violations = find_violations(root, paths)
+    if not violations:
+        return 0
+    for violation in violations:
+        logger.error("%s", violation.render())
+    logger.error(
+        "%d env-dump finding(s). A committed environment dump publishes every "
+        "credential in it. See .claude/rules/secrets-out-of-the-shell-env.md",
+        len(violations),
+    )
+    return 1

--- a/python/src/dotfiles_setup/graph_bakeoff.py
+++ b/python/src/dotfiles_setup/graph_bakeoff.py
@@ -49,7 +49,6 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-import os
 import shutil
 import statistics
 import subprocess
@@ -57,6 +56,8 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+from dotfiles_setup.child_env import without_env_diff
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
@@ -146,7 +147,9 @@ def _run(
     args: Sequence[str], *, cwd: Path, env: dict[str, str]
 ) -> subprocess.CompletedProcess[str]:
     """Execute graphify. The module's only external boundary."""
-    merged = {**os.environ, **env}
+    # `without_env_diff` first: a bake-off arm writes artifacts we read back,
+    # and __MISE_DIFF would carry every exported credential into them.
+    merged = {**without_env_diff(), **env}
     # Wall-clock is bounded by graphify's own --api-timeout in FIXED_FLAGS.
     return subprocess.run(
         list(args), cwd=cwd, env=merged, capture_output=True, text=True, check=False

--- a/python/src/dotfiles_setup/graphify.py
+++ b/python/src/dotfiles_setup/graphify.py
@@ -15,6 +15,8 @@ import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from dotfiles_setup.child_env import without_env_diff
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -35,13 +37,19 @@ class QueryResult:
 
 
 def _run(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
-    """Run graphify and capture text output (the sole external boundary)."""
+    """Run graphify and capture text output (the sole external boundary).
+
+    The child does not inherit ``__MISE_DIFF``: graphify writes artifacts we
+    commit, and that variable carries every exported credential in one opaque
+    zlib+base64 field. See `.claude/rules/secrets-out-of-the-shell-env.md`.
+    """
     return subprocess.run(
         args,
         cwd=cwd,
         check=False,
         capture_output=True,
         text=True,
+        env=without_env_diff(),
     )
 
 

--- a/python/src/dotfiles_setup/hk_builtins_audit.py
+++ b/python/src/dotfiles_setup/hk_builtins_audit.py
@@ -1,0 +1,270 @@
+"""Generate `docs/hk-builtins-audit.md` from `hk builtins` + the hk configs.
+
+## Why this is generated
+
+The hand-written audit it replaces was a 2026-04-05 snapshot that drifted badly
+and was never checked against anything. Measured 2026-07-27 on hk 1.52.0:
+
+| | |
+|---|---|
+| `hk builtins` lists | 144 |
+| the doc said it audited | 71 |
+| the doc said "used" | 41 |
+| actually wired (`Builtins.*`) | 28 |
+
+Fifteen names it listed as *used* were not wired builtins — twelve appeared
+nowhere in any config, three were custom steps miscategorised as builtins — and
+a sixteenth, **`betterleaks`**, was listed as a "second scanner alongside
+gitleaks" while being wired nowhere at all. A document asserting that a security
+scanner runs, when it does not, is worse than one that claims nothing.
+
+The doc did carry a "point-in-time, superseded" banner. That is not a defence:
+the tables underneath still read as statements of fact, and the one that
+mattered was false. So the tables are now derived, and a contract fails CI the
+moment the committed file stops matching what this generator produces.
+
+## What is derived and what is authored
+
+Everything factual — which builtins exist, which are wired, in which config,
+and which steps are custom — is read from `hk builtins` and the three `.pkl`
+files. Only :data:`NOT_ADOPTED` is authored, because "why we chose not to" is a
+judgement no tool can recover. It is validated on every run: an entry naming
+something that is not a builtin, or something that IS now wired, fails — the
+same "keep the map honest" rule as :mod:`dotfiles_setup.bash_budget`.
+
+Regenerate with ``mise run hk-audit``; CI runs it with ``--check``.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+CONFIGS: tuple[str, ...] = ("hk.pkl", "hk-common.pkl", "hk-image.pkl")
+
+# A builtin is WIRED only when it is assigned — `= Builtins.x` or
+# `= (Builtins.x) { … }`. A bare `Builtins.x` also matches a COMMENT, which is
+# not a subtlety: the first draft of this module used the loose pattern and
+# immediately reported `gitleaks` as wired in hk.pkl, on the strength of a
+# comment in this very PR that names `Builtins.gitleaks` while describing the
+# audit. The same substring trap the module exists to document.
+_ASSIGNED_BUILTIN = r"=\s*\(?Builtins\.([a-zA-Z0-9_]+)"
+DOC_PATH = "docs/hk-builtins-audit.md"
+
+GENERATED_BANNER = (
+    "<!-- GENERATED FILE — do not edit by hand.\n"
+    "     Regenerate: mise run hk-audit\n"
+    "     Gated by: workflow.hk-builtins-audit (suites.toml) + the hk_audit step.\n"
+    "     Authored content lives in python/src/dotfiles_setup/hk_builtins_audit.py\n"
+    "     (NOT_ADOPTED); everything else is read from `hk builtins` + the configs. -->"
+)
+
+# Builtins deliberately not adopted, and why. Seeded from the hand-written
+# audit, keeping only entries that name a builtin hk actually has — the old
+# list also carried 14 names that were never hk builtins at all (`pyright`,
+# `bandit`, `clippy`, `gofmt`, `tflint`, …), which is itself evidence it was a
+# generic linter survey rather than an audit of this tool.
+NOT_ADOPTED: dict[str, str] = {
+    "biome": "No JS source in project",
+    "black": "Superseded by ruff format",
+    "dprint": "Redundant with the taplo/yamlfmt/prettier set",
+    "eslint": "No JS source in project",
+    "flake8": "Superseded by ruff",
+    "golangci_lint": "No Go source in project",
+    "go_fmt": "No Go source in project",
+    "isort": "Superseded by ruff's I rules",
+    "markdown_lint": "Runs markdownlint v1; repo uses markdownlint-cli2 (#154)",
+    "mdschema": "Requires a schema file that does not exist yet (#160 T12)",
+    "mypy": "Using ty instead",
+    "no_commit_to_branch": "Fails on CI's detached HEAD; branch protection covers it",
+    "pinact": "GitHub API rate-limit in the hook; use `mise run pin-actions`",
+    "pylint": "Superseded by ruff",
+    "rubocop": "No Ruby source in project",
+    "rumdl": "591 findings across 56 files — a burn-down project, deferred (#160 T12)",
+    "rustfmt": "No Rust source in project",
+    "ryl": "Redundant with yamllint",
+    "stylelint": "No CSS files",
+    "terraform": "No Terraform files",
+    "tf_lint": "No Terraform files",
+    "tombi": "Redundant with taplo",
+    "tombi_format": "Redundant with the taplo formatter",
+    "vale": "No formal style guide; network dependency in the hook",
+    "xmllint": "No XML files in project",
+}
+
+
+def hk_version() -> str:
+    """The hk version string, recorded in the generated doc."""
+    result = subprocess.run(
+        ["hk", "--version"], capture_output=True, text=True, check=False
+    )
+    return result.stdout.strip() or "unknown"
+
+
+def available_builtins() -> list[str]:
+    """Every builtin `hk builtins` reports — the authoritative list."""
+    result = subprocess.run(
+        ["hk", "builtins"], capture_output=True, text=True, check=False
+    )
+    if result.returncode != 0:
+        logger.error("hk builtins failed: %s", result.stderr.strip())
+        return []
+    return sorted(result.stdout.split())
+
+
+def wired_builtins(root: Path, available: list[str]) -> dict[str, list[str]]:
+    """Builtin -> the configs that reference it as `Builtins.<name>`."""
+    known = set(available)
+    wired: dict[str, list[str]] = {}
+    for name in CONFIGS:
+        path = root / name
+        if not path.exists():
+            continue
+        for match in re.findall(_ASSIGNED_BUILTIN, path.read_text()):
+            if match in known:
+                wired.setdefault(match, [])
+                if name not in wired[match]:
+                    wired[match].append(name)
+    return dict(sorted(wired.items()))
+
+
+def defined_steps(root: Path) -> dict[str, list[str]]:
+    """Step name -> the configs that define it, builtin-backed or custom."""
+    steps: dict[str, list[str]] = {}
+    for name in CONFIGS:
+        path = root / name
+        if not path.exists():
+            continue
+        pattern = r'^\s*\["([a-zA-Z0-9_-]+)"\]'
+        for match in re.findall(pattern, path.read_text(), re.MULTILINE):
+            steps.setdefault(match, [])
+            if name not in steps[match]:
+                steps[match].append(name)
+    return dict(sorted(steps.items()))
+
+
+def stale_entries(available: list[str], wired: dict[str, list[str]]) -> list[str]:
+    """NOT_ADOPTED entries that have stopped being true."""
+    known = set(available)
+    problems = [
+        f"{name}: not a builtin in this hk version — drop the entry"
+        for name in NOT_ADOPTED
+        if name not in known
+    ]
+    problems += [
+        f"{name}: listed as not-adopted but IS wired in {', '.join(wired[name])}"
+        for name in NOT_ADOPTED
+        if name in wired
+    ]
+    return sorted(problems)
+
+
+def render(root: Path) -> str:
+    """The full generated document, as a string."""
+    available = available_builtins()
+    wired = wired_builtins(root, available)
+    steps = defined_steps(root)
+    custom = {n: c for n, c in steps.items() if n not in wired}
+    unlisted = [n for n in available if n not in wired and n not in NOT_ADOPTED]
+
+    out: list[str] = [
+        "# hk Builtins Audit",
+        "",
+        GENERATED_BANNER,
+        "",
+        f"- **hk version:** {hk_version()}",
+        f"- **Builtins available:** {len(available)}",
+        f"- **Wired as builtins:** {len(wired)}",
+        f"- **Steps defined in total:** {len(steps)} "
+        f"({len(custom)} custom, with their own check/fix commands)",
+        "",
+        "A *wired builtin* is referenced as `Builtins.<name>`. A *custom step* is a",
+        '`["name"] { … }` block carrying its own commands — it may share a',
+        "name with a builtin without being one, which is how the previous",
+        "hand-written audit came to list `ruff_format` and `editorconfig-checker`",
+        "as builtins in use.",
+        "",
+        f"## Wired builtins ({len(wired)})",
+        "",
+        "| Builtin | Declared in |",
+        "|---------|-------------|",
+    ]
+    out += [f"| `{name}` | {', '.join(cfgs)} |" for name, cfgs in wired.items()]
+
+    out += [
+        "",
+        f"## Custom steps ({len(custom)})",
+        "",
+        "Not builtins. Each carries its own `check`/`fix`, so `hk builtins` has no",
+        "opinion about them, and neither does this table beyond recording them.",
+        "",
+        "| Step | Declared in |",
+        "|------|-------------|",
+    ]
+    out += [f"| `{name}` | {', '.join(cfgs)} |" for name, cfgs in custom.items()]
+
+    out += [
+        "",
+        f"## Deliberately not adopted ({len(NOT_ADOPTED)})",
+        "",
+        "The only authored section — a judgement no tool can recover. Edit it in",
+        "`hk_builtins_audit.py`; an entry that stops naming a real builtin, or that",
+        "names one now wired, fails the gate.",
+        "",
+        "| Builtin | Reason |",
+        "|---------|--------|",
+    ]
+    out += [f"| `{name}` | {NOT_ADOPTED[name]} |" for name in sorted(NOT_ADOPTED)]
+
+    out += [
+        "",
+        f"## Not yet considered ({len(unlisted)})",
+        "",
+        "Available in this hk version, neither wired nor explicitly declined.",
+        "Listed so the unexamined remainder is visible rather than implied — the",
+        "previous audit's biggest silent gap was 87 builtins it never mentioned.",
+        "",
+        "```",
+    ]
+    rows = (", ".join(unlisted[i : i + 6]) for i in range(0, len(unlisted), 6))
+    out += ["\n".join(rows)]
+    out += ["```", ""]
+    return "\n".join(out)
+
+
+def hk_builtins_audit_main(root: Path, *, check: bool = False) -> int:
+    """Write the audit doc, or (with ``check``) verify the committed one."""
+    available = available_builtins()
+    if not available:
+        logger.error("`hk builtins` produced nothing — cannot audit. Is hk installed?")
+        return 1
+
+    problems = stale_entries(available, wired_builtins(root, available))
+    if problems:
+        for problem in problems:
+            logger.error("NOT_ADOPTED %s", problem)
+        return 1
+
+    content = render(root)
+    target = root / DOC_PATH
+    if not check:
+        target.write_text(content)
+        logger.info("wrote %s", DOC_PATH)
+        return 0
+
+    current = target.read_text() if target.exists() else ""
+    if current == content:
+        return 0
+    logger.error(
+        "%s is out of date with `hk builtins` + the hk configs. "
+        "Regenerate with `mise run hk-audit`.",
+        DOC_PATH,
+    )
+    return 1

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -29,6 +29,7 @@ from dotfiles_setup.doc_refs import (
     find_unresolved_task_refs,
 )
 from dotfiles_setup.docker import DevContainerManager
+from dotfiles_setup.env_blob_scan import env_blob_scan_main
 from dotfiles_setup.eval_cases import cases as eval_cases_for
 from dotfiles_setup.gcc_sha import gcc_sha_main
 from dotfiles_setup.ghcr import validate_ghcr_prereqs
@@ -40,6 +41,7 @@ from dotfiles_setup.graph_bakeoff import (
     bakeoff_main,
 )
 from dotfiles_setup.graphify import graphify_main
+from dotfiles_setup.hk_builtins_audit import hk_builtins_audit_main
 from dotfiles_setup.hook_guard import pretooluse_main
 from dotfiles_setup.hook_selfcheck import hook_selfcheck_main
 from dotfiles_setup.image import ImageCommand
@@ -63,6 +65,7 @@ from dotfiles_setup.pr import automerge_main, land_main, ship_main
 from dotfiles_setup.renovate import renovate_status_main
 from dotfiles_setup.renovate_dryrun import renovate_dryrun_main
 from dotfiles_setup.sync import SyncOptions, sync_main
+from dotfiles_setup.token_audit import token_audit_main
 from dotfiles_setup.verify import main as verify_main
 from dotfiles_setup.workflow_hooks import workflow_hooks_main
 
@@ -138,6 +141,57 @@ def _add_apt_repo_subcommand(subparsers: _SubParsers) -> None:
         "--exclude-runtime",
         action="store_true",
         help="Drop Section: libs packages (they arrive via Depends:)",
+    )
+
+
+def _add_honesty_subcommands(subparsers: _SubParsers) -> None:
+    """Register the gates that keep a claim and its reality in step.
+
+    Grouped because they answer one question — does this artifact still say
+    something true? A committed environment dump, a generated doc that has
+    drifted from the tool it describes, and a contract token satisfied by a
+    stand-in are the same failure wearing three costumes. Extracted into a
+    helper for the reason `_add_consistency_subcommands` was: `setup_parser`
+    sits at ruff's PLR0915 statement ceiling.
+
+    Args:
+        subparsers: The parent subparsers action to attach these to.
+    """
+    env_blob_parser = subparsers.add_parser(
+        "env-blob-scan",
+        help="Reject a committed environment dump — a __MISE_DIFF-shaped blob, "
+        "any base64 run that decompresses to text naming secret variables, or a "
+        "literal credential value. Covers what gitleaks and betterleaks cannot: "
+        "measured, both are blind to the compressed form",
+    )
+    env_blob_parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Repo-relative files to scan (default: every tracked file)",
+    )
+    hk_audit_parser = subparsers.add_parser(
+        "hk-builtins-audit",
+        help="Regenerate docs/hk-builtins-audit.md from `hk builtins` + the hk "
+        "configs. The hand-written version drifted to claiming 15 builtins were "
+        "used that were not wired, one of them a security scanner",
+    )
+    hk_audit_parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail instead of writing when the committed doc is out of date",
+    )
+    subparsers.add_parser(
+        "token-audit",
+        help="Contract-token uniqueness: every per_path_tokens entry should "
+        "match its target file exactly once, because a token matching twice can "
+        "be satisfied by a stand-in (#394). Genuine multiplicity is allowlisted "
+        "with a reason in token_audit.py",
+    )
+    subparsers.add_parser(
+        "bash-budget",
+        help="Enforce zero-bash-logic: every scripts/*.sh + "
+        ".devcontainer/scripts/*.sh must be allowlisted and within its "
+        "per-file line budget (new/grown scripts fail — move logic to python/)",
     )
 
 
@@ -734,12 +788,7 @@ def setup_parser() -> argparse.ArgumentParser:
     apt_pins_parser.add_argument(
         "--json", action="store_true", help="Emit the probe result as JSON"
     )
-    subparsers.add_parser(
-        "bash-budget",
-        help="Enforce zero-bash-logic: every scripts/*.sh + "
-        ".devcontainer/scripts/*.sh must be allowlisted and within its "
-        "per-file line budget (new/grown scripts fail — move logic to python/)",
-    )
+    _add_honesty_subcommands(subparsers)
     subparsers.add_parser(
         "workflow-hooks",
         help="Enforce ADR-0001: every CI job that commits or pushes must set "
@@ -1263,6 +1312,13 @@ def _build_command_handlers(
             apt_pins_main(project_root, json_output=args.json)
         ),
         "bash-budget": lambda: sys.exit(bash_budget_main(project_root)),
+        "token-audit": lambda: sys.exit(token_audit_main(project_root)),
+        "env-blob-scan": lambda: sys.exit(
+            env_blob_scan_main(project_root, args.paths or None)
+        ),
+        "hk-builtins-audit": lambda: sys.exit(
+            hk_builtins_audit_main(project_root, check=args.check)
+        ),
         "workflow-hooks": lambda: sys.exit(workflow_hooks_main(project_root)),
         "bootstrap-gap-report": lambda: handle_bootstrap_gap_report(args, project_root),
         "lock-stage": lambda: handle_lock_stage(args, project_root),

--- a/python/src/dotfiles_setup/token_audit.py
+++ b/python/src/dotfiles_setup/token_audit.py
@@ -1,0 +1,211 @@
+"""Contract-token uniqueness: a token that matches twice can be satisfied twice.
+
+## Why this exists (#394, 2026-07-27)
+
+The #394 sweep anchored 164 enforcement-seam tokens so a prefix-preserving
+rename could not hide inside them, then proved the three holes that were live
+by deleting the real wiring line and leaving the swallower standing. **Anchoring
+fixed none of them:**
+
+| token | line deleted | what kept the contract green |
+|---|---|---|
+| `permissionDecision` | the deny-emit | the TEST FILE's assertion (union) |
+| `selfcheck` | the subparser registration | the `elif command ==` dispatch branch |
+| `--output` | `command_audit_parser`'s flag | `memory_index_parser`'s own `--output` |
+
+Every one is the same shape: the token matched **somewhere other than the site
+it meant**. A word-boundary matcher — #394's step 4, and the obvious next move —
+would have caught none of them, which is why the audit recommended this instead.
+
+The rule is cheap to state and mechanical to check: **a `per_path_tokens` entry
+should match its target file exactly once.** One match cannot be satisfied by a
+stand-in. Where the multiplicity is genuine — a lockfile section repeated per
+package, a doc that naturally names a task several times, a test fixture reused
+across cases — it is recorded in :data:`AMBIGUITY_ALLOWED` with a reason, and a
+NEW ambiguity fails.
+
+Same shape as :mod:`dotfiles_setup.bash_budget`: an explicit map with
+justifications, where a stale entry fails too, so the map cannot rot.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from dotfiles_setup import verify
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+MANIFEST = "python/verification/suites.toml"
+
+# (suite, path, token) -> why matching more than once is correct here.
+# Measured 2026-07-27: 25 entries were ambiguous; 7 were real defects of the
+# `selfcheck` shape and were fixed by binding the unique site instead. These 18
+# are the genuine remainder.
+AMBIGUITY_ALLOWED: dict[tuple[str, str, str], str] = {
+    (
+        "build.locked-install-with-conda-sha",
+        ".devcontainer/mise-system.lock",
+        "[conda-packages.linux-x64",
+    ): "a lockfile section header, once per package — multiplicity IS the assertion",
+    (
+        "build.locked-install-with-conda-sha",
+        ".devcontainer/Dockerfile",
+        "mise install --system --locked",
+    ): "one install per build stage; every stage must carry --locked",
+    (
+        "eval.tier1-runner-wiring",
+        "python/src/dotfiles_setup/eval_cases.py",
+        "control=",
+    ): "one per eval case — every case declaring a control arm is the point",
+    (
+        "eval.gate-reports-status",
+        "python/src/dotfiles_setup/pr.py",
+        "gh pr view rc={view.returncode}",
+    ): "two real call sites, both of which must report the rc",
+    (
+        "workflow.adr-0001-enforcement",
+        "tests/test_workflow_hooks.py",
+        "HK_SKIP_HOOKS: pre-commit",
+    ): "a test fixture reused across cases",
+    (
+        "workflow.adr-0001-enforcement",
+        "tests/test_workflow_hooks.py",
+        "workflow_hooks.job_writes_to_git(",
+    ): "the function under test, called from several cases",
+    (
+        "workflow.apt-pins-enforcement",
+        "tests/test_pr.py",
+        'verify-apt-pins"',
+    ): "the gate name asserted from several test cases",
+    (
+        "workflow.automerge-wiring",
+        "python/src/dotfiles_setup/hook_guard.py",
+        "mise run automerge -- <PR#>",
+    ): "both the automerge rule and the generic merge rule name the verb (#369)",
+    (
+        "workflow.md-budget-enforcement",
+        ".claude/rules/md-size-budgets.md",
+        "Windsurf",
+    ): "prose: the vendor whose limit the rule documents, named throughout",
+    (
+        "workflow.md-budget-enforcement",
+        ".claude/rules/md-size-budgets.md",
+        "SKILL.md",
+    ): "prose: a load class the rule discusses in several places",
+    (
+        "workflow.command-audit-wiring",
+        ".claude/rules/mise-tasks-only.md",
+        "mise run command-audit`",
+    ): "prose: a rule doc naturally names its task more than once",
+    (
+        "workflow.command-audit-wiring",
+        ".claude/rules/mise-tasks-only.md",
+        "SessionEnd`",
+    ): "prose: the hook event, named where it is chosen and where it is justified",
+    (
+        "workflow.memory-index-wiring",
+        ".claude/skills/memory-index-curation/SKILL.md",
+        "mise run memory-index`",
+    ): "prose: a skill naturally names its task more than once",
+    (
+        "workflow.memory-index-wiring",
+        ".claude/skills/memory-index-curation/SKILL.md",
+        "THEN shorten",
+    ): "prose: the ordering rule, stated and then restated as the procedure",
+    (
+        "workflow.ship-land-wiring",
+        ".claude/skills/pr-workflow/SKILL.md",
+        "mise run ship`",
+    ): "prose: the skill's own subject",
+    (
+        "workflow.ship-land-wiring",
+        ".claude/skills/pr-workflow/SKILL.md",
+        "mise run land`",
+    ): "prose: the skill's own subject",
+    (
+        "workflow.sync-wiring",
+        ".claude/skills/devcontainer-sync/SKILL.md",
+        "mise run sync`",
+    ): "prose: the skill's own subject",
+    (
+        "workflow.tool-currency-wiring",
+        ".github/workflows/refresh.yml",
+        "Tool currency report (daily)",
+    ): "the job step name and the issue title it upserts",
+}
+
+
+@dataclass(frozen=True)
+class Ambiguity:
+    """A per-path token that does not match its file exactly once."""
+
+    suite: str
+    path: str
+    token: str
+    count: int
+
+    @property
+    def key(self) -> tuple[str, str, str]:
+        """The allowlist key: suite, path, token."""
+        return (self.suite, self.path, self.token)
+
+    def render(self) -> str:
+        """One line naming the suite, the file, the token and its match count."""
+        return f"{self.suite} [{self.path}] {self.token!r} matches {self.count}x"
+
+
+def find_ambiguous(root: Path) -> list[Ambiguity]:
+    """Every per-path token that matches its target file other than once."""
+    suites = verify.load_manifest(root / MANIFEST)
+    found: list[Ambiguity] = []
+    for suite in suites:
+        for raw, tokens in suite.get("per_path_tokens", {}).items():
+            target = root / raw
+            text = target.read_text() if target.exists() else ""
+            for token in tokens:
+                count = text.count(token)
+                if count != 1:
+                    found.append(Ambiguity(suite["name"], raw, token, count))
+    return found
+
+
+def find_violations(root: Path) -> list[str]:
+    """New ambiguity, plus allowlist entries that have stopped being true."""
+    ambiguous = find_ambiguous(root)
+    seen = {a.key for a in ambiguous}
+
+    problems = [
+        f"{a.render()} — not in AMBIGUITY_ALLOWED. Bind the ONE site that means "
+        f"it (see #394), or add an entry with a reason."
+        for a in ambiguous
+        if a.key not in AMBIGUITY_ALLOWED
+    ]
+    problems += [
+        f"{suite} [{path}] {token!r} is allowlisted but now matches exactly "
+        f"once (or is gone) — drop the entry."
+        for (suite, path, token) in AMBIGUITY_ALLOWED
+        if (suite, path, token) not in seen
+    ]
+    return sorted(problems)
+
+
+def token_audit_main(root: Path) -> int:
+    """CLI entrypoint: report every ambiguous-binding problem; 1 if any."""
+    problems = find_violations(root)
+    if not problems:
+        return 0
+    for problem in problems:
+        logger.error("%s", problem)
+    logger.error(
+        "%d contract-token binding problem(s). A token matching more than once "
+        "can be satisfied by a stand-in — that is how a deleted registration "
+        "stayed green (#394).",
+        len(problems),
+    )
+    return 1

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -1194,12 +1194,86 @@ paths = [
     "tests/test_bash_budget.py",
     ".claude/rules/zero-bash-logic.md",
 ]
-per_path_tokens = { "hk.pkl" = ['bash_logic_budget"', 'dotfiles-setup bash-budget"'], "python/src/dotfiles_setup/main.py" = ['bash-budget"'], "python/src/dotfiles_setup/bash_budget.py" = ['def find_violations(', 'def bash_budget_main('] }
+per_path_tokens = { "hk.pkl" = ['bash_logic_budget"', 'dotfiles-setup bash-budget"'], "python/src/dotfiles_setup/main.py" = ['"bash-budget",', '"bash-budget": lambda'], "python/src/dotfiles_setup/bash_budget.py" = ['def find_violations(', 'def bash_budget_main('] }
 tokens = [
     'dotfiles-setup bash-budget"',
     'def bash_budget_main(',
     'def find_violations(',
     'ALLOWLIST:',
+]
+
+[[suite]]
+name = "workflow.token-audit-wiring"
+description = "Contract-token uniqueness gate (#394 step 4). The sweep anchored 164 tokens so a prefix-preserving rename could not hide inside them — and then the three holes that were LIVE all survived their anchor, because each token matched somewhere other than the site it meant: `permissionDecision` was satisfied by the test file's own assertion (bare tokens are a union), `selfcheck` by the `elif command ==` dispatch branch after the subparser registration was deleted, `--output` by a sibling parser's identical flag. A word-boundary matcher would have caught none of them, which is why the audit recommended a UNIQUENESS signal instead: a per_path_tokens entry should match its file exactly once, because one match cannot be satisfied by a stand-in. Genuine multiplicity — a lockfile section per package, a doc naming its own task, a reused test fixture — is allowlisted with a reason; a NEW ambiguity fails, and so does a stale entry. Asserts the chain: hk step, CLI subcommand, module, allowlist, tests."
+category = "workflow"
+check_type = "static"
+handler = "require_tokens"
+paths_required = true
+paths = [
+    "hk.pkl",
+    "python/src/dotfiles_setup/main.py",
+    "python/src/dotfiles_setup/token_audit.py",
+    "tests/test_token_audit.py",
+]
+per_path_tokens = { "hk.pkl" = [
+    'contract_token_uniqueness"',
+    'dotfiles-setup token-audit"',
+], "python/src/dotfiles_setup/main.py" = [
+    '"token-audit",',
+    '"token-audit": lambda',
+], "python/src/dotfiles_setup/token_audit.py" = [
+    "def find_ambiguous(",
+    "def find_violations(",
+    "def token_audit_main(",
+    "AMBIGUITY_ALLOWED: dict",
+], "tests/test_token_audit.py" = [
+    "def test_a_token_matching_once_is_silent(",
+    "def test_every_allowlist_entry_is_still_ambiguous(",
+] }
+tokens = [
+    'dotfiles-setup token-audit"',
+    "def find_ambiguous(",
+]
+
+[[suite]]
+name = "workflow.env-dump-enforcement"
+description = "Env-dump gate wiring (2026-07-27). fnox exports real credentials into the interactive shell and mise records the whole delta in `__MISE_DIFF` — zlib+base64 — which every child process inherits, so any tool that writes its environment to a file writes those credentials in a form that looks like noise. Measured, both arms, with synthetic secrets: gitleaks 8.30.1 finds 2 in the plaintext and 0 in the blob; betterleaks 1.7.1 finds 1 and 0. That measured blindness is what justifies custom code here at all (`use-tool-builtins.md`) — both scanners stay wired, and this covers only the decode. Asserts the whole chain: the hk step, the CLI subcommand, the module's three checks (named assignment, bare compressed blob, literal value), its tests, and the rule doc. The hk step is deliberately glob-less because an env dump can land in ANY tracked file — including `docs/research/kb/` and `docs/research/runs/`, which `.gitleaks.toml` allowlists away and git tracks. Tokens follow the #394 rules: an invocation, extended past the renamable identifier, bound to the one site that means it."
+category = "workflow"
+check_type = "static"
+handler = "require_tokens"
+paths_required = true
+paths = [
+    "hk.pkl",
+    "mise.toml",
+    "python/src/dotfiles_setup/main.py",
+    "python/src/dotfiles_setup/env_blob_scan.py",
+    "tests/test_env_blob_scan.py",
+    ".claude/rules/secrets-out-of-the-shell-env.md",
+]
+per_path_tokens = { "hk.pkl" = [
+    'no_env_dump"',
+    'dotfiles-setup env-blob-scan"',
+    "Builtins.betterleaks)",
+], "mise.toml" = [
+    '"aqua:betterleaks/betterleaks" =',
+], "python/src/dotfiles_setup/main.py" = [
+    '"env-blob-scan",', '"env-blob-scan": lambda',
+    "env_blob_scan_main(project_root",
+], "python/src/dotfiles_setup/env_blob_scan.py" = [
+    "def find_violations(",
+    "def decode_blob(",
+    "def env_blob_scan_main(",
+    "ENV_DIFF_NAME =",
+    "EXEMPT_PREFIXES:",
+], "tests/test_env_blob_scan.py" = [
+    "def test_a_bare_blob_with_no_variable_name_is_still_caught(",
+    "def test_a_long_base64_run_that_is_not_compressed_data_is_ignored(",
+    "def test_the_real_repo_is_clean(",
+] }
+tokens = [
+    'dotfiles-setup env-blob-scan"',
+    "def decode_blob(",
+    "Builtins.betterleaks)",
 ]
 
 [[suite]]
@@ -1216,7 +1290,7 @@ paths = [
     "tests/test_workflow_hooks.py",
     "docs/adr/0001-hk-hooks-do-not-run-in-ci.md",
 ]
-per_path_tokens = { "hk.pkl" = ['workflow_hk_skip_hooks"', 'dotfiles-setup workflow-hooks"'], "python/src/dotfiles_setup/main.py" = ['workflow-hooks"', "workflow_hooks_main(project_root)"], "python/src/dotfiles_setup/workflow_hooks.py" = ["violations = find_violations(root)", "job_writes_to_git(job, writers) and not skips_required_hooks(job)", "classification_gaps(root)", "mise_task_git_writers(root)", "redact_heredoc_bodies(run_text)"], "tests/test_workflow_hooks.py" = ["workflow_hooks.job_writes_to_git(", "workflow_hooks.find_violations(REPO_ROOT) == []", "HK_SKIP_HOOKS: pre-commit", "workflow_hooks.workflow_hooks_main(tmp_path) == 1", 'setup_parser().parse_args(["workflow-hooks"])'], "docs/adr/0001-hk-hooks-do-not-run-in-ci.md" = ['dotfiles-setup workflow-hooks`', 'workflow_hk_skip_hooks`', "Closed 2026-07-21"] }
+per_path_tokens = { "hk.pkl" = ['workflow_hk_skip_hooks"', 'dotfiles-setup workflow-hooks"'], "python/src/dotfiles_setup/main.py" = ['"workflow-hooks",', '"workflow-hooks": lambda', "workflow_hooks_main(project_root)"], "python/src/dotfiles_setup/workflow_hooks.py" = ["violations = find_violations(root)", "job_writes_to_git(job, writers) and not skips_required_hooks(job)", "classification_gaps(root)", "mise_task_git_writers(root)", "redact_heredoc_bodies(run_text)"], "tests/test_workflow_hooks.py" = ["workflow_hooks.job_writes_to_git(", "workflow_hooks.find_violations(REPO_ROOT) == []", "HK_SKIP_HOOKS: pre-commit", "workflow_hooks.workflow_hooks_main(tmp_path) == 1", 'setup_parser().parse_args(["workflow-hooks"])'], "docs/adr/0001-hk-hooks-do-not-run-in-ci.md" = ['dotfiles-setup workflow-hooks`', 'workflow_hk_skip_hooks`', "Closed 2026-07-21"] }
 
 [[suite]]
 name = "workflow.tool-currency-wiring"
@@ -1272,7 +1346,7 @@ paths = [
     "tests/test_memory_index.py",
     ".claude/skills/memory-index-curation/SKILL.md",
 ]
-per_path_tokens = { "mise.toml" = ["[tasks.memory-index]", "dotfiles-setup memory-index'"], "python/src/dotfiles_setup/memory_index.py" = ['def memory_index_main(', 'def audit_index(', 'def distinctive_facts(', 'def fact_present(', 'def inbound_refs(', 'def load_cutoff_line(', 'LINE_BUDGET =', 'BYTE_BUDGET ='], "python/src/dotfiles_setup/main.py" = ['memory-index"', '--refs"'], "tests/test_memory_index.py" = ['def test_the_index_does_not_satisfy_its_own_facts(', 'def test_size_matches_across_a_space_the_prototype_reported_as_missing(', 'def test_fact_only_in_the_hook_is_index_only_and_fails_the_check(', 'def test_an_entry_past_the_byte_cutoff_fails_even_when_under_200_lines(', 'def test_distinctive_facts_ignores_plain_numbers_that_are_all_hex_digits(', 'def test_a_matching_size_in_an_unrelated_memory_is_not_the_same_fact(', 'def test_a_fact_in_the_title_is_checked_not_just_the_hook(', 'def test_inbound_refs_finds_every_citation_form_the_memories_use('], ".claude/skills/memory-index-curation/SKILL.md" = ['mise run memory-index`', '--refs <', "THEN shorten"] }
+per_path_tokens = { "mise.toml" = ["[tasks.memory-index]", "dotfiles-setup memory-index'"], "python/src/dotfiles_setup/memory_index.py" = ['def memory_index_main(', 'def audit_index(', 'def distinctive_facts(', 'def fact_present(', 'def inbound_refs(', 'def load_cutoff_line(', 'LINE_BUDGET =', 'BYTE_BUDGET ='], "python/src/dotfiles_setup/main.py" = ['"memory-index",', '"memory-index": lambda', '--refs"'], "tests/test_memory_index.py" = ['def test_the_index_does_not_satisfy_its_own_facts(', 'def test_size_matches_across_a_space_the_prototype_reported_as_missing(', 'def test_fact_only_in_the_hook_is_index_only_and_fails_the_check(', 'def test_an_entry_past_the_byte_cutoff_fails_even_when_under_200_lines(', 'def test_distinctive_facts_ignores_plain_numbers_that_are_all_hex_digits(', 'def test_a_matching_size_in_an_unrelated_memory_is_not_the_same_fact(', 'def test_a_fact_in_the_title_is_checked_not_just_the_hook(', 'def test_inbound_refs_finds_every_citation_form_the_memories_use('], ".claude/skills/memory-index-curation/SKILL.md" = ['mise run memory-index`', '--refs <', "THEN shorten"] }
 tokens = [
     "dotfiles-setup memory-index'",
     'def memory_index_main(',
@@ -1298,7 +1372,7 @@ paths = [
     "tests/test_hook_guard.py",
     ".claude/rules/mise-tasks-only.md",
 ]
-per_path_tokens = { "mise.toml" = ["[tasks.command-audit]", "dotfiles-setup command-audit'"], "python/src/dotfiles_setup/command_audit.py" = ['def command_audit_main(', 'def classify(', 'def iter_bash_commands(', 'def write_report(', 'def _executed_ids('], "python/src/dotfiles_setup/hook_guard.py" = ['class Rule:', "since: str", 'def match('], "python/src/dotfiles_setup/main.py" = ['command-audit"', "command_audit_parser.add_argument(\n        \"--output\","], "python/src/dotfiles_setup/hook_selfcheck.py" = ['SessionEnd"', '_SESSION_END_REPORT ='], ".claude/settings.json" = ['SessionEnd"', "mise run command-audit -- --output .agent/command-audit.md"], ".gitignore" = [".agent/command-audit.md"], "tests/test_command_audit.py" = ['def test_main_output_writes_file_instead_of_stdout(', 'def test_iter_bash_commands_pairs_results_to_attempts('], "tests/test_hook_guard.py" = ['def test_every_rule_carries_a_usable_since_date('], ".claude/rules/mise-tasks-only.md" = ['mise run command-audit`', 'SessionEnd`', "since"] }
+per_path_tokens = { "mise.toml" = ["[tasks.command-audit]", "dotfiles-setup command-audit'"], "python/src/dotfiles_setup/command_audit.py" = ['def command_audit_main(', 'def classify(', 'def iter_bash_commands(', 'def write_report(', 'def _executed_ids('], "python/src/dotfiles_setup/hook_guard.py" = ['class Rule:', "since: str", 'def match('], "python/src/dotfiles_setup/main.py" = ['"command-audit",', '"command-audit": lambda', "command_audit_parser.add_argument(\n        \"--output\","], "python/src/dotfiles_setup/hook_selfcheck.py" = ['SessionEnd"', '_SESSION_END_REPORT ='], ".claude/settings.json" = ['SessionEnd"', "mise run command-audit -- --output .agent/command-audit.md"], ".gitignore" = [".agent/command-audit.md"], "tests/test_command_audit.py" = ['def test_main_output_writes_file_instead_of_stdout(', 'def test_iter_bash_commands_pairs_results_to_attempts('], "tests/test_hook_guard.py" = ['def test_every_rule_carries_a_usable_since_date('], ".claude/rules/mise-tasks-only.md" = ['mise run command-audit`', 'SessionEnd`', "Give it a `since`"] }
 tokens = [
     "dotfiles-setup command-audit'",
     'def command_audit_main(',
@@ -1321,7 +1395,7 @@ paths = [
     "tests/test_pr.py",
     ".claude/rules/local-devcontainer-first.md",
 ]
-per_path_tokens = { "mise.toml" = ['tasks.verify-apt-pins]', "dotfiles-setup apt-pins'"], "python/src/dotfiles_setup/main.py" = ['apt-pins"'], "python/src/dotfiles_setup/apt_pins.py" = ['def pinned_apt_packages(', 'def probe_script(', 'def apt_pins_main('], "python/src/dotfiles_setup/pr.py" = ['_APT_PIN_PATTERNS =', "if changes_apt_pin_inputs(paths):", "Gate(\"verify-apt-pins\""], "tests/test_pr.py" = ['verify-apt-pins"'], ".claude/rules/local-devcontainer-first.md" = ['mise run verify-apt-pins`'] }
+per_path_tokens = { "mise.toml" = ['tasks.verify-apt-pins]', "dotfiles-setup apt-pins'"], "python/src/dotfiles_setup/main.py" = ['"apt-pins",', '"apt-pins": lambda'], "python/src/dotfiles_setup/apt_pins.py" = ['def pinned_apt_packages(', 'def probe_script(', 'def apt_pins_main('], "python/src/dotfiles_setup/pr.py" = ['_APT_PIN_PATTERNS =', "if changes_apt_pin_inputs(paths):", "Gate(\"verify-apt-pins\""], "tests/test_pr.py" = ['verify-apt-pins"'], ".claude/rules/local-devcontainer-first.md" = ['mise run verify-apt-pins`'] }
 tokens = [
     "dotfiles-setup apt-pins'",
     'def apt_pins_main(',

--- a/tests/test_child_env.py
+++ b/tests/test_child_env.py
@@ -1,0 +1,85 @@
+"""Tests for the child-process environment scrub."""
+
+from __future__ import annotations
+
+from dotfiles_setup.child_env import (
+    ENV_DIFF_NAME,
+    clean_env,
+    dropped_names,
+    is_credential,
+    without_env_diff,
+)
+
+# Values are named rather than inline so no assertion below reads as a
+# hardcoded credential (ruff S105) — and so a value change stays in one place.
+SENTINEL = "s3nt1nel"
+PLAIN = "kept"
+
+SAMPLE = {
+    ENV_DIFF_NAME: "eJxopaque",
+    "AWS_SECRET_ACCESS_KEY": SENTINEL,
+    "AWS_ACCESS_KEY_ID": SENTINEL,
+    "GITHUB_TOKEN": SENTINEL,
+    "BSKY_APP_PASSWORD": SENTINEL,
+    "GOOGLE_CLIENT_SECRET": SENTINEL,
+    "PATH": "/usr/bin",
+    "HOME": "/home/x",
+    "AWS_REGION": "us-east-1",
+    "TOKENIZER_BACKEND": "hf",
+}
+
+
+def test_without_env_diff_drops_only_the_blob() -> None:
+    """The default strength must not break a child by removing what it needs."""
+    out = without_env_diff(SAMPLE)
+    assert ENV_DIFF_NAME not in out
+    assert out["AWS_SECRET_ACCESS_KEY"] == SENTINEL
+    assert len(out) == len(SAMPLE) - 1
+
+
+def test_clean_env_drops_every_credential_shaped_name() -> None:
+    out = clean_env(SAMPLE)
+    for name in (
+        ENV_DIFF_NAME,
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_ACCESS_KEY_ID",
+        "GITHUB_TOKEN",
+        "BSKY_APP_PASSWORD",
+        "GOOGLE_CLIENT_SECRET",
+    ):
+        assert name not in out, name
+
+
+def test_clean_env_keeps_the_ordinary_environment() -> None:
+    """The control arm: a scrub that removed everything would also 'pass' above."""
+    out = clean_env(SAMPLE)
+    assert out["PATH"] == "/usr/bin"
+    assert out["HOME"] == "/home/x"
+    assert out["AWS_REGION"] == "us-east-1"
+
+
+def test_a_name_that_merely_starts_with_token_is_not_a_credential() -> None:
+    """`TOKENIZER_BACKEND` contains 'TOKEN' but is not one — anchor on segments."""
+    assert not is_credential("TOKENIZER_BACKEND")
+    assert clean_env(SAMPLE)["TOKENIZER_BACKEND"] == "hf"
+
+
+def test_keep_is_an_explicit_per_call_exception() -> None:
+    out = clean_env(SAMPLE, keep=frozenset({"GITHUB_TOKEN"}))
+    assert out["GITHUB_TOKEN"] == SENTINEL
+    assert "AWS_SECRET_ACCESS_KEY" not in out
+
+
+def test_the_source_environment_is_never_modified() -> None:
+    before = dict(SAMPLE)
+    clean_env(SAMPLE)
+    without_env_diff(SAMPLE)
+    assert before == SAMPLE
+
+
+def test_dropped_names_reports_names_and_never_values() -> None:
+    names = dropped_names(SAMPLE)
+    assert ENV_DIFF_NAME in names
+    assert "GITHUB_TOKEN" in names
+    assert "PATH" not in names
+    assert all(SAMPLE[n] not in "".join(names) for n in names if SAMPLE[n])

--- a/tests/test_env_blob_scan.py
+++ b/tests/test_env_blob_scan.py
@@ -1,0 +1,174 @@
+"""Tests for the env-dump gate.
+
+Every credential literal here is SYNTHETIC and is built by concatenation, never
+written as one token — so this file is clean to gitleaks, to betterleaks, and
+to the very scanner it tests. A test fixture that trips the repo's own secret
+gates is a test that gets deleted.
+"""
+
+from __future__ import annotations
+
+import base64
+import subprocess
+import zlib
+from pathlib import Path
+
+import pytest
+from dotfiles_setup import env_blob_scan
+from dotfiles_setup.env_blob_scan import (
+    ENV_DIFF_NAME,
+    MIN_BLOB_CHARS,
+    decode_blob,
+    env_blob_scan_main,
+    find_violations,
+)
+
+# Split so no complete credential ever appears as a literal in this file.
+FAKE_AWS_KEY = "AKIA" + "3QZ7WTVB2NKLDXPR"
+FAKE_GH_PAT = "gh" + "p_9fK2mQ8xR4tV6yB1nC3dE5gH7jL0pS2wX4zA"
+FAKE_GOOGLE_SECRET = "GOCSPX-" + "kL9mN2pQ4rS6tU8vW0xY2zA4bC6d"
+# Split for the same reason: the whole marker in one literal would trip the
+# very gate under test when it scans this repo.
+FAKE_KEY_HEADER = "-----BEGIN " + "RSA PRIVATE KEY-----"
+
+ENV_DUMP = (
+    "\n".join(f"VAR_{i}=value{i}" for i in range(40))
+    + f"\nAWS_ACCESS_KEY_ID={FAKE_AWS_KEY}"
+    + "\nAWS_SECRET_ACCESS_KEY=wJalr9XUtnFEMI0K7MDENG2bPxRfiCYnotreal"
+    + f"\nGITHUB_TOKEN={FAKE_GH_PAT}\n"
+)
+
+
+def _blob(text: str) -> str:
+    return base64.b64encode(zlib.compress(text.encode())).decode()
+
+
+def _write(tmp_path: Path, name: str, body: str) -> list:
+    (tmp_path / name).write_text(body)
+    return find_violations(tmp_path, [name])
+
+
+def test_a_named_mise_diff_assignment_is_a_finding(tmp_path: Path) -> None:
+    hits = _write(tmp_path, "log.txt", f"{ENV_DIFF_NAME}={_blob(ENV_DUMP)}\n")
+    assert [h.kind for h in hits] == ["env-dump-blob"]
+
+
+def test_a_bare_blob_with_no_variable_name_is_still_caught(tmp_path: Path) -> None:
+    """The hardest case: someone pastes the value alone, without its name."""
+    hits = _write(tmp_path, "log.txt", _blob(ENV_DUMP) + "\n")
+    assert [h.kind for h in hits] == ["compressed-env-dump"]
+
+
+def test_a_long_base64_run_that_is_not_compressed_data_is_ignored(
+    tmp_path: Path,
+) -> None:
+    """The negative control. Without it, the gate could be flagging any base64."""
+    body = "signature=" + base64.b64encode(b"x" * 400).decode() + "\n"
+    assert _write(tmp_path, "sig.txt", body) == []
+
+
+def test_a_compressed_blob_naming_only_one_secret_var_is_not_enough(
+    tmp_path: Path,
+) -> None:
+    """One name is a coincidence; the gate wants two before it calls it a dump."""
+    single = "\n".join(f"VAR_{i}=value{i}" for i in range(60)) + "\nMY_TOKEN=abc\n"
+    assert _write(tmp_path, "one.txt", _blob(single)) == []
+
+
+# Explicit ids: pytest derives a node id from the parameter VALUE otherwise, and
+# writes it into `.pytest_cache/v/cache/nodeids` — where gitleaks, which scans
+# the whole working tree, finds a credential-shaped string in a generated file.
+# Naming the cases keeps the values out of every artifact pytest writes.
+@pytest.mark.parametrize(
+    ("value", "kind"),
+    [
+        pytest.param(FAKE_AWS_KEY, "aws-access-key-id", id="aws-key"),
+        pytest.param(FAKE_GH_PAT, "github-pat", id="github-pat"),
+        pytest.param(FAKE_GOOGLE_SECRET, "google-client-secret", id="google"),
+        pytest.param(FAKE_KEY_HEADER, "private-key-header", id="private-key"),
+    ],
+)
+def test_literal_credential_values_are_caught(
+    tmp_path: Path, value: str, kind: str
+) -> None:
+    hits = _write(tmp_path, "creds.txt", f"secret = {value}\n")
+    assert [h.kind for h in hits] == [kind]
+
+
+def test_prose_that_merely_names_a_variable_is_not_a_finding(tmp_path: Path) -> None:
+    body = (
+        "The guard exports AWS_SECRET_ACCESS_KEY and GITHUB_TOKEN into the\n"
+        "environment, which is why __MISE_DIFF matters.\n"
+    )
+    assert _write(tmp_path, "doc.md", body) == []
+
+
+def test_the_vendor_doc_cache_is_the_only_exemption(tmp_path: Path) -> None:
+    """Exempt by prefix — and the exemption must not extend to a sibling path."""
+    body = f"key = {FAKE_AWS_KEY}\n"
+    exempt = tmp_path / "docs/research/mintlify-cache/vendor"
+    exempt.mkdir(parents=True)
+    (exempt / "llms.txt").write_text(body)
+    tracked = tmp_path / "docs/research/kb"
+    tracked.mkdir(parents=True)
+    (tracked / "report.md").write_text(body)
+
+    exempt_rel = "docs/research/mintlify-cache/vendor/llms.txt"
+    assert find_violations(tmp_path, [exempt_rel]) == []
+    # docs/research/kb is allowlisted in .gitleaks.toml AND is tracked — the
+    # exact hole this gate exists to close. It must NOT be exempt here.
+    assert len(find_violations(tmp_path, ["docs/research/kb/report.md"])) == 1
+
+
+def test_a_dump_just_over_the_length_floor_is_caught(tmp_path: Path) -> None:
+    """Pins the floor the first draft got wrong.
+
+    MIN_BLOB_CHARS was 200; a small synthetic dump compressed to ~180 chars and
+    slipped under it, so the probe's own fixture was invisible to the gate.
+    """
+    # Padding must be VARIED, not repeated: 12 identical lines compress to an
+    # 88-char blob, which would have made this test assert the wrong thing.
+    body = "AWS_SECRET_ACCESS_KEY=x\nGITHUB_TOKEN=y\n" + "".join(
+        f"PAD_{i}=q{i * 7919:x}z\n" for i in range(5)
+    )
+    blob = _blob(body)
+    assert MIN_BLOB_CHARS <= len(blob) < 200, f"fixture is {len(blob)} chars"
+    assert len(_write(tmp_path, "small.txt", blob)) == 1
+
+
+def test_decode_blob_returns_none_for_anything_that_is_not_compressed() -> None:
+    assert decode_blob("not base64 at all !!!") is None
+    assert decode_blob(base64.b64encode(b"plain, uncompressed").decode()) is None
+    assert decode_blob(_blob("hello")) == "hello"
+
+
+def test_main_returns_zero_on_a_clean_tree_and_one_on_a_dirty_one(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "clean.md").write_text("nothing to see\n")
+    assert env_blob_scan_main(tmp_path, ["clean.md"]) == 0
+    (tmp_path / "dirty.txt").write_text(f"{ENV_DIFF_NAME}={_blob(ENV_DUMP)}\n")
+    assert env_blob_scan_main(tmp_path, ["dirty.txt"]) == 1
+
+
+def test_the_real_repo_is_clean() -> None:
+    """The gate must pass on the tree it ships in — or it would never be run."""
+    root = Path(__file__).resolve().parent.parent
+    assert find_violations(root) == []
+
+
+def test_tracked_files_reads_the_repo_and_not_an_empty_list() -> None:
+    """Control arm for the default scope: an empty list would mean scanning nothing."""
+    root = Path(__file__).resolve().parent.parent
+    tracked = env_blob_scan.tracked_files(root)
+    assert "python/verification/suites.toml" in tracked
+    assert len(tracked) > 100
+
+
+def test_untracked_files_are_out_of_scope(tmp_path: Path) -> None:
+    """The gate guards what a PUSH carries, so gitignored files are irrelevant."""
+    subprocess.run(["git", "-C", str(tmp_path), "init", "-q"], check=True)
+    (tmp_path / ".gitignore").write_text("secret.log\n")
+    (tmp_path / "secret.log").write_text(f"{ENV_DIFF_NAME}={_blob(ENV_DUMP)}\n")
+    subprocess.run(["git", "-C", str(tmp_path), "add", ".gitignore"], check=True)
+    assert find_violations(tmp_path) == []

--- a/tests/test_hk_builtins_audit.py
+++ b/tests/test_hk_builtins_audit.py
@@ -1,0 +1,68 @@
+"""Tests for the generated hk-builtins audit."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dotfiles_setup import hk_builtins_audit as audit
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_the_committed_doc_matches_the_generator() -> None:
+    """The gate itself: if this fails, run `mise run hk-audit`."""
+    assert audit.hk_builtins_audit_main(ROOT, check=True) == 0
+
+
+def test_not_adopted_names_are_real_builtins_and_none_are_wired() -> None:
+    available = audit.available_builtins()
+    assert len(available) > 100, "hk builtins returned an implausibly short list"
+    wired = audit.wired_builtins(ROOT, available)
+    assert audit.stale_entries(available, wired) == []
+
+
+def test_stale_entries_fires_on_a_name_that_is_not_a_builtin() -> None:
+    """Control arm: the staleness check must be able to return the other answer."""
+    problems = audit.stale_entries(["ruff", "gitleaks"], {})
+    assert problems, "a NOT_ADOPTED map full of non-builtins produced no complaint"
+    assert all("not a builtin" in p for p in problems)
+
+
+def test_stale_entries_fires_when_a_declined_builtin_is_wired() -> None:
+    declined = next(iter(audit.NOT_ADOPTED))
+    problems = audit.stale_entries(list(audit.NOT_ADOPTED), {declined: ["hk.pkl"]})
+    assert [p for p in problems if "IS wired" in p]
+
+
+def test_wired_builtins_finds_the_scanners_and_names_their_config() -> None:
+    wired = audit.wired_builtins(ROOT, audit.available_builtins())
+    assert wired["gitleaks"] == ["hk-common.pkl"]
+    # betterleaks is host-only and lives in the project config: hk-common.pkl
+    # is spread into hk-image.pkl, and a tool referenced there must also be in
+    # the image — which costs a cold base rebuild.
+    assert wired["betterleaks"] == ["hk.pkl"]
+
+
+def test_a_custom_step_is_not_reported_as_a_wired_builtin() -> None:
+    """`ruff_format` is a custom step sharing a builtin's name.
+
+    Conflating the two is exactly what the hand-written audit did.
+    """
+    available = audit.available_builtins()
+    assert "ruff_format" in available
+    assert "ruff_format" not in audit.wired_builtins(ROOT, available)
+    assert "ruff_format" in audit.defined_steps(ROOT)
+
+
+def test_check_mode_fails_on_a_modified_doc(tmp_path: Path) -> None:
+    """Both arms of the gate, against a copy so the real doc is untouched."""
+    for name in (*audit.CONFIGS, "docs/hk-builtins-audit.md"):
+        src = ROOT / name
+        dst = tmp_path / name
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        dst.write_text(src.read_text())
+    assert audit.hk_builtins_audit_main(tmp_path, check=True) == 0
+
+    doc = tmp_path / audit.DOC_PATH
+    doc.write_text(doc.read_text().replace("## Wired builtins", "## Wired builtinz"))
+    assert audit.hk_builtins_audit_main(tmp_path, check=True) == 1

--- a/tests/test_token_audit.py
+++ b/tests/test_token_audit.py
@@ -1,0 +1,114 @@
+"""Tests for the contract-token uniqueness gate (#394 step 4)."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from dotfiles_setup import token_audit
+from dotfiles_setup.token_audit import (
+    AMBIGUITY_ALLOWED,
+    MANIFEST,
+    find_ambiguous,
+    find_violations,
+    token_audit_main,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_the_real_manifest_has_no_unexplained_ambiguity() -> None:
+    """The gate itself. A failure here names the token and what to do."""
+    assert find_violations(ROOT) == []
+
+
+def test_every_allowlist_entry_is_still_ambiguous() -> None:
+    """A stale entry must fail, so the map cannot rot (bash_budget's rule)."""
+    keys = {a.key for a in find_ambiguous(ROOT)}
+    assert set(AMBIGUITY_ALLOWED) <= keys
+
+
+def test_the_allowlist_is_not_empty_and_every_entry_carries_a_reason() -> None:
+    assert AMBIGUITY_ALLOWED
+    assert all(reason.strip() for reason in AMBIGUITY_ALLOWED.values())
+
+
+def _fixture(
+    tmp_path: Path,
+    tokens: str,
+    body: str,
+    monkeypatch: pytest.MonkeyPatch | None = None,
+) -> Path:
+    """A one-suite manifest, with the real allowlist swapped out.
+
+    The allowlist names real repo paths, so against a fixture tree every entry
+    reads as stale — which would drown the assertion under 18 unrelated lines.
+    """
+    if monkeypatch is not None:
+        monkeypatch.setattr(token_audit, "AMBIGUITY_ALLOWED", {})
+    (tmp_path / "python/verification").mkdir(parents=True)
+    (tmp_path / MANIFEST).write_text(
+        "[[suite]]\n"
+        'name = "demo.suite"\n'
+        'handler = "require_tokens"\n'
+        'paths = ["target.txt"]\n'
+        f'per_path_tokens = {{ "target.txt" = [{tokens}] }}\n'
+    )
+    (tmp_path / "target.txt").write_text(body)
+    return tmp_path
+
+
+def test_a_token_matching_twice_is_reported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _fixture(tmp_path, '"wire"', "wire here\nand wire there\n", monkeypatch)
+    problems = find_violations(tmp_path)
+    assert len(problems) == 1
+    assert "matches 2x" in problems[0]
+
+
+def test_a_token_matching_once_is_silent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The control arm: without it the gate could be flagging everything."""
+    _fixture(tmp_path, '"wire"', "wire here\nand nothing there\n", monkeypatch)
+    assert find_violations(tmp_path) == []
+
+
+def test_a_token_matching_zero_times_is_also_reported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Absent is not once. `require_tokens` fails too, but say WHY here."""
+    _fixture(tmp_path, '"wire"', "nothing at all\n", monkeypatch)
+    problems = find_violations(tmp_path)
+    assert len(problems) == 1
+    assert "matches 0x" in problems[0]
+
+
+def test_main_returns_one_when_a_binding_is_ambiguous(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _fixture(tmp_path, '"wire"', "wire here\nand wire there\n", monkeypatch)
+    assert token_audit_main(tmp_path) == 1
+
+
+def test_main_returns_zero_on_the_real_repo() -> None:
+    assert token_audit_main(ROOT) == 0
+
+
+def test_an_allowlisted_entry_that_became_unique_is_reported(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The stale-entry direction, proved rather than asserted."""
+    shutil.copytree(ROOT / "python/verification", tmp_path / "python/verification")
+    monkeypatch.setattr(
+        token_audit,
+        "AMBIGUITY_ALLOWED",
+        {**AMBIGUITY_ALLOWED, ("demo.suite", "gone.txt", "nope"): "stale on purpose"},
+    )
+    problems = find_violations(tmp_path)
+    assert [p for p in problems if "is allowlisted but now matches exactly once" in p]

--- a/typos.toml
+++ b/typos.toml
@@ -13,3 +13,10 @@ ba41c3748e298012 = "ba41c3748e298012"
 # format is not ours to rename, and weakening the check to dodge the word
 # (grepping for the hex anywhere in the output) would match a subkey too.
 fpr = "fpr"
+
+# `sherif` is the real name of an hk builtin (and of its upstream monorepo
+# linter, QuiiBz/sherif), not a misspelling of "sheriff". It reaches this repo
+# through the GENERATED docs/hk-builtins-audit.md, which lists every builtin
+# `hk builtins` reports — so the name is not ours to spell differently, and
+# hand-editing the generated file would fail its own gate on the next run.
+sherif = "sherif"


### PR DESCRIPTION
Three guardrails, all research-first. The tool releases changed the design of
two of them, so the research is recorded alongside the code.

**1. Nothing leaked.** The exact live AWS key id and Google client secret from
`__MISE_DIFF` return 0 commits across the full history of both public repos,
against a control term returning 339 (dotfiles) / 94 (knowledge-base). The one
`AKIA` in dotfiles history is a vendor example in `docs/research/mintlify-cache/`.

**2. No scanner could have caught it — measured, both arms.** Synthetic
credentials, the same content in two forms:

  gitleaks 8.30.1   plaintext: 2 leaks   as a __MISE_DIFF blob: 0
  betterleaks 1.7.1 plaintext: 1 leak    as a __MISE_DIFF blob: 0

The control arm fires on the plaintext, so the zero is a real negative. That is
the whole justification for custom code here (use-tool-builtins.md): both
scanners stay, and `no_env_dump` covers only what neither can do — decode. It
is glob-less on purpose: a dump can land in any tracked file, and the two trees
most likely to receive one (`docs/research/kb/`, `docs/research/runs/`) are
tracked AND allowlisted in `.gitleaks.toml`, so gitleaks is looking away from
exactly the wrong place.

**3. fnox already ships the source fix.** v1.30.0's `env = "exec"` names this
threat verbatim — keep secrets out of the interactive shell "where AI coding
agents and other inherited processes would see them". fnox here is 1.31.1, so
it is one line, not a redesign. Written up in the new rule rather than applied:
it is a user-level file. `child_env.without_env_diff()` is the containment
under it, applied where this repo spawns artifact-writing tools.

The same research explains the `[redacted]` digit-masking that has made every
`mise run` number unreadable: mise redacts a redacted variable's VALUE wherever
it appears, and `GEMINI_TELEMETRY_ENABLED` / `_LOG_PROMPTS` hold one-character
all-digit values. Telemetry flags marked as secrets, not a mise bug.

**`docs/hk-builtins-audit.md` is now GENERATED.** It claimed 41 builtins were
used; 28 are wired. Fifteen names were not wired builtins at all, and a
sixteenth — `betterleaks`, described as a "second scanner alongside gitleaks" —
was wired nowhere. It is wired now (host-only in `mise.toml`: the shared
fragment is a base image build input and a second scanner does not justify a
cold rebuild). The generator's own first draft counted a `Builtins.gitleaks`
mention in a COMMENT as a wiring — the same substring trap — and now requires
an assignment.

**#394 step 4, as the audit recommended it.** Not a word-boundary matcher: it
would have caught none of the three live holes, which were all ambiguous
binding. `token-audit` warns when a `per_path_tokens` entry matches its file
other than once. 25 were ambiguous; 7 were real defects of the `selfcheck`
shape and are fixed here by binding the unique site; the remaining 18 are
allowlisted with a reason, and a stale entry fails too.

Also: `mise lock <TOOL>` locks surgically (+70 lines) where the canonical bare
`mise lock` rewrote 4,814 (net -2,600). Recorded on #370.

Gates: `mise run lint` rc=0 · pytest 987 passed · verify 108 passed, 0 failed ·
`mise run lint-docs` rc=0.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CzPdn3iHw6uhMWEdVPADfW

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787795472&installation_model_id=429246&pr_number=399&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F399&signature=045b48c496f6850fc53976520815ab355331fafa17e6d6a67a26c2c57cab1c63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added safeguards to prevent credentials from being exposed to subprocesses.
  * Added scanning for compressed or encoded environment data that may contain secrets.
  * Added secret-detection checks for common credential formats.

* **Documentation**
  * Added guidance for preventing secret leakage through shell environments.
  * Regenerated the built-in configuration audit with current usage and adoption details.

* **Developer Experience**
  * Added commands to run security, configuration, and contract audits.
  * Added automated validation and tests for the new safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->