### PR TITLE
feat(contracts): bring the suites.toml tail under the uniqueness gate — 33 live holes (#397)

### DIFF
--- a/docs/specs/eval-harness-design.md
+++ b/docs/specs/eval-harness-design.md
@@ -943,7 +943,80 @@ skipped one element, because an anchor may itself end in `]`
 the manifest and compares the token lists against the plan — the same shape as
 the arms above: a tool that only ever reports success has not been tested.
 
-## GitHub repos touched
+### 2026-07-28 revision (#397: the tail swept — 33 of 33 rebindings were LIVE)
+
+The other ~87 suites, in the order Ray locked: **bare-union first, anchoring
+second.** The re-derivation on `47048ca` matched #397's counts exactly (87 tail
+suites; `build` 43 / `ci` 25 / `arch` 9 / `identity` 6 / `policy` 4) — and
+refuted the issue's premise about *why* the union mattered here.
+
+**The union is structurally absent from the tail.** `_resolve_paths` does no
+globbing, so a bare `tokens` list over ONE path is identical in effect to
+`per_path_tokens` for that path — and **51 of the tail's 54 `require_tokens`
+suites name exactly one path**. The three that name more already carried
+`per_path_tokens` for exactly those tokens; their bare lists were vestigial
+duplicates. Control arm, and the reason the claim is reportable at all: the
+same probe over the **seams** returns **19**, which is where
+`permissionDecision` actually lived.
+
+**The conversion was still the right first move, for a better reason.**
+`token_audit.find_ambiguous` reads only `per_path_tokens`, so every bare token
+was exempt from the uniqueness gate — #394's own step-4 recommendation could
+not see the half of the manifest it was most needed on. Converting brought
+**105 tokens** under it.
+
+| | |
+|---|---|
+| tail bare `require_tokens` tokens | 105 |
+| ambiguities the gate then reported | 39 |
+| **rebound because the hole was LIVE** | **33** |
+| allowlisted (multiplicity IS the assertion) | 8, incl. 2 that survived a rebind |
+
+Each rebinding was armed against the **real engine** on a temp tree: the old
+token PASSES with the wiring line deleted (so the hole was live), the rebound
+token FAILS *with the reason naming it*, and it PASSES on the clean tree. The
+harness's own control arm ran arm A over the **103** already-unique tail tokens
+— all 103 correctly reported *not a hole*, so the 33/33 is a measurement and
+not a stuck needle.
+
+**The stand-in has a different shape here than in the seams.** #394's three
+were sibling *code*: a dispatch branch, another parser's flag, a test
+assertion. The tail's are overwhelmingly **a comment or a prose sentence in the
+same file naming the thing it wires**. `.devcontainer/devcontainer.json` opens
+with a header block narrating every mount and lifecycle command;
+`build-publish.yml` documents its own jobs; the Dockerfile explains each `ARG`
+above it. Delete the wiring and the narration remains — `authorized_keys`,
+`doppler secrets download`, `dotfiles-setup p2996-hash`, `REFRESH_APP_ID`,
+`actions/create-github-app-token` were every one of them satisfied by their own
+documentation. A well-commented file is *more* exposed to this than a terse
+one, which is the opposite of the intuition.
+
+Two were the plain prefix-swallow instead: `type=gha,scope=dotfiles-dev` was
+satisfied by the `,mode=max` line below it (now two anchored tokens, so the
+cache-from and cache-to are asserted separately), and `sha256sum -c -` in the
+Dockerfile was satisfied by **graphviz's** checksum while the contract meant
+gcc-latest's.
+
+**The gate now has a second rule, because the first one had a blind spot by
+construction.** `find_unaudited` refuses a `require_tokens` suite that names
+one path and binds through a bare `tokens` list: that form is convertible with
+zero semantic change, so writing it only ever means exempting the suite from
+the uniqueness audit. A bare list over *several* paths still says "any of
+these" and is left alone. Both directions are pinned in
+`tests/test_token_audit.py`, and armed against the live manifest before
+shipping (reintroduce the bare form on a real suite → reported; the
+`per_path_tokens` form → silent).
+
+**Anchoring — deliberately NOT in this change, and the evidence is against it
+being urgent.** 64 tail tokens still end at an open identifier. But the arm
+that would justify anchoring cannot discriminate: appending to an identifier
+*preserves* the substring by construction, so "does the rename survive?" is
+answered "yes" for every open-tailed token and is exactly equivalent to the
+static property. It is authoring judgment, not a probe. Meanwhile the arm that
+*can* discriminate found 33 live holes, none of which anchoring would have
+reached — the same verdict #394 reached from three cases, now from 33.
+
+### GitHub repos touched
 
 - [wshobson/agents](https://github.com/wshobson/agents) — `plugins/plugin-eval` + `docs/plugin-eval.md`; the three-layer taxonomy and the triggering-F1 method.
 - [microsoft/SkillOpt](https://github.com/microsoft/SkillOpt) — README (KB source #5); the held-out validation-gate discipline.

--- a/python/src/dotfiles_setup/token_audit.py
+++ b/python/src/dotfiles_setup/token_audit.py
@@ -26,6 +26,33 @@ NEW ambiguity fails.
 
 Same shape as :mod:`dotfiles_setup.bash_budget`: an explicit map with
 justifications, where a stale entry fails too, so the map cannot rot.
+
+## The blind spot this gate had, and the second rule (#397, 2026-07-28)
+
+:func:`find_ambiguous` reads **only** ``per_path_tokens``. A bare ``tokens``
+list was therefore invisible to it — and the ``build.*`` / ``ci.*`` / ``arch.*``
+tail was 105 bare tokens, none of them audited. Converting them cost nothing
+semantically: ``_resolve_paths`` does no globbing, so a bare list over ONE path
+is identical in effect to ``per_path_tokens`` for that path, and 51 of the
+tail's 54 ``require_tokens`` suites named exactly one path.
+
+The gate then had plenty to say. **33 of the 39 ambiguities it surfaced were
+LIVE holes** — delete the real wiring line, leave the other match standing, and
+the contract stays green. Proven both directions against the real engine on a
+temp tree (old token + mutated tree PASSES; the rebound token FAILS naming
+itself), with a control arm over the 103 already-unique tail tokens, every one
+of which correctly reported *not* a hole.
+
+The dominant stand-in was not a sibling registration, as #394's three were — it
+was **a comment or a prose sentence in the same file naming the thing**. A
+Dockerfile that explains its own ``ARG`` above it, a workflow that documents its
+own job, a devcontainer.json whose header block narrates every mount. Deleting
+the wiring left the narration, and the narration satisfied the token.
+
+Hence :func:`find_unaudited`: a ``require_tokens`` suite naming exactly one path
+must bind through ``per_path_tokens``, never a bare ``tokens`` list. That form
+is convertible with zero semantic change, so there is no reason to write it —
+and writing it silently exempts the suite from the rule above.
 """
 
 from __future__ import annotations
@@ -47,6 +74,12 @@ MANIFEST = "python/verification/suites.toml"
 # Measured 2026-07-27: 25 entries were ambiguous; 7 were real defects of the
 # `selfcheck` shape and were fixed by binding the unique site instead. These 18
 # are the genuine remainder.
+#
+# #397 (2026-07-28) brought the `build.*`/`ci.*`/`arch.*` tail under this gate
+# by converting its single-path bare `tokens` to `per_path_tokens`. That
+# surfaced 39 more ambiguities: 31 were the `selfcheck` shape — overwhelmingly
+# a PROSE OR COMMENT MENTION standing in for the wiring line — and were
+# rebound; the 8 below are genuine.
 AMBIGUITY_ALLOWED: dict[tuple[str, str, str], str] = {
     (
         "build.locked-install-with-conda-sha",
@@ -138,6 +171,54 @@ AMBIGUITY_ALLOWED: dict[tuple[str, str, str], str] = {
         ".github/workflows/refresh.yml",
         "Tool currency report (daily)",
     ): "the job step name and the issue title it upserts",
+    # ---- #397: the build.* / ci.* / arch.* tail ----------------------------
+    (
+        "build.amd64-platform-wired-mise",
+        "mise.toml",
+        'DOCKER_DEFAULT_PLATFORM = "linux/amd64/v2"',
+    ): "one per lifecycle task (up / dev-rebuild / verify-image) — PR #86's "
+    "split-brain WAS one task missing it, so multiplicity IS the assertion",
+    (
+        "build.clang-p2996-ref-in-bake",
+        "docker-bake.hcl",
+        "CLANG_P2996_REF = CLANG_P2996_REF",
+    ): "one per target whose cache the ref must invalidate (dev, p2996-cache)",
+    (
+        "ci.sbom-attestation",
+        "docker-bake.hcl",
+        "type=sbom",
+    ): "one per published target (dev / base / p2996-cache); all three attest "
+    "identically by design (#160 T7)",
+    (
+        "ci.provenance-attestation",
+        "docker-bake.hcl",
+        "type=provenance,mode=max",
+    ): "one per published target (dev / base / p2996-cache) — #160 T7",
+    (
+        "ci.p2996-ref-dispatch-wired",
+        ".github/workflows/build-publish.yml",
+        "inputs.p2996_ref != ''",
+    ): "the 'Resolve p2996 ref override' step repeats in p2996-prep / dev-prep "
+    "/ build so all three track the SAME upstream SHA — multiplicity IS the "
+    "assertion",
+    (
+        "ci.p2996-ref-dispatch-wired",
+        ".github/workflows/build-publish.yml",
+        "CLANG_P2996_REF=${P2996_REF}",
+    ): "the same three resolve steps as the sibling token above",
+    (
+        "ci.p2996-prep-job-exists",
+        ".github/workflows/build-publish.yml",
+        "docker manifest inspect",
+    ): "the registry cache-probe idiom is textually IDENTICAL in base-prep / "
+    "p2996-prep / dev-prep, so no substring can discriminate them; the job "
+    "identity is carried by the sibling `p2996-prep:` token",
+    (
+        "ci.dev-prep-gate-exists",
+        ".github/workflows/build-publish.yml",
+        "hash=$(uv run --project python dotfiles-setup dev-hash)",
+    ): "twice by design — dev-prep computes the probe hash, dev-tag recomputes "
+    "it to stamp the validated marker; both clauses are the contract",
 }
 
 
@@ -175,12 +256,32 @@ def find_ambiguous(root: Path) -> list[Ambiguity]:
     return found
 
 
+def find_unaudited(root: Path) -> list[str]:
+    """Single-path ``require_tokens`` suites that bind through a bare list.
+
+    Such a token is invisible to :func:`find_ambiguous`, and the bare form buys
+    nothing: with one path, the union IS that path. A suite naming SEVERAL
+    paths is a different question (#299's union) and is left alone.
+    """
+    return [
+        f"{suite['name']} binds {len(suite['tokens'])} token(s) through a bare "
+        f"`tokens` list over the single path {suite['paths'][0]!r} — that form "
+        f"is invisible to the uniqueness audit and means exactly the same "
+        f"thing as `per_path_tokens`. Move them (#397)."
+        for suite in verify.load_manifest(root / MANIFEST)
+        if suite.get("handler") == "require_tokens"
+        and suite.get("tokens")
+        and len(suite.get("paths", [])) == 1
+    ]
+
+
 def find_violations(root: Path) -> list[str]:
-    """New ambiguity, plus allowlist entries that have stopped being true."""
+    """New ambiguity, unaudited bare tokens, and allowlist entries gone stale."""
     ambiguous = find_ambiguous(root)
     seen = {a.key for a in ambiguous}
 
-    problems = [
+    problems = find_unaudited(root)
+    problems += [
         f"{a.render()} — not in AMBIGUITY_ALLOWED. Bind the ONE site that means "
         f"it (see #394), or add an entry with a reason."
         for a in ambiguous

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -20,9 +20,24 @@ version = "2"
 #     registration was deleted, and `--output` by a sibling parser's own flag.
 #     Anchoring does NOT reach this one — bind the unique site.  (#394)
 #
+#     This is the question that finds real holes.  #397 swept the tail and
+#     **33 of 33** rebindings closed a LIVE one, and the stand-in was usually
+#     not a sibling registration — it was **a COMMENT or a prose sentence in
+#     the same file naming the thing**.  A Dockerfile explains its own `ARG`
+#     above it; a workflow documents its own job; devcontainer.json narrates
+#     every mount in a header block.  Delete the wiring, the narration stays,
+#     and the contract never notices.  `dotfiles-setup token-audit` is the
+#     machine form of this question — run it after adding a token.
+#
 # And bare `tokens` is a UNION across every listed path: `permissionDecision`
 # was satisfied by the TEST FILE asserting the string, with the guard's emit
 # deleted.  Use `per_path_tokens` when it matters which file carries it.
+#
+# With ONE path there is nothing to choose between, so a bare list means
+# exactly what `per_path_tokens` means — except that the uniqueness audit
+# cannot see it.  `find_unaudited` therefore REFUSES the single-path bare
+# form.  A bare list over several paths is still the way to say "any of
+# these", and is left alone.  (#397)
 #
 # Tails that cannot be prefix-renamed (`true`, `lambda`, `str`, a date, a
 # `.sh`/`.md` extension, a vendor's product name) need no anchor.
@@ -38,7 +53,7 @@ category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/Dockerfile"]
-tokens = ["MISE_DATA_DIR=/usr/local/share/mise"]
+per_path_tokens = { ".devcontainer/Dockerfile" = ["MISE_DATA_DIR=/usr/local/share/mise"] }
 
 [[suite]]
 name = "build.mise-install-path-system"
@@ -47,7 +62,7 @@ category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/Dockerfile"]
-tokens = ["MISE_INSTALL_PATH=/usr/local/bin/mise"]
+per_path_tokens = { ".devcontainer/Dockerfile" = ["MISE_INSTALL_PATH=/usr/local/bin/mise"] }
 
 [[suite]]
 name = "build.no-custom-mise-cache-dir"
@@ -129,9 +144,9 @@ category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/devcontainer.json"]
-tokens = [
-    "--platform=linux/amd64/v2",
-]
+per_path_tokens = { ".devcontainer/devcontainer.json" = [
+    "\"options\": [\"--platform=linux/amd64/v2\"]",
+] }
 
 [[suite]]
 name = "build.amd64-platform-wired-mise"
@@ -140,9 +155,9 @@ category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = ["mise.toml"]
-tokens = [
+per_path_tokens = { "mise.toml" = [
     "DOCKER_DEFAULT_PLATFORM = \"linux/amd64/v2\"",
-]
+] }
 
 [[suite]]
 name = "build.ssh-r1-inbound-wired"
@@ -151,11 +166,11 @@ category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/devcontainer.json"]
-tokens = [
-    "ghcr.io/devcontainers/features/sshd",
+per_path_tokens = { ".devcontainer/devcontainer.json" = [
+    "\"ghcr.io/devcontainers/features/sshd:1\": {}",
     "${localEnv:DEVCONTAINER_SSH_PORT}:2222",
-    "authorized_keys",
-]
+    "install -m 600 /tmp/dotfiles-host-state/authorized_keys ~/.ssh/authorized_keys",
+] }
 
 [[suite]]
 name = "build.ssh-r2-outbound-native-docker-desktop-wired"
@@ -164,12 +179,12 @@ category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/devcontainer.json"]
-tokens = [
+per_path_tokens = { ".devcontainer/devcontainer.json" = [
     "source=/run/host-services/ssh-auth.sock",
     "target=/run/host-services/ssh-auth.sock",
     "\"SSH_AUTH_SOCK\": \"/run/host-services/ssh-auth.sock\"",
-    "dotfiles-setup docker initialize-host",
-]
+    "dotfiles-setup docker initialize-host\"",
+] }
 
 [[suite]]
 name = "build.uv-link-mode-not-global"
@@ -187,7 +202,7 @@ category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/Dockerfile"]
-tokens = ["ARG BASE_IMAGE"]
+per_path_tokens = { ".devcontainer/Dockerfile" = ["ARG BASE_IMAGE"] }
 
 
 [[suite]]
@@ -197,7 +212,7 @@ category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/mise-system.toml"]
-tokens = ["\"apt:gnupg\""]
+per_path_tokens = { ".devcontainer/mise-system.toml" = ["\"apt:gnupg\""] }
 
 [[suite]]
 name = "build.apt-via-mise-bootstrap"
@@ -206,11 +221,11 @@ category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/Dockerfile"]
-tokens = [
+per_path_tokens = { ".devcontainer/Dockerfile" = [
   "mise bootstrap packages apply --manager apt --yes --update",
   "mise bootstrap packages status --json --missing",
   "/etc/apt/apt.conf.d/99no-install-recommends",
-]
+] }
 
 [[suite]]
 name = "build.npm-no-update-notifier"
@@ -219,7 +234,7 @@ category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/mise-system.toml"]
-tokens = ['npm_config_update_notifier = "false"']
+per_path_tokens = { ".devcontainer/mise-system.toml" = ['npm_config_update_notifier = "false"'] }
 
 [[suite]]
 name = "build.path-includes-mise-shims"
@@ -229,7 +244,6 @@ check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/Dockerfile.host-user", ".devcontainer/devcontainer.json", "home/.chezmoi.toml.tmpl"]
 per_path_tokens = { ".devcontainer/Dockerfile.host-user" = [".local/share/mise/shims"] }
-tokens = [".local/share/mise/shims"]
 
 [[suite]]
 name = "build.no-custom-cargo-home"
@@ -296,7 +310,7 @@ category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/Dockerfile"]
-tokens = ["sed -i '/^path-exclude=\\/usr\\/share\\/man\\/\\*$/d' /etc/dpkg/dpkg.cfg.d/excludes"]
+per_path_tokens = { ".devcontainer/Dockerfile" = ["sed -i '/^path-exclude=\\/usr\\/share\\/man\\/\\*$/d' /etc/dpkg/dpkg.cfg.d/excludes"] }
 
 [[suite]]
 name = "build.rustup-skip-path-check"
@@ -305,7 +319,7 @@ category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/mise-system.toml"]
-tokens = ['RUSTUP_INIT_SKIP_PATH_CHECK = "yes"']
+per_path_tokens = { ".devcontainer/mise-system.toml" = ['RUSTUP_INIT_SKIP_PATH_CHECK = "yes"'] }
 
 [[suite]]
 name = "build.gcc-latest-deb-checksum"
@@ -314,10 +328,10 @@ category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/Dockerfile"]
-tokens = [
-  "ARG GCC_LATEST_DEB_SHA256=",
-  "sha256sum -c -",
-]
+per_path_tokens = { ".devcontainer/Dockerfile" = [
+    "ARG GCC_LATEST_DEB_SHA256=",
+    "\"${GCC_LATEST_DEB_SHA256}  ${GCC_LATEST_DEB}\" | sha256sum -c -",
+] }
 
 [[suite]]
 name = "build.gcc-latest-reflection"
@@ -326,7 +340,11 @@ category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/Dockerfile"]
-tokens = ["gcc-latest.deb", "/opt/gcc-latest/bin/g++", "-freflection"]
+per_path_tokens = { ".devcontainer/Dockerfile" = [
+    "gcc-latest.deb",
+    "test -x /opt/gcc-latest/bin/g++",
+    "-freflection \\\n      /tmp/refl-gcc.cpp",
+] }
 
 [[suite]]
 name = "build.clang-p2996-reflection"
@@ -335,7 +353,11 @@ category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/Dockerfile"]
-tokens = ["clang-p2996", "CLANG_P2996_REF", "COPY --from=clang-builder"]
+per_path_tokens = { ".devcontainer/Dockerfile" = [
+    "-DCMAKE_INSTALL_PREFIX=/opt/clang-p2996",
+    "ARG CLANG_P2996_REF=",
+    "COPY --from=clang-builder",
+] }
 
 [[suite]]
 name = "build.clang-p2996-ref-in-bake"
@@ -344,7 +366,10 @@ category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = ["docker-bake.hcl"]
-tokens = ["CLANG_P2996_REF"]
+per_path_tokens = { "docker-bake.hcl" = [
+    "variable \"CLANG_P2996_REF\" {",
+    "CLANG_P2996_REF = CLANG_P2996_REF",
+] }
 
 [[suite]]
 name = "build.p2996-cache-target"
@@ -353,11 +378,12 @@ category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = ["docker-bake.hcl"]
-tokens = [
-  "target \"p2996-cache\"",
-  "p2996-export",
-  "BUILDER_IMAGE",
-]
+per_path_tokens = { "docker-bake.hcl" = [
+    "target \"p2996-cache\"",
+    "target   = \"p2996-export\"",
+    "variable \"BUILDER_IMAGE\" {",
+    "args = {\n    BUILDER_IMAGE",
+] }
 
 [[suite]]
 name = "build.base-cache-target"
@@ -366,10 +392,10 @@ category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = ["docker-bake.hcl"]
-tokens = [
-  "target \"base\"",
-  "devcontainer-base",
-]
+per_path_tokens = { "docker-bake.hcl" = [
+    "target \"base\"",
+    "target   = \"devcontainer-base\"",
+] }
 
 [[suite]]
 name = "build.no-retired-indirection-args"
@@ -401,12 +427,12 @@ category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/Dockerfile"]
-tokens = [
+per_path_tokens = { ".devcontainer/Dockerfile" = [
   "BASE_HASH_BEGIN",
   "BASE_HASH_END",
   "P2996_HASH_BEGIN",
   "P2996_HASH_END",
-]
+] }
 
 [[suite]]
 name = "build.p2996-cache-dockerfile-stages"
@@ -415,11 +441,11 @@ category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/Dockerfile"]
-tokens = [
+per_path_tokens = { ".devcontainer/Dockerfile" = [
   "FROM ${BUILDER_IMAGE} AS clang-builder-cold",
   "AS p2996-export",
   "COPY --from=p2996-export /opt/clang-p2996",
-]
+] }
 
 [[suite]]
 name = "build.locked-install-with-conda-sha"
@@ -436,10 +462,6 @@ per_path_tokens = { ".devcontainer/Dockerfile" = [
 ], ".devcontainer/mise-system.lock" = [
   "[conda-packages.linux-x64",
 ] }
-tokens = [
-  "mise install --system --locked",
-  "[conda-packages.linux-x64",
-]
 
 [[suite]]
 name = "build.base-image-digest-pinned"
@@ -458,12 +480,12 @@ category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/Dockerfile"]
-tokens = [
+per_path_tokens = { ".devcontainer/Dockerfile" = [
   "FROM devcontainer AS devcontainer-runtime",
   "ENV MISE_ENV=runtime",
   "/usr/local/share/mise/config.runtime.toml",
   "/usr/local/share/mise/mise.runtime.lock",
-]
+] }
 
 [[suite]]
 name = "build.dev-target-publishes-runtime-stage"
@@ -472,7 +494,7 @@ category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = ["docker-bake.hcl"]
-tokens = ["target   = \"devcontainer-runtime\""]
+per_path_tokens = { "docker-bake.hcl" = ["target   = \"devcontainer-runtime\""] }
 
 [[suite]]
 name = "build.doppler-secrets-wired"
@@ -481,11 +503,11 @@ category = "build"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/devcontainer.json"]
-tokens = [
-    "--env-file",
-    "doppler.env",
-    "doppler secrets download",
-]
+per_path_tokens = { ".devcontainer/devcontainer.json" = [
+    "\"--env-file\",",
+    "dotfiles/doppler.env\",",
+    "&& doppler secrets download --format docker",
+] }
 
 # =============================================================================
 # CI Constraints (~6) — Workflow correctness
@@ -498,7 +520,7 @@ category = "ci"
 check_type = "static"
 handler = "require_tokens"
 paths = ["docker-bake.hcl"]
-tokens = ["type=sbom"]
+per_path_tokens = { "docker-bake.hcl" = ["type=sbom"] }
 
 [[suite]]
 name = "ci.provenance-attestation"
@@ -507,7 +529,7 @@ category = "ci"
 check_type = "static"
 handler = "require_tokens"
 paths = ["docker-bake.hcl"]
-tokens = ["type=provenance,mode=max"]
+per_path_tokens = { "docker-bake.hcl" = ["type=provenance,mode=max"] }
 
 [[suite]]
 name = "ci.bootstrap-gap-report-wired"
@@ -516,11 +538,11 @@ category = "ci"
 check_type = "static"
 handler = "require_tokens"
 paths = [".github/workflows/build-publish.yml"]
-tokens = [
-  "mise bootstrap packages status --json",
-  "dotfiles-setup bootstrap-gap-report",
-  "bootstrap-gap-report.json",
-]
+per_path_tokens = { ".github/workflows/build-publish.yml" = [
+    "mise bootstrap packages status --json",
+    "dotfiles-setup bootstrap-gap-report",
+    "path: /tmp/bootstrap-gap-report.json",
+] }
 
 [[suite]]
 name = "ci.no-mise-data-in-cache-map"
@@ -538,7 +560,10 @@ category = "ci"
 check_type = "static"
 handler = "require_tokens"
 paths = ["docker-bake.hcl"]
-tokens = ["type=gha,scope=dotfiles-dev"]
+per_path_tokens = { "docker-bake.hcl" = [
+    "\"type=gha,scope=dotfiles-dev\",",
+    "\"type=gha,scope=dotfiles-dev,mode=max\",",
+] }
 
 [[suite]]
 name = "ci.no-actions-cache-workaround"
@@ -565,7 +590,7 @@ category = "ci"
 check_type = "static"
 handler = "require_tokens"
 paths = [".github/workflows/ci.yml"]
-tokens = ["ray-manaloto/dotfiles-devcontainer"]
+per_path_tokens = { ".github/workflows/ci.yml" = ["ray-manaloto/dotfiles-devcontainer"] }
 
 [[suite]]
 name = "ci.explicit-packages-write"
@@ -574,7 +599,9 @@ category = "ci"
 check_type = "static"
 handler = "require_tokens"
 paths = [".github/workflows/ci.yml"]
-tokens = ["packages: write"]
+per_path_tokens = { ".github/workflows/ci.yml" = [
+    "\npermissions:\n  contents: read\n  packages: write\n",
+] }
 
 [[suite]]
 name = "ci.push-to-main-skips-build"
@@ -583,7 +610,7 @@ category = "ci"
 check_type = "static"
 handler = "require_tokens"
 paths = [".github/workflows/ci.yml"]
-tokens = ["(github.event_name != 'push' || github.ref != 'refs/heads/main')"]
+per_path_tokens = { ".github/workflows/ci.yml" = ["(github.event_name != 'push' || github.ref != 'refs/heads/main')"] }
 
 [[suite]]
 name = "ci.ci-gate-aggregator-exists"
@@ -592,12 +619,11 @@ category = "ci"
 check_type = "static"
 handler = "require_tokens"
 paths = [".github/workflows/ci.yml"]
-tokens = [
-  "ci-gate:",
-  "needs.build-publish.result",
-  "if: always()",
-  "success|skipped",
-]
+per_path_tokens = { ".github/workflows/ci.yml" = [
+    "  ci-gate:\n    needs: [lint, contract-preflight, changes, build-publish]\n    if: always()\n",
+    "needs.build-publish.result",
+    "success|skipped",
+] }
 
 [[suite]]
 name = "ci.promote-job-exists"
@@ -606,12 +632,12 @@ category = "ci"
 check_type = "static"
 handler = "require_tokens"
 paths = [".github/workflows/ci.yml"]
-tokens = [
-  "promote:",
-  "docker buildx imagetools create",
-  "associatedPullRequests",
-  "force_dev_tag",
-]
+per_path_tokens = { ".github/workflows/ci.yml" = [
+    "promote:",
+    "docker buildx imagetools create",
+    "associatedPullRequests(first:1) { nodes { number } }",
+    "-f force_dev_tag=true",
+] }
 
 [[suite]]
 name = "ci.p2996-prep-job-exists"
@@ -620,14 +646,14 @@ category = "ci"
 check_type = "static"
 handler = "require_tokens"
 paths = [".github/workflows/build-publish.yml"]
-tokens = [
-  "p2996-prep:",
-  "dotfiles-setup p2996-hash",
-  "docker manifest inspect",
-  "p2996-cache",
-  "dev.contexts.p2996-export=docker-image://",
-  "dev.contexts.devcontainer-base=docker-image://",
-]
+per_path_tokens = { ".github/workflows/build-publish.yml" = [
+    "\n  p2996-prep:\n",
+    "hash=$(uv run --project python dotfiles-setup p2996-hash)",
+    "docker manifest inspect",
+    "targets: p2996-cache",
+    "dev.contexts.p2996-export=docker-image://",
+    "dev.contexts.devcontainer-base=docker-image://",
+] }
 
 [[suite]]
 name = "ci.dev-prep-gate-exists"
@@ -636,12 +662,12 @@ category = "ci"
 check_type = "static"
 handler = "require_tokens"
 paths = [".github/workflows/build-publish.yml"]
-tokens = [
-  "dev-prep:",
-  "dotfiles-setup dev-hash",
-  "dev-tag:",
-  "needs.smoke-test.result == 'success'",
-]
+per_path_tokens = { ".github/workflows/build-publish.yml" = [
+    "dev-prep:",
+    "hash=$(uv run --project python dotfiles-setup dev-hash)",
+    "dev-tag:",
+    "needs.smoke-test.result == 'success'",
+] }
 
 [[suite]]
 name = "ci.p2996-ref-dispatch-wired"
@@ -652,10 +678,10 @@ handler = "require_tokens"
 paths = [
   ".github/workflows/build-publish.yml",
 ]
-tokens = [
+per_path_tokens = { ".github/workflows/build-publish.yml" = [
   "inputs.p2996_ref != ''",
   "CLANG_P2996_REF=${P2996_REF}",
-]
+] }
 
 [[suite]]
 name = "ci.refresh-uses-app-token"
@@ -664,12 +690,12 @@ category = "ci"
 check_type = "static"
 handler = "require_tokens"
 paths = [".github/workflows/refresh.yml"]
-tokens = [
-  "actions/create-github-app-token",
-  "REFRESH_APP_ID",
-  "REFRESH_APP_PRIVATE_KEY",
-  "auto-merge:",
-]
+per_path_tokens = { ".github/workflows/refresh.yml" = [
+    "uses: actions/create-github-app-token@",
+    "app-id: ${{ secrets.REFRESH_APP_ID }}",
+    "REFRESH_APP_PRIVATE_KEY",
+    "auto-merge:",
+] }
 
 [[suite]]
 name = "ci.lock-refresh-wired"
@@ -678,12 +704,12 @@ category = "ci"
 check_type = "static"
 handler = "require_tokens"
 paths = [".github/workflows/refresh.yml"]
-tokens = [
-  "lock-refresh:",
-  "uses: ./.github/actions/lock-refresh",
-  ".devcontainer/mise-system.lock",
-  ".devcontainer/devcontainer-lock.json",
-]
+per_path_tokens = { ".github/workflows/refresh.yml" = [
+    "lock-refresh:",
+    "uses: ./.github/actions/lock-refresh",
+    "\n            .devcontainer/mise-system.lock\n",
+    "\n            .devcontainer/devcontainer-lock.json\n",
+] }
 
 [[suite]]
 name = "ci.lint-locked-installs"
@@ -692,7 +718,7 @@ category = "ci"
 check_type = "static"
 handler = "require_tokens"
 paths = [".github/workflows/ci.yml"]
-tokens = ["MISE_LOCKED: \"1\""]
+per_path_tokens = { ".github/workflows/ci.yml" = ["MISE_LOCKED: \"1\""] }
 
 [[suite]]
 name = "ci.refresh-no-dispatch-hack"
@@ -710,7 +736,7 @@ category = "ci"
 check_type = "static"
 handler = "require_tokens"
 paths = ["renovate.json"]
-tokens = ["custom.regex"]
+per_path_tokens = { "renovate.json" = ["custom.regex"] }
 
 [[suite]]
 name = "ci.renovate-extends-jdx-preset"
@@ -719,7 +745,7 @@ category = "ci"
 check_type = "static"
 handler = "require_tokens"
 paths = ["renovate.json"]
-tokens = ["github>jdx/renovate-config"]
+per_path_tokens = { "renovate.json" = ["github>jdx/renovate-config"] }
 
 [[suite]]
 name = "ci.dive-config-present"
@@ -728,7 +754,7 @@ category = "ci"
 check_type = "static"
 handler = "require_tokens"
 paths = [".dive-ci"]
-tokens = ["lowestEfficiency"]
+per_path_tokens = { ".dive-ci" = ["lowestEfficiency"] }
 
 [[suite]]
 name = "ci.trivy-scan-wired"
@@ -737,11 +763,11 @@ category = "ci"
 check_type = "static"
 handler = "require_tokens"
 paths = [".github/workflows/image-analysis.yml"]
-tokens = [
-  "aquasecurity/trivy-action",
-  "github/codeql-action/upload-sarif",
-  "trivy.sarif",
-]
+per_path_tokens = { ".github/workflows/image-analysis.yml" = [
+    "aquasecurity/trivy-action",
+    "github/codeql-action/upload-sarif",
+    "output: trivy.sarif",
+] }
 
 [[suite]]
 name = "ci.mise-task-pre-commit-named"
@@ -750,7 +776,7 @@ category = "ci"
 check_type = "static"
 handler = "require_tokens"
 paths = ["mise.toml"]
-tokens = ["[tasks.pre-commit]"]
+per_path_tokens = { "mise.toml" = ["[tasks.pre-commit]"] }
 
 # =============================================================================
 # Identity Constraints (~6) — User/group handling
@@ -806,7 +832,7 @@ category = "identity"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/Dockerfile.host-user"]
-tokens = ["rm -f /etc/sudoers.d/devcontainer"]
+per_path_tokens = { ".devcontainer/Dockerfile.host-user" = ["rm -f /etc/sudoers.d/devcontainer"] }
 
 [[suite]]
 name = "identity.username-validation"
@@ -828,7 +854,9 @@ category = "architecture"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/devcontainer.json"]
-tokens = ["${localEnv:USER}"]
+per_path_tokens = { ".devcontainer/devcontainer.json" = [
+    "\"remoteUser\": \"${localEnv:USER}\"",
+] }
 
 [[suite]]
 name = "arch.base-image-dockerfile-host-user"
@@ -837,7 +865,7 @@ category = "architecture"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/Dockerfile.host-user"]
-tokens = ["ghcr.io/ray-manaloto/dotfiles-devcontainer:dev"]
+per_path_tokens = { ".devcontainer/Dockerfile.host-user" = ["ghcr.io/ray-manaloto/dotfiles-devcontainer:dev"] }
 
 [[suite]]
 name = "arch.devcontainer-json-base-image-localenv"
@@ -846,7 +874,7 @@ category = "architecture"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/devcontainer.json"]
-tokens = ["${localEnv:BASE_IMAGE}"]
+per_path_tokens = { ".devcontainer/devcontainer.json" = ["${localEnv:BASE_IMAGE}"] }
 
 [[suite]]
 name = "arch.devcontainer-json-no-bare-image-tag"
@@ -864,7 +892,7 @@ category = "architecture"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/devcontainer.json"]
-tokens = ["\"updateRemoteUserUID\": false"]
+per_path_tokens = { ".devcontainer/devcontainer.json" = ["\"updateRemoteUserUID\": false"] }
 
 [[suite]]
 name = "arch.no-mise-home-volume"
@@ -882,7 +910,7 @@ category = "architecture"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/mise-system.toml"]
-tokens = ["npm.package_manager = \"bun\""]
+per_path_tokens = { ".devcontainer/mise-system.toml" = ["npm.package_manager = \"bun\""] }
 
 [[suite]]
 name = "arch.pipx-uses-uvx"
@@ -891,7 +919,7 @@ category = "architecture"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/mise-system.toml"]
-tokens = ["pipx.uvx = true"]
+per_path_tokens = { ".devcontainer/mise-system.toml" = ["pipx.uvx = true"] }
 
 [[suite]]
 name = "arch.cargo-uses-binstall"
@@ -900,7 +928,7 @@ category = "architecture"
 check_type = "static"
 handler = "require_tokens"
 paths = [".devcontainer/mise-system.toml"]
-tokens = ["cargo.binstall = true"]
+per_path_tokens = { ".devcontainer/mise-system.toml" = ["cargo.binstall = true"] }
 
 # =============================================================================
 # Policy Constraints (~4) — Human-only, not automatable
@@ -1204,7 +1232,7 @@ tokens = [
 
 [[suite]]
 name = "workflow.token-audit-wiring"
-description = "Contract-token uniqueness gate (#394 step 4). The sweep anchored 164 tokens so a prefix-preserving rename could not hide inside them — and then the three holes that were LIVE all survived their anchor, because each token matched somewhere other than the site it meant: `permissionDecision` was satisfied by the test file's own assertion (bare tokens are a union), `selfcheck` by the `elif command ==` dispatch branch after the subparser registration was deleted, `--output` by a sibling parser's identical flag. A word-boundary matcher would have caught none of them, which is why the audit recommended a UNIQUENESS signal instead: a per_path_tokens entry should match its file exactly once, because one match cannot be satisfied by a stand-in. Genuine multiplicity — a lockfile section per package, a doc naming its own task, a reused test fixture — is allowlisted with a reason; a NEW ambiguity fails, and so does a stale entry. Asserts the chain: hk step, CLI subcommand, module, allowlist, tests."
+description = "Contract-token uniqueness gate (#394 step 4). The sweep anchored 164 tokens so a prefix-preserving rename could not hide inside them — and then the three holes that were LIVE all survived their anchor, because each token matched somewhere other than the site it meant: `permissionDecision` was satisfied by the test file's own assertion (bare tokens are a union), `selfcheck` by the `elif command ==` dispatch branch after the subparser registration was deleted, `--output` by a sibling parser's identical flag. A word-boundary matcher would have caught none of them, which is why the audit recommended a UNIQUENESS signal instead: a per_path_tokens entry should match its file exactly once, because one match cannot be satisfied by a stand-in. Genuine multiplicity — a lockfile section per package, a doc naming its own task, a reused test fixture — is allowlisted with a reason; a NEW ambiguity fails, and so does a stale entry. #397 added the second rule the first one needs to be reachable: the audit reads ONLY per_path_tokens, so a bare `tokens` list was exempt from it — and the build/ci/arch tail was 105 such tokens. With a single path the two forms mean the same thing, so `find_unaudited` refuses the bare one; converting the tail then surfaced 39 ambiguities of which 33 were LIVE, the stand-in usually being a COMMENT or prose sentence in the same file rather than a sibling registration. Asserts the chain: hk step, CLI subcommand, module (both checks + the call site wiring the second into find_violations), allowlist, tests (both directions of each rule)."
 category = "workflow"
 check_type = "static"
 handler = "require_tokens"
@@ -1223,12 +1251,16 @@ per_path_tokens = { "hk.pkl" = [
     '"token-audit": lambda',
 ], "python/src/dotfiles_setup/token_audit.py" = [
     "def find_ambiguous(",
+    "def find_unaudited(",
     "def find_violations(",
     "def token_audit_main(",
     "AMBIGUITY_ALLOWED: dict",
+    "problems = find_unaudited(root)",
 ], "tests/test_token_audit.py" = [
     "def test_a_token_matching_once_is_silent(",
     "def test_every_allowlist_entry_is_still_ambiguous(",
+    "def test_a_single_path_bare_token_list_is_reported(",
+    "def test_the_same_binding_as_per_path_tokens_is_silent(",
 ] }
 tokens = [
     'dotfiles-setup token-audit"',
@@ -1484,7 +1516,6 @@ paths = [
     ".github/workflows/refresh.yml",
 ]
 per_path_tokens = { ".github/workflows/autofix.yml" = ["GIT_CONFIG_KEY_0: init.defaultBranch"], ".github/workflows/build-publish.yml" = ["GIT_CONFIG_KEY_0: init.defaultBranch"], ".github/workflows/ci.yml" = ["GIT_CONFIG_KEY_0: init.defaultBranch"], ".github/workflows/gcc-sha-repair.yml" = ["GIT_CONFIG_KEY_0: init.defaultBranch"], ".github/workflows/ghcr-cleanup.yml" = ["GIT_CONFIG_KEY_0: init.defaultBranch"], ".github/workflows/image-analysis.yml" = ["GIT_CONFIG_KEY_0: init.defaultBranch"], ".github/workflows/refresh.yml" = ["GIT_CONFIG_KEY_0: init.defaultBranch"] }
-tokens = ["GIT_CONFIG_KEY_0: init.defaultBranch"]
 
 # =============================================================================
 # Orchestration + eval contracts (#354 tier 0) — every declaration gets an
@@ -1535,10 +1566,6 @@ per_path_tokens = { ".claude/settings.json" = [
     "\"fable-orchestrator@fable-orchestrator\": true",
     "\"antigravity@antigravity-for-claude-code\": true",
 ] }
-tokens = [
-    "\"fable-orchestrator@fable-orchestrator\": true",
-    "\"antigravity@antigravity-for-claude-code\": true",
-]
 
 [[suite]]
 name = "orchestration.config-placement"
@@ -1650,4 +1677,3 @@ per_path_tokens = { "python/src/dotfiles_setup/pr.py" = [
     "FAIL  ship: git push rc={push_rc}",
     "gh pr view rc={view.returncode}",
 ] }
-tokens = ["FAIL  ship: gh pr create rc={create_rc}"]

--- a/tests/test_token_audit.py
+++ b/tests/test_token_audit.py
@@ -11,6 +11,7 @@ from dotfiles_setup.token_audit import (
     AMBIGUITY_ALLOWED,
     MANIFEST,
     find_ambiguous,
+    find_unaudited,
     find_violations,
     token_audit_main,
 )
@@ -98,6 +99,53 @@ def test_main_returns_one_when_a_binding_is_ambiguous(
 
 def test_main_returns_zero_on_the_real_repo() -> None:
     assert token_audit_main(ROOT) == 0
+
+
+def _single_path_manifest(tmp_path: Path, binding: str) -> Path:
+    """A one-suite manifest naming ONE path, binding it however `binding` says."""
+    (tmp_path / "python/verification").mkdir(parents=True)
+    (tmp_path / MANIFEST).write_text(
+        "[[suite]]\n"
+        'name = "demo.suite"\n'
+        'handler = "require_tokens"\n'
+        'paths = ["target.txt"]\n'
+        f"{binding}\n"
+    )
+    (tmp_path / "target.txt").write_text("wire here\n")
+    return tmp_path
+
+
+def test_a_single_path_bare_token_list_is_reported(tmp_path: Path) -> None:
+    """#397: the bare form is invisible to `find_ambiguous`, so it is refused."""
+    _single_path_manifest(tmp_path, 'tokens = ["wire"]')
+    problems = find_unaudited(tmp_path)
+    assert len(problems) == 1
+    assert "demo.suite" in problems[0]
+    assert "bare `tokens` list" in problems[0]
+
+
+def test_the_same_binding_as_per_path_tokens_is_silent(tmp_path: Path) -> None:
+    """The control arm: the gate must accept the form it redirects TO."""
+    _single_path_manifest(tmp_path, 'per_path_tokens = { "target.txt" = ["wire"] }')
+    assert find_unaudited(tmp_path) == []
+
+
+def test_a_multi_path_bare_token_list_is_left_alone(tmp_path: Path) -> None:
+    """A union over SEVERAL paths is #299's question, not this gate's."""
+    (tmp_path / "python/verification").mkdir(parents=True)
+    (tmp_path / MANIFEST).write_text(
+        "[[suite]]\n"
+        'name = "demo.suite"\n'
+        'handler = "require_tokens"\n'
+        'paths = ["a.txt", "b.txt"]\n'
+        'tokens = ["wire"]\n'
+    )
+    assert find_unaudited(tmp_path) == []
+
+
+def test_the_real_manifest_binds_every_single_path_suite_per_path() -> None:
+    """The gate on the repo itself — #397 converted the last of them."""
+    assert find_unaudited(ROOT) == []
 
 
 def test_an_allowlisted_entry_that_became_unique_is_reported(


### PR DESCRIPTION
#394 swept the enforcement seams and recommended a UNIQUENESS signal over a
word-boundary matcher. That gate reads only `per_path_tokens`, so the
`build.*` / `ci.*` / `arch.*` tail — 105 bare tokens — was exempt from the very
check it most needed. This converts the tail and acts on what the gate says.

The issue's premise about the union did not survive re-derivation, and the
control arm is what makes that reportable: `_resolve_paths` does no globbing,
so a bare `tokens` list over ONE path is identical in effect to
`per_path_tokens` for that path — and 51 of the tail's 54 `require_tokens`
suites name exactly one path. Bare-token suites naming >1 path: tail 3 (all
already per_path-bound), seams 19. The union hole lived in the seams, which is
where #394 found it.

The conversion is semantics-preserving; `verify run` stayed at 110 passed
throughout. What it changes is visibility: 105 tokens entered the audit, which
reported 39 ambiguities. 33 were LIVE — delete the real wiring line, leave the
other match standing, and the contract stays green. Each rebinding is armed
against the real engine on a temp tree (old token + mutated tree PASSES;
rebound token FAILS naming itself; rebound token + clean tree PASSES), and the
harness itself is control-armed over the 103 already-unique tail tokens, all of
which correctly report "not a hole".

The stand-in has a different shape here than in the seams. #394's three were
sibling code; the tail's are overwhelmingly a COMMENT or prose sentence in the
same file naming the thing it wires. `authorized_keys`, `doppler secrets
download`, `dotfiles-setup p2996-hash`, `REFRESH_APP_ID` and
`actions/create-github-app-token` were each satisfied by their own
documentation. A well-commented file is more exposed to this, not less. Two
were the plain prefix-swallow: `type=gha,scope=dotfiles-dev` was satisfied by
the `,mode=max` line below it, and `sha256sum -c -` by graphviz's checksum
while the contract meant gcc-latest's.

8 ambiguities are genuine and allowlisted with reasons — one per published bake
target, one per lifecycle task, one per job that must honour the same dispatch
input, and one cache-probe idiom that is textually identical across three jobs
so no substring can discriminate it.

`find_unaudited` is the second rule the first one needs to be reachable: a
single-path `require_tokens` suite must bind through `per_path_tokens`, since
the bare form means the same thing and only ever exempts the suite from the
audit. Both directions are tested, and armed against the live manifest before
shipping. The two remaining seam stragglers are converted too, so the rule
holds repo-wide.

Anchoring the 64 still-open tails is deliberately NOT here. The arm that would
justify it cannot discriminate — appending to an identifier preserves the
substring by construction — so it is authoring judgment, not a probe; and 33 of
33 live holes were ambiguity, which anchoring does not reach. Same verdict as
#394, now from 33 cases instead of three.

Gates: lint rc=0 · pytest 1022 passed · verify 110 passed, 0 failed ·
lint-docs rc=0 · token-audit rc=0.

Refs #394, #299, #62.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CzPdn3iHw6uhMWEdVPADfW

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787807988&installation_model_id=429246&pr_number=403&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F403&signature=4b6098dc4d4491c46551f41740fe22b3440bdbcaec79953465f78b8c8e75fd25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added auditing for single-path token checks that use an unscoped token list, helping identify suites that could bypass uniqueness validation.
  * Expanded reported audit findings and documented the updated token-audit rules.

* **Improvements**
  * Updated verification suites to use path-specific token matching for more precise validation.
  * Refined workflow audit checks and expanded approved exceptions for known tail-suite cases.

* **Tests**
  * Added coverage for detecting, accepting, and excluding the appropriate token-list formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->