### PR TITLE
docs(secrets): attribute the wipe trigger — it is the documented happy path

### DIFF
--- a/.claude/rules/probes-need-a-control-arm.md
+++ b/.claude/rules/probes-need-a-control-arm.md
@@ -71,9 +71,17 @@ Full case tables — five false negatives, five cross-check disagreements:
    Bounds come in more forms than they look: **display bounds** (`| head`,
    `| tail`, a bare `ls` of a large dir), **checking N exact paths** instead of
    asking "does it exist anywhere", **relative time bounds** that a given `find`
-   cannot parse, and — most common of all — **a TOKEN SPELLING**. A session once
-   grepped `lmstudio`/`lm_studio`, got 0, and reported the feature unsupported;
-   it is spelled `LM Studio`, with a space.
+   cannot parse, **YOUR OWN PARSER** (a single-line regex over a multi-line
+   record silently drops the tail — a `^: ts;(.*)$` read of `~/.zsh_history`
+   hid the very command a 4-hour investigation was hunting, and the absence was
+   published as a finding), and — most common of all — **a TOKEN SPELLING**. A
+   session once grepped `lmstudio`/`lm_studio`, got 0, and reported the feature
+   unsupported; it is spelled `LM Studio`, with a space.
+
+   **Arm the component you actually depend on.** That same probe *did* run a
+   control arm — it proved `sharehistory` was set, i.e. that the FILE was
+   complete. True, and irrelevant: the broken part was the READER. A control arm
+   aimed at the wrong link certifies the one thing that was never in doubt.
 
    The habit that would have caught every one: **a 0-result grep is not an
    answer until a control arm has run.** Before reporting absence, grep a term

--- a/.claude/rules/secrets-out-of-the-shell-env.md
+++ b/.claude/rules/secrets-out-of-the-shell-env.md
@@ -70,10 +70,14 @@ every opt-in **by construction**; the full `fnox sync` its callers run next
 matches the wipe exactly — the blocks *look* intact because every ciphertext in
 them was replaced. **fnox is EXONERATED**: an authorized write probe rewrote all
 49 values and preserved the mode and all 4 opt-ins, on both its scoped and bulk
-paths. The **invoker** is still unattributed (launchd, every Claude session and
-hook, and interactive history all excluded *with control arms*), so it is
-non-interactive and unlogged. Probe table, re-derived line refs, and the armed
-negatives: `docs/rules-evidence/secrets-out-of-the-shell-env.md`.
+paths, and fnox's `env` is a real struct field its writers round-trip.
+
+⚠️ **The trigger is the DOCUMENTED HAPPY PATH.** It was `mde-secret-add
+LINEAR_API_KEY`, run by hand after an agent recommended it from the mde repo's own
+docs. So **every secret you add or update re-exposes all 49 credentials** until
+something re-reads the config — which is the whole job of `fnox-baseline`. Filed
+as `macos-development-environment#82`. Probe table, the timeline and the
+re-derived line refs: `docs/rules-evidence/secrets-out-of-the-shell-env.md`.
 
 ⚠️ **The config is GENERATED** — *"Managed by `mde-py secrets bootstrap-config`.
 Do not edit by hand."* A hand edit is therefore **not a fix, it is a patch with a

--- a/docs/rules-evidence/secrets-out-of-the-shell-env.md
+++ b/docs/rules-evidence/secrets-out-of-the-shell-env.md
@@ -191,35 +191,74 @@ from), and the config mtime does not move across dozens of calls.
 neither half does on its own. ✅ The inherited `manage.py:318` reference is
 correct.
 
-### The invoker is still unattributed — but the negatives are now armed
+### The invoker: `mde-secret-add`, run by hand — the DOCUMENTED happy path
 
-Every "not it" below was re-run with a control arm, because the first pass's
-negatives came from bounded probes:
+A first pass reported the invoker "non-interactive and unlogged". **That was
+false, and the fault was the probe, not the world.** The command was in
+`~/.zsh_history` the entire time:
+
+| time (CDT) | event | source |
+|---|---|---|
+| 00:45:36 | Ray asks an agent "i have a linear key how do i set it?" | codex session rollout |
+| 00:46:11 | the agent, reading the mde repo's own docs, answers **"run `mde-secret-add LINEAR_API_KEY`"** | codex session rollout |
+| **00:46:51** | Ray runs `source ~/.zshrc` **then `mde-secret-add LINEAR_API_KEY`** — *one multi-line history entry* | `~/.zsh_history` |
+| **00:47:00** | config rewritten; mode + 4 opt-ins gone, 49 ciphertexts fresh | the artifact |
+| 00:47:19 | Ray confirms "it is set" | codex session rollout |
+
+`add_secret` is an **upsert** and `LINEAR_API_KEY` already existed — which is why
+the key count stayed at 49, and why "an update of an existing key" was deducible
+from the artifact before the command was found.
+
+> 🔬 **A multi-line history entry defeated a single-line parser, and the absence
+> was reported as a finding.** zsh writes an entry as `: <epoch>:<elapsed>;` plus a
+> body that may span lines (continuations end with `\`). The parser was
+> `^: (\d+):(\d+);(.*)$`, so it captured `source ~/.zshrc` and **silently dropped
+> the `mde-secret-add` on the next line**. Split on the *marker* and take
+> everything up to the next one.
+>
+> The control arm that ran was on the wrong property: it confirmed `sharehistory`
+> was set — that the **file** was complete — which was true and irrelevant, because
+> the broken component was the **reader**. Arm the step you actually depend on. The
+> cheap catch here: grep the corpus for a token you know is present
+> (`mde-secret` → 2 hits, ever) instead of trusting a structured parse.
+
+Ruled out along the way, each with a control arm (the first pass's negatives came
+from bounded probes, so they were re-run):
 
 | ruled out | control arm |
 |---|---|
 | launchd | 8 user plists, none match mde/fnox/secret/doppler by **content**; 7 match `Label`, so the grep can see. The mde maintenance/validation agents are not installed. (First pass grepped *labels* with `head -5`.) |
 | any Claude session | **zero** tool calls 00:44-00:49 across **2272 transcripts / 70 projects**; the dotfiles session was idle 00:43:44 → 00:48:19 |
 | a Claude **hook** (invisible to transcripts) | no settings file invokes `mde-py`; `.claude/settings.json` matches `hooks` 6× |
-| an interactive shell command | `sharehistory` is set, so history is complete and immediate (`setopt` returned 19 lines); it holds only `source ~/.zshrc` @ 00:46:51 and `cd` @ 00:48:42 |
-| mde-py running at all | no `bootstrap_config_written` in any log; mde logs are stale since **April** |
+| a mise `enter` hook | **no `[hooks]` in any mde mise config** — the leading hypothesis, killed by reading the config rather than probing |
+| mde-py's own logging | no `bootstrap_config_written` anywhere; mde logs stale since **April**, so this route could never have answered |
 
 **Doppler's audit log is INCONCLUSIVE, not negative** — `doppler activity`
 returns empty because the token lacks workplace scope, while `doppler secrets
---only-names` returns rows. That is a "never asked", not a "no"
+--only-names` returns rows. A "never asked", not a "no"
 ([[probes-need-a-control-arm]] rule 4).
 
-So the invocation was **non-interactive and unlogged**. `source ~/.zshrc` nine
-seconds earlier is a temporal correlate, but both mechanisms it fires
-(`fnox activate`, then `hook-env` at the next prompt) are measured innocent.
+### Why this is severe rather than a one-off
 
-**The durable lesson:** "APPLIED 2026-07-27 by Ray" was recorded as a settled
-state, and nothing re-read the artifact for three days. A config you do not own
-the generator for is not fixed by editing it once — it is fixed by a check that
-re-reads it, which is what `fnox-baseline` now is. The second lesson is narrower:
-**an untested hypothesis, left in place, quietly becomes the working story.** The
-rule blamed fnox for a day on nothing but plausibility; one authorized write
-settled it in two commands.
+`mde-secret-add` / `-update` / `-rm` are **the sanctioned interface** — an agent
+reading the repo's docs recommends them unprompted, which is exactly what
+happened. So **every secret added or updated re-exposes all 49 credentials** to
+the shell until something re-reads the config. Filed with the confirmed trigger as
+[macos-development-environment#82](https://github.com/ray-manaloto/macos-development-environment/issues/82).
+
+**The durable lessons:**
+
+1. "APPLIED 2026-07-27 by Ray" was recorded as settled and nothing re-read the
+   artifact for three days. A config whose generator you do not own is not fixed
+   by editing it once — it is fixed by a check that re-reads it, which is what
+   `fnox-baseline` is.
+2. **An untested hypothesis, left in place, quietly becomes the working story.**
+   The rule blamed fnox for a day on plausibility alone; one authorized write
+   settled it in two commands.
+3. **"I could not find it" is not "it is not there."** Publishing an absence as an
+   attribution ("non-interactive and unlogged") dressed a failed search as a
+   conclusion. An unattributed cause is an open question, and it should be
+   labelled as one until a *source* — not a silence — closes it.
 
 ## GitHub repos touched
 


### PR DESCRIPTION
The wipe diagnosis (#425) named the author but reported the invoker as
"non-interactive and unlogged". That was wrong, and the fault was the probe.

It was `mde-secret-add LINEAR_API_KEY`, run by hand:

  00:45:36  Ray asks an agent "i have a linear key how do i set it?"
  00:46:11  the agent, reading the mde repo's own docs, answers
            "run `mde-secret-add LINEAR_API_KEY`"
  00:46:51  Ray runs `source ~/.zshrc` THEN `mde-secret-add LINEAR_API_KEY`
            -- one multi-line zsh history entry
  00:47:00  config rewritten: mode + 4 opt-ins gone, 49 ciphertexts fresh
  00:47:19  Ray confirms "it is set"

`add_secret` upserts and LINEAR_API_KEY already existed, which is why the key
count stayed at 49 -- and why "an update of an existing key" was deducible from
the artifact before the command was found.

The probe failure is the durable part. zsh writes a history entry as
`: <epoch>:<elapsed>;` plus a body that may span lines; the parser was
`^: (\d+):(\d+);(.*)$`, so it captured `source ~/.zshrc` and silently dropped the
`mde-secret-add` on the next line. Worse, a control arm DID run -- it proved
`sharehistory` was set, i.e. that the FILE was complete. True, irrelevant, and
aimed at the wrong link: the broken component was the reader. Recorded in
probes-need-a-control-arm as a new bound form ("your own parser") plus the
habit of arming the component you actually depend on.

Corroboration that did hold, from fnox's source rather than inference:
`Config::save()` (config.rs:993-1011) re-serialises the struct via
toml_edit::ser::to_string_pretty and so drops comments -- it cannot have written
the wiped file, which kept its `# Managed by mde-py` header -- while `fnox sync`
edits the existing document in place (save_secrets_to_source, config.rs:1223),
preserving comments while rewriting every ciphertext. `env` is a real struct
field (config.rs:169, :243) written back at :1982/:2044. Also killed the leading
mise-`enter`-hook hypothesis by reading the configs: no [hooks] in any of them.

Severity is higher than a one-off: `mde-secret-add`/`-update`/`-rm` is the
sanctioned interface, recommended unprompted by an agent reading the docs, so
every secret added or updated re-exposes all 49 credentials until something
re-reads the config. macos-development-environment#82 updated with the trigger.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G2t5CzSpQ9mMG9AgmbMXvn

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788015883&installation_model_id=429246&pr_number=428&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F428&signature=812f5405d9f25f987a41ef34a84fbe2c2ef77d12a5ef720496a6790cfef29801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance on validating searches, including risks of parser omissions and misleading absence findings.
  * Updated the secrets incident documentation with a clarified trigger, supporting timeline, and corrected history analysis.
  * Added details on alternative explanations, audit limitations, and the conditions that can re-expose credentials.
  * Clarified lessons around verification, evidence quality, and treating unconfirmed findings as unresolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->