### PR TITLE
fix(devcontainer): unstick the base build — libssl-dev pin went stale

### DIFF
--- a/.devcontainer/mise-system.toml
+++ b/.devcontainer/mise-system.toml
@@ -155,7 +155,7 @@ cargo-binstall = "latest"
 "apt:libbz2-dev" = "1.0.8-6build2"
 "apt:libreadline-dev" = "8.3-4"
 "apt:libsqlite3-dev" = "3.46.1-9ubuntu0.2"
-"apt:libssl-dev" = "3.5.5-1ubuntu3.2"
+"apt:libssl-dev" = "3.5.5-1ubuntu3.3"
 "apt:zlib1g-dev" = "1:1.3.dfsg+really1.3.1-1ubuntu3"
 # LLVM-22 C++ toolchain (#222 PR-C) — Ubuntu 26.04's version-suffixed apt packages
 # all depend on ONE shared libLLVM-22 runtime, replacing the 8 conda LLVM tools that


### PR DESCRIPTION
`mise run verify-apt-pins` FAILs on main:

    E: Version '3.5.5-1ubuntu3.2' for 'libssl-dev' was not found

Ubuntu superseded the security update, so the pin no longer resolves and
`mise bootstrap packages apply` exits 100. This breaks base-prep for ANY
change that touches an image build input — it is what makes PR #427
(lockfile refresh) red, in a file #427 does not touch.

main is currently green only because nothing has rebuilt the base since
the pin went stale. It is a latent landmine, not a #427 defect.

Evidence, both arms:

  verify-apt-pins BEFORE  FAIL  (libssl-dev 3.5.5-1ubuntu3.2 not found)
  verify-apt-pins AFTER   PASS  (66 pinned packages resolve together)

A per-pin probe in the digest-pinned base (ubuntu:26.04) checked all 66
against the real repos: ok=65, stale=1 — libssl-dev is the only one, and
the 52 apt.llvm.org pins are all still served. Available versions were
3.5.5-1ubuntu3 and 3.5.5-1ubuntu3.3; this takes the newest, per
`feedback_ubuntu_release_pocket_pins_dont_install`.

Split out of Renovate PR #442, which carries this same one-line bump but
cannot go green: it is also #421's hk 1.53.0 content, blocked on a
linux-x64 lock regen that cannot run on macOS. Closing #442 without
extracting this would have discarded a fix for a live breakage.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014x8jGSieFkDBV95KLXYhTC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788141221&installation_model_id=429246&pr_number=454&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F454&signature=dc507b6c331b4eb48b47265f2c42231f68462ac8f592f36c6e998866c31d8489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development environment’s pinned OpenSSL development package version for improved setup consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->