### PR TITLE
docs(rules): finish rules-evidence extraction (-15.5KB eager, -20.4% total)

### DIFF
--- a/.claude/rules/agent-artifact-conventions.md
+++ b/.claude/rules/agent-artifact-conventions.md
@@ -4,12 +4,11 @@ Agent working artifacts live under **`.agent/`** (gitignored, machine-local).
 Anything that should survive a clone is **tracked**, and lives under `docs/` —
 never in `.agent/`. Do not create ad-hoc directories in either.
 
-> **Renamed from `.omc/` (2026-07-25).** That tree was named after the
-> `oh-my-claudecode` plugin, which is **not enabled** — a convention named for
-> a tool nothing loads. `.agent/` was verified before adopting, not assumed:
-> control-armed over Claude Code's full docs corpus, `.agent/` → **0 hits**
-> while `CLAUDE.md` → 439, so the probe discriminates. Claude Code claims
-> `.claude/**` exclusively and has no opinion about `.agent/`.
+> **Renamed from `.omc/` (2026-07-25)** — that tree was named after a plugin
+> that is not enabled. `.agent/` was control-armed before adopting, not assumed
+> (`.agent/` → 0 hits in Claude Code's docs, `CLAUDE.md` → 439). Archaeology,
+> and why the ignore lives in `.gitignore` rather than `.git/info/exclude`:
+> `docs/rules-evidence/agent-artifact-conventions.md`.
 
 ## Local, gitignored — swept away by `git clean -xdf`
 
@@ -35,20 +34,18 @@ never in `.agent/`. Do not create ad-hoc directories in either.
 | `docs/adr/` | Domain-shaped decisions (our ADRs are `.claude/rules/*.md`) |
 | `docs/rules-evidence/` | Archaeology extracted OUT of an eager rule: one `<rule>.md` per `.claude/rules/<rule>.md` |
 
-**`docs/rules-evidence/` exists to buy back eager context.** Every unscoped
-`.claude/rules/*.md` loads in full at session start — measured 2026-07-28 with an
-`InstructionsLoaded` hook, they are ~88% of the eager corpus. Scoping cannot fix
-that (`md-size-budgets.md` § "the trigger test"), so the lever is moving the
-case histories, provenance tables and worked-failure logs into a tracked sibling
-the rule links by path. The rule keeps its directive, its operative constraints,
-and **one** canonical worked example; nothing leaves git, it just stops being
+**`docs/rules-evidence/` exists to buy back eager context.** Unscoped
+`.claude/rules/*.md` are ~88% of the eager corpus and scoping cannot fix that
+(`md-size-budgets.md` § "the trigger test"), so the lever is moving case
+histories, provenance tables and worked-failure logs into a tracked sibling the
+rule links by path. The rule keeps its directive, its operative constraints, and
+**one** canonical worked example; nothing leaves git, it just stops being
 re-injected every session. Name the file after the rule, one-to-one.
 
 **Promoting is the default for anything an eval, a rule, or a future session
-will cite.** The migration surfaced why: five eager rules cited research that
-had never been tracked, so every reader outside this one machine hit a dead
-link — and `doc_refs` could not see it, because the whole `.omc/` prefix sat in
-its allowlist. A citation to something only you can open is not a citation.
+will cite** — the migration found five eager rules citing research that had
+never been tracked, so every reader outside this one machine hit a dead link.
+A citation to something only you can open is not a citation.
 
 ## Two things that must NOT be normalised
 
@@ -74,18 +71,6 @@ its allowlist. A citation to something only you can open is not a citation.
    `.agent/` — Claude Code's loader does not scan anywhere else. Frontmatter
    `name` should match the directory name so slash-invocation and auto-loading
    stay consistent. Same for `.claude/rules/` and `.claude/agents/`.
-
-## Why `.gitignore`, not `.git/info/exclude`
-
-`.omc/*` was excluded via `.git/info/exclude`, which is **per-clone and does
-not survive a fresh clone** — which is exactly why every artifact anyone
-actually wanted tracked had to be force-added with `git add -f`. An ignore rule
-that exists on one machine is not a convention, it is an accident. `.agent/` is
-in the real `.gitignore`.
-
-`.omc/` also remains ignored: the statusline HUD configured in the **user-level**
-`~/.claude/settings.json` still recreates `.omc/state/` in whichever repo is
-cwd. Retiring that is a user-config change this repo does not make unasked.
 
 ## Why this rule cannot be `paths:`-scoped
 

--- a/.claude/rules/agent-report-persistence.md
+++ b/.claude/rules/agent-report-persistence.md
@@ -8,16 +8,14 @@ end.
 
 ## Why this rule exists
 
-Session 2026-07-05: an 11-agent release-notes sweep produced 13 detailed
-reports (syntax sketches, file:line misconfiguration tables, probe
-transcripts, a backend status matrix). The notepad got condensed summaries
-as the work progressed, but the full reports existed **only in the
-session's context window** — one `/clear` away from being lost. A manual
-round-2 pass recovered them; this rule makes that recovery unnecessary.
+Session 2026-07-05: an 11-agent sweep produced 13 detailed reports that
+existed **only in the session's context window** — one `/clear` from
+being lost. A manual round-2 pass recovered them.
 
 Condensation is lossy in exactly the way that hurts later: the summary
 keeps the conclusion but drops the evidence, the exact command lines, and
-the file:line anchors the implementing session needs.
+the file:line anchors the implementing session needs. Three incidents:
+`docs/rules-evidence/agent-report-persistence.md`.
 
 ## Rules
 
@@ -26,24 +24,16 @@ the file:line anchors the implementing session needs.
    `docs/research/kb/reports/agents/<agent-name>.md` in the SAME turn — before acting on
    its content. Sources the agent fetched go to `.agent/kb/raw/<slug>.md`.
 
-   > **Path changed 2026-07-20; the old path was `docs/research/runs/<topic>/agents/`.**
-   > `docs/research/kb/` is the corpus root and is **tracked in git** (added with
-   > `git add -f`, since `.git/info/exclude` carries `.agent/*`), so artifacts
-   > survive a fresh clone. `docs/research/runs/**` is not tracked and does not.
-   > The two conventions co-existed for one session and immediately cost
-   > something: an agent correctly followed the *old* rule, the caller looked in
-   > the *new* path, and wrongly reported it as non-compliant. **One path.**
-   > Existing `docs/research/runs/**` artifacts stay where they are; new ones go to
-   > `docs/research/kb/`. See memory `feedback_store_research_in_graphify`.
+   > **ONE path.** `docs/research/kb/` is tracked and survives a fresh clone;
+   > the old `docs/research/runs/<topic>/agents/` does not. Existing artifacts
+   > stay where they are; new ones go to `docs/research/kb/`.
 
 1b. **Instruct agents to persist INCREMENTALLY, not at the end.** Tell a
-   research delegation to write each source as it fetches it and to write its
-   report early and update it. On 2026-07-20 two agents held everything in
-   memory, died silently after ~40 minutes, and left **nothing**; re-dispatched
-   with an incremental instruction, they produced output within minutes. An
-   agent that dies having written 13 of 20 sources leaves 13. This is the same
-   principle as `PostCompact`/`SubagentStop` capture — durable capture must be
-   incremental, never end-of-run.
+   research delegation to write each source as it fetches it, and to write its
+   report early and update it. Two agents that held everything in memory died
+   silently after ~40 minutes and left **nothing**. An agent that dies having
+   written 13 of 20 sources leaves 13; one planning to write at the end leaves
+   0. Durable capture must be incremental, never end-of-run.
 2. **Verbatim means verbatim.** Keep the agent's tables, evidence links,
    probe output, and repos-touched enumeration intact. Annotating
    decisions inline afterwards (e.g. "DECIDED: option A") is encouraged;

--- a/.claude/rules/ai-cli-invocation.md
+++ b/.claude/rules/ai-cli-invocation.md
@@ -1,17 +1,9 @@
 # AI CLI Invocation Policy
 
-> **This rule is deliberately EAGER (no `paths:` frontmatter).** It guards an
-> *action* — invoking an external AI CLI from Bash — not a file. Path-scoped
-> rules "trigger when Claude **reads** files matching the pattern", and no glob
-> predicts the moment you are about to shell out to `codex`. It was scoped to
-> `AGENTS.md`/`.claude/**`/`scripts/**`/`.agent/**` until 2026-07-20, which meant
-> it could only fire by accident: a session invoked `codex exec "prompt"`
-> positionally (the documented-wrong form), wasted a probe on the resulting
-> stdin hang, and only saw this rule *afterwards*, because it happened to write
-> into `.agent/**`. That is the same defect `zero-skip-policy` and
-> `clean-git-state` were un-scoped for on 2026-07-15. See
-> `.claude/rules/md-size-budgets.md` § "Scoping: the trigger test" — this rule
-> is **behaviour-triggered**, and behaviour-triggered rules stay eager.
+> **EAGER on purpose** — behaviour-triggered, so no glob predicts it
+> (`md-size-budgets.md` § "the trigger test"). While it was scoped it could only
+> fire *after* the mistake, and did. Archaeology:
+> `docs/rules-evidence/ai-cli-invocation.md`.
 
 When calling external AI CLIs (Codex, Gemini, OpenCode) from Bash, you MUST use the
 correct invocation patterns. Incorrect flags waste tokens and cause silent failures.
@@ -73,16 +65,9 @@ Codex or Gemini. For background tasks, use:
 
 ## Reference
 
-**The patterns above ARE the reference — there is no script to consult.** This
-section used to point at the octopus `orchestrate.sh` / `get_agent_command()`.
-That file does not exist in this repo (control-armed: `find . -name
-orchestrate.sh` → 0, while `find . -maxdepth 1 -name hk-common.pkl` → 1, so the
-probe discriminates); it lives only inside the `octo@nyldn-plugins` plugin
-cache, which is `false` in BOTH `.claude/settings.json` and
-`~/.claude/settings.json` and may vanish on plugin GC. A reader could not act
-on it.
-
-When a pattern here looks wrong, **re-probe the CLI itself** (`codex exec
---help`, `gemini --help`) rather than hunting for a canonical script — these
-flags change between releases, which is how the wrong forms above got
-documented in the first place.
+**The patterns above ARE the reference — there is no script to consult.** When a
+pattern here looks wrong, **re-probe the CLI itself** (`codex exec --help`,
+`gemini --help`) rather than hunting for a canonical script; these flags change
+between releases, which is how the wrong forms got documented in the first
+place. (This section once pointed at a file that does not exist in this repo —
+control arm and detail: `docs/rules-evidence/ai-cli-invocation.md`.)

--- a/.claude/rules/do-not.md
+++ b/.claude/rules/do-not.md
@@ -1,10 +1,8 @@
 # Do Not — Project Invariants
 
 This is the authoritative list of things agents (and humans) must not do
-in this repo. Moved out of `AGENTS.md` in session 2026-04-09c as part of
-a doc-size split (the root `AGENTS.md` was exceeding the
-`claude_md_size_limit` hk step and this list was the largest
-self-contained block). Each item's context is preserved verbatim.
+in this repo. Control arms and case history for each entry:
+`docs/rules-evidence/do-not.md`.
 
 1. **Do NOT launch CLion or VS Code from the dock for devcontainer work.**
    macOS GUI processes don't inherit terminal env, so `mise`, `uv`, and
@@ -33,74 +31,35 @@ self-contained block). Each item's context is preserved verbatim.
    2026-04-09c's debug goose-chase. See
    `feedback_docker_desktop_runtime.md`.
 
-8. **Do NOT run bare `graphify install` — always pass `--project`.** One flag
-   separates safe from destructive (verified in the installed 0.9.20
-   `install.py`, 2026-07-20):
-   - `graphify claude install` → **project only** (`./CLAUDE.md` +
-     `./.claude/settings.json`).
-   - `graphify install --project` → **project only** (adds
-     `./.claude/skills/graphify/**` + a block in `./.claude/CLAUDE.md`).
-   - ⚠️ `graphify install` **without** `--project` → **mutates `~/.claude`**:
-     ~43 KB of skill files, **appends a `# graphify` H1 to
-     `~/.claude/CLAUDE.md`** (creating it if absent), and sprays
-     `.graphify_version` stamps into every other installed platform's user
-     skill dir.
-
-   Control arm on the safe claim: all **18** `Path.home()` call sites in
-   `install.py` sit on `project=False` branches; the project-scoped call chain
-   contains none. **`CLAUDE_CONFIG_DIR` is NOT containment** — it redirects the
-   skill dir only, while the `~/.claude/CLAUDE.md` write is hardcoded. This is
-   the machine-level expression of the PROJECT-ONLY invariant; also never run
+8. **Do NOT run bare `graphify install` — always pass `--project`.** Without it,
+   graphify **mutates `~/.claude`**: ~43 KB of skill files and a `# graphify`
+   H1 appended to `~/.claude/CLAUDE.md`. `CLAUDE_CONFIG_DIR` is NOT containment
+   (it redirects the skill dir only; that write is hardcoded). Never run
    `graphify hook install` or `graphify --watch`.
 
-   **This generalises to EVERY platform, in two flavours (verified 2026-07-21,
-   0.9.22).** Run any `graphify <platform> install` in a **throwaway directory
-   outside this repo**, never here:
-   - ⚠️ **`graphify codex install` breaks our lint gate with OR without
-     `--project`.** Both paths call `_agents_install` (`install.py:1463`), which
-     appends a 13-line / 1,129-byte `## graphify` block to the root
-     `AGENTS.md` — a file at exactly **200/200 lines**. Result: 213 lines and a
-     failed `md_size_budget` step. `--project` only relocates the *skill* file.
-   - ⚠️ **`graphify antigravity install` without `--project` writes OUTSIDE the
-     project** — `~/.gemini/config/skills/graphify/SKILL.md`. With `--project`
-     it stays in-repo (control arm: `_project_install`'s body contains **zero**
-     `Path.home()` calls).
+   ⚠️ **This generalises to every platform, and `--project` is not always
+   enough** — `graphify codex install` appends to the root `AGENTS.md` and
+   fails our size gate either way. Run any `graphify <platform> install` in a
+   **throwaway directory outside this repo**, never here.
 
 9. **Do NOT commit onto the default branch — branch FIRST.** Create the branch
-   *before* the commit, then `mise run ship`. It happened twice: 34 files on
-   2026-07-20, and 19 on 2026-07-27 straight after `mise run land` (which
-   **leaves you on `main`**). Both were recoverable only because nothing had
-   been pushed — the objection came at push time, from `mise run ship`'s own
-   refusal. Recovery is `git branch <new> && git reset --hard origin/main`.
+   *before* the commit, then `mise run ship`. It has happened twice, the second
+   time straight after `mise run land` (which **leaves you on `main`**).
+   Recovery is `git branch <new> && git reset --hard origin/main`.
 
-   **This is now machine-enforced (#400), in three layers:**
-   - `no_commit_to_branch` — an hk BUILTIN, wired in `hk.pkl`'s **pre-commit**
-     hook. Declined in #154 because it treated a detached HEAD as fatal;
-     hk v1.52.0 (`jdx/hk#1075`) fixed it, probed on all four arms here (branch
-     → 0, `main` → 1, detached → 0, `master` → 1). It is deliberately NOT in
-     `allSteps`: that mapping is spread into `check`/`fix`, so `mise run lint`
-     — and CI's lint job, which checks out a real `main` — would fail on it.
-   - the PreToolUse guard denies `--no-verify` / `git commit -n` and a
-     `HK_SKIP_HOOKS=` prefix. **No git hook can catch these** — git decides not
-     to run the hook before the hook exists as a process, so a pre-push hook is
-     not a fix and should not be built.
-   - a repository **ruleset requires a pull request for `main`**, which is the
-     only layer an agent cannot skip. Everything local is advisory.
-
-   The guidance already existed in the `git-branch-commit-push-workflow` skill
-   — but that skill carries `disable-model-invocation: true`, which **agnix
-   `--strict` requires** for state-mutating "dangerous" skills, so the model
-   cannot reach it at decision time. Hence this line: an eager rule is the only
-   layer that fires before the mistake. Do not "fix" the skill by removing the
-   flag; the docs gate will reject it, and correctly.
+   Machine-enforced (#400) in three layers: hk's `no_commit_to_branch` in the
+   **pre-commit** hook, the PreToolUse guard denying `--no-verify` / `git commit
+   -n` / a `HK_SKIP_HOOKS=` prefix (**no git hook can catch those** — git skips
+   the hook before it exists as a process), and a repository **ruleset requiring
+   a PR for `main`** — the only layer an agent cannot skip.
 
 10. **Do NOT write an environment dump into a tracked file.** Not `env`, not
     `printenv`, not `export -p`, not a debug log carrying them. The interactive
     shell holds real credentials, and mise packs the whole delta into
     `__MISE_DIFF` (zlib + base64) — a form **no secret scanner can read**
-    (measured: gitleaks 2 → 0, betterleaks 1 → 0 on the same content). Write a
-    dump to the scratchpad and delete it. Gated by the `no_env_dump` hk step;
-    see `secrets-out-of-the-shell-env.md`.
+    (measured: gitleaks 2 → 0, betterleaks 1 → 0). Write a dump to the
+    scratchpad and delete it. Gated by `no_env_dump`; see
+    `secrets-out-of-the-shell-env.md`.
 
 > **Relaxed 2026-07-19 — MCP registration is no longer a "do not".** Native
 > MCP registration (`claude mcp add`, a plugin's bundled servers, a project

--- a/.claude/rules/gh-cli-watch.md
+++ b/.claude/rules/gh-cli-watch.md
@@ -6,39 +6,21 @@ When waiting on a GHA workflow run or PR check completion via the
 
 ## Why this rule exists
 
-The `gh` CLI has first-class support for live-monitoring with
-appropriate refresh intervals, exit codes, and table updates:
+`gh` has first-class live-monitoring with correct refresh intervals,
+exit codes, and table updates. A hand-rolled loop has none of that: it
+buries the real exit code (the `grep` becomes the shell's exit), races
+on multi-run queues, burns API quota, and shows the operator nothing.
 
-- `gh pr checks <n> --watch [--fail-fast] [--interval N]` — refreshes
-  every 10s by default until terminal state. Exit code reflects
-  pass/fail/pending. Docs: <https://cli.github.com/manual/gh_pr_checks>.
-- `gh run watch <run-id> --exit-status` — same shape for a specific
-  run. Caveat in `feedback_gh_run_watch.md`: cross-verify exit code
-  with `gh run view <id> --json conclusion` after — `--exit-status`
-  has reported 0 prematurely on edge cases.
+The canonical break: under `set -o pipefail`, `cmd | grep -q PAT`
+returns **141** when the match *succeeds* — a check that can only fail.
+That is `hk.pkl`'s `no_grep_q_under_pipefail` step.
 
-Hand-rolled poll loops:
+⚠️ `gh run watch --exit-status` has reported **0 prematurely** — always
+cross-verify with `gh run view <id> --json conclusion`.
 
-- Bury exit codes (the `grep` becomes the shell's exit, masking API
-  errors).
-- Race on multi-run scenarios (`gh run list --limit 1` matches the
-  wrong run when multiple are queued).
-- Burn API quota on aggressive sleeps.
-- Don't redraw / show progress; the operator stares at silence.
-
-## When to reach for Claude Code's `Monitor` tool instead
-
-Only when one of these is true:
-
-1. You need **per-transition notifications** (each new ✔/✗ should
-   surface as a separate event in chat). `gh pr checks --watch` shows
-   a redrawing live table — fine for humans, low signal for an
-   automation that wants to react per-transition.
-2. The command is on a **non-GHA system** with no built-in watch flag.
-3. You need to **filter** the events (e.g., only emit on failure).
-
-For "wait until done, tell me when", prefer `gh pr checks --watch`
-straight up.
+Full rationale, the anti-pattern catalogue, and when Claude Code's
+`Monitor` tool is the right tool instead (per-transition notifications,
+non-GHA systems, event filtering): `docs/rules-evidence/gh-cli-watch.md`.
 
 ## Canonical patterns
 
@@ -67,20 +49,17 @@ gh run view 1234567890 --json conclusion --jq '.conclusion'
 gh pr checks --watch        # auto-detects from current branch
 ```
 
-## Anti-patterns
+## Anti-pattern
 
 ```bash
 # WRONG — hand-rolled poll, no exit-code awareness:
 while ! gh pr checks 123 --json bucket | grep -q success; do
   sleep 30
 done
-
-# WRONG — racy on multi-run queues:
-gh run list --limit 1 --json status
-
-# WRONG — fixed-time wait, never reflects actual completion:
-sleep 600 && gh pr checks 123
 ```
+
+Two more (a racy `gh run list --limit 1`, a fixed `sleep 600`) are in
+the evidence file.
 
 ## Applies to
 

--- a/.claude/rules/local-devcontainer-first.md
+++ b/.claude/rules/local-devcontainer-first.md
@@ -44,33 +44,26 @@ If a failure mode recurs, it earns a task + a `python/` module
 ## Pick the right container — a dirty one lies
 
 The environment must match the one whose failure you are predicting, and the
-running devcontainer often is NOT it. Measured 2026-07-16 (#288): simulating
-`curl=8.18.0-1ubuntu2` **failed in the devcontainer** and **passed in a clean
-base container**, because the devcontainer already had a newer curl installed
-and apt refuses to downgrade. The pin was fine; the environment lied.
+running devcontainer often is NOT it. Measured (#288): the same apt pin
+**failed in the devcontainer** and **passed in a clean base container**, because
+the devcontainer already had a newer package and apt refuses to downgrade. The
+pin was fine; the environment lied.
 
-- Predicting the **base build**? Use a throwaway `docker run --rm` on the
-  digest-pinned `BASE_IMAGE` — that is what the build actually starts from. An
-  ephemeral probe container is not devcontainer lifecycle, so `do-not.md` #3
-  does not apply.
-- Predicting **runtime behavior in the shipped image**? Use the devcontainer
-  via `devcontainer exec` — and keep `verify-container-latest`'s rule that it
-  must be current (`verify-before-advancing.md`).
+- Predicting the **base build**? A throwaway `docker run --rm` on the
+  digest-pinned `BASE_IMAGE` — that is what the build actually starts from (an
+  ephemeral probe is not devcontainer lifecycle, so `do-not.md` #3 doesn't bind).
+- Predicting **runtime behavior in the shipped image**? The devcontainer via
+  `devcontainer exec`, kept current per `verify-container-latest`.
 
 Read the base image and any pinned constants **out of the Dockerfile** rather
 than restating them, or the probe drifts into testing an image nobody builds.
 
 ## What this does NOT license
 
-- **It does not replace CI.** A green local probe answers one question. CI
-  still builds, smokes, and publishes. Never skip a gate because a probe passed
-  (`zero-skip-policy.md`).
-- **It does not license local base builds.** `mise run build` / `docker buildx
-  bake dev-load` remain CI-only (`do-not.md` #2). A probe *simulates* or
-  *inspects*; it does not build the image.
-- **It does not make an arm64 Mac a substitute for the amd64 image.** The full
-  smoke cannot run here (Rosetta/TSan); `feedback_image_smoke_mac_rosetta_tsan`
-  still holds. Pass `--platform linux/amd64` and know what the probe can't see.
+A green probe does not replace CI, does not license a local base build
+(`do-not.md` #2), and does not make this arm64 Mac a substitute for the amd64
+image (the full smoke can't run here — Rosetta/TSan). Detail:
+`docs/rules-evidence/local-devcontainer-first.md`.
 
 ## Applies to
 

--- a/.claude/rules/long-running-command-hangs.md
+++ b/.claude/rules/long-running-command-hangs.md
@@ -6,25 +6,26 @@ potentially-slow command and then wait on it indefinitely.
 
 ## Why this rule exists
 
-Session 2026-06-29: a `hk run pre-commit --all --stash none` invocation
-hung at **0% CPU with no child processes for ~7 hours** before it was
-noticed. hk has no native timeout, so nothing aborted it. Worse, the run
-had been launched as `hk ... 2>&1 | tail -40`, so when it was finally
-killed the pipeline reported **exit 0** (tail's exit code) — masking the
-fact that the gate never actually passed. Two traps in one incident:
-unbounded wait + pipe-masked exit code.
+Session 2026-06-29: a `hk run pre-commit --all` invocation hung at **0%
+CPU with no child processes for ~7 hours** — hk has no native timeout,
+so nothing aborted it. It had been launched as `hk ... 2>&1 | tail -40`,
+so when it was finally killed **the pipeline reported exit 0** (tail's),
+masking the fact that the gate never passed. Two traps in one incident;
+both are now operative rules below, and both are guard-enforced.
+
+Case history — the backgrounding reversal, which log file to read, and
+the ruff wedge's two published red herrings:
+`docs/rules-evidence/long-running-command-hangs.md`.
 
 ## Rules
 
 1. **Use `mise run lint`, not raw `hk run check`/`hk run pre-commit`.**
    `mise run lint` runs the **read-only** `hk run check --all` (identical
-   to CI — local == CI, no silent source rewriting; the fix path is
-   `mise run fmt` → `hk fix`) wrapped in an out-of-process hard timeout
-   (hk has none of its own — verified against hk 1.46 and the live v1.48
-   docs: no `--timeout` flag, no `timeout` step key, no `HK_*` timeout env
-   var). On expiry it kills hk's whole process group and prints the tail
-   of the debug log. Default 600s; override with `--timeout <secs>` or
-   `DOTFILES_LINT_TIMEOUT=<secs> mise run lint`. Source:
+   to CI — no silent source rewriting; the fix path is `mise run fmt`)
+   wrapped in an out-of-process hard timeout, because **hk has none of
+   its own**. On expiry it kills hk's whole process group and prints the
+   debug-log tail. Default 600s; override with `--timeout <secs>` or
+   `DOTFILES_LINT_TIMEOUT=<secs>`. Source:
    `python/src/dotfiles_setup/lint.py`.
 
 2. **For any command expected to exceed ~30s, never wait blind.** Either
@@ -32,11 +33,9 @@ unbounded wait + pipe-masked exit code.
    debug log. **EXCEPTION — Mac-side container ops: background-and-idle gets
    them REAPED.** `mise run ship`/`land`, `verify-local`, `sync`, and image
    pulls are killed if the turn goes idle waiting on them, so "background it"
-   — the default advice above — is precisely wrong here and cost a killed
-   20-minute image pull (2026-07-16). Measured both ways: a foreground 10-min
-   bound also killed a `ship` mid-`shellcheck` (rc=143). What works is
-   **in-turn polling** — background the command, then keep the turn engaged
-   reading its log until it finishes:
+   is precisely wrong here (measured both ways — a foreground 10-min bound
+   also killed a `ship` at rc=143). What works is **in-turn polling** —
+   background the command, then keep the turn engaged reading its log:
 
    ```bash
    deadline=$((SECONDS+540))
@@ -49,17 +48,15 @@ unbounded wait + pipe-masked exit code.
    not background operators and stay allowed.
 
    **Backgrounding stays correct for CI/remote waits** (`gh pr checks --watch`,
-   `gh run watch`) — those run on GitHub's infrastructure, not this Mac, and
-   nothing local reaps them. The hazard is specifically local, long, Mac-side
-   work. See `feedback_long_mac_ops_keep_turn_engaged`, which this rule used to
-   contradict outright. For a `mise run lint` run the log is
-   **`~/.local/state/dotfiles/hk-lint.log`** — the per-run `HK_LOG_FILE`
-   the wrapper sets (`lint.py` `DEFAULT_LOG_FILE`). Read THAT one:
-   `~/.local/state/hk/hk.log` is a *different* file written by other hk
-   entrypoints (e.g. the pre-push hook) and is typically stale, which
-   makes a live hang look idle (misread 2026-07-14). mise →
-   `~/.local/state/mise/mise.log` (`MISE_LOG_FILE`, debug level set in
-   `mise.toml [env]`). Use a count-diff monitor loop, not a fixed sleep.
+   `gh run watch`) — those run on GitHub's infrastructure and nothing local
+   reaps them. The hazard is specifically local, long, Mac-side work.
+
+   For `mise run lint` the log is **`~/.local/state/dotfiles/hk-lint.log`**
+   (the per-run `HK_LOG_FILE` the wrapper sets). Read THAT one —
+   `~/.local/state/hk/hk.log` is a *different*, usually stale file, and
+   reading it made a live hang look idle. mise →
+   `~/.local/state/mise/mise.log`. Use a count-diff monitor loop, not a
+   fixed sleep.
 
 3. **Preserve real exit codes — never `cmd 2>&1 | tail -N` to capture.**
    *Machine-enforced since 2026-07-21* — the PreToolUse guard denies a
@@ -78,36 +75,23 @@ unbounded wait + pipe-masked exit code.
 
 5. **hk specifics.** hk parallelises via per-file read/write locks
    *within* a run; a crashed/killed run can leave stale state under
-   `~/.local/state/hk/`. (The old "clear ~/Library/Caches/hk/configs/
-   after editing hk.pkl" guidance is retired — the cache is
-   content-hashed since hk 1.47; see `ci-local-parity.md` rule 5.)
+   `~/.local/state/hk/`. (The old "clear the pkl config cache" guidance is
+   retired — content-hashed since hk 1.47; `ci-local-parity.md` rule 5.)
 
-6. **The ruff-error wedge is FIXED (#268) — and its published diagnosis
-   was wrong.** A ruff violation now fails `mise run lint` with `rc=1`
-   and a `✗ ruff` summary. Root cause was **`depends` + `fail_fast =
-   false`**, not ruff: hk never releases a dependent whose dependency
-   FAILED, so `ruff_format` (which we had given `depends = List("ruff")`)
-   sat at `waiting for ruff` forever. Fixed by ordering with `exclusive
-   = true` instead; `hk.pkl`'s `no_hk_depends` step now blocks `depends`
-   from coming back. Reproduced on hk 1.50.0 AND 1.51.0 — **not** fixed
-   by a bump.
+6. **The ruff-error wedge is FIXED (#268), and it was never ruff.** Root
+   cause was **`depends` + `fail_fast = false`** — hk never releases a
+   dependent whose dependency FAILED, so `ruff_format` sat at `waiting
+   for ruff` forever. `hk.pkl`'s `no_hk_depends` step blocks `depends`
+   from coming back.
 
-   **Two red herrings this rule itself repeated for two days, both worth
-   remembering:**
-   - *"The `ruff` step has `fix=true`."* It does not. `fix` on a builtin
-     Step is a **command string**; the boolean lives on the **hook**
-     (`hk.pkl` `["pre-commit"] { fix = true }`). Same key name, two
-     meanings, opposite levels.
-   - *"`failed to get write locks …` is the wedge."* It is a **DEBUG-level,
-     non-fatal** retry line from whole-repo hygiene steps contending over
-     the first file alphabetically; it appears on runs that finish fine.
-     The wedge is one line lower: `waiting for <dep>`. **A scary log line
-     adjacent to a hang is not the hang** — confirm a suspect by removing
-     it and re-probing, which is what finally isolated `depends`.
+   Generalisation, learned by publishing the wrong diagnosis twice:
+   **a scary log line adjacent to a hang is not the hang** (`failed to
+   get write locks …` is a benign DEBUG retry; the wedge was one line
+   lower). Confirm a suspect by removing it and re-probing. Both red
+   herrings: `docs/rules-evidence/long-running-command-hangs.md`.
 
-   The durable habit survives: **when lint hangs, run `uv run --project
-   python ruff check` DIRECTLY** — seconds, and it never lies about your
-   own code.
+   Durable habit: **when lint hangs, run `uv run --project python ruff
+   check` DIRECTLY** — seconds, and it never lies about your own code.
 
 7. **Find the wedged step by name.** Grep the lint output for a
    `❯ <step>` with no matching `✔ <step>` — that names it directly,

--- a/.claude/rules/md-size-budgets.md
+++ b/.claude/rules/md-size-budgets.md
@@ -166,8 +166,10 @@ The repo's applied form of that is **`docs/rules-evidence/<rule>.md`**: a rule's
 archaeology, provenance tables and worked-failure logs move to a tracked sibling
 it links by path, keeping the directive plus one canonical example eager. See
 `agent-artifact-conventions.md`. Measured 2026-07-28 — unscoped rules are
-**~88%** of the eager corpus, so this is where the bytes actually are; the first
-four extractions took it 132,683 → 120,356 B.
+**~88%** of the eager corpus, so this is where the bytes actually are. The pass
+took it **132,683 → 105,648 B (−20.4%)** across 19 of 21 eager rules;
+`clarify-before-acting` and `clean-git-state` were left alone as already at the
+directive-plus-one-example floor.
 
 ## Applies to
 

--- a/.claude/rules/notepad-enforcement.md
+++ b/.claude/rules/notepad-enforcement.md
@@ -8,14 +8,11 @@ findings to the notepad immediately — not at session end.
 The notepad is **`.agent/notepad.md`** (gitignored). Write to it with the ordinary
 Write/Edit tools, appending as you go.
 
-Until 2026-07-15 this rule named
-`mcp__plugin_oh-my-claudecode_t__notepad_write_working` / `..._write_priority`.
-Those tools ship with the `oh-my-claudecode` plugin, which is **disabled** — so
-they are absent from every session, and a `/doctor` scan measured **zero
-invocations across 941 transcripts**. The rule was unfollowable as written; the
-notepad file itself stayed current because sessions wrote it by hand. Naming the
-real mechanism is the fix. If OMC is ever re-enabled, its notepad tools write
-this same file — the rule does not change.
+Do **not** reach for the `oh-my-claudecode` notepad MCP tools this rule used to
+name: that plugin is disabled, so they are absent from every session (measured:
+**0 invocations across 941 transcripts**). A rule naming a mechanism nobody can
+invoke is indistinguishable from no rule at all.
+Detail: `docs/rules-evidence/notepad-enforcement.md`.
 
 ## Rules
 
@@ -34,14 +31,11 @@ this same file — the rule does not change.
 
 ## Why
 
-In the 2026-04-05 session, the python-pro agent and debugger team performed
-extensive analysis but did NOT write to notepad. When context was lost, their
-findings had to be re-derived. This policy prevents that waste.
+2026-04-05: agents performed extensive analysis but did NOT write to the
+notepad. When context was lost, every finding had to be re-derived.
 
-## Verification
-
-After an agent completes work, check `.agent/notepad.md` for findings. If it is
-empty or stale relative to the work performed, the agent did not comply.
+**Verification:** after an agent completes work, check `.agent/notepad.md`. Empty
+or stale relative to the work performed means it did not comply.
 
 ## See also
 

--- a/.claude/rules/persistence-gate-retry.md
+++ b/.claude/rules/persistence-gate-retry.md
@@ -1,14 +1,11 @@
 # Persistence Gate: Retry Once on Transient DNS
 
 The `persistence` gate inside `mise run verify-local` calls
-`@devcontainers/cli up` mid-cycle to bring the container back up. That
-path re-resolves `ghcr.io/devcontainers/features/sshd` for feature
-dependencies, so the gate is **network-sensitive** in a way that's not
-obvious from `mise.toml [tasks.persistence]` alone. A transient DNS
-blip on the host (or in Docker Desktop's DNS layer) surfaces as
-`getaddrinfo ENOTFOUND ghcr.io` and aborts the gate — but the image
-bytes are healthy, the prior gates have already validated R1/R2/R3,
-and the new content-hashed `:dev` lineage is unaffected.
+`@devcontainers/cli up` mid-cycle, which re-resolves the sshd feature —
+so the gate is **network-sensitive** in a way `mise.toml
+[tasks.persistence]` does not show. A transient host (or Docker
+Desktop) DNS blip aborts it while the image bytes are perfectly
+healthy.
 
 ## Retry-once heuristic
 
@@ -33,14 +30,13 @@ Before triaging a `persistence` failure as a real defect:
 
 ## Why this rule exists
 
-Session 2026-05-01 hit this exact pattern: a ~30s host DNS hiccup
-during the persistence gate's bring-back-up produced a
-`verify-local rc=1`. The first-pass log made it look like an
-R-invariant regression in the post-PR-#93 retagged `:dev`. The retry
-ran clean in 18 minutes, all gates green (R1 inbound, R2 outbound,
-R3 amd64, persistence, secrets) — no code changes. Without this rule,
-future sessions would re-run `dev-rebuild` (expensive) before checking
-whether the failure was environmental.
+Session 2026-05-01: a ~30s host DNS hiccup during the gate's
+bring-back-up produced `verify-local rc=1`, and the first-pass log made
+it look like an **R-invariant regression** in the freshly-retagged
+`:dev`. The retry ran clean in 18 minutes, all gates green, no code
+changes. Without the rule, the next session reaches for `dev-rebuild`
+(~30 min) to chase a transient that already cleared.
+Detail: `docs/rules-evidence/persistence-gate-retry.md`.
 
 ## Failure-mode signatures
 

--- a/.claude/rules/research-doc-sources.md
+++ b/.claude/rules/research-doc-sources.md
@@ -18,12 +18,9 @@ worked.
    catalog — if yes, the cache is the authoritative source and `curl`
    is only needed for per-page `.md` fetches or cache refresh.
 
-   **Common trap (session 2026-04-09c):** do NOT guess a project's
-   docs domain (e.g., `containers.dev/llms.txt` → 404). The
-   devcontainer spec/CLI/features/images docs are all hosted on
-   mintlify at `www.mintlify.com/devcontainers/<repo>/`, not on
-   `containers.dev`. Grep the cache or the catalog to find the
-   right URL before curling anything.
+   **Common trap:** do NOT guess a project's docs domain
+   (`containers.dev/llms.txt` → 404; the devcontainer docs are on
+   mintlify). Grep the cache or the catalog for the right URL first.
 
 1. **`curl <site>/llms.txt`** — AI-optimized plain-text index, one entry
    per page. Cheapest possible *remote* lookup. Works for every repo in
@@ -46,89 +43,40 @@ worked.
    ctx7 docs <libraryId> <query>      # fetch the docs
    ```
 
-   Corrected 2026-07-23: this step used to say `ctx7` was "a
-   skill-management CLI … **not** a direct doc-fetcher", routing every
-   lookup through a skill wrapper that adds nothing. Verified against
-   `ctx7 --help` (0.5.5, the `mise.toml` pin): the documented commands are
-   `login/logout/whoami/setup/remove/library/docs/upgrade`.
-
-   The `skills` subcommands still *run* (`ctx7 skills list` → rc=0) but are
-   **hidden from `--help` and deprecated** — "Skill commands are deprecated
-   and will stop working in the next major release." So do not build on
-   them, and do not treat their absence from `--help` as proof they are
-   gone. `.claude/skills/context7-cli/SKILL.md` remains the setup reference.
+   Do not build on the deprecated `skills` subcommands — and do not
+   treat their absence from `--help` as proof they are gone (they still
+   run). `.claude/skills/context7-cli/SKILL.md` is the setup reference.
 
 4. **Raw HTML fetch** (`curl <url>` or `npx @teng-lin/agent-fetch <url>`) —
    **last resort only.** Pays the full HTML-parse cost in agent
    context. Use `defuddle` where available to clean HTML before
    parsing.
 
-## Why `mcp2cli` against per-repo mintlify MCPs is NOT in the chain
+## Never `mcp2cli` a per-repo mintlify MCP URL
 
-An earlier revision of this rule listed
-`mcp2cli https://mintlify.com/<owner>/<repo>/mcp <tool>` as a
-fuzzy-search step. **That step does not work** and has been removed.
+`mcp2cli https://mintlify.com/<owner>/<repo>/mcp <tool>` was once step 2
+of this chain. **It does not work.** Those URLs are GET-only *preview
+descriptors*: a `curl GET` returns a plausible JSON tool-schema, while
+the POST `mcp2cli` sends returns `404`. There is no server behind them,
+and an API key does not unlock one (Mintlify keys are org-scoped).
 
-Summary of the probe evidence (full log:
-`docs/research/mintlify-catalog-validation-log.md`):
+The ban is specific to per-repo mintlify subpath URLs. `mcp2cli` stays
+in active use for real MCP servers (`@github`, `@docker`, or a
+customer-domain MCP like `docs.anthropic.com/mcp`) — see
+`.claude/skills/mcp2cli/SKILL.md`. Four probes, incl. the central-MCP
+scope limit: `docs/rules-evidence/research-doc-sources.md`.
 
-- The `https://mintlify.com/<owner>/<repo>/mcp` URLs are **GET-only
-  preview descriptors** auto-generated for every repo Mintlify
-  indexes. `curl GET` returns a JSON tool-schema descriptor; POST
-  (which `mcp2cli` sends to speak MCP protocol) returns `404 Not
-  found`. There is no live MCP server behind the descriptor.
-- **Live mintlify MCP servers exist only at the customer's own
-  documentation domain** (e.g., `docs.anthropic.com/mcp`,
-  `resend.com/docs/mcp`, `docs.perplexity.ai/mcp`). None of the 16
-  repos currently in `docs/research/mintlify-catalog.md` host a
-  live MCP server anywhere — verified against their own domains
-  (`chezmoi.io/mcp`, `starship.rs/mcp`, `mise.jdx.dev/mcp`, etc.)
-  which all return plain nginx 405/404, not MCP protocol.
-- **Mintlify's central MCP** at `https://mintlify.com/docs/mcp`
-  works but is scope-limited to Mintlify's own platform docs (how
-  to build a mintlify site, MDX syntax, agent workflows). It does
-  NOT search the per-repo customer sites in our catalog. Verified
-  with real queries: `search-mintlify --query "mise shell_alias"`
-  returned zero results from `jdx/mise`.
-- **An API key does not unlock this path.** Mintlify API keys are
-  organization-scoped; they authenticate you only against docs
-  owned by the same Mintlify organization as the key. You cannot
-  use a key to access `jdx/mise`, `twpayne/chezmoi`, or any other
-  org's content.
+## `mcp2cli`-first — a preference, not a gate
 
-`mcp2cli` itself remains in active use in this repo for **other**
-MCP servers (e.g., `@github`, `@docker` shorthands from
-`~/CLAUDE.md`, or a customer-domain MCP like `docs.anthropic.com/mcp`
-if we need to research Anthropic docs). See
-`.claude/skills/mcp2cli/SKILL.md` for invocation patterns. The ban
-is specifically on using it against per-repo mintlify subpath URLs,
-not on `mcp2cli` in general.
+**Prefer `mcp2cli` (process-spawn) or the curl steps above** for one-off
+lookups: native registration injects every tool's JSON schema into the system
+prompt for **every** conversation, forever, including ones that never call it.
 
-## `mcp2cli`-first, but MCP registration is allowed when required
-
-**Prefer `mcp2cli` (process-spawn) or the curl-based options above** for
-one-off doc/tool lookups. Registering an MCP server natively injects every
-tool's JSON schema into Claude's system prompt for every conversation,
-forever — even conversations that never call the tool pay that context tax.
-So for a server you would query rarely, `mcp2cli` is the cheaper path.
-
-**But native MCP registration is NOT forbidden (relaxed 2026-07-19).** When
-a third-party plugin or tool **requires** MCP for its features, registering
-it (`claude mcp add`, a plugin's bundled servers, or a project `.mcp.json`)
-is allowed — done knowingly, accepting the per-conversation schema cost. The
-former hard ban (the `no_mcp_registration` hk step) has been removed; this is
-now a documented **preference**, not a gate. See the memory rule
-`feedback_no_mcp_registration.md` and `.claude/skills/mcp2cli/SKILL.md` for
-the cost rationale (the reason to still reach for `mcp2cli` first).
-
-## When to register natively instead
-
-`mcp2cli` is the default because it pays no per-conversation schema cost. But
-when a third-party plugin or tool **requires** native MCP for its features,
-registering it is fine (relaxed 2026-07-19 — no longer gated). Judgement call:
-if you'd query the server rarely, `mcp2cli` still wins on cost; if the plugin's
-value depends on Claude selecting its tools natively and you'll use it often,
-register it and accept the schema cost. When unsure, reach for `mcp2cli` first.
+**Native registration is NOT forbidden** (relaxed 2026-07-19; the
+`no_mcp_registration` hk step is gone). When a plugin or tool *requires* MCP,
+register it knowingly. Judgement call: rare queries → `mcp2cli` wins on cost;
+a plugin whose value depends on native tool selection → register it. When
+unsure, reach for `mcp2cli` first.
 
 ## See also
 

--- a/.claude/rules/research-repo-enumeration.md
+++ b/.claude/rules/research-repo-enumeration.md
@@ -7,15 +7,12 @@ docs were consulted while producing the artifact.
 
 ## Why
 
-Research artifacts accumulate over time. Without an enumeration section,
-it becomes impossible to answer "which repos have we already researched?"
-or "which repos does this finding depend on?" without re-reading every
-artifact. The enumeration section is the cheap-to-grep index that makes
-artifacts bisectable after the fact.
-
-It also feeds `docs/research/mintlify-catalog.md`: any repo enumerated
-in a research artifact should either already be in the catalog or be
-appended to its request queue during the same commit.
+Without an enumeration section you cannot answer "which repos have we
+already researched?" without re-reading every artifact. It is the
+cheap-to-grep index that makes artifacts bisectable after the fact, and
+it feeds `docs/research/mintlify-catalog.md` — a repo enumerated in an
+artifact should already be in the catalog, or be appended to its request
+queue in the same commit.
 
 ## Format
 
@@ -57,12 +54,10 @@ Rules:
 
 ## Enforcement
 
-For tracked research artifacts, this rule is documented but not yet
-machine-enforced: `docs/research/runs/**` is gitignored at the per-clone
-level, so an hk grep-check on staged `docs/research/runs/*.md` files is a
-no-op in this repo. A future commit can add an hk step targeting
-`docs/research/**/*.md` when the first tracked research artifact lands;
-until then, this rule relies on reviewer enforcement.
+**Reviewer-enforced, not machine-enforced.** An hk grep-check on staged
+`docs/research/runs/*.md` would be a no-op — that tree is gitignored, so
+nothing is ever staged from it. A step targeting `docs/research/**/*.md`
+becomes worth adding once tracked research artifacts are routine.
 
 ## See also
 

--- a/.claude/rules/tool-currency-and-native-first.md
+++ b/.claude/rules/tool-currency-and-native-first.md
@@ -14,38 +14,23 @@ custom code you wrote last year may now be dead weight.*
 
 ## Why this rule exists
 
-The managed tools in this repo (mise, hk, Renovate, uv, docker, chezmoi) move
-fast, and their **docs lag their code** — the merged CHANGELOG/PRs are often the
-only truthful source. Stated twice by Ray (2026-07-04), and verified repeatedly
-in the devcontainer build-input program:
+The managed tools here (mise, hk, Renovate, uv, docker, chezmoi) move fast, and
+their **docs lag their code** — the merged CHANGELOG/PRs are often the only
+truthful source. Stated twice by Ray (2026-07-04).
 
-- **mise's rattler `conda:` backend does NOT yet lock (verified 0/3, r3
-  round, 2026-07-10).** An earlier revision of this rule claimed the backend
-  writes per-platform `sha256` + transitive deps to `mise.lock` as of v2026.5.0
-  and that this *retires* the custom `mise-system-resolved.json` snapshot +
-  `mise_snapshot.py`. That was wrong: v2026.5.0 only graduated the conda
-  backend's **experimental flag** — conda resolutions still land in **no
-  lockfile tier**, and native conda locking remains open upstream
-  (`jdx/mise#7700`). This is itself a case of "docs/assumption lag code": the
-  assumption that conda had reached lockfile parity did not survive probing.
-  **The snapshot machinery is nonetheless GONE** — `mise_snapshot.py` was
-  deleted in `352063a` (#160 T4–T13). This rule told readers "do NOT retire" it
-  for ~2 weeks after it had already been retired, while the
-  `tool-currency-check` skill said "RETIRED in #160 T1" — two docs, opposite
-  claims, neither checked. Corrected 2026-07-24; the durable fact is the conda
-  gap, not the file.
-- **`minimum_release_age` / `lockfile` / `lockfile_platforms`** are native — no
-  custom cooldown or platform-scoping machinery needed.
-- **Renovate's native `mise` manager + the `github>jdx/renovate-config` preset**
-  made **8 of 11** hand-rolled `customManagers` redundant (PR #161).
-- **`get_env()` vs the Tera `env.VAR` variable** (mise 2026.7.0): the
-  *documented* function was insufficient for a mise.local.toml `[env]` override;
-  only empirically probing both revealed which one the task actually needed. The
-  native mechanism is the default answer, but *verify which native mechanism*.
+Canonical case: **Renovate's native `mise` manager + the
+`github>jdx/renovate-config` preset** made **8 of 11** hand-rolled
+`customManagers` redundant (PR #161).
 
 The failure mode this prevents: shipping (or preserving) homegrown machinery for
 a problem the tool already solves — paying maintenance cost forever, and often
 getting a *weaker* result (version-only vs sha256-verified) than the native path.
+
+Two lessons the case history is worth reading for: an *assumption* about a tool
+lags its code exactly as docs do (the conda-lockfile claim that failed 0/3 on
+probing), and a superseded file can leave two of your own docs asserting
+opposite things for weeks. Cases, tables and the currency-engine wiring:
+`docs/rules-evidence/tool-currency-and-native-first.md`.
 
 ## Rules
 
@@ -90,39 +75,26 @@ chezmoi, pinact, agnix, and future additions. Especially the custom machinery in
 `renovate.json` customManagers — the two largest reservoirs of "does the tool do
 this natively now?" surface area.
 
-## How currency is checked now — the shared engine
+## How currency is checked now
 
-The version-currency MECHANICS (in-sync validation, release-note review,
-tracked-issue movement, the six-gate auto-apply bar, the committed report) live
-in the **shared `kb_setup.currency` engine** — a pinned `uv` git dep on the
-knowledge-base package, so both repos run ONE implementation (D2/G4; dotfiles'
-old broad-sweep module was deleted). What this repo declares is `currency.toml`
-(graphify is deep-tracked; hk/uv/etc. ride the broad `mise outdated` sweep) and
-two thin mise tasks:
+Version-currency MECHANICS live in the **shared `kb_setup.currency` engine** (a
+SHA-pinned `uv` git dep on the knowledge-base package — one implementation, both
+repos). This repo declares `currency.toml` and two thin tasks:
 
 - `mise run tool-currency` → `kb-setup currency daily` — the daily report
-  (deep verdicts + broad sweep) refresh.yml upserts as the standing issue.
-- `mise run tool-currency-check` → `kb-setup currency check` — the offline
-  step-1 drift check the SessionStart hook runs every session (silent unless
-  drift).
+  `refresh.yml` upserts as the standing issue.
+- `mise run tool-currency-check` → `kb-setup currency check` — the offline drift
+  check the SessionStart hook runs every session (silent unless drift).
 
-This rule's remaining, un-automatable job is the **native-first judgment**: is a
-piece of custom code now superseded by a tool feature (the `mise_snapshot.py` →
-`mise.lock` class)? The engine tracks versions; only a human decides retirement.
+The engine tracks **versions**. This rule's remaining, un-automatable job is the
+**native-first judgment**: is a piece of custom code now superseded by a tool
+feature? Only a human decides retirement.
 
-## Machine enforcement
-
-Partially machine-backed, not fully automatable (judgment is required):
-
-- **`workflow.tool-currency-wiring`** (suites.toml) asserts the whole chain:
-  `currency.toml` → the two mise tasks → the `kb-setup` dep in
-  `python/pyproject.toml` → refresh.yml's daily job → the SessionStart hook.
-- **hk cross-file version-parity** (`hk_version_parity` in `hk.pkl` — SHIPPED): asserts `hk@<ver>` is
-  identical across `hk.pkl` / `hk-common.pkl` / `hk-image.pkl` and matches the
-  `mise.toml` binary pin — catches pin drift that this rule would otherwise
-  catch by hand.
-- **Renovate PRs carry the CHANGELOG** — bump review IS release-note review.
-- **agnix** structurally validates this rule file + the skill.
+Machine enforcement is partial by nature — `workflow.tool-currency-wiring`
+(suites.toml) asserts the whole chain exists, `hk_version_parity` catches hk pin
+drift across the three pkl files, Renovate PRs carry the CHANGELOG, and agnix
+validates this file structurally. Detail:
+`docs/rules-evidence/tool-currency-and-native-first.md`.
 
 ## See also
 

--- a/.claude/rules/use-tool-builtins.md
+++ b/.claude/rules/use-tool-builtins.md
@@ -32,69 +32,38 @@ parser, a detector, or a wrapper, STOP and research first.
    or an adjacent native feature (e.g. auto-merge instead of watch-then-merge)
    that sidesteps the flaw. Reinvention is the last resort even then.
 
-### Worked failure (2026-07-11)
-
-Asked to fix a ship/land CI-wait that used a fixed timeout, the agent hand-rolled
-a custom `await_pr_checks_terminal()` polling loop — WITHOUT first researching
-that GitHub offers **native auto-merge** (`gh pr merge --auto`), **merge queue**,
-`gh run watch`, `workflow_run` triggers, and webhooks, several of which eliminate
-the polling entirely. The maintainer had to send the agent back to research. This
-rule is strengthened so that never recurs: research existing tools/services
-first, every time, unprompted.
-
 ## Tool built-in facts (the original case)
 
 Before designing custom detection logic, custom data variables, custom env-var
 parsing, or custom helper scripts to discriminate environments / machines /
 states, **research the tool's official docs first** and prefer its built-in
-facts and canonical patterns over a homegrown solution.
+facts and canonical patterns over a homegrown solution. Check whether a built-in
+fact already discriminates your cases — `chezmoi.os`, mise's `os`/`arch`,
+`runner.os`, `TARGETARCH` — and whether the tool has a *declarative* way to
+express the intent before you write a `run_*` detection script.
 
-## Why this rule exists
+### Worked failure — the chezmoi `is_container` reinvention (2026-04-06g)
 
-In session 2026-04-06g we discovered `home/.chezmoi.toml.tmpl` had ~20 lines
-of custom `$isContainer` env-var detection (`REMOTE_CONTAINERS` /
-`CODESPACES` / `DEVCONTAINER`) feeding a custom `is_container` data variable,
-used by `.chezmoiignore` to gate the mise overlay.
+`home/.chezmoi.toml.tmpl` carried ~20 lines of custom `$isContainer` env-var
+detection (`REMOTE_CONTAINERS` / `CODESPACES` / `DEVCONTAINER`) feeding a custom
+`is_container` data variable, used by `.chezmoiignore` to gate the mise overlay.
+The canonical chezmoi pattern is `{{ eq .chezmoi.os "linux" }}` — a built-in
+runtime fact, always correct, identical across CI / Mac / devcontainer.
 
-The chezmoi.io docs
-(<https://www.chezmoi.io/user-guide/manage-machine-to-machine-differences/>)
-show the canonical pattern is `{{ eq .chezmoi.os "linux" }}` — a built-in
-runtime fact that's always correct, never depends on env vars or stale
-config, and works identically across CI / local Mac / devcontainer.
+**The reinvention introduced a real bug**: a stale
+`~/.config/chezmoi/chezmoi.toml` holding `is_container=false` would have made
+`chezmoi apply` overwrite the user's `~/CLAUDE.md` and run `run_*.sh.tmpl`
+scripts on the **Mac host**. Fixed in `bd40767`.
 
-The reinvention introduced a real bug: the session-F handoff Option B
-would have run `chezmoi apply` against a stale
-`~/.config/chezmoi/chezmoi.toml` with `is_container=false`, overwriting
-the user's `~/CLAUDE.md` and executing `run_*.sh.tmpl` scripts on the
-Mac host.
+A second case — a hand-rolled CI poller written without noticing GitHub's native
+auto-merge, merge queue, and `workflow_run` — plus the full built-ins checklist:
+`docs/rules-evidence/use-tool-builtins.md`.
 
-## Rules
-
-1. **Before writing custom detection logic**, fetch the tool's official
-   docs on the relevant feature (chezmoi.io, mise.jdx.dev, hk.jdx.dev,
-   docs.astral.sh, docs.docker.com, docs.github.com/actions, etc.).
-   Look for built-in facts, canonical patterns, and "common gotchas"
-   sections.
-
-2. **Before introducing a custom data variable**, check whether a
-   built-in fact already discriminates the cases you care about.
-   Examples of built-ins to check first:
-   - chezmoi: `chezmoi.os`, `chezmoi.hostname`, `chezmoi.arch`,
-     `chezmoi.kernel`, `chezmoi.username`
-   - mise: `os`, `arch`, `tool_dir`
-   - GitHub Actions: `runner.os`, `runner.arch`, `github.event_name`
-   - Docker: `TARGETOS`, `TARGETARCH`, `BUILDKIT_INLINE_CACHE`
-
-3. **Before writing detection scripts in `run_*` templates or postinstall
-   hooks**, check whether the tool has a declarative way to express the
-   same intent.
-
-4. **Justify any custom solution in writing.** If you do introduce custom
-   logic, the commit body or rule file must say *why* the built-in
-   approach is insufficient (e.g., "we have 3 Linux variants and
-   chezmoi.os can't tell them apart, so we need a custom fact"). Without
-   that justification, the default answer is "delete the custom logic,
-   use the built-in".
+**Justify any custom solution in writing.** The commit body or rule file must say
+*why* the built-in is insufficient (e.g. "3 Linux variants, `chezmoi.os` can't
+tell them apart"). Without that, the default answer is "delete the custom logic,
+use the built-in" — a later reviewer cannot tell "we checked" from "we never
+looked".
 
 ## Applies to
 

--- a/.claude/rules/zero-bash-logic.md
+++ b/.claude/rules/zero-bash-logic.md
@@ -28,17 +28,11 @@ can't rot after a script is deleted.
 ## Why the check logic is in python
 
 A big inline-bash grep in the hk step would itself violate the policy it
-enforces. So the allowlist + budget logic lives in `bash_budget.py`; the hk
-step and the CLI subcommand are thin wrappers over `find_violations`. This
-mirrors `hook_guard.py` (the PreToolUse guard) and `lint.py` (the hk timeout
-wrapper): logic in python, a thin shell/hk seam.
-
-## Wiring (kept honest by a contract)
-
-`workflow.bash-logic-enforcement` in `python/verification/suites.toml` asserts
-the whole chain exists — hk step ↔ `dotfiles-setup bash-budget` ↔ module ↔
-tests ↔ this rule — so the guard can't silently drift out. Same pattern as
-`workflow.mise-tasks-enforcement`.
+enforces — so the logic lives in `bash_budget.py` and the hk step is a thin
+wrapper, mirroring `hook_guard.py` and `lint.py`. The whole chain (hk step ↔
+CLI ↔ module ↔ tests ↔ this rule) is asserted by
+`workflow.bash-logic-enforcement` in suites.toml, so it can't silently drift
+out. Detail: `docs/rules-evidence/zero-bash-logic.md`.
 
 ## Applies to
 

--- a/.claude/rules/zero-skip-policy.md
+++ b/.claude/rules/zero-skip-policy.md
@@ -58,12 +58,8 @@ GitHub Actions, actionlint, pinact, agnix, and any future additions.
 
 ## Why this rule is eager (never `paths:`-scoped)
 
-It has no `paths:` frontmatter deliberately. Path-scoped rules "trigger when
-Claude **reads** files matching the pattern"
-(<https://code.claude.com/docs/en/memory>) — but this rule fires the moment a
-warning is about to be *dismissed*, which no glob can predict. It was scoped
-to `**/*.py`/`hk.pkl`/workflows until 2026-07-15, so a session editing only
-markdown or shell never loaded the rule forbidding skipped warnings — absent
-from exactly the sessions it exists to govern. Rules that guard **judgment**
-stay eager; only rules whose trigger IS a file (e.g. `ci-local-parity.md`) are
-safe to scope. See `.claude/rules/md-size-budgets.md`.
+It fires the moment a warning is about to be *dismissed*, which no glob can
+predict. It was scoped until 2026-07-15, so a session editing only markdown or
+shell never loaded the rule forbidding skipped warnings — absent from exactly
+the sessions it exists to govern. Rules that guard **judgment** stay eager. See
+`md-size-budgets.md` § "Scoping: the trigger test".

--- a/docs/rules-evidence/agent-artifact-conventions.md
+++ b/docs/rules-evidence/agent-artifact-conventions.md
@@ -1,0 +1,74 @@
+# Evidence — `agent-artifact-conventions`
+
+Archaeology behind `.claude/rules/agent-artifact-conventions.md`. Extracted so
+the eager copy carries the path tables and the operative rules, and this file
+carries why the tree is named and ignored the way it is.
+
+## The `.omc/` → `.agent/` rename (2026-07-25)
+
+`.omc/` was named after the `oh-my-claudecode` plugin — which is **not enabled**.
+A convention named for a tool nothing loads.
+
+**`.agent/` was verified before adopting, not assumed.** Control-armed over
+Claude Code's full docs corpus: `.agent/` → **0 hits**, while `CLAUDE.md` → 439.
+The probe discriminates, so the zero is a real negative rather than a broken
+search. Claude Code claims `.claude/**` exclusively and has no opinion about
+`.agent/`.
+
+## Why `.gitignore`, not `.git/info/exclude`
+
+`.omc/*` was excluded via `.git/info/exclude`, which is **per-clone and does not
+survive a fresh clone**. That is precisely why every artifact anyone actually
+wanted tracked had to be force-added with `git add -f`.
+
+**An ignore rule that exists on one machine is not a convention, it is an
+accident.** `.agent/` is in the real `.gitignore`.
+
+`.omc/` also remains ignored, for a live reason: the statusline HUD configured in
+the **user-level** `~/.claude/settings.json` still recreates `.omc/state/` in
+whichever repo is cwd. Retiring that is a user-config change this repo does not
+make unasked (`feedback_no_user_level_file_updates`).
+
+## Why promoting to tracked is the default
+
+The migration surfaced the cost of not doing it: **five eager rules cited
+research that had never been tracked**, so every reader outside this one machine
+hit a dead link — and `doc_refs` could not see the breakage, because the whole
+`.omc/` prefix sat in its allowlist.
+
+**A citation to something only you can open is not a citation.** Anything an
+eval, a rule, or a future session will cite belongs under `docs/`.
+
+## Why `docs/rules-evidence/` exists
+
+Every unscoped `.claude/rules/*.md` loads in full at session start. Measured
+2026-07-28 with an `InstructionsLoaded` hook: unscoped rules are **~88% of the
+eager corpus**.
+
+Scoping cannot fix that (`md-size-budgets.md` § "the trigger test" — the rules
+that dominate are behaviour- and creation-triggered, and a glob cannot predict a
+decision). So the lever is moving case histories, provenance tables and
+worked-failure logs into a tracked sibling the rule links by path. The rule keeps
+its directive, its operative constraints, and **one** canonical worked example.
+Nothing leaves git; it just stops being re-injected every session.
+
+Measured across the whole pass: **132,683 → 105,648 B (−20.4%)**, covering 19 of
+the 21 eager rules. `clarify-before-acting` and `clean-git-state` were left
+untouched — both were already at the directive-plus-one-example floor, where an
+extraction would add a file and a hop while saving a few hundred bytes.
+
+⚠️ **The instrument that produced the 88% figure has no content field** — the
+`InstructionsLoaded` hook reports *which* file loaded and *why*, never how big.
+And it cannot see `MEMORY.md` at all (auto-memory is a separate channel, and the
+file lives outside the repo, so `md-budget` misses it too). Real eager was
+≈157 KB, not the 132,683 the rules-only measurement showed. A probe can be blind
+to the largest thing it measures and will never say so.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the rule,
+  `.gitignore`, `hk-common.pkl`'s `excludePaths`, PRs #412/#413/#414.
+
+_Named in the extracted text but **not** resolved during this extraction: Claude
+Code's documentation corpus (the `.agent/` control arm was run in an earlier
+session) and the `oh-my-claudecode` plugin._

--- a/docs/rules-evidence/agent-report-persistence.md
+++ b/docs/rules-evidence/agent-report-persistence.md
@@ -1,0 +1,49 @@
+# Evidence — `agent-report-persistence`
+
+Case history behind `.claude/rules/agent-report-persistence.md`. Extracted so
+the eager copy carries the directive and the five operative rules, and this file
+carries the three incidents that produced them.
+
+## Why persist at all (2026-07-05)
+
+An 11-agent release-notes sweep produced **13 detailed reports** — syntax
+sketches, file:line misconfiguration tables, probe transcripts, a backend status
+matrix. The notepad got condensed summaries as the work progressed, but the full
+reports existed **only in the session's context window**: one `/clear` away from
+being lost. A manual round-2 pass recovered them.
+
+**Condensation is lossy in exactly the way that hurts later.** The summary keeps
+the conclusion and drops the evidence, the exact command lines, and the file:line
+anchors the *implementing* session needs.
+
+## Why INCREMENTALLY, not at the end (2026-07-20)
+
+Two agents held everything in memory, **died silently after ~40 minutes, and
+left nothing.** Re-dispatched with an explicit incremental instruction, they
+produced output within minutes.
+
+The arithmetic is the whole argument: an agent that dies having written 13 of 20
+sources leaves **13**. An agent that dies planning to write all 20 at the end
+leaves **0**. Same principle as `PostCompact` / `SubagentStop` capture — durable
+capture must be incremental, never end-of-run.
+
+## The path change, and what two conventions cost (2026-07-20)
+
+The old path was `docs/research/runs/<topic>/agents/`; the current one is
+`docs/research/kb/reports/agents/<agent-name>.md`.
+
+`docs/research/kb/` is the corpus root and is **tracked in git** (added with
+`git add -f`, since `.git/info/exclude` carried `.agent/*`), so artifacts survive
+a fresh clone. `docs/research/runs/**` is not tracked and does not.
+
+**The two conventions co-existed for exactly one session and immediately cost
+something:** an agent correctly followed the *old* rule, the caller looked in the
+*new* path, and wrongly reported the agent as non-compliant. One path.
+
+Existing `docs/research/runs/**` artifacts stay where they are; new ones go to
+`docs/research/kb/`. See memory `feedback_store_research_in_graphify`.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the rule,
+  `docs/research/kb/`, `.claude/skills/clear-prep/SKILL.md`.

--- a/docs/rules-evidence/ai-cli-invocation.md
+++ b/docs/rules-evidence/ai-cli-invocation.md
@@ -1,0 +1,47 @@
+# Evidence — `ai-cli-invocation`
+
+Archaeology behind `.claude/rules/ai-cli-invocation.md`. Extracted so the eager
+copy is just the invocation patterns, and this file carries why the rule is
+un-scoped and why it no longer points at a canonical script.
+
+## Why the rule is EAGER, and the accident that proved it
+
+The rule guards an *action* — shelling out to an external AI CLI — not a file.
+Path-scoped rules "trigger when Claude **reads** files matching the pattern", and
+no glob predicts the moment you are about to run `codex`.
+
+It was scoped to `AGENTS.md` / `.claude/**` / `scripts/**` / `.agent/**` until
+2026-07-20, which meant **it could only fire by accident**. And it did: a session
+invoked `codex exec "prompt"` positionally — the documented-wrong form — wasted a
+probe on the resulting stdin hang, and only saw this rule *afterwards*, because
+it happened to write into `.agent/**`.
+
+That is the same defect `zero-skip-policy` and `clean-git-state` were un-scoped
+for on 2026-07-15. See `md-size-budgets.md` § "Scoping: the trigger test":
+behaviour-triggered rules stay eager.
+
+## Why there is no canonical script to consult
+
+The "Reference" section used to point at the octopus `orchestrate.sh` /
+`get_agent_command()`.
+
+**That file does not exist in this repo.** Control-armed: `find . -name
+orchestrate.sh` → **0**, while `find . -maxdepth 1 -name hk-common.pkl` → **1**,
+so the probe discriminates and the zero is a real negative. It lives only inside
+the `octo@nyldn-plugins` plugin cache, which is `false` in **both**
+`.claude/settings.json` and `~/.claude/settings.json`, and may vanish on plugin
+GC. A reader could not have acted on the pointer.
+
+Hence the rule's standing instruction: when a pattern looks wrong, **re-probe the
+CLI itself** (`codex exec --help`, `gemini --help`) rather than hunting for a
+canonical script. These flags change between releases — which is exactly how the
+wrong forms got documented in the first place.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the rule,
+  `.claude/settings.json`.
+
+_Named in the extracted text but **not** resolved during this extraction: the
+`octo@nyldn-plugins` plugin and the Codex / Gemini / OpenCode CLIs. The flag
+forms in the rule are dated — re-probe `--help` before trusting one._

--- a/docs/rules-evidence/do-not.md
+++ b/docs/rules-evidence/do-not.md
@@ -1,0 +1,104 @@
+# Evidence — `do-not`
+
+Control arms and case history behind `.claude/rules/do-not.md`. Extracted so the
+eager copy stays a scannable list of invariants and this file carries the proof
+for the two entries whose evidence ran longest (#8 graphify, #9 branch-first).
+
+The list itself was moved out of `AGENTS.md` in session 2026-04-09c as part of a
+doc-size split — the root `AGENTS.md` was exceeding its size gate and this list
+was the largest self-contained block.
+
+## #8 — `graphify install` without `--project` mutates `~/.claude`
+
+Verified in the installed 0.9.20 `install.py` (2026-07-20). One flag separates
+safe from destructive:
+
+| Invocation | Scope |
+|---|---|
+| `graphify claude install` | **project only** — `./CLAUDE.md` + `./.claude/settings.json` |
+| `graphify install --project` | **project only** — adds `./.claude/skills/graphify/**` + a block in `./.claude/CLAUDE.md` |
+| ⚠️ `graphify install` (no `--project`) | **mutates `~/.claude`** — ~43 KB of skill files, **appends a `# graphify` H1 to `~/.claude/CLAUDE.md`** (creating it if absent), and sprays `.graphify_version` stamps into every other installed platform's user skill dir |
+
+**Control arm on the safe claim:** all **18** `Path.home()` call sites in
+`install.py` sit on `project=False` branches; the project-scoped call chain
+contains none. So the probe can distinguish the two paths — a scan that found
+zero `Path.home()` calls *everywhere* would have proved nothing.
+
+**`CLAUDE_CONFIG_DIR` is NOT containment.** It redirects the skill dir only; the
+`~/.claude/CLAUDE.md` write is hardcoded. Never run `graphify hook install` or
+`graphify --watch` either.
+
+### It generalises to every platform, in two flavours (0.9.22, 2026-07-21)
+
+- ⚠️ **`graphify codex install` breaks our lint gate with OR without
+  `--project`.** Both paths call `_agents_install` (`install.py:1463`), which
+  appends a 13-line / 1,129-byte `## graphify` block to the root `AGENTS.md` — a
+  file sitting at exactly **200/200 lines**. Result: 213 lines and a failed
+  `md_size_budget` step. `--project` only relocates the *skill* file.
+- ⚠️ **`graphify antigravity install` without `--project` writes OUTSIDE the
+  project** — `~/.gemini/config/skills/graphify/SKILL.md`. With `--project` it
+  stays in-repo. Control arm: `_project_install`'s body contains **zero**
+  `Path.home()` calls.
+
+Hence the operative form in the rule: run any `graphify <platform> install` in a
+throwaway directory outside this repo, never here.
+
+## #9 — commit onto `main`: it happened twice, and the local layers are advisory
+
+**34 files on 2026-07-20, and 19 on 2026-07-27** — the second straight after
+`mise run land`, which **leaves you on `main`**. Both were recoverable only
+because nothing had been pushed: the objection came at push time, from
+`mise run ship`'s own refusal. Recovery is
+`git branch <new> && git reset --hard origin/main`.
+
+Machine-enforced since #400, in three layers of decreasing skippability:
+
+1. **`no_commit_to_branch`** — an hk BUILTIN, wired in `hk.pkl`'s **pre-commit**
+   hook. It was declined in #154 because it treated a detached HEAD as fatal;
+   hk v1.52.0 (`jdx/hk#1075`) fixed that, probed here on **all four arms**
+   (branch → 0, `main` → 1, detached → 0, `master` → 1). It is deliberately NOT
+   in `allSteps`: that mapping is spread into `check`/`fix`, so `mise run lint` —
+   and CI's lint job, which checks out a real `main` — would fail on it.
+2. **The PreToolUse guard** denies `--no-verify` / `git commit -n` and a
+   `HK_SKIP_HOOKS=` prefix. **No git hook can catch these** — git decides not to
+   run the hook *before* the hook exists as a process, so a pre-push hook is not
+   a fix and should not be built.
+3. **A repository ruleset requiring a PR for `main`** — the only layer an agent
+   cannot skip. Everything local is advisory.
+
+### Why the rule line exists even though a skill already said it
+
+The guidance already lived in the `git-branch-commit-push-workflow` skill. But
+that skill carries `disable-model-invocation: true`, which **agnix `--strict`
+requires** for state-mutating "dangerous" skills — so the model cannot reach it
+at decision time. An eager rule is the only layer that fires *before* the
+mistake. Do not "fix" the skill by removing the flag; the docs gate will reject
+it, and correctly.
+
+This is the concrete instance of `md-size-budgets.md` § "the trigger test":
+behaviour-triggered guidance that cannot be delegated to a skill.
+
+## Smaller entries' provenance
+
+- **#1 (no dock launch)** — macOS GUI processes don't inherit terminal env, so
+  `mise`, `uv` and `$SSH_AUTH_SOCK` are missing from `initializeCommand`, which
+  then fails to spawn the host-side SSH agent proxy.
+- **#7 (no `docker context` switch)** — silent drift away from `desktop-linux`
+  caused session 2026-04-09c's debug goose-chase; the SSH path is
+  Docker-Desktop-only.
+- **#10 (no env dump)** — measured: gitleaks **2 → 0**, betterleaks **1 → 0** on
+  the same content once it was zlib+base64 packed into `__MISE_DIFF`. Full
+  incident: `docs/rules-evidence/secrets-out-of-the-shell-env.md`.
+- **The MCP relaxation (2026-07-19)** — native MCP registration is no longer a
+  "do not". `mcp2cli` stays the *preferred* path for one-off doc/tool calls, a
+  preference rather than a gate. See `research-doc-sources.md`.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the rule,
+  `hk.pkl`, the PreToolUse guard, PRs #154/#400.
+
+_Named in the extracted text but **not** resolved during this extraction:
+`jdx/hk` (issue #1075) and the graphify distribution whose `install.py` line
+numbers are quoted above — those were probed in earlier sessions at 0.9.20 /
+0.9.22 and the pin has since moved. Re-probe before relying on a line number._

--- a/docs/rules-evidence/gh-cli-watch.md
+++ b/docs/rules-evidence/gh-cli-watch.md
@@ -1,0 +1,79 @@
+# Evidence — `gh-cli-watch`
+
+Rationale and worked anti-patterns behind `.claude/rules/gh-cli-watch.md`.
+Extracted from the rule so the eager copy carries the directive and the canonical
+invocations, and this file carries the *why*. Read it before changing the rule or
+before arguing that a hand-rolled poll loop is fine this once.
+
+## What `gh` gives you natively
+
+- **`gh pr checks <n> --watch [--fail-fast] [--interval N]`** — refreshes every
+  10s by default until terminal state; the exit code reflects pass/fail/pending.
+  Docs: <https://cli.github.com/manual/gh_pr_checks>.
+- **`gh run watch <run-id> --exit-status`** — the same shape for a specific run.
+  Carries a known caveat (below).
+
+## Why a hand-rolled poll loop is worse, in four specific ways
+
+1. **It buries exit codes.** In `gh ... | grep -q success`, the `grep` becomes
+   the shell's exit status, so an API error reads as "not done yet" forever. This
+   is the same defect class as `feedback_pipe_kills_exit_code`.
+2. **It races on multi-run scenarios.** `gh run list --limit 1` matches the
+   *wrong* run whenever several are queued — which is the normal state on a busy
+   branch.
+3. **It burns API quota** on aggressive sleeps.
+4. **It shows nothing.** No redraw, no progress; the operator stares at silence
+   and cannot tell a slow check from a wedged one.
+
+## The `--exit-status` caveat
+
+`gh run watch --exit-status` has reported **0 prematurely** on edge cases. Always
+cross-verify:
+
+```bash
+gh run watch 1234567890 --exit-status
+gh run view 1234567890 --json conclusion --jq '.conclusion'
+```
+
+Recorded in `feedback_gh_run_watch.md`, and echoed in `do-not.md` #6 ("do NOT
+trust `gh run watch --exit-status`").
+
+## Anti-patterns, verbatim
+
+```bash
+# WRONG — hand-rolled poll, no exit-code awareness:
+while ! gh pr checks 123 --json bucket | grep -q success; do
+  sleep 30
+done
+
+# WRONG — racy on multi-run queues:
+gh run list --limit 1 --json status
+
+# WRONG — fixed-time wait, never reflects actual completion:
+sleep 600 && gh pr checks 123
+```
+
+The first is doubly broken here: under `set -o pipefail`, `cmd | grep -q PAT`
+returns **141** when the match succeeds (SIGPIPE), so the check can *only* fail.
+That is the `no_grep_q_under_pipefail` step in `hk.pkl`, and the inverse case in
+`probes-need-a-control-arm.md`.
+
+## When Claude Code's `Monitor` tool is the right tool instead
+
+Only when one of these holds:
+
+1. You need **per-transition notifications** — each new ✔/✗ surfacing as a
+   separate event. `gh pr checks --watch` draws a redrawing live table: fine for
+   a human, low signal for automation that wants to react per transition.
+2. The command is on a **non-GHA system** with no built-in watch flag.
+3. You need to **filter** events (e.g. emit only on failure).
+
+For "wait until done, tell me when", `gh pr checks --watch` wins outright.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the rule,
+  `hk.pkl`'s `no_grep_q_under_pipefail` step, `.github/workflows/AGENTS.md`.
+
+_Named in the extracted text but **not** resolved during this extraction: the
+`gh` CLI manual page above was carried over from the rule, not re-fetched._

--- a/docs/rules-evidence/local-devcontainer-first.md
+++ b/docs/rules-evidence/local-devcontainer-first.md
@@ -1,0 +1,62 @@
+# Evidence — `local-devcontainer-first`
+
+Case history behind `.claude/rules/local-devcontainer-first.md`. Extracted so
+the eager copy carries the gate and the local-tier table, and this file carries
+the measurement that produced the rule.
+
+## The measurement: a dirty container lies (#288, 2026-07-16)
+
+Simulating the apt pin `curl=8.18.0-1ubuntu2`:
+
+| Environment | Result |
+|---|---|
+| the running devcontainer | **FAILED** |
+| a clean base container | **PASSED** |
+
+The devcontainer already had a newer curl installed, and apt refuses to
+downgrade. **The pin was fine; the environment lied.**
+
+This is why the rule insists the probe environment must match the one whose
+failure you are predicting, rather than just being "a container":
+
+- Predicting the **base build** → a throwaway `docker run --rm` on the
+  digest-pinned `BASE_IMAGE`, because that is what the build actually starts
+  from. An ephemeral probe container is not devcontainer *lifecycle*, so
+  `do-not.md` #3 does not apply to it.
+- Predicting **runtime behaviour in the shipped image** → the devcontainer via
+  `devcontainer exec`, kept current per `verify-container-latest`.
+
+And why the rule says to read the base image and pinned constants **out of the
+Dockerfile** rather than restating them: a restated constant drifts, and the
+probe quietly starts testing an image nobody builds.
+
+The worked example the rule was extracted from is
+`python/src/dotfiles_setup/apt_pins.py`.
+
+## The economics
+
+A CI base rebuild costs **~2.5h** (`feedback_ci_build_duration_baseline`). The
+equivalent local probe is usually **under a minute**. Pushing to find out is the
+expensive way to ask a cheap question — and `zero-skip-policy.md` already bans
+"push to trigger CI to see if it passes". This rule is the constructive half:
+here is what to do instead.
+
+## What a green local probe does NOT license
+
+- **It does not replace CI.** A local probe answers one question; CI still
+  builds, smokes, and publishes. Never skip a gate because a probe passed.
+- **It does not license local base builds.** `mise run build` / `docker buildx
+  bake dev-load` remain CI-only (`do-not.md` #2). A probe *simulates* or
+  *inspects*; it does not build the image.
+- **It does not make an arm64 Mac a substitute for the amd64 image.** The full
+  smoke cannot run here (Rosetta/TSan — `feedback_image_smoke_mac_rosetta_tsan`).
+  Pass `--platform linux/amd64` and know what the probe cannot see.
+
+When the local probe and CI disagree, **CI is authoritative** — and that
+disagreement is itself a defect in the probe, worth fixing rather than
+explaining away.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the rule,
+  `python/src/dotfiles_setup/apt_pins.py`, issue #288.

--- a/docs/rules-evidence/long-running-command-hangs.md
+++ b/docs/rules-evidence/long-running-command-hangs.md
@@ -1,0 +1,102 @@
+# Evidence — `long-running-command-hangs`
+
+Incidents and misdiagnoses behind `.claude/rules/long-running-command-hangs.md`.
+Extracted from the rule so the eager copy carries the operative rules and this
+file carries the case history. Several entries record what the rule *itself* got
+wrong for a while — those are the ones worth reading.
+
+## The founding incident (2026-06-29)
+
+A `hk run pre-commit --all --stash none` invocation hung at **0% CPU with no
+child processes for ~7 hours** before anyone noticed. hk has no native timeout,
+so nothing aborted it.
+
+Worse: it had been launched as `hk ... 2>&1 | tail -40`, so when it was finally
+killed **the pipeline reported exit 0** — tail's exit code — masking the fact
+that the gate never passed.
+
+Two traps in one incident: an unbounded wait, and a pipe-masked exit code. Both
+are now separate operative rules, and both are machine-enforced by the PreToolUse
+guard as of 2026-07-21.
+
+## Why hk needs an out-of-process timeout
+
+Verified against hk 1.46 and the live v1.48 docs: **no `--timeout` flag, no
+`timeout` step key, no `HK_*` timeout env var.** That is why
+`python/src/dotfiles_setup/lint.py` wraps it. On expiry the wrapper kills hk's
+whole process group and prints the tail of the debug log. Default 600s; override
+with `--timeout <secs>` or `DOTFILES_LINT_TIMEOUT=<secs>`.
+
+## The backgrounding reversal (2026-07-16)
+
+The rule originally said, flatly, "run it in the background and monitor its debug
+log". For **Mac-side container ops that is precisely wrong** — `mise run
+ship`/`land`, `verify-local`, `sync`, and image pulls are **reaped** when the
+turn goes idle waiting on them. It cost a killed 20-minute image pull.
+
+Measured both ways: a foreground 10-minute bound *also* killed a `ship`
+mid-`shellcheck` (rc=143). Neither default works. What works is in-turn polling —
+background the command, then keep the turn engaged reading its log.
+
+Backgrounding stays correct for **CI/remote** waits (`gh pr checks --watch`,
+`gh run watch`): those run on GitHub's infrastructure, nothing local reaps them.
+The hazard is specifically local, long, Mac-side work. This reversal is why
+`feedback_long_mac_ops_keep_turn_engaged` exists — the rule used to contradict it
+outright.
+
+## Which log file to read (misread 2026-07-14)
+
+| Path | Written by | Use it? |
+|---|---|---|
+| `~/.local/state/dotfiles/hk-lint.log` | the per-run `HK_LOG_FILE` `lint.py` sets (`DEFAULT_LOG_FILE`) | **yes** |
+| `~/.local/state/hk/hk.log` | *other* hk entrypoints, e.g. the pre-push hook | no — typically stale |
+| `~/.local/state/mise/mise.log` | mise (`MISE_LOG_FILE`, debug level in `mise.toml [env]`) | for mise |
+
+Reading the wrong one made a **live hang look idle**. Use a count-diff monitor
+loop against the right file, not a fixed sleep.
+
+## The ruff wedge (#268) — and its two published red herrings
+
+The wedge is **FIXED**: a ruff violation now fails `mise run lint` with `rc=1`
+and a `✗ ruff` summary.
+
+**Root cause was `depends` + `fail_fast = false`, not ruff.** hk never releases a
+dependent whose dependency FAILED, so `ruff_format` — which had been given
+`depends = List("ruff")` — sat at `waiting for ruff` forever. Fixed by ordering
+with `exclusive = true` instead; `hk.pkl`'s `no_hk_depends` step now blocks
+`depends` from coming back. Reproduced on hk **1.50.0 AND 1.51.0** — it was
+never going to be fixed by a version bump.
+
+Two red herrings the rule itself repeated for two days:
+
+1. **"The `ruff` step has `fix=true`."** It does not. `fix` on a builtin Step is
+   a **command string**; the boolean lives on the **hook**
+   (`hk.pkl` `["pre-commit"] { fix = true }`). Same key name, two meanings,
+   opposite levels.
+2. **"`failed to get write locks …` is the wedge."** It is a **DEBUG-level,
+   non-fatal** retry line from whole-repo hygiene steps contending over the first
+   file alphabetically. It appears on runs that finish fine. The wedge is one
+   line lower: `waiting for <dep>`.
+
+The durable generalisation: **a scary log line adjacent to a hang is not the
+hang.** Confirm a suspect by removing it and re-probing — which is what finally
+isolated `depends`.
+
+The durable habit: **when lint hangs, run `uv run --project python ruff check`
+DIRECTLY.** Seconds, and it never lies about your own code.
+
+## hk locking specifics
+
+hk parallelises via per-file read/write locks *within* a run, and a crashed or
+killed run can leave stale state under `~/.local/state/hk/`. The old "clear
+`~/Library/Caches/hk/configs/` after editing hk.pkl" guidance is **retired** —
+the cache has been content-hashed since hk 1.47 (`ci-local-parity.md` rule 5).
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the rule,
+  `python/src/dotfiles_setup/lint.py`, `hk.pkl`, issues #142/#268.
+
+_Named in the extracted text but **not** resolved during this extraction: the hk
+upstream project (version claims about 1.46/1.47/1.48/1.50/1.51 are carried over
+from the rule, not re-probed)._

--- a/docs/rules-evidence/notepad-enforcement.md
+++ b/docs/rules-evidence/notepad-enforcement.md
@@ -1,0 +1,52 @@
+# Evidence — `notepad-enforcement`
+
+Archaeology behind `.claude/rules/notepad-enforcement.md`. Extracted so the
+eager copy states the mechanism and the four operative rules, and this file
+carries how the rule spent months naming a mechanism that did not exist.
+
+## The rule named tools that are absent from every session
+
+Until 2026-07-15 the rule named
+`mcp__plugin_oh-my-claudecode_t__notepad_write_working` and
+`..._write_priority` as *the* way to record findings.
+
+Those tools ship with the `oh-my-claudecode` plugin, which is **disabled**. So
+they are absent from every session — and a `/doctor` scan measured **zero
+invocations across 941 transcripts**.
+
+**The rule was unfollowable as written.** What kept the notepad current was
+sessions writing `.agent/notepad.md` by hand, i.e. doing the right thing by a
+mechanism the rule never mentioned. Naming the real mechanism — an ordinary file,
+written with Write/Edit — is the whole fix.
+
+If OMC is ever re-enabled, its notepad tools write this same file, so the rule
+does not change.
+
+The generalisable shape: **a rule that names a mechanism nobody can invoke is
+indistinguishable from no rule at all**, and it will not announce itself — the
+outcome looked fine because humans were compensating. The 941-transcript count is
+what made it visible.
+
+## Why the rule exists at all (2026-04-05)
+
+The python-pro agent and the debugger team performed extensive analysis and did
+**not** write to the notepad. When context was lost, every finding had to be
+re-derived.
+
+That is the same failure `agent-report-persistence.md` covers at full fidelity;
+this rule covers the running condensed layer. Both, every time.
+
+## Verifying compliance
+
+After an agent completes work, check `.agent/notepad.md`. If it is empty or stale
+relative to the work performed, the agent did not comply — and the finding is
+gone unless it is still in context.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the rule,
+  `.agent/notepad.md`.
+
+_Named in the extracted text but **not** resolved during this extraction: the
+`oh-my-claudecode` plugin. Its disabled state was verified in an earlier session
+(2026-07-28-e), not re-probed here._

--- a/docs/rules-evidence/persistence-gate-retry.md
+++ b/docs/rules-evidence/persistence-gate-retry.md
@@ -1,0 +1,56 @@
+# Evidence — `persistence-gate-retry`
+
+The incident behind `.claude/rules/persistence-gate-retry.md`. Extracted from the
+rule so the eager copy carries the heuristic and the signature table, and this
+file carries the case history.
+
+## Why the gate is network-sensitive at all
+
+The `persistence` gate inside `mise run verify-local` calls
+`@devcontainers/cli up` **mid-cycle** to bring the container back up. That path
+re-resolves `ghcr.io/devcontainers/features/sshd` for feature dependencies — so
+the gate touches the network in a way that is not visible from
+`mise.toml [tasks.persistence]` alone.
+
+A transient DNS blip on the host, or inside Docker Desktop's DNS layer, surfaces
+as `getaddrinfo ENOTFOUND ghcr.io` and aborts the gate. Meanwhile the image bytes
+are healthy, the prior gates have already validated R1/R2/R3, and the
+content-hashed `:dev` lineage is unaffected.
+
+## The incident (2026-05-01)
+
+A ~30s host DNS hiccup during the persistence gate's bring-back-up produced
+`verify-local rc=1`.
+
+**The first-pass log made it look like an R-invariant regression** in the
+post-PR-#93 retagged `:dev` — i.e. a real defect in freshly-published image
+bytes, which is about the most alarming thing this gate can report.
+
+The retry ran clean in **18 minutes**, all gates green: R1 inbound, R2 outbound,
+R3 amd64, persistence, secrets. **No code changes.**
+
+Without the rule, a future session reading that log would reach for
+`mise run dev-rebuild` — ~30 min on this Mac — to chase a transient that had
+already cleared. That is the cost the retry-once heuristic buys back.
+
+## Why the DNS pre-checks are the ones they are
+
+Before retrying, the rule has you confirm the host can actually resolve and
+reach the registry:
+
+- `dscacheutil -q host -a name ghcr.io` → should return an `ip_address`.
+- `curl -sI -o /dev/null -w "%{http_code}\n" https://ghcr.io/v2/ --max-time 10`
+  → should return **405**, the registry's expected *unauthenticated* response.
+
+The 405 matters: a `200` would mean something is intercepting, and a `000` means
+the probe never got an answer at all — "never asked" is not "answered no"
+(`probes-need-a-control-arm.md` rule 4).
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the rule,
+  `mise.toml [tasks.persistence]`, PR #93.
+
+_Named in the extracted text but **not** resolved during this extraction: the
+`devcontainers/features` sshd feature image reference is carried over from the
+rule, not re-fetched._

--- a/docs/rules-evidence/research-doc-sources.md
+++ b/docs/rules-evidence/research-doc-sources.md
@@ -1,0 +1,86 @@
+# Evidence — `research-doc-sources`
+
+Probe logs and corrections behind `.claude/rules/research-doc-sources.md`.
+Extracted from the rule so the eager copy carries the preference chain itself and
+this file carries the evidence for why each step is where it is — and why one
+step was deleted outright.
+
+## Why `mcp2cli` against per-repo mintlify MCPs is NOT in the chain
+
+An earlier revision listed `mcp2cli https://mintlify.com/<owner>/<repo>/mcp
+<tool>` as a fuzzy-search step. **That step does not work** and was removed.
+
+Probe evidence (full log: `docs/research/mintlify-catalog-validation-log.md`):
+
+- **The URLs are GET-only preview descriptors**, auto-generated for every repo
+  Mintlify indexes. `curl GET` returns a JSON tool-schema descriptor; **POST** —
+  which `mcp2cli` sends to speak MCP protocol — returns `404 Not found`. There is
+  no live MCP server behind the descriptor. The descriptor's existence is exactly
+  the trap: it *looks* like a live endpoint to a GET-shaped probe.
+- **Live mintlify MCP servers exist only at the customer's own documentation
+  domain** (e.g. `docs.anthropic.com/mcp`, `resend.com/docs/mcp`,
+  `docs.perplexity.ai/mcp`). None of the 16 repos then in
+  `docs/research/mintlify-catalog.md` host one anywhere — verified against their
+  own domains (`chezmoi.io/mcp`, `starship.rs/mcp`, `mise.jdx.dev/mcp`), all of
+  which return plain nginx 405/404, not MCP protocol.
+- **Mintlify's central MCP** at `https://mintlify.com/docs/mcp` works, but is
+  scope-limited to Mintlify's *own* platform docs (how to build a mintlify site,
+  MDX syntax, agent workflows). It does not search the per-repo customer sites in
+  the catalog — verified with a real query: `search-mintlify --query "mise
+  shell_alias"` returned zero results from `jdx/mise`.
+- **An API key does not unlock this path.** Mintlify API keys are
+  organization-scoped: they authenticate you only against docs owned by the same
+  Mintlify organization as the key. A key cannot reach `jdx/mise`,
+  `twpayne/chezmoi`, or any other org's content.
+
+`mcp2cli` itself remains in active use for **other** MCP servers (`@github`,
+`@docker` shorthands, or a customer-domain MCP such as `docs.anthropic.com/mcp`).
+The ban is specifically on per-repo mintlify subpath URLs, not on `mcp2cli`.
+
+## The `ctx7` correction (2026-07-23)
+
+Step 3 of the chain used to say `ctx7` was "a skill-management CLI … **not** a
+direct doc-fetcher", which routed every lookup through a skill wrapper that adds
+nothing.
+
+Verified against `ctx7 --help` (0.5.5, the `mise.toml` pin): the documented
+commands are `login / logout / whoami / setup / remove / library / docs /
+upgrade`. It **is** a direct doc-fetcher, called in two steps.
+
+The subtlety worth keeping: the `skills` subcommands **still run**
+(`ctx7 skills list` → rc=0) but are hidden from `--help` and deprecated —
+*"Skill commands are deprecated and will stop working in the next major
+release."* So do not build on them, **and do not treat their absence from
+`--help` as proof they are gone.** A command missing from help output is not a
+command that does not exist; that is a display bound, in the sense of
+`probes-need-a-control-arm.md` rule 3.
+
+## The docs-domain guessing trap (session 2026-04-09c)
+
+Do **not** guess a project's docs domain. `containers.dev/llms.txt` → 404. The
+devcontainer spec / CLI / features / images docs are all hosted on mintlify at
+`www.mintlify.com/devcontainers/<repo>/`, not on `containers.dev`. Grep the
+cache or the catalog to find the right URL before curling anything.
+
+## The MCP-registration relaxation (2026-07-19)
+
+The rule used to carry a hard ban, machine-enforced by a `no_mcp_registration`
+hk step. That step has been **removed**; native registration is now a documented
+*preference*, not a gate.
+
+The cost that still justifies the preference: registering an MCP server natively
+injects every tool's JSON schema into Claude's system prompt for **every**
+conversation, forever — even conversations that never call the tool. So for a
+server you would query rarely, `mcp2cli`'s process-spawn is strictly cheaper. If
+a plugin's value depends on Claude selecting its tools natively and you will use
+it often, register it and accept the schema cost.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the rule,
+  `docs/research/mintlify-catalog.md`, the validation log.
+
+_Named in the extracted text but **not** resolved during this extraction (carried
+over from the rule, not re-probed): `jdx/mise`, `twpayne/chezmoi`, and the
+mintlify / Context7 endpoints above. The probe results are dated; re-run them
+before relying on a negative._

--- a/docs/rules-evidence/tool-currency-and-native-first.md
+++ b/docs/rules-evidence/tool-currency-and-native-first.md
@@ -1,0 +1,101 @@
+# Evidence — `tool-currency-and-native-first`
+
+Archaeology and provenance behind
+`.claude/rules/tool-currency-and-native-first.md`. Extracted from the rule so the
+eager copy carries the directive and this file carries the case history. Read it
+when you want to know *why* a line in that rule is worded the way it is, or
+before changing one.
+
+## The conda-lockfile case — and the two-week contradiction it left behind
+
+*(r3 probe round, 2026-07-10; corrected in the rule 2026-07-24.)*
+
+An earlier revision of the rule claimed mise's rattler `conda:` backend writes
+per-platform `sha256` + transitive deps to `mise.lock` as of **v2026.5.0**, and
+that this *retires* the custom `mise-system-resolved.json` snapshot plus
+`mise_snapshot.py`.
+
+**That was wrong, and the probe said so: 0 of 3.** v2026.5.0 only graduated the
+conda backend's **experimental flag**. Conda resolutions still land in **no
+lockfile tier**, and native conda locking remained open upstream
+(`jdx/mise#7700`).
+
+The failure is itself an instance of the rule: the *assumption* that conda had
+reached lockfile parity lagged the code, exactly as docs do.
+
+**The second defect is the more expensive one.** The snapshot machinery had
+already been deleted — `mise_snapshot.py` went in `352063a` (#160 T4–T13) — yet:
+
+| Doc | What it said | Reality |
+|---|---|---|
+| this rule | "do NOT retire `mise_snapshot.py`" | already deleted for ~2 weeks |
+| `tool-currency-check` skill | "RETIRED in #160 T1" | correct |
+
+Two docs, opposite claims about the same file, neither checked against the
+filesystem. The durable fact worth carrying forward is **the conda lockfile
+gap**, not the file's existence.
+
+## The other three verified cases
+
+- **`minimum_release_age` / `lockfile` / `lockfile_platforms` are native.** No
+  custom cooldown or platform-scoping machinery was ever needed.
+- **Renovate's native `mise` manager + the `github>jdx/renovate-config` preset**
+  made **8 of 11** hand-rolled `customManagers` redundant (PR #161). This is the
+  canonical example kept in the rule.
+- **`get_env()` vs the Tera `env.VAR` variable** (mise 2026.7.0). The
+  *documented* function was insufficient for a `mise.local.toml` `[env]`
+  override; only empirically probing both revealed which one the task actually
+  needed. The native mechanism is the default answer — but *verify which native
+  mechanism*. This is the evidence behind rule 4.
+
+Stated twice by Ray (2026-07-04): the managed tools here (mise, hk, Renovate,
+uv, docker, chezmoi) move fast and their **docs lag their code**, so the merged
+CHANGELOG/PRs are often the only truthful source.
+
+## The failure mode the rule prevents
+
+Shipping — or preserving — homegrown machinery for a problem the tool already
+solves. You pay maintenance cost forever, and often get a *weaker* result
+(version-only vs sha256-verified) than the native path.
+
+## How currency is checked now — the shared engine
+
+The version-currency MECHANICS (in-sync validation, release-note review,
+tracked-issue movement, the six-gate auto-apply bar, the committed report) live
+in the shared `kb_setup.currency` engine — a pinned `uv` git dep on the
+knowledge-base package, so both repos run ONE implementation (D2/G4; dotfiles'
+old broad-sweep module was deleted).
+
+What this repo declares is `currency.toml` (graphify is deep-tracked; hk/uv/etc.
+ride the broad `mise outdated` sweep) plus two thin mise tasks:
+
+| Task | Delegates to | When |
+|---|---|---|
+| `mise run tool-currency` | `kb-setup currency daily` | the daily report `refresh.yml` upserts as the standing issue |
+| `mise run tool-currency-check` | `kb-setup currency check` | the offline step-1 drift check the SessionStart hook runs every session (silent unless drift) |
+
+The engine tracks **versions**. The rule's remaining, un-automatable job is the
+**native-first judgment** — is a piece of custom code now superseded by a tool
+feature (the `mise_snapshot.py` → `mise.lock` class)? Only a human decides
+retirement.
+
+## Machine enforcement (partial — judgment cannot be automated)
+
+- **`workflow.tool-currency-wiring`** (`python/verification/suites.toml`) asserts
+  the whole chain: `currency.toml` → the two mise tasks → the `kb-setup` dep in
+  `python/pyproject.toml` → `refresh.yml`'s daily job → the SessionStart hook.
+- **`hk_version_parity`** (`hk.pkl`, SHIPPED) asserts `hk@<ver>` is identical
+  across `hk.pkl` / `hk-common.pkl` / `hk-image.pkl` and matches the `mise.toml`
+  binary pin — catching pin drift the rule would otherwise catch by hand.
+- **Renovate PRs carry the CHANGELOG** — bump review IS release-note review.
+- **agnix** structurally validates the rule file and the skill.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the rule,
+  the mise tasks, PRs #160/#161, commit `352063a`.
+
+_Named in the extracted text but **not** resolved during this extraction (do not
+treat these as verified links): `jdx/mise` (issue #7700, the
+`github>jdx/renovate-config` preset) and the knowledge-base sibling repo that
+hosts `kb_setup.currency`._

--- a/docs/rules-evidence/use-tool-builtins.md
+++ b/docs/rules-evidence/use-tool-builtins.md
@@ -1,0 +1,88 @@
+# Evidence — `use-tool-builtins`
+
+Worked failures and archaeology behind `.claude/rules/use-tool-builtins.md`.
+Extracted from the rule so the eager copy carries the hard gate and one canonical
+example, and this file carries the case history.
+
+## Worked failure 1 — the chezmoi `is_container` reinvention (2026-04-06g)
+
+This is the case the rule was born from.
+
+`home/.chezmoi.toml.tmpl` carried ~20 lines of custom `$isContainer` env-var
+detection — checking `REMOTE_CONTAINERS` / `CODESPACES` / `DEVCONTAINER` — that
+fed a custom `is_container` data variable, which `.chezmoiignore` then used to
+gate the mise overlay.
+
+The chezmoi.io docs
+(<https://www.chezmoi.io/user-guide/manage-machine-to-machine-differences/>) show
+the canonical pattern is `{{ eq .chezmoi.os "linux" }}` — a **built-in runtime
+fact**. It is always correct, never depends on env vars or stale config, and
+works identically across CI, the local Mac, and the devcontainer.
+
+**The reinvention introduced a real bug, not just clutter.** The session-F
+handoff's Option B would have run `chezmoi apply` against a stale
+`~/.config/chezmoi/chezmoi.toml` holding `is_container=false` — overwriting the
+user's `~/CLAUDE.md` and executing `run_*.sh.tmpl` scripts on the **Mac host**,
+which this repo forbids outright.
+
+Fixed in commit `bd40767`, the refactor that proved out the rule.
+
+## Worked failure 2 — the hand-rolled CI poller (2026-07-11)
+
+Asked to fix a `ship`/`land` CI-wait that used a fixed timeout, the agent
+hand-rolled a custom `await_pr_checks_terminal()` polling loop — **without first
+researching** that GitHub already offers:
+
+- native **auto-merge** (`gh pr merge --auto`),
+- **merge queue**,
+- `gh run watch`,
+- `workflow_run` triggers,
+- webhooks.
+
+Several of those eliminate the polling entirely. The maintainer had to send the
+agent back to research. This is why the rule's step 2 says *assume the native
+mechanism exists until you've confirmed it doesn't*, and why step 4 exists: a
+known-flaky native tool is not license to hand-roll a replacement.
+
+See also `gh-cli-watch.md`, which is the specific instance of this failure, and
+`mise-tasks-only.md`, whose `automerge` verb is the native mechanism that
+eventually landed.
+
+## Built-in facts worth checking before inventing one
+
+The originally-documented checklist, kept here in full:
+
+| Tool | Built-ins to check first |
+|---|---|
+| chezmoi | `chezmoi.os`, `chezmoi.hostname`, `chezmoi.arch`, `chezmoi.kernel`, `chezmoi.username` |
+| mise | `os`, `arch`, `tool_dir` |
+| GitHub Actions | `runner.os`, `runner.arch`, `github.event_name` |
+| Docker | `TARGETOS`, `TARGETARCH`, `BUILDKIT_INLINE_CACHE` |
+
+Two further habits from the original rule text:
+
+- **Before writing detection scripts** in `run_*` templates or postinstall hooks,
+  check whether the tool has a *declarative* way to express the same intent.
+- **Before writing custom detection logic**, fetch the tool's official docs on
+  the relevant feature (chezmoi.io, mise.jdx.dev, hk.jdx.dev, docs.astral.sh,
+  docs.docker.com, docs.github.com/actions) and read its "common gotchas"
+  section.
+
+## Why the bar is "justify in writing"
+
+If custom logic does ship, the commit body or rule file must say *why* the
+built-in approach is insufficient — e.g. "we have 3 Linux variants and
+`chezmoi.os` can't tell them apart, so we need a custom fact". Without that
+justification the default answer is **delete the custom logic, use the built-in**,
+because a reviewer six months later cannot distinguish "we checked and it didn't
+fit" from "we never looked".
+
+Reinvention is the most common source of subtle bugs in this repo.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the rule,
+  `home/.chezmoi.toml.tmpl`, commit `bd40767`.
+
+_Named in the extracted text but **not** resolved during this extraction: the
+chezmoi documentation URL above was carried over from the rule, not re-fetched._

--- a/docs/rules-evidence/zero-bash-logic.md
+++ b/docs/rules-evidence/zero-bash-logic.md
@@ -1,0 +1,48 @@
+# Evidence — `zero-bash-logic`
+
+Design rationale behind `.claude/rules/zero-bash-logic.md`. Extracted so the
+eager copy carries the gate itself and this file carries why it is built the way
+it is.
+
+## Why the check logic lives in python
+
+A big inline-bash grep in the hk step **would itself violate the policy it
+enforces**. So the allowlist + budget logic lives in
+`python/src/dotfiles_setup/bash_budget.py`, and both the hk step and the CLI
+subcommand are thin wrappers over `find_violations`.
+
+This mirrors the two other guards in this repo:
+
+| Guard | Logic in python | Thin seam |
+|---|---|---|
+| PreToolUse redirect guard | `hook_guard.py` | `settings.json` → wrapper |
+| hk timeout wrapper | `lint.py` | `mise run lint` |
+| bash budget | `bash_budget.py` | `bash_logic_budget` hk step |
+
+Logic in python, a thin shell/hk seam — in every case.
+
+## Wiring, kept honest by a contract
+
+`workflow.bash-logic-enforcement` in `python/verification/suites.toml` asserts
+the whole chain exists: hk step ↔ `dotfiles-setup bash-budget` ↔ module ↔ tests
+↔ the rule file. So the guard cannot silently drift out — the same pattern as
+`workflow.mise-tasks-enforcement`.
+
+This matters because every layer of the chain is individually deletable without
+breaking anything visible: an hk step can be commented out, a CLI subcommand can
+be renamed, and nothing fails until the day it was supposed to catch something.
+
+## History
+
+The policy was **doc-only** (a paragraph in the root `AGENTS.md`) until the
+`bash_logic_budget` hk step gave it machine teeth. The two mechanisms it added —
+an allowlist that gates NEW files, and a per-file `max_lines` budget that flags
+GROWTH — exist because a doc-only version can be violated by a diff nobody
+reads. A stale entry (an allowlisted path no longer tracked) also fails, so the
+map cannot rot after a script is deleted.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the rule,
+  `python/src/dotfiles_setup/bash_budget.py`, `hk.pkl`,
+  `python/verification/suites.toml`.


### PR DESCRIPTION
Completes the extraction started in #413. Moves archaeology, provenance
tables and worked-failure logs out of 15 more eager rules into tracked
`docs/rules-evidence/<rule>.md` siblings, leaving each rule with its
directive, its operative constraints, and ONE canonical worked example.

Eager context: 121,104 -> 105,648 B (-15,456, -12.8%), and 132,683 ->
105,648 B (-20.4%) cumulative since the pass began. Re-derived both
endpoints with `kb-setup md-budget` rather than carrying the handoff's
figures forward.

19 of 21 eager rules are now extracted. `clarify-before-acting` and
`clean-git-state` are deliberately untouched: both were already at the
directive-plus-one-example floor, where extraction would add a file and
a hop to save a few hundred bytes.

One finding that was not archaeology: `research-doc-sources.md` carried
two adjacent near-duplicate sections on MCP registration (~900 B of pure
redundancy). Collapsed rather than extracted.

Control arm on the dead-link gate: mutating a real
`docs/rules-evidence/` link in gh-cli-watch.md made `check-doc-refs`
exit 1 naming the exact file:line; restoring it returned 0. So the
"all refs resolve" green is a real negative, not a blind pass.

Gates: mise run lint rc=0 - pytest 1033 passed - mise run verify
110 passed/0 failed - mise run lint-docs rc=0 (agnix --strict).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CzPdn3iHw6uhMWEdVPADfW

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787849075&installation_model_id=429246&pr_number=415&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F415&signature=fa63bd0de34f3c2f8041292fbba31a62201913c604308f2f49b3aca264f2f4de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->