### PR TITLE
fix(devcontainer): install tokei from conda, not a cargo source build (#380)

### DIFF
--- a/docs/specs/graphify-autonomous-queue.md
+++ b/docs/specs/graphify-autonomous-queue.md
@@ -439,9 +439,11 @@ into the handoff, `/clear`, and let the SessionStart hook re-inject this file.
 5. Phase 0 is a triage workflow that reports the DAG **for approval** before any
    build. Its first check is the §5a version-skew gate.
 
-**Known tax:** a branch touching `mise.toml` makes ship's `sync-full` gate run
-`mise install`, which currently compiles `tokei` from source — ~25 minutes, and
-it looks like a hang. Tracked as **#380**.
+**Known tax — FIXED (#380).** A branch touching `mise.toml` makes ship's
+`sync-full` gate run `mise install`. That used to compile `tokei` from source
+(~25 minutes, and it looked like a hang — once it wedged outright, aborting
+every overlay tool declared after it). The overlay now pins the `conda:`
+backend, so the whole eager install completes in ~41s.
 
 ## GitHub repos touched
 

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -28,7 +28,13 @@ btop = "latest"
 "conda:procs" = "latest"
 "conda:ncdu" = "latest"
 dust = "latest"
-tokei = "latest"
+# conda:, not bare `tokei` (#380): tokei ships NO release assets since v12.1.2
+# (2021), so mise's registry defaults it to `cargo:` — a source build that took
+# ~25 min or wedged indefinitely, aborting every overlay tool after it. aqua:
+# and ubi: cannot help (aqua declares it a cargo-type package; ubi finds no
+# asset). conda-forge builds it: 14.0.0 installs in ~4s. Keep the `conda:`
+# prefix on any bump.
+"conda:tokei" = "latest"
 hexyl = "latest"
 "conda:hyperfine" = "latest"
 # Terminal & shell UX


### PR DESCRIPTION
The overlay declared a bare `tokei = "latest"`. mise's registry defaults
tokei to `cargo:` — because tokei ships **no release assets** on v13.0.0 or
v14.0.0; it stopped publishing binaries after v12.1.2 (2021). So every
container create paid a ~25-minute source build, and on 2026-07-28 it wedged
outright: cargo-binstall at 0.0% CPU for 29:30 with no compiler children,
which killed a `land` run mid-validation.

It is worse than "slow". `mise install` aborts at tokei, so every overlay
tool declared *after* it never installs. The running container had **12
missing tools** — tokei plus the entire tail of the file (hexyl, hyperfine,
starship, zellij, tealdeer, glow, vim, gitui, lazygit, HTTPie, xh).

`aqua:` and `ubi:` cannot fix this, measured in-container on both arms:

    aqua:XAMPPRocky/tokei@latest -> package type `cargo` is not supported
                                    in the aqua backend
    ubi:XAMPPRocky/tokei@latest  -> could not find a release asset after
                                    filtering for valid extensions

conda-forge does build it. `conda:tokei@14.0.0` installs in **3.9s**, and the
`conda:` prefix is already the file's idiom for 8 other tools — so this keeps
the deliberate "free on latest, no lockfile" overlay design intact. No pin,
no removal.

Class audit — the whole overlay, in-container: tokei is the **only** one of
the 28 tools whose default backend is a source builder. Every other
non-`conda:` tool defaults to `aqua:`, and all 7 that had never been attempted
have linux-x86_64 assets on their latest tag. The class is a singleton.

Verified by running the real path (`.devcontainer/scripts/on-create.sh`, which
is what `onCreateCommand` invokes): chezmoi render + full eager install now
completes in **41.4s** with rc=0 and `mise ls` reporting **0 missing**;
`tokei --version` -> 14.0.0. Control arms throughout: `mise ls-remote` on a
bogus aqua ref returns no versions while the real one returns 14.0.0, and
`gh release view` reports 0 assets for tokei v14.0.0 against 5 for xh v0.26.1.

Gates: lint rc=0 - pytest 1033 passed - verify 110 passed, 0 failed.

Closes #380

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CzPdn3iHw6uhMWEdVPADfW

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787839548&installation_model_id=429246&pr_number=408&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F408&signature=c59e394ae53e4013d5a5a3908c04bf84dd18b6079616d51e9e44619ad7576718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation reliability for the Tokei tool by selecting a faster prebuilt package source.
  * Full environment synchronization now completes more quickly, avoiding lengthy or apparently stalled source compilation.

* **Documentation**
  * Updated the runbook to reflect the resolved installation issue and the expected synchronization time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->