### PR TITLE
docs/mcp lanes and secrets diagnosis

### DIFF
--- a/.claude/rules/do-not.md
+++ b/.claude/rules/do-not.md
@@ -61,12 +61,19 @@ in this repo. Control arms and case history for each entry:
     scratchpad and delete it. Gated by `no_env_dump`; see
     `secrets-out-of-the-shell-env.md`.
 
-> **Relaxed 2026-07-19 — MCP registration is no longer a "do not".** Native
-> MCP registration (`claude mcp add`, a plugin's bundled servers, a project
-> `.mcp.json`) is **allowed when a plugin or tool requires it**. `mcp2cli`
-> (process-spawn, no schema-injection tax) stays the *preferred* path for
-> one-off doc/tool calls — a preference, not a gate. See
-> `research-doc-sources.md` and `feedback_no_mcp_registration.md`.
+11. **Do NOT reach for MCP to solve one of OUR OWN problems.** For anything this
+    project builds, calls, or looks up: the tool's CLI or a plain HTTP **API**
+    first, then `mcp2cli`, and native registration only as a documented last
+    resort. A registered server taxes **every** conversation's system prompt
+    with **every** tool's schema, forever — paying that for a call a `curl`
+    already makes is pure loss.
+
+    ✅ **NOT a "do not": a third-party plugin or skill that REQUIRES MCP.**
+    Enabling one (bundled servers, `claude mcp add`, a project `.mcp.json`) is
+    allowed and needs no justification — there the schema tax buys a capability
+    we cannot build. The hard ban was relaxed 2026-07-19. **Unsure which case
+    you are in? You are in the first one.** See `research-doc-sources.md`
+    § "MCP: two lanes".
 
 ## See also
 

--- a/.claude/rules/research-doc-sources.md
+++ b/.claude/rules/research-doc-sources.md
@@ -66,17 +66,38 @@ customer-domain MCP like `docs.anthropic.com/mcp`) — see
 `.claude/skills/mcp2cli/SKILL.md`. Four probes, incl. the central-MCP
 scope limit: `docs/rules-evidence/research-doc-sources.md`.
 
-## `mcp2cli`-first — a preference, not a gate
+## MCP: two lanes. Which lane you are in decides the answer
 
-**Prefer `mcp2cli` (process-spawn) or the curl steps above** for one-off
-lookups: native registration injects every tool's JSON schema into the system
-prompt for **every** conversation, forever, including ones that never call it.
+The cost is the same either way — a natively-registered server injects **every**
+one of its tool schemas into the system prompt of **every** conversation,
+forever, including the ones that never call it. What differs is whether you
+control the alternative.
 
-**Native registration is NOT forbidden** (relaxed 2026-07-19; the
-`no_mcp_registration` hk step is gone). When a plugin or tool *requires* MCP,
-register it knowingly. Judgement call: rare queries → `mcp2cli` wins on cost;
-a plugin whose value depends on native tool selection → register it. When
-unsure, reach for `mcp2cli` first.
+**Lane 1 — a third-party plugin or skill requires MCP: ALLOWED, no
+justification needed.** Enabling a plugin that bundles an MCP server, or a tool
+whose features only work over MCP, is a normal thing to do. You are buying the
+plugin's value and paying its schema cost knowingly. Do not fight it, do not
+wrap it, do not refuse a useful plugin over this. Relaxed 2026-07-19; the
+`no_mcp_registration` hk step is gone and is not coming back.
+
+**Lane 2 — anything THIS project builds, calls, or looks up: AVOID MCP.**
+For our own doc lookups, tool calls and automation, exhaust these first, in
+order:
+
+1. the cache / `llms.txt` / `.md` steps above, or the tool's own CLI;
+2. a plain HTTP **API** (`curl` + `gh api` + a documented endpoint);
+3. **`mcp2cli`** — process-spawn, pays zero per-conversation schema cost;
+4. native registration — **last resort**, and say in the commit body why 1–3
+   could not do it.
+
+The asymmetry is deliberate. In lane 1 the schema tax buys a capability we
+cannot build; in lane 2 it buys something a `curl` already does, so it is pure
+loss — permanent context spend for a call we make twice a month. When a lookup
+is one-off, `mcp2cli` wins outright and there is nothing to weigh.
+
+**If you are unsure which lane you are in, you are in lane 2.** Lane 1 is
+specifically "an external plugin/skill I did not write requires it"; everything
+else is our own code, and our own code uses an API.
 
 ## See also
 

--- a/.claude/rules/secrets-out-of-the-shell-env.md
+++ b/.claude/rules/secrets-out-of-the-shell-env.md
@@ -106,6 +106,17 @@ Findings, control arms, and the verification that passed while blind:
    short or empty "secret" corrupts every log the tool writes.
 4. **When a scanner reports clean, ask what it can see.** Compression, encoding,
    and a path allowlist each turn "no findings" into "never looked".
+5. **A new env-var consumer is a new `env = true` decision.** With `env = "exec"`,
+   a config that interpolates `${VAR}` gets an **empty string**, not an error — the
+   tool starts, reports healthy, and silently drops to an anonymous tier (context7
+   MCP did exactly this, 2026-07-29). Check the consumer's authenticated
+   *identity*, never its connection status.
+6. **Diagnose by layer, and never run `fnox get` to do it.** A `-v` presence test
+   under `fnox exec` (present) vs the same in a plain shell (absent) identifies
+   `env = "exec"` on its own; `fnox sync --dry-run -p age VAR` answers staleness
+   without reading a value. Full ordered recipe, the result-reading table, and the
+   ⚠️ `bootstrap-config` **wipe hazard** (it drops `env = "exec"`, all 3 opt-ins,
+   and 49 `sync` blocks): `docs/secrets-doppler-fnox-keychain.md`.
 
 ## See also
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "env": {
+    "CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD": "1",
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
   "permissions": {
     "deny": [
       "Bash(chezmoi apply:*)",
@@ -69,10 +73,10 @@
     "code-simplifier@claude-plugins-official": false,
     "feature-dev@claude-plugins-official": false,
     "typescript-lsp@claude-plugins-official": false,
-    "claude-md-management@claude-plugins-official": false,
+    "claude-md-management@claude-plugins-official": true,
     "commit-commands@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
-    "claude-code-setup@claude-plugins-official": false,
+    "claude-code-setup@claude-plugins-official": true,
     "pyright-lsp@claude-plugins-official": false,
     "pyright@claude-code-lsps": false,
     "explanatory-output-style@claude-plugins-official": true,
@@ -102,7 +106,8 @@
     "mattpocock-skills@mattpocock": true,
     "ty@claude-code-lsps": false,
     "fable-orchestrator@fable-orchestrator": true,
-    "antigravity@antigravity-for-claude-code": true
+    "antigravity@antigravity-for-claude-code": true,
+    "context7@context7-marketplace": true
   },
   "extraKnownMarketplaces": {
     "fable-orchestrator": {
@@ -119,9 +124,5 @@
     }
   },
   "prefersReducedMotion": true,
-  "env": {
-    "CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD": "1",
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
-  },
   "teammateMode": "auto"
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -7,10 +7,6 @@
         "EXA_API_KEY": "${EXA_API_KEY}"
       }
     },
-    "context7": {
-      "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp"]
-    },
     "memory": {
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-memory"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,9 +112,9 @@ locally before pushing Dockerfile changes.
   `.claude/rules/zero-skip-policy.md`.
 - **Zero inline suppressions**: The `no_lint_skip` hk step rejects
   `noqa`/`type: ignore`/`pylint: disable`/`nosec` in Python source.
-- **MCP: `mcp2cli`-first (not banned)**: prefer `mcp2cli`/`llms.txt`/`.md`
-  (no schema-injection tax); native MCP registration IS allowed when a
-  plugin/tool requires it. See `.claude/rules/research-doc-sources.md`.
+- **MCP has two lanes**: a 3rd-party plugin/skill that REQUIRES it → allowed,
+  no justification. Anything WE build/look up → avoid it; API or `mcp2cli`
+  first, register last. Unsure = lane 2. `.claude/rules/research-doc-sources.md`.
 - **CI-local parity**: Every CI lint step has a local hk equivalent; every
   hk tool is in `mise.toml`. See `.claude/rules/ci-local-parity.md`.
 - **Research before fixing**: Check docs/changelogs/issues before fixing — don't guess at CI failures.

--- a/docs/secrets-doppler-fnox-keychain.md
+++ b/docs/secrets-doppler-fnox-keychain.md
@@ -18,12 +18,39 @@ is done. Treat this file as the interim contract.
 
 | layer | role | what it holds here |
 |---|---|---|
-| **Doppler** | shared authority — the value of record | project `dotfiles`, configs `dev` (46 secrets) and **`dev_personal` (50)** |
+| **Doppler** | shared authority — the value of record | project `dotfiles`, config **`dev_personal`** (49 secrets as of 2026-07-29) |
 | **fnox** | declaration + resolution + optional encrypted cache | `~/.config/fnox/config.toml`; providers `keychain`, `age`, `doppler_dotfiles_dev_personal` |
 | **macOS Keychain** | machine-local bootstrap vault | service **`mde-fnox`**, holds `DOPPLER_TOKEN` — the credential that unlocks everything else |
 | **environment** | temporary process delivery | injected by `fnox exec` or shell activation; never the source of truth |
 
 The chain: **Keychain → `DOPPLER_TOKEN` → Doppler → fnox declaration → process env.**
+
+### The `env` mode — the gate on the last layer (added 2026-07-29)
+
+A secret being *declared and resolvable* does **not** mean it reaches the shell.
+Since 2026-07-27 this config is globally:
+
+```toml
+env = "exec"   # secrets stay OUT of the interactive shell
+```
+
+| `env` | interactive shell / `fnox export` | `fnox exec` | `fnox get` |
+|---|:-:|:-:|:-:|
+| `true` (fnox default) | yes | yes | yes |
+| **`"exec"` (ours)** | **no** | yes | yes |
+| `false` | no | no | yes |
+
+Only secrets carrying an explicit per-secret `env = true` are exported. **Three
+are** — `EXA_API_KEY`, `GITHUB_TOKEN`, `MISE_GITHUB_TOKEN` — chosen because their
+consumers can *only* read the environment (an `.mcp.json` `${VAR}` interpolation
+at MCP-server spawn; `gh` and `mise` reading their tokens).
+
+**This is the single most likely cause of "the variable isn't set".** It is not a
+sync failure. See the diagnosis recipe below before suspecting Doppler.
+
+⚠️ **Any consumer that reads a credential from the environment needs either
+`fnox exec --` or an explicit `env = true`.** A new one added without either gets
+an **empty string**, not an error — see "Incidents".
 
 ## Deltas from the honeymoon-period guide (this repo)
 
@@ -32,11 +59,34 @@ The chain: **Keychain → `DOPPLER_TOKEN` → Doppler → fnox declaration → p
    `config = "dev_personal"`). A secret written to `dev` lands in Doppler and
    **never reaches the environment**. This is the single easiest mistake to make
    and it fails silently.
-2. **The config's stated owner is gone.** `~/.config/fnox/config.toml` opens with
-   *"Managed by `mde-py secrets bootstrap-config`. Do not edit by hand."* —
-   but **`mde-py` is not on PATH** (verified 2026-07-20). `fnox edit` is the only
-   remaining route. The header is stale; treat hand-editing as sanctioned until
-   the planned skill replaces it.
+2. **The config's stated owner is gone — and re-running it would be
+   DESTRUCTIVE.** `~/.config/fnox/config.toml` opens with *"Managed by `mde-py
+   secrets bootstrap-config`. Do not edit by hand."* but **`mde-py` is not on
+   PATH** (re-verified 2026-07-29). `fnox edit` is the only route, so
+   hand-editing is sanctioned.
+
+   ⚠️ **The generator still exists in source and would wipe the config's most
+   important fields.** `mde/secrets/manage.py` → `bootstrap_config()` rebuilds the
+   file from a template whose per-secret line is:
+
+   ```python
+   lines.append(f'{key} = {{ provider = "{provider_name}", value = "{key}" }}')  # :72
+   ```
+
+   `provider` and `value` only — the function contains **zero** references to
+   `env`, and preserves only `DOPPLER_TOKEN`. Measured against the live config:
+
+   | field | present now | generator emits |
+   |---|---:|---:|
+   | global `env = "exec"` | 1 | **0** |
+   | per-secret `env = true` | 3 | **0** |
+   | `sync = { provider = "age", … }` | **49** | **0** |
+
+   So a single `bootstrap-config` run silently reverts every secret to
+   shell-exported — undoing the whole reason `env = "exec"` was adopted — and
+   drops every offline age-encrypted copy. **Do not run it** until the generator
+   preserves those fields. Tracked for the sibling repo in
+   knowledge-base issue **#74**.
 3. **fnox is already shell-activated** on this machine (3 `FNOX_*` vars present,
    `DOPPLER_TOKEN` resolving from Keychain). No bootstrap needed.
 4. **An `age` provider is configured** (`recipients = ["age16djrq…"]`), so the
@@ -119,6 +169,51 @@ or a minimal request returning an expected status).
 Never record token prefixes/suffixes, hashes of low-entropy secrets, auth
 headers, raw env dumps, or the contents of a secret-bearing config.
 
+## Diagnose "the variable isn't set" — in this order
+
+Work down the layers. Each step is contract-compliant (no value is read or
+printed), and each **discriminates**, so a pass genuinely rules that layer out.
+
+```sh
+# 1. Is fnox itself healthy?  Expect: "Configuration is healthy" + counts.
+fnox check
+
+# 2. Is the secret DECLARED?  names only, never --values.
+fnox list | grep KEY_NAME
+
+# 3. Does it resolve to a process?  (present here + absent in step 4 == env="exec")
+fnox exec -- zsh -c '[[ -v KEY_NAME ]] && print present || print ABSENT'
+
+# 4. Is it in the plain interactive shell?
+zsh -c '[[ -v KEY_NAME ]] && print present || print ABSENT'
+
+# 5. Is the offline age copy stale vs Doppler?  dry-run reveals no values.
+fnox sync --dry-run -p age KEY_NAME
+#   "Would sync 1 secrets … KEY_NAME (from doppler_…)"  -> a copy would change
+#   "No secrets to sync"                                -> nothing to do / unknown key
+```
+
+**Reading the result:**
+
+| step 3 | step 4 | meaning |
+|---|---|---|
+| present | **ABSENT** | **`env = "exec"` working as designed.** Consumer must use `fnox exec --`, or the secret needs `env = true`. *Not a bug.* |
+| ABSENT | ABSENT | declaration or provider problem — go back to steps 1–2 |
+| present | present | it has `env = true`; if a consumer still sees nothing, the consumer is the fault |
+
+**Always control-arm the negative.** A `0`/ABSENT result is worthless until the
+same command shape returns present for something you *know* is set:
+
+```sh
+zsh -c '[[ -v HOME ]] && print "control ok: [[ -v ]] works"'
+```
+
+A 2026-07-29 session reported a variable "set, 43 chars" and later "unset" from
+two different probes in the same session. The control arm is what settled it.
+
+⚠️ **`env | grep` is forbidden inside a secret-injected process** (see the
+contract above). Use `[[ -v VAR ]]`, which reveals presence without the value.
+
 ## Evidence record
 
 ```text
@@ -132,8 +227,53 @@ Consumer health check: <safe result>
 Timestamp: <ISO-8601>
 ```
 
+## Incidents
+
+### 2026-07-29 — Context7 MCP ran anonymous for days; nothing noticed
+
+The Upstash context7 plugin interpolates `"Authorization": "${CONTEXT7_API_KEY:-}"`.
+That secret is exec-only, so the header resolved to **empty** and the server used
+the anonymous tier — while reporting `✓ connected` the whole time.
+
+What made it invisible:
+
+- **`${VAR:-}` substitutes an empty string instead of failing.** Silent by
+  construction.
+- **Doppler → fnox was perfectly healthy**, so every instinct to blame "the sync"
+  was wrong. `fnox check` green; the value matched Doppler exactly.
+- **The opt-in list was drawn before the consumer existed.** The three `env = true`
+  entries were chosen 2026-07-27 for the three consumers that existed then; the
+  plugin arrived 2026-07-29 and nothing re-checked the list.
+
+Generalisation: **a new env-var consumer is a new opt-in decision, and nothing
+enforces it.** Tracked as dotfiles issue **#418** (project-doctor SessionStart
+check: every `${VAR}` interpolated by an MCP/plugin config must be `env = true`).
+
+### Contract breaches by an agent in that same session — recorded, not excused
+
+While diagnosing the above, the agent violated the operating contract three ways:
+
+1. **Ran `fnox get` and `doppler secrets get`** — both explicitly on the MUST NOT
+   list — to sha256-compare the two values. Output was truncated to 12 hex chars,
+   never the value, but the commands themselves are forbidden.
+2. **Interpolated a live key into `curl -H "Authorization: $K"`** — a secret in a
+   command argument, which the contract forbids because argv is observable.
+3. Reached for `env | grep` on secret names (permitted here only because the
+   variables in question were *absent*; the compliant form is `[[ -v VAR ]]`).
+
+None of it reached a tracked file or the transcript, and the endpoint was the
+credential's legitimate vendor. It was still avoidable: **`fnox sync --dry-run -p age`
+answers the staleness question without reading any value**, and `[[ -v ]]` answers
+presence. Both are in the MAY list. The compliant recipe is now written above so
+the next session reaches for it first.
+
 ## Gotchas
 
+- **A silently-empty credential is the default failure mode.** `${VAR:-}` and
+  `${VAR}` interpolation in MCP/plugin configs yield an empty string when the var
+  is exec-only. The server starts, reports healthy, and degrades to an anonymous
+  or unauthenticated tier. Check the *consumer's* authenticated identity, never
+  its connection status.
 - **A running process keeps its env snapshot.** After a rotation, restart
   consumers — a green write proves nothing about live processes.
 - **`fnox sync` caches**; a Doppler change does not propagate to the encrypted


### PR DESCRIPTION
- **docs(rules): finish rules-evidence extraction (-15.5KB eager, -20.4% total)**
- **docs(mcp,secrets): make the MCP two-lane policy explicit; document the fnox env-mode trap**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787946309&installation_model_id=429246&pr_number=419&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F419&signature=ec057d237878d00e31d66a4f7c927384475df0d0dad7f0750ecaecff9817aed0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->