### PR TITLE
docs(guard): record #400's two redirects and the main ruleset where they are looked for

### DIFF
--- a/.claude/rules/mise-tasks-only.md
+++ b/.claude/rules/mise-tasks-only.md
@@ -26,6 +26,8 @@ task (wrapping the python library, zero-bash-logic) in the same change.
 | `gh workflow run` / `gh run rerun` | `mise run gha-dispatch -- <wf>` / `mise run gha-rerun -- <id>` |
 | `npx <tool>` | the mise-pinned binary directly |
 | `chezmoi apply/update` on the Mac host | nothing — devcontainer-only |
+| `git commit --no-verify` / `-n` / `-nm`, `git push --no-verify` | nothing — fix what the hook reports. pre-commit is what runs `no_commit_to_branch`; pre-push runs the suite. Git skips a hook BEFORE it exists as a process, so no hook can catch its own suppression and this guard is the only layer (#400). `git push -n` is `--dry-run` and stays allowed |
+| `HK_SKIP_HOOKS=` / `HK_SKIP_STEPS=` as a local command prefix | nothing — they exist for CI jobs that commit or push (ADR-0001, gated by `workflow_hk_skip_hooks`); locally they only turn the gate off |
 
 Diagnostic/read-only commands (`docker ps`, `gh pr view`, `git status`,
 single-test `pytest path::test` via uv) are NOT wrapped and stay direct.
@@ -36,13 +38,11 @@ i.e. cwd) → `ship`/`land`; knowledge-base → `kb-ship`/`kb-land`; **any other
 repo → ALLOW**. Allowing the rest is deliberate — no canonical task exists for
 a sibling repo, so a deny would redirect to nothing and merely block real work.
 
-This was a real defect, not a hypothetical: the rules used to match `gh pr
-merge` unconditionally, so a knowledge-base PR was denied and pointed at `mise
-run land` — a *dotfiles* task with no repo parameter that watches dotfiles'
-main CI and re-validates the dotfiles devcontainer. The guard blocked the only
-working command and named a task that could not do the job; KB PRs #1 and #2
-were merged by hand as a result. A guard whose redirect target cannot perform
-the redirected action is not enforcement, it is an outage.
+A real defect, not a hypothetical: the rules matched `gh pr merge`
+unconditionally, so a knowledge-base PR was denied and pointed at `mise run
+land` — a *dotfiles* task with no repo parameter, which watches dotfiles' main
+CI. KB PRs #1 and #2 were merged by hand as a result. A guard whose redirect
+target cannot perform the redirected action is not enforcement, it is an outage.
 
 **It recurred along a second axis — PR PROVENANCE (#369, 2026-07-27).** Only
 `ship` arms auto-merge and a bot PR never runs it; `land` refuses an OPEN PR;

--- a/.claude/skills/pr-workflow/SKILL.md
+++ b/.claude/skills/pr-workflow/SKILL.md
@@ -103,9 +103,19 @@ land is the **post-merge validation** step (ship's auto-merge does the merge):
    can't run in CI. `land` is idempotent (safe to re-run); the `--resume`
    flag is accepted for compatibility but has no separate effect.
 
-The **merge approval is enabling auto-merge at ship** (`main` requires only
-`ci-gate`, no review); GitHub merges when green. `--match-head-commit`
+The **merge approval is enabling auto-merge at ship** (`main` requires
+`ci-gate` and no review); GitHub merges when green. `--match-head-commit`
 scopes it to the SHA the local gates validated.
+
+**A PR is now mandatory, server-side** (#400, 2026-07-27): the repository
+ruleset `main: require a pull request` is active with **0 required approvals
+and no bypass actors**, so a direct push to `main` is refused by GitHub — the
+one layer an agent cannot skip. It costs these verbs nothing, because all three
+already go through a PR; verified end-to-end when PR #401 armed auto-merge under
+the active ruleset and squash-merged itself 181s after `ci-gate` went green,
+with `reviewDecision` empty throughout. If a future ruleset change ever demanded
+an approval, `ship` and `automerge` would arm and then sit — that is the
+symptom to look for, and the fix is the ruleset, not the verb.
 
 ## Failure modes
 

--- a/docs/adr/0001-hk-hooks-do-not-run-in-ci.md
+++ b/docs/adr/0001-hk-hooks-do-not-run-in-ci.md
@@ -49,6 +49,12 @@ v0.7.0→v1.51.0: zero hits), so the skip must be explicit.
 ## Consequences
 
 - Any **new** workflow that commits or pushes must set `HK_SKIP_HOOKS` too.
+- **This is a CI-only sanction. Locally, `HK_SKIP_HOOKS=` is guard-denied**
+  (#400): the PreToolUse rule `HK_SKIP_HOOKS prefix` rejects it at a command
+  position, alongside `--no-verify`. Not a contradiction — a runner *cannot*
+  satisfy `ghcr_publish_prereqs` or `test`, while a Mac can and must. The
+  documented escape hatch being real is precisely why it needed a local guard:
+  reaching for it interactively looks sanctioned when it is not.
 - ~~Correctness now depends on remembering.~~ **Closed 2026-07-21 — the guard now exists.** The
   `workflow_hk_skip_hooks` hk step runs `dotfiles-setup workflow-hooks`
   (`python/src/dotfiles_setup/workflow_hooks.py`), which fails when *any* job that commits or


### PR DESCRIPTION
Follow-up to #401. Three docs described a world that stopped being true when
the branch guard landed.

`mise-tasks-only.md` is the authority for what the PreToolUse guard denies, and
its own "Extending" section requires a table row per redirect — the two #400
rules had none. Added, with the asymmetry that matters at the call site:
`git push -n` is `--dry-run` and stays allowed. The file was at 199/200 lines,
so the #349 repo-aware paragraph is compressed by two lines to pay for them;
no fact dropped, only the restatement the closing sentence already makes.

ADR-0001 documents `HK_SKIP_HOOKS` as the sanctioned CI mechanism, and a reader
meeting the new local deny would reasonably read the two as contradicting. They
do not: a runner cannot satisfy `ghcr_publish_prereqs` or `test`, a Mac can and
must. Recorded in Consequences, because the escape hatch being genuinely
documented is exactly why reaching for it interactively looks sanctioned.

The pr-workflow skill said `main` "requires only ci-gate". It now also requires
a pull request, server-side, with no bypass actors. That costs ship/automerge/
land nothing — all three already go through a PR — but the skill is where
someone looks when a verb arms and then sits, so it names the symptom and says
the fix is the ruleset, not the verb.

Gates: mise run lint rc=0 · verify 110 passed, 0 failed · token-audit rc=0 ·
lint-docs rc=0.

Refs #400

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787805304&installation_model_id=429246&pr_number=402&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F402&signature=bd8e684a6f80784da3ae1f6cbba9ad83fd972062e288d5629543504010770dc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->