### PR TITLE
docs(rules): extract rule archaeology to docs/rules-evidence/ (-12.3KB eager)

### DIFF
--- a/.claude/rules/mise-tasks-only.md
+++ b/.claude/rules/mise-tasks-only.md
@@ -89,81 +89,44 @@ call — the wrapper exits 0 when the Python>=3.14 interpreter is absent, e.g. a
 cold web session) but **records every one** (#343). Hard bans that must never
 fail open belong in settings.json permission deny rules, not the hook.
 
-> **Enforcement design note (2026-07-14, research-backed):** we deliberately do
-> NOT re-inject a "use mise tasks" reminder every turn (UserPromptSubmit) or
-> nudge after every command (PostToolUse). Anthropic's guidance routes static
-> conventions to CLAUDE.md and enforcement to the PreToolUse hook, and the
-> LLM-behavior evidence ranks a hard gate (zero decay) far above per-turn
-> reminders (which decay, cost instruction budget, and sit in the lowest-trust
-> tier). See `docs/research/runs/research-20260714-hook-enforcement/report.md`.
-> The improvement path is layer 4 mining transcripts — not more per-turn hooks.
+We deliberately do NOT re-inject a per-turn "use mise tasks" reminder: a hard
+gate has zero decay, while reminders decay and cost instruction budget. The
+improvement path is layer 4 mining transcripts, not more hooks.
 
 ## Reading the command-audit report
 
 Only **`bypass`** is an alarm: a command that matched a rule ALREADY LIVE
 (`timestamp > rule.since`) and that really executed. The others are not:
 
-- **`blocked`** — the guard denied it; it never ran. The guard working. Audit
-  these for FALSE POSITIVES (#265), not for evasion of the matcher.
-- **`pre_rule`** — it predates the rule that matches it. History. **Trust this
-  only as far as `since` is right** — see "`since` dates COVERAGE" below.
-- **`one_off`** — refine-loop candidates, known-noisy (#266): top shapes are
-  sanctioned work (plain git, ad-hoc scripts, wait-loops). Discount until then.
+- **`blocked`** — the guard denied it; it never ran. Audit these for FALSE
+  POSITIVES (#265), not for evasion of the matcher.
+- **`pre_rule`** — it predates the rule that matches it. **Trust only as far as
+  `since` is right** — see "`since` dates COVERAGE" below.
+- **`one_off`** — refine-loop candidates, known-noisy (#266). Discount for now.
 
-Both distinctions are load-bearing: a bare "matched a rule" verdict is almost
-pure noise. Measured over 3,615 commands (2026-07-14): **155** matched a rule —
-**147** predated it, **3** were denials, **0** bypasses. The transcript forces
-the second axis, recording the `tool_use` block whether or not the command ran (a
-deny lands *after* the model emits it), so a denial and a bypass are identical
-until you pair the attempt to its result.
+Both axes are load-bearing: a denial and a bypass look identical until you pair
+the attempt to its result, because the transcript records the `tool_use` block
+whether or not the command ran.
 
-**"Nothing has ever evaded the guard" stood here until 2026-07-28 and was false
-in BOTH directions at once (#343).** Re-judged against the `hook_guard.py` live
-at each command's own timestamp rather than trusting `since`: of 128 rows, **3
-false**, **125 genuine**. The 125 ran because **the guard never ran** — hooks
-execute "in the current directory", so the relative `bash
-scripts/pretooluse-guard.sh` was absent whenever a session worked in the sibling
-repo (rc=127), and a non-zero non-2 PreToolUse exit is a **non-blocking error
-that lets the call proceed**. Every path is now anchored to
-`$CLAUDE_PROJECT_DIR` (settings.json AND the wrapper's equally-relative `uv
---project`), and `hook_selfcheck` drives a **foreign-cwd arm** — both old arms
-ran at the project root, which is precisely why this survived. **A fail-open
-that nothing counts is indistinguishable from enforcement**, so each is now
-recorded (`~/.local/state/dotfiles/guard-fail-open.log`) and reported by
-`command-audit`. Evidence: `docs/research/runs/research-20260728-guard-fail-open/`.
+⚠️ **Do not read "nothing has evaded the matcher" as "nothing has evaded the
+guard".** #343 found **125** commands that bypassed it entirely by never reaching
+it — a relative hook path made the guard absent off-root, and a non-zero non-2
+`PreToolUse` exit is a non-blocking error that lets the call proceed. Fail-opens
+are now recorded (`~/.local/state/dotfiles/guard-fail-open.log`).
 
-## Fixed: prose content in compound commands (#265)
+## Masking, and what stays fail-open by design
 
-The guard used to match the RAW Bash string, so a separator inside
-quoted/heredoc CONTENT read as a shell separator and the denied literal after it
-looked like it sat at a command position (`grep -iE "…|devcontainer up|…"` was
-denied). A deny cancels the ENTIRE compound command, silently skipping its other
-parts — so the cost was a command that looked like it ran.
+Rules match AFTER `hook_guard._inert_masked` neuters every separator that is
+DATA (quoted spans, heredoc bodies), so a quoted mention of a denied literal no
+longer denies (#265).
 
-**Fixed 2026-07-14** by `hook_guard._inert_masked`: separators (`;&|` + newline)
-that are DATA get neutered before the rules run — inside quoted spans (content
-preserved, only separators blanked, since a rule may need to read a quoted
-argument) and inside heredoc bodies (`<<EOF`, `<<'EOF'`, `<<-EOF` — redacted
-whole; a body is stdin data and can never be a command). Rule patterns are
-untouched, so recall is preserved by construction. `blocked` went **3 → 1**,
-keeping the one denial that was always correct.
+Still fail-open BY DESIGN (a redirect guard, not a sandbox): `$(…)`,
+`sh -c`/`eval`, base64, aliases. If a deny looks wrong: write the script with the
+Write tool and run `python3 <file>` — and after ANY deny, re-check that the
+intended side effects actually happened.
 
-Still fail-open BY DESIGN (a redirect guard, not a sandbox): `$(…)`, `sh
--c`/`eval`, base64, aliases. Masking narrows that class deliberately — `eval
-"echo x; gh pr create"` was denied before (the quoted `;` anchored `_CMD`) and is
-allowed now. An accident, not coverage: bare `eval "gh pr create"` was always
-allowed, so only the separator-bearing variant was ever caught. Giving it up IS
-the precision-over-recall trade. If a deny looks wrong: write the script with the
-Write tool and run `python3 <file>` — and after ANY deny, re-check the intended
-side effects happened.
-
-**Against the MATCHER, false positives were the defect, not evasion** (#265): 2
-of the 3 denials ever recorded were the quoted-regex shape, and the survivor (an
-`npx` behind a real `||`) was correct — hence 3 → 1, not 3 → 0. Twice a predicted
-risk was refuted by probing and the real one was its mirror image (#264's
-cd-prefix; #265's quoting): measure before believing. **That scope matters** —
-nothing has evaded the *matcher*, but #343 found 125 commands bypassing the
-guard entirely by never reaching it.
+Full case history — the 3,615-command measurement, the #343 fail-open, the #265
+quoting defect and the #308 back-dating: `docs/rules-evidence/mise-tasks-only.md`.
 
 ## Extending
 
@@ -177,12 +140,10 @@ erodes trust in the guard.
 
 Never bump it on a reword — but **widening a pattern to cover a NEW shape is not
 a reword and needs its own date.** One `Rule` carries one `since`, so a widened
-rule must be **split into two entries**. `68f28c9` (#308) brought `hk run check`
-under the guard on 2026-07-18 by widening the `hk run pre-commit` rule, leaving
-`since` at 2026-07-07 — so the audit back-dated 11 days of coverage and cried
-bypass on three calls the guard of that day correctly allowed (#343). Now `_V1`
-and `_V1B`. **A proxy goes stale silently:** when a bypass count moves, check the
-rule's history (`git log -S` on the pattern) before believing it.
+rule must be **split into two entries** (`_V1` / `_V1B`). **A proxy goes stale
+silently:** when a bypass count moves, check the rule's history (`git log -S` on
+the pattern) before believing it. The #308 back-dating that proved this:
+`docs/rules-evidence/mise-tasks-only.md`.
 
 Rules match AFTER `_inert_masked` has neutered every separator that is data, so
 write the pattern against real shell syntax and let masking handle quoting — do

--- a/.claude/rules/probes-need-a-control-arm.md
+++ b/.claude/rules/probes-need-a-control-arm.md
@@ -14,18 +14,10 @@ nothing reviews them.
 ## Why this rule exists
 
 Session 2026-07-15 produced **five false negatives in one session**, every one
-from a probe that could not have succeeded:
-
-| Probe | Said | Truth |
-|---|---|---|
-| `find … -maxdepth 4 -iname '*grill*'` | "`grill-with-docs` doesn't exist" | It exists at **depth 7**. |
-| `find … -name 'agent-*.jsonl'` | "AGENT DEAD, no transcript" | Alive; teammate transcripts are `<uuid>.jsonl`, so the glob **can never match**. It delivered a 34 KB report. ~10 min of work redone for nothing. |
-| `curl …/resolute/` → 301 | (nothing — 301 for every dist) | A redirect, not evidence. `noble` returned 301 too. |
-| PyPI loop with `jq -e '.info'` | "python-debian NOT ON PYPI" | It is. The very next query returned its metadata. |
-| `clang++ … /dev/null` compile | "openmp FAIL" | My heredoc quoting was broken; openmp was fine. |
-
-Each one was cheap to disprove and expensive to believe. The `find`-based ones
-cost the most: they produced confident, wrong statements to the user.
+from a probe that could not have succeeded. The canonical one:
+`find … -name 'agent-*.jsonl'` reported "AGENT DEAD, no transcript" — teammate
+transcripts are `<uuid>.jsonl`, so the glob **can never match**. The agent was
+alive and had delivered a 34 KB report.
 
 The **inverse** bites too. `cmd | grep -q PAT` under `set -o pipefail` returns
 **141**, so the check fails *because the match succeeded* — a probe that can
@@ -35,31 +27,24 @@ only fail. That broke the #289 base build; see `no_grep_q_under_pipefail` in
 ## Cross-check: when two probes disagree, one of them is broken
 
 The cheapest bug detector available is a **second probe of the same fact by a
-different route**. It needs no fixture and no reasoning: if two probes of one
-fact disagree, you have found a defect *for free* — and it is in a probe far
-more often than in the world. Reach for this the moment a result surprises you,
-before you write up the surprise.
+different route**. No fixture, no reasoning: if two probes of one fact disagree
+you have found a defect for free — and it is in a probe far more often than in
+the world. Reach for it the moment a result surprises you, *before* you write up
+the surprise.
 
-The value is that it names *which* answer to distrust. A lone probe returning
-"MISSING" is indistinguishable from a probe that cannot see; a second route
-returning "PRESENT" proves the first one is blind. Three instances, all
-2026-07-16, all cheap to cross-check and expensive to believe:
+It names *which* answer to distrust. A lone probe returning "MISSING" is
+indistinguishable from a probe that cannot see; a second route returning
+"PRESENT" proves the first one is blind.
 
-| the probe said | the disagreeing route | what was actually broken |
-|---|---|---|
-| pin `curl=8.18.0-1ubuntu2` FAILS to install | same pin in a **clean base container** → installs fine | the **devcontainer was dirty** — it already had a newer curl, and apt refuses to downgrade. The pin was correct; the environment lied. |
-| CI job SKIPPED ⇒ "unaffected by this change" | reading the job's `if:` condition | a SKIPPED job **never asked the question**. "Never ran" is not "ran and found nothing". |
-| every package reports MISSING | running the same command without the outer quoting | the **inner shell ate the variable** — a nested-quote format string expanded to empty, so every lookup compared against `""`. |
-| graphify **issue #959 is OPEN** ⇒ "custom OpenAI endpoints are blocked" | reading the **installed** `llm.py:112` | the feature shipped in **0.8.40**; the issue is stale-open. A viable path was nearly discarded on the strength of an unclosed ticket. |
-| the CC Discord plugin says *"Discord's search API isn't exposed to bots"* (asserted in **3** places) | reading **Discord's own** API docs | `GET /guilds/{id}/messages/search` was documented **2026-03-20** — two days *after* the plugin's first commit. Search is a **plugin** limit, not a platform limit. |
+**Source beats issue tracker; a tool's claim about a platform ages.** The
+recurring shape is a *secondary* artifact (an unclosed issue, a dependency's
+README) read as the current state of a *primary* one (the shipped source, the
+platform's API). Issues stay open after the fix lands; vendored docs freeze at
+their commit date. When a secondary source says "impossible" and it matters,
+**go read the code or the owner's docs**.
 
-**Source beats issue tracker. A tool's claim about a platform ages.** Both rows
-above are the same shape: a *secondary* artifact (an unclosed issue, a
-dependency's README) was read as the current state of a *primary* one (the
-shipped source, the platform's API). Issues stay open after the fix lands;
-vendored docs freeze at their commit date. When a secondary source says
-"impossible" and the thing matters, **go read the code or the owner's docs**
-before you believe it.
+Full case tables — five false negatives, five cross-check disagreements:
+`docs/rules-evidence/probes-need-a-control-arm.md`.
 
 ## Rules
 
@@ -72,59 +57,29 @@ before you believe it.
    returned empty, so `bash -c ""` "passed".)
 
    **Reintroduce the bug REALISTICALLY — a mutation that isn't the real failure
-   proves nothing.** 2026-07-16: to prove a contract would catch a symbol's
-   removal, the probe renamed `def changes_apt_pin_inputs` →
-   `def changes_apt_pin_inputs_REMOVED`. The contract passed, which read as a
-   contract defect — but the renamed symbol **still contains the original as a
-   substring** and the check is a substring match, so the probe was a no-op.
-   The probe was the bug. Two lessons, and the second is the expensive one:
-   - a mutation must actually *destroy* what the check looks for;
-   - and it must be a break that could **really happen**. The realistic break
-     was not renaming the function at all — it was **deleting the wiring line
-     that calls it**. Probing THAT (`if changes_apt_pin_inputs(paths):` removed
-     from `gate_matrix`) exposed a genuine hole the first probe never reached:
-     the contract stayed green because its token survived in a *comment* and a
-     *docstring*. Ask "what would the regression actually look like?" before
-     mutating — an unrealistic mutation can only ever accuse the wrong party.
+   proves nothing.** Two lessons, the second the expensive one: a mutation must
+   actually *destroy* what the check looks for (renaming a symbol leaves the
+   original as a substring, so a substring check is a no-op); and it must be a
+   break that could **really happen** — usually deleting the wiring line that
+   calls a function, not renaming the function. Ask "what would the regression
+   actually look like?" before mutating; an unrealistic mutation can only ever
+   accuse the wrong party. Worked case: `docs/rules-evidence/`.
 3. **Bound-limited searches are suspect by construction.** `-maxdepth`,
    `head -N`, `--limit`, a time window, a `2>/dev/null`: each can turn "absent"
    into "unreachable". Either remove the bound or prove the target is inside it.
 
-   **Display bounds count too — `ls … | tail -15` is a bound.** 2026-07-20: a
-   session ran `ls .agent/plans/ | tail -15`, did not see the handoff's
-   designated "bible", and reported it **missing**. The file existed; `plan-*`
-   simply sorts before `session-*` and fell outside the last 15 lines. `| head`,
-   `| tail`, and a bare `ls` of a large directory are all display bounds.
-
-   **So is checking N exact paths instead of asking "does it exist anywhere".**
-   Same session: an agent was declared non-compliant for "not writing its
-   report" after two specific paths were checked; it had written a 39 KB report
-   to a third. The probe answered "not at these two paths" and was read as "not
-   written". When the question is *existence*, search the tree, not a guess.
-
-   **And a relative time bound can be silently invalid.** `find … -newermt "-20
-   minutes"` returns nothing on macOS/BSD `find`, which does not parse that
-   relative form — indistinguishable from "no recent files". Control-arm any
-   time-bounded search against a window you know contains hits.
-
-   **A TOKEN SPELLING is a bound too — this is the most common form.** On
-   2026-07-21 a session grepped `lmstudio` and `lm_studio`, got 0, and reported
-   *"graphify supports NONE of MLX / LM Studio / Jan"* to the user. graphify
-   spells it **`LM Studio`, with a space** — 3 hits, one of them its own
-   `--help`: *"openai also reaches self-hosted OpenAI-compatible servers
-   (llama.cpp, vLLM, LM Studio): set OPENAI_BASE_URL"*. The literal grep was
-   true; the conclusion was backwards. A later agent caught it.
-
-   That session produced **five** bad-bound probes, which is why this paragraph
-   exists: a backtick defeated a search of its own handoff; a hyphen-vs-underscore
-   filename made a present pointer read as absent; a `cd` persisted so the
-   "control arm" ran in the same directory as the test; and zsh's lack of
-   word-splitting made `grep -l $f` (multi-line `$f`) silently match nothing.
+   Bounds come in more forms than they look: **display bounds** (`| head`,
+   `| tail`, a bare `ls` of a large dir), **checking N exact paths** instead of
+   asking "does it exist anywhere", **relative time bounds** that a given `find`
+   cannot parse, and — most common of all — **a TOKEN SPELLING**. A session once
+   grepped `lmstudio`/`lm_studio`, got 0, and reported the feature unsupported;
+   it is spelled `LM Studio`, with a space.
 
    The habit that would have caught every one: **a 0-result grep is not an
    answer until a control arm has run.** Before reporting absence, grep a term
    you KNOW is present in the same corpus with the same command shape. If that
-   also returns 0, the probe is broken — not the world.
+   also returns 0, the probe is broken — not the world. Worked cases:
+   `docs/rules-evidence/probes-need-a-control-arm.md`.
 4. **A redirect/timeout/parse-error is not a "no".** HTTP 301/000, a `jq` miss,
    an empty `grep` — distinguish "answered no" from "never asked".
 5. **Say which arm you ran.** When reporting a probe result, state the control:
@@ -136,21 +91,12 @@ before you believe it.
    else's unverified note into your finding, and the provenance is gone the
    moment you restate it.
 
-   2026-07-21: a session inherited a 5-row model bake-off table from a handoff
-   and reported it as "same corpus, same flags, so it is comparable". Only the
-   corpus was ever actually constant. graphify records **no backend or model in
-   any artifact** (control arm: the corpus filename *is* recorded), three of the
-   directories were identical in shape, the semantic cache key is model-blind,
-   and every arm was n=1. The whole comparison had to be discarded — after a
-   claim from it ("gemma4 wins on cross-doc edges, 2 to 1") had already been
-   reported to the user as a finding. It was a gap of **one**, from single runs,
-   with no noise floor.
-
    So: before repeating an inherited number, either (a) re-derive it and say you
    did, or (b) mark it explicitly as unverified and inherited. And when the
    number ranks things, ask what the **noise floor** is — a difference smaller
    than the same-input variance is not a difference. If nothing establishes that
-   floor, the ranking is not reportable at any confidence.
+   floor, the ranking is not reportable at any confidence. The bake-off table
+   that had to be discarded: `docs/rules-evidence/probes-need-a-control-arm.md`.
 
 7. **Cross-check a surprise before you report it.** A second route to the same
    fact costs seconds and settles which side is broken. Disagreement is a

--- a/.claude/rules/secrets-out-of-the-shell-env.md
+++ b/.claude/rules/secrets-out-of-the-shell-env.md
@@ -5,37 +5,22 @@ A credential that lives in the interactive shell's environment is inherited by
 form no secret scanner can read. Keep secrets out of the shell; inject them into
 the one process that needs them.
 
-## What happened (2026-07-27)
+## What happened, and why no scanner caught it
 
-`fnox activate` exported 49 variables into the login shell. mise records the
-whole environment delta in **`__MISE_DIFF`** (zlib-compressed, base64-encoded)
-so it can undo it on directory exit, and that variable is inherited by every
-child. Decoded, the live blob carried an AWS access key id and secret, several
-API tokens, an app password, and a Google client secret.
+`fnox activate` exported 49 credentials into the login shell. mise records the
+environment delta in **`__MISE_DIFF`** (zlib + base64) so it can undo it on
+directory exit, and every child process inherits that variable. Nothing reached a
+public remote, but the blob sat in every child, and one `env > notes.md` in a
+tracked directory would have published all of it.
 
-**Nothing reached a public remote.** Verified by pickaxing the exact live values
-across the full history of both public repos: **0 commits** each, against a
-control term returning 339 (dotfiles) and 94 (knowledge-base), so the probe
-discriminates. The single `AKIA` in dotfiles history is a vendor example inside
-`docs/research/mintlify-cache/`.
+**No secret scanner can read it** — measured on the same content in two forms:
+gitleaks 8.30.1 went **2 leaks → 0**, betterleaks 1.7.1 **1 → 0**. The control
+arm fires on the plaintext, so the zero is a real negative. Compression destroys
+the patterns both scanners match on. That gap is the one thing justifying custom
+code here at all (see [[use-tool-builtins]]), and it covers only the decode.
 
-The exposure was real anyway: the blob sat in every child process, and one
-`env > notes.md` inside a tracked directory would have published all of it.
-
-## Why no scanner would have caught it
-
-Measured 2026-07-27 with synthetic, format-valid credentials — the same content
-in two forms:
-
-| scanner | plaintext env dump | the same content as a `__MISE_DIFF` blob |
-|---|---|---|
-| gitleaks 8.30.1 | **2 leaks** | **0** |
-| betterleaks 1.7.1 | **1 leak** | **0** |
-
-The control arm fires on the plaintext, so the zero is a real negative and not
-a blind probe. Both scanners are pattern matchers; compression destroys the
-patterns. This is the one gap that justifies custom code here at all
-(see [[use-tool-builtins]]) — and the custom code covers only the decode.
+Full incident, measurements and control arms:
+`docs/rules-evidence/secrets-out-of-the-shell-env.md`.
 
 ## The source fix — fnox already ships it
 
@@ -64,67 +49,27 @@ With `env = "exec"` there is no delta for mise to record, so `__MISE_DIFF`
 stops carrying credentials at the source. Everything below is the net under
 that, not a substitute for it.
 
-Probed on the pinned **1.31.1** in a throwaway project, both arms: with
-`env = "exec"`, `fnox export --format shell` emitted **only** the `env = true`
-opt-in, while `fnox exec -- env` still carried both. The table above is the
-tool's measured behaviour here, not a restatement of its release notes.
+The table above is the tool's **measured** behaviour on the pinned 1.31.1 (both
+arms probed), not a restatement of its release notes.
 
-### Applying it — three findings, 2026-07-27
+**APPLIED 2026-07-27 by Ray** — 46 of 49 exec-only, 3 opted back in. Two
+variables must stay `env = true` because this repo runs on them: `.mcp.json`
+interpolates one at MCP-server spawn, and `gh` (every `ship`/`land`/`automerge`
+and `gh api` call) reports its active account as the environment-authenticated
+one. Exec-only for those degrades tooling *silently*.
 
-1. **A local override is NOT honoured at the user config root.** The config is
-   `~/.config/fnox/config.toml`, and `fnox config-files` lists it alone; adding
-   `config.local.toml` or `fnox.local.toml` beside it changed that output not at
-   all. Control arm: in a *project* directory the same command lists `fnox.toml`
-   **and** `fnox.local.toml` **and** the user root — three lines — so it can
-   report more than one file. The override layer is project-scoped only, so
-   there is no non-invasive place to put this.
-2. **The file is generated.** Its first line reads *"Managed by `mde-py secrets
-   bootstrap-config`. Do not edit by hand."*, so a hand edit survives only until
-   the next bootstrap. The durable fix belongs in **`mde-py`'s generator**.
-3. **Two variables must be opted back in with `env = true`, and they are the two
-   this repo runs on.** `.mcp.json` interpolates one at MCP-server spawn, and
-   `gh` — which `ship`/`land`/`automerge` and every `gh api` call use — reports
-   its *active* account as the environment-authenticated one, with a
-   narrower-scoped fallback behind it. Exec-only for those two degrades tooling
-   silently rather than loudly.
+⚠️ **The config is GENERATED** — *"Managed by `mde-py secrets bootstrap-config`.
+Do not edit by hand."* A hand edit survives only until the next bootstrap, so the
+durable fix belongs in `mde-py`'s generator. There is no user-root local override
+to hide it in; that layer is project-scoped only.
 
-   A grep of `~/.zshrc`, `~/.zprofile`, `~/.config/mise/config.toml`,
-   `~/.claude/settings.json`, `~/.gitconfig` and `home/**` for all 49 names found
-   **zero** other declared consumers (control arm: 7 hits for
-   `export|source|eval` in the same `.zshrc`, so the grep works). State that
-   bound: it finds *declared* consumers only. A tool that reads a variable by
-   convention appears in no config file, so absence here is not absence.
+This also fixed the `[redacted]` digit-masking: two fnox telemetry flags held
+one-character all-digit values and were marked redacted, so mise masked every
+digit in every `mise run` line. Never a mise bug — collateral from treating a
+non-secret as a secret. **It returns if `mde-py` re-bootstraps the config.**
 
-**APPLIED 2026-07-27 — by Ray, not by an agent.** The standing rule is to never
-touch a user-level file unasked (`feedback_no_user_level_file_updates`); Ray
-approved this one edit explicitly, and the harness permission layer *still*
-refused the write — correctly, and independently of that approval. Two layers,
-and the outer one does not read approvals. So the recipe was prepared here and
-Ray ran it: 46 of the 49 exec-only, 3 opted back in.
-
-Verified in a **fresh interactive login shell**, not the session's own: the
-opted-in variable is set, two exec-only ones are not, and the recorded delta
-shrank from ~16.8 KB decoded to a 5.2 KB blob.
-
-The first attempt at that verification was **broken and looked like a clean
-pass** — `zsh -l -c` (non-interactive) never sources `.zshrc`, so nothing
-activated and the variable was "absent". The control arm, the same probe against
-the pre-fix config, ALSO said "absent", which is the only reason it was caught.
-`-i` is what makes the probe able to answer.
-
-## The same setting fixes the `[redacted]` digit-masking
-
-mise redacts every occurrence of a redacted variable's **value** in task output.
-fnox marks all 49 of its variables redacted, and two of them —
-`GEMINI_TELEMETRY_ENABLED` and `GEMINI_TELEMETRY_LOG_PROMPTS` — hold
-**one-character, all-digit values**. So mise faithfully masks every digit in
-every `mise run` line, which is why a number read from `mise run` output cannot
-be trusted (memory `feedback_mise_run_masks_digits`). `LANGSMITH_WORKSPACE_ID`
-is worse: an **empty** value.
-
-Those are telemetry flags, not secrets. Moving them out of fnox — or marking
-them `redact = false` — restores readable task output. The digit-masking was
-never a mise bug; it was collateral from treating a non-secret as a secret.
+Findings, control arms, and the verification that passed while blind:
+`docs/rules-evidence/secrets-out-of-the-shell-env.md`.
 
 ## The gates that now exist in this repo
 

--- a/.claude/rules/verify-before-advancing.md
+++ b/.claude/rules/verify-before-advancing.md
@@ -10,14 +10,11 @@ passed, and you read the real result.
 
 ## Why this rule exists
 
-Repeatedly, the expensive failure mode is declaring a step complete on an
-*assumption*: "the warm path will skip the build", "that's a trivial
-edit", "lint should be fine". The assumption is sometimes wrong, and the
-gap is discovered a task later when it is costly to unwind. This rule
-makes verification a hard gate between every unit of work, not an
-optional courtesy. It is the operational teeth behind
-[[zero-skip-policy]] and CLAUDE.md → `AGENTS.md` "Local validation
-first".
+The expensive failure mode is declaring a step complete on an *assumption*
+("that's a trivial edit", "lint should be fine"); the gap then surfaces a task
+later, when unwinding it is costly. Verification is a hard gate between units of
+work, not a courtesy — the operational teeth behind [[zero-skip-policy]].
+Case history: `docs/rules-evidence/verify-before-advancing.md`.
 
 ## The check matrix — run what applies to the change
 
@@ -109,35 +106,13 @@ Every task in this repo — local edits, PRs, merges, multi-step work, and
 agent-delegated work (the delegating context is responsible for
 confirming the delegate's checks actually passed).
 
-> **This file is where the ≤12000-char misattribution was born (2026-07-15
-> archaeology).** The row above once asserted a "≤200-line / ≤12000-char limit"
-> for a gate that enforced **only** lines. The number is REAL — it is
-> **Windsurf's** AGENTS.md limit (agnix AGM-003) — but it arrived here without
-> its source, was later machine-enforced to match this prose, and was captioned
-> "per Claude Code memory docs", which never stated it. **A true fact that
-> travels without its source becomes indistinguishable from an invented one**,
-> and gets applied to files its real owner never governed. Cite a figure only
-> where you can name the vendor; when code and a doc disagree, re-read the
-> source before making either match the other. See [[md-size-budgets]].
->
-> **The other half is SCOPE: a fact needs the CONDITION that makes it true, not
-> just its source.** Provenance alone is not enough. Each fact below is genuine
-> and correctly sourced, and each was still wrong where it was used — because it
-> travelled without its "true when". This is *harder* to catch than invention:
-> the citation checks out, so the claim survives review.
->
-> | fact | true when | was applied to | what it cost |
-> |---|---|---|---|
-> | 12,000-char limit | Windsurf / agnix AGM-003 | all Claude markdown | a gate enforcing a limit its real owner never set |
-> | renovate "extracts NOTHING" under an unsupported node | some older renovate | 43.265.1, which extracts fine | a hunt for a data-loss bug that does not exist |
-> | 2–2.5h cold build | the p2996 cache **misses** | any `mise-system.toml` touch | a ~4x over-warning; measured ~37 min |
->
-> A stated condition is also what makes a fact **falsifiable later**: "2.5h when
-> p2996 misses" tells the next reader what to check, while a bare "2.5h" can only
-> be believed or doubted. So when you carry a number, carry its condition — and
-> when you meet one, ask "what has to be true for this to hold, and is it true
-> HERE?" (Deliberately folded into this blockquote rather than given its own
-> eager rule: one idea, one place.)
+> **Carry a number with its CONDITION, not just its source.** This file is where
+> the ≤12,000-char misattribution was born: a real figure (Windsurf's, via agnix
+> AGM-003) travelled here without its source, was captioned to Anthropic, and was
+> then machine-enforced against files its real owner never governed. A true fact
+> without its provenance *or* its "true when" is indistinguishable from an
+> invented one. Three worked cases, and the habit that catches them:
+> `docs/rules-evidence/verify-before-advancing.md`.
 
 ## See also
 

--- a/docs/rules-evidence/mise-tasks-only.md
+++ b/docs/rules-evidence/mise-tasks-only.md
@@ -1,0 +1,119 @@
+# Evidence — `mise-tasks-only`
+
+Case history behind `.claude/rules/mise-tasks-only.md`. The eager rule carries
+the canonical task map and the operative constraints; this file carries the
+measurements, the two defect stories, and the design rationale.
+
+## Why we do NOT re-inject a per-turn reminder
+
+*(2026-07-14, research-backed.)*
+
+We deliberately do not re-inject a "use mise tasks" reminder every turn
+(`UserPromptSubmit`) or nudge after every command (`PostToolUse`). Anthropic's
+guidance routes static conventions to `CLAUDE.md` and enforcement to the
+`PreToolUse` hook, and the LLM-behaviour evidence ranks a hard gate (zero decay)
+far above per-turn reminders, which decay, cost instruction budget, and sit in
+the lowest-trust tier.
+
+Source: `docs/research/runs/research-20260714-hook-enforcement/report.md`.
+
+The improvement path is layer 4 mining transcripts — not more per-turn hooks.
+
+## Reading the command-audit report: why two axes are needed
+
+A bare "matched a rule" verdict is almost pure noise. Measured over 3,615
+commands (2026-07-14): **155** matched a rule — **147** predated it, **3** were
+denials, **0** bypasses.
+
+The transcript forces the second axis, recording the `tool_use` block whether or
+not the command ran (a deny lands *after* the model emits it), so a denial and a
+bypass are identical until you pair the attempt to its result.
+
+## "Nothing has ever evaded the guard" was false in BOTH directions (#343)
+
+That sentence stood in the rule until 2026-07-28.
+
+Re-judged against the `hook_guard.py` live at each command's own timestamp
+rather than trusting `since`: of 128 rows, **3 false**, **125 genuine**.
+
+The 125 ran because **the guard never ran**. Hooks execute "in the current
+directory", so the relative `bash scripts/pretooluse-guard.sh` was absent
+whenever a session worked in the sibling repo (rc=127) — and a non-zero, non-2
+`PreToolUse` exit is a **non-blocking error that lets the call proceed**.
+
+Every path is now anchored to `$CLAUDE_PROJECT_DIR` (settings.json AND the
+wrapper's equally-relative `uv --project`), and `hook_selfcheck` drives a
+**foreign-cwd arm** — both old arms ran at the project root, which is precisely
+why this survived so long.
+
+**A fail-open that nothing counts is indistinguishable from enforcement.** Each
+is now recorded (`~/.local/state/dotfiles/guard-fail-open.log`) and reported by
+`command-audit`.
+
+Evidence: `docs/research/runs/research-20260728-guard-fail-open/`.
+
+## Fixed: prose content in compound commands (#265)
+
+The guard used to match the RAW Bash string, so a separator inside quoted or
+heredoc CONTENT read as a shell separator, and the denied literal after it looked
+like it sat at a command position (`grep -iE "…|devcontainer up|…"` was denied).
+A deny cancels the ENTIRE compound command, silently skipping its other parts —
+so the cost was a command that *looked* like it ran.
+
+**Fixed 2026-07-14** by `hook_guard._inert_masked`: separators (`;&|` + newline)
+that are DATA get neutered before the rules run — inside quoted spans (content
+preserved, only separators blanked, since a rule may need to read a quoted
+argument) and inside heredoc bodies (`<<EOF`, `<<'EOF'`, `<<-EOF` — redacted
+whole; a body is stdin data and can never be a command). Rule patterns are
+untouched, so recall is preserved by construction. `blocked` went **3 → 1**,
+keeping the one denial that was always correct.
+
+Masking narrows the fail-open class deliberately: `eval "echo x; gh pr create"`
+was denied before (the quoted `;` anchored `_CMD`) and is allowed now. That was
+an accident, not coverage — bare `eval "gh pr create"` was always allowed, so
+only the separator-bearing variant was ever caught. Giving it up IS the
+precision-over-recall trade.
+
+**Against the MATCHER, false positives were the defect, not evasion.** 2 of the
+3 denials ever recorded were the quoted-regex shape, and the survivor (an `npx`
+behind a real `||`) was correct — hence 3 → 1, not 3 → 0.
+
+Twice a predicted risk was refuted by probing and the real one was its mirror
+image (#264's cd-prefix; #265's quoting): **measure before believing**.
+
+**Scope matters:** nothing has evaded the *matcher*, but #343 found 125 commands
+bypassing the guard entirely by never reaching it. Those are different claims.
+
+## `since` dates COVERAGE, not the Rule object — the #308 back-dating
+
+`68f28c9` (#308) brought `hk run check` under the guard on 2026-07-18 by
+**widening** the existing `hk run pre-commit` rule, leaving `since` at
+2026-07-07. The audit therefore back-dated 11 days of coverage and cried bypass
+on three calls the guard of that day had correctly allowed (#343). Now split
+into `_V1` and `_V1B`.
+
+**A proxy goes stale silently:** when a bypass count moves, check the rule's
+history (`git log -S` on the pattern) before believing it.
+
+## The repo-aware dispatch defect
+
+The rules once matched `gh pr merge` unconditionally, so a knowledge-base PR was
+denied and pointed at `mise run land` — a *dotfiles* task with no repo parameter,
+watching dotfiles' main CI. KB PRs #1 and #2 were merged by hand.
+
+**A guard whose redirect target cannot perform the redirected action is not
+enforcement, it is an outage.** Hence dispatch by target repo, and hence
+"any other repo → ALLOW".
+
+## The provenance axis (#369)
+
+It recurred along a second axis. Only `ship` arms auto-merge and a bot PR never
+runs it; `land` refuses an OPEN PR; `gh pr merge` redirected to `land`. #138,
+#236 and #386 sat green and unmergeable. `automerge` is the missing verb.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the guard,
+  its rules, and issues #264/#265/#266/#308/#343/#369.
+- [ray-manaloto/knowledge-base](https://github.com/ray-manaloto/knowledge-base) —
+  the sibling repo whose PRs exposed the repo-aware dispatch defect.

--- a/docs/rules-evidence/probes-need-a-control-arm.md
+++ b/docs/rules-evidence/probes-need-a-control-arm.md
@@ -1,0 +1,127 @@
+# Evidence — `probes-need-a-control-arm`
+
+Worked failures behind `.claude/rules/probes-need-a-control-arm.md`. The eager
+rule states the discipline and keeps one example per lesson; this file holds the
+full case tables. Read it when you want the concrete failure a rule clause was
+written against.
+
+## Five false negatives in one session (2026-07-15)
+
+Every one from a probe that could not have succeeded:
+
+| Probe | Said | Truth |
+|---|---|---|
+| `find … -maxdepth 4 -iname '*grill*'` | "`grill-with-docs` doesn't exist" | It exists at **depth 7**. |
+| `find … -name 'agent-*.jsonl'` | "AGENT DEAD, no transcript" | Alive; teammate transcripts are `<uuid>.jsonl`, so the glob **can never match**. It delivered a 34 KB report. ~10 min of work redone for nothing. |
+| `curl …/resolute/` → 301 | (nothing — 301 for every dist) | A redirect, not evidence. `noble` returned 301 too. |
+| PyPI loop with `jq -e '.info'` | "python-debian NOT ON PYPI" | It is. The very next query returned its metadata. |
+| `clang++ … /dev/null` compile | "openmp FAIL" | The heredoc quoting was broken; openmp was fine. |
+
+Each was cheap to disprove and expensive to believe. The `find`-based ones cost
+the most: they produced confident, wrong statements to the user.
+
+**The inverse bites too.** `cmd | grep -q PAT` under `set -o pipefail` returns
+**141**, so the check fails *because the match succeeded* — a probe that can only
+fail. That broke the #289 base build; see `no_grep_q_under_pipefail` in `hk.pkl`.
+
+## Cross-check: when two probes disagree, one of them is broken
+
+A lone probe returning "MISSING" is indistinguishable from a probe that cannot
+see; a second route returning "PRESENT" proves the first one is blind.
+
+| the probe said | the disagreeing route | what was actually broken |
+|---|---|---|
+| pin `curl=8.18.0-1ubuntu2` FAILS to install | same pin in a **clean base container** → installs fine | the **devcontainer was dirty** — it already had a newer curl, and apt refuses to downgrade. The pin was correct; the environment lied. |
+| CI job SKIPPED ⇒ "unaffected by this change" | reading the job's `if:` condition | a SKIPPED job **never asked the question**. "Never ran" is not "ran and found nothing". |
+| every package reports MISSING | running the same command without the outer quoting | the **inner shell ate the variable** — a nested-quote format string expanded to empty, so every lookup compared against `""`. |
+| graphify **issue #959 is OPEN** ⇒ "custom OpenAI endpoints are blocked" | reading the **installed** `llm.py:112` | the feature shipped in **0.8.40**; the issue is stale-open. A viable path was nearly discarded on the strength of an unclosed ticket. |
+| the CC Discord plugin says *"Discord's search API isn't exposed to bots"* (asserted in **3** places) | reading **Discord's own** API docs | `GET /guilds/{id}/messages/search` was documented **2026-03-20** — two days *after* the plugin's first commit. Search is a **plugin** limit, not a platform limit. |
+
+**Source beats issue tracker. A tool's claim about a platform ages.** The last
+two rows are the same shape: a *secondary* artifact (an unclosed issue, a
+dependency's README) read as the current state of a *primary* one (the shipped
+source, the platform's API). Issues stay open after the fix lands; vendored docs
+freeze at their commit date.
+
+## Rule 2 — reintroduce the bug REALISTICALLY
+
+2026-07-16: to prove a contract would catch a symbol's removal, the probe renamed
+`def changes_apt_pin_inputs` → `def changes_apt_pin_inputs_REMOVED`. The contract
+passed, which read as a contract defect — but the renamed symbol **still contains
+the original as a substring** and the check is a substring match, so the probe was
+a no-op. The probe was the bug.
+
+Two lessons, the second being the expensive one:
+
+- a mutation must actually *destroy* what the check looks for;
+- and it must be a break that could **really happen**. The realistic break was
+  not renaming the function at all — it was **deleting the wiring line that calls
+  it**. Probing THAT (`if changes_apt_pin_inputs(paths):` removed from
+  `gate_matrix`) exposed a genuine hole the first probe never reached: the
+  contract stayed green because its token survived in a *comment* and a
+  *docstring*.
+
+Ask "what would the regression actually look like?" before mutating — an
+unrealistic mutation can only ever accuse the wrong party.
+
+Arming the positive also caught a broken test harness: `pkl eval -x` returned
+empty, so `bash -c ""` "passed".
+
+## Rule 3 — every kind of bound that turned "absent" into "unreachable"
+
+**Display bounds count.** 2026-07-20: a session ran `ls .agent/plans/ | tail -15`,
+did not see the handoff's designated "bible", and reported it **missing**. The
+file existed; `plan-*` sorts before `session-*` and fell outside the last 15
+lines. `| head`, `| tail`, and a bare `ls` of a large directory are all display
+bounds.
+
+**Checking N exact paths is a bound.** Same session: an agent was declared
+non-compliant for "not writing its report" after two specific paths were checked;
+it had written a 39 KB report to a third. When the question is *existence*, search
+the tree, not a guess.
+
+**A relative time bound can be silently invalid.** `find … -newermt "-20 minutes"`
+returns nothing on macOS/BSD `find`, which does not parse that relative form —
+indistinguishable from "no recent files".
+
+**A TOKEN SPELLING is a bound, and it is the most common form.** On 2026-07-21 a
+session grepped `lmstudio` and `lm_studio`, got 0, and reported *"graphify
+supports NONE of MLX / LM Studio / Jan"*. graphify spells it **`LM Studio`, with
+a space** — 3 hits, one of them its own `--help`. The literal grep was true; the
+conclusion was backwards. A later agent caught it.
+
+That session produced **five** bad-bound probes: a backtick defeated a search of
+its own handoff; a hyphen-vs-underscore filename made a present pointer read as
+absent; a `cd` persisted so the "control arm" ran in the same directory as the
+test; and zsh's lack of word-splitting made `grep -l $f` (multi-line `$f`)
+silently match nothing.
+
+## Rule 6 — the inherited bake-off table
+
+2026-07-21: a session inherited a 5-row model bake-off table from a handoff and
+reported it as "same corpus, same flags, so it is comparable". Only the corpus
+was ever actually constant.
+
+graphify records **no backend or model in any artifact** (control arm: the corpus
+filename *is* recorded), three of the directories were identical in shape, the
+semantic cache key is model-blind, and every arm was n=1.
+
+The whole comparison had to be discarded — after a claim from it ("gemma4 wins on
+cross-doc edges, 2 to 1") had already been reported to the user as a finding. It
+was a gap of **one**, from single runs, with no noise floor.
+
+So: before repeating an inherited number, either re-derive it and say so, or mark
+it explicitly as unverified and inherited. And when the number ranks things, ask
+what the **noise floor** is — a difference smaller than the same-input variance is
+not a difference.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the probes,
+  `hk.pkl`'s `no_grep_q_under_pipefail`, and the #289 base build.
+
+graphify's issue #959 and its `LM Studio` spelling are cited above as
+cross-check examples. Its upstream repo is deliberately **not** enumerated here:
+the owner/repo was not re-verified while writing this file, and a URL asserted
+from memory is the same defect the rule warns about. Resolve it from the
+installed package metadata before adding the row.

--- a/docs/rules-evidence/secrets-out-of-the-shell-env.md
+++ b/docs/rules-evidence/secrets-out-of-the-shell-env.md
@@ -1,0 +1,109 @@
+# Evidence — `secrets-out-of-the-shell-env`
+
+The 2026-07-27 incident and its measurements, behind
+`.claude/rules/secrets-out-of-the-shell-env.md`. The eager rule carries the
+directive, the fix, and the gates; this file carries what happened and how each
+claim was measured.
+
+## What happened (2026-07-27)
+
+`fnox activate` exported 49 variables into the login shell. mise records the
+whole environment delta in **`__MISE_DIFF`** (zlib-compressed, base64-encoded) so
+it can undo it on directory exit, and that variable is inherited by every child.
+Decoded, the live blob carried an AWS access key id and secret, several API
+tokens, an app password, and a Google client secret.
+
+**Nothing reached a public remote.** Verified by pickaxing the exact live values
+across the full history of both public repos: **0 commits** each, against a
+control term returning 339 (dotfiles) and 94 (knowledge-base), so the probe
+discriminates. The single `AKIA` in dotfiles history is a vendor example inside
+`docs/research/mintlify-cache/`.
+
+The exposure was real anyway: the blob sat in every child process, and one
+`env > notes.md` inside a tracked directory would have published all of it.
+
+## Why no scanner would have caught it
+
+Measured 2026-07-27 with synthetic, format-valid credentials — the same content
+in two forms:
+
+| scanner | plaintext env dump | the same content as a `__MISE_DIFF` blob |
+|---|---|---|
+| gitleaks 8.30.1 | **2 leaks** | **0** |
+| betterleaks 1.7.1 | **1 leak** | **0** |
+
+The control arm fires on the plaintext, so the zero is a real negative and not a
+blind probe. Both scanners are pattern matchers; compression destroys the
+patterns. This is the one gap that justifies custom code here at all — and the
+custom code covers only the decode.
+
+## The fix was probed, not quoted
+
+Probed on the pinned **1.31.1** in a throwaway project, both arms: with
+`env = "exec"`, `fnox export --format shell` emitted **only** the `env = true`
+opt-in, while `fnox exec -- env` still carried both. The rule's table is the
+tool's measured behaviour here, not a restatement of its release notes.
+
+## Applying it — three findings
+
+1. **A local override is NOT honoured at the user config root.** The config is
+   `~/.config/fnox/config.toml`, and `fnox config-files` lists it alone; adding
+   `config.local.toml` or `fnox.local.toml` beside it changed that output not at
+   all. Control arm: in a *project* directory the same command lists `fnox.toml`
+   **and** `fnox.local.toml` **and** the user root — three lines — so it can
+   report more than one file. The override layer is project-scoped only.
+2. **The file is generated.** Its first line reads *"Managed by `mde-py secrets
+   bootstrap-config`. Do not edit by hand."*, so a hand edit survives only until
+   the next bootstrap. The durable fix belongs in **`mde-py`'s generator**.
+3. **Two variables must be opted back in with `env = true`, and they are the two
+   this repo runs on.** `.mcp.json` interpolates one at MCP-server spawn, and
+   `gh` — which `ship`/`land`/`automerge` and every `gh api` call use — reports
+   its *active* account as the environment-authenticated one, with a
+   narrower-scoped fallback behind it. Exec-only for those two degrades tooling
+   silently rather than loudly.
+
+   A grep of `~/.zshrc`, `~/.zprofile`, `~/.config/mise/config.toml`,
+   `~/.claude/settings.json`, `~/.gitconfig` and `home/**` for all 49 names found
+   **zero** other declared consumers (control arm: 7 hits for
+   `export|source|eval` in the same `.zshrc`, so the grep works). State that
+   bound: it finds *declared* consumers only. A tool that reads a variable by
+   convention appears in no config file, so absence here is not absence.
+
+## APPLIED 2026-07-27 — by Ray, not by an agent
+
+The standing rule is to never touch a user-level file unasked
+(`feedback_no_user_level_file_updates`). Ray approved this one edit explicitly,
+and the harness permission layer *still* refused the write — correctly, and
+independently of that approval. **Two layers, and the outer one does not read
+approvals.** So the recipe was prepared here and Ray ran it: 46 of the 49
+exec-only, 3 opted back in.
+
+Verified in a **fresh interactive login shell**, not the session's own: the
+opted-in variable is set, two exec-only ones are not, and the recorded delta
+shrank from ~16.8 KB decoded to a 5.2 KB blob.
+
+The first attempt at that verification was **broken and looked like a clean
+pass** — `zsh -l -c` (non-interactive) never sources `.zshrc`, so nothing
+activated and the variable was "absent". The control arm, the same probe against
+the pre-fix config, ALSO said "absent", which is the only reason it was caught.
+`-i` is what makes the probe able to answer.
+
+## The same setting fixed the `[redacted]` digit-masking
+
+mise redacts every occurrence of a redacted variable's **value** in task output.
+fnox marked all 49 of its variables redacted, and two of them —
+`GEMINI_TELEMETRY_ENABLED` and `GEMINI_TELEMETRY_LOG_PROMPTS` — held
+**one-character, all-digit values**. So mise faithfully masked every digit in
+every `mise run` line, which is why a number read from `mise run` output could
+not be trusted. `LANGSMITH_WORKSPACE_ID` was worse: an **empty** value.
+
+Those are telemetry flags, not secrets. The digit-masking was never a mise bug;
+it was collateral from treating a non-secret as a secret. It returns if `mde-py`
+re-bootstraps the config.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the
+  `no_env_dump` gate, `env_blob_scan.py`, and the history pickaxe.
+- [ray-manaloto/knowledge-base](https://github.com/ray-manaloto/knowledge-base) —
+  the second public repo checked by the same pickaxe.

--- a/docs/rules-evidence/verify-before-advancing.md
+++ b/docs/rules-evidence/verify-before-advancing.md
@@ -1,0 +1,66 @@
+# Evidence — `verify-before-advancing`
+
+Archaeology and provenance behind `.claude/rules/verify-before-advancing.md`.
+Extracted from the rule so the eager copy carries the directive and this file
+carries the case history. Read it when you want to know *why* a line in that
+rule is worded the way it is, or before changing one.
+
+## Why the rule exists
+
+The expensive failure mode is declaring a step complete on an *assumption*:
+"the warm path will skip the build", "that's a trivial edit", "lint should be
+fine". The assumption is sometimes wrong, and the gap surfaces a task later,
+when unwinding it is costly. The rule makes verification a hard gate between
+units of work rather than an optional courtesy. It is the operational teeth
+behind `zero-skip-policy.md`.
+
+## This file is where the ≤12,000-char misattribution was born
+
+*(2026-07-15 archaeology.)*
+
+The rule's conditional matrix once asserted a "≤200-line / ≤12,000-char limit"
+for a gate that enforced **only** lines.
+
+The number is REAL — it is **Windsurf's** `AGENTS.md` limit (agnix AGM-003) —
+but it arrived here without its source, was later machine-enforced to match this
+prose, and was captioned "per Claude Code memory docs", which never stated it.
+
+**A true fact that travels without its source becomes indistinguishable from an
+invented one**, and gets applied to files its real owner never governed.
+
+Cite a figure only where you can name the vendor; when code and a doc disagree,
+re-read the source before making either match the other. See
+`.claude/rules/md-size-budgets.md`, which now owns the budgets and their
+provenance in full.
+
+## The other half is SCOPE: a fact needs its CONDITION, not just its source
+
+Provenance alone is not enough. Each fact below is genuine and correctly
+sourced, and each was still wrong where it was used — because it travelled
+without its "true when". This is *harder* to catch than invention: the citation
+checks out, so the claim survives review.
+
+| fact | true when | was applied to | what it cost |
+|---|---|---|---|
+| 12,000-char limit | Windsurf / agnix AGM-003 | all Claude markdown | a gate enforcing a limit its real owner never set |
+| renovate "extracts NOTHING" under an unsupported node | some older renovate | 43.265.1, which extracts fine | a hunt for a data-loss bug that does not exist |
+| 2–2.5h cold build | the p2996 cache **misses** | any `mise-system.toml` touch | a ~4x over-warning; measured ~37 min |
+
+A stated condition is also what makes a fact **falsifiable later**: "2.5h when
+p2996 misses" tells the next reader what to check, while a bare "2.5h" can only
+be believed or doubted.
+
+So when you carry a number, carry its condition — and when you meet one, ask
+"what has to be true for this to hold, and is it true HERE?"
+
+## Why this lives in one place
+
+Deliberately folded into the rule's evidence file rather than given its own
+eager rule: one idea, one place. Making it a separate rule would add a fourth
+eager file restating what `md-size-budgets.md` and this rule already carry.
+
+## GitHub repos touched
+
+- _None._ — this is internal repo archaeology; the Windsurf figure is cited from
+  <https://docs.windsurf.com/windsurf/cascade/memories>, a vendor docs site
+  rather than a GitHub repo.


### PR DESCRIPTION
Every `.claude/rules/*.md` without `paths:` frontmatter loads at session start,
in full. Measured this session with an `InstructionsLoaded` hook: 23
`session_start` events + 1 `include`, reconciling exactly with 21 unscoped rules
+ CLAUDE.md + .claude/CLAUDE.md + AGENTS.md. Unscoped rules are 117,095 B — 88%
of the eager corpus.

Scoping cannot fix that. `md-size-budgets.md` § "the trigger test" already
establishes that behaviour- and creation-triggered rules MUST stay eager, and
moving them to skills reproduces the `disable-model-invocation` hole that
`do-not.md` #9 exists because of. Trimming is the only lever.

So: each rule keeps its directive, its operative constraints, and one worked
example; the archaeology, provenance tables and case histories move to a tracked
`docs/rules-evidence/<rule>.md` and are reachable by Read on demand. Nothing
leaves git — the evidence stops being re-injected into every session.

| rule | before | after |
|---|---:|---:|
| mise-tasks-only | 13,823 | 10,810 |
| probes-need-a-control-arm | 11,398 | 6,867 |
| secrets-out-of-the-shell-env | 9,239 | 6,124 |
| verify-before-advancing | 8,976 | 7,308 |

Eager corpus 132,683 -> 120,356 B (~33,170 -> ~30,089 tokens), -9.3%. 17 rules
remain; the pattern is established and the rest can follow incrementally.

Deliberately NOT extracted: the directive itself, the check matrices, and one
canonical worked failure per rule — the example is what makes a rule stick, and
an agent that does not follow the link still gets a persuasive rule.

Gates: lint rc=0 · lint-docs rc=0 (agnix, --strict) · pytest 1033 · verify 110
passed, 0 failed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CzPdn3iHw6uhMWEdVPADfW

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787846732&installation_model_id=429246&pr_number=413&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F413&signature=62d5477f0af48ec51a0f1c83ac720e21b8577f319487d3dbccd786fb10ca958b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->