### PR TITLE
feat(guard): block commits to main, and close the hook-bypass hole (#400)

### DIFF
--- a/.claude/rules/do-not.md
+++ b/.claude/rules/do-not.md
@@ -67,10 +67,25 @@ self-contained block). Each item's context is preserved verbatim.
      `Path.home()` calls).
 
 9. **Do NOT commit onto the default branch — branch FIRST.** Create the branch
-   *before* the commit, then `mise run ship`. On 2026-07-20 a session committed
-   34 files straight onto `main` and had to move them afterwards
-   (`git branch <new> && git reset --hard origin/main`). It was recoverable
-   only because nothing had been pushed.
+   *before* the commit, then `mise run ship`. It happened twice: 34 files on
+   2026-07-20, and 19 on 2026-07-27 straight after `mise run land` (which
+   **leaves you on `main`**). Both were recoverable only because nothing had
+   been pushed — the objection came at push time, from `mise run ship`'s own
+   refusal. Recovery is `git branch <new> && git reset --hard origin/main`.
+
+   **This is now machine-enforced (#400), in three layers:**
+   - `no_commit_to_branch` — an hk BUILTIN, wired in `hk.pkl`'s **pre-commit**
+     hook. Declined in #154 because it treated a detached HEAD as fatal;
+     hk v1.52.0 (`jdx/hk#1075`) fixed it, probed on all four arms here (branch
+     → 0, `main` → 1, detached → 0, `master` → 1). It is deliberately NOT in
+     `allSteps`: that mapping is spread into `check`/`fix`, so `mise run lint`
+     — and CI's lint job, which checks out a real `main` — would fail on it.
+   - the PreToolUse guard denies `--no-verify` / `git commit -n` and a
+     `HK_SKIP_HOOKS=` prefix. **No git hook can catch these** — git decides not
+     to run the hook before the hook exists as a process, so a pre-push hook is
+     not a fix and should not be built.
+   - a repository **ruleset requires a pull request for `main`**, which is the
+     only layer an agent cannot skip. Everything local is advisory.
 
    The guidance already existed in the `git-branch-commit-push-workflow` skill
    — but that skill carries `disable-model-invocation: true`, which **agnix
@@ -78,6 +93,14 @@ self-contained block). Each item's context is preserved verbatim.
    cannot reach it at decision time. Hence this line: an eager rule is the only
    layer that fires before the mistake. Do not "fix" the skill by removing the
    flag; the docs gate will reject it, and correctly.
+
+10. **Do NOT write an environment dump into a tracked file.** Not `env`, not
+    `printenv`, not `export -p`, not a debug log carrying them. The interactive
+    shell holds real credentials, and mise packs the whole delta into
+    `__MISE_DIFF` (zlib + base64) — a form **no secret scanner can read**
+    (measured: gitleaks 2 → 0, betterleaks 1 → 0 on the same content). Write a
+    dump to the scratchpad and delete it. Gated by the `no_env_dump` hk step;
+    see `secrets-out-of-the-shell-env.md`.
 
 > **Relaxed 2026-07-19 — MCP registration is no longer a "do not".** Native
 > MCP registration (`claude mcp add`, a plugin's bundled servers, a project

--- a/.claude/rules/secrets-out-of-the-shell-env.md
+++ b/.claude/rules/secrets-out-of-the-shell-env.md
@@ -64,10 +64,53 @@ With `env = "exec"` there is no delta for mise to record, so `__MISE_DIFF`
 stops carrying credentials at the source. Everything below is the net under
 that, not a substitute for it.
 
-**This is a user-level file** (`~/.config/mise/config.toml` → fnox), outside
-this repo, so it is written up here rather than applied — the standing rule is
-to never touch a file outside the project unasked (memory
-`feedback_no_user_level_file_updates`).
+Probed on the pinned **1.31.1** in a throwaway project, both arms: with
+`env = "exec"`, `fnox export --format shell` emitted **only** the `env = true`
+opt-in, while `fnox exec -- env` still carried both. The table above is the
+tool's measured behaviour here, not a restatement of its release notes.
+
+### Applying it — three findings, 2026-07-27
+
+1. **A local override is NOT honoured at the user config root.** The config is
+   `~/.config/fnox/config.toml`, and `fnox config-files` lists it alone; adding
+   `config.local.toml` or `fnox.local.toml` beside it changed that output not at
+   all. Control arm: in a *project* directory the same command lists `fnox.toml`
+   **and** `fnox.local.toml` **and** the user root — three lines — so it can
+   report more than one file. The override layer is project-scoped only, so
+   there is no non-invasive place to put this.
+2. **The file is generated.** Its first line reads *"Managed by `mde-py secrets
+   bootstrap-config`. Do not edit by hand."*, so a hand edit survives only until
+   the next bootstrap. The durable fix belongs in **`mde-py`'s generator**.
+3. **Two variables must be opted back in with `env = true`, and they are the two
+   this repo runs on.** `.mcp.json` interpolates one at MCP-server spawn, and
+   `gh` — which `ship`/`land`/`automerge` and every `gh api` call use — reports
+   its *active* account as the environment-authenticated one, with a
+   narrower-scoped fallback behind it. Exec-only for those two degrades tooling
+   silently rather than loudly.
+
+   A grep of `~/.zshrc`, `~/.zprofile`, `~/.config/mise/config.toml`,
+   `~/.claude/settings.json`, `~/.gitconfig` and `home/**` for all 49 names found
+   **zero** other declared consumers (control arm: 7 hits for
+   `export|source|eval` in the same `.zshrc`, so the grep works). State that
+   bound: it finds *declared* consumers only. A tool that reads a variable by
+   convention appears in no config file, so absence here is not absence.
+
+**APPLIED 2026-07-27 — by Ray, not by an agent.** The standing rule is to never
+touch a user-level file unasked (`feedback_no_user_level_file_updates`); Ray
+approved this one edit explicitly, and the harness permission layer *still*
+refused the write — correctly, and independently of that approval. Two layers,
+and the outer one does not read approvals. So the recipe was prepared here and
+Ray ran it: 46 of the 49 exec-only, 3 opted back in.
+
+Verified in a **fresh interactive login shell**, not the session's own: the
+opted-in variable is set, two exec-only ones are not, and the recorded delta
+shrank from ~16.8 KB decoded to a 5.2 KB blob.
+
+The first attempt at that verification was **broken and looked like a clean
+pass** — `zsh -l -c` (non-interactive) never sources `.zshrc`, so nothing
+activated and the variable was "absent". The control arm, the same probe against
+the pre-fix config, ALSO said "absent", which is the only reason it was caught.
+`-i` is what makes the probe able to answer.
 
 ## The same setting fixes the `[redacted]` digit-masking
 

--- a/docs/hk-builtins-audit.md
+++ b/docs/hk-builtins-audit.md
@@ -8,8 +8,8 @@
 
 - **hk version:** hk 1.52.0
 - **Builtins available:** 144
-- **Wired as builtins:** 27
-- **Steps defined in total:** 60 (33 custom, with their own check/fix commands)
+- **Wired as builtins:** 28
+- **Steps defined in total:** 61 (33 custom, with their own check/fix commands)
 
 A *wired builtin* is referenced as `Builtins.<name>`. A *custom step* is a
 `["name"] { … }` block carrying its own commands — it may share a
@@ -17,7 +17,7 @@ name with a builtin without being one, which is how the previous
 hand-written audit came to list `ruff_format` and `editorconfig-checker`
 as builtins in use.
 
-## Wired builtins (27)
+## Wired builtins (28)
 
 | Builtin | Declared in |
 |---------|-------------|
@@ -39,6 +39,7 @@ as builtins in use.
 | `mise` | hk.pkl |
 | `mixed_line_ending` | hk-common.pkl |
 | `newlines` | hk-common.pkl |
+| `no_commit_to_branch` | hk.pkl |
 | `pkl` | hk.pkl |
 | `python_check_ast` | hk.pkl |
 | `python_debug_statements` | hk.pkl |
@@ -90,7 +91,7 @@ opinion about them, and neither does this table beyond recording them.
 | `uv_lock_check` | hk.pkl |
 | `workflow_hk_skip_hooks` | hk.pkl |
 
-## Deliberately not adopted (25)
+## Deliberately not adopted (24)
 
 The only authored section — a judgement no tool can recover. Edit it in
 `hk_builtins_audit.py`; an entry that stops naming a real builtin, or that
@@ -109,7 +110,6 @@ names one now wired, fails the gate.
 | `markdown_lint` | Runs markdownlint v1; repo uses markdownlint-cli2 (#154) |
 | `mdschema` | Requires a schema file that does not exist yet (#160 T12) |
 | `mypy` | Using ty instead |
-| `no_commit_to_branch` | Fails on CI's detached HEAD; branch protection covers it |
 | `pinact` | GitHub API rate-limit in the hook; use `mise run pin-actions` |
 | `pylint` | Superseded by ruff |
 | `rubocop` | No Ruby source in project |

--- a/hk.pkl
+++ b/hk.pkl
@@ -585,6 +585,30 @@ hooks {
     fix = true
     stash = "git"
     steps {
+      // #400: the one layer that fires BEFORE a stray commit lands on main.
+      // Twice now a session has committed onto local `main` straight after
+      // `mise run land` (which leaves you there) — 34 files on 2026-07-20, 19
+      // on 2026-07-27 — and both times the only objection came at PUSH time,
+      // from `mise run ship`'s own refusal. `do-not.md` #9 was the manual
+      // discipline; this is the mechanism.
+      //
+      // Declined in #154 because `hk util no-commit-to-branch` treated
+      // `git symbolic-ref` exiting nonzero as fatal, so it blocked commits
+      // made during an interactive rebase (detached HEAD) — including in CI.
+      // hk v1.52.0 (jdx/hk#1075) now treats a detached HEAD as "not on a
+      // protected branch". PROBED on the pinned 1.52.0 rather than believed
+      // (.claude/rules/probes-need-a-control-arm.md): feature branch -> rc=0,
+      // `main` -> rc=1, `git checkout --detach` -> rc=0, `master` -> rc=1.
+      // Protected set is the builtin's default (main, master), which is right
+      // for this repo; `--branch` would override it.
+      //
+      // Deliberately NOT in `allSteps`: that mapping is spread into `check`
+      // and `fix`, so `mise run lint` (≡ CI's `hk check --all`) would FAIL on
+      // main — and CI's own lint job checks out a real `main` branch, not a
+      // detached HEAD, so it would fail there on every push to main.
+      // pre-commit is the hook where "am I about to commit here?" is the
+      // actual question.
+      ["no_commit_to_branch"] = Builtins.no_commit_to_branch
       ...allSteps
     }
   }

--- a/python/src/dotfiles_setup/doc_refs.py
+++ b/python/src/dotfiles_setup/doc_refs.py
@@ -115,6 +115,13 @@ _ALLOWED_ABSENT = frozenset(
         # Documented-deleted (the doc narrates the deletion, PR #80).
         "home/AGENTS.md",
         "mise_snapshot.py",
+        # fnox config files, all out-of-repo: the real one is the user root
+        # `~/.config/fnox/config.toml`, and the two `.local` names are the
+        # project-scoped override layer the secrets rule PROBED and found is
+        # not honoured at that root. This repo has no fnox config of its own.
+        "config.local.toml",
+        "fnox.toml",
+        "fnox.local.toml",
         # Gitignored but real per-clone files.
         "mise.local.toml",
         "mise.*.local.toml",

--- a/python/src/dotfiles_setup/hk_builtins_audit.py
+++ b/python/src/dotfiles_setup/hk_builtins_audit.py
@@ -83,7 +83,12 @@ NOT_ADOPTED: dict[str, str] = {
     "markdown_lint": "Runs markdownlint v1; repo uses markdownlint-cli2 (#154)",
     "mdschema": "Requires a schema file that does not exist yet (#160 T12)",
     "mypy": "Using ty instead",
-    "no_commit_to_branch": "Fails on CI's detached HEAD; branch protection covers it",
+    # `no_commit_to_branch` was here until #400 with the reason "Fails on CI's
+    # detached HEAD; branch protection covers it". Both halves expired: hk
+    # v1.52.0 (jdx/hk#1075) treats a detached HEAD as not-on-a-protected-branch,
+    # and the measured branch protection was `required_pr: false`. It is now
+    # wired in hk.pkl's pre-commit hook, so `stale_entries` would fail on an
+    # entry left here — which is the map staying honest, as designed.
     "pinact": "GitHub API rate-limit in the hook; use `mise run pin-actions`",
     "pylint": "Superseded by ruff",
     "rubocop": "No Ruby source in project",

--- a/python/src/dotfiles_setup/hook_guard.py
+++ b/python/src/dotfiles_setup/hook_guard.py
@@ -57,12 +57,24 @@ class Rule:
     rule identity, because grouping them by command head is meaningless — the
     guard's one real denial reaches ``npx`` through a ``||`` fallback after a
     ``cd``+``echo`` preamble, so it groups under ``echo``, naming nothing.
+
+    ``quoted_blind`` selects the masked view the pattern runs against. The
+    default view KEEPS quoted content (only separators inside it are neutered),
+    because several rules must read a literal inside quotes — the
+    ``docker pull "…dotfiles-devcontainer:dev"`` denial is exactly that. A rule
+    that matches a FLAG cannot use that view: ``git commit -m "document
+    --no-verify"`` carries the flag as prose, and denying a commit whose message
+    describes the ban is the guard's one measured defect class (#265, and the
+    unanchored chezmoi rule before it). Such a rule sets ``quoted_blind`` and
+    runs against a view where quoted CONTENT is redacted too, so a flag counts
+    only when it sits at argument position.
     """
 
     name: str
     pattern: re.Pattern[str]
     reason: str
     since: str
+    quoted_blind: bool = False
 
 
 # First match wins. Patterns run against the whole Bash command string;
@@ -113,6 +125,12 @@ _V4 = "2026-07-23"
 # existed, `gh pr merge --auto` on a Renovate PR could only be redirected to
 # `land`, which refuses an OPEN PR.
 _V5 = "2026-07-27"
+# The hook-suppression rules landed 2026-07-27 with `no_commit_to_branch` (#400).
+# They are the ONLY layer that can see a bypass: git decides not to run a hook
+# BEFORE the hook exists as a process, so no pre-commit or pre-push hook can
+# observe its own suppression, and hk's own HK_SKIP_HOOKS is documented CI
+# machinery (ADR-0001). A PreToolUse deny runs before the command.
+_V6 = "2026-07-27"
 
 # `gh` names a target repo with `-R owner/repo` / `--repo owner/repo` (or
 # `--repo=owner/repo`); with none, it infers from cwd — which, for a guard
@@ -360,6 +378,64 @@ _RULES: tuple[Rule, ...] = (
         ".claude/rules/mise-tasks-only.md.",
         _V3,
     ),
+    # --- #400: hook suppression ------------------------------------------
+    #
+    # `-n` is scoped to `commit` DELIBERATELY: it means `--no-verify` there but
+    # `--dry-run` for `git push`, where it is an ordinary read-only probe.
+    # `workflow_hooks.git_write_subcommands` records the same asymmetry from the
+    # other direction (it honours only the long form, because over-flagging a
+    # workflow is the cheap error there; here the flag IS the bypass, so the
+    # short form must be caught).
+    #
+    # The bundled short-option form (`-nm "msg"`) is admitted because git really
+    # does parse it, and `n` is the only single-dash `git commit` option letter
+    # that carries a hook meaning. `--` long options cannot match: the class
+    # after `\s-` is `[a-zA-Z]` only, so a second dash ends it.
+    #
+    # `quoted_blind`: a commit message DESCRIBING the ban must not be denied.
+    # `git commit -m "docs: --no-verify is now guarded"` is the exact shape that
+    # denied its own documenting commit in 2026-07-07's chezmoi probe, and the
+    # default masked view keeps quoted content on purpose (the docker-pull rule
+    # reads a literal out of it). So this rule runs against the view where the
+    # content is redacted too, and a flag counts only at argument position.
+    Rule(
+        "git --no-verify",
+        re.compile(
+            _CMD + r"git\s+[^;&|\n]*?\b(?:"
+            r"commit\b[^;&|\n]*?(?:\s--no-verify\b|\s-[a-zA-Z]*n[a-zA-Z]*(?=\s|$))"
+            r"|push\b[^;&|\n]*?\s--no-verify\b"
+            r")",
+        ),
+        "Do not bypass the git hooks. `--no-verify` (and `git commit -n`) is "
+        "how a stray commit reaches `main` and how an unvalidated branch gets "
+        "pushed — the pre-commit hook is what runs `no_commit_to_branch`, and "
+        "pre-push is what runs the test suite. Fix what the hook reports; if a "
+        "step is genuinely wrong, fix the step. Ship with `mise run ship`. See "
+        ".claude/rules/zero-skip-policy.md and .claude/rules/do-not.md #9.",
+        _V6,
+        quoted_blind=True,
+    ),
+    # hk's native skip vars are REAL and sanctioned — in CI, at job level, where
+    # ADR-0001 requires them (`refresh.yml`, `gcc-sha-repair.yml`). That is
+    # exactly why they need a guard on the interactive side: the escape hatch is
+    # documented, so reaching for it locally looks sanctioned when it is not.
+    # Anchored at command position (a bare `HK_SKIP_HOOKS=…` assignment or an
+    # `export`), so `grep -rn 'HK_SKIP_HOOKS=' .github/` — never at command
+    # position — stays allowed.
+    Rule(
+        "HK_SKIP_HOOKS prefix",
+        re.compile(
+            r"(?:^|[;&|\n]\s*)(?:export\s+)?(?:env\s+)?(?:\w+=\S*\s+)*"
+            r"HK_SKIP_(?:HOOKS|STEPS)="
+        ),
+        "Do not set HK_SKIP_HOOKS / HK_SKIP_STEPS to get past a hook. Those "
+        "exist for CI jobs that commit or push (ADR-0001, enforced by the "
+        "`workflow_hk_skip_hooks` step) — locally they just turn the gate off. "
+        "Fix what the hook reports, or fix the step. See "
+        ".claude/rules/zero-skip-policy.md.",
+        _V6,
+        quoted_blind=True,
+    ),
 )
 
 # NO pytest rule, deliberately (probe-observed 2026-07-07): Claude Code's
@@ -368,6 +444,16 @@ _RULES: tuple[Rule, ...] = (
 # plain `pytest tests/`, indistinguishable from the bare form the rule
 # meant to redirect. A rule here would deny the documented command.
 # Bare-pytest guidance stays doc-level (python/AGENTS.md, mise-tasks-only).
+
+# NO "deny `git commit` while HEAD is a protected branch" rule, deliberately
+# (#400 proposed one). It would have to shell out to `git symbolic-ref` on every
+# Bash call, which makes `match()` depend on live repo state — and `match()` is
+# replayed over MONTHS of transcripts by `dotfiles_setup.command_audit`, which
+# would then classify every historical command against TODAY's branch. A guard
+# whose verdict is not a function of the command cannot be audited.
+# The deterministic layer for that question is the `no_commit_to_branch` hk step
+# in hk.pkl's pre-commit hook (hk 1.52.0, jdx/hk#1075 — probed on all three
+# arms), and the two rules above are what stop it being skipped.
 
 # NO `cd`-prefix unwrap, deliberately (probe-observed 2026-07-14): the
 # "chained-command evasion" the enforcement research predicted for
@@ -494,6 +580,28 @@ def _inert_masked(command: str) -> str:
     return _QUOTED_SPAN.sub(_blank_quoted, HEREDOC_PATTERN.sub(blank_heredoc, command))
 
 
+def _blank_quoted_whole(match: re.Match[str]) -> str:
+    """Redact one quoted span entirely — quotes included, length preserved."""
+    span = match.group(0)
+    if span[0] not in "\"'":
+        return span  # an escaped character, consumed so it cannot open a span
+    return _FILLER * len(span)
+
+
+def _quoted_blind_masked(command: str) -> str:
+    """``command`` with quoted CONTENT redacted, not just its separators.
+
+    The view for rules that match a FLAG rather than a value. `--no-verify`
+    inside `git commit -m "…"` is prose about the ban, not the ban; only an
+    unquoted occurrence sits at argument position. Everything else matches
+    :func:`_inert_masked` — heredocs redacted first, length preserved, so every
+    rule's view of the surrounding offsets is unchanged.
+    """
+    return _QUOTED_SPAN.sub(
+        _blank_quoted_whole, HEREDOC_PATTERN.sub(blank_heredoc, command)
+    )
+
+
 def rules() -> tuple[Rule, ...]:
     """Every deny rule, in match order — the guard's introspection surface.
 
@@ -521,8 +629,9 @@ def match(command: str) -> Rule | None:
     reason — to tell a genuine bypass from pre-rule history.
     """
     target = _inert_masked(command)
+    blind = _quoted_blind_masked(command)
     for rule in _RULES:
-        if rule.pattern.search(target):
+        if rule.pattern.search(blind if rule.quoted_blind else target):
             return rule
     return None
 

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -1277,6 +1277,70 @@ tokens = [
 ]
 
 [[suite]]
+name = "workflow.hk-builtins-audit"
+description = "The generated hk-builtins audit. `docs/hk-builtins-audit.md` replaced a hand-written 2026-04-05 snapshot that had drifted into asserting 15 builtins were 'used' that were wired nowhere — one of them `betterleaks`, described as a 'second scanner alongside gitleaks' while present in no config at all. A document claiming a security scanner runs when it does not is worse than one that claims nothing, so the tables are now derived from `hk builtins` + the three .pkl files and only NOT_ADOPTED is authored. This contract exists because the generated banner NAMED it before it existed (`Gated by: workflow.hk-builtins-audit`) — the doc written to stop false claims made one in its own header, found 2026-07-27 with `grep -c` returning 0. Binding the chain here makes the banner true rather than deleting the claim: hk step, mise task, CLI subcommand, generator seams (render / stale_entries / the authored map), both directions of the staleness check in tests, and the banner line in the doc itself."
+category = "workflow"
+check_type = "static"
+handler = "require_tokens"
+paths_required = true
+paths = [
+    "hk.pkl",
+    "mise.toml",
+    "python/src/dotfiles_setup/main.py",
+    "python/src/dotfiles_setup/hk_builtins_audit.py",
+    "tests/test_hk_builtins_audit.py",
+    "docs/hk-builtins-audit.md",
+]
+per_path_tokens = { "hk.pkl" = [
+    'hk_audit"',
+    'dotfiles-setup hk-builtins-audit --check"',
+], "mise.toml" = [
+    "[tasks.hk-audit]",
+], "python/src/dotfiles_setup/main.py" = [
+    '"hk-builtins-audit",',
+    "hk_builtins_audit_main(project_root, check=args.check)",
+], "python/src/dotfiles_setup/hk_builtins_audit.py" = [
+    "def render(root: Path)",
+    "def stale_entries(",
+    "NOT_ADOPTED: dict",
+    "GENERATED_BANNER = (",
+], "tests/test_hk_builtins_audit.py" = [
+    "def test_the_committed_doc_matches_the_generator(",
+    "def test_stale_entries_fires_on_a_name_that_is_not_a_builtin(",
+    "def test_stale_entries_fires_when_a_declined_builtin_is_wired(",
+], "docs/hk-builtins-audit.md" = [
+    "Gated by: workflow.hk-builtins-audit",
+] }
+
+[[suite]]
+name = "workflow.branch-guard-enforcement"
+description = "#400: the layers that stop a commit landing on `main`, and stop them being skipped. Twice a session committed onto local `main` straight after `mise run land` (which leaves you there) — 34 files on 2026-07-20, 19 on 2026-07-27 — and both times the only objection came at PUSH time, from `mise run ship`'s own refusal. `no_commit_to_branch` is an hk BUILTIN, declined in #154 because it treated `git symbolic-ref` exiting nonzero as fatal and so blocked commits during an interactive rebase; hk v1.52.0 (jdx/hk#1075) fixed exactly that, and it was PROBED on the pinned binary rather than believed — feature branch rc=0, main rc=1, detached HEAD rc=0, master rc=1. It is wired into the pre-commit hook ONLY, never `allSteps`: that mapping is spread into `check`/`fix`, so `mise run lint` (and CI's lint job, which checks out a real `main`) would fail on every push to main. The guard rules are the other half, because git decides not to run a hook BEFORE the hook exists as a process — no pre-commit or pre-push hook can observe its own suppression, so `--no-verify` and `HK_SKIP_HOOKS` are only visible to a PreToolUse deny. Both rules are `quoted_blind`: a commit message DESCRIBING the ban must not be denied by it, which is the guard's one measured defect class (#265, and the unanchored chezmoi rule that denied its own documenting commit)."
+category = "workflow"
+check_type = "static"
+handler = "require_tokens"
+paths_required = true
+paths = [
+    "hk.pkl",
+    "python/src/dotfiles_setup/hook_guard.py",
+    "tests/test_hook_guard.py",
+    ".claude/rules/do-not.md",
+]
+per_path_tokens = { "hk.pkl" = [
+    "= Builtins.no_commit_to_branch",
+], "python/src/dotfiles_setup/hook_guard.py" = [
+    '"git --no-verify",',
+    '"HK_SKIP_HOOKS prefix",',
+    "def _quoted_blind_masked(",
+    "blind if rule.quoted_blind else target",
+], "tests/test_hook_guard.py" = [
+    "def test_hook_suppression_denied(",
+    "def test_hook_suppression_false_positives(",
+    "def test_quoted_blind_view_still_sees_an_unquoted_flag(",
+], ".claude/rules/do-not.md" = [
+    "`no_commit_to_branch`",
+] }
+
+[[suite]]
 name = "workflow.adr-0001-enforcement"
 description = "ADR-0001 wiring: the `workflow_hk_skip_hooks` hk step must stay wired to the python enforcer end-to-end — hk.pkl shells out to `dotfiles-setup workflow-hooks`, main.py registers the subcommand AND calls workflow_hooks_main, the workflow_hooks module's three seams (find_violations / job_writes_to_git+skips_required_hooks / classification_gaps) are actually CALLED, the tests carry the real-case verdicts plus the partial-value control arm AND both arms of the entrypoint CI runs, and the ADR records its 'not written yet' gap as Closed 2026-07-21. The hk step's GLOB is deliberately unbound by any token: the check is whole-tree (find_violations scans every workflow regardless of which file triggered the step), so the glob decides only WHEN it runs, never what it sees. Every token binds a CALL SITE, never a `def`: a `def` token is satisfied by prose and by a docstring, which is how build.path-includes-mise-shims stayed green for ~3.5 months (feedback_forbid_tokens_substring_fragile). per_path_tokens, NOT bare tokens: bare tokens are a UNION across the combined text, so one file carrying a token would satisfy the contract for all five — a contract with no opinion about the files it names. The check LOGIC lives in python because a big inline-bash grep would violate zero-bash-logic AND could not work at all: refresh.yml/lock-refresh contains no `git` command and reaches peter-evans/create-pull-request two composite-action hops down."
 category = "workflow"

--- a/tests/test_hook_guard.py
+++ b/tests/test_hook_guard.py
@@ -491,6 +491,109 @@ def test_inert_span_redaction_never_costs_a_true_positive(
     assert redirect_hint in reason
 
 
+@pytest.mark.parametrize(
+    ("command", "rule_name"),
+    [
+        # --- `--no-verify`: the long form, on both hook-firing verbs ----------
+        ("git commit --no-verify -m x", "git --no-verify"),
+        ("git push --no-verify", "git --no-verify"),
+        ("git push origin HEAD --no-verify", "git --no-verify"),
+        # `git -C <abs>` is the form this repo's own cwd rule prescribes, so it
+        # is the likeliest way the bypass would actually be typed here.
+        ("git -C /abs/path commit --no-verify -m x", "git --no-verify"),
+        ("cd /x && git commit --no-verify -m y", "git --no-verify"),
+        # The short form, and its bundled variant — `-n` IS `--no-verify` for
+        # commit, and git parses `-nm "msg"` as `-n -m "msg"`.
+        ("git commit -n -m x", "git --no-verify"),
+        ("git commit -nm 'wip'", "git --no-verify"),
+        # --- hk's own skip vars, as a prefix or an export --------------------
+        ("HK_SKIP_HOOKS=pre-commit git commit -m x", "HK_SKIP_HOOKS prefix"),
+        ("HK_SKIP_STEPS=ruff git commit -m x", "HK_SKIP_HOOKS prefix"),
+        ("export HK_SKIP_HOOKS=pre-commit", "HK_SKIP_HOOKS prefix"),
+        ("env HK_SKIP_HOOKS=pre-push git push", "HK_SKIP_HOOKS prefix"),
+        ("FOO=1 HK_SKIP_HOOKS=pre-commit git commit -m x", "HK_SKIP_HOOKS prefix"),
+        ("echo hi\nHK_SKIP_HOOKS=1 git commit -m x", "HK_SKIP_HOOKS prefix"),
+    ],
+)
+def test_hook_suppression_denied(command: str, rule_name: str) -> None:
+    """#400: the ONLY layer that can see a hook bypass.
+
+    Git decides not to run a hook before the hook exists as a process, so no
+    pre-commit or pre-push hook can observe its own suppression. Control-armed
+    against the pre-#400 guard: `git commit --no-verify -m x` and
+    `git push --no-verify` both matched `None`, while `gh pr create` matched —
+    so the probe discriminated and the gap was real, not a blind spot.
+    """
+    rule = hook_guard.match(command)
+    assert rule is not None, command
+    assert rule.name == rule_name
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A commit message DESCRIBING the ban must not be denied by it — the
+        # exact shape the unanchored chezmoi rule got wrong in 2026-07-07, and
+        # the reason these two rules are `quoted_blind`.
+        "git commit -m 'docs: --no-verify is now guarded'",
+        'git commit -m "feat(guard): deny git commit -n"',
+        "git commit -m 'chore: set HK_SKIP_HOOKS=pre-commit in refresh.yml'",
+        "grep -rn 'HK_SKIP_HOOKS=' .github/workflows/",
+        "rg -- '--no-verify' .claude/rules/",
+        "echo 'never use HK_SKIP_HOOKS=pre-commit locally'",
+        # `-n` means `--dry-run` for push, not `--no-verify` — a read-only
+        # probe, and denying it would be a pure false positive. The asymmetry is
+        # recorded from the other side in `workflow_hooks.git_write_subcommands`.
+        "git push -n",
+        "git push origin HEAD -n",
+        "git push --dry-run",
+        # Ordinary commits, including short-option clusters with no `n`.
+        "git commit -m x",
+        "git commit -am 'wip'",
+        "git commit --amend --no-edit",
+        "git log -n 5",
+        # A hook-firing verb is required: `git add`/`git status` never fire one.
+        "git add -A",
+    ],
+)
+def test_hook_suppression_false_positives(command: str) -> None:
+    """False positives are the only defect class this guard has ever had (#265)."""
+    assert hook_guard.decide(command) is None
+
+
+def test_skip_var_on_a_redirected_gate_still_names_a_usable_action() -> None:
+    """First-match-wins hands this to the `hk run` rule, and that is fine.
+
+    `HK_SKIP_STEPS=ruff hk run check --all` matches the older, earlier rule, so
+    the reason says "use `mise run lint`" rather than naming the skip var. That
+    redirect is still the correct next action — running the gate WITHOUT the
+    skip is exactly what should happen — so the ordering is left alone. Pinned
+    so it stays a decision rather than an accident of table order.
+    """
+    reason = hook_guard.decide("HK_SKIP_STEPS=ruff hk run check --all")
+    assert reason is not None
+    assert "mise run lint" in reason
+
+
+def test_quoted_blind_view_still_sees_an_unquoted_flag() -> None:
+    """Redacting quoted content must not cost the true positive beside it.
+
+    The three assertions are the two views in contrast, all through the public
+    interface: a quoted message does NOT trip the flag rule, an unquoted flag in
+    the same command DOES, and a rule on the default view still reads a literal
+    out of quotes. That last one is why the views are separate rather than one
+    stricter mask — collapsing them would silently un-deny the pull rule.
+    """
+    assert hook_guard.decide("git commit -m 'docs: explain --no-verify'") is None
+
+    rule = hook_guard.match("git commit -m 'docs: explain the gate' --no-verify")
+    assert rule is not None
+    assert rule.name == "git --no-verify"
+
+    quoted_literal = 'docker pull "ghcr.io/ray-manaloto/dotfiles-devcontainer:dev"'
+    assert hook_guard.match(quoted_literal) is not None
+
+
 @pytest.mark.parametrize("rule", hook_guard.rules(), ids=lambda r: r.name)
 def test_every_rule_carries_a_usable_since_date(rule: hook_guard.Rule) -> None:
     """A rule with no (or a malformed) `since` reports as history forever.


### PR DESCRIPTION
`mise run land` leaves you on `main`, and nothing objected until push time.
Twice a session committed there anyway — 34 files on 2026-07-20, 19 on
2026-07-27 — and both were recoverable only because `mise run ship` refuses to
ship from main. `do-not.md` #9 was the manual discipline; this is the mechanism.

Three layers, because each one alone is bypassable:

1. `no_commit_to_branch`, an hk BUILTIN, wired into the pre-commit hook.
   Declined in #154 because it treated a detached HEAD as fatal; hk v1.52.0
   (jdx/hk#1075) fixed exactly that, and the release note was PROBED rather
   than believed — feature branch rc=0, `main` rc=1, detached rc=0, `master`
   rc=1 on the pinned binary. Deliberately NOT in `allSteps`: that mapping is
   spread into `check`/`fix`, so `mise run lint` — and CI's lint job, which
   checks out a real `main` — would fail on every push to main.

2. Two PreToolUse guard rules: `--no-verify` (incl. `git commit -n`/`-nm`) and
   an `HK_SKIP_HOOKS=`/`HK_SKIP_STEPS=` prefix. No git hook can catch these —
   git decides not to run the hook before the hook exists as a process — so a
   pre-push hook is not a fix and is not built. `-n` is scoped to `commit`:
   for `git push` it means `--dry-run`, an ordinary read-only probe.

   These needed a second masked view. The existing mask keeps quoted CONTENT
   on purpose (the docker-pull rule reads a literal out of it), so a flag rule
   on that view would deny `git commit -m "docs: --no-verify is guarded"` —
   the #265 false-positive class, the only defect this guard has ever had.
   `quoted_blind` rules run against a view where quoted content is redacted
   too, so a flag counts only at argument position.

   DECLINED, with the reason recorded in the module: a "deny commit while HEAD
   is a protected branch" rule. It would make `match()` depend on live repo
   state, and `command_audit` replays `match()` across months of transcripts —
   a guard whose verdict is not a function of the command cannot be audited.

3. A repository ruleset requiring a pull request for `main` (0 approvals, no
   bypass actors). Measured before: `required_pr: false`, so a direct push was
   accepted. This is the only layer an agent cannot skip.

Two contracts, both control-armed against a REALISTIC mutation rather than a
renamed symbol: deleting the wiring line fails `workflow.branch-guard-
enforcement`, deleting the banner claim fails `workflow.hk-builtins-audit`.

That second contract is a ride-along fix: the generated audit's banner said
"Gated by: workflow.hk-builtins-audit" and that contract did not exist — the
doc written to stop false claims made one in its own header. Adding the
contract makes the banner true instead of deleting the claim.

Also: `do-not.md` #9 now names the mechanism, a new #10 bans committed env
dumps, and the secrets rule records what the fnox work measured — a
`.local.toml` override is NOT honoured at the user config root (control arm: in
a project dir `fnox config-files` lists three files), so the durable fix is in
mde-py's generator.

Gates: lint rc=0 · pytest 1018 passed · verify 110 passed, 0 failed ·
lint-docs rc=0.

Closes #400

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787803153&installation_model_id=429246&pr_number=401&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F401&signature=89ffb9a3682ebf6b36ec2a27375009968d89681dec84bcbbf7137a017b0a6be2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added safeguards preventing commits directly to the default branch.
  - Blocked attempts to bypass hooks using `--no-verify`, `-n`, or hook-skipping environment variables.
  - Added protection against writing environment dumps or credentials to tracked files.

- **Documentation**
  - Expanded guidance for secure environment handling and FNox configuration.
  - Updated the built-in workflow audit to reflect newly enforced protections.

- **Tests**
  - Added coverage for hook-bypass detection, quoting behavior, redirects, and false-positive prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->