### PR TITLE
docs(contracts): count the comment stand-ins instead of calling them "overwhelmingly" (#397)

### DIFF
--- a/docs/specs/eval-harness-design.md
+++ b/docs/specs/eval-harness-design.md
@@ -979,17 +979,36 @@ harness's own control arm ran arm A over the **103** already-unique tail tokens
 — all 103 correctly reported *not a hole*, so the 33/33 is a measurement and
 not a stuck needle.
 
-**The stand-in has a different shape here than in the seams.** #394's three
-were sibling *code*: a dispatch branch, another parser's flag, a test
-assertion. The tail's are overwhelmingly **a comment or a prose sentence in the
-same file naming the thing it wires**. `.devcontainer/devcontainer.json` opens
-with a header block narrating every mount and lifecycle command;
-`build-publish.yml` documents its own jobs; the Dockerfile explains each `ARG`
-above it. Delete the wiring and the narration remains — `authorized_keys`,
-`doppler secrets download`, `dotfiles-setup p2996-hash`, `REFRESH_APP_ID`,
-`actions/create-github-app-token` were every one of them satisfied by their own
-documentation. A well-commented file is *more* exposed to this than a terse
-one, which is the opposite of the intuition.
+**A new stand-in shape appears here — and the first write-up of it overstated
+its share.** #394's three were sibling *code*: a dispatch branch, another
+parser's flag, a test assertion. The tail adds **the file's own comment**.
+Classified by deleting each wiring line and asking what the surviving matches
+sit on:
+
+| the surviving stand-in(s) | count |
+|---|---|
+| **a COMMENT alone** | **11** |
+| a comment, plus code | 10 |
+| code only | 12 |
+
+A comment was the *sole* thing keeping **11 of 33** contracts green.
+`authorized_keys`, `doppler secrets download`, `dotfiles-setup p2996-hash`,
+`REFRESH_APP_ID` and `actions/create-github-app-token` were each satisfied by
+the sentence documenting them: `.devcontainer/devcontainer.json` opens with a
+header block narrating every mount and lifecycle command, `build-publish.yml`
+documents its own jobs, and the Dockerfile explains each `ARG` above it.
+
+**The correction matters more than the finding.** PR #403's commit message and
+the first draft of this section said the tail's stand-ins were
+*"overwhelmingly"* comments. Counted afterwards, they are **a third** — real,
+novel (the seams produced none), and a genuine reason a well-commented file
+carries a failure mode a terse one does not, but nowhere near a majority. The
+word was written from the examples that were vivid while triaging, not from a
+count, and it then travelled into four other documents before anything measured
+it. That is `probes-need-a-control-arm.md` §6 from the inside: **a
+characterisation is a measurement claim, and asserting one without counting is
+the same error as repeating an inherited number.** The commit on `main` is
+immutable and stands uncorrected, which is why the number lives here.
 
 Two were the plain prefix-swallow instead: `type=gha,scope=dotfiles-dev` was
 satisfied by the `,mode=max` line below it (now two anchored tokens, so the

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -67,6 +67,14 @@ Two engine defaults bind every contract you write (#299):
   which file must carry which token — otherwise a contract has no opinion
   about the files it names (`build.path-includes-mise-shims` named a file that
   stopped wiring PATH and stayed green ~3.5 months).
+- **A single-path `require_tokens` suite MUST use `per_path_tokens`** (#397,
+  gated by `dotfiles-setup token-audit`). With one path the two forms mean the
+  same thing, but only `per_path_tokens` is read by the uniqueness audit — the
+  bare form silently exempts the suite. Ask the audit's question yourself when
+  adding a token: **how many places in that file match it?** More than one and
+  a stand-in can satisfy it. 33 of 33 tail rebindings closed a LIVE hole, and
+  in **11** of them the sole stand-in was a **comment** — so a file's own
+  documentation can satisfy a contract about its wiring.
 
 Contracts use handler types like `policy_doc` (references a doc file)
 and `regex_forbid` (pattern-based rejection). Note: static contract

--- a/python/src/dotfiles_setup/token_audit.py
+++ b/python/src/dotfiles_setup/token_audit.py
@@ -43,11 +43,14 @@ temp tree (old token + mutated tree PASSES; the rebound token FAILS naming
 itself), with a control arm over the 103 already-unique tail tokens, every one
 of which correctly reported *not* a hole.
 
-The dominant stand-in was not a sibling registration, as #394's three were — it
-was **a comment or a prose sentence in the same file naming the thing**. A
-Dockerfile that explains its own ``ARG`` above it, a workflow that documents its
-own job, a devcontainer.json whose header block narrates every mount. Deleting
-the wiring left the narration, and the narration satisfied the token.
+A stand-in shape appeared that #394's three did not have: **the file's own
+comment**. Counted, not eyeballed — for 11 of the 33 the sole surviving match
+was a comment line, for 10 it was a comment plus code, and for 12 code alone.
+A Dockerfile explains its own ``ARG`` above it, a workflow documents its own
+job, devcontainer.json narrates every mount in a header block; deleting the
+wiring leaves the narration, and the narration satisfies the token. (PR #403's
+commit message called this "overwhelmingly" the case before anyone counted. It
+is a third. See the spec's 2026-07-28 revision.)
 
 Hence :func:`find_unaudited`: a ``require_tokens`` suite naming exactly one path
 must bind through ``per_path_tokens``, never a bare ``tokens`` list. That form
@@ -77,9 +80,8 @@ MANIFEST = "python/verification/suites.toml"
 #
 # #397 (2026-07-28) brought the `build.*`/`ci.*`/`arch.*` tail under this gate
 # by converting its single-path bare `tokens` to `per_path_tokens`. That
-# surfaced 39 more ambiguities: 31 were the `selfcheck` shape — overwhelmingly
-# a PROSE OR COMMENT MENTION standing in for the wiring line — and were
-# rebound; the 8 below are genuine.
+# surfaced 39 more ambiguities; 33 were the `selfcheck` shape and were rebound
+# (in 11 of those, the sole stand-in was a COMMENT). The 8 below are genuine.
 AMBIGUITY_ALLOWED: dict[tuple[str, str, str], str] = {
     (
         "build.locked-install-with-conda-sha",

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -21,13 +21,14 @@ version = "2"
 #     Anchoring does NOT reach this one — bind the unique site.  (#394)
 #
 #     This is the question that finds real holes.  #397 swept the tail and
-#     **33 of 33** rebindings closed a LIVE one, and the stand-in was usually
-#     not a sibling registration — it was **a COMMENT or a prose sentence in
-#     the same file naming the thing**.  A Dockerfile explains its own `ARG`
-#     above it; a workflow documents its own job; devcontainer.json narrates
-#     every mount in a header block.  Delete the wiring, the narration stays,
-#     and the contract never notices.  `dotfiles-setup token-audit` is the
-#     machine form of this question — run it after adding a token.
+#     **33 of 33** rebindings closed a LIVE one.  Counted by what the
+#     surviving matches sit on: **11** were held up by a COMMENT alone, 10 by
+#     a comment plus code, 12 by code alone.  A Dockerfile explains its own
+#     `ARG` above it; a workflow documents its own job; devcontainer.json
+#     narrates every mount in a header block.  Delete the wiring, the
+#     narration stays, and the contract never notices.
+#     `dotfiles-setup token-audit` is the machine form of this question — run
+#     it after adding a token.
 #
 # And bare `tokens` is a UNION across every listed path: `permissionDecision`
 # was satisfied by the TEST FILE asserting the string, with the guard's emit
@@ -1232,7 +1233,7 @@ tokens = [
 
 [[suite]]
 name = "workflow.token-audit-wiring"
-description = "Contract-token uniqueness gate (#394 step 4). The sweep anchored 164 tokens so a prefix-preserving rename could not hide inside them — and then the three holes that were LIVE all survived their anchor, because each token matched somewhere other than the site it meant: `permissionDecision` was satisfied by the test file's own assertion (bare tokens are a union), `selfcheck` by the `elif command ==` dispatch branch after the subparser registration was deleted, `--output` by a sibling parser's identical flag. A word-boundary matcher would have caught none of them, which is why the audit recommended a UNIQUENESS signal instead: a per_path_tokens entry should match its file exactly once, because one match cannot be satisfied by a stand-in. Genuine multiplicity — a lockfile section per package, a doc naming its own task, a reused test fixture — is allowlisted with a reason; a NEW ambiguity fails, and so does a stale entry. #397 added the second rule the first one needs to be reachable: the audit reads ONLY per_path_tokens, so a bare `tokens` list was exempt from it — and the build/ci/arch tail was 105 such tokens. With a single path the two forms mean the same thing, so `find_unaudited` refuses the bare one; converting the tail then surfaced 39 ambiguities of which 33 were LIVE, the stand-in usually being a COMMENT or prose sentence in the same file rather than a sibling registration. Asserts the chain: hk step, CLI subcommand, module (both checks + the call site wiring the second into find_violations), allowlist, tests (both directions of each rule)."
+description = "Contract-token uniqueness gate (#394 step 4). The sweep anchored 164 tokens so a prefix-preserving rename could not hide inside them — and then the three holes that were LIVE all survived their anchor, because each token matched somewhere other than the site it meant: `permissionDecision` was satisfied by the test file's own assertion (bare tokens are a union), `selfcheck` by the `elif command ==` dispatch branch after the subparser registration was deleted, `--output` by a sibling parser's identical flag. A word-boundary matcher would have caught none of them, which is why the audit recommended a UNIQUENESS signal instead: a per_path_tokens entry should match its file exactly once, because one match cannot be satisfied by a stand-in. Genuine multiplicity — a lockfile section per package, a doc naming its own task, a reused test fixture — is allowlisted with a reason; a NEW ambiguity fails, and so does a stale entry. #397 added the second rule the first one needs to be reachable: the audit reads ONLY per_path_tokens, so a bare `tokens` list was exempt from it — and the build/ci/arch tail was 105 such tokens. With a single path the two forms mean the same thing, so `find_unaudited` refuses the bare one; converting the tail then surfaced 39 ambiguities of which 33 were LIVE, and 11 of those were held green by a COMMENT alone — a stand-in shape the seams never produced. Asserts the chain: hk step, CLI subcommand, module (both checks + the call site wiring the second into find_violations), allowlist, tests (both directions of each rule)."
 category = "workflow"
 check_type = "static"
 handler = "require_tokens"


### PR DESCRIPTION
PR #403's commit message and its write-up said the tail's contract stand-ins
were "overwhelmingly" a comment or prose sentence. That was asserted from the
examples that were vivid while triaging, never counted — and the word then
travelled into the spec, `suites.toml`'s header, `token_audit.py`, the issue
comment and the memory before anything measured it.

Measured, by deleting each wiring line and classifying what the surviving
matches sit on:

| the surviving stand-in(s) | count |
|---|---|
| a COMMENT alone | 11 |
| a comment, plus code | 10 |
| code only | 12 |

A third, not a majority. The finding stands and is still novel — the seams
produced no comment stand-ins at all, and `authorized_keys`, `doppler secrets
download`, `dotfiles-setup p2996-hash`, `REFRESH_APP_ID` and
`actions/create-github-app-token` really were each held green by the sentence
documenting them. A well-commented file does carry a failure mode a terse one
does not. It is simply not the dominant one.

Nothing about #403 is affected: 33 of 33 were still live holes, all 33 are
still rebound, every arm still fired.

The durable lesson is recorded rather than the number quietly swapped: **a
characterisation is a measurement claim**, so count it or hedge it. That is
`probes-need-a-control-arm.md` §6 reached from the authoring side instead of
the reading side — the rule already forbids repeating an inherited number, and
this is the same error committed at the point the number is born.

Also adds the #397 rule to `python/AGENTS.md`, which is where contract authors
look: a single-path `require_tokens` suite must bind through
`per_path_tokens`, and the question to ask when adding a token is how many
places in that file match it.

The commit on `main` is immutable and stands uncorrected; the count lives in
`docs/specs/eval-harness-design.md` § `2026-07-28 revision`.

Refs #397, #394.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CzPdn3iHw6uhMWEdVPADfW

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787811885&installation_model_id=429246&pr_number=404&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F404&signature=c870b9bd9bfa3e46649b473c3c0e6733aa1481e7170ca1cec9ab7a32e580c33e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the documented classification of token stand-ins with quantified counts across comment-only, comment-plus-code, and code-only cases.
  * Clarified the documented ambiguity and audit findings, including comment-only stand-ins and live ambiguity totals.
  * Added guidance requiring single-path verification suites to use per-path token definitions for accurate auditing.
  * Expanded verification documentation with details about token uniqueness and wiring checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->