### PR TITLE
docs(rules): register docs/rules-evidence/ as a tracked artifact convention

### DIFF
--- a/.claude/rules/agent-artifact-conventions.md
+++ b/.claude/rules/agent-artifact-conventions.md
@@ -33,6 +33,16 @@ never in `.agent/`. Do not create ad-hoc directories in either.
 | `docs/research/kb/reports/` | Persisted verbatim agent reports |
 | `docs/handoffs/` | Cross-surface session handoffs |
 | `docs/adr/` | Domain-shaped decisions (our ADRs are `.claude/rules/*.md`) |
+| `docs/rules-evidence/` | Archaeology extracted OUT of an eager rule: one `<rule>.md` per `.claude/rules/<rule>.md` |
+
+**`docs/rules-evidence/` exists to buy back eager context.** Every unscoped
+`.claude/rules/*.md` loads in full at session start — measured 2026-07-28 with an
+`InstructionsLoaded` hook, they are ~88% of the eager corpus. Scoping cannot fix
+that (`md-size-budgets.md` § "the trigger test"), so the lever is moving the
+case histories, provenance tables and worked-failure logs into a tracked sibling
+the rule links by path. The rule keeps its directive, its operative constraints,
+and **one** canonical worked example; nothing leaves git, it just stops being
+re-injected every session. Name the file after the rule, one-to-one.
 
 **Promoting is the default for anything an eval, a rule, or a future session
 will cite.** The migration surfaced why: five eager rules cited research that

--- a/.claude/rules/md-size-budgets.md
+++ b/.claude/rules/md-size-budgets.md
@@ -162,6 +162,13 @@ Claude can derive from the codebase (directory layouts, dependency lists,
 architecture overviews) and keep pitfalls, rationale, and conventions that
 differ from tool defaults. That is `/doctor`'s documented heuristic.
 
+The repo's applied form of that is **`docs/rules-evidence/<rule>.md`**: a rule's
+archaeology, provenance tables and worked-failure logs move to a tracked sibling
+it links by path, keeping the directive plus one canonical example eager. See
+`agent-artifact-conventions.md`. Measured 2026-07-28 — unscoped rules are
+**~88%** of the eager corpus, so this is where the bytes actually are; the first
+four extractions took it 132,683 → 120,356 B.
+
 ## Applies to
 
 Every tracked `CLAUDE.md`, `AGENTS.md`, `.claude/rules/*.md`, and


### PR DESCRIPTION
PR #413 created `docs/rules-evidence/` and 10 rule lines now cite it, but no
conventions doc listed it — in the very file whose first rule is "no ad-hoc
directories". A tracked artifact directory that the conventions doc does not
know about is how the next session invents a second one beside it.

- `agent-artifact-conventions.md` — add the row plus why it exists: unscoped
  rules are ~88% of the eager corpus (measured 2026-07-28 with an
  `InstructionsLoaded` hook), scoping cannot fix that per `md-size-budgets.md`
  § "the trigger test", so archaeology moves to a tracked sibling and the rule
  keeps its directive plus one canonical example. One file per rule.
- `md-size-budgets.md` — point its "trimming, not scoping" paragraph at the
  applied form, with the first four extractions' measured result.

Eager corpus 120,356 -> 121,104 B: `agent-artifact-conventions.md` is itself
eager, so documenting the convention costs 748 B, while `md-size-budgets.md` is
`paths:`-scoped and its addition is free. Net for the session is still
132,683 -> 121,104 (-8.7%).

Gates: lint rc=0 · lint-docs rc=0 (agnix --strict) · pytest 1033 · verify 110
passed, 0 failed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CzPdn3iHw6uhMWEdVPADfW

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787847704&installation_model_id=429246&pr_number=414&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F414&signature=43d4270cc335b69e8b8505a6092a651e9177a863b3105fd67266b257bc2d6200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->