### PR TITLE
docs(issue-tracker): record the receipt pilot in the wayfinding operations

### DIFF
--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -76,8 +76,17 @@ Used by `/wayfinder`. The **map** is a single issue with **child** issues as tic
   map's sub-issues / task list), drop any with an open blocker
   (`issue_dependencies_summary.blocked_by > 0`) or an assignee; first in map order wins.
 - **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Receipt** (pilot, from #449): a `wayfinder:*` ticket carries a hand-written
+  **`docs/receipts/<n>.md`**, copied from `docs/receipts/TEMPLATE.md` and filled **as you work, not
+  at close** — sources actually opened, the prior-art search with its control arm, the adversarial
+  review result. Running for the next **three** wayfinder tickets, then judged. **There is no tool
+  and no gate, deliberately**: three adversarial review rounds killed the automation (42 findings,
+  0 refuted) because only the prior-art search is machine-verifiable, and even then only that *a*
+  query ran. Design of record + the 42 reasons: `docs/specs/ticket-bound-receipts.md` (⛔ NOT FOR
+  BUILD). Worked example: `docs/receipts/449.md`.
 - **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a
-  context pointer to the map's Decisions-so-far.
+  context pointer to the map's Decisions-so-far. The verdict goes in the **comment**; the evidence
+  stays in the **receipt**, linked — they carry different content, never mirrored.
 
 ### Prerequisites — all verified live on 2026-07-15
 


### PR DESCRIPTION
The #449 receipt pilot was discoverable only from the spec and a gitignored
handoff, so a fresh session had no durable pointer to it. `docs/issue-tracker.md`
is what the wayfinder skills read for tracker conventions, which makes it the
right home.

Adds the Receipt step (hand-written `docs/receipts/<n>.md` from the template,
filled as you work), states plainly that there is no tool and no gate and why —
three adversarial review rounds returned do-not-build on 42 findings, 0 refuted,
because only the prior-art search is machine-verifiable and even then only that
a query ran — and records the verdict/evidence split on the Resolve step.

Gates: lint rc=0 · lint-docs rc=0.

Refs #449

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014x8jGSieFkDBV95KLXYhTC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788138418&installation_model_id=429246&pr_number=453&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F453&signature=623b1bf988b63b9f0d57a299a71a041e383e78353ee70058162efe3638cdae53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->