### PR TITLE
docs/fnox wipe recurrence

### DIFF
--- a/.claude/rules/secrets-out-of-the-shell-env.md
+++ b/.claude/rules/secrets-out-of-the-shell-env.md
@@ -52,16 +52,30 @@ that, not a substitute for it.
 The table above is the tool's **measured** behaviour on the pinned 1.31.1 (both
 arms probed), not a restatement of its release notes.
 
-**APPLIED 2026-07-27 by Ray** — 46 of 49 exec-only, 3 opted back in. Two
-variables must stay `env = true` because this repo runs on them: `.mcp.json`
-interpolates one at MCP-server spawn, and `gh` (every `ship`/`land`/`automerge`
-and `gh api` call) reports its active account as the environment-authenticated
-one. Exec-only for those degrades tooling *silently*.
+**APPLIED 2026-07-27 by Ray; 4 opt-ins since 2026-07-30** — 45 of 49 exec-only.
+Three must stay `env = true` because this repo runs on them: `.mcp.json`
+interpolates `EXA_API_KEY` at MCP-server spawn, the context7 plugin interpolates
+`CONTEXT7_API_KEY` into an `Authorization` header (exec-only made it an empty
+string and the server served an **anonymous tier while reporting connected**),
+and `gh` reports its active account as the environment-authenticated one. Exec-only
+for those degrades tooling *silently*.
+
+⚠️ **AND IT DOES NOT STAY APPLIED.** Measured 2026-07-30: the config was rewritten
+~5h after the fix, losing the global `env` line **and all 4 opt-ins**, so all 49
+credentials were shell-visible again until `mise run doctor`'s `fnox-baseline`
+check caught it. **The documented `bootstrap-config` signature only half-matches**
+— all 49 `sync` blocks survived — and the trigger is **unattributed** (no
+LaunchAgent, no crontab, `mde-py` not even on `PATH`). So do not name that
+generator as the cause; an untested hypothesis is that **fnox itself** drops
+`env` fields when it re-serialises. Full timeline, both corrections and the
+probe that would settle it: `docs/rules-evidence/secrets-out-of-the-shell-env.md`.
 
 ⚠️ **The config is GENERATED** — *"Managed by `mde-py secrets bootstrap-config`.
-Do not edit by hand."* A hand edit survives only until the next bootstrap, so the
-durable fix belongs in `mde-py`'s generator. There is no user-root local override
-to hide it in; that layer is project-scoped only.
+Do not edit by hand."* A hand edit is therefore **not a fix, it is a patch with a
+half-life**; the durable fix belongs upstream. There is no user-root local
+override to hide it in; that layer is project-scoped only. What makes the hand
+edit safe to rely on meanwhile is the check that re-reads the artifact every
+session, not the edit itself.
 
 This also fixed the `[redacted]` digit-masking: two fnox telemetry flags held
 one-character all-digit values and were marked redacted, so mise masked every
@@ -121,8 +135,9 @@ Findings, control arms, and the verification that passed while blind:
    under `fnox exec` (present) vs the same in a plain shell (absent) identifies
    `env = "exec"` on its own; `fnox sync --dry-run -p age VAR` answers staleness
    without reading a value. Full ordered recipe, the result-reading table, and the
-   ⚠️ `bootstrap-config` **wipe hazard** (it drops `env = "exec"`, all 3 opt-ins,
-   and 49 `sync` blocks): `docs/secrets-doppler-fnox-keychain.md`.
+   ⚠️ **wipe hazard** — something drops `env = "exec"` and every opt-in (measured
+   twice; `sync` blocks survived the 2026-07-30 recurrence, so the culprit is NOT
+   established): `docs/secrets-doppler-fnox-keychain.md`.
 
 ## See also
 

--- a/.claude/rules/secrets-out-of-the-shell-env.md
+++ b/.claude/rules/secrets-out-of-the-shell-env.md
@@ -61,14 +61,19 @@ and `gh` reports its active account as the environment-authenticated one. Exec-o
 for those degrades tooling *silently*.
 
 ⚠️ **AND IT DOES NOT STAY APPLIED.** Measured 2026-07-30: the config was rewritten
-~5h after the fix, losing the global `env` line **and all 4 opt-ins**, so all 49
+~4h40m after the fix, losing the global `env` line **and all 4 opt-ins**, so all 49
 credentials were shell-visible again until `mise run doctor`'s `fnox-baseline`
-check caught it. **The documented `bootstrap-config` signature only half-matches**
-— all 49 `sync` blocks survived — and the trigger is **unattributed** (no
-LaunchAgent, no crontab, `mde-py` not even on `PATH`). So do not name that
-generator as the cause; an untested hypothesis is that **fnox itself** drops
-`env` fields when it re-serialises. Full timeline, both corrections and the
-probe that would settle it: `docs/rules-evidence/secrets-out-of-the-shell-env.md`.
+check caught it. **Diagnosed the same day.** `mde-py`'s `bootstrap_config()`
+rebuilds the file from scratch and never re-emits `env`, so it drops the mode and
+every opt-in **by construction**; the full `fnox sync` its callers run next
+(`add`/`update`/`remove_secret`) regenerates all 49 `sync` blocks. That composite
+matches the wipe exactly — the blocks *look* intact because every ciphertext in
+them was replaced. **fnox is EXONERATED**: an authorized write probe rewrote all
+49 values and preserved the mode and all 4 opt-ins, on both its scoped and bulk
+paths. The **invoker** is still unattributed (launchd, every Claude session and
+hook, and interactive history all excluded *with control arms*), so it is
+non-interactive and unlogged. Probe table, re-derived line refs, and the armed
+negatives: `docs/rules-evidence/secrets-out-of-the-shell-env.md`.
 
 ⚠️ **The config is GENERATED** — *"Managed by `mde-py secrets bootstrap-config`.
 Do not edit by hand."* A hand edit is therefore **not a fix, it is a patch with a
@@ -135,9 +140,9 @@ Findings, control arms, and the verification that passed while blind:
    under `fnox exec` (present) vs the same in a plain shell (absent) identifies
    `env = "exec"` on its own; `fnox sync --dry-run -p age VAR` answers staleness
    without reading a value. Full ordered recipe, the result-reading table, and the
-   ⚠️ **wipe hazard** — something drops `env = "exec"` and every opt-in (measured
-   twice; `sync` blocks survived the 2026-07-30 recurrence, so the culprit is NOT
-   established): `docs/secrets-doppler-fnox-keychain.md`.
+   ⚠️ **wipe hazard** — `mde-py`'s `bootstrap_config()` drops `env = "exec"` and
+   every opt-in (measured twice; diagnosed 2026-07-30, and **not** fnox):
+   `docs/secrets-doppler-fnox-keychain.md`.
 
 ## See also
 

--- a/docs/rules-evidence/secrets-out-of-the-shell-env.md
+++ b/docs/rules-evidence/secrets-out-of-the-shell-env.md
@@ -101,49 +101,125 @@ Those are telemetry flags, not secrets. The digit-masking was never a mise bug;
 it was collateral from treating a non-secret as a secret. It returns if `mde-py`
 re-bootstraps the config.
 
-## The wipe RECURRED, and its signature is not what we documented (2026-07-30)
+## The wipe RECURRED — and the diagnosis (2026-07-30)
 
 The `env = "exec"` mode is **not durable**. Measured, on the day the #418 doctor
 shipped:
 
-| time (local) | event |
+| time (**local CDT**) | event |
 |---|---|
-| 20:07 | `CONTEXT7_API_KEY` opted back in (4th opt-in). Verified: `fnox export` names **4 of 49** |
+| 20:07 (Jul 29) | `CONTEXT7_API_KEY` opted back in (4th opt-in). Verified: `fnox export` names **4 of 49** |
 | ~20:10 | `mise run doctor` → `fnox-baseline` PASS |
-| **00:47** | **`~/.config/fnox/config.toml` rewritten.** Global `env = "exec"` line GONE, all **4** per-secret `env = true` fields GONE |
-| 05:48 | `mise run doctor` → `fnox-baseline` **DRIFT**, on its first real firing |
+| **00:47 (Jul 30)** | **`~/.config/fnox/config.toml` rewritten.** Global `env = "exec"` GONE, all **4** per-secret `env = true` GONE |
+| 00:48 | `mise run doctor` → `fnox-baseline` **DRIFT**, on its first real firing |
+| 00:50 | Restored; `fnox export` back to 4 of 49, doctor 7/7 |
 
-For that ~5-hour window every one of the **49** credentials was shell-visible
+For that ~4h40m window every one of the **49** credentials was shell-visible
 again, inherited by every child process — the exact exposure this rule exists to
-prevent. Restored and control-armed: `fnox export` back to 4 of 49, doctor 7/7.
-The wiped file is preserved at
-`~/.config/fnox/config.toml.WIPED-evidence-20260730-055104`.
+prevent. The wiped file is preserved at
+`~/.config/fnox/config.toml.WIPED-evidence-20260730-055104` (that suffix is
+**UTC**; the file dates from 00:51:04 local).
 
-**Two corrections to what this repo asserted.**
+> ⏰ **Read the clock before reading the timeline.** The first write-up of this
+> incident mixed local and UTC stamps in one table, which put the wipe "last
+> night" when it had happened **30 minutes earlier**. `date -u`-derived filenames
+> and locally-observed mtimes do not belong in the same column unlabelled.
 
-1. **The documented `bootstrap-config` signature is only a PARTIAL match.** The
-   rule says that generator drops `env = "exec"`, the opt-ins **and the 49
-   `sync` blocks**. Here **all 49 sync blocks survived**, along with all 3
-   providers; the file *grew* by 170 bytes while losing 4 lines. Only the `env`
-   fields went. So either that generator changed, or something else did this —
-   and a signature that matches half-way is not an attribution.
-2. **The trigger is UNATTRIBUTED.** No LaunchAgent, no crontab entry, and
-   `mde-py` is not on `PATH` in the shell at all. Naming `bootstrap-config` as
-   the cause here would be exactly the [[probes-need-a-control-arm]] failure of
-   reading a plausible secondary story as a measurement.
+### What actually changed in the file
 
-**Untested hypothesis, recorded as such:** fnox re-serialising its own config
-after a sync/re-encrypt and dropping `env` fields it does not round-trip on
-write. The 170-byte growth with sync intact fits a re-encrypt rewrite. If true,
-the rule blames the wrong tool entirely. The only arm that can settle it is a
-**real** `fnox sync` write with a before/after hash — a `--dry-run` cannot, since
-the whole suspected defect lives in the write path (the #370 lesson, one tool
-over). Authorized by Ray 2026-07-30, backup first; not yet run.
+Diffing the three states with a TOML parser (keys and value **lengths** only,
+never values — `scratchpad/fnox_structdiff.py`):
+
+| | pre-wipe backup | WIPED | restored |
+|---|---|---|---|
+| global `env` | `"exec"` | **absent** | `"exec"` |
+| per-secret `env = true` | 3 (pre-CONTEXT7) | **0** | 4 |
+| secrets / providers | 49 / 3 | 49 / 3 | 49 / 3 |
+| `sync.value` ciphertexts | — | **all 49 REPLACED** (net +436 chars) | unchanged from WIPED |
+| outer `value`, `provider` | — | unchanged for all 49 | unchanged |
+
+**This overturns the first write-up's correction #1.** "All 49 sync blocks
+survived" is true only *structurally*: every ciphertext inside them was
+regenerated. The event was a **whole-config rebuild plus a full re-sync**, not a
+surgical removal of `env` fields. A signature read at the wrong granularity
+looked like a half-match when it was a full one.
+
+> 🔬 **`grep -c 'env = true'` is not a control arm for "how many opt-ins".** It
+> counted **5** where the parser counted **4** — the config's own header comment
+> contains the literal string. Parse the format; don't pattern-match it.
+
+### fnox is EXONERATED — hypothesis falsified with an armed probe
+
+The recorded hypothesis was that **fnox itself** drops `env` when it
+re-serialises. Ray authorized a real write against the live store (a `--dry-run`
+could not settle it — the suspected defect lived in the write path, the #370
+lesson one tool over). Backup first, byte-exact restore after, names never values:
+
+| probe | wrote? | `env` preserved? |
+|---|---|---|
+| `fnox activate zsh` | **no** | n/a |
+| `fnox hook-env -s zsh` (the precmd hook) | **no** — hash byte-identical | n/a; correctly exported an opt-in |
+| `fnox sync -g -p age <ONE> -f` | yes — 1/49 ciphertexts | **yes** — global + all 4 |
+| `fnox sync -g -p age -f` (all) | yes — **49/49**, reproducing the wipe's exact ciphertext signature | **yes** — global + all 4 |
+
+The bulk arm is what makes this a real negative: it rewrote every one of the 49
+values, so it *could* have dropped the `env` fields, and did not. **fnox
+round-trips `env` on both its scoped and its bulk write path.**
+
+`fnox activate` is control-armed for free by any agent session: the Bash tool
+sources `~/.zshrc` on every call (that is where the `fnox` shell function comes
+from), and the config mtime does not move across dozens of calls.
+
+### The author: the mde-py composite, not either half alone
+
+`macos-development-environment/src/mde/secrets/manage.py` (line refs
+**re-derived**, not inherited):
+
+- **`bootstrap_config()` — L247.** Rebuilds the file from scratch as a list of
+  literal lines. It emits `KEY = { provider, value }` (**L318**) and preserves
+  **only** `DOPPLER_TOKEN` (L292-296). It never reads or re-emits `env`, so the
+  global `env = "exec"` and every per-secret `env = true` are **dropped by
+  construction**. The "Do not edit by hand" header is written at L275.
+- It writes **no `sync` blocks at all** — so bootstrap alone *cannot* produce the
+  wiped file, which had all 49.
+- **`add_secret` (L166)** and **`remove_secret` (L208)** each call it and then
+  immediately run a **full** `_run_fnox_sync_age()` (**L169** / **L211**), which
+  regenerates all 49 sync blocks with fresh ciphertexts. `update_secret` (L177)
+  is an alias for `add_secret`.
+
+`bootstrap_config` + full sync reproduces the observed signature **exactly**, and
+neither half does on its own. ✅ The inherited `manage.py:318` reference is
+correct.
+
+### The invoker is still unattributed — but the negatives are now armed
+
+Every "not it" below was re-run with a control arm, because the first pass's
+negatives came from bounded probes:
+
+| ruled out | control arm |
+|---|---|
+| launchd | 8 user plists, none match mde/fnox/secret/doppler by **content**; 7 match `Label`, so the grep can see. The mde maintenance/validation agents are not installed. (First pass grepped *labels* with `head -5`.) |
+| any Claude session | **zero** tool calls 00:44-00:49 across **2272 transcripts / 70 projects**; the dotfiles session was idle 00:43:44 → 00:48:19 |
+| a Claude **hook** (invisible to transcripts) | no settings file invokes `mde-py`; `.claude/settings.json` matches `hooks` 6× |
+| an interactive shell command | `sharehistory` is set, so history is complete and immediate (`setopt` returned 19 lines); it holds only `source ~/.zshrc` @ 00:46:51 and `cd` @ 00:48:42 |
+| mde-py running at all | no `bootstrap_config_written` in any log; mde logs are stale since **April** |
+
+**Doppler's audit log is INCONCLUSIVE, not negative** — `doppler activity`
+returns empty because the token lacks workplace scope, while `doppler secrets
+--only-names` returns rows. That is a "never asked", not a "no"
+([[probes-need-a-control-arm]] rule 4).
+
+So the invocation was **non-interactive and unlogged**. `source ~/.zshrc` nine
+seconds earlier is a temporal correlate, but both mechanisms it fires
+(`fnox activate`, then `hook-env` at the next prompt) are measured innocent.
 
 **The durable lesson:** "APPLIED 2026-07-27 by Ray" was recorded as a settled
 state, and nothing re-read the artifact for three days. A config you do not own
 the generator for is not fixed by editing it once — it is fixed by a check that
-re-reads it, which is what `fnox-baseline` now is.
+re-reads it, which is what `fnox-baseline` now is. The second lesson is narrower:
+**an untested hypothesis, left in place, quietly becomes the working story.** The
+rule blamed fnox for a day on nothing but plausibility; one authorized write
+settled it in two commands.
 
 ## GitHub repos touched
 

--- a/docs/rules-evidence/secrets-out-of-the-shell-env.md
+++ b/docs/rules-evidence/secrets-out-of-the-shell-env.md
@@ -101,6 +101,50 @@ Those are telemetry flags, not secrets. The digit-masking was never a mise bug;
 it was collateral from treating a non-secret as a secret. It returns if `mde-py`
 re-bootstraps the config.
 
+## The wipe RECURRED, and its signature is not what we documented (2026-07-30)
+
+The `env = "exec"` mode is **not durable**. Measured, on the day the #418 doctor
+shipped:
+
+| time (local) | event |
+|---|---|
+| 20:07 | `CONTEXT7_API_KEY` opted back in (4th opt-in). Verified: `fnox export` names **4 of 49** |
+| ~20:10 | `mise run doctor` → `fnox-baseline` PASS |
+| **00:47** | **`~/.config/fnox/config.toml` rewritten.** Global `env = "exec"` line GONE, all **4** per-secret `env = true` fields GONE |
+| 05:48 | `mise run doctor` → `fnox-baseline` **DRIFT**, on its first real firing |
+
+For that ~5-hour window every one of the **49** credentials was shell-visible
+again, inherited by every child process — the exact exposure this rule exists to
+prevent. Restored and control-armed: `fnox export` back to 4 of 49, doctor 7/7.
+The wiped file is preserved at
+`~/.config/fnox/config.toml.WIPED-evidence-20260730-055104`.
+
+**Two corrections to what this repo asserted.**
+
+1. **The documented `bootstrap-config` signature is only a PARTIAL match.** The
+   rule says that generator drops `env = "exec"`, the opt-ins **and the 49
+   `sync` blocks**. Here **all 49 sync blocks survived**, along with all 3
+   providers; the file *grew* by 170 bytes while losing 4 lines. Only the `env`
+   fields went. So either that generator changed, or something else did this —
+   and a signature that matches half-way is not an attribution.
+2. **The trigger is UNATTRIBUTED.** No LaunchAgent, no crontab entry, and
+   `mde-py` is not on `PATH` in the shell at all. Naming `bootstrap-config` as
+   the cause here would be exactly the [[probes-need-a-control-arm]] failure of
+   reading a plausible secondary story as a measurement.
+
+**Untested hypothesis, recorded as such:** fnox re-serialising its own config
+after a sync/re-encrypt and dropping `env` fields it does not round-trip on
+write. The 170-byte growth with sync intact fits a re-encrypt rewrite. If true,
+the rule blames the wrong tool entirely. The only arm that can settle it is a
+**real** `fnox sync` write with a before/after hash — a `--dry-run` cannot, since
+the whole suspected defect lives in the write path (the #370 lesson, one tool
+over). Authorized by Ray 2026-07-30, backup first; not yet run.
+
+**The durable lesson:** "APPLIED 2026-07-27 by Ray" was recorded as a settled
+state, and nothing re-read the artifact for three days. A config you do not own
+the generator for is not fixed by editing it once — it is fixed by a check that
+re-reads it, which is what `fnox-baseline` now is.
+
 ## GitHub repos touched
 
 - [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the

--- a/docs/secrets-doppler-fnox-keychain.md
+++ b/docs/secrets-doppler-fnox-keychain.md
@@ -83,10 +83,19 @@ an **empty string**, not an error — see "Incidents".
    | `sync = { provider = "age", … }` | **49** | **0** |
 
    So a single `bootstrap-config` run silently reverts every secret to
-   shell-exported — undoing the whole reason `env = "exec"` was adopted — and
-   drops every offline age-encrypted copy. **Do not run it** until the generator
-   preserves those fields. Tracked for the sibling repo in
-   knowledge-base issue **#74**.
+   shell-exported — undoing the whole reason `env = "exec"` was adopted. **Do not
+   run it** until the generator preserves those fields. Tracked for the sibling
+   repo in knowledge-base issue **#74**.
+
+   ⚠️ **You will not notice by looking at the `sync` blocks — and you do not have
+   to run the generator by hand to get hit.** `add_secret` (`:166`) and
+   `remove_secret` (`:208`) call `bootstrap_config()` and then immediately run a
+   **full** `_run_fnox_sync_age()` (`:169`/`:211`), which regenerates all 49 sync
+   blocks with fresh ciphertexts. So the observable damage is *only* the missing
+   `env` fields, while every ciphertext silently changes. That composite is what
+   hit this host on **2026-07-30**, and diffing it proved **fnox innocent** — an
+   authorized `fnox sync` rewrote all 49 values and kept the mode and every
+   opt-in. Evidence: `docs/rules-evidence/secrets-out-of-the-shell-env.md`.
 3. **fnox is already shell-activated** on this machine (3 `FNOX_*` vars present,
    `DOPPLER_TOKEN` resolving from Keychain). No bootstrap needed.
 4. **An `age` provider is configured** (`recipients = ["age16djrq…"]`), so the


### PR DESCRIPTION
- **docs(secrets): the fnox env wipe RECURRED, and our documented signature half-matches**
- **docs(secrets): diagnose the fnox env wipe — fnox is innocent, the mde-py composite is the author**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787985615&installation_model_id=429246&pr_number=425&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F425&signature=5e3ebe304b51d6aa57cb2d01bb5f7ee69e2179ee15950177bc8d785687261023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded incident guidance on secret visibility and configuration safety.
  * Documented how configuration regeneration can remove shell-environment settings and regenerate encrypted secret data.
  * Added follow-up evidence, timelines, diagnostic findings, and verification details.
  * Clarified that generated configuration should be validated after bootstrap operations rather than edited manually.
  * Updated warnings and troubleshooting guidance based on the latest investigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->