### PR TITLE
fix(memory-index): stop reading `KB` as kilobytes — it means knowledge-base

### DIFF
--- a/python/src/dotfiles_setup/memory_index.py
+++ b/python/src/dotfiles_setup/memory_index.py
@@ -106,7 +106,21 @@ _SHA = re.compile(r"\b(?=[0-9a-f]*\d)(?=[0-9a-f]*[a-f])[0-9a-f]{7,40}\b")
 # A byte size, e.g. `17.5 GB` / `25.8GB` / `38GB`. Units are a closed set: an
 # open `[A-Za-z]{1,3}` suffix matches the start of ordinary words after any
 # number ("4 facts"), and each imprecise class costs the report its credibility.
-_SIZE = re.compile(r"\b(?P<n>\d+(?:\.\d+)?)\s*(?P<unit>[KMGT]i?B|B)\b")
+#
+# Bare `KB` is EXCLUDED (`KiB` still counts). In this repo's vocabulary `KB`
+# means **knowledge-base** — the sibling `ray-manaloto/knowledge-base` repo — far
+# more often than kilobytes, and the index writes its sizes in B/GB. The hook
+# `11 KB + 10 dotfiles issues` (11 knowledge-base issues, 10 dotfiles issues) was
+# extracted as an `11 KB` size, found absent from the topic file, and reported as
+# an index-only fact that a trim would destroy. It was neither a size nor
+# index-only: the topic file says `11 knowledge-base issues + 10 dotfiles`.
+#
+# Same trade as `_SHA` above, and made the same way: a real kilobyte figure in a
+# hook now goes unchecked (one missed fact), whereas a unit that cries wolf on
+# the repo's own noun costs the whole report its credibility. Measured before
+# narrowing — across the live index, `KB` had **1** occurrence and it was the
+# knowledge-base sense, i.e. 0 genuine kilobyte uses to lose.
+_SIZE = re.compile(r"\b(?P<n>\d+(?:\.\d+)?)\s*(?P<unit>KiB|[MGT]i?B|B)\b")
 
 _MEMORY_INDEX = "MEMORY.md"
 

--- a/tests/test_memory_index.py
+++ b/tests/test_memory_index.py
@@ -157,6 +157,40 @@ def test_distinctive_facts_ignores_a_short_hex_run() -> None:
     assert mi.distinctive_facts("abc123 is not a sha") == []
 
 
+def test_bare_kb_is_not_a_size_because_kb_means_knowledge_base() -> None:
+    """The live false positive, verbatim from the index hook that produced it.
+
+    `11 KB + 10 dotfiles issues` counts **knowledge-base** issues, not kilobytes.
+    Read as a size it went looking for `11 KB` in the topic file, did not find it
+    (the file says `11 knowledge-base issues + 10 dotfiles`), and was reported as
+    an index-only fact a trim would destroy — failing the gate on the repo's own
+    noun.
+    """
+    hook = (
+        "runbook = `docs/specs/graphify-autonomous-queue.md`;"
+        " 11 KB + 10 dotfiles issues"
+    )
+    assert [f for f in mi.distinctive_facts(hook) if f.kind == "size"] == []
+    assert mi.distinctive_facts("the 25KB auto-load cap") == []
+
+
+def test_every_other_size_unit_still_extracts() -> None:
+    """Control arm for the `KB` exclusion: the class must still be able to fire.
+
+    Without this, dropping a unit is indistinguishable from breaking the size
+    class outright — a probe that can only return "no size found".
+    """
+    for text, expected in [
+        ("image is 17.5 GB", "17.5GB"),
+        ("image is 25.8GB", "25.8GB"),
+        ("blob is 512 B", "512B"),
+        ("page is 64 KiB", "64KiB"),
+        ("cache is 900 MB", "900MB"),
+        ("array is 2 TB", "2TB"),
+    ]:
+        assert mi.Fact("size", expected) in mi.distinctive_facts(text), text
+
+
 # ---------------------------------------------------------- normalized fact matching
 
 


### PR DESCRIPTION
`mise run memory-index` was rc=1 on a false positive. The index hook
`11 KB + 10 dotfiles issues` counts **knowledge-base** issues (the sibling
ray-manaloto/knowledge-base repo), not kilobytes. `_SIZE` extracted it as an
`11 KB` size, went looking for that size in the linked topic file, did not find
it — the file says `11 knowledge-base issues + 10 dotfiles` — and reported it as
an index-only fact a trim would destroy.

Neither claim was true: not a size, not index-only. The gate was failing on the
repo's own noun.

Fix: drop bare `KB` from the closed unit set; `KiB` still counts. Same trade as
`_SHA`'s digit/letter lookaheads and made the same way — a real kilobyte figure
in a hook now goes unchecked (one missed fact), whereas a unit that cries wolf
on a word the index uses constantly costs the whole report its credibility.

Measured before narrowing: across the live index `KB` had **1** occurrence and
it was the knowledge-base sense, so there were 0 genuine kilobyte uses to lose.

Tests pin both directions — the false positive stays unextracted, and a control
arm asserts B/KiB/MB/GB/TB all still extract, so dropping a unit cannot be
confused with breaking the size class outright. Verified the new test fails
against the old regex (it extracted `11KB`/`25KB`).

Gates: lint rc=0 · pytest 1035 passed · verify 110 passed, 0 failed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CzPdn3iHw6uhMWEdVPADfW

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787845736&installation_model_id=429246&pr_number=412&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F412&signature=0b1f96654eddf7c7b17d51fa9fa39956c1194ab63c6b0ea8f84a17eb1523e64b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved size detection to avoid incorrectly interpreting “KB” as a storage unit in knowledge-base references.
  - Continued recognizing valid units such as B, KiB, MB, GB, and TB.
- **Tests**
  - Added coverage to verify that knowledge-base references are excluded while legitimate storage sizes are still identified correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->