### PR TITLE
docs(mcp): the schema tax is deferred — the rule's cost claim was 33x too high

### DIFF
--- a/.claude/rules/research-doc-sources.md
+++ b/.claude/rules/research-doc-sources.md
@@ -68,10 +68,19 @@ scope limit: `docs/rules-evidence/research-doc-sources.md`.
 
 ## MCP: two lanes. Which lane you are in decides the answer
 
-The cost is the same either way — a natively-registered server injects **every**
-one of its tool schemas into the system prompt of **every** conversation,
-forever, including the ones that never call it. What differs is whether you
-control the alternative.
+⚠️ **This rule used to justify itself with a cost that is no longer real.** It
+claimed a registered server "injects **every** one of its tool schemas into the
+system prompt of **every** conversation, forever". **Measured 2026-07-30 and
+false in this harness:** Claude Code presents MCP tools **deferred — names
+only** — and loads a schema on demand via `ToolSearch`. Across the 3 servers this
+repo registers: **25,925 B of schemas vs 778 B of names, a 33× difference**
+(~6.5k vs ~195 tokens at 4 B/token; both arms read from the same `tools/list`).
+So the standing tax is ~195 tokens for 25 tools, not ~6.5k. Do not cite the old
+sentence, and do not refuse a registration on its strength. Method, per-server
+table and the caveats: `docs/rules-evidence/research-doc-sources.md`.
+
+The residual cost is real but small, and it is the same either way. What actually
+differs between the lanes is whether you control the alternative.
 
 **Lane 1 — a third-party plugin or skill requires MCP: ALLOWED, no
 justification needed.** Enabling a plugin that bundles an MCP server, or a tool
@@ -90,10 +99,12 @@ order:
 4. native registration — **last resort**, and say in the commit body why 1–3
    could not do it.
 
-The asymmetry is deliberate. In lane 1 the schema tax buys a capability we
-cannot build; in lane 2 it buys something a `curl` already does, so it is pure
-loss — permanent context spend for a call we make twice a month. When a lookup
-is one-off, `mcp2cli` wins outright and there is nothing to weigh.
+The asymmetry is deliberate, but **the reason is simplicity, not context spend**
+(that argument was 33× overstated — see above). In lane 1 registration buys a
+capability we cannot build; in lane 2 it buys something a `curl` already does,
+while adding a spawned process, a version to pin, an auth path and a failure mode
+to the setup the doctor has to police. When a lookup is one-off, `mcp2cli` wins
+outright and there is nothing to weigh.
 
 **If you are unsure which lane you are in, you are in lane 2.** Lane 1 is
 specifically "an external plugin/skill I did not write requires it"; everything

--- a/docs/rules-evidence/research-doc-sources.md
+++ b/docs/rules-evidence/research-doc-sources.md
@@ -75,6 +75,70 @@ server you would query rarely, `mcp2cli`'s process-spawn is strictly cheaper. If
 a plugin's value depends on Claude selecting its tools natively and you will use
 it often, register it and accept the schema cost.
 
+## The MCP schema tax is deferred, and the rule's figure was 33× too high (2026-07-30)
+
+The rule justified its lane-2 preference with a cost claim: a registered server
+"injects **every** one of its tool schemas into the system prompt of **every**
+conversation, forever". Sessions kept contradicting it — MCP tools arrive as a
+**names-only** deferred list, and a `ToolSearch` is offered to load a schema. The
+claim was carried unmeasured for months, so it got measured.
+
+### Method
+
+`scratchpad/mcp_schema_cost.py` speaks JSON-RPC over stdio to each server this
+repo declares in `.mcp.json` (`initialize` → `notifications/initialized` →
+`tools/list`) and reports two numbers from **the same response**:
+
+- **loaded** — `json.dumps(tools)` compact: what the model carries if the schemas
+  are injected eagerly.
+- **names** — the comma-joined `mcp__<server>__<tool>` list: what the deferred
+  presentation actually costs.
+
+Reading both arms off one `tools/list` is the point — a ratio between two
+differently-sourced numbers would not be comparable.
+
+### Result
+
+| server | tools | loaded B | names B | ratio |
+|---|---:|---:|---:|---:|
+| memory | 9 | 10,750 | 262 | 41.0× |
+| filesystem | 14 | 12,973 | 467 | 27.8× |
+| exa | 2 | 2,202 | 49 | 44.9× |
+| **TOTAL** | **25** | **25,925** | **778** | **33.3×** |
+
+At the conventional 4 B/token that is **~6,481 tokens if eager vs ~195 deferred**
+— about **6,286 tokens per conversation** that the rule assumed were being spent
+and are not.
+
+### What this does and does not license
+
+The prescription barely moves; only its *reason* does. Preferring a `curl` over a
+registration is still right for lane 2 — a server adds a spawned process, a pin,
+an auth path and a failure mode — but "permanent context spend" was doing
+argumentative work it had not earned, and it was being used to refuse
+registrations.
+
+### Caveats, stated so the number is not over-read
+
+1. **4 B/token is a convention, not a tokenizer run.** The ratio is exact; the
+   token figures are estimates. JSON schema text is punctuation-dense and likely
+   tokenizes *worse* than 4 B/token, which would make the eager side larger, not
+   smaller.
+2. **Scope is the 3 servers `.mcp.json` declares.** Plugin-bundled servers and the
+   `MCP_DOCKER` gateway are excluded; the gateway is large enough that the #418
+   doctor had to add `Server.repo_owned` to stop it emitting 32 findings, so a
+   whole-host total would be much bigger on both sides of the ratio.
+3. **Deferral is harness behaviour observed on one day**, not a documented
+   guarantee. It may be conditional (tool count, model, settings) and may change.
+   Re-run the script before relying on it.
+4. ⚠️ **The mechanism description that ships with the deferred list did not
+   reproduce.** It states that calling a deferred tool directly "will fail with
+   `InputValidationError`". Two direct calls **succeeded** without any
+   `ToolSearch` — `mcp__memory__read_graph` (no args, so a weak arm) and then
+   `mcp__memory__search_nodes` with its required `query` (the real arm). So
+   whatever the loading mechanism is, "it will fail" is not a reliable
+   description of it, and this evidence does not claim to explain it.
+
 ## GitHub repos touched
 
 - [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the rule,

--- a/docs/secrets-doppler-fnox-keychain.md
+++ b/docs/secrets-doppler-fnox-keychain.md
@@ -84,8 +84,11 @@ an **empty string**, not an error — see "Incidents".
 
    So a single `bootstrap-config` run silently reverts every secret to
    shell-exported — undoing the whole reason `env = "exec"` was adopted. **Do not
-   run it** until the generator preserves those fields. Tracked for the sibling
-   repo in knowledge-base issue **#74**.
+   run it** until the generator preserves those fields. Filed upstream as
+   **[macos-development-environment#82](https://github.com/ray-manaloto/macos-development-environment/issues/82)**
+   (2026-07-30), with the suggested fix: preserve the top-level `env` key and any
+   per-secret `env` on keys that still exist. Tracked for the sibling repo in
+   knowledge-base issue **#74**.
 
    ⚠️ **You will not notice by looking at the `sync` blocks — and you do not have
    to run the generator by hand to get hit.** `add_secret` (`:166`) and


### PR DESCRIPTION
`research-doc-sources.md` justified its lane-2 preference with "a registered
server injects every one of its tool schemas into the system prompt of every
conversation, forever". Sessions have been contradicting that for weeks — MCP
tools arrive as a names-only deferred list — but nobody measured it, so the
sentence kept being cited as fact.

Measured by speaking JSON-RPC tools/list to the 3 servers .mcp.json declares and
reading both arms off the SAME response:

  server       tools   loaded B   names B   ratio
  memory           9     10,750       262   41.0x
  filesystem      14     12,973       467   27.8x
  exa              2      2,202        49   44.9x
  TOTAL           25     25,925       778   33.3x

~6,481 tokens if eager vs ~195 deferred — about 6,286 tokens per conversation the
rule assumed were being spent and are not.

The prescription barely moves; its reason does. Lane 2 still prefers a curl, but
for setup simplicity — a spawned process, a pin, an auth path, a failure mode the
doctor must police — not for context spend, which was doing argumentative work it
had not earned and was being used to refuse registrations.

Caveats recorded rather than buried: 4 B/token is a convention, not a tokenizer
run; the scope excludes plugin servers and the MCP_DOCKER gateway; and deferral is
one day's harness behaviour, not a documented guarantee. Also noted — the
deferred list's own claim that a direct call "will fail with InputValidationError"
did NOT reproduce: two calls succeeded without any ToolSearch, including one with
a required argument.

Also references macos-development-environment#82, filed today for the
bootstrap_config() generator bug diagnosed in #425.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G2t5CzSpQ9mMG9AgmbMXvn

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787986549&installation_model_id=429246&pr_number=426&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F426&signature=f0437c49c0aa21d57cf2ff0ec5794d6b1a09e6768a9b319c7461aa23db1e127f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->