### PR TITLE
fix/guard fail open counter

### DIFF
--- a/.claude/rules/mise-tasks-only.md
+++ b/.claude/rules/mise-tasks-only.md
@@ -1,9 +1,9 @@
 # Mise Tasks Only: No One-Off Commands for Canonical Workflows
 
-Every recurring workflow in this repo has (or gets) a canonical mise
-task. When a task exists, USE IT — never hand-roll the underlying
-command sequence. When you build a new recurring workflow, ship its mise
-task (wrapping the python library, zero-bash-logic) in the same change.
+Every recurring workflow in this repo has (or gets) a canonical mise task. When
+a task exists, USE IT — never hand-roll the underlying command sequence. When
+you build a new recurring workflow, ship its mise task (wrapping the python
+library, zero-bash-logic) in the same change.
 
 ## The canonical task map
 
@@ -32,168 +32,169 @@ task (wrapping the python library, zero-bash-logic) in the same change.
 Diagnostic/read-only commands (`docker ps`, `gh pr view`, `git status`,
 single-test `pytest path::test` via uv) are NOT wrapped and stay direct.
 
-**The `gh pr` redirects are REPO-AWARE (2026-07-23).** Dispatch is by the
-target repo, resolved from an explicit `-R`/`--repo`: dotfiles (or no `-R`,
-i.e. cwd) → `ship`/`land`; knowledge-base → `kb-ship`/`kb-land`; **any other
-repo → ALLOW**. Allowing the rest is deliberate — no canonical task exists for
-a sibling repo, so a deny would redirect to nothing and merely block real work.
+**The `gh pr` redirects are REPO-AWARE (2026-07-23).** Dispatch is by the target
+repo, resolved from an explicit `-R`/`--repo`: dotfiles (or no `-R`, i.e. cwd) →
+`ship`/`land`; knowledge-base → `kb-ship`/`kb-land`; **any other repo → ALLOW**.
+Allowing the rest is deliberate — no canonical task exists for a sibling repo, so
+a deny would redirect to nothing and merely block real work. A real defect, not a
+hypothetical: the rules matched `gh pr merge` unconditionally, so a KB PR was
+denied and pointed at `mise run land` — a *dotfiles* task with no repo parameter,
+watching dotfiles' main CI. KB PRs #1 and #2 were merged by hand. **A guard whose
+redirect target cannot perform the redirected action is not enforcement, it is an
+outage.**
 
-A real defect, not a hypothetical: the rules matched `gh pr merge`
-unconditionally, so a knowledge-base PR was denied and pointed at `mise run
-land` — a *dotfiles* task with no repo parameter, which watches dotfiles' main
-CI. KB PRs #1 and #2 were merged by hand as a result. A guard whose redirect
-target cannot perform the redirected action is not enforcement, it is an outage.
-
-**It recurred along a second axis — PR PROVENANCE (#369, 2026-07-27).** Only
-`ship` arms auto-merge and a bot PR never runs it; `land` refuses an OPEN PR;
-`gh pr merge` redirected to `land`. #138/#236/#386 sat green, unmergeable.
-`automerge` is the missing verb: **bot-authored PRs ONLY**, armed and exited
-(the required checks run against the merge RESULT, so a branch behind main is
-fine). `ship` gates the tree before arming and `automerge` does not, so one
-verb per provenance means no judgement call at the call site.
+**It recurred along a second axis — PR PROVENANCE (#369).** Only `ship` arms
+auto-merge and a bot PR never runs it; `land` refuses an OPEN PR; `gh pr merge`
+redirected to `land`. #138/#236/#386 sat green, unmergeable. `automerge` is the
+missing verb: **bot-authored PRs ONLY**, armed and exited (required checks run
+against the merge RESULT, so a branch behind main is fine). `ship` gates the tree
+before arming and `automerge` does not, so one verb per provenance means no
+judgement call at the call site.
 
 ## Enforcement layers (deep-research verified, 2026-07-07)
 
-1. **PreToolUse hook (hard deny)** — `.claude/settings.json` wires every
-   Bash call through `dotfiles-setup hook pretooluse`
-   (`python/src/dotfiles_setup/hook_guard.py`): a matched one-off command
-   is DENIED with the redirect reason fed back (JSON
-   `permissionDecision: "deny"`; deterministic, applies even in
-   bypassPermissions mode). The rules are tested in
+1. **PreToolUse hook (hard deny)** — `.claude/settings.json` wires every Bash
+   call through `dotfiles-setup hook pretooluse` (`hook_guard.py`): a match is
+   DENIED with the redirect reason fed back (JSON `permissionDecision: "deny"`;
+   deterministic, applies even in bypassPermissions mode). Rules tested in
    `tests/test_hook_guard.py`.
 2. **ship/land `hook-selfcheck` gate** — `mise run ship` / `land` run
-   `dotfiles-setup hook selfcheck`
-   (`python/src/dotfiles_setup/hook_selfcheck.py`) as an always-run gate: it
-   drives the WIRED PreToolUse guard end-to-end (settings.json wiring +
-   `Bash` matcher, the real wrapper, `bash -n` on the scripts), so a hook
-   regression fails a PR like lint/pytest. Tested in
-   `tests/test_hook_selfcheck.py`.
-3. **This rule + skills** — `pr-workflow` and `devcontainer-sync` skills
-   name the canonical tasks; markdown alone is "relying on the LLM", so
-   it is never the only layer.
-4. **Self-learning loop (`mise run command-audit`)** —
-   `python/src/dotfiles_setup/command_audit.py` scans this project's recent
-   Claude Code transcript JSONL (native capture — no logging hook) and flags
-   mutating one-off Bash commands the guard does NOT yet cover, so the layers
-   above get refined over time. It is the *inverse* of Claude Code's
-   `fewer-permission-prompts` skill (same transcript mine + command+subcommand
-   grouping, opposite verdict). Review the report, then add a `mise run` task
-   (+ a `hook_guard._RULES` redirect for a known-bad shape) for the top
-   culprits. A rule-matching command is only an alarm (`bypass`) when it ran
-   AFTER its rule's `since` date AND actually executed — see "Reading the
-   report" below. Ongoing, not one-shot — a **`SessionEnd` hook** in
-   `.claude/settings.json` runs it once per session (`-- --output
-   .agent/command-audit.md`), so the report is always waiting rather than
-   remember-to-run. `SessionEnd` and not `Stop`: it fires once per session at
-   termination and *cannot block*, while `Stop` fires every turn and can block
-   (exit 2 continues the turn) — a transcript scan belongs on neither the
-   per-turn path nor a blocking one. It is also **local-only by nature** (it
-   reads `~/.claude` transcripts), so it is a hook and never a GHA job — a CI
-   runner has no transcripts. The report stays out of git via `.gitignore`.
-5. **Contracts** — `workflow.mise-tasks-enforcement` (the deny guard),
-   `workflow.hook-selfcheck-wiring` (the selfcheck gate), and
-   `workflow.command-audit-wiring` (the self-learning loop) in suites.toml
-   assert the whole chain exists (settings.json → wrapper → CLI → module →
-   tests), so nothing silently drifts out.
+   `dotfiles-setup hook selfcheck` (`hook_selfcheck.py`) as an always-run gate
+   driving the WIRED guard end-to-end: settings.json wiring + `Bash` matcher,
+   **every hook command anchored to `$CLAUDE_PROJECT_DIR`**, the real wrapper
+   denying from **both** the project root and a foreign cwd (#343), and `bash
+   -n` on the scripts. A hook regression fails a PR like lint/pytest.
+3. **This rule + skills** — `pr-workflow` and `devcontainer-sync` name the
+   canonical tasks; markdown alone is "relying on the LLM", never the only layer.
+4. **Self-learning loop (`mise run command-audit`)** — `command_audit.py` scans
+   this project's recent Claude Code transcript JSONL (native capture — no
+   logging hook) and flags mutating one-off Bash commands the guard does NOT yet
+   cover, so the layers above get refined over time. The *inverse* of Claude
+   Code's `fewer-permission-prompts` skill (same transcript mine, opposite
+   verdict). Review the report, then add a `mise run` task (+ a `_RULES`
+   redirect for a known-bad shape) for the top culprits. A rule-matching command
+   is only an alarm (`bypass`) when it ran AFTER its rule's `since` AND actually
+   executed — see "Reading the report". Ongoing: a **`SessionEnd` hook** runs it
+   per session (`--output .agent/command-audit.md`). `SessionEnd` and not `Stop`
+   — it fires once at termination and *cannot block*, while `Stop` fires every
+   turn and can block, and a transcript scan belongs on neither. **Local-only by
+   nature** (it reads `~/.claude` transcripts), so it is a hook and never a GHA
+   job — a CI runner has no transcripts. Report kept out of git by `.gitignore`.
+5. **Contracts** — `workflow.mise-tasks-enforcement`, `.hook-selfcheck-wiring`
+   and `.command-audit-wiring` in suites.toml assert the whole chain exists
+   (settings.json → wrapper → CLI → module → tests), so nothing drifts out.
 
-The hook fails OPEN on its own errors (a crashed guard must not brick every
-Bash call — the wrapper exits 0 when the Python>=3.14 interpreter is absent,
-e.g. a cold Claude-web session). Hard one-off bans that must never fail open
-belong in settings.json permission deny rules, not the hook.
+The hook fails OPEN on its own errors (a crashed guard must not brick every Bash
+call — the wrapper exits 0 when the Python>=3.14 interpreter is absent, e.g. a
+cold web session) but **records every one** (#343). Hard bans that must never
+fail open belong in settings.json permission deny rules, not the hook.
 
-> **Enforcement design note (2026-07-14, research-backed):** we deliberately
-> do NOT re-inject a "use mise tasks" reminder every turn (UserPromptSubmit)
-> or nudge after every command (PostToolUse). Anthropic's guidance routes
-> static conventions to CLAUDE.md and enforcement to the PreToolUse hook,
-> and the LLM-behavior evidence ranks a hard gate (zero decay) far above
-> per-turn reminders (which decay, cost instruction budget, and sit in the
-> lowest-trust context tier). See
-> `docs/research/runs/research-20260714-hook-enforcement/report.md`. The improvement
-> path is the self-learning loop (`mise run command-audit`, layer 4 above) that
-> mines native transcripts for one-off-command culprits to refine these layers
-> — not more per-turn hooks.
+> **Enforcement design note (2026-07-14, research-backed):** we deliberately do
+> NOT re-inject a "use mise tasks" reminder every turn (UserPromptSubmit) or
+> nudge after every command (PostToolUse). Anthropic's guidance routes static
+> conventions to CLAUDE.md and enforcement to the PreToolUse hook, and the
+> LLM-behavior evidence ranks a hard gate (zero decay) far above per-turn
+> reminders (which decay, cost instruction budget, and sit in the lowest-trust
+> tier). See `docs/research/runs/research-20260714-hook-enforcement/report.md`.
+> The improvement path is layer 4 mining transcripts — not more per-turn hooks.
 
 ## Reading the command-audit report
 
 Only **`bypass`** is an alarm: a command that matched a rule ALREADY LIVE
-(`timestamp > rule.since`) and that really executed. The other rule-matching
-classes are not:
+(`timestamp > rule.since`) and that really executed. The others are not:
 
 - **`blocked`** — the guard denied it; it never ran. The guard working. Audit
-  these for FALSE POSITIVES (see #265 below), not for evasion — that is the
-  direction every measured defect has come from.
-- **`pre_rule`** — it predates the rule that matches it. History.
-- **`one_off`** — the refine-loop candidates, but known-noisy (#266): its top
-  shapes are currently sanctioned work (plain git, ad-hoc scripts, the
-  prescribed wait-loops). Read it with that discount until #266 lands.
+  these for FALSE POSITIVES (#265), not for evasion of the matcher.
+- **`pre_rule`** — it predates the rule that matches it. History. **Trust this
+  only as far as `since` is right** — see "`since` dates COVERAGE" below.
+- **`one_off`** — refine-loop candidates, known-noisy (#266): top shapes are
+  sanctioned work (plain git, ad-hoc scripts, wait-loops). Discount until then.
 
-Both distinctions are load-bearing, because a bare "matched a rule" verdict is
-almost pure noise. Measured over 3,615 real commands (2026-07-14): **155**
-matched a rule — **147** predated it, **3** were denials, and **0** were
-bypasses. Nothing has ever evaded the guard. The transcript is what forces the
-second axis: it records the Bash `tool_use` block whether or not the command
-ran (a PreToolUse deny lands *after* the model emits it), so a denial and a
-bypass are byte-identical until you pair the attempt to its result.
+Both distinctions are load-bearing: a bare "matched a rule" verdict is almost
+pure noise. Measured over 3,615 commands (2026-07-14): **155** matched a rule —
+**147** predated it, **3** were denials, **0** bypasses. The transcript forces
+the second axis, recording the `tool_use` block whether or not the command ran (a
+deny lands *after* the model emits it), so a denial and a bypass are identical
+until you pair the attempt to its result.
+
+**"Nothing has ever evaded the guard" stood here until 2026-07-28 and was false
+in BOTH directions at once (#343).** Re-judged against the `hook_guard.py` live
+at each command's own timestamp rather than trusting `since`: of 128 rows, **3
+false**, **125 genuine**. The 125 ran because **the guard never ran** — hooks
+execute "in the current directory", so the relative `bash
+scripts/pretooluse-guard.sh` was absent whenever a session worked in the sibling
+repo (rc=127), and a non-zero non-2 PreToolUse exit is a **non-blocking error
+that lets the call proceed**. Every path is now anchored to
+`$CLAUDE_PROJECT_DIR` (settings.json AND the wrapper's equally-relative `uv
+--project`), and `hook_selfcheck` drives a **foreign-cwd arm** — both old arms
+ran at the project root, which is precisely why this survived. **A fail-open
+that nothing counts is indistinguishable from enforcement**, so each is now
+recorded (`~/.local/state/dotfiles/guard-fail-open.log`) and reported by
+`command-audit`. Evidence: `docs/research/runs/research-20260728-guard-fail-open/`.
 
 ## Fixed: prose content in compound commands (#265)
 
 The guard used to match the RAW Bash string, so a separator inside
-quoted/heredoc CONTENT read as a shell separator and the denied literal
-after it looked like it sat at a command position. `grep -iE
-"…|devcontainer up|…"` was denied — and a deny cancels the ENTIRE
-compound command, silently skipping its other parts, so the cost was a
-command that looked like it ran.
+quoted/heredoc CONTENT read as a shell separator and the denied literal after it
+looked like it sat at a command position (`grep -iE "…|devcontainer up|…"` was
+denied). A deny cancels the ENTIRE compound command, silently skipping its other
+parts — so the cost was a command that looked like it ran.
 
-**Fixed 2026-07-14** by `hook_guard._inert_masked`: before the rules run,
-separators (`;&|` + newline) that are DATA get neutered — inside quoted
-spans (content preserved, only separators blanked, since a rule may need
-to read a quoted argument) and inside heredoc bodies (`<<EOF`, `<<'EOF'`,
-`<<-EOF` — redacted whole, since a body is stdin data and can never be a
-command). Rule patterns are untouched, so recall is preserved by
-construction. Measured: the `blocked` bucket went **3 → 1**, keeping the
-one denial that was always correct.
+**Fixed 2026-07-14** by `hook_guard._inert_masked`: separators (`;&|` + newline)
+that are DATA get neutered before the rules run — inside quoted spans (content
+preserved, only separators blanked, since a rule may need to read a quoted
+argument) and inside heredoc bodies (`<<EOF`, `<<'EOF'`, `<<-EOF` — redacted
+whole; a body is stdin data and can never be a command). Rule patterns are
+untouched, so recall is preserved by construction. `blocked` went **3 → 1**,
+keeping the one denial that was always correct.
 
-Still fail-open BY DESIGN (this is a redirect guard, not a sandbox):
-`$(…)` substitution, `sh -c`/`eval`, base64, aliases. Masking narrows
-that class slightly and on purpose — `eval "echo x; gh pr create"` was
-denied before (the quoted `;` anchored `_CMD`) and is allowed now. That
-was an accident, not coverage: bare `eval "gh pr create"` was always
-allowed, so the class was never guarded, only its separator-bearing
-variant. Giving that up IS the precision-over-recall trade, with evasion
-measured at 0.
+Still fail-open BY DESIGN (a redirect guard, not a sandbox): `$(…)`, `sh
+-c`/`eval`, base64, aliases. Masking narrows that class deliberately — `eval
+"echo x; gh pr create"` was denied before (the quoted `;` anchored `_CMD`) and is
+allowed now. An accident, not coverage: bare `eval "gh pr create"` was always
+allowed, so only the separator-bearing variant was ever caught. Giving it up IS
+the precision-over-recall trade. If a deny looks wrong: write the script with the
+Write tool and run `python3 <file>` — and after ANY deny, re-check the intended
+side effects happened.
 
-If a deny ever does look wrong, the workaround remains: write the script
-with the Write tool and run `python3 <file>` — and after ANY deny,
-re-check that the command's intended side effects actually happened.
-
-**Evasion was never the defect — false positives were** (#265, now closed):
-2 of the 3 denials ever recorded were the quoted-regex shape above, and the
-survivor (an `npx` reached through a real `||` fallback) was correct all along
-— which is why the fix targets 3 → 1, not 3 → 0. Twice now a predicted risk has
-been refuted by probing and the real one turned out to be its mirror image
-(#264's cd-prefix "evasion"; #265's quoting): measure before believing.
+**Against the MATCHER, false positives were the defect, not evasion** (#265): 2
+of the 3 denials ever recorded were the quoted-regex shape, and the survivor (an
+`npx` behind a real `||`) was correct — hence 3 → 1, not 3 → 0. Twice a predicted
+risk was refuted by probing and the real one was its mirror image (#264's
+cd-prefix; #265's quoting): measure before believing. **That scope matters** —
+nothing has evaded the *matcher*, but #343 found 125 commands bypassing the
+guard entirely by never reaching it.
 
 ## Extending
 
-New redirect = new `_RULES` entry in `hook_guard.py` + a test + a row in
-the table above, same change. Give it a `since` date (the day it lands on
-main) — the audit needs it to tell a real bypass from pre-rule history, and a
-rule missing one classifies every match as history forever, darkening the
-alarm. `since` dates the RULE, not its wording: never bump it on a reword.
-Keep patterns narrow: a redirect that misfires on legitimate diagnostics
+New redirect = new `_RULES` entry in `hook_guard.py` + a test + a row in the
+table above, same change. Give it a `since` date (the day it lands on main) —
+without one the audit reads every match as history forever and the alarm goes
+dark. Keep patterns narrow: a redirect that misfires on legitimate diagnostics
 erodes trust in the guard.
 
-Rules match the command AFTER `hook_guard._inert_masked` has neutered every
-separator that is data, so write the pattern against real shell syntax and let
-masking handle quoting — do NOT add quote-awareness to a rule. Test a new rule
-against a quoted mention of itself (`echo "…|<your literal>"`) as well as the
-real invocation; the first must pass, the second must deny.
+### `since` dates COVERAGE, not the Rule object
+
+Never bump it on a reword — but **widening a pattern to cover a NEW shape is not
+a reword and needs its own date.** One `Rule` carries one `since`, so a widened
+rule must be **split into two entries**. `68f28c9` (#308) brought `hk run check`
+under the guard on 2026-07-18 by widening the `hk run pre-commit` rule, leaving
+`since` at 2026-07-07 — so the audit back-dated 11 days of coverage and cried
+bypass on three calls the guard of that day correctly allowed (#343). Now `_V1`
+and `_V1B`. **A proxy goes stale silently:** when a bypass count moves, check the
+rule's history (`git log -S` on the pattern) before believing it.
+
+Rules match AFTER `_inert_masked` has neutered every separator that is data, so
+write the pattern against real shell syntax and let masking handle quoting — do
+NOT add quote-awareness to a rule. Test a new rule against a quoted mention of
+itself (`echo "…|<your literal>"`) as well as the real invocation; the first
+must pass, the second must deny.
 
 ## See also
 
-- `.claude/rules/verify-before-advancing.md` — the gates the ship/land
-  tasks encode.
-- `.claude/rules/long-running-command-hangs.md` — why `mise run lint`.
+- `verify-before-advancing.md` — the gates ship/land encode.
+- `long-running-command-hangs.md` — why `mise run lint`.
 - `docs/research/runs/research-20260707-gha-shipland-enforcement/report.md` —
-  the evidence base (hooks deny; allow-lists live in permissions; hookify
-  is advisory-grade).
+  the evidence base (hooks deny; allow-lists live in permissions; hookify is
+  advisory-grade).
+- `docs/research/runs/research-20260728-guard-fail-open/report.md` — #343.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,7 +12,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/pretooluse-guard.sh",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}/scripts/pretooluse-guard.sh\"",
             "timeout": 20
           }
         ]
@@ -22,7 +22,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/graphify-hook-guard.sh search",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}/scripts/graphify-hook-guard.sh\" search",
             "timeout": 15
           }
         ]
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/graphify-hook-guard.sh read",
+            "command": "bash \"${CLAUDE_PROJECT_DIR:-.}/scripts/graphify-hook-guard.sh\" read",
             "timeout": 15
           }
         ]
@@ -44,7 +44,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if [ \"${CLAUDE_CODE_REMOTE:-}\" = \"true\" ]; then bash scripts/web-setup.sh; else mise run tool-currency-check; fi",
+            "command": "if [ \"${CLAUDE_CODE_REMOTE:-}\" = \"true\" ]; then bash \"${CLAUDE_PROJECT_DIR:-.}/scripts/web-setup.sh\"; else mise -C \"${CLAUDE_PROJECT_DIR:-.}\" run tool-currency-check; fi",
             "timeout": 600
           }
         ]
@@ -55,7 +55,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "mise run command-audit -- --output .agent/command-audit.md",
+            "command": "mise -C \"${CLAUDE_PROJECT_DIR:-.}\" run command-audit -- --output \"${CLAUDE_PROJECT_DIR:-.}/.agent/command-audit.md\"",
             "timeout": 120
           }
         ]

--- a/docs/research/runs/research-20260728-guard-fail-open/report.md
+++ b/docs/research/runs/research-20260728-guard-fail-open/report.md
@@ -1,0 +1,176 @@
+# The PreToolUse guard failed open for every cross-repo session (#343)
+
+Date: 2026-07-28. Repo: `ray-manaloto/dotfiles`. Issue: [#343].
+
+Investigating #343's report of "the first non-zero `bypass` count ever (3), one
+confirmed genuine" found that **all three were false**, and that a *different*,
+much larger defect was live and unreported: **125 genuine bypasses**, caused by
+the guard never running at all.
+
+---
+
+## 1. Method — re-judge against the guard that was live at the time
+
+`command_audit.classify` compares a historical command against **today's** rule
+set and uses the matched rule's `since` date to filter out pre-rule history.
+That is sound only while a rule's pattern never changes after it lands.
+
+So the `since` proxy was removed entirely: for each flagged row, check out the
+real `python/src/dotfiles_setup/hook_guard.py` as of that row's own timestamp
+(`git rev-list -1 --until=<ts> main`), import it, and ask `decide()` directly.
+
+**Control arms on the historical module**, so a "the old guard allowed it"
+answer is not merely a broken import:
+
+| probe | guard of 2026-07-16 | guard today |
+|---|---|---|
+| `gh pr create --title x` | DENY | DENY |
+| `git log --oneline \| head -5` | allow | allow |
+
+Both stable ⇒ the historical module loads and decides. Its verdicts are evidence.
+
+## 2. Result
+
+128 rows classified `bypass` by today's audit (50-session window + #343's own
+session, which sits outside it):
+
+| verdict | n |
+|---:|---|
+| **GENUINE** — denied then, hook could not run (cwd off-root) | **125** |
+| **FALSE** — the rule did not cover it yet | **3** |
+
+By rule:
+
+| rule | n | verdict |
+|---|---:|---|
+| `gate command piped to head/tail` | 118 | genuine |
+| `gh pr checks --watch` | 6 | genuine |
+| `hk run pre-commit/check` | 3 | **false** |
+| `gh pr merge` | 1 | genuine |
+
+## 3. The 3 false ones — `since` dated the Rule, not its coverage
+
+All three are `hk run check …` from 2026-07-17T03:14–03:17Z, at `cwd = dotfiles`.
+
+At that time the rule was named `hk run pre-commit` with pattern
+`hk\s+run\s+pre-commit\b` — it **did not cover `check`**. Commit `68f28c9`
+(2026-07-18 16:15, #308, "make `mise run lint` run read-only `hk run check
+--all`") widened it:
+
+```diff
+-        "hk run pre-commit",
+-        re.compile(_CMD + r"hk\s+run\s+pre-commit\b"),
++        "hk run pre-commit/check",
++        re.compile(_CMD + r"hk\s+run\s+(?:pre-commit|check)\b"),
+```
+
+`since` stayed `_V1 = 2026-07-07`. The audit therefore back-dated ~37 hours of
+new coverage onto history that predates it. The guard of the day allowed those
+commands **correctly**.
+
+**Fix:** split into two `Rule` entries — `hk run pre-commit` (`_V1`,
+2026-07-07) and `hk run check` (`_V1B`, 2026-07-18). A single `Rule` carries one
+`since`, so a pattern widened to a new command shape must become a new entry.
+
+## 4. The 125 genuine ones — the hook path was relative
+
+Every one of the 125 has `cwd = /Users/…/knowledge-base`. **Zero** at the
+dotfiles root. Control arm: 30 of the 35 `blocked` rows *are* at the dotfiles
+root, so the correlation discriminates.
+
+`.claude/settings.json` wired:
+
+```
+bash scripts/pretooluse-guard.sh
+```
+
+Three documented mechanics combine into a silent fail-open
+(<https://code.claude.com/docs/en/hooks>):
+
+1. **"Handlers run in the current directory"** — not the project root. So a
+   relative path resolves against whatever directory the session is in.
+2. `CLAUDE_PROJECT_DIR` **is** exported to hook commands — the portable idiom
+   was available and unused (KB's own settings already used it).
+3. For `PreToolUse`, **only exit 2 blocks**. "Any other exit code is a
+   non-blocking error… the tool call proceeds."
+
+Measured, running the exact wired command from each cwd:
+
+```
+cwd=dotfiles         → {"permissionDecision":"deny",…}   rc=0
+cwd=knowledge-base   → bash: scripts/pretooluse-guard.sh: No such file…  rc=127
+```
+
+rc=127 ⇒ non-blocking error ⇒ **the Bash call proceeded, unchecked**.
+
+### 4a. Anchoring settings.json alone would NOT have fixed it
+
+The wrapper's own last line was `exec uv run --project python …` — also
+relative. Probed with the script path anchored and cwd off-root:
+
+```
+cwd=knowledge-base, script anchored → rc=2, "Failed to spawn: dotfiles-setup"
+```
+
+Both layers had to be anchored. A fix that changed only `settings.json` would
+have looked correct and still failed open.
+
+## 5. Why nothing caught it
+
+`hook_selfcheck.check_pretooluse_endtoend` — the ship/land gate that exists
+precisely to drive the wired guard end-to-end — passed `cwd=project_root` on
+**both** of its arms. It could only ever exercise the one directory in which
+the relative paths happen to resolve. A probe with no arm outside its bound.
+
+## 6. Fixes landed
+
+| # | Fix |
+|---|---|
+| 1 | Every hook command in `.claude/settings.json` anchored to `${CLAUDE_PROJECT_DIR:-.}` (all 5, not just the guard — the defect is a property of any unanchored command) |
+| 2 | `scripts/pretooluse-guard.sh` resolves `$ROOT` from `$CLAUDE_PROJECT_DIR` (falling back to its own `BASH_SOURCE` dirname) and threads it into `uv run --project "$ROOT/python"` |
+| 3 | **Every fail-open is recorded** to `~/.local/state/dotfiles/guard-fail-open.log`, surfaced as a section in the command-audit report |
+| 4 | `hook_selfcheck._check_offroot_arm` drives the real wrapper from a foreign cwd, with a **scrubbed env** |
+| 5 | `hook_selfcheck._unanchored_hooks` rejects any unanchored hook command, reading the whole hook block so a hook added later is covered |
+| 6 | The `hk` rule split so `since` dates coverage (`_V1B`) |
+| 7 | `workflow.mise-tasks-enforcement` + `workflow.command-audit-wiring` contracts updated to assert the anchoring |
+
+### The control arm that was broken first
+
+The off-root arm initially **passed with the defect reintroduced**. Cause: it
+inherited `os.environ` wholesale, and since the selfcheck itself runs under
+`uv run --project python`, the child already had the project venv on `PATH` —
+so `dotfiles-setup` resolved no matter what the wrapper asked for.
+
+**A probe that inherits a pre-resolved answer cannot observe the resolution it
+is testing.** Fixed by dropping `VIRTUAL_ENV`/`UV_PROJECT_ENVIRONMENT` and every
+`PATH` entry inside the project. Re-armed, it fails with the real error.
+
+Verified FAIL arms after the fix:
+
+| reintroduced bug | caught by | rc |
+|---|---|---|
+| `settings.json` back to bare relative path | `settings-wiring` | 1 |
+| wrapper's `uv --project` back to relative | `pretooluse-endtoend` (off-root arm) | 1 |
+| `$CLAUDE_PROJECT_DIR` removed, dirname fallback kept | *(correctly still green — the fallback is a real second anchor)* | 0 |
+
+## 7. What this says about the epic
+
+#354's thesis is "our setup is asserted, never measured". This is a textbook
+instance, with a twist worth keeping: the assertion was not merely unmeasured,
+it was **measured wrongly in both directions at once** — over-reporting 3
+bypasses that never happened while under-reporting 125 that did — and the two
+errors were independent. A number being non-zero is not evidence it is right.
+
+The durable rule: **a fail-open that nothing counts is indistinguishable from
+enforcement.**
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the guard,
+  its wrapper, the audit, and the settings wiring under investigation.
+- [ray-manaloto/knowledge-base](https://github.com/ray-manaloto/knowledge-base) —
+  read-only: the sibling clone whose cwd triggered the fail-open, and whose
+  `.claude/settings.json` already used the portable `${CLAUDE_PROJECT_DIR:-.}`
+  idiom this repo was missing.
+
+[#343]: https://github.com/ray-manaloto/dotfiles/issues/343

--- a/python/src/dotfiles_setup/bash_budget.py
+++ b/python/src/dotfiles_setup/bash_budget.py
@@ -89,8 +89,13 @@ ALLOWLIST: dict[str, BashAllowance] = {
         74, "hk/mise precondition wrapper — starts Docker Desktop if the daemon is down"
     ),
     "scripts/pretooluse-guard.sh": BashAllowance(
-        25,
-        "fail-open shim — execs `dotfiles-setup hook pretooluse` (the guard is Python)",
+        42,
+        "fail-open shim — runs `dotfiles-setup hook pretooluse` (the guard is "
+        "Python). 25 -> 42 for #343: the shim must anchor every path to "
+        "$CLAUDE_PROJECT_DIR (it runs in the session's cwd, not the repo) and "
+        "must RECORD each fail-open. Both have to be bash — they are the layer "
+        "that runs when Python cannot, so a Python fail-open counter could "
+        "never observe the case it exists to count",
     ),
     "scripts/graphify-hook-guard.sh": BashAllowance(
         30,

--- a/python/src/dotfiles_setup/command_audit.py
+++ b/python/src/dotfiles_setup/command_audit.py
@@ -551,7 +551,74 @@ def _table(groups: list[tuple[str, int, str]], label: str) -> list[str]:
     ]
 
 
-def render_report(result: AuditResult) -> str:
+#: Where `scripts/pretooluse-guard.sh` records a fail-open. Per-user state, not
+#: per-repo: the wrapper may fail open precisely because the repo's toolchain is
+#: not resolvable, so the record cannot depend on it.
+FAIL_OPEN_LOG = Path.home() / ".local" / "state" / "dotfiles" / "guard-fail-open.log"
+
+#: Tab-separated fields the wrapper writes: timestamp, reason, cwd. A short line
+#: is a partial write, not a fail-open — skip it rather than count it wrongly.
+_FAIL_OPEN_FIELDS = 3
+
+
+def fail_open_summary(log: Path | None = None) -> tuple[int, dict[str, int], str]:
+    """``(total, reason -> count, most-recent timestamp)`` from the fail-open log.
+
+    The guard is documented as covering every Bash call, and it exits 0 whether
+    it decided or merely could not run — so without this record the two are
+    indistinguishable from the outside. That is how #343's 125 unchecked
+    commands went unnoticed: nothing counted the times the guard was absent.
+
+    A missing log is ``(0, {}, "")`` — the guard has never failed open on this
+    host, which is the expected state, not an error.
+    """
+    path = log if log is not None else FAIL_OPEN_LOG
+    try:
+        raw = path.read_text(errors="replace")
+    except OSError:
+        return 0, {}, ""
+    reasons: Counter[str] = Counter()
+    latest = ""
+    total = 0
+    for line in raw.splitlines():
+        parts = line.split("\t")
+        if len(parts) < _FAIL_OPEN_FIELDS:
+            continue
+        timestamp, reason = parts[0], parts[1]
+        total += 1
+        reasons[reason] += 1
+        latest = max(latest, timestamp)
+    return total, dict(reasons.most_common()), latest
+
+
+def _fail_open_section(log: Path | None) -> list[str]:
+    """The report's guard-availability section."""
+    total, reasons, latest = fail_open_summary(log)
+    lines = [
+        "## Guard fail-opens (times the guard could not run at all)",
+        "",
+        "The wrapper exits 0 — allowing the call — when it cannot reach its "
+        "interpreter or the guard errors. That is deliberate (a cold web "
+        "session must not be bricked), but an UNCOUNTED fail-open is "
+        "indistinguishable from enforcement. See `.claude/rules/"
+        "mise-tasks-only.md` and issue #343.",
+        "",
+    ]
+    if not total:
+        lines += ["_None recorded — the guard ran every time it was invoked._", ""]
+        return lines
+    lines += [
+        f"**{total}** recorded, most recent `{latest}`.",
+        "",
+        "| count | reason |",
+        "|---:|---|",
+        *(f"| {n} | `{reason}` |" for reason, n in reasons.items()),
+        "",
+    ]
+    return lines
+
+
+def render_report(result: AuditResult, *, fail_open_log: Path | None = None) -> str:
     """A frequency-ranked markdown report for human review of the refine loop."""
     c = result.counts
     lines = [
@@ -597,6 +664,7 @@ def render_report(result: AuditResult) -> str:
             "",
             *_table(result.blocked_groups, "rule"),
         ]
+    lines += _fail_open_section(fail_open_log)
     lines += [
         "## One-off culprits (candidates for a mise task + python function)",
         "",

--- a/python/src/dotfiles_setup/hook_guard.py
+++ b/python/src/dotfiles_setup/hook_guard.py
@@ -125,6 +125,15 @@ _V4 = "2026-07-23"
 # existed, `gh pr merge --auto` on a Renovate PR could only be redirected to
 # `land`, which refuses an OPEN PR.
 _V5 = "2026-07-27"
+# `hk run check` came under the guard on 2026-07-18 (68f28c9, #308), when
+# `mise run lint` switched to the read-only `hk run check --all`. It was folded
+# into the EXISTING `hk run pre-commit` rule by widening its pattern to
+# `(?:pre-commit|check)` while leaving `since` at _V1 — so the audit back-dated
+# 11 days of new coverage onto history that predates it, and reported three
+# 2026-07-17 `hk run check` calls as guard bypasses (#343). They were allowed,
+# correctly, by the guard of the day. Hence its own cutoff: a pattern widened to
+# cover a NEW command shape is a NEW rule, whatever it is spelled next to.
+_V1B = "2026-07-18"
 # The hook-suppression rules landed 2026-07-27 with `no_commit_to_branch` (#400).
 # They are the ONLY layer that can see a bypass: git decides not to run a hook
 # BEFORE the hook exists as a process, so no pre-commit or pre-push hook can
@@ -185,12 +194,23 @@ _RULES: tuple[Rule, ...] = (
         _V1,
     ),
     Rule(
-        "hk run pre-commit/check",
-        re.compile(_CMD + r"hk\s+run\s+(?:pre-commit|check)\b"),
+        "hk run pre-commit",
+        re.compile(_CMD + r"hk\s+run\s+pre-commit\b"),
         "Use `mise run lint` (read-only gate, ≡ CI) — it wraps hk in a hard "
         "timeout (hk has none) with log-tail diagnostics. To apply fixes use "
         "`mise run fmt`. See .claude/rules/long-running-command-hangs.md.",
         _V1,
+    ),
+    # Split from the rule above rather than spelled as one `(?:pre-commit|check)`
+    # alternation: the two shapes came under the guard 11 days apart, and a
+    # single Rule can carry only one `since`. See _V1B.
+    Rule(
+        "hk run check",
+        re.compile(_CMD + r"hk\s+run\s+check\b"),
+        "Use `mise run lint` (read-only gate, ≡ CI) — it wraps hk in a hard "
+        "timeout (hk has none) with log-tail diagnostics. To apply fixes use "
+        "`mise run fmt`. See .claude/rules/long-running-command-hangs.md.",
+        _V1B,
     ),
     Rule(
         "devcontainer up",

--- a/python/src/dotfiles_setup/hook_selfcheck.py
+++ b/python/src/dotfiles_setup/hook_selfcheck.py
@@ -221,17 +221,27 @@ def check_pretooluse_endtoend(project_root: Path) -> list[str]:
 def _offroot_env(project_root: Path) -> dict[str, str]:
     """The hook's environment with this process's own venv resolution removed.
 
-    Drops ``VIRTUAL_ENV``/``UV_PROJECT_ENVIRONMENT`` and every ``PATH`` entry
-    inside the project, so the wrapper must resolve the guard from
-    ``$CLAUDE_PROJECT_DIR`` rather than from a venv it inherited. See
-    :func:`check_offroot_arm` for what this bought.
+    Drops ``VIRTUAL_ENV`` and every ``PATH`` entry inside the project, so the
+    wrapper must resolve the guard through ``$CLAUDE_PROJECT_DIR`` rather than
+    through a venv it happened to inherit. See :func:`check_offroot_arm`.
+
+    ``UV_PROJECT_ENVIRONMENT`` is deliberately PRESERVED, and that is a
+    correction, not an oversight. Stripping it broke the devcontainer, where
+    ``devcontainer.json`` sets it to ``/home/$USER/.venvs/dotfiles-python`` on
+    purpose: without it uv falls back to ``<project>/.venv`` inside the
+    bind-mounted workspace and dies on the host's stale copy (``failed to remove
+    directory python/.venv/lib: Directory not empty``). It is environment
+    CONFIGURATION the container requires, not an answer leaked from this
+    process — the distinction the first version got wrong, and only the
+    in-container `sync-full` gate caught it.
+
+    Bound worth stating: where that variable already points at a ready venv
+    holding ``dotfiles-setup``, this arm verifies the wrapper is REACHABLE
+    off-root rather than that it re-resolves its project. The resolution half is
+    covered on the host, and statically everywhere by :func:`_unanchored_hooks`.
     """
     root = str(project_root)
-    env = {
-        k: v
-        for k, v in os.environ.items()
-        if k not in ("VIRTUAL_ENV", "UV_PROJECT_ENVIRONMENT")
-    }
+    env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
     env["PATH"] = os.pathsep.join(
         p for p in env.get("PATH", "").split(os.pathsep) if p and not p.startswith(root)
     )

--- a/python/src/dotfiles_setup/hook_selfcheck.py
+++ b/python/src/dotfiles_setup/hook_selfcheck.py
@@ -28,14 +28,13 @@ and returns 0 iff every check passed.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
-from typing import TYPE_CHECKING
+import tempfile
+from pathlib import Path
 
 from dotfiles_setup import hook_guard
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 _PROBE_TIMEOUT_S = 60.0
 
@@ -46,9 +45,10 @@ _DENIED_SAMPLE = "gh pr create --fill"
 _DENIED_HINT = "mise run ship"
 _ALLOWED_SAMPLE = "git status --porcelain"
 
-_PRETOOLUSE_WRAPPER = "scripts/pretooluse-guard.sh"
+#: Public: the tests drive this wrapper and the off-root arm by name.
+PRETOOLUSE_WRAPPER = "scripts/pretooluse-guard.sh"
 _WEB_SETUP = "scripts/web-setup.sh"
-_HOOK_SCRIPTS = (_PRETOOLUSE_WRAPPER, _WEB_SETUP)
+_HOOK_SCRIPTS = (PRETOOLUSE_WRAPPER, _WEB_SETUP)
 
 # Each settings.json hook event -> (command substrings that MUST appear in its
 # wired command(s), required matcher or None). Keeps the project hooks from
@@ -62,14 +62,27 @@ _HOOK_SCRIPTS = (_PRETOOLUSE_WRAPPER, _WEB_SETUP)
 # which would put a transcript scan on the per-turn path.
 _SESSION_END_REPORT = ".agent/command-audit.md"
 _SETTINGS_WIRING: tuple[tuple[str, tuple[str, ...], str | None], ...] = (
-    ("PreToolUse", (_PRETOOLUSE_WRAPPER,), "Bash"),
+    ("PreToolUse", (PRETOOLUSE_WRAPPER,), "Bash"),
     ("SessionStart", (_WEB_SETUP, "CLAUDE_CODE_REMOTE"), None),
-    ("SessionEnd", ("mise run command-audit", _SESSION_END_REPORT), None),
+    ("SessionEnd", ("run command-audit", _SESSION_END_REPORT), None),
 )
+
+# Claude Code runs hooks "in the current directory", not the project root, and
+# exports ${CLAUDE_PROJECT_DIR} so a hook can find its own repo anyway. A hook
+# command that names a bare relative path therefore resolves against whatever
+# directory the session happens to be in — and silently fails open there, since
+# a non-zero non-2 PreToolUse exit is a NON-BLOCKING error that lets the tool
+# call proceed. That is #343: 125 denied Bash calls executed unchecked while the
+# cwd was a sibling repo. Every wired command must anchor its paths.
+_PROJECT_DIR_ANCHOR = "CLAUDE_PROJECT_DIR"
 
 
 def _run(
-    cmd: list[str], *, stdin: str | None = None, cwd: Path | None = None
+    cmd: list[str],
+    *,
+    stdin: str | None = None,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     try:
         return subprocess.run(
@@ -80,6 +93,7 @@ def _run(
             check=False,
             timeout=_PROBE_TIMEOUT_S,
             cwd=cwd,
+            env=env,
         )
     except subprocess.TimeoutExpired:
         return subprocess.CompletedProcess(cmd, 124, "", "probe timed out")
@@ -129,6 +143,32 @@ def check_settings_wiring(settings_path: Path) -> list[str]:
                 f"settings.json {event} hook must be scoped with matcher "
                 f"{matcher!r} (tool events fire on every tool otherwise)"
             )
+    failures.extend(_unanchored_hooks(settings))
+    return failures
+
+
+def _unanchored_hooks(settings: dict) -> list[str]:
+    """Every wired hook command must anchor its paths to ``$CLAUDE_PROJECT_DIR``.
+
+    Hooks run in the session's CURRENT directory, so a bare relative path is
+    resolved against a sibling repo the moment the session works in one — and
+    the guard then fails open silently (#343). Checking the whole hook block
+    rather than a named list is deliberate: the defect is a property of *any*
+    unanchored command, so a hook added later must not be able to reintroduce
+    it unnoticed.
+    """
+    failures: list[str] = []
+    for event, entries in settings.get("hooks", {}).items():
+        if not isinstance(entries, list):
+            continue
+        for matcher, command in _event_entries(settings, str(event)):
+            if _PROJECT_DIR_ANCHOR in command:
+                continue
+            failures.append(
+                f"settings.json {event} hook (matcher={matcher or '-'!r}) does "
+                f"not anchor its paths to ${_PROJECT_DIR_ANCHOR} and will "
+                f"resolve against whatever cwd the session is in: {command!r}"
+            )
     return failures
 
 
@@ -140,7 +180,7 @@ def check_pretooluse_endtoend(project_root: Path) -> list[str]:
     pretooluse`` -> :func:`hook_guard.decide`), not just ``decide`` alone.
     """
     failures: list[str] = []
-    wrapper = str(project_root / _PRETOOLUSE_WRAPPER)
+    wrapper = str(project_root / PRETOOLUSE_WRAPPER)
 
     denied = _run(
         ["bash", wrapper], stdin=_hook_payload(_DENIED_SAMPLE), cwd=project_root
@@ -174,7 +214,73 @@ def check_pretooluse_endtoend(project_root: Path) -> list[str]:
             f"pretooluse wrapper was not silent on the allowed command "
             f"{_ALLOWED_SAMPLE!r}: {allowed.stdout.strip()!r}"
         )
+    failures.extend(check_offroot_arm(project_root, wrapper))
     return failures
+
+
+def _offroot_env(project_root: Path) -> dict[str, str]:
+    """The hook's environment with this process's own venv resolution removed.
+
+    Drops ``VIRTUAL_ENV``/``UV_PROJECT_ENVIRONMENT`` and every ``PATH`` entry
+    inside the project, so the wrapper must resolve the guard from
+    ``$CLAUDE_PROJECT_DIR`` rather than from a venv it inherited. See
+    :func:`check_offroot_arm` for what this bought.
+    """
+    root = str(project_root)
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if k not in ("VIRTUAL_ENV", "UV_PROJECT_ENVIRONMENT")
+    }
+    env["PATH"] = os.pathsep.join(
+        p for p in env.get("PATH", "").split(os.pathsep) if p and not p.startswith(root)
+    )
+    env[_PROJECT_DIR_ANCHOR] = root
+    return env
+
+
+def check_offroot_arm(project_root: Path, wrapper: str) -> list[str]:
+    """The same deny, driven from a cwd that is NOT the project root (#343).
+
+    Both arms above run with ``cwd=project_root``, so they could not observe the
+    defect that let 125 denied commands through: hooks execute in the session's
+    current directory, and every relative path in the chain — settings.json's
+    script path AND the wrapper's own ``uv run --project python`` — resolved
+    against a sibling repo instead. Measured before the fix: rc=127 from the
+    script path, rc=2 from the uv project. Both exit non-zero-non-2, which
+    PreToolUse treats as a non-blocking error, so the call proceeded.
+
+    A throwaway directory is the foreign cwd rather than a sibling clone: the
+    arm must hold on any machine, including CI, where no second repo exists.
+
+    THE ENVIRONMENT IS SCRUBBED, and that is what makes the arm able to fail.
+    The first version inherited ``os.environ`` wholesale — and since the
+    selfcheck itself runs under ``uv run --project python``, the child already
+    had the project's venv on ``PATH``. So ``dotfiles-setup`` resolved no matter
+    what the wrapper asked for, and the probe passed with the defect
+    reintroduced. A probe that inherits a pre-resolved answer cannot observe the
+    resolution it is testing.
+    """
+    with tempfile.TemporaryDirectory() as foreign:
+        result = _run(
+            ["bash", wrapper],
+            stdin=_hook_payload(_DENIED_SAMPLE),
+            cwd=Path(foreign),
+            env=_offroot_env(project_root),
+        )
+    if result.returncode != 0:
+        return [
+            f"pretooluse wrapper exited {result.returncode} when run from a "
+            f"foreign cwd — it must resolve via ${_PROJECT_DIR_ANCHOR}: "
+            f"{result.stderr.strip()}"
+        ]
+    if '"permissionDecision": "deny"' not in result.stdout:
+        return [
+            f"pretooluse wrapper did not DENY {_DENIED_SAMPLE!r} when run from "
+            f"a foreign cwd — the guard fails OPEN off-root (#343). "
+            f"stdout={result.stdout.strip()!r} stderr={result.stderr.strip()!r}"
+        ]
+    return []
 
 
 def check_guard_decisions() -> list[str]:

--- a/python/src/dotfiles_setup/token_audit.py
+++ b/python/src/dotfiles_setup/token_audit.py
@@ -136,11 +136,6 @@ AMBIGUITY_ALLOWED: dict[tuple[str, str, str], str] = {
     (
         "workflow.command-audit-wiring",
         ".claude/rules/mise-tasks-only.md",
-        "mise run command-audit`",
-    ): "prose: a rule doc naturally names its task more than once",
-    (
-        "workflow.command-audit-wiring",
-        ".claude/rules/mise-tasks-only.md",
         "SessionEnd`",
     ): "prose: the hook event, named where it is chosen and where it is justified",
     (

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -1105,10 +1105,12 @@ paths = [
     ".claude/settings.json",
     "scripts/pretooluse-guard.sh",
     "python/src/dotfiles_setup/hook_guard.py",
+    "python/src/dotfiles_setup/hook_selfcheck.py",
     "tests/test_hook_guard.py",
+    "tests/test_hook_selfcheck.py",
     ".claude/rules/mise-tasks-only.md",
 ]
-per_path_tokens = { ".claude/settings.json" = ["scripts/pretooluse-guard.sh"], "scripts/pretooluse-guard.sh" = ["dotfiles-setup hook pretooluse\n"], "python/src/dotfiles_setup/hook_guard.py" = ['def _inert_masked(', "_inert_masked(command)", '"permissionDecision": "deny"'], "tests/test_hook_guard.py" = ['def test_separators_inside_inert_spans_do_not_anchor(', 'def test_real_npx_denial_was_a_true_positive(', 'def test_inert_span_redaction_never_costs_a_true_positive(', 'def test_masking_trades_the_incidental_eval_catch('] }
+per_path_tokens = { ".claude/settings.json" = ['bash \"${CLAUDE_PROJECT_DIR:-.}/scripts/pretooluse-guard.sh\"'], "scripts/pretooluse-guard.sh" = ['uv run --project "$ROOT/python" dotfiles-setup hook pretooluse', 'ROOT="${CLAUDE_PROJECT_DIR:-}"', "fail_open() {"], "python/src/dotfiles_setup/hook_guard.py" = ['def _inert_masked(', "_inert_masked(command)", '"permissionDecision": "deny"', '_V1B = "2026-07-18"'], "python/src/dotfiles_setup/hook_selfcheck.py" = ['def check_offroot_arm(', 'def _unanchored_hooks(', 'def _offroot_env('], "tests/test_hook_guard.py" = ['def test_separators_inside_inert_spans_do_not_anchor(', 'def test_real_npx_denial_was_a_true_positive(', 'def test_inert_span_redaction_never_costs_a_true_positive(', 'def test_masking_trades_the_incidental_eval_catch(', 'def test_hk_run_check_before_its_rule_is_history_not_a_bypass(', 'def test_hk_run_check_after_its_rule_is_a_bypass('], "tests/test_hook_selfcheck.py" = ['def test_unanchored_hook_command_fails(', 'def test_real_wrapper_denies_from_a_foreign_cwd(', 'def test_a_newly_added_hook_must_also_be_anchored('] }
 tokens = [
     'dotfiles-setup hook pretooluse`',
     'def pretooluse_main(',
@@ -1469,7 +1471,7 @@ paths = [
     "tests/test_hook_guard.py",
     ".claude/rules/mise-tasks-only.md",
 ]
-per_path_tokens = { "mise.toml" = ["[tasks.command-audit]", "dotfiles-setup command-audit'"], "python/src/dotfiles_setup/command_audit.py" = ['def command_audit_main(', 'def classify(', 'def iter_bash_commands(', 'def write_report(', 'def _executed_ids('], "python/src/dotfiles_setup/hook_guard.py" = ['class Rule:', "since: str", 'def match('], "python/src/dotfiles_setup/main.py" = ['"command-audit",', '"command-audit": lambda', "command_audit_parser.add_argument(\n        \"--output\","], "python/src/dotfiles_setup/hook_selfcheck.py" = ['SessionEnd"', '_SESSION_END_REPORT ='], ".claude/settings.json" = ['SessionEnd"', "mise run command-audit -- --output .agent/command-audit.md"], ".gitignore" = [".agent/command-audit.md"], "tests/test_command_audit.py" = ['def test_main_output_writes_file_instead_of_stdout(', 'def test_iter_bash_commands_pairs_results_to_attempts('], "tests/test_hook_guard.py" = ['def test_every_rule_carries_a_usable_since_date('], ".claude/rules/mise-tasks-only.md" = ['mise run command-audit`', 'SessionEnd`', "Give it a `since`"] }
+per_path_tokens = { "mise.toml" = ["[tasks.command-audit]", "dotfiles-setup command-audit'"], "python/src/dotfiles_setup/command_audit.py" = ['def command_audit_main(', 'def classify(', 'def iter_bash_commands(', 'def write_report(', 'def _executed_ids('], "python/src/dotfiles_setup/hook_guard.py" = ['class Rule:', "since: str", 'def match('], "python/src/dotfiles_setup/main.py" = ['"command-audit",', '"command-audit": lambda', "command_audit_parser.add_argument(\n        \"--output\","], "python/src/dotfiles_setup/hook_selfcheck.py" = ['SessionEnd"', '_SESSION_END_REPORT ='], ".claude/settings.json" = ['SessionEnd"', 'run command-audit -- --output \"${CLAUDE_PROJECT_DIR:-.}/.agent/command-audit.md\"'], ".gitignore" = [".agent/command-audit.md"], "tests/test_command_audit.py" = ['def test_main_output_writes_file_instead_of_stdout(', 'def test_iter_bash_commands_pairs_results_to_attempts('], "tests/test_hook_guard.py" = ['def test_every_rule_carries_a_usable_since_date('], ".claude/rules/mise-tasks-only.md" = ['mise run command-audit`', 'SessionEnd`', "Give it a `since`"] }
 tokens = [
     "dotfiles-setup command-audit'",
     'def command_audit_main(',

--- a/scripts/pretooluse-guard.sh
+++ b/scripts/pretooluse-guard.sh
@@ -3,23 +3,40 @@
 # PreToolUse guard (belt-and-braces for the web-setup.sh SessionStart bootstrap).
 #
 # Runs the real guard when its interpreter (Python >=3.14 via uv) is present;
-# FAILS OPEN (exit 0 = allow the Bash call) only when that interpreter is
-# ABSENT — so a cold Claude-web session, before web-setup.sh has installed the
-# toolchain, is not bricked by every Bash call being denied.
+# FAILS OPEN (exit 0 = allow the Bash call) when it cannot run — so a cold
+# Claude-web session, before web-setup.sh has installed the toolchain, is not
+# bricked by every Bash call being denied.
 #
-# This aligns actual behavior with the documented intent in
-# .claude/rules/mise-tasks-only.md: "The hook fails OPEN on its own errors (a
-# crashed guard must not brick every Bash call)." Enforcement is UNCHANGED
-# everywhere the toolchain is present (devcontainer, CI, a bootstrapped web
-# session), where the real guard runs exactly as before. The only environments
-# that now fail open are precisely the ones where the guard could not run at all
-# — a strict improvement over fail-closed, never a bypass where enforcement was
-# previously effective.
+# EVERY PATH IS ANCHORED TO THE PROJECT ROOT, NOT THE CWD (#343). Claude Code
+# runs hooks "in the current directory", so in a session that also works in a
+# sibling repo a relative path resolves against THAT repo. Measured: 125 Bash
+# calls this guard denies executed unchecked while the cwd was the
+# knowledge-base clone. Anchoring settings.json's script path alone is NOT
+# enough — `uv run --project python` is relative too and fails rc=2 off-root,
+# so $ROOT is threaded into the exec line as well.
+#
+# AND EVERY FAIL-OPEN IS COUNTED. A fail-open nobody records is
+# indistinguishable from enforcement — which is exactly how this went unseen:
+# the guard was documented as covering every Bash call while it silently
+# allowed them. See .claude/rules/mise-tasks-only.md and issue #343.
 set -uo pipefail
 
-if ! command -v uv >/dev/null 2>&1 || ! uv python find '>=3.14' >/dev/null 2>&1; then
-  # The interpreter the guard needs is unavailable — allow, do not brick.
+ROOT="${CLAUDE_PROJECT_DIR:-}"
+[ -n "$ROOT" ] || ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG="${DOTFILES_GUARD_FAILOPEN_LOG:-$HOME/.local/state/dotfiles/guard-fail-open.log}"
+
+# Record, then allow. Never let bookkeeping failure turn a fail-open into a
+# brick: the exit 0 stands whether or not the line was written.
+fail_open() {
+  mkdir -p -- "$(dirname -- "$LOG")" 2>/dev/null &&
+    printf '%s\t%s\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" "$PWD" >>"$LOG" 2>/dev/null
   exit 0
+}
+
+if ! command -v uv >/dev/null 2>&1 || ! uv python find '>=3.14' >/dev/null 2>&1; then
+  fail_open "interpreter-absent"
 fi
 
-exec uv run --project python dotfiles-setup hook pretooluse
+decision="$(uv run --project "$ROOT/python" dotfiles-setup hook pretooluse)" ||
+  fail_open "guard-error-rc=$?"
+printf '%s' "$decision"

--- a/tests/test_hook_guard.py
+++ b/tests/test_hook_guard.py
@@ -12,7 +12,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
 
 import pytest
-from dotfiles_setup import hook_guard
+from dotfiles_setup import command_audit, hook_guard
 
 
 @pytest.mark.parametrize(
@@ -615,6 +615,57 @@ def test_rule_names_are_unique_and_nonempty() -> None:
     names = [r.name for r in hook_guard.rules()]
     assert all(names)
     assert len(set(names)) == len(names)
+
+
+# --- #343: `since` dates COVERAGE, not the Rule object ----------------------
+#
+# `hk run check` was folded into the existing `hk run pre-commit` rule on
+# 2026-07-18 (68f28c9, #308) by widening its pattern to `(?:pre-commit|check)`
+# while leaving `since` at 2026-07-07. The audit then back-dated 11 days of new
+# coverage onto history that predates it and reported three 2026-07-17 calls as
+# guard bypasses. They were correctly ALLOWED by the guard of the day.
+
+
+@pytest.mark.parametrize(
+    ("command", "expected_name", "expected_since"),
+    [
+        ("hk run pre-commit --all", "hk run pre-commit", "2026-07-07"),
+        ("hk run check --all", "hk run check", "2026-07-18"),
+    ],
+)
+def test_hk_shapes_carry_the_date_they_actually_landed(
+    command: str, expected_name: str, expected_since: str
+) -> None:
+    rule = hook_guard.match(command)
+    assert rule is not None, command
+    assert rule.name == expected_name
+    assert rule.since == expected_since
+
+
+def test_hk_run_check_before_its_rule_is_history_not_a_bypass() -> None:
+    """The exact #343 shape: a 2026-07-17 `hk run check` must read as pre_rule.
+
+    Control arm below pins the opposite direction, so this is not a check that
+    can only pass.
+    """
+    before = command_audit.BashCommand(
+        "hk run check --all --plan",
+        session="s",
+        timestamp="2026-07-17T03:16:54.821Z",
+        executed=True,
+    )
+    assert command_audit.classify(before) == "pre_rule"
+
+
+def test_hk_run_check_after_its_rule_is_a_bypass() -> None:
+    """Control arm: the same command AFTER 2026-07-18 must still alarm."""
+    after = command_audit.BashCommand(
+        "hk run check --all --plan",
+        session="s",
+        timestamp="2026-07-19T03:16:54.821Z",
+        executed=True,
+    )
+    assert command_audit.classify(after) == "bypass"
 
 
 def test_match_returns_the_rule_behind_the_reason() -> None:

--- a/tests/test_hook_selfcheck.py
+++ b/tests/test_hook_selfcheck.py
@@ -13,6 +13,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
 
 from dotfiles_setup import hook_selfcheck
@@ -42,21 +44,33 @@ def _hook(matcher: str | None, command: str) -> dict:
     return entry
 
 
+_ANCHOR = '"${CLAUDE_PROJECT_DIR:-.}"'
+
+
 def _full_settings() -> dict:
-    """A minimally-complete, passing settings shape for tampering in tests."""
+    """A minimally-complete, passing settings shape for tampering in tests.
+
+    Every command anchors its paths to ``$CLAUDE_PROJECT_DIR`` — hooks run in
+    the session's cwd, so the unanchored form silently fails open in a
+    cross-repo session (#343).
+    """
     return {
         "hooks": {
-            "PreToolUse": [_hook("Bash", "bash scripts/pretooluse-guard.sh")],
+            "PreToolUse": [
+                _hook("Bash", f"bash {_ANCHOR}/scripts/pretooluse-guard.sh")
+            ],
             "SessionStart": [
                 _hook(
                     "startup|resume",
                     'if [ "$CLAUDE_CODE_REMOTE" = "true" ]; then '
-                    "bash scripts/web-setup.sh; fi",
+                    f"bash {_ANCHOR}/scripts/web-setup.sh; fi",
                 )
             ],
             "SessionEnd": [
                 _hook(
-                    None, "mise run command-audit -- --output .agent/command-audit.md"
+                    None,
+                    f"mise -C {_ANCHOR} run command-audit -- "
+                    f"--output {_ANCHOR}/.agent/command-audit.md",
                 )
             ],
         }
@@ -114,3 +128,54 @@ def test_unreadable_settings_fails(tmp_path: Path) -> None:
 def test_selfcheck_main_passes_on_real_repo() -> None:
     """End-to-end: drives the real wrappers; the ship/land gate itself."""
     assert hook_selfcheck.hook_selfcheck_main(_REPO) == 0
+
+
+# --- #343: hooks run in the session's cwd, not the project root -------------
+#
+# A hook command naming a bare relative path resolves against whatever
+# directory the session happens to be in. Measured: 125 Bash calls the guard
+# denies executed unchecked while the cwd was a sibling repo, because
+# `bash scripts/pretooluse-guard.sh` was not there (rc=127) and a non-zero
+# non-2 PreToolUse exit is a NON-BLOCKING error that lets the call proceed.
+
+
+@pytest.mark.parametrize(
+    "event",
+    ["PreToolUse", "SessionStart", "SessionEnd"],
+)
+def test_unanchored_hook_command_fails(tmp_path: Path, event: str) -> None:
+    """The FAIL direction: strip the anchor off any event and it must go red."""
+    settings = _full_settings()
+    for entry in settings["hooks"][event]:
+        for hook in entry["hooks"]:
+            hook["command"] = hook["command"].replace(_ANCHOR, ".")
+    failures = _wiring(tmp_path, settings)
+    assert any(event in f and "CLAUDE_PROJECT_DIR" in f for f in failures), failures
+
+
+def test_anchored_hook_command_passes(tmp_path: Path) -> None:
+    """The PASS direction, so the check above is not merely always-red."""
+    assert _wiring(tmp_path, _full_settings()) == []
+
+
+def test_a_newly_added_hook_must_also_be_anchored(tmp_path: Path) -> None:
+    """The check reads the whole hook block, not a fixed list of known events.
+
+    A hook added later is the likeliest way this defect returns, so it must be
+    covered without anyone remembering to extend a list.
+    """
+    settings = _full_settings()
+    settings["hooks"]["PostToolUse"] = [_hook("Bash", "bash scripts/something-new.sh")]
+    failures = _wiring(tmp_path, settings)
+    assert any("PostToolUse" in f and "CLAUDE_PROJECT_DIR" in f for f in failures)
+
+
+def test_real_wrapper_denies_from_a_foreign_cwd() -> None:
+    """The arm the old end-to-end check could not run: deny with cwd != repo.
+
+    Both pre-existing arms passed ``cwd=project_root``, which is precisely why
+    the defect survived — the probe could only ever exercise the one directory
+    where the relative paths happened to resolve.
+    """
+    wrapper = str(_REPO / hook_selfcheck.PRETOOLUSE_WRAPPER)
+    assert hook_selfcheck.check_offroot_arm(_REPO, wrapper) == []


### PR DESCRIPTION
- **fix(guard): the PreToolUse guard failed open for every cross-repo session (#343)**
- **fix(guard): keep UV_PROJECT_ENVIRONMENT in the off-root arm's env (#343)**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787816562&installation_model_id=429246&pr_number=406&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F406&signature=e4a160c35bfc20adbe38fb7b2f036732d7754e800081e083d85c04d0da8c70f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command protection when working from a different directory or project location.
  * Hook failures are now recorded and surfaced in audit reports instead of remaining hidden.
  * Corrected command-history classification to distinguish legitimate pre-rule activity from policy bypasses.

* **Documentation**
  * Clarified enforcement guidance, provenance handling, coverage dates, auditing criteria, and extension procedures.

* **Tests**
  * Added verification for anchored hook commands and protection from foreign working directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->