### PR TITLE
chore(mcp): empty .mcp.json — all 3 servers measured dead, and fix a now-false doctor reason

### DIFF
--- a/.claude/rules/secrets-out-of-the-shell-env.md
+++ b/.claude/rules/secrets-out-of-the-shell-env.md
@@ -53,12 +53,22 @@ The table above is the tool's **measured** behaviour on the pinned 1.31.1 (both
 arms probed), not a restatement of its release notes.
 
 **APPLIED 2026-07-27 by Ray; 4 opt-ins since 2026-07-30** — 45 of 49 exec-only.
-Three must stay `env = true` because this repo runs on them: `.mcp.json`
-interpolates `EXA_API_KEY` at MCP-server spawn, the context7 plugin interpolates
-`CONTEXT7_API_KEY` into an `Authorization` header (exec-only made it an empty
-string and the server served an **anonymous tier while reporting connected**),
-and `gh` reports its active account as the environment-authenticated one. Exec-only
-for those degrades tooling *silently*.
+Four must stay `env = true` because this repo runs on them: the context7 plugin
+interpolates `CONTEXT7_API_KEY` into an `Authorization` header (exec-only made it
+an empty string and the server served an **anonymous tier while reporting
+connected**), `gh` reports its active account as the environment-authenticated
+one, `mise` rate-limits to 60/h without `MISE_GITHUB_TOKEN`, and the
+`/last30days` engine's web lane reads **`EXA_API_KEY` from the process
+environment**. Exec-only for those degrades tooling *silently*.
+
+⚠️ **`EXA_API_KEY`'s stated reason was wrong until 2026-07-30.** It read
+"`.mcp.json` interpolates it at MCP-server spawn" — true when written, false once
+that server was dropped. The credential is still needed, by a consumer nobody had
+recorded: it is **not** in `~/.config/last30days/.env` and **not** in the
+keychain, so last30days reads it straight from the shell (probed: present at
+length 36, against `AWS_SECRET_ACCESS_KEY` absent, so the check discriminates).
+**A reason that names one consumer is a claim that there is only one** — and that
+claim is what nearly dropped a live credential.
 
 ⚠️ **AND IT DOES NOT STAY APPLIED.** Measured 2026-07-30: the config was rewritten
 ~4h40m after the fix, losing the global `env` line **and all 4 opt-ins**, so all 49

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -101,7 +101,8 @@
     "fable-orchestrator@fable-orchestrator": true,
     "antigravity@antigravity-for-claude-code": true,
     "context7@context7-marketplace": true,
-    "last30days@last30days-skill": true
+    "last30days@last30days-skill": true,
+    "exa@exa": true
   },
   "extraKnownMarketplaces": {
     "fable-orchestrator": {

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,24 +1,3 @@
 {
-  "mcpServers": {
-    "exa": {
-      "command": "npx",
-      "args": ["-y", "exa-mcp-server@3.2.1"],
-      "env": {
-        "EXA_API_KEY": "${EXA_API_KEY}"
-      }
-    },
-    "memory": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-memory@2026.7.4"]
-    },
-    "filesystem": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-filesystem@2026.7.10",
-        "/Users/rmanaloto/dev/github/ray-manaloto/dotfiles",
-        "/Users/rmanaloto/dev/github/ray-manaloto/knowledge-base"
-      ]
-    }
-  }
+  "mcpServers": {}
 }

--- a/docs/secrets-doppler-fnox-keychain.md
+++ b/docs/secrets-doppler-fnox-keychain.md
@@ -40,10 +40,18 @@ env = "exec"   # secrets stay OUT of the interactive shell
 | **`"exec"` (ours)** | **no** | yes | yes |
 | `false` | no | no | yes |
 
-Only secrets carrying an explicit per-secret `env = true` are exported. **Three
-are** — `EXA_API_KEY`, `GITHUB_TOKEN`, `MISE_GITHUB_TOKEN` — chosen because their
-consumers can *only* read the environment (an `.mcp.json` `${VAR}` interpolation
-at MCP-server spawn; `gh` and `mise` reading their tokens).
+Only secrets carrying an explicit per-secret `env = true` are exported. **Four
+are** — `CONTEXT7_API_KEY`, `EXA_API_KEY`, `GITHUB_TOKEN`, `MISE_GITHUB_TOKEN` —
+chosen because their consumers can *only* read the environment: the context7
+plugin interpolates `${CONTEXT7_API_KEY:-}` into an `Authorization` header, the
+`/last30days` engine's web lane reads `EXA_API_KEY` from the process environment
+(it is in neither that plugin's own `.env` nor the keychain), and `gh` and `mise`
+read their tokens.
+
+⚠️ `EXA_API_KEY`'s recorded reason used to be "an `.mcp.json` `${VAR}`
+interpolation at MCP-server spawn". That stopped being true on 2026-07-30 when
+this repo's `.mcp.json` was emptied — but the credential is still required, by a
+second consumer that had never been written down.
 
 **This is the single most likely cause of "the variable isn't set".** It is not a
 sync failure. See the diagnosis recipe below before suspecting Doppler.

--- a/doctor.toml
+++ b/doctor.toml
@@ -30,7 +30,14 @@ env = "exec"
 #                      that default is the trap: exec-only made the header an
 #                      empty string, so the server reported connected and served
 #                      an anonymous tier for weeks. Added 2026-07-30 (#418).
-#   EXA_API_KEY        `.mcp.json` interpolates it when spawning the exa server.
+#   EXA_API_KEY        the `/last30days` engine's web lane reads it from the
+#                      PROCESS ENVIRONMENT. It is NOT in that plugin's own
+#                      `~/.config/last30days/.env` and NOT in the keychain, so
+#                      exec-only silently drops its web backend from exa to the
+#                      keyless floor. Re-derived 2026-07-30 when `.mcp.json`
+#                      stopped declaring the exa server: the OLD reason on this
+#                      line (".mcp.json interpolates it") is now false, but the
+#                      opt-in stays — a second consumer was always there.
 #   GITHUB_TOKEN       `gh` reports its active account as the environment-
 #                      authenticated one; every ship/land/automerge runs on it.
 #   MISE_GITHUB_TOKEN  mise's GitHub API calls (release lookups) rate-limit

--- a/renovate.json
+++ b/renovate.json
@@ -174,18 +174,6 @@
       ],
       "datasourceTemplate": "deb",
       "versioningTemplate": "deb"
-    },
-    {
-      "customType": "regex",
-      "description": "#418: the npm-pinned MCP servers in .mcp.json. Renovate's native npm manager parses package.json/lockfiles only, so it cannot see an npm spec sitting in an `args` array \u2014 and an UNPINNED spec is what this closes: `npx -y <pkg>` resolves the current dist-tag on every spawn, so a server's tool set can change between two sessions with no diff anywhere in this repo, and a tool that appears is a tool no permission rule covers. Pinning without a bump path would just trade drift for rot, hence this manager. `mise run doctor` (mcp-pin) enforces that the pin exists; this keeps it current. Scoped and unscoped specs both matched: the optional leading `@` plus a `/` in the name character class.",
-      "managerFilePatterns": [
-        "/(^|/)\\.mcp\\.json$/"
-      ],
-      "matchStrings": [
-        "\"(?<depName>@?[a-z0-9._/-]+)@(?<currentValue>[0-9][^\"]*)\""
-      ],
-      "datasourceTemplate": "npm",
-      "versioningTemplate": "npm"
     }
   ],
   "customDatasources": {

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -967,8 +967,30 @@ def test_the_sessionstart_hook_runs_the_doctor() -> None:
 def test_collect_reads_the_real_repo_without_touching_the_real_home(
     tmp_path: Path,
 ) -> None:
-    """The `home` seam is what keeps this suite machine-independent."""
+    """The `home` seam is what keeps this suite machine-independent.
+
+    This used to assert the repo's server set was ``{exa, memory, filesystem}``,
+    which doubled as the proof that ``collect`` had really read ``REPO_ROOT``.
+    ``.mcp.json`` was emptied on 2026-07-30 (all three servers measured at 1-2
+    calls across 179 transcripts), so that assertion would now be ``== set()``
+    — a check that can only pass, and indistinguishable from ``collect``
+    reading nothing at all. See ``tests/AGENTS.md`` on probes without a control
+    arm.
+
+    The repo-was-read proof therefore moves to ``doctor.toml``, which is
+    non-empty and unambiguously sourced from ``REPO_ROOT``.
+    """
     setup = doctor.collect(REPO_ROOT, home=tmp_path, environ={})
+
+    # The home seam, and it genuinely discriminates: this machine HAS a real
+    # ~/.config/fnox, so a broken seam flips this to True.
     assert not setup.fnox.exists
-    assert {s.name for s in setup.servers} == {"exa", "memory", "filesystem"}
-    assert all(s.origin == "project" for s in setup.servers)
+
+    # The repo seam — positive evidence that REPO_ROOT was read.
+    assert setup.fnox_baseline().get("env") == "exec"
+    assert setup.mcp_baseline().get("scope_servers")
+
+    # Current declared state, pinned deliberately so a future reader does not
+    # "restore" the stale expectation above. The parsing path itself is covered
+    # by the fixtures in test_collect_servers_* — not by this test.
+    assert [s.name for s in setup.servers] == []


### PR DESCRIPTION
Counting real `tool_use` blocks across 179 transcripts of this project:
claude-in-chrome 70 calls / 7 transcripts, context7 4, memory 2, exa 1,
filesystem 1. Every server this repo declared was dead weight, and the only
MCP that earns its place is not in `.mcp.json` at all. That is the repo's own
"MCP lane 2" doctrine confirmed empirically.

The file is kept as `{"mcpServers": {}}` so the doctor still has a project
source and re-adding is a one-line diff.

Removing `exa` also ends a same-name collision: `.mcp.json` declared a stdio
`exa` (npx + EXA_API_KEY) while the newly-installed `exa@exa` plugin declares
an http `exa` over OAuth. Removing `filesystem` ends the standing mcp-scope
DRIFT the doctor reported every session (it declared 2 dirs, the harness sends
3 roots, and roots REPLACE the server's args, so the declared scope restricted
nothing).

`EXA_API_KEY` STAYS `env = true`. Its recorded justification — ".mcp.json
interpolates it when spawning the exa server" — is false as of this commit,
but the credential is still required by a consumer nobody had written down:
the `/last30days` engine's web lane reads it from the process environment. It
is in neither that plugin's own `~/.config/last30days/.env` nor the keychain.
Probed: present at length 36, against AWS_SECRET_ACCESS_KEY absent, so the
check discriminates. A reason that names one consumer is a claim that there is
only one — and that claim nearly dropped a live credential.

Also: retire the now-inert renovate customManager that pinned npm specs inside
`.mcp.json`, and record the exa@exa plugin enablement.

⚠️ Four doctor checks go VACUOUS with no repo-owned servers —
check_mcp_pin, check_mcp_guard_coverage, check_mcp_duplicate, check_mcp_scope
all iterate `setup.servers`. A green doctor here now means "nothing to check",
not "all clear". The traps they guard against still bind every plugin-provided
server: MCP tool names match no PreToolUse matcher, Roots replace declared
scope, and `${VAR:-}` fails silently.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014x8jGSieFkDBV95KLXYhTC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788047576&installation_model_id=429246&pr_number=444&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F444&signature=b5a6fc7daad36dd9ec6de3a4430f7ef7f3e2edeb2011f0e7a9c8f0c6bf77b2bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->