### PR TITLE
docs(449): ticket-bound receipts — spec, 3-round review, hand-written pilot

### DIFF
--- a/docs/receipts/449.md
+++ b/docs/receipts/449.md
@@ -1,0 +1,99 @@
+# Receipt — #449: Wayfinder loop — research + adversarial review are not enforced
+
+**Verdict:** The receipt is defined as a hand-written, ticket-keyed artifact at
+`docs/receipts/<n>.md`; the automation that would enforce it is **deferred**, because three
+adversarial review rounds returned `do-not-build` on 42 findings (42 accepted, 0 refuted) and two
+probes showed the design's freshness gate could only ever fail and its one machine-verifiable control
+could not resolve its corpus under this repo's squash-merge strategy — so the next three
+`wayfinder:*` tickets run the template by hand and that pilot decides what, if anything, gets built.
+
+**Kind:** decision
+**Resolved:** 2026-07-31
+
+This is **instance #1** of the pilot, and it is the ticket that specified the pilot. If the template
+could not carry its own defining decision, nothing else would be worth trying.
+
+## Sources — what I actually opened
+
+- `gh issue view 449` — the scope items and the four findings the design had to answer.
+- `docs/specs/research-nudge-hooks.md` §§ "The problem", "What the harness actually offers",
+  Appendices A–D — the rejected design and its measured evidence base; the `permissionDecisionReason`
+  and `SubagentStart` facts come from here, sourced to the md5-verified hooks.md mirror.
+- `docs/research/kb/reports/agents/code-review-spec-axis-449.md` — the prior review's findings and
+  the corrections already applied.
+- `docs/issue-tracker.md` § "Wayfinding operations" — the GitHub mechanics (sub-issues, native
+  dependencies, `wayfinder:<type>` labels, the resolve sequence) the design had to fit.
+- `.claude/rules/agent-report-persistence.md` — why artifacts are tracked rather than on a throwaway
+  branch; the one deliberate divergence from wayfinder's own convention.
+- `hk-common.pkl:42-53` — the `excludePaths` list. **Decisive, and not anticipated:** it excludes
+  `docs/research/kb/**` from every hk builtin so a typo-fixer never edits a verbatim agent report.
+  That is why receipts live at `docs/receipts/`, not in the kb tree — filing them there would have
+  silently opted them out of every markdown check.
+- `python/src/dotfiles_setup/hook_guard.py:37-78, 616-700` — `Rule`, `match()`, `decide()`,
+  `pretooluse_main()`. Established that the guard emits **`deny` only**, which is what made a
+  redirect-shaped design far cheaper than an `ask`/`additionalContext` one.
+- `gh issue close --help` — the native escape flags (`--reason {completed|not planned|duplicate}`,
+  `--duplicate-of`). Read rather than assumed; they are why the design needed no invented opt-out.
+- `~/.claude/plugins/marketplaces/mattpocock/skills/engineering/wayfinder/SKILL.md` :23, :71, :115,
+  :125 — quoted via the session handoff, which carried them verbatim with line numbers.
+
+## Prior art — the search I ran
+
+**Query:** `grep -rilE 'receipt|attestation'` and `grep -rilE 'wayfinder'`
+**Corpus:** `docs/research/kb/reports/`, `docs/specs/`
+**Control arm:** `graphify` → 5+ hits (present); `zzznotarealtoken` → 0 hits (absent).
+Both arms fire, so the search discriminates.
+
+| Hit | What I did with it |
+|---|---|
+| `docs/research/kb/reports/agents/deep-research-takeover-20260730.md` | **Read.** The genuine topical hit — it is the chezmoi-vs-mise research whose re-derivation is one of the two misses #449 was filed about. Confirmed it is still the answer #448 needs and left it untouched. |
+| `docs/specs/research-nudge-hooks.md` | **Read in full.** The rejected design; its Appendices A–D are this work's evidence base. |
+| `docs/research/kb/reports/agents/code-review-spec-axis-449.md` | **Read in full.** Its C1/C2 corrections are already applied upstream. |
+| `docs/research/kb/reports/agents/graphify-mining.md` | **Dismissed** — matched "receipt" incidentally; about graph ingestion. |
+| `docs/research/kb/reports/agents/codex-nim-wiring.md`, `codex-nim-research.md` | **Dismissed** — incidental match; NIM/Codex wiring, unrelated. |
+| `docs/research/kb/reports/agents/currency-review-correctness.md`, `currency-review-silent-failure.md` | **Dismissed** — incidental match; tool-currency review. |
+
+⚠️ **What the search did not do, recorded because it is the point.** 4 of 7 hits were incidental
+word matches. A *generated and hash-verified* version of this table — which revision 3 of the spec
+specified — would have passed identically while telling you nothing more, because the machine can
+verify that **a** query ran, not that the **right** question was asked. That is the residual hole
+that decided against building it.
+
+## Adversarial review
+
+**Lens:** Codex (GPT-5.6) via `codex exec --ephemeral --sandbox read-only`,
+`model_reasoning_effort=high`, cross-family cold, **three rounds**
+**Verdict:** `do-not-build` — all three rounds
+**Findings:** 16 + 13 + 13 = **42**, all persisted verbatim at
+`docs/research/kb/reports/agents/codex-adversarial-449-receipt-spec.md`
+**Disposition:** **42 accepted, 0 refuted**, each with a fix or an explicit acceptance in the linked
+file's three disposition tables. Two were upgraded from the reviewer's `unverified` to measured:
+
+- Posting a comment **advances an issue's `updated_at`** (#433: comment `23:18:21Z`, updated
+  `23:18:22Z`; #434 likewise), so the spec's freshness gate **could only ever fail** — the exact
+  defect `.claude/rules/probes-need-a-control-arm.md` names, in a document citing that rule.
+- `git merge-base --is-ancestor feat/436-… origin/main` → **false** (control: `60d2558` → true), so a
+  feature-branch `corpus_sha` is unreachable from a fresh clone under squash-merge, breaking the one
+  machine-verifiable control by construction.
+
+Every finding was found **before a line of code existed**, which is the result the "spec first,
+review before building" decision was taken for.
+
+## Notes
+
+- **What ships:** `docs/receipts/TEMPLATE.md`, this receipt, and
+  `docs/specs/ticket-bound-receipts.md` as the design of record for what *would* be built.
+  **No `mise` task, no hook rule, no audit, no schema validator.**
+- **The pilot:** the next three `wayfinder:*` tickets get a hand-written receipt. Then judge which
+  fields earned their keep, whether anyone reads them, and whether query drift is real. Only then
+  reconsider automation.
+- **The scope Ray fixed (2026-07-31):** receipts bind `wayfinder:*` tickets only — 16 exist, 11 open.
+  Not every closed issue (57 all-time, 35 in the last 30 days), because a directory of near-empty
+  filler is the reflex the earlier review predicted for the `ask` dialog.
+- **One bug recurred in all three revisions:** the non-`wayfinder` branch of the resolve verb was
+  incoherent every time, in a different way each time. If the automation is ever revisited, that
+  branch is where the design does not want to be simple.
+- **Deliberate divergence from wayfinder:** its `SKILL.md:115` puts assets on a throwaway
+  `research/<name>` branch; this repo tracks them under `docs/` per
+  `.claude/rules/agent-report-persistence.md`, so they survive a clone. Recorded so a future session
+  does not "fix" it back.

--- a/docs/receipts/TEMPLATE.md
+++ b/docs/receipts/TEMPLATE.md
@@ -1,0 +1,63 @@
+# Receipt template — copy to `docs/receipts/<issue>.md`
+
+**Hand-written. There is no tool, and that is deliberate** — see
+`docs/specs/ticket-bound-receipts.md` § "Decision". Three adversarial review rounds killed the
+automation spine; this template is the pilot that runs in its place, on the next three
+`wayfinder:*` tickets, to find out which fields are worth anything before anything is built.
+
+**Fill it as you work, not at resolution time.** A receipt written from memory at close is the
+failure mode the whole exercise exists to catch. This is the same discipline
+`.claude/rules/notepad-enforcement.md` already requires.
+
+Delete this header block when you copy it. Delete nothing else — **an empty section is an answer**,
+and "none" written down is worth more than a section quietly removed.
+
+---
+
+# Receipt — #<n>: <ticket title>
+
+**Verdict:** <one sentence — the answer. This exact text goes in the resolution comment.>
+
+**Kind:** research | decision | task | none-required
+**Resolved:** <YYYY-MM-DD>
+
+## Sources — what I actually opened
+
+<Every primary source. A path in this repo, a URL, a doc page. If a decision is about a third-party
+tool and this list does not contain that tool's own docs, that is the miss #449 was filed about,
+visible on the page.>
+
+- `path/or/URL` — one line on what it settled
+- …
+
+**None opened:** <required if the list is empty — say why in a sentence.>
+
+## Prior art — the search I ran
+
+**Query:** `<the actual command or search terms>`
+**Corpus:** `docs/research/kb/reports/`, `docs/specs/`, …
+**Control arm:** `<a term known present> → N hits` / `<a term known absent> → 0`
+*(per `.claude/rules/probes-need-a-control-arm.md` — a 0-result search is not an answer until a
+control has run)*
+
+| Hit | What I did with it |
+|---|---|
+| `path` | read — <what it changed> **or** dismissed — <why it does not apply> |
+
+**Every hit gets a row.** Finding the prior art and not reading it is the exact failure this field
+exists to catch, and it is invisible unless the dismissal is written down.
+
+## Adversarial review
+
+**Lens:** codex-reviewer | grok-reviewer | /mattpocock-skills:code-review | none
+**Verdict:** clean | needs-attention | not-run
+**Findings:** <n> — <where the full report is persisted>
+**Disposition:** <accepted / refuted, and where the reasoning lives>
+
+**Not run:** <required if `lens: none` — say why in a sentence. "Not run" is a legitimate answer;
+a silently absent section is not.>
+
+## Notes
+
+<Anything the next reader needs: dead ends, what was nearly done and why it wasn't, what to
+re-check if this is revisited.>

--- a/docs/research/kb/reports/agents/codex-adversarial-449-receipt-spec.md
+++ b/docs/research/kb/reports/agents/codex-adversarial-449-receipt-spec.md
@@ -1,0 +1,476 @@
+# Codex adversarial review — `docs/specs/ticket-bound-receipts.md` (2026-07-31)
+
+Persisted verbatim per `.claude/rules/agent-report-persistence.md`. Run against the **first draft**
+of the #449 receipt spec, before any code existed — the point of reviewing a design rather than an
+implementation.
+
+- **Reviewer:** `codex exec --ephemeral --sandbox read-only -c model_reasoning_effort="high"`,
+  codex-cli 0.146.0 (GPT-5.6). Cross-family cold lens per
+  `feedback_refuters_and_cold_review_find_disjoint_defects`.
+- **Method:** the whole spec was piped in on stdin with an explicit *"do NOT read the disk, do NOT
+  run tools, do NOT load skill files"* instruction, so every finding is grounded in a quoted line of
+  the document and nothing is inherited from the repo. Codex was told to label anything it could not
+  ground as `unverified` — it labelled 10 items, reproduced below.
+- **Verdict: `do-not-build`.** 16 findings.
+
+---
+
+## Verbatim
+
+VERDICT: do-not-build
+
+FINDINGS:
+
+1. **The staleness model makes legitimate work fail while letting a false `base` pass.**
+
+   Scenario: work branches from commit A, edits `hk-common.pkl`, then reads and cites the finished file at commit B. Using the required branch point A makes the receipt stale because the cited file changed; using the scaffolded B passes but falsely claims B was the branch point.
+
+   Attacked lines: “`base: ... # full 40-char SHA of the branch point the work was done from`”; “**`local:`** | stale iff the path appears in `git diff --name-only <base>..HEAD`”; “`base` filled from `git rev-parse HEAD`”.
+
+2. **L1 can close a ticket using an untracked receipt that immediately disappears.**
+
+   Scenario: an agent scaffolds `docs/receipts/449.md`, never commits it, runs `mise run resolve -- 449`, and then deletes the checkout. The issue is closed and commented, but the supposedly durable artifact never reaches the repository; L3 can only complain later.
+
+   Attacked lines: “**Tracked, one file per ticket**”; “**Receipt exists** at `docs/receipts/<n>.md`, parses, `issue:` matches the filename.”
+
+3. **Removing or omitting a label disables every receipt control, including the claimed full-coverage audit.**
+
+   Scenario: a decision-shaped ticket is filed without `wayfinder:*`, or the label is removed immediately before closure. L1 skips validation and L3 no longer includes it in “every closed-as-completed `wayfinder:*` issue,” so the closure permanently passes without a receipt.
+
+   Attacked lines: “**If it carries no `wayfinder:*` label → skip every receipt check**”; “The scope is a hand-applied label, so exemption is the default”; “including retroactively, since a label can be removed.”
+
+4. **The allowed close reasons form a second complete bypass.**
+
+   Scenario: a `wayfinder:*` ticket representing completed work is closed with `gh issue close 449 --reason "not planned"`. L2 explicitly permits it, while L3 audits only `closed-as-completed` issues, so no receipt is ever required.
+
+   Attacked lines: “Native escapes stay native — `--reason "not planned"`, `--reason duplicate`, `--duplicate-of <n>` are **allowed unchanged**”; “every closed-as-completed `wayfinder:*` issue has a well-formed, non-stale receipt.”
+
+5. **`prior_art` does not make research happen; it only makes fabrication slightly more verbose.**
+
+   Scenario: without running any search, an author writes `query: "chezmoi hooks"`, `hits: 1`, a plausible control count, and a known report path. Every declared value validates, yet the allegedly prospective work never happened.
+
+   Attacked line: “`hits` and `control` cannot be filled without running the search. This is the one field that makes the work happen rather than merely recording it.”
+
+6. **The schema validates presence, not semantic coherence.**
+
+   Scenario: a receipt says `review.lens: none`, `review.verdict: clean`, `review.findings: 5`, and `review.disposition: ""`. All fields are present, and the only explicit non-empty constraint applies to `sources`, so a contradictory receipt may be considered well formed.
+
+   Attacked lines: “**Every field is REQUIRED. `none` / `not-run` / `none-required` are legal values; omission is not.**”; “**Every required field present**, `sources` non-empty unless `kind: none-required`.”
+
+7. **`kind: none-required` is the reflexive checkbox the design claims to prevent.**
+
+   Scenario: authors discover that selecting `none-required` avoids documenting sources and use it for routine closures. The gate accepts the value without requiring a reason, approver, ticket category, or objective eligibility test.
+
+   Attacked lines: “`[]` is illegal; use `kind: none-required`”; “What stops it becoming the default answer, the way F3 predicted for the `ask` dialog?”
+
+8. **The non-wayfinder path jumps to an operation whose input does not exist.**
+
+   Scenario: `mise run resolve -- 123` reads an unlabeled ticket, skips the receipt checks, and jumps to step 5. Step 5 must post `verdict`, but no receipt was required or parsed, so the task must crash, post an empty value, or rely on behavior absent from the spec.
+
+   Attacked lines: “If it carries no `wayfinder:*` label → skip every receipt check and go to step 5”; “Post `verdict` as the **resolution comment**.”
+
+9. **The canonical verb is non-transactional but is described as fail-closed.**
+
+   Scenario: posting the verdict succeeds, closing fails transiently, and retrying posts a duplicate comment. Worse, closing succeeds and the map append fails: the command reports failure after the ticket is already closed, with no rollback or resumable-state definition.
+
+   Attacked lines: “It does, in order, failing closed at the first red step”; steps 5–7: “Post `verdict`,” “`gh issue close`,” then “**Append the context pointer**.”
+
+10. **L3 is neither full coverage nor enforcement at closure time.**
+
+   Scenario: a ticket is closed from the web without a receipt and no later `mise run land` occurs. The invalid closure is never examined. If a later unrelated PR lands, the audit runs only after that merge and can report damage it could not prevent.
+
+   Attacked lines: “**L3 — the retrospective audit. Full coverage, after the fact.**”; “Wiring: run it inside `mise run land` (the repo's existing post-merge gate).”
+
+11. **Auditing all historical receipts for current staleness guarantees accumulating false failures.**
+
+   Scenario: a valid 2026 receipt cites `hk-common.pkl`. In 2027 that file changes for unrelated reasons. Every future audit now declares the historical receipt stale, even though it accurately records the evidence used for the 2026 decision. Repair requires rewriting history’s attestation or weakening the audit.
+
+   Attacked lines: “every closed-as-completed `wayfinder:*` issue has a well-formed, **non-stale receipt**”; “stale iff the path appears in `git diff --name-only <base>..HEAD`.”
+
+12. **Any later substantive ticket edit can invalidate a completed receipt indefinitely.**
+
+   Scenario: after closure, the owner adds a clarification to the ticket body. The receipt’s base now predates the latest substantive edit, so future land operations fail even though the resolution process was valid when performed.
+
+   Attacked line: “receipt `base` predates the ticket's last substantive body edit | ... | **yes**.”
+
+13. **The audit cannot identify “the resolution comment” because the receipt stores no comment identity.**
+
+   Scenario: an older discussion comment happens to contain the same verdict text, while L1’s actual comment post fails. The ticket is manually closed; L3 finds matching text somewhere in the comments and passes, unless it relies on an unspecified heuristic.
+
+   Attacked lines: “every `verdict` matches its posted resolution comment”; “`verdict` in the receipt *is* the text L1 posts as the comment.”
+
+14. **The build order has no migration plan and can strand unrelated work.**
+
+   Scenario: step 3 audits the five already-closed wayfinder tickets, but step 1 creates only `449.md`. Turning that audit blocking later makes every land fail on inherited debt. Step 5 then denies the raw close command still emitted by the documented Wayfinder skill, but updating that skill is absent from the build order.
+
+   Attacked lines: “`docs/receipts/449.md` as the worked first instance”; “`dotfiles-setup receipts audit` ... non-blocking at first”; “the skill will still emit the raw commands, and L2 denies one of them mid-sequence”; “Steps 1–5 are the spec's substance.”
+
+15. **The headline 55% measurement does not measure the population being governed.**
+
+   Scenario: all nine unseen recent closures may be non-wayfinder tickets, while the scoped history is 5-of-5 hook coverage. That does not prove L3 is unnecessary, but it does mean the cited measurement cannot quantify the scoped failure it is used to justify.
+
+   Attacked lines: “a PreToolUse hook on `gh issue close` covers ~55% of *all* resolutions”; “on the population this spec actually binds, coverage is 5 of 5”; “The full-coverage layer (§4.2 L3) is justified by the 55%.”
+
+16. **The design is over-built around attestations while its only prospective control remains unauditable.**
+
+   Scenario: seven layers are implemented, but an author can still invent the `prior_art` values, choose `none-required`, remove the label, or use a non-completed reason. The reminders and subagent hooks add surface area without repairing the enforcement boundary.
+
+   Attacked lines: “A receipt is an **attestation, not a proof**”; “If only one of the two ships, ship `prior_art`”; “Steps 1–5 are the spec's substance. 6–7 are additive.”
+
+   A cheaper design would generate prior-art evidence through one executable command that records the exact query, corpus revision, tool version, and result hashes; require that generated receipt to be committed on the protected branch before closure; and validate closure through a GitHub-side event check. Cut L4 and L5 unless measured failures later justify them.
+
+WHAT YOU COULD NOT CHECK:
+
+- `unverified`: The issue counts, label counts, transcript counts, and 5-of-5 scoped coverage measurements.
+- `unverified`: Whether the transcript extractor correctly distinguishes unseen closes from extraction failures.
+- `unverified`: The claimed Claude hook output semantics, timeout behavior, and delivery of `permissionDecisionReason`.
+- `unverified`: Whether `hook_guard.py` can reliably distinguish completed closes from the allowed native escape forms.
+- `unverified`: Whether `mise run land` is truly post-merge and whether failures there block any meaningful state transition.
+- `unverified`: Whether GitHub exposes enough history to determine a ticket’s “last substantive body edit.”
+- `unverified`: The claimed existing repository rules, lint exclusions, Wayfinder behavior, and persistence guarantees.
+- `unverified`: Whether map updates are local-file edits or GitHub mutations, and whether concurrent appends can lose data.
+- `unverified`: How L3 selects the specific resolution comment or handles edited, deleted, duplicated, and reordered comments.
+- `unverified`: Whether historical closed wayfinder tickets will be backfilled before the audit becomes blocking.
+---
+
+## Disposition by the main session
+
+**All 16 accepted.** Not one was refuted. That is itself the finding: a one-pass design document
+fails a cold adversarial lens comprehensively, and it cost zero implementation to learn.
+
+| # | Claim | Disposition | Fix in the revised spec |
+|---|---|---|---|
+| 1 | Staleness model fails legitimate work / passes a false `base` | **ACCEPTED** | Global `base` demoted to provenance. Staleness is **per-source blob hash** recorded at read time, and is **advisory, never blocking**. §3 |
+| 2 | L1 can close on an **uncommitted** receipt | **ACCEPTED — sharp** | L1 requires the receipt to be tracked *and* clean: `git ls-files --error-unmatch` + `git diff --quiet HEAD --`. §4.2 |
+| 3 | Removing/omitting the label disables every control | **ACCEPTED** | L3 audits by label **history** via the timeline, not current labels. ⚠️ Control-arm gap: `labeled` events are observable (13 in the repo's last 100), but `unlabeled` → **0**, so the removal half is documented-but-unobserved here. Recorded as such. §4.2 L3 |
+| 4 | `--reason "not planned"` is a second complete bypass | **ACCEPTED** | L3 audits **every** closed wayfinder ticket regardless of `stateReason`; a non-completed close on one is itself a finding. §4.2 L3 |
+| 5 | `prior_art` is fabricable — it does not make research happen | **ACCEPTED — the most valuable finding** | The field is no longer typed. `mise run receipt -- <n> --prior-art "<query>"` **runs** the search and writes the query, corpus commit, hit paths and result hash. §1.2, §6 |
+| 6 | Schema validates presence, not coherence | **ACCEPTED** | Explicit cross-field rules (`lens: none` ⇒ `verdict: not-run`; `findings > 0` ⇒ `disposition` non-empty). §1.2 |
+| 7 | `kind: none-required` is the reflexive checkbox | **ACCEPTED** | It now requires a written `reason`, does **not** exempt `prior_art`, and its rate is reported. §1.2, §4.2 L3 |
+| 8 | Non-wayfinder path jumps to a step whose input does not exist | **ACCEPTED — plain spec bug** | `resolve` takes `--verdict` for tickets that need no receipt. §4.2 L1 |
+| 9 | The verb is non-transactional but described as fail-closed | **ACCEPTED** | Every step made **idempotent and resumable**; re-running completes the remainder. §4.2 L1 |
+| 10 | L3 is neither full coverage nor at closure time | **ACCEPTED** | Reframed: L3 covers every close *route*, not every *moment*. Delivery changed to a **standing upserted issue** (the `tool-currency` pattern) plus PR-scoped blocking. §4.2 L3 |
+| 11 | Historical receipts accumulate false staleness | **ACCEPTED** | A closed ticket's receipt is **frozen** — never re-staleness-checked. §3 |
+| 12 | A later ticket edit invalidates a valid receipt forever | **ACCEPTED** | The ticket-edit check applies **only before close**. §3 |
+| 13 | The audit cannot identify "the resolution comment" | **ACCEPTED** | L1 writes the posted comment's `id` back into the receipt. Probe-confirmed the identity exists and is retrievable (`issues/433/comments` → `id`, `html_url`). §1.2, §4.2 L1 |
+| 14 | Build order strands the repo on inherited debt | **ACCEPTED** | Step 1 **backfills the 5 already-closed** wayfinder receipts; the audit never blocks on debt it did not introduce; `docs/issue-tracker.md` is updated in the same step as the hook redirect. §8 |
+| 15 | The 55% does not measure the governed population | **ACCEPTED — and now measured, not conceded** | Codex could only say the 9 unseen closes *may* be non-wayfinder. Probed: **0 of 9 carry a `wayfinder:*` label** (`auto-queue`, `bug`, `question`, or none). So the scoped observed miss rate is **0 of 5**, and 55% is an upper bound from a different population. L3 is now justified by the **mechanism** (close routes the hook structurally cannot see), never by the rate. §0, §4.2 L3 |
+| 16 | Over-built; the one prospective control is unauditable | **ACCEPTED in part** | Its concrete proposal (generate prior-art evidence by command) is adopted verbatim as the fix for #5. **L5 (`UserPromptSubmit`) is cut entirely**; L4 (`SubagentStart`) stays explicitly optional. |
+
+### On the `unverified` list
+
+All 10 are correctly labelled — Codex was denied disk access by design, so it could not check the
+repo-side claims. Four were verified here afterwards: the label-event mechanism (#3, with the gap
+noted), the comment identity (#13), the wayfinder-label population (#15), and `gh issue close`'s
+native reason flags. The rest are repo facts cited with their sources in the spec.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the spec under review, and the
+  issue/label/timeline probes behind the disposition table.
+
+---
+
+# Round 2 — same reviewer, revision 2 of the spec
+
+Same invocation and same no-disk constraint as round 1. Codex was told round 1's 16 findings were
+**all accepted** and shown the revision that answers them, with an explicit instruction not to
+re-litigate a closed finding unless the fix was wrong or incomplete.
+
+**Verdict: `do-not-build`.** 13 findings. Six of round 1's confirmed closed (F4, F6, F8's missing
+input, F13's data model, F15, F16); the rest were re-opened as incompletely fixed.
+
+## Verbatim
+
+## VERDICT: `do-not-build`
+
+Revision 2 is materially better, but it is not executable as specified. The primary resolution path invalidates its own committed-receipt prerequisite, the first build step requires tooling that does not exist until step 2, and the backfill would describe present-day reconstruction as historical decision provenance. More fundamentally, L1 blocks on paperwork completeness while allowing irrelevant sources and a deliberately useless but genuinely executed prior-art query.
+
+## FINDINGS
+
+1. **L1 dirties the receipt after verifying it is committed, then closes the ticket against an uncommitted receipt.**
+
+   Scenario: Step 3 confirms `449.md` is clean. Step 5 posts the comment and writes its ID into `449.md`, making it dirty. Step 6 closes the issue immediately. HEAD still contains an empty `resolution_comment`; the working tree contains the only valid version. If the task instead stops for a commit, it is neither one-shot nor self-converging as claimed.
+
+   Attacks: “**Receipt is committed** … `git diff --quiet HEAD -- docs/receipts/<n>.md`.” / “**write that id back into the receipt** as `resolution_comment`.” / “`gh issue close <n> --reason completed`.” / “re-running the verb completes whatever remains.”
+
+2. **The unlabelled-ticket branch jumps to a step that requires the receipt it explicitly skipped.**
+
+   Scenario: Resolve an ordinary unlabelled issue with `--verdict`. Step 1 skips every receipt check and jumps to step 5; step 5 must write `resolution_comment` into `docs/receipts/<n>.md`, which need not exist. Either the command fails, silently creates an out-of-scope receipt, or closes without recording the ID.
+
+   Attacks: “**No `wayfinder:*` label → skip every receipt check**, require an explicit `--verdict "<text>"` argument, and go to step 5.” / “**write that id back into the receipt** as `resolution_comment`.”
+
+3. **Build step 1 cannot satisfy the schema because generated `prior_art` does not exist until build step 2.**
+
+   Scenario: Step 1 must create six valid receipts, while `prior_art` is required for every kind and may never be typed. The only authorized generator ships in step 2. Step 1 must therefore violate the schema, hand-manufacture purported tool output, or depend on unshipped code. It is not independently safe or useful.
+
+   Attacks: “`prior_art`: **GENERATED by `mise run receipt -- <n> --prior-art`. Never typed.**” / “**`prior_art` is required for EVERY `kind`**.” / Build order step 1: “backfill all 5 … + `449.md`.” / Step 2: “`mise run receipt -- <n>` incl. `--prior-art` generation.”
+
+4. **The backfill manufactures decision provenance that cannot now be known.**
+
+   Scenario: An author opens a source and runs prior-art search today for #433. The receipt then truthfully records what was opened today, but the corpus treats it as “how a decision was reached” before that ticket closed. `review: not-run` does not repair fabricated historical `sources`, `prior_art`, or `verified_at` semantics.
+
+   Attacks: “a durable, ticket-keyed record of **how a decision was reached**.” / “`sources:` — **what was ACTUALLY opened**.” / “backfill all 5 already-closed wayfinder tickets.”
+
+5. **“Generated” has no machine-verifiable meaning in the proposed validator, so the central fabrication fix only relocates the lie.**
+
+   Scenario: An author types a plausible query, corpus SHA, hit list, timestamp, and random `result_sha256`. Every field and cross-field rule passes. Neither L1 nor L3 is specified to rerun the search and compare its exact output. The act is more deliberate than filling revision 1’s field, but acceptance remains structurally identical.
+
+   Attacks: “**`prior_art` is generated, never typed.**” / “Schema valid … `prior_art` generated.” / “This is still forgeable … reproducible-checkable after the fact.”
+
+6. **Even an authentic generated block can be a valid no-op and does not establish that prior art was examined.**
+
+   Scenario: Run the real generator with an irrelevant query such as a ticket number or generic phrase that yields zero useful hits. The receipt passes because the search genuinely executed. Alternatively, it finds the relevant report but the author never opens it; nothing requires a hit to appear in `sources`. The observed re-derivation failure remains possible.
+
+   Attacks: “`--prior-art "<query>"`.” / “Running the search surfaces that file.” / “the only control worth anything is the one that executes.”
+
+7. **The staleness model contradicts itself: L3 promises statistics that §3 forbids it from computing.**
+
+   Scenario: L3 audits closed tickets and claims to report staleness. Section 3 says closed receipts are never re-staleness-checked. No close-time staleness result is stored, so L3 has neither permission nor persisted data from which to produce the statistic.
+
+   Attacks: “Once a ticket is closed … **never re-staleness-checked**.” / L3: “`kind: none-required` rate, **and staleness, reported as statistics**.”
+
+8. **L3 has no specified high-frequency trigger, so its route coverage may never execute.**
+
+   Scenario: A web-UI or auto-close bypass occurs. Nobody manually runs the audit, and no PR is merged through `mise run land` afterward. The standing issue remains stale forever. Defining an audit command and an upsert destination is not a delivery schedule.
+
+   Attacks: “**The standing audit. Every close route, at a high frequency.**” / “delivered as a **standing upserted issue**.” / “`mise run land` prints the current audit summary post-merge.”
+
+9. **Crash recovery depends on an undefined receipt marker that conflicts with the exact-comment contract.**
+
+   Scenario: The API creates the comment, then the process dies before recording its ID. On retry, the task must find a comment “carrying the receipt marker,” but the posted body is specified to be the exact `verdict`, and no marker format is defined. It either duplicates the comment or changes the body so it no longer exactly matches `verdict`.
+
+   Attacks: “Posting checks for an existing comment **carrying the receipt marker**.” / “This exact text is posted as the ticket’s resolution comment.” / “Post `verdict` as the **resolution comment**.”
+
+10. **The step-5 fix updates documentation but leaves the known raw-close emitter unchanged.**
+
+    Scenario: Wayfinder follows its own emitted `gh issue close` command. The new hook denies it mid-sequence. Updating `docs/issue-tracker.md` may educate a human, but it does not change the skill output that the spec itself identifies as incompatible.
+
+    Attacks: “the **wayfinder skill still emits the raw `gh issue close`, which L2 will deny mid-sequence**.” / “`docs/issue-tracker.md` … updated in the same change.”
+
+11. **The map update happens after the irreversible remote outcome and has no durability gate.**
+
+    Scenario: The comment is posted and the ticket closes; appending the map then fails or merely dirties a local file. The primary outcome has completed, the user has little reason to rerun, and neither L1 nor L3 checks whether the pointer was committed.
+
+    Attacks: “`gh issue close <n> --reason completed`.” / “**Append the context pointer to the map’s Decisions-so-far**.”
+
+12. **L1 has a race between validation and closure, while `verified_at` is only date-granular.**
+
+    Scenario: The ticket body changes after step 4’s validation but before steps 5–6. The task posts and closes using a receipt verified against the earlier body. A date such as `2026-07-31` cannot order two same-day edits even without a race.
+
+    Attacks: “`verified_at: 2026-07-31`.” / “`verified_at` predates the ticket’s last substantive body edit.” / “Order, failing closed at the first red step.”
+
+13. **Step 6 can inject incorrect ticket context because “the current ticket” is undefined.**
+
+    Scenario: A session delegates work unrelated to the active wayfinder issue—or has several tickets in context. Every subagent receives one receipt path and prior-art corpus without any specified ticket-resolution mechanism, contaminating unrelated work.
+
+    Attacks: “Injects `additionalContext` into **every delegated agent: the receipt path for the current ticket**.”
+
+## Round-1 findings genuinely closed
+
+These revisions are real improvements:
+
+- F4 is closed conceptually: the audit now includes every close reason.
+- F6 is closed: review cross-field combinations are explicitly validated.
+- F8’s missing input is closed: unlabelled tickets now require `--verdict`, although the new jump-to-step-5 bug remains.
+- F13’s identity ambiguity is solved at the data-model level by storing the comment ID, although its write ordering is broken.
+- F15 is closed: the 55% statistic is no longer misapplied to the scoped population.
+- F16 is closed: L5 was removed.
+
+F2, F3, F5, F9, F10/F14, and the staleness findings are not fully closed for the reasons above.
+
+## Build-order safety
+
+| Step | Assessment |
+|---|---|
+| 1 | **Unsafe:** impossible before the generator exists and historically misleading. |
+| 2 | **Insufficient:** safe as scaffolding, but neither authenticity nor query relevance is enforced. |
+| 3 | **Non-blocking but incomplete:** no invocation schedule; staleness reporting contradicts §3. |
+| 4 | **Unsafe:** closes against a newly dirtied receipt and has an unlabelled-path failure. |
+| 5 | **Unsafe:** activates a denial before the known raw-close emitter is actually changed. |
+| 6 | **Not justified as written:** optional, unobserved benefit, and “current ticket” resolution is undefined. |
+
+## Decisive answers to §11
+
+1. **It relocates fabrication; it does not resist it at acceptance time.** Resistance requires L1 to rerun a deterministic, versioned search against a clean, identified corpus and compare the generated block.
+
+2. **Advisory staleness can be useful as a pre-close diagnostic, but the post-close statistic is currently fiction.** Either store the close-time result or remove staleness from L3. URL age also needs a defined threshold before “stale” has meaning.
+
+3. **Forty characters are a longer checkbox, not a substantive bar.** Use enumerated eligibility conditions, independent review, or accept that `none-required` is an unrestricted opt-out.
+
+4. **Yes.** Without a scheduled invocation, named owner, response expectation, and escalation/closure rule, the standing issue is merely a passive sink.
+
+5. **Steps 1–5 are too much machinery in their present form.** The issue is not merely “twice on one ticket”; the machinery’s only research control still permits a valid irrelevant search, while its primary state machine is unsafe. A much smaller corrected design might earn its cost, but this one has not.
+
+6. **Yes, ordinary backfilled receipts poison the corpus.** Add a distinct `pre-dates-policy` kind or an explicit grandfathered baseline. Record only objective facts recoverable now—ticket identity, existing resolution comment ID, close state/date, and links to surviving artifacts. Do not populate historical `sources`, `prior_art`, review, or “how reached” claims.
+## Disposition of round 2 by the main session
+
+**All 13 accepted; one accepted in part.** Combined with round 1 that is **29 of 29** findings
+accepted across two rounds without a single refutation — which is the strongest available evidence
+that reviewing the design rather than the implementation was the right call.
+
+| # | Claim | Disposition | Fix in revision 3 |
+|---|---|---|---|
+| 1 | L1 dirties the receipt after verifying it committed, then closes against it | **ACCEPTED — the sharpest finding of either round** | `resolution_comment` is **deleted from the schema**. The binding moves into the *comment*: a machine-readable footer `<!-- receipt: docs/receipts/<n>.md@<sha> -->`. The receipt is never mutated after it is committed. Kills #1, #2 and #9 together. |
+| 2 | The unlabelled branch jumps to a step that writes the receipt it skipped | **ACCEPTED** | Dissolved by #1's fix — no step writes a receipt. |
+| 3 | Build step 1 needs the generator that ships in step 2 | **ACCEPTED — plain ordering bug** | Order swapped: the generator ships first, then the schema's first live instance. |
+| 4 | The backfill manufactures decision provenance | **ACCEPTED** | Backfill drops to `kind: pre-dates-policy` carrying **only objectively recoverable facts** — ticket id, close date, existing comment, surviving artifact links. **No `sources`, no `prior_art`, no `review`, no "how reached" claim.** Codex's §11 Q6 answer adopted verbatim. |
+| 5 | "Generated" has no machine-verifiable meaning; the fix relocates the lie | **ACCEPTED — and the fix is now real** | `mise run resolve` **re-runs the prior-art search itself** against the recorded `corpus_sha` (deterministic: a local search over a tracked corpus at a fixed SHA) and compares `result_sha256`. Fabrication becomes detectable at acceptance, not merely afterwards. |
+| 6 | An authentic search can be a valid no-op — irrelevant query, or hits never opened | **ACCEPTED** | Every `prior_art` hit must appear in `sources` **or** carry an explicit `dismissed:` reason. Closes the found-but-never-opened half. ⚠️ The irrelevant-query half **cannot be closed by machine** and is recorded as a residual hole, not papered over. |
+| 7 | L3 promises staleness statistics §3 forbids it computing | **ACCEPTED — real self-contradiction** | Staleness removed from L3 entirely. It is a **pre-close diagnostic only**. |
+| 8 | L3 has no invocation schedule, so its coverage may never run | **ACCEPTED** | Wired to the existing scheduled `refresh.yml`, the same trigger that upserts the `tool-currency` standing issue. A named trigger, not an aspiration. |
+| 9 | Undefined marker conflicts with the exact-comment contract | **ACCEPTED** | Dissolved by #1's fix; the footer *is* the marker and it is defined. |
+| 10 | Updating the doc does not change the skill's emitted raw close | **ACCEPTED IN PART** | True that it is instruction-following, not enforcement. But the mechanism is **precedented and working**: `docs/issue-tracker.md` is what the wayfinder skills read for tracker conventions, and it already redirects `gh pr create` → `mise run ship` the same way. The guard's deny reason reaches Claude, so a mid-sequence denial is recoverable rather than terminal. Recorded as a known weakness with its precedent, not as solved. |
+| 11 | The map append happens after the irreversible close, with no durability gate | **ACCEPTED** | Order changed to validate → comment → **map append** → close. The least recoverable step goes last. |
+| 12 | Validate/close race, and `verified_at` is date-granular | **ACCEPTED** | `verified_at` becomes a full ISO-8601 timestamp; the ticket's `updated_at` is re-checked immediately before close. |
+| 13 | `SubagentStart`'s "current ticket" is undefined | **ACCEPTED** | **L4 is cut.** Combined with L5's removal in revision 2, the design is now only its enforcement spine. |
+
+### On §11 Q5 — "is this too much machinery for a failure observed twice?"
+
+Codex's answer: *"Steps 1–5 are too much machinery in their present form… A much smaller corrected
+design might earn its cost, but this one has not."* Taken. Cutting L4, L5 and the backfill leaves
+four things — generate prior art, verify it at resolve, redirect the close, report on a schedule.
+That spine is what revision 3 specifies. The judgement that it earns its cost is the author's and is
+flagged for Ray explicitly rather than assumed.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the spec under review across
+  both rounds, and the issue/label/timeline/transcript probes behind the disposition tables.
+
+---
+
+# Round 3 — same reviewer, revision 3 of the spec
+
+Same invocation, same no-disk constraint. Codex was shown §10's table of what rounds 1–2 forced and
+told not to re-litigate closed findings. It was asked directly whether the honest answer to §11 Q6 is
+"do it by hand three times first", and told to say so unambiguously if it was.
+
+**Verdict: `do-not-build`.** 13 findings. Its closing line: *"Revision 3 is better than revision 2
+because it removed ineffective layers and the post-commit mutation, but it introduced an incoherent
+L1 branch and still lacks a reproducible, durable verification protocol."*
+
+## Verbatim
+
+VERDICT: `do-not-build`
+
+## FINDINGS
+
+1. **The non-wayfinder branch is internally impossible.** A non-wayfinder ticket jumps to step 5 without a receipt, but step 5 needs `prior_art`, step 6 needs `verified_at`, and step 7 requires a receipt footer. Scenario: `mise run resolve -- 418 --verdict "Done"` reaches step 5 and has no `corpus_sha` to search. Attacked: **“No `wayfinder:*` label → skip every receipt check … and jump to step 5. Nothing in steps 5–8 touches a receipt.”**
+
+2. **The freshness check probably invalidates itself (`unverified`).** If posting a GitHub comment advances the issue’s `updated_at`, step 7 changes the value step 9 requires to remain unchanged; the first run posts but cannot close, while subsequent runs reject the receipt as stale because the tool’s own comment is newer than `verified_at`. Attacked: **“Re-check `updated_at` is unchanged since step 6.”**
+
+3. **“Committed” is still not durable.** Step 3 accepts a receipt committed only on a local or disposable feature branch. Scenario: resolve posts the footer and closes the ticket, then the branch is abandoned or never pushed; the durable repository has neither receipt nor referenced blob. Attacked: **“Receipt is committed and clean — `git ls-files --error-unmatch` and `git diff --quiet HEAD --`.”**
+
+4. **`result_sha256` is not reproducible because the byte protocol is unspecified.** “Raw search output” varies with search engine and version, regex interpretation, config files, locale, path order, path prefix, line endings, color, and final newline. Two correct implementations can reject each other’s valid receipts. Attacked: **“That is deterministic and cheap … the output either hashes to `result_sha256` or it does not.”**
+
+5. **The verified hash does not bind the declared hit list.** The stated verifier compares only `result_sha256`; the schema merely requires every *listed* hit to have a resolution. Scenario: a real search finds an inconvenient report, the author deletes that item from `hits`, retains the genuine raw-output hash, and passes. Attacked: **“Re-run the recorded `query` … and compare `result_sha256`”** and **“Requiring every hit to be read or dismissed in writing closes the ‘found it and ignored it’ half.”**
+
+6. **L3 does not execute the sole machine-verifiable control on the routes it exists to cover.** The audit checks for a “well-formed” receipt but does not say it re-runs prior-art verification. Scenario: a web close bypasses L1; a later hand-written receipt with a random hash satisfies schema and clears the retrospective audit. Attacked: **“Every closed wayfinder ticket … has a committed, well-formed receipt.”**
+
+7. **Cutting the backfill contradicts the audit’s universal scope.** The optional baseline leaves all five existing closed wayfinder tickets in immediate violation. The first scheduled run therefore creates known inherited debt, undermining the claimed false-positive measurement and training users to ignore the standing issue. Attacked: **“Every closed wayfinder ticket … has a committed, well-formed receipt”** versus **“Optional, separately decidable: a `pre-dates-policy` baseline for the 5 closed wayfinder tickets.”**
+
+8. **`corpus_sha` is not durable in the stated squash-merge workflow.** A receipt generated against a feature-branch commit can survive squash as a file while the recorded commit becomes unreachable from a fresh clone; `git show <corpus_sha>:<path>` then cannot reproduce anything. Attacked: **“Re-run it via `git show <corpus_sha>:<path>`”** and **“this repo squash-merges.”**
+
+9. **The footer binds a blob marker, not the comment’s asserted verdict.** L3 checks that a comment contains the marker, but not that its body equals `verdict`; editing the comment while retaining the footer—or attaching the marker to unrelated text—passes. Attacked: **“The two are kept from drifting by the footer.”**
+
+10. **The shown seven-hex footer is not an exact identity.** A short Git abbreviation can become ambiguous as the object database grows; it is also not enough to establish reachability at the recorded path. Use the full object ID and specify the Git object format. Attacked: **“Identity … by an exact marker”** and **“`<!-- receipt: docs/receipts/449.md@8f2e1c9 -->`.”**
+
+11. **The map append has no specified idempotency key.** Scenario: step 8 succeeds and the process dies before step 9; rerunning can append the same pointer twice even though the comment is deduplicated. Attacked: **“Every step is idempotent and the verb is resumable.”**
+
+12. **The final freshness check still has an unavoidable race.** A human can edit the ticket after step 9’s read but before `gh issue close`; the tool then closes against evidence verified for the previous state. Attacked: **“the order is load-bearing, because the least recoverable action goes last.”** The spec must either name this as residual TOCTOU or use a real conditional mutation if GitHub offers one.
+
+13. **The implementation remains disproportionate to its evidence.** Two misses on one ticket do not justify two commands, a schema, validator, audit command, CI contract, scheduled workflow, standing issue, resolver, hook rule, and documentation mutation—especially when the only executed control accepts a bad query. Attacked: **“Steps 1–5 remain. Is the spine now proportionate…?”**
+
+## §11 ANSWERS
+
+1. **No.** It becomes deterministic only after defining a versioned canonical search protocol: engine and version, query semantics, ignored configuration, locale, corpus enumeration and sorting, encoding/error policy, output schema, newline rules, and canonical serialization. Hash canonical structured results, not tool stdout.
+
+2. **A current corpus change should not break it if the old snapshot is searched exactly.** The receipt directory is outside the stated corpus. The real problem is availability: a feature-branch `corpus_sha` may disappear after squash or may not exist in another clone.
+
+3. **A full blob OID is stable across amend, rebase, and squash if the receipt bytes remain identical.** The commit changing does not change the blob. But the shown short prefix is inadequate, and a blob OID proves neither path nor durable repository reachability. If the bytes change, the old comment binds the old receipt and a rerun may post a second resolution comment.
+
+4. **No—cutting `SubagentStart` was correct.** It would not have fired for either observed failure and would not prove delegated research was read or understood. Delegation remains subject to the same receipt attestations; adding instrumentation would be theater.
+
+5. **It is fatal to the claim that the executed control prevents the observed prior-art failure.** It is not fatal to a receipt’s value as a reviewed manual record. The machine verifies that *a query* ran, not that the necessary search happened.
+
+6. **Yes: do it by hand for the next three wayfinder tickets.** Use a fixed template, manually record searches and resolutions, and measure actual repetition, review value, query drift, and failure modes. Do not build the automation spine before that pilot.
+
+Revision 3 is better than revision 2 because it removed ineffective layers and the post-commit mutation, but it introduced an incoherent L1 branch and still lacks a reproducible, durable verification protocol.
+---
+
+## Disposition of round 3 by the main session
+
+**All 13 accepted. Two were verified by direct probe, and both are decisive.**
+
+### The two that end the build
+
+**F2 — the freshness check can only fail. CONFIRMED BY MEASUREMENT.**
+Codex marked this `unverified` because it could not reach GitHub. Probed:
+
+| Issue | last comment `created_at` | issue `updated_at` |
+|---|---|---|
+| #433 | `2026-07-30T23:18:21Z` | `2026-07-30T23:18:22Z` |
+| #434 | `2026-07-31T00:21:59Z` | `2026-07-31T00:22:03Z` |
+
+Posting a comment **advances `updated_at`**. So L1 step 7 posts the verdict and step 9 then requires
+`updated_at` to be *unchanged* — a gate that **can never pass**. That is precisely the failure class
+`.claude/rules/probes-need-a-control-arm.md` exists to name ("a check that can only fail"), written
+into a spec that cites that rule.
+
+**F8 — `corpus_sha` is unreachable after a squash merge. CONFIRMED BY MEASUREMENT.**
+`git merge-base --is-ancestor feat/436-builder-skills-and-research-loop origin/main` → **false**
+(control: `60d2558` → true). This repo squash-merges, so a commit recorded on a feature branch is not
+an ancestor of `main` and `git show <corpus_sha>:<path>` cannot resolve it in a fresh clone. The
+prior-art re-verification — **the only machine-verifiable control in the entire design** — breaks by
+construction under the repo's own merge strategy.
+
+### The rest
+
+| # | Claim | Disposition |
+|---|---|---|
+| 1 | The non-wayfinder branch is internally impossible — jumps to a step needing `prior_art`/`verified_at`/footer | **ACCEPTED.** Revision 3 renumbered the steps and left the branch pointing at the wrong one. Third revision, third incarnation of the same bug: the unlabelled path has never once been coherent. |
+| 3 | "Committed" is not durable — a local or abandoned branch passes | **ACCEPTED.** The check proves the bytes are in *a* commit, not that they reach `main`. |
+| 4 | `result_sha256` is unreproducible — engine, version, locale, ordering, newlines all unspecified | **ACCEPTED.** Fixing it needs a versioned canonical search protocol, which is a project in itself. |
+| 5 | The hash does not bind the declared hit list — delete an inconvenient hit and the raw hash still matches | **ACCEPTED.** The verification and the schema check different objects. |
+| 6 | L3 never re-runs the one verifiable control on the routes it exists to cover | **ACCEPTED.** |
+| 7 | Cutting the backfill leaves all 5 closed wayfinder tickets in immediate violation | **ACCEPTED.** Removing the fiction re-created the debt. |
+| 9 | The footer binds a blob, not the verdict text | **ACCEPTED.** |
+| 10 | A 7-hex abbreviation is not an exact identity | **ACCEPTED.** |
+| 11 | The map append has no idempotency key | **ACCEPTED.** |
+| 12 | Residual TOCTOU between the last read and the close | **ACCEPTED** as residual and now unfixable-by-ordering, given F2. |
+| 13 | The implementation is disproportionate to its evidence | **ACCEPTED — and it is the finding that decides the outcome.** |
+
+### The answer to the proportionality question
+
+Asked directly, the reviewer was unambiguous:
+
+> **"Yes: do it by hand for the next three wayfinder tickets.** Use a fixed template, manually record
+> searches and resolutions, and measure actual repetition, review value, query drift, and failure
+> modes. **Do not build the automation spine before that pilot."**
+
+And on the control that the whole design was built around:
+
+> *"It is fatal to the claim that the executed control prevents the observed prior-art failure. It is
+> not fatal to a receipt's value as a reviewed manual record. The machine verifies that* a *query ran,
+> not that the necessary search happened."*
+
+That is the recommendation carried forward: **adopt the receipt as a hand-written artifact, pilot it
+on three tickets, and defer every line of automation** until the pilot says which part is worth
+building. The spec remains the design of record for what would be built if it is.
+
+## Running total across three rounds
+
+| Round | Verdict | Findings | Accepted | Refuted |
+|---|---|---|---|---|
+| 1 | `do-not-build` | 16 | 16 | 0 |
+| 2 | `do-not-build` | 13 | 13 | 0 |
+| 3 | `do-not-build` | 13 | 13 | 0 |
+| **Total** | — | **42** | **42** | **0** |
+
+Every one found before a line of code existed.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the spec under review across all
+  three rounds, and the issue/label/timeline/transcript/merge-base probes behind the dispositions.

--- a/docs/specs/ticket-bound-receipts.md
+++ b/docs/specs/ticket-bound-receipts.md
@@ -1,0 +1,520 @@
+# Spec — ticket-bound resolution receipts
+
+> # ⛔ NOT FOR BUILD
+>
+> **Decided 2026-07-31 (Ray): the automation in this document is DEFERRED. Nothing below §4 is
+> being built.** What ships instead is `docs/receipts/TEMPLATE.md` — the receipt, hand-written —
+> piloted on the next three `wayfinder:*` tickets. See § "Decision".
+>
+> This document remains the **design of record**: it is what would be built if the pilot shows the
+> automation is worth its cost, and it carries the 42 reasons the first three attempts were not.
+> Do not resurrect any layer from it without reading § "Decision" first.
+
+**Status: revision 3, superseded by the pilot decision. No code was ever written.**
+
+Three adversarial review rounds by Codex (GPT-5.6, cold, cross-family, no disk access) returned
+`do-not-build` **every time**: 16 findings, then 13, then 13 — **42 in total, 42 accepted, 0
+refuted**. All three are persisted verbatim with their disposition tables at
+`docs/research/kb/reports/agents/codex-adversarial-449-receipt-spec.md`. §10 records what each round
+changed.
+
+That is the point of the exercise: **42 defects found at zero implementation cost.** Revision 3 is
+materially smaller than revision 1 — two whole layers and the backfill were cut, not added — and it
+was still not buildable.
+
+Resolves scope items 1–4 of [#449](https://github.com/ray-manaloto/dotfiles/issues/449). Supersedes
+nothing: `docs/specs/research-nudge-hooks.md` stays under its NO-SHIP banner as the design that was
+tried, and its Appendices A–D are the evidence base this spec rests on.
+
+**The claim in one sentence:** findings 1, 3 and 5 of the *earlier* review all want the same missing
+artifact — a durable, ticket-keyed record of how a decision was reached — and of everything such a
+record could contain, **exactly one part can be machine-verified**, so the design is built around
+that part and honest about the rest.
+
+---
+
+## 0. What was measured before designing
+
+Every number was taken this session, both arms armed. The design is downstream of them.
+
+| Fact | Value | Control arm |
+|---|---|---|
+| Issues closed all-time | **57**, every one `stateReason=COMPLETED` | 96 open, so the query sees both states |
+| Closed since 2026-07-01 | **35** | — |
+| Closed by a commit/PR (auto-close) | **3 of 57** (#3, #8, #249) | the field *does* populate, so the other 54 nulls are a real negative, not a blind probe |
+| `gh issue close` typed through a Claude Bash call | **30 commands / 436 transcripts / 8 project dirs** | `gh pr` → **853**, so the extractor is not blind |
+| Of the **last 20** closed issues, seen by the hook | **11** (439, 435, 434, 433, 432, 397, 394, 369, 343, 299, 288) | — |
+| …not seen | **9** (418, 400, 391, 380, 332, 327, 294, 290, 265) | widening the sweep 182 → 436 transcripts added **none** of the 9 ⇒ they were closed outside Claude entirely |
+| Issues carrying any `wayfinder:*` label | **16** — 11 open, **5 closed** | 96 open total, so the filter is selective, not vacuous |
+| …of those 5 closed, seen by the hook | **5 of 5** (439, 435, 434, 433, 432) | the same extractor reports 9 *un*seen closes, so it can produce the other answer |
+| …of the 9 unseen closes, carrying `wayfinder:*` | **0 of 9** — they are `auto-queue`, `bug`, `question`, or unlabelled | the extractor found the label on 16 other issues, so it is not blind to it |
+| `gh issue close` escape flags | `-r/--reason {completed \| not planned \| duplicate}`, `--duplicate-of <n>` | read from `--help`, not assumed |
+| `hook_guard.py` output shapes today | **`deny` only** (`pretooluse_main`, `decide() -> str \| None`) | — |
+| `docs/research/kb/reports/agents/` | **17** files; **2** carry a ticket number | — |
+
+### What the 55% does and does not license
+
+⚠️ **The headline "a hook sees ~55% of closes" describes a population this spec does not govern**, and
+revision 1 wrongly used it to justify the audit layer. Measured: **0 of the 9 hook-unseen closes carry
+a `wayfinder:*` label**, and all 5 closed wayfinder tickets went through a Claude `gh issue close`.
+On the scoped population the observed miss rate is **0 of 5** — and n = 5 is far too small to call a
+rate in either direction.
+
+The audit layer (§4.2 L3) is justified by the **mechanism, never the rate**: close routes exist that a
+PreToolUse hook structurally cannot see — the web UI, a human's own terminal, PR auto-close — and 9
+real closes demonstrably took them. That argument needs no percentage and does not weaken if the
+scoped rate stays at 0.
+
+---
+
+## 1. The artifact — a resolution receipt
+
+### 1.1 Where it lives
+
+```
+docs/receipts/<issue-number>.md      # e.g. docs/receipts/449.md
+```
+
+**Tracked, one file per ticket, named by the bare issue number.**
+
+- **Tracked — and *checked* to be tracked.** §4.2 L1 verifies the file is in the index with no
+  uncommitted modifications. A receipt that exists only in a working tree is exactly as durable as no
+  receipt at all.
+- **Immutable once committed.** Nothing in this design writes to a receipt after its commit — see
+  §1.4, which is where revision 2's worst bug lived.
+- **Bare number, no slug** — the lookup is a total function of the issue number:
+  `Path("docs/receipts/449.md").exists()`. No glob semantics to get wrong, no way to end up with two
+  receipts for one ticket. The cost is a directory that reads as `433.md 449.md …`.
+- **`docs/`, NOT `docs/research/kb/`** — and the repo already encodes why. `hk-common.pkl:52`
+  excludes `docs/research/kb/**` from **every** hk builtin, on purpose, so a typo-fixer can never edit
+  a **verbatim** persisted agent report. A receipt is *authored* content that should be linted like
+  any other doc; filing it in the kb tree would silently opt it out of every markdown check. The
+  exclusion's own comment says it: *"Authored docs under `docs/` are still checked."*
+
+The receipt **links to** the verbatim evidence in `docs/research/kb/reports/agents/`; it never copies
+it.
+
+### 1.2 Schema
+
+```yaml
+---
+issue: 449
+kind: research | decision | task | none-required | pre-dates-policy
+reason: >-                        # REQUIRED when kind == none-required
+  Label applied for tracking only; the answer was already fixed by #435's resolution.
+verdict: >-
+  One sentence. This exact text is the body of the ticket's resolution comment.
+provenance:
+  branched_from: 5f90f99c1e4a…    # 40-char SHA. Provenance ONLY — never a staleness input.
+  verified_at: 2026-07-31T14:02:11Z   # full ISO-8601; a date cannot order two same-day edits
+sources:                          # what was ACTUALLY opened. Empty is illegal except pre-dates-policy.
+  - local: hk-common.pkl
+    sha: 8f2e1c9…                 # `git hash-object` of the blob AS READ
+  - url: https://www.chezmoi.io/reference/configuration-file/hooks/
+    fetched: 2026-07-31
+    via: llms.txt                 # which step of research-doc-sources.md answered
+prior_art:                        # GENERATED and RE-VERIFIED. See §1.3.
+  query: "chezmoi hooks"
+  corpus: docs/research/kb/reports/agents/
+  corpus_sha: 60d2558…            # repo SHA the search ran against
+  result_sha256: 3ab9…            # hash of the raw search output
+  ran_at: 2026-07-31T14:02:11Z
+  hits:                           # EVERY hit must be resolved — read it, or dismiss it in writing
+    - path: docs/research/kb/reports/agents/deep-research-takeover-20260730.md
+      resolution: in-sources
+    - path: docs/research/kb/reports/agents/graphify-mining.md
+      resolution: dismissed
+      why: "Covers graph ingestion, not chezmoi's config surface."
+review:
+  lens: codex-reviewer | grok-reviewer | mattpocock-skills:code-review | none
+  verdict: clean | needs-attention | not-run
+  findings: 29
+  disposition: docs/research/kb/reports/agents/codex-adversarial-449-receipt-spec.md
+---
+```
+
+**Every field is REQUIRED. `none` / `not-run` / `none-required` are legal values; omission is not.**
+
+That decision comes from a failure this repo already had: session 2026-07-31-c's Standards review axis
+never delivered, and the gap was visible only because it was *written down as N/A* rather than left
+implied. A schema permitting omission cannot distinguish "no adversarial review ran" from "someone
+forgot the field."
+
+**Presence is not enough.** These cross-field rules are validated too — revision 1 accepted
+`lens: none` + `verdict: clean` + `findings: 5` + empty `disposition` as well-formed:
+
+| Rule | Rejects |
+|---|---|
+| `lens: none` ⇒ `verdict: not-run` and `findings: 0` | a verdict from a review that never ran |
+| `findings > 0` ⇒ `disposition` names an existing path | findings with nowhere to read them |
+| `kind: none-required` ⇒ `reason` ≥ 40 chars | a one-token opt-out |
+| **`prior_art` required for every kind except `pre-dates-policy`** | opting out of the one control that is not self-reported |
+| every `prior_art.hits[]` has `resolution: in-sources` **and appears in `sources`**, or `dismissed` **with a `why`** | finding the prior art and never opening it |
+| `kind: pre-dates-policy` ⇒ `sources`, `prior_art`, `review` **absent** | a reconstructed history presented as a record |
+
+### 1.3 The one control that is not self-reported
+
+Revision 1 claimed `prior_art` was prospective — that its fields "cannot be filled without running
+the search." **False, and it was the spec's central claim.** Revision 2 made the block *generated*;
+review round 2 correctly observed that "generated" had no machine-verifiable meaning, so an author
+could type a plausible query, corpus SHA, hit list and random hash and pass every rule.
+
+**Revision 3 closes it: `mise run resolve` re-runs the search itself and compares.**
+
+The search is a local text search over a tracked corpus at a recorded `corpus_sha`. That is
+**deterministic and cheap** — re-run it via `git show <corpus_sha>:<path>` and the output either
+hashes to `result_sha256` or it does not. Fabrication becomes detectable **at acceptance**, not
+merely reproducible afterwards by someone who thinks to check.
+
+**What this still does not close, stated plainly:** a *genuine* search with a badly-chosen query
+returns nothing useful and passes. Requiring every hit to be read or dismissed in writing closes the
+"found it and ignored it" half; nothing machine-checkable closes "asked the wrong question." That is
+a residual hole (§8.1), not a solved problem.
+
+Everything else in the receipt is an **attestation, not a proof**. No gate can verify a cited source
+was read or understood. Their value is that the claim must be written, lands in a reviewed diff, and
+is falsifiable afterwards — the same epistemics as the `since` dates on the guard's rules, which
+nothing verifies either and which work anyway.
+
+### 1.4 The receipt is never written after it is committed
+
+Revision 2 had L1 verify the receipt was committed, then write the posted comment's id back into it,
+then close the ticket — leaving HEAD holding a receipt without the id and the only valid version in a
+dirty working tree. **The sharpest finding of either round, and it was self-inflicted** by revision
+2's own fix for comment identity.
+
+The binding moves to the **comment**. Every resolution comment ends with:
+
+```html
+<!-- receipt: docs/receipts/449.md@8f2e1c9 -->
+```
+
+The footer names the receipt path and the blob SHA of the receipt as committed. That gives:
+
+- **Identity** — the audit finds *the* resolution comment by an exact marker, not by text-matching a
+  verdict sentence an older comment might also contain.
+- **Idempotency** — "has this already been posted?" is "does a comment with this marker exist?", so a
+  crashed run re-runs without duplicating.
+- **Immutability** — the receipt is committed once and never touched again, so there is no window in
+  which the committed and working copies disagree.
+
+---
+
+## 2. Binding to a ticket
+
+Two routes: the **filename** (`docs/receipts/<n>.md`, what the gate resolves) and the frontmatter
+**`issue: <n>`** (what the contract validates). A mismatch is a hard failure.
+
+Both are written by the same scaffold in the same breath, so this is **not** independent redundancy
+against authoring error — it guards against later hand-editing and against a copied receipt, which is
+the realistic drift. Said plainly because revision 1 implied more than it delivers.
+
+Today `docs/research/kb/reports/agents/` is topic+date named with **2 of 17** files carrying a ticket.
+**That convention does not change** — renaming 17 verbatim archive files would edit records the
+persistence rule exists to protect. A thin ticket-keyed layer sits alongside and links into it.
+
+---
+
+## 3. Staleness — a pre-close diagnostic, and nothing else
+
+Revision 1's model was incoherent in three ways and revision 2's still contradicted itself. It is now
+scoped down to what it can honestly do.
+
+**What broke it:** a single `base` SHA diffed against HEAD meant citing a file and then editing it as
+part of the same work made your own receipt stale; a valid 2026 receipt went stale forever the first
+time an unrelated 2027 commit touched a cited file; a post-close clarification to a ticket body
+invalidated a receipt that was correct when written; and revision 2 then had the audit report
+staleness statistics for closed receipts it had just forbidden itself to check.
+
+**The replacement:**
+
+| Signal | How | Blocking? |
+|---|---|---|
+| `local:` source changed since read | current `git hash-object` ≠ the recorded per-source `sha` | **no — printed at resolve time** |
+| `url:` source age | `fetched` date | **no — printed at resolve time** |
+| ticket edited since the receipt | `verified_at` vs the ticket's `updated_at` | **yes — and only before close** |
+
+Three rules:
+
+1. **Per-source hash, not a global diff.** Each `local:` source records the blob hash *as read*. Edit
+   the file afterwards, re-read it, and the scaffold re-records — so the receipt says what you
+   actually read, which is the only thing staleness can honestly mean.
+2. **Advisory except the ticket-edit rule.** A changed source is printed; it never blocks. A file
+   changing does not mean the reading was wrong, and a check that cannot tell the difference must not
+   hold a gate.
+3. **Never checked after close, and never reported after close.** A closed ticket's receipt documents
+   the evidence used *then*. Staleness is therefore **absent from the audit entirely** — revision 2
+   promised a statistic it had no data to compute.
+
+---
+
+## 4. Enforcement
+
+### 4.1 Two harness facts that forbid the obvious designs
+
+`permissionDecisionReason` on `allow`/`ask` reaches **the user, not Claude** (hooks.md:1551, verbatim,
+control-armed: `additionalContext` → 40 hits, a bogus token → 0). Only `deny` carries a reason back to
+Claude, so a close-time `ask` can never tell Claude what to do about it — which killed the previous
+design's tier 1.3.
+
+And a **harness-side timeout kill never reaches `fail_open()`** — *a hook cannot record its own
+death*. Anything load-bearing lives where failure is loud.
+
+### 4.2 The layers — three, down from five
+
+**L1 — `mise run resolve -- <n>`. The gate.**
+
+Resolution stops being a raw `gh` command and becomes a mise task, exactly as `gh pr create` became
+`mise run ship` — the repo's proven enforcement pattern reused rather than reinvented
+(`.claude/rules/mise-tasks-only.md`). **The task has network**, which dissolves the offline/online
+tension: it reads labels, validates against the live ticket, and acts.
+
+**Every step is idempotent and the verb is resumable**; a partial run followed by a re-run converges
+and never double-posts (the comment footer, §1.4, is what makes that decidable).
+
+Order — and the order is load-bearing, because the least recoverable action goes **last**:
+
+1. **Read the ticket.** No `wayfinder:*` label → skip every receipt check, require an explicit
+   `--verdict "<text>"`, and jump to step 5. Nothing in steps 5–8 touches a receipt, so this branch is
+   now coherent. *(Ray's decision, 2026-07-31: receipts bind wayfinder tickets only — ~1 per real
+   decision, not ~35/month of near-empty files, which is precisely the reflex the earlier review
+   predicted for the `ask` dialog.)*
+2. **Receipt exists**, parses, `issue:` matches the filename.
+3. **Receipt is committed and clean** — `git ls-files --error-unmatch` *and* `git diff --quiet HEAD --`.
+4. **Schema valid** — every field, every cross-field rule (§1.2). Staleness printed, not enforced.
+5. **Prior art re-verified** — re-run the recorded `query` against `corpus` at `corpus_sha` and
+   compare `result_sha256`. Mismatch is a hard failure. This is the only step that verifies rather
+   than reads (§1.3).
+6. **Ticket freshness** — `updated_at` not newer than `verified_at`.
+7. **Post the verdict** as the resolution comment, with the §1.4 footer.
+8. **Append the map pointer** to Decisions-so-far. Skipped with a printed notice when the ticket is
+   not a child of a `wayfinder:map` issue — #449 itself is deliberately not one.
+9. **Re-check `updated_at` is unchanged since step 6**, then `gh issue close <n> --reason completed`.
+
+Steps 7→9 put the map append *before* the close, because a failure after the close leaves the user
+with no reason to re-run and the pointer permanently missing.
+
+Failure prints the offending item and the remediation: **`mise run receipt -- <n>`**, which scaffolds
+the file from the ticket with every field present, `provenance` filled, and `--prior-art "<query>"` to
+generate that block. A fail-closed gate with no way forward is an outage, not enforcement — this repo
+has shipped that mistake once, when `gh pr merge` redirected KB PRs to a dotfiles-only task.
+
+**L2 — PreToolUse deny on `gh issue close`. Redirect only.**
+
+One new rule in `hook_guard.py`'s existing table: `gh issue close` → *"use `mise run resolve -- <n>`"*.
+
+**The guard's contract does not change.** It stays deny-or-silence: no `ask`, no `allow`, no
+`additionalContext`, no new output shape, no change to `command_audit`'s classifier or to
+`decide() -> str | None`. That is a large amount of new surface the previous design required and this
+one does not.
+
+Native escapes stay allowed at the hook — `--reason "not planned"`, `--reason duplicate`,
+`--duplicate-of <n>`. A close that is not a completion should not be forced through a resolution verb.
+**They are not a free pass**: L3 reads *every* closed wayfinder ticket regardless of reason, because
+"hook allows non-completed" plus "audit reads only completed" composed into a second complete bypass.
+
+Coverage on the scoped population is 5 of 5 (§0), n = 5. This layer stops *the agent* bypassing the
+verb; it is not the coverage story.
+
+**L3 — the standing audit. Every close route, on a named schedule.**
+
+`dotfiles-setup receipts audit`:
+
+- every **closed** wayfinder ticket — **any `stateReason`** — has a committed, well-formed receipt;
+- selection is by **label history via the issue timeline**, not current labels, so removing the label
+  before closing does not erase the requirement;
+- every receipt names a real issue; no orphans; no duplicate `issue:`;
+- every closed ticket has a comment carrying the §1.4 footer, and the footer's blob SHA matches the
+  committed receipt;
+- `kind: none-required` and `pre-dates-policy` rates reported. **No staleness** (§3).
+
+⚠️ **Control-arm gap.** `labeled` events are observable here (13 in the last 100 issue events).
+`unlabeled` → **0** — no label has ever been removed in this repo, so the removal half is
+*documented but unobserved*. **Arm it before building**: add and remove a label on a scratch issue and
+confirm the event appears. Do not ship on the documentation alone.
+
+**Delivery — named triggers, not an aspiration.** The audit's findings are repo-wide debt an unrelated
+PR did not cause; failing that PR's CI on inherited debt is stranding. So:
+
+- **blocking** only on receipts the PR itself touches (schema, filename↔frontmatter, dead links) — an
+  offline `suites.toml` contract;
+- **scheduled** — the audit runs in the existing `refresh.yml`, on the same trigger that already
+  upserts the `tool-currency` standing issue, and upserts its own;
+- **`mise run land`** prints the current summary post-merge.
+
+**L1 is the enforcement; L3 is detection across the routes L1 cannot see.** Its coverage is of
+*routes*, not *moments* — it finds a bad close whenever it next runs, not as it happens.
+
+---
+
+## 5. Divergence from wayfinder, recorded deliberately
+
+| | Wayfinder `SKILL.md` | This repo |
+|---|---|---|
+| Where the verdict goes | resolution comment (`:125`) | **same** — adopted verbatim |
+| Where evidence goes | *"a throwaway `research/<name>` branch"* (`:115`) | **tracked `docs/`**, per `.claude/rules/agent-report-persistence.md` |
+| Restating | *"a decision lives in exactly one place — its ticket"* (`:23`) | **same** — the receipt is the *method*, the comment is the *answer*; different content, not mirrored |
+
+The reason for the one divergence: a throwaway branch does not survive a clone. Recorded so a future
+session does not "fix" it back.
+
+**Which half the gate reads:** the **file**. Not because the comment is less authoritative — for a
+human it is more so — but because the file is the half a check can read. The two are kept from
+drifting by the footer (§1.4), which names the exact committed blob the comment was posted for.
+
+---
+
+## 6. What this would have caught — and what it would not
+
+Both observed misses were on **#436**, which carries `wayfinder:grilling`, so the scope binds them.
+
+| Miss | Caught? | By what |
+|---|---|---|
+| Five #436 decisions taken before reading chezmoi's docs (it ships native `[hooks]`) | **Partially — and late.** | `sources:` must name chezmoi's docs or be visibly empty, and empty is illegal. It fires at *resolution*, not at *decision*: it converts an invisible miss into a visible one at a defined checkpoint. **It does not make research happen.** |
+| chezmoi-vs-mise re-derived despite `deep-research-takeover-20260730.md` answering it | **Yes — conditional on the query.** | The search is generated *and re-verified*, and every hit must be read or dismissed in writing. A reasonable query surfaces that file and forces a written response to it. A bad query still passes (§1.3). |
+
+**One control executes; everything else is a written claim a reviewer can check later.** That is the
+whole spec, and stating it that plainly is what two review rounds bought.
+
+## 7. Deliberately not proposed
+
+- **`SubagentStart` injection (was L4).** Cut in revision 3: "the current ticket" was undefined for a
+  session holding several, and the premise for prioritising it was already refuted — both observed
+  misses launched **0** subagents (`6b4602f4`: Agent=0, control Bash=132; `d4299a7a`: 0/48) against
+  **239** `Agent` launches project-wide. It would have fired zero times in the session it was proposed
+  to fix.
+- **`UserPromptSubmit` reminders (was L5).** Cut in revision 2 as surface without enforcement. For the
+  record the reason is **not** the timeout the previous spec asserted: measured on the live guard
+  wrapper, 20 clean runs on a loaded host, min 256 / median 1013 / max 1978 ms = **6.6% of the 30 s
+  budget, ~15× headroom**. Timeout was never the risk; silent absence was.
+- **Backfilling ordinary receipts for the 5 already-closed wayfinder tickets.** Writing `sources` and
+  `prior_art` for decisions nobody now remembers manufactures provenance. If a baseline is wanted, it
+  is `kind: pre-dates-policy` carrying only objectively recoverable facts — ticket id, close date, the
+  existing resolution comment, links to surviving artifacts — and **nothing about how the decision was
+  reached**.
+- **Tier 2, the statusline context-budget sensor.** Split off per the earlier review.
+- **A new rule file.** Already measured to have failed: the rule saying *research the tool's release
+  notes first* is unscoped, therefore eager, therefore loaded — and it did not fire, twice.
+- **Retro-fitting ticket keys onto `docs/research/kb/reports/agents/`.** §2.
+
+## 8. Known holes — named, not papered over
+
+1. **A badly-chosen prior-art query passes.** The search is verified to have *run*; its *relevance* is
+   not machine-checkable. §1.3.
+2. **Everything except `prior_art` is attestation, not proof.** Accepted ceiling.
+3. **The scope is a hand-applied label, so exemption is the default.** 11 of 96 open issues carry
+   `wayfinder:*`; nothing forces a decision-shaped ticket to be labelled one. L3's label-history
+   selection closes the *removal* half; the *never-applied* half stays open by design.
+4. **L2 redirects; it does not compel the emitter.** The wayfinder skill still emits a raw
+   `gh issue close`, and updating `docs/issue-tracker.md` is instruction-following, not enforcement.
+   The mechanism is precedented and working — that file is what the wayfinder skills read for tracker
+   conventions and it already redirects `gh pr create` → `mise run ship` — and a `deny` reason reaches
+   Claude, so a mid-sequence denial is recoverable. It is still the weakest link in the chain.
+5. **The guard is a redirect guard, not a sandbox.** `$(…)`, `sh -c`, `eval`, aliases and base64 all
+   fail open by documented design. This gate is discipline, not security.
+6. **L3 is retrospective** — it detects, it does not prevent.
+7. **PR auto-close bypasses L2 entirely** — 3 of 57 historically, 0 of the last 20. L3 catches it.
+8. **The `unlabeled` timeline event is unobserved in this repo** and must be armed before the
+   label-history fix is relied on. §4.2 L3.
+9. **A standing issue nobody reads is a passive sink.** Named as a real risk by review round 2; the
+   scheduled trigger fixes *delivery*, not *attention*.
+10. **Nothing here makes `/clear`, `clear-prep`, `handoff`, `resume` or `wayfinder` invocable by
+    Claude.** All are `disable-model-invocation: true` and `/clear` is a CLI command. Automation
+    prepares and nudges; the keystroke stays human.
+
+## 9. Build order
+
+Each step is independently useful, independently revertible, and depends only on what precedes it —
+revision 2's step 1 required a generator that did not ship until step 2.
+
+| # | Ships | Why this order |
+|---|---|---|
+| 1 | `mise run receipt -- <n>` — scaffold + **`--prior-art` generation** | The generator must exist before any receipt can satisfy the schema. Useful alone: it makes the search reproducible even with nothing gating on it. |
+| 2 | `docs/receipts/` + the schema + validator + **`449.md` as the first live instance**, produced by step 1's tool | Dogfooding #449 with its own generated receipt is the control arm: if the tool cannot produce a valid receipt for the ticket that specified it, nothing else is worth building. |
+| 3 | `dotfiles-setup receipts audit`, advisory, + the `suites.toml` contract for PR-touched receipts + the `refresh.yml` schedule. **Includes arming the `unlabeled` control.** | Detection layer measured for false positives before anything leans on it. |
+| 4 | `mise run resolve -- <n>` | The gate. Only after 1–3 exist. Carries the §4.2 L1 order, the footer, and prior-art re-verification. |
+| 5 | `hook_guard.py` redirect + `since` date + test, **and `docs/issue-tracker.md` § Wayfinding operations updated in the same change** | A redirect whose target the documentation does not name sends the reader nowhere. The doc that tells the session what to run must change with the guard. |
+
+Optional, separately decidable: a `pre-dates-policy` baseline for the 5 closed wayfinder tickets (§7).
+
+## 10. Review history
+
+| Round | Verdict | Findings | Accepted | Structural changes it forced |
+|---|---|---|---|---|
+| 1 | `do-not-build` | 16 | **16** | `prior_art` generated not typed; receipt must be committed; staleness rewritten; audit reads label history and every close reason; standing issue instead of a CI gate; `UserPromptSubmit` cut; the 55% re-measured |
+| 2 | `do-not-build` | 13 | **13** | Receipt never written after commit (comment footer instead); prior art **re-verified**, not merely generated; every hit read or dismissed; staleness removed from the audit; map append before close; build order reordered; `SubagentStart` cut; backfill reduced to `pre-dates-policy` |
+
+**29 of 29 accepted, zero refuted.** Revision 3 is smaller than revision 1: two enforcement layers and
+the backfill were removed, and one verification step was added.
+
+## Decision — pilot by hand, defer the build (2026-07-31)
+
+Round 3 was asked directly whether the honest answer was "do it by hand three times first". It was
+unambiguous:
+
+> **"Yes: do it by hand for the next three wayfinder tickets.** Use a fixed template, manually record
+> searches and resolutions, and measure actual repetition, review value, query drift, and failure
+> modes. **Do not build the automation spine before that pilot."**
+
+Two of its findings were upgraded from `unverified` to **measured**, and both are fatal to the
+design as written:
+
+1. **The freshness gate can only fail.** Posting a comment **advances an issue's `updated_at`**
+   (#433: comment `2026-07-30T23:18:21Z`, issue updated `…:22Z`; #434 the same). L1 step 7 posts the
+   verdict and step 9 then requires `updated_at` to be unchanged. That check can never pass — the
+   exact defect `.claude/rules/probes-need-a-control-arm.md` exists to name, written into a spec that
+   cites that rule.
+2. **The one machine-verifiable control cannot resolve its corpus.**
+   `git merge-base --is-ancestor feat/436-… origin/main` → **false** (control: `60d2558` → true).
+   This repo squash-merges, so a `corpus_sha` recorded on a feature branch is unreachable from a
+   fresh clone and `git show <corpus_sha>:<path>` fails. Prior-art re-verification — the only thing
+   in the design that verified rather than attested — breaks by construction.
+
+And the ceiling was never going to move: a *genuine* search with a badly-chosen query passes every
+check. The machine can verify that **a** query ran, never that the **right** question was asked.
+
+### What ships instead
+
+| Artifact | What it is |
+|---|---|
+| `docs/receipts/TEMPLATE.md` | The receipt, hand-written. Every field that existed only to serve a verifier — blob SHAs, `corpus_sha`, `result_sha256`, the comment footer — is **gone**. What remains is what a human reads. |
+| `docs/receipts/449.md` | Instance #1 — this ticket's own receipt, written from the template. |
+| this file | The design of record, plus 42 reasons. |
+
+**Nothing else.** No `mise run receipt`, no `mise run resolve`, no `hook_guard.py` rule, no audit
+command, no `suites.toml` contract, no scheduled workflow, no standing issue.
+
+### The pilot
+
+Write a receipt by hand for the next **three** `wayfinder:*` tickets. Then answer, from data rather
+than design:
+
+1. Which fields were filled with something real, and which became ritual?
+2. Did anyone ever read a receipt after the ticket closed?
+3. Did query drift actually happen — did a search miss prior art that was there?
+4. What did writing it by hand cost, per ticket?
+
+Only then reconsider automation, and only for the parts the pilot proves. The layers below are
+available to lift from — with their findings attached.
+
+## 11. Questions review round 3 answered
+
+| # | Question | Answer |
+|---|---|---|
+| 1 | Is the prior-art search deterministic at a fixed `corpus_sha`? | **No.** Only after defining a versioned canonical search protocol — engine and version, query semantics, ignored config, locale, corpus enumeration and sorting, encoding policy, newline rules, canonical serialisation. Hash canonical structured results, never tool stdout. That is a project in itself. |
+| 2 | Does a legitimate corpus change break a valid receipt? | **Not if the old snapshot is searched exactly** — but the snapshot may not exist. See the squash-merge measurement in § "Decision". |
+| 3 | Is the receipt's blob SHA a stable identity? | **The full OID is** stable across amend/rebase/squash while the bytes are unchanged. The 7-hex abbreviation shown in §1.4 was not, and a blob OID proves neither the path nor durable reachability. |
+| 4 | Does cutting `SubagentStart` leave a regression to own? | **No — cutting it was correct.** It would not have fired for either observed failure and would not prove delegated research was read. Adding it would be theatre. |
+| 5 | Is a genuine search with a bad query fatal? | **Fatal to the claim that the executed control prevents the observed failure.** Not fatal to a receipt's value as a reviewed manual record — which is precisely the split that produced the pilot decision. |
+| 6 | Is the spine proportionate, or should this be done by hand three times first? | **By hand, three times first.** Quoted in full in § "Decision". |
+
+---
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the repo this specifies;
+  `hook_guard.py`, `hk-common.pkl`, `docs/issue-tracker.md`, `.claude/rules/*`, and the closed-issue,
+  label, timeline and transcript measurements in §0.
+- [ray-manaloto/knowledge-base](https://github.com/ray-manaloto/knowledge-base) — the
+  `sources/agent-harness-docs/docs/claude-code/hooks.md` mirror behind the `permissionDecisionReason`
+  and `SubagentStart` claims.


### PR DESCRIPTION
Three adversarial review rounds (Codex GPT-5.6, cold, cross-family, no disk
access) returned `do-not-build` every time: 16 + 13 + 13 = 42 findings, 42
accepted, 0 refuted — every one before a line of code existed.

Two were upgraded from the reviewer's `unverified` to measured, and both are
fatal to the design as written:

- Posting a comment ADVANCES an issue's `updated_at` (#433: comment 23:18:21Z,
  issue updated 23:18:22Z), so the spec's freshness gate — post the verdict at
  step 7, require `updated_at` unchanged at step 9 — could only ever fail. That
  is the exact defect `probes-need-a-control-arm.md` names, written into a
  document that cites that rule.
- `git merge-base --is-ancestor feat/436-… origin/main` is false (control:
  60d2558 → true). This repo squash-merges, so a feature-branch `corpus_sha` is
  unreachable from a fresh clone and `git show <sha>:<path>` cannot resolve it —
  breaking prior-art re-verification, the only machine-verifiable control in the
  design, by construction.

Decision (Ray, 2026-07-31): the automation is DEFERRED. What ships is the
receipt itself, hand-written, piloted on the next three `wayfinder:*` tickets.
No mise task, no hook rule, no audit, no contract, no scheduled workflow.

- docs/receipts/TEMPLATE.md — the receipt; every field that existed only to
  serve a verifier (blob SHAs, corpus_sha, result_sha256, comment footer) is gone
- docs/receipts/449.md — instance #1, this ticket's own receipt
- docs/specs/ticket-bound-receipts.md — design of record under a NOT FOR BUILD
  banner, carrying the 42 reasons
- docs/research/kb/reports/agents/codex-adversarial-449-receipt-spec.md — all
  three rounds verbatim with per-finding disposition tables

Gates: lint rc=0 · pytest 1144 passed · verify 112 passed / 0 failed.

Refs #449

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014x8jGSieFkDBV95KLXYhTC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788136878&installation_model_id=429246&pr_number=452&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F452&signature=111382b5945f075479f3460df6a3de974ad421f0d0079994a62b540a710d8d17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a specification for ticket-bound resolution receipts, including provenance, verification, auditing, and known limitations.
  * Added a reusable template for documenting `wayfinder:*` ticket receipts.
  * Added receipt `#449` with the decision to defer automation and use a handwritten pilot.
  * Added an adversarial review report documenting findings from three review rounds and recommended next steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->