### PR TITLE
chore(claude): remove dead enabledPlugins entries; document how they actually resolve

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,9 +4,6 @@
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
   "permissions": {
-    "additionalDirectories": [
-      "/Users/rmanaloto/dev/github/ray-manaloto/knowledge-base"
-    ],
     "allow": [
       "mcp__context7__resolve-library-id",
       "mcp__memory__create_entities",
@@ -23,6 +20,9 @@
       "mcp__filesystem__edit_file",
       "mcp__filesystem__create_directory",
       "mcp__filesystem__move_file"
+    ],
+    "additionalDirectories": [
+      "/Users/rmanaloto/dev/github/ray-manaloto/knowledge-base"
     ]
   },
   "hooks": {
@@ -83,12 +83,8 @@
     ]
   },
   "enabledPlugins": {
-    "ultrapowers@ultrapowers": false,
-    "ultrapowers-dev@ultrapowers": false,
     "code-review@claude-plugins-official": false,
     "code-simplifier@claude-plugins-official": false,
-    "feature-dev@claude-plugins-official": false,
-    "typescript-lsp@claude-plugins-official": false,
     "claude-md-management@claude-plugins-official": true,
     "commit-commands@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
@@ -96,34 +92,16 @@
     "pyright-lsp@claude-plugins-official": false,
     "pyright@claude-code-lsps": false,
     "explanatory-output-style@claude-plugins-official": true,
-    "plugin-dev@claude-plugins-official": false,
     "hookify@claude-plugins-official": true,
     "learning-output-style@claude-plugins-official": true,
-    "gopls-lsp@claude-plugins-official": false,
-    "csharp-lsp@claude-plugins-official": false,
-    "rust-analyzer-lsp@claude-plugins-official": false,
-    "php-lsp@claude-plugins-official": false,
-    "jdtls-lsp@claude-plugins-official": false,
-    "clangd-lsp@claude-plugins-official": false,
-    "swift-lsp@claude-plugins-official": false,
-    "kotlin-lsp@claude-plugins-official": false,
-    "lua-lsp@claude-plugins-official": false,
-    "ruby-lsp@claude-plugins-official": false,
     "octo@nyldn-plugins": false,
-    "claude-mem@thedotmack": false,
-    "chrome-devtools-mcp@chrome-devtools-plugins": false,
-    "discord@claude-plugins-official": false,
-    "pskoett-ai-skills@claude-community": false,
-    "auto-memory@claude-community": false,
-    "guide@claude-code-guide": false,
-    "codex@openai-codex": false,
+    "codex@openai-codex": true,
     "astral@astral-sh": true,
-    "cli-anything@cli-anything": false,
     "mattpocock-skills@mattpocock": true,
-    "ty@claude-code-lsps": false,
     "fable-orchestrator@fable-orchestrator": true,
     "antigravity@antigravity-for-claude-code": true,
-    "context7@context7-marketplace": true
+    "context7@context7-marketplace": true,
+    "last30days@last30days-skill": true
   },
   "extraKnownMarketplaces": {
     "fable-orchestrator": {
@@ -136,6 +114,18 @@
       "source": {
         "source": "github",
         "repo": "yuting0624/antigravity-for-claude-code"
+      }
+    },
+    "last30days-skill": {
+      "source": {
+        "source": "github",
+        "repo": "mvanhorn/last30days-skill"
+      }
+    },
+    "openai-codex": {
+      "source": {
+        "source": "github",
+        "repo": "openai/codex-plugin-cc"
       }
     }
   },

--- a/docs/claude-plugin-config-hygiene.md
+++ b/docs/claude-plugin-config-hygiene.md
@@ -1,0 +1,135 @@
+# Claude Code plugin config: how `enabledPlugins` actually resolves
+
+Investigation and fix for a `/plugin` panel reporting **30 load errors**, 2026-07-30.
+The headline finding is not the errors — it is the resolution model underneath them,
+which is easy to get wrong and which bit this repo twice in one session.
+
+## TL;DR
+
+| | |
+|---|---|
+| **Symptom** | `/reload-plugins --force` → *"30 errors during load"*, each *"Plugin X is enabled in project settings but isn't installed here"* |
+| **Root cause** | An `enabledPlugins` entry has an effect **by being present**, not by being `true`. Entries also **aggregate across every project's settings on the machine**, not just the open one. |
+| **Fix** | **Delete** stale entries; do not set them `false`. 187 removed across three files. |
+| **Result** | 30 errors → **1**, and that one is correct configuration. Zero behavioural change: every file's set of *enabled* plugins was byte-identical afterwards. |
+
+## The two facts that make this counter-intuitive
+
+### 1. Presence has an effect; the boolean does not gate the check
+
+`zoominfo`, `srclight` and `remember` were all reported as *"is enabled in project
+settings"* while being **`false`** in that settings file. So the loader's validation
+walks the **keys** of `enabledPlugins` and complains about any whose plugin is not
+installed for the current project — regardless of value.
+
+This makes the error text actively misleading, and it is why the first repair
+attempt failed: it removed entries whose plugin was not installed *for the project
+that declared them*, when the criterion is *not installed **for the project you have
+open***.
+
+> **Consequence for hygiene:** a `false` entry is not free. It is not "disabled and
+> harmless" — it is a live key that participates in validation. Remove entries you
+> do not want; only keep a `false` when it is doing real work (below).
+
+### 2. Enablement aggregates across unrelated projects
+
+`superpowers` was among the errors. It is declared in
+`guilde-lite-tdd-sprint/.claude/settings.json` — **a repo never opened in the
+session**. Others traced to `macos-development-environment`, which was only present
+as an *additional working directory*.
+
+So the panel's "project settings" means *the union of settings files it can see*,
+which on a machine with many checkouts is a large set. Config in one repo shows up
+as an error in another.
+
+## When a `false` IS load-bearing — the rule that prevents breakage
+
+Precedence, per the panel's own remediation text
+(*"project settings override `~/.claude/settings.json`"*, *"set … in
+`.claude/settings.local.json` instead"*):
+
+```
+settings.local.json   >   .claude/settings.json   >   ~/.claude/settings.json
+      (local)                   (project)                    (user)
+```
+
+A `false` is meaningful **only when some other in-scope file marks the same plugin
+`true`**. Deleting such an entry silently *enables* the plugin.
+
+**This is not hypothetical.** A first pass compared each `false` against **user
+scope only** and concluded nothing was load-bearing. A second pass, comparing
+against *all* loaded scopes, found **10** that were — including **both** entries in
+this repo's `settings.local.json`:
+
+| entry | local | project | deleting it would have… |
+|---|---|---|---|
+| `explanatory-output-style@claude-plugins-official` | `false` | `true` | switched the output style **on** |
+| `learning-output-style@claude-plugins-official` | `false` | `true` | switched the output style **on** |
+
+The lesson generalises: **check the key against every scope that loads, not just the
+one above it.**
+
+## The procedure that worked
+
+1. **Back up everything first** — all settings files *and* `installed_plugins.json`.
+2. **Classify, don't bulk-delete.** For each file, a `false` entry is removable only
+   if no other in-scope file marks that key `true`.
+3. **Delete by line, not by JSON round-trip.** Rewriting via `json.dump` reorders and
+   reformats the whole file, burying a 20-line change in a 200-line diff. Matching
+   `^\s*"key"\s*:\s*(true|false),?$` and dropping those lines leaves every other line
+   byte-identical, then repair any dangling comma with `,(\s*[}\]])` → `\1`.
+4. **Gate on parse.** `json.loads(text)` before writing — never write an unparsed
+   result.
+5. **Verify the enabled SET, not the entry count.** The invariant that matters is
+   that the set of `true` keys is unchanged:
+
+   ```
+   user      entries 28  -> 6    TRUE 1  -> 1    identical_true=True
+   mde       entries 164 -> 22   TRUE 22 -> 22   identical_true=True
+   dotfiles  entries 42  -> 19   TRUE 14 -> 14   identical_true=True
+   ```
+
+6. **Predict the outcome before asking for a reload.** State the expected error count
+   and treat a miss as information. The first attempt predicted a drop and produced
+   none — which is what exposed fact #1 above.
+
+## What was left alone, and why
+
+- **`challenger@claude-community`** — the single residual error. Installed and
+  `true` for `macos-development-environment` only, and real in its marketplace. Not
+  a defect; removed from mde because that repo is being retired into this one, not
+  because the config was wrong.
+- **`codex@openai-codex`** — a ⚠ warning, not an error: this repo's tracked settings
+  enable it, which overrides a `false` at user scope. Intended. To make the user-level
+  disable win, put `"codex@openai-codex": false` in `.claude/settings.local.json`.
+- **The plugin caches.** `~/.claude/plugins/cache` is **5.7 GB** and live — 234
+  install records point into it; clearing it uninstalls every plugin. `cache.bak` is
+  **1.1 GB**, last written 2026-04-08, and provably orphaned (**0** references,
+  against a control of 234 into the live cache) — safe to delete, deliberately left
+  in place for now. `claude plugins prune --dry-run` reports **nothing to prune** at
+  either scope; it only handles auto-installed dependencies.
+
+## Cost worth knowing about
+
+Adding a second repo as a working directory **inherits its entire plugin surface**.
+After adding `macos-development-environment`, the reload reported **19 plugins · 34
+skills · 42 agents · 12 hooks** — skills and agents from that repo's plugin set now
+load into every turn, charged against the eager-context budget this repo works to
+keep near ~112 KB ([[md-size-budgets]], #414). Add the directory to read source;
+drop it when done.
+
+## Where this connects
+
+The shape is the same one this repo hit with the fnox `env` wipe the same day:
+**declarative config in one location silently changing behaviour in another, with a
+status readout that reports the wrong thing.** Both were found by distrusting a
+message and measuring the artifact instead. See
+`docs/rules-evidence/secrets-out-of-the-shell-env.md` and
+`.claude/rules/probes-need-a-control-arm.md`.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — `.claude/settings.json`, `.claude/settings.local.json`.
+- [ray-manaloto/macos-development-environment](https://github.com/ray-manaloto/macos-development-environment) — `.claude/settings.json`; the source of most stale entries, being retired into this repo.
+- [mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill) — installed project-scoped during this work.
+- [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc) — installed project-scoped; source of the residual warning.

--- a/docs/research/kb/reports/agents/adversarial-secrets-takeover-20260730.md
+++ b/docs/research/kb/reports/agents/adversarial-secrets-takeover-20260730.md
@@ -1,0 +1,119 @@
+# Adversarial review — chezmoi takeover + multi-agent secrets CLI
+
+Reviewer: `codex exec` (gpt-5.6-sol, reasoning=high, read-only sandbox), 2026-07-30.
+Prompt: `scratchpad/adversarial-prompt.md` (cold — no disk access; facts supplied inline).
+
+## Ranked objections
+
+### 1. Critical: “ANY agent” and PreToolUse enforcement are incompatible
+
+A PreToolUse guard is policy for one harness, not machine-wide enforcement. It does nothing against:
+
+- Other agent products or harnesses.
+- Shell scripts, editors, IDE tasks, launchd jobs, or humans.
+- Direct library calls.
+- Renamed or wrapped executables.
+- Absolute paths if the guard only recognizes “bare” commands.
+- A writer that edits `config.toml` directly.
+- Doppler CLI invocations outside the sanctioned CLI.
+
+Calling the CLI the “ONLY sanctioned writer” is merely documentation unless unauthorized writers are technically unable to write.
+
+If agents run as the same macOS user, ordinary file permissions also cannot distinguish the sanctioned CLI from an agent invoking `fnox`, Python, or a text editor. Real enforcement requires an OS-level privilege boundary: for example, a separately privileged broker owns the writable files and Doppler credentials, while agents receive only a constrained API. Even then, the broker needs authorization, audit, and concurrency semantics.
+
+The broker architecture is plainly better than a CLI plus harness hook for the stated requirement.
+
+### 2. Critical: the flock does not provide the promised concurrency guarantee
+
+The lock coordinates only callers that voluntarily acquire that exact lock. It is bypassed by:
+
+- `fnox set`.
+- `mde-secret-*`.
+- Any direct file edit or regeneration.
+- mise or chezmoi applying the file.
+- Another agent implementation.
+- Another machine writing Doppler.
+- Any workflow that locks a different path, symlink, or inode.
+
+There is also a classic locking bug if the config file itself is locked and then atomically replaced: the lock remains attached to the old inode. A waiter can lock the old file while another caller begins operating on the replacement. A stable, separately created lock file is required.
+
+Even a correct stable lock only serializes local file operations. It does not prevent:
+
+- Stale-read semantic conflicts.
+- Concurrent Doppler changes.
+- A local operation racing with remote synchronization.
+- One agent deleting a secret another agent just read and intends to update.
+- Duplicate retries after an uncertain network result.
+- Indefinite blocking or denial of service by a process holding the lock.
+
+The requirement needs versioning or compare-and-swap semantics, operation IDs, and conflict reporting—not merely mutual exclusion around one file.
+
+### 3. Critical: there is no transaction or defined source of truth
+
+The proposed Doppler-plus-fnox workflow is a distributed update without a transaction.
+
+If Doppler succeeds and the local step fails:
+
+- The remote secret exists or changed, but local configuration does not reflect it.
+- A retry cannot safely distinguish “previous call succeeded” from “new update.”
+- An attempted rollback may overwrite a concurrent legitimate change.
+## Ranked objections
+
+### 1. Critical: “ANY agent” and PreToolUse enforcement are incompatible
+
+A PreToolUse guard is policy for one harness, not machine-wide enforcement. It does nothing against:
+
+- Other agent products or harnesses.
+- Shell scripts, editors, IDE tasks, launchd jobs, or humans.
+- Direct library calls.
+- Renamed or wrapped executables.
+- Absolute paths if the guard only recognizes “bare” commands.
+- A writer that edits `config.toml` directly.
+- Doppler CLI invocations outside the sanctioned CLI.
+
+Calling the CLI the “ONLY sanctioned writer” is merely documentation unless unauthorized writers are technically unable to write.
+
+If agents run as the same macOS user, ordinary file permissions also cannot distinguish the sanctioned CLI from an agent invoking `fnox`, Python, or a text editor. Real enforcement requires an OS-level privilege boundary: for example, a separately privileged broker owns the writable files and Doppler credentials, while agents receive only a constrained API. Even then, the broker needs authorization, audit, and concurrency semantics.
+
+The broker architecture is plainly better than a CLI plus harness hook for the stated requirement.
+
+### 2. Critical: the flock does not provide the promised concurrency guarantee
+
+The lock coordinates only callers that voluntarily acquire that exact lock. It is bypassed by:
+
+- `fnox set`.
+- `mde-secret-*`.
+- Any direct file edit or regeneration.
+- mise or chezmoi applying the file.
+- Another agent implementation.
+- Another machine writing Doppler.
+- Any workflow that locks a different path, symlink, or inode.
+
+There is also a classic locking bug if the config file itself is locked and then atomically replaced: the lock remains attached to the old inode. A waiter can lock the old file while another caller begins operating on the replacement. A stable, separately created lock file is required.
+
+Even a correct stable lock only serializes local file operations. It does not prevent:
+
+- Stale-read semantic conflicts.
+- Concurrent Doppler changes.
+- A local operation racing with remote synchronization.
+- One agent deleting a secret another agent just read and intends to update.
+- Duplicate retries after an uncertain network result.
+- Indefinite blocking or denial of service by a process holding the lock.
+
+The requirement needs versioning or compare-and-swap semantics, operation IDs, and conflict reporting—not merely mutual exclusion around one file.
+
+### 3. Critical: there is no transaction or defined source of truth
+
+The proposed Doppler-plus-fnox workflow is a distributed update without a transaction.
+
+If Doppler succeeds and the local step fails:
+
+- The remote secret exists or changed, but local configuration does not reflect it.
+- A retry cannot safely distinguish “previous call succeeded” from “new update.”
+- An attempted rollback may overwrite a concurrent legitimate change.
+
+## GitHub repos touched
+
+- [jdx/fnox](https://github.com/jdx/fnox) — provider capabilities, absence of locking, MCP tool set.
+- [jdx/mise](https://github.com/jdx/mise) — `mise bootstrap dotfiles` modes and edit entries.
+- [ray-manaloto/macos-development-environment](https://github.com/ray-manaloto/macos-development-environment) — `bootstrap_config()`, the subject of the repair.


### PR DESCRIPTION
`/reload-plugins --force` reported 30 load errors, each "Plugin X is enabled in
project settings but isn't installed here". Two facts made that hard to read, and
both are now written down:

1. An `enabledPlugins` entry has an effect by BEING PRESENT, not by being `true`.
   zoominfo, srclight and remember were all reported as "enabled" while set to
   `false`. The loader validates the KEYS, so a `false` entry is not free — it is
   a live key that participates in validation. Disabling is therefore not a way to
   retire an entry; deleting is.

2. Enablement aggregates across every settings file on the machine, not the open
   project. `superpowers` traced to guilde-lite-tdd-sprint, a repo never opened in
   the session.

Fix: delete rather than disable. 187 entries removed across user, mde and this
repo (23 here, 42 -> 19). The invariant checked was the set of ENABLED plugins,
not the entry count -- byte-identical in every file afterwards, so zero
behavioural change. 30 errors -> 1, and that one is correct config.

Ten entries were KEPT because a `false` is load-bearing when another in-scope file
marks the same key `true`. A first pass compared only against user scope and would
have deleted both entries in .claude/settings.local.json, silently switching the
explanatory and learning output styles ON. Checking against every loaded scope is
the rule, and it is in the doc.

Also adds the adversarial review of the chezmoi/secrets takeover
(docs/research/kb/reports/agents/) per agent-report-persistence, and enables the
project-scoped codex + last30days plugins requested during that work.

Caches deliberately untouched: the live 5.7GB cache has 234 install records
pointing into it, and `claude plugins prune --dry-run` reports nothing to prune.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G2t5CzSpQ9mMG9AgmbMXvn

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788022537&installation_model_id=429246&pr_number=429&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F429&signature=25fc0346378765df4cc0a9f9494ba650dcaa324200011d4688f79f313a5a9368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on Claude Code plugin configuration, including enablement rules, scope behavior, safe cleanup, and troubleshooting.
  * Added an adversarial research report reviewing secrets-management and multi-agent workflow risks.
* **Chores**
  * Updated Claude Code plugin settings and marketplace sources.
  * Enabled Codex and the `last30days-skill` plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->