### PR TITLE
docs(secrets): correct manage.py line ref 72 -> 318

### DIFF
--- a/docs/secrets-doppler-fnox-keychain.md
+++ b/docs/secrets-doppler-fnox-keychain.md
@@ -70,7 +70,7 @@ an **empty string**, not an error — see "Incidents".
    file from a template whose per-secret line is:
 
    ```python
-   lines.append(f'{key} = {{ provider = "{provider_name}", value = "{key}" }}')  # :72
+   lines.append(f'{key} = {{ provider = "{provider_name}", value = "{key}" }}')  # :318
    ```
 
    `provider` and `value` only — the function contains **zero** references to


### PR DESCRIPTION
The bootstrap_config per-secret template is at manage.py:318, not :72.
I derived :72 from a function-RELATIVE offset (bootstrap_config starts at
:247, and the template is its 71st line) and published it as an absolute
file line. Caught by clear-prep's file:line spot-check, which read the
cited line and found a different function there.

The substantive claim is unaffected and re-verified: bootstrap_config
contains ZERO `env` references, so a run still drops env="exec", the 3
env=true opt-ins, and all 49 sync blocks.

Same correction applied to knowledge-base#74 and dotfiles#418 (both
verified from the API, not from memory).

Gates: mise run lint rc=0 - mise run lint-docs rc=0 (agnix --strict).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CzPdn3iHw6uhMWEdVPADfW

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787947460&installation_model_id=429246&pr_number=420&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F420&signature=05a6b9b3838e1d859296a88aae3d21e5c4e2d331850d6b3cc4a4c97388fbffc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->