### PR TITLE
feat/436 builder skills and research loop

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -102,7 +102,8 @@
     "antigravity@antigravity-for-claude-code": true,
     "context7@context7-marketplace": true,
     "last30days@last30days-skill": true,
-    "exa@exa": true
+    "exa@exa": true,
+    "builder-skills@builder-skills": true
   },
   "extraKnownMarketplaces": {
     "fable-orchestrator": {
@@ -127,6 +128,12 @@
       "source": {
         "source": "github",
         "repo": "openai/codex-plugin-cc"
+      }
+    },
+    "builder-skills": {
+      "source": {
+        "source": "github",
+        "repo": "BuilderIO/skills"
       }
     }
   },

--- a/docs/skills-inventory.md
+++ b/docs/skills-inventory.md
@@ -1,0 +1,201 @@
+# Skills inventory — every skill reviewed, and the research behind each call
+
+Commissioned 2026-07-31 during wayfinder #436, after the second time in a short
+run that Ray had to ask for research and adversarial review that the loop should
+have produced on its own. Two jobs:
+
+1. **Coverage.** One row per skill in every marketplace we have adopted, so
+   "nothing was skipped" is checkable rather than asserted.
+2. **The loop gap.** Name where research and adversarial review are *supposed*
+   to fire in our flow, and where they actually don't.
+
+Sibling of `currency.toml` (tool versions) and `parity.toml` (cross-repo set):
+a declarative record that goes stale loudly rather than silently. Re-run the
+review when a marketplace publishes new skills.
+
+## How to read the status column
+
+| Status | Meaning |
+|---|---|
+| **ADOPT** | We use it, or should start now. |
+| **CANDIDATE** | Plausibly useful here; needs a decision, named below. |
+| **BLOCKED** | Wants something we do not have (a hosted connector, a desktop app, a host tool). |
+| **SKIP** | Reviewed and declined, with the reason. Not "unread". |
+
+**Depth** records how far the review actually went, because a frontmatter skim
+and a body read are not the same evidence:
+
+- `body` — SKILL.md read.
+- `fm` — frontmatter + description only.
+
+Nothing in this file is marked reviewed that was not at least `fm`-read on
+2026-07-31.
+
+---
+
+## BuilderIO/skills → `builder-skills@builder-skills`
+
+Registered at **project scope** on 2026-07-31 (`.claude/settings.json`
+`extraKnownMarketplaces` + `enabledPlugins`; user-level
+`~/.claude/plugins/config.json` untouched, verified `.marketplaces` still
+absent). 3,876 stars, last push 2026-07-29. Ships **skills only** — no agents,
+no commands, no MCP server of its own.
+
+| Skill | Depth | Status | Call |
+|---|---|---|---|
+| `read-the-damn-docs` | body | **ADOPT** | Forces a web-search of current official docs before answering or coding, triggered by "latest/current/official/supported/recommended" and by third-party API, auth, billing, migration and deployment work. This is the exact failure mode that stopped #436. Zero MCP mentions (control-armed against the visual skills' 9–17). |
+| `plan-arbiter` | body | **ADOPT** | Turns competing plans from different agents into one execution handoff — normalise claims, cross-review, pick a winner or a hybrid, and record the rejected alternatives. The adversarial-review half of Ray's complaint. Read-only unless told otherwise. |
+| `agent-watchdog` | body | **CANDIDATE** | Watch/audit/audit-and-fix/compare over another agent's session, PR, branch or transcript; returns a gap report between what was asked and what was verified. Overlaps our `verify-before-advancing` discipline; worth trying on a delegated run before committing. |
+| `visual-plan` | body | **BLOCKED** | Interactive visual plans — diagrams, file maps, annotated code, open questions, optional wireframe/prototype canvas. **Requires the hosted Agent-Native Plan MCP connector** (9 MCP / 7 connector / 13 agent-native mentions). |
+| `visual-recap` | body | **BLOCKED** | The reverse: a PR/branch/diff rendered as an interactive recap. Explicitly refuses to degrade — *"the deliverable is ALWAYS a published Agent-Native Plan … NEVER inline chat content"*, and instructs a hard STOP if the connector is missing. Same hosted dependency (14 MCP mentions). |
+| `visual-edit` | body | **BLOCKED** | Opens a running localhost app as URL-backed iframe screens on a Design canvas. Needs the hosted Design MCP connector *and* a running local app (17 MCP mentions). Least applicable here — this repo has no web UI. |
+| `efficient-frontier` | body | **CANDIDATE** | Keep architecture/prioritisation/synthesis on the expensive model, delegate research scans, inventories, docs extraction and mechanical edits to cheaper subagents. Substantially the same doctrine as `fable-orchestrator:orchestration`, which we already run — adopt only if it beats it. |
+| `efficient-fable` | body | **SKIP** | The same pattern named for Fable specifically. Redundant with `efficient-frontier` and with our own orchestrator config; adopting both would give two documents saying one thing. |
+| `plow-ahead` | body | **SKIP** | An autonomy contract: convert ordinary ambiguity into stated assumptions and keep going without clarification stops. Directly opposes `.claude/rules/clarify-before-acting.md` and Ray's standing "always ask via AskUserQuestion" preference. Declined on conflict, not on quality. |
+| `quick-recap` | body | **CANDIDATE** | A red/yellow/green status line ending every response. Cheap and legible. It installs itself by writing managed `AGENTS.md`/`CLAUDE.md` blocks — which our `claude_md_import_stub` gate and the 200/200-line `AGENTS.md` will reject, so it would have to be hand-placed in `.claude/CLAUDE.md`. |
+| `stay-within-limits` | body | **CANDIDATE** | Checks 5-hour and weekly usage between waves of parallel subagents, pauses at ≥95%. Useful only once we routinely fan out; needs a host usage/budget tool to read. |
+| `rewind` | body | **BLOCKED** | Local screen memory via Clips Rewind. Needs the signed Clips Desktop app on macOS plus a local agent connection. Not installed. |
+
+### `BuilderIO/agent-native` — reviewed 2026-07-31, **DEFERRED**
+
+A second, separate BuilderIO marketplace (`agent-native-apps`), pushed the same
+day it was reviewed. It is what the three visual skills above depend on: its
+`agent-native-visual-plans` and `agent-native-design` plugins are the Plan and
+Design MCP connectors. **Not registered.** Findings, so the decision does not
+have to be re-derived:
+
+| Question | Answer | How it was established |
+|---|---|---|
+| Licence | **MIT** | Declared in the README's `## License` section. GitHub's API reports `license: null` and the repo has **0** LICENSE files — a missing file blinds the detector, it does not make the project proprietary. Control arm: `BuilderIO/skills` has 1 LICENSE file, MIT. |
+| What the skills actually call | **Hosted SaaS** | `.agents/plugins/agent-native-visual-plans/.mcp.json` is `{"plan": {"type": "http", "url": "https://plan.agent-native.com/mcp"}}`; Design is the same shape. |
+| Account required? | **Yes** | `plan.agent-native.com/mcp` → **401**, `design.agent-native.com/mcp` → **401**. Controls: `github.com` → 200 (the probe works), a bogus `*.agent-native.com` subdomain → 000 (so 401 is "authenticate", not a dead host). |
+| Price | **Unpublished** | README has zero mentions of free, pricing, account, sign-up or self-host. |
+| Update model | **`autoUpdate: true`** | Declared on both plugins in its `marketplace.json` — they update themselves from the marketplace. |
+
+So: an MIT framework fronting a closed, authenticated service at an unknown
+price. Self-hosting is legally open under MIT but is not documented as a path.
+
+**Deferred, not rejected.** Nothing in the current work depends on it, and the
+two skills that answer the loop gap — `read-the-damn-docs` and `plan-arbiter` —
+need no connector. **Revisit when** either (a) native `Artifact` visuals prove
+insufficient in a specific, nameable way, or (b) agent-native publishes pricing.
+Adopting on neither of those is adopting on novelty.
+
+### The visual question is not settled by installing the plugin
+
+All three visual skills are hosted-connector skills. Registering an Agent-Native
+MCP server is **allowed without justification** — it is lane 1 in
+`.claude/rules/research-doc-sources.md` (a third-party skill that requires MCP) —
+so the objection is not policy. It is that a Builder.io-hosted service would
+receive our plan and diff content, which is Ray's call and nobody else's.
+
+**There is a native alternative that costs nothing.** Claude Code ships an
+`Artifact` tool that publishes self-contained interactive HTML — mermaid
+diagrams, tables, theme-aware, private by default on claude.ai — with no
+external service and no connector. For "make it easier to visualise what we are
+building" during a grilling session, that is the `use-tool-builtins.md` answer
+and it works today. The Builder visual skills buy annotation and an editable
+canvas on top; that increment is what the decision is actually about.
+
+---
+
+## mattpocock/skills → `mattpocock-skills@mattpocock`
+
+Installed 1.2.0; upstream's latest tagged release is v1.1.0 (2026-07-08) with
+commits through 2026-07-28, so the installed copy carries unreleased work. `dmi`
+marks `disable-model-invocation: true` — a skill only a human can start.
+
+### engineering
+
+| Skill | dmi | Depth | Status | Call |
+|---|:-:|---|---|---|
+| `wayfinder` | yes | body | **ADOPT** | The map we are running (#431). Charting + one decision ticket per session. |
+| `grilling` | no | body | **ADOPT** | The interview technique. In use for every `wayfinder:grilling` ticket. |
+| `domain-modeling` | no | fm | **ADOPT** | Paired with grilling by the map's Notes. |
+| `research` | no | body | **ADOPT — under-used** | Background agent, primary sources, findings to a Markdown file. Registered and available all along; #436 reached decision 5 without anyone invoking it. This is the gap. |
+| `prototype` | no | fm | **ADOPT** | Used for #432 (`prototype/432-secrets-cli-shape`). Unreleased changeset makes the prototype a retained primary source on a throwaway branch — which is exactly what we did. |
+| `code-review` | no | fm | **ADOPT** | Standards + Spec axes in parallel subagents. |
+| `codebase-design` | no | fm | **CANDIDATE** | Deep-module vocabulary. Not yet exercised here. |
+| `diagnosing-bugs` | no | fm | **ADOPT** | Available; used on demand. |
+| `tdd` | no | fm | **CANDIDATE** | Our gate discipline is contract//suite-shaped rather than red-green. |
+| `resolving-merge-conflicts` | no | fm | **ADOPT** | Available on demand. |
+| `ask-matt` | yes | fm | **CANDIDATE** | *A router over the skills in this repo* — a skill that picks the skill. Directly relevant to the loop gap: a router consulted at ticket start is one way research stops being forgotten. |
+| `grill-with-docs` | yes | body | **SKIP** | Body is one line: *"Run a `/grilling` session, using the `/domain-modeling` skill."* Despite the name it adds no docs-research step. Named here so nobody re-discovers it hoping otherwise. |
+| `to-spec` | yes | fm | **CANDIDATE** | Synthesise the conversation into a spec on the tracker. The map's destination is a buildable spec, so this is the likely closing move for #431. |
+| `to-tickets` | yes | fm | **CANDIDATE** | Break a plan into tracer-bullet tickets with blocking declared. Overlaps wayfinder's own charting. |
+| `implement` | yes | fm | **SKIP** | Implement from a spec/tickets. The map is planning-only by its Notes. |
+| `triage` | yes | fm | **CANDIDATE** | Issue/PR state machine over the five roles in `docs/triage-labels.md`. |
+| `improve-codebase-architecture` | yes | fm | **CANDIDATE** | Scans for deepening opportunities and presents a **visual HTML report** — notable given the visualisation goal, and it needs no connector. |
+| `setup-matt-pocock-skills` | yes | body | **SKIP — do not run** | Writes the root `CLAUDE.md` and `docs/agents/*.md`, both of which our gates reject. Already documented in `docs/issue-tracker.md`; repeated here so the inventory is self-contained. |
+
+### productivity
+
+| Skill | dmi | Depth | Status | Call |
+|---|:-:|---|---|---|
+| `grilling` | no | body | **ADOPT** | Listed above; lives in this category. |
+| `grill-me` | yes | fm | **SKIP** | Older single-purpose variant of `grilling`. |
+| `handoff` | yes | fm | **CANDIDATE** | Compact the conversation into a handoff. We have `.claude/skills/handoff/` and `/clear-prep` already; compare before adopting a second one. |
+| `teach` | yes | fm | **SKIP** | Not our use case. |
+| `writing-great-skills` | yes | fm | **CANDIDATE** | Reference for authoring skills. Useful when we next write one. |
+
+### in-progress (unreleased upstream)
+
+| Skill | dmi | Depth | Status | Call |
+|---|:-:|---|---|---|
+| `batch-grill-me` | yes | fm | **CANDIDATE** | Asks every frontier question at once, round by round. A direct answer to grilling's round-trip cost — the reason a 6-decision ticket takes 6 exchanges. Unreleased; treat as an idea to borrow, not a dependency. |
+| `claude-handoff` | yes | fm | **CANDIDATE** | Hands the conversation to a fresh background agent. |
+| `loop-me` | yes | fm | **CANDIDATE** | *Grill me about specs for the workflows I want to build* — i.e. grilling aimed at our own loop. Relevant to this very document. |
+| `to-questionnaire` | yes | fm | **SKIP** | For decisions someone else must answer. |
+| `wizard` | yes | fm | **CANDIDATE** | Generates an interactive bash wizard for a manual procedure. Collides with `.claude/rules/zero-bash-logic.md`; would need the logic in `python/`. |
+| `setup-ts-deep-modules` | yes | fm | **SKIP** | TypeScript/dependency-cruiser. No TS here. |
+| `writing-beats` · `writing-fragments` · `writing-shape` | yes | fm | **SKIP** | Article-writing pipeline. Not this repo. |
+
+### misc / personal / deprecated
+
+| Skill | Depth | Status | Call |
+|---|---|---|---|
+| `misc/git-guardrails-claude-code` | fm | **SKIP** | Claude Code hooks blocking dangerous git commands. We already have `hook_guard.py` plus a `main` ruleset (#400); a second guard would be drift surface. |
+| `misc/setup-pre-commit` | fm | **SKIP** | Husky + lint-staged. We use hk. |
+| `misc/migrate-to-shoehorn` · `misc/scaffold-exercises` | fm | **SKIP** | TypeScript-specific. |
+| `personal/edit-article` · `personal/obsidian-vault` | fm | **SKIP** | Author's personal workflow. |
+| `deprecated/design-an-interface` · `qa` · `request-refactor-plan` · `ubiquitous-language` | fm | **SKIP** | Upstream-deprecated. `ubiquitous-language` is superseded by `domain-modeling`, which we use. |
+
+---
+
+## The loop gap this review was commissioned to find
+
+**Research and adversarial review are both available and neither is wired to
+fire.** Three specific findings:
+
+1. **Wayfinder's ticket types are disjoint.** `research` is its own AFK ticket
+   type, resolved by a subagent at charting time. A `wayfinder:grilling` ticket
+   has **no research step at all** — so a decision ticket about a third-party
+   tool can reach its final answer without anyone reading that tool's docs.
+   #436 got five decisions deep designing a custom guard before Ray asked
+   whether chezmoi ships one. It does: native `[hooks]`, which aborts on
+   non-zero and can see `--source`.
+2. **Our own rule already says this, and nothing enforces it.**
+   `.claude/rules/tool-currency-and-native-first.md` rule 1 — *"before writing
+   custom tooling around a managed tool, research its release notes first"* —
+   is exactly the missed step. It is eager context. It was loaded. It did not
+   fire, because nothing in the wayfinder flow has a point where it is checked.
+3. **Adversarial review has no seat in the flow either.** Memory
+   `feedback_refuters_and_cold_review_find_disjoint_defects` records that
+   refuters and cold review find *different* defect classes and both should
+   run. The map's Notes name `/grilling`, `/domain-modeling`, `/prototype` and
+   `/research` — no review lens at all.
+
+The candidate mechanisms are `read-the-damn-docs` (item 1), `plan-arbiter` and
+the existing cross-family reviewers (item 3), and a wayfinder Notes change that
+makes both a required step of a decision ticket rather than a separate ticket
+type. **Not yet decided** — the proposal is the next thing to grill.
+
+---
+
+## GitHub repos touched
+
+- [BuilderIO/skills](https://github.com/BuilderIO/skills) — every one of its 12 skills read; marketplace manifest and plugin shape inspected.
+- [BuilderIO/agent-native](https://github.com/BuilderIO/agent-native) — licence, marketplace manifest, MCP wiring and README scanned for the deferral decision above.
+- [mattpocock/skills](https://github.com/mattpocock/skills) — full skill inventory across 6 categories, unreleased changesets, release tags and recent commits.
+- [twpayne/chezmoi](https://github.com/twpayne/chezmoi) — v2.71.1 release notes and the `hooks.md` reference that produced the #436 finding driving this review.
+- [sushichan044/dotfiles](https://github.com/sushichan044/dotfiles) · [btkostner/dotfiles](https://github.com/btkostner/dotfiles) · [jetersen/dotfiles](https://github.com/jetersen/dotfiles) — real-world `[hooks.*]` and multi-OS chezmoi idiom.

--- a/docs/specs/research-nudge-hooks.md
+++ b/docs/specs/research-nudge-hooks.md
@@ -10,8 +10,11 @@
 > It proposes a different shape — **ticket-bound receipts plus a fail-closed resolution
 > workflow** — with `SubagentStart` promoted from footnote to primary lever.
 >
-> **The findings are not yet verified.** Read [Appendix B](#appendix-b--verifying-the-findings-before-acting)
-> before acting on any of them; a review is evidence, not a verdict.
+> **The findings are now VERIFIED (2026-07-31)** — see
+> [Appendix C](#appendix-c--verification-results-2026-07-31-measured). Four survive intact; the
+> fifth (`SubagentStart`) survives as a mechanism but its stated premise is measurably wrong —
+> both documented misses launched **zero** subagents. Appendix B is the method; Appendix C is the
+> result.
 >
 > The research below (29 hook events, the md5 cross-check, the statusline sensor, the two
 > hard constraints) stands on its own measurements and survives the redesign. The *design*
@@ -205,6 +208,63 @@ building against it.
 gap, but the two documented misses were both made inline by the main session. Adopting
 `SubagentStart` as the *primary* lever would harden a path that did not fail, while leaving the path
 that did. Worth resolving before the redesign commits to it.
+
+## Appendix C — verification results (2026-07-31, measured)
+
+Appendix B's checks were run. Every number below was **re-derived**, not inherited from the
+handoff ([[probes-need-a-control-arm]] rule 6), and every negative carries its control arm.
+
+**Verdict: 4 of 5 findings survive intact. F2 survives as a mechanism but its stated premise is
+measurably wrong. F5's severity is lower than argued, but its conclusion survives on a stronger
+argument than the one it was filed under.**
+
+| # | Finding | Verdict | Decisive evidence |
+|---|---|---|---|
+| 1 | No tier is a prerequisite | **CONFIRMED** | Read-back: 1.1/1.2 emit `additionalContext` (informational), 1.3 emits `ask` (gates on judgement, not evidence), tier 3 is prose. No tier keys on an artifact existing. |
+| 2 | `SubagentStart` omitted | **mechanism CONFIRMED · premise REFUTED** | Both miss sessions launched **0** subagents (`6b4602f4`: Agent=0, `subagent_type`=0, control Bash=132; `d4299a7a`: 0/0/48) against **239** Agent launches across all 181 project transcripts. `SubagentStart` would have fired **zero times** in the session it is proposed to fix. |
+| 3 | Close-time `ask` is uninformed | **CONFIRMED (both halves)** | (a) hooks.md:1551 verbatim — *"For `allow` and `ask`, shown to the user but not Claude"* (control: `additionalContext`→40, bogus token→0). (b) No ticket-bound receipt convention exists: `reports/agents/` is 16 files named topic+date; 1 of 16 carries a ticket (control: 28 filenames match the date convention). |
+| 4 | Statusline state unscoped / non-atomic | **CONFIRMED · premise now measured** | The path is global — keyed by neither session **nor project** — with no timestamp, atomic replace, or expiry. Concurrency, asserted in Appendix B, measured across all `~/.claude/projects` (251 transcripts, 7 days): **60 of 91 hours (66%) had ≥2 sessions active, peaking at 4.** Collision is the normal case. |
+| 5 | `UserPromptSubmit` fails open | **direction CONFIRMED · magnitude CORRECTED** | See below. |
+
+### Finding 5 in detail — the right conclusion for the wrong reason
+
+The spec's mitigation ("pure string match ⇒ the 30s timeout must never be approached") was
+asserted. Measured on `scripts/pretooluse-guard.sh` — the closest live analogue — 20 sequential
+runs on a genuinely loaded host (load avg 15.23/19.34/31.66): **min 256 ms · median 1013 ms ·
+max 1978 ms**, i.e. **6.6% of the 30s budget, ~15× headroom**. The regex is free; the *wrapper*
+costs about a second. **Timeout is not the realistic failure mode**, so Codex overstates that half.
+
+> A first 20-run batch read max = 3914 ms and was **discarded**: the measuring command had itself
+> spawned 20 background processes. It measured its own load. Re-run clean.
+
+Its *other* half is the real one, and it is stronger than the timeout argument: **absence is
+unobservable**. Armed both directions — hiding the interpreter (`PATH=/usr/bin:/bin`) makes the
+wrapper exit 0 *and* write `interpreter-absent` to the fail-open log; the same input on a normal
+PATH writes nothing. The path works and discriminates, and
+`~/.local/state/dotfiles/guard-fail-open.log` does not exist — a real negative, meaning the
+PreToolUse guard has not failed open since #343's telemetry landed.
+
+⚠️ **But that telemetry is wrapper-side.** A harness-side *timeout kill* never reaches
+`fail_open()`, so it leaves no trace at all. A hook cannot record its own death. Whatever
+establishes that research happened must therefore be **durable evidence outside the hook** — which
+is finding 1's recommendation arriving by a second route.
+
+### The scoping correction F2 forces
+
+`SubagentStart` is not useless — 239 delegations across ~50 transcripts is real traffic, and
+research delegated to a subagent is genuinely uninstrumented. But it addresses a path that **has
+not been observed to fail**, while both observed misses were inline. A redesign that makes it the
+*primary* lever hardens the wrong path. It belongs in the design as a **secondary** lever, and the
+primary one must cover inline main-session work.
+
+### What all five findings converge on
+
+Findings 1, 3 and 5 arrive independently at the same missing thing: **a ticket-bound receipt**.
+F1 wants a completion gate to key on; F3 wants something for the guard to cite; F5 wants evidence
+that survives the hook not running. That artifact does not exist today — which makes it the first
+thing the redesign must define, ahead of any hook.
+
+Finding 4 is separable and should be split out, exactly as Codex recommends.
 
 ## GitHub repos touched
 

--- a/docs/specs/research-nudge-hooks.md
+++ b/docs/specs/research-nudge-hooks.md
@@ -1,0 +1,212 @@
+# Build plan — enforce research + adversarial review in the wayfinder loop
+
+> **STATUS: NO-SHIP (2026-07-31). Superseded pending redesign. Nothing here is built,
+> and the tiers below should NOT be built as written.**
+>
+> A Codex adversarial review returned `needs-attention` with four high findings and one
+> medium — the full text is in [Appendix A](#appendix-a--codex-adversarial-review-verbatim),
+> verbatim. Its core objection: every tier is the same *class* of mechanism as the eager
+> rule that already failed twice, so changing delivery time does not establish completion.
+> It proposes a different shape — **ticket-bound receipts plus a fail-closed resolution
+> workflow** — with `SubagentStart` promoted from footnote to primary lever.
+>
+> **The findings are not yet verified.** Read [Appendix B](#appendix-b--verifying-the-findings-before-acting)
+> before acting on any of them; a review is evidence, not a verdict.
+>
+> The research below (29 hook events, the md5 cross-check, the statusline sensor, the two
+> hard constraints) stands on its own measurements and survives the redesign. The *design*
+> does not.
+
+Written 2026-07-31 after two misses in one session: five decisions on #436 were designed before
+anyone read chezmoi's docs (it ships native `[hooks]` that do the job), and the chezmoi-vs-mise
+overlap was re-derived despite `deep-research-takeover-20260730.md` having already answered it. Both
+were caught by Ray asking, not by the loop.
+
+## The problem, stated precisely
+
+**A rule is not enough, and we have direct evidence.** `.claude/rules/tool-currency-and-native-first.md`
+rule 1 says, in as many words: *research the tool's release notes before writing custom tooling around
+it.* It is unscoped, therefore eager, therefore loaded at launch. It was loaded in that session. It
+did not fire — twice. Adding a rule file is the option measured to have already failed.
+
+The three structural gaps:
+
+1. **Wayfinder's ticket types are disjoint.** `research` is its own AFK type resolved by subagents at
+   *charting* time. A `wayfinder:grilling` ticket has **no research step at all**, so a decision about
+   a third-party tool can reach its answer without that tool's docs being opened.
+2. **Adversarial review has no seat.** Map #431's `## Notes` name `/grilling`, `/domain-modeling`,
+   `/prototype`, `/research` — no review lens, despite `feedback_refuters_and_cold_review_find_disjoint_defects`
+   recording that refuters and cold review find *different* defect classes.
+3. **Prior research is not consulted.** `docs/research/kb/reports/agents/` is the durable record and
+   nothing in the flow reads it before starting new work.
+
+## What the harness actually offers
+
+Established from the KB mirror `sources/agent-harness-docs/docs/claude-code/hooks.md`, which is
+**md5-identical** to the live `code.claude.com/docs/en/hooks.md` fetched the same day
+(`0a8c3a6542d7c5085c1b451b994b9ce8`; a control file hashes differently, so the comparison
+discriminates).
+
+⚠️ **A first pass at this list was wrong, and the way it was wrong matters.** It grepped an
+alternation of the event names already expected and found exactly those — 11. An unbounded
+`^### [A-Z][A-Za-z]+$` returns **29**. Everything below rests on the unbounded enumeration.
+
+| Event | Bearing on this plan |
+|---|---|
+| `UserPromptSubmit` | Once per turn, before the prompt is processed. Receives raw `prompt`. `additionalContext` is **injected as a system reminder with no visible transcript entry**. ⚠️ 30s default timeout, and a timed-out hook's context is **discarded** — the prompt proceeds without it. So the check must be a pure string match, no network. |
+| `PreToolUse` | Every tool call. `permissionDecision` ∈ allow / **ask** / deny / defer; precedence deny > defer > ask > allow. For `ask`, `permissionDecisionReason` is shown **to the user, not to Claude**; `additionalContext` is the field that reaches Claude. |
+| `SubagentStart` | Cannot block, but **injects `additionalContext` into the subagent's context**, matched on `agent_type`. The only route to enforcing research discipline on delegated work. |
+| `PermissionRequest` | Distinct from `PreToolUse` — fires only when permission is about to be asked, or a call would be auto-denied. |
+| `async` / `asyncRewake` | Command hooks only. Cannot block or return decisions; output arrives **next turn**. `asyncRewake` wakes Claude on exit code 2 with stderr shown as a system reminder. |
+| Statusline (not a hook) | Hooks receive **no** context usage — control-armed: `transcript_path` → 35 mentions in hooks.md, `context_usage`/`token_count`/`percent` → **0**. The statusline receives `context_window.used_percentage`, `total_input_tokens`, and a broken-out `current_usage`. |
+
+**Two hard constraints that no design removes:**
+
+- `/clear` is a CLI command, and `clear-prep`, `handoff`, `resume` and `wayfinder` are all
+  `disable-model-invocation: true`. **Claude cannot invoke any of them.** Automation can prepare
+  everything and nudge; the keystroke stays human.
+- Ray's statusline is configured at **user** level (`node $HOME/.claude/hud/omc-hud.mjs`). A
+  project-level `statusLine` overrides it. **Decided 2026-07-31 (Ray): overriding is fine — we are
+  migrating away from the OMC HUD regardless.** So tier 2 replaces rather than wraps. Note the
+  override is scoped to this repo; every other project keeps the user-level HUD until the wider
+  migration happens, which is not part of this plan.
+
+## Proposed build
+
+### Tier 1 — the nudges (no statusline, no user-level changes)
+
+Ray selected all three triggers.
+
+1. **`UserPromptSubmit`** — matches `/wayfinder`, `/grilling`, `/mattpocock-skills:*` in `prompt`.
+   Emits `additionalContext`: read the tool's primary docs and release notes; grep
+   `docs/research/kb/reports/agents/` for prior coverage first; run adversarial review before
+   resolving. Pure string match, no IO beyond the match — the 30s timeout must never be approached.
+2. **`PreToolUse`** on `gh issue edit <n> --add-assignee` — `allow` + `additionalContext`, same
+   checklist. Covers a ticket claimed without `/wayfinder` being typed (resumed session, work picked
+   up mid-flight).
+3. **`PreToolUse`** on `gh issue close` / a resolution comment on a `wayfinder:*` ticket — **`ask`**,
+   not `deny`. The guard cannot verify research happened, so a `deny` would make closing any
+   wayfinder ticket impossible. `ask` puts the judgement with Ray.
+
+This is a **new output shape for `hook_guard.py`**, which today emits only `deny`. `ask` and
+`additionalContext` are new capabilities, requiring their own tests and a suites.toml contract, plus
+`since` dates per `mise-tasks-only.md` § "since dates COVERAGE".
+
+### Tier 2 — the context-budget trigger
+
+Sensor → channel → actuator, because the sensor and the actuator are different subsystems:
+
+- **Sensor:** a project `statusLine` script (`python/`, per zero-bash-logic) that writes
+  `context_window.used_percentage` to `~/.local/state/dotfiles/context-usage`.
+- **Actuator:** a `Stop` hook (once per turn) reading that file; above threshold, emits a reminder
+  to run `/clear-prep`.
+
+⚠️ **Replace-vs-wrap was reopened by measurement.** Overriding the HUD was sanctioned on the
+assumption it was a dead shim. It is not. Fed representative statusline JSON on stdin it returns
+rc=0 and renders:
+
+```
+[OMC#4.15.7L] | Model: Opus 5 | 5h:[#-------]12%(1h28m) wk:[##------]25%(4d14h)
+extra:[####----]55%($109.73/$200.00) | session:0m | ctx:[####------]42%
+```
+
+So it already carries the **5-hour window**, the **weekly window**, **credit spend against a cap**,
+session duration — and it **already reads `used_percentage` itself**. Those first three are exactly
+what `builder-skills:stay-within-limits` needs and nothing else in the setup provides. It works
+despite `oh-my-claudecode` being absent from `enabledPlugins`, because `~/.claude/hud/omc-hud.mjs` is
+a **resolver shim** that imports from the plugin *cache* (6 built copies present), independent of
+enablement.
+
+⇒ **Recommended: wrap, not replace.** A project `statusLine` that tees stdin — hand it to the HUD,
+print the HUD's output verbatim, and separately write `used_percentage` to the state file. Costs
+nothing, loses nothing, and survives the eventual OMC migration by being one `exec` line to
+re-point. Replacing is still available if Ray wants the HUD gone now, but it is a strict loss of the
+usage and cost meters until something reimplements them.
+
+**Residual risk that survives either choice:** `current_usage` is `null` before the first API call
+and again immediately after `/compact` until the next call. The state file therefore has a genuine
+unknown state, and the actuator must treat "no reading" as "no nudge", never as "0%".
+
+### Tier 3 — the wayfinder map's `## Notes`
+
+Notes are ours, not vendored, and wayfinder states that a session invokes the skills the Notes name.
+Add the research + adversarial step there so it applies to every ticket on map #431 without touching
+the plugin.
+
+## What is deliberately NOT proposed
+
+- **Auto-advance on "no issues or ambiguity found".** That judgement is exactly what failed twice.
+  Both times the honest self-report would have been "no ambiguity". Keying auto-advance on *evidence*
+  — a research artifact exists, an adversarial review returned findings — is a different and safer
+  trigger, but it is not this plan.
+- **Merging `handoff` into `clear-prep`.** They are already deliberately different and both
+  frontmatters say so: `clear-prep` (247 lines) is same-machine `/clear` continuity; `handoff`
+  (83 lines) is cross-surface, tracked and pushed, with `resume` as its other half.
+- **A new rule file.** See the opening paragraph.
+
+## Questions an adversarial review should attack
+
+1. Does tier 1 actually prevent the failure, or only make it visible later? The `UserPromptSubmit`
+   nudge is still instruction-following — better-timed instruction-following, but not a gate.
+2. Is `ask` on close a speed bump that gets clicked through? What would make it carry information
+   rather than become reflex?
+3. Does the statusline wrapper introduce a worse failure than the one it detects?
+4. Is `SubagentStart` the better primary lever, given delegated work is where research is most often
+   skipped and it is the one place context can be injected unconditionally?
+5. Three overlapping nudges — does redundancy here reduce misses, or train the reader to skim all of
+   them?
+
+## Appendix A — Codex adversarial review, verbatim
+
+Run 2026-07-31, `--scope working-tree`, GPT-5.6 via `codex-companion.mjs`. Reproduced unedited.
+
+> Target: working tree diff
+> Verdict: needs-attention
+>
+> No-ship: the proposal multiplies reminders around a behavior that already ignored an eagerly loaded instruction twice. It provides no evidence-backed completion gate and adds silent fail-open, click-through, and fragile statusline paths. The loop needs a different mechanism, not more instruction-shaped nudges.
+>
+> Findings:
+> - [high] No proposed tier makes research or adversarial review a prerequisite (docs/specs/research-nudge-hooks.md:61-78)
+>   Tier 1 emits checklists, Tier 3 adds another instruction, and the plan explicitly declines the only evidence-oriented alternative. These are the same class of mechanism as the eager rule that lines 12-15 say failed twice; changing delivery time does not establish completion. The likely result is false confidence while unresearched decisions still resolve normally.
+>   Recommendation: Do not build these tiers as enforcement. Define ticket-bound research and adversarial-review receipts, then make the supported resolution workflow fail closed when required evidence is missing or stale. Otherwise label the hooks as optional UX reminders and do not claim they fix the loop.
+> - [high] The only unconditional delegated-work injection is omitted from the build (docs/specs/research-nudge-hooks.md:61-78)
+>   The draft identifies delegated research as the structural gap and calls SubagentStart the only route that injects context directly into a subagent, yet none of the three Tier 1 triggers uses it. The proposed Notes path still depends on the agent noticing and following instructions. The workflow most responsible for research therefore remains untouched.
+>   Recommendation: Make narrowly matched SubagentStart context the primary delivery mechanism for research workers, and require those workers to emit a ticket-bound artifact. Because SubagentStart cannot verify completion, pair it with the resolution evidence gate rather than treating injection alone as enforcement.
+> - [high] The close-time ask cannot support an informed approval (docs/specs/research-nudge-hooks.md:72-78)
+>   The plan admits the guard cannot verify that research happened, but still asks Ray to judge closure without presenting ticket-specific evidence. A repeated generic permission dialog provides no basis for distinguishing completed work from another miss and is likely to become reflex approval. It therefore adds friction without closing the failure path.
+>   Recommendation: Have the guard report concrete receipt paths, source identities, review results, and missing requirements. Missing evidence should deny closure through a supported remediation workflow; reserve ask for genuine exceptions carrying enough evidence for a deliberate decision.
+> - [high] The statusline side channel can lose the existing HUD and consume stale or cross-session state (docs/specs/research-nudge-hooks.md:82-113)
+>   The single home-directory state file is not scoped by session and has no freshness or atomicity contract. Concurrent sessions can overwrite each other's percentages, and a null reading after compaction can leave a previous high or low value indistinguishable from current state. The wrapper also makes the working usage/cost HUD depend on new parsing, file I/O, and an unenabled plugin-cache shim; an uncaught child failure can remove the visibility the change is meant to preserve. The assertion that wrapping costs and loses nothing is unsupported.
+>   Recommendation: Split Tier 2 from this proposal. Before adoption, key state by session, record timestamp and explicit unknown state, use atomic replacement and expiry, isolate and time-bound the HUD child, preserve a fallback display, and test concurrent sessions, null-after-compact, missing cache, malformed input, and child timeout.
+> - [medium] UserPromptSubmit silently fails open when its context is most needed (docs/specs/research-nudge-hooks.md:41-68)
+>   The draft states that timeout discards additionalContext and proceeds with no visible transcript entry. A fast regex does not bound process startup, interpreter, wrapper, scheduling, or hook-wiring failures, so 'must never be approached' is not a guarantee. Tests of matching logic would not reveal runtime delivery loss, leaving the nudge absent and unobservable.
+>   Recommendation: Remove UserPromptSubmit from the correctness boundary. Add wired end-to-end self-checks and fail-open telemetry if retained as a reminder, while enforcing completion later through durable evidence that survives hook timeout or absence.
+>
+> Next steps:
+> - Redesign the wayfinder loop around verifiable per-ticket artifacts and a fail-closed resolution workflow.
+> - Prototype SubagentStart plus receipt generation against the two documented miss scenarios.
+> - Review the statusline sensor as an independent reliability change only after concurrency and degraded-mode behavior are specified.
+
+## Appendix B — verifying the findings before acting
+
+A review is evidence, not a verdict, and this repo's own rule is that an inherited claim is not a
+measurement ([[probes-need-a-control-arm]] rule 6). Each finding below is checkable; check it before
+building against it.
+
+| Finding | What would confirm it | What would refute it |
+|---|---|---|
+| No tier is a prerequisite | Trace the two real misses: would any tier have *stopped* the decision from resolving? Neither a `UserPromptSubmit` reminder nor a Notes line can — both are readable-and-ignorable. | A tier that gates rather than informs. None is proposed, so this looks **correct as stated**. |
+| `SubagentStart` omitted | Confirm it is absent from all three Tier 1 triggers (it is) **and** that delegated work is where the misses happened. ⚠️ This half is doubtful: **both misses this session were made inline, not by a subagent.** | If neither miss involved delegation, `SubagentStart` is the right lever for a *different* failure than the one observed — an important scoping correction, not a refutation of the mechanism. |
+| Close-time `ask` is uninformed | Confirm `permissionDecisionReason` is shown to the user but not to Claude (measured: it is) and that the guard has no receipt to cite. | A receipt format existing to cite. There isn't one yet, so **correct**, and it is the same gap as finding 1. |
+| Statusline state is unscoped / non-atomic | Read back the tier-2 text: the state file is a single unscoped path with no timestamp or atomicity. **Correct as written.** Also verify the "wrapping loses nothing" claim — measured against the HUD's real output, which does render usage and cost. | Nothing refutes the concurrency point; multiple Claude Code sessions on this Mac are routine. |
+| `UserPromptSubmit` fails open | Confirm from the hooks doc that a timed-out hook's context is discarded and the prompt proceeds (measured: it is, with a transcript notice only since v2.1.196). | The claim that a regex "must never approach" 30s ignores process startup — **correct**; the mitigation was asserted, never measured. |
+
+**The one finding to push back on** is the second: it asserts delegated research is the structural
+gap, but the two documented misses were both made inline by the main session. Adopting
+`SubagentStart` as the *primary* lever would harden a path that did not fail, while leaving the path
+that did. Worth resolving before the redesign commits to it.
+
+## GitHub repos touched
+
+_None — the sources are Claude Code's own hooks and statusline documentation, mirrored in the
+knowledge-base repo._


### PR DESCRIPTION
- **feat(skills): adopt BuilderIO/skills at project scope; inventory every skill with its research**
- **docs(specs): record the nudge-hooks plan and the adversarial review that rejected it**
- **docs(specs): verify the Codex review against measurement (#449)**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled the Builder Skills plugin for supported workflows.

* **Documentation**
  * Added an inventory of reviewed skills, adoption notes, dependencies, and registration details.
  * Added a research plan for improving research and adversarial review within the wayfinder workflow, including verification findings and proposed safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->