### PR TITLE
docs(437): receipt pilot ticket 1 — source of truth is Doppler, but only one path is structural

### DIFF
--- a/docs/receipts/437.md
+++ b/docs/receipts/437.md
@@ -1,0 +1,173 @@
+# Receipt — #437: What is the source of truth between Doppler and fnox?
+
+**Verdict:** Doppler is the declared source of truth and fnox holds a reference resolved at read
+time (plus, where `fnox sync` has run, an encrypted local *cache copy*); fnox **cannot** write to
+Doppler — verified from source at the installed version — so that one path is closed structurally,
+but single-writer-per-store overall is **policy, not a structural property**, resting on the
+`doppler` CLI being the sole human write path with no gate enforcing it; the live integrity risk is
+the local fnox config, not cross-store atomicity.
+
+**Kind:** decision
+**Resolved:** 2026-07-31
+
+## Sources — what I actually opened
+
+Pinned to the **installed** fnox version (`fnox 1.31.1`), not mutable `main`, after the review
+flagged that gap:
+
+- `https://raw.githubusercontent.com/jdx/fnox/v1.31.1/crates/fnox-core/src/providers/doppler.rs`
+  — **primary.** 464 lines, `sha256:256b1e1591133344…`. Implements `get_secret` (L111),
+  `get_secrets_batch` (L118), `test_connection` (L188) and nothing else; `put_secret` and
+  `capabilities` are **absent (0 hits)**. Byte-identical to `main` at time of reading.
+- `https://raw.githubusercontent.com/jdx/fnox/v1.31.1/crates/fnox-core/src/providers/mod.rs`
+  — **primary.** 485 lines, `sha256:8e51f6cf1e99ade4…`. The two default bodies that complete the
+  chain, quoted verbatim:
+
+  ```rust
+  // L228-231
+  fn capabilities(&self) -> Vec<ProviderCapability> {
+      // Default: read-only remote provider (like 1Password, Bitwarden)
+      vec![ProviderCapability::RemoteRead]
+  }
+
+  // L208-225 — with only RemoteRead, both branches above fall through:
+  } else {
+      // Read-only provider
+      Err(crate::error::FnoxError::Provider(
+          "This provider does not support storing secrets".to_string(),
+      ))
+  }
+  ```
+
+- `https://raw.githubusercontent.com/jdx/fnox/main/crates/fnox-core/src/providers/keychain.rs`
+  — the control arm for the 0 (see "Prior art").
+- `docs/secrets-doppler-fnox-keychain.md` — the wired contract on this Mac: Doppler is *"shared
+  authority — the value of record"*, fnox is *"declaration + resolution + optional encrypted
+  cache"*, environment is *"never the source of truth"*. Also the operational grounding: values are
+  created by `doppler secrets set 'KEY' --project dotfiles --config dev_personal --silent`.
+- `docs/research/kb/reports/agents/concurrency-sweep-433.md` — Q3a, Q2 (no versioning/etag/conflict
+  detection in the fnox write path), Q1b (the daemon has no write path).
+- `docs/research/kb/reports/agents/adversarial-secrets-takeover-20260730.md` — Critical #3 verbatim.
+- `docs/research/kb/reports/agents/deep-research-takeover-20260730.md` — findings 3, 4, 5.
+- `.claude/rules/secrets-out-of-the-shell-env.md` — the `env = "exec"` decision and the 2026-07-30
+  config wipe.
+- GitHub issue #437 body, including its "Updated by the resolution of the concurrency research".
+
+## Prior art — the search I ran
+
+**Query:**
+
+```bash
+grep -rlEi 'source of truth|single.writer|read-only|RemoteRead' \
+  docs/research/kb/reports/ docs/specs/ docs/ .claude/rules/ \
+  | xargs grep -lEi 'doppler|fnox'
+```
+
+**Corpus:** `docs/research/kb/reports/`, `docs/specs/`, `docs/`, `.claude/rules/`
+**Control arm:** `fnox` → **39 files** (known present) / `zzqqxxsecretstore` → **0** (known absent)
+
+A second control arm was needed for the load-bearing claim, because it is asserted by an *absence*.
+`grep -nE 'put_secret|capabilities' doppler.rs` → **0 hits**; the identical command shape against
+`keychain.rs` → **hits at L62, L100, L188**. The probe produces both answers, so the 0 is a real
+negative and not a blind grep. *(per `.claude/rules/probes-need-a-control-arm.md`)*
+
+| Hit | What I did with it |
+|---|---|
+| `docs/secrets-doppler-fnox-keychain.md` | **read** — the position already in force, plus the operational detail (where values are created) that keeps the verdict from being purely self-referential. |
+| `docs/research/kb/reports/agents/concurrency-sweep-433.md` | **read** — Q3a's chain (which I then re-derived rather than inherited); Q2 relocated the risk to single-store. Most load-bearing hit. |
+| `docs/research/kb/reports/agents/deep-research-takeover-20260730.md` | **read** — established the Doppler MCP trap: `secrets_update`/`configs_lock` ship by default, `--read-only` is a startup filter. |
+| `docs/research/kb/reports/agents/adversarial-secrets-takeover-20260730.md` | **read** — Critical #3 was premised on a dual-write workflow that does not exist. |
+| `.claude/rules/secrets-out-of-the-shell-env.md` | **read** — the 2026-07-30 wipe. Note the correction under "Notes": it is *not* evidence of an unlocked-write race. |
+| `docs/research/mintlify-cache/jdx/fnox/llms-full.txt` | **dismissed** — vendor prose, superseded by the source I fetched. |
+| `docs/research/runs/research-20260709-r2-secrets/agents/doppler-platform.md` | **dismissed** — 2026-07-09 survey, predates both the `env = "exec"` adoption and the read-only verification. |
+| `docs/research/runs/research-20260709-r2-secrets/agents/fnox-division.md` | **dismissed** — R2 division of labour, not write authority. |
+| `docs/research/runs/research-20260709-r2-secrets/agents/full-secret-map.md` | **dismissed** — which secret goes where; orthogonal. |
+| `docs/research/runs/plan-20260710-r2-implementation.md` + remaining `research-20260709/10/11` hits | **dismissed** — term collision on "read-only"/"source of truth" in CI-pipeline, event-trigger and graphify contexts. |
+| `docs/research/mintlify-cache/twpayne/chezmoi/llms-full.txt` | **dismissed** — "source of truth" in chezmoi's source-directory sense. |
+| `docs/research/mintlify-catalog.md` | **dismissed** — index file. |
+| `docs/specs/deep-interview-research-tooling-wiring.md` | **dismissed** — mentions fnox only as an available provider. |
+
+## Adversarial review
+
+**Lens:** codex CLI 0.146.0 / `gpt-5.6-sol`, `codex exec --ephemeral --sandbox read-only`,
+`model_reasoning_effort=high`, whole document on stdin with *"do NOT read the disk"*
+**Verdict:** needs-attention — the review materially changed the verdict
+**Findings:** 11 (2 critical, 8 major, 1 minor) — verbatim in
+`docs/research/kb/reports/agents/codex-adversarial-437-source-of-truth.md`
+**Disposition:** **8 accepted, 3 partially accepted, 0 refuted.**
+
+| # | Sev | Claim | Disposition |
+|---|---|---|---|
+| 1 | critical | The `RemoteRead` default body was second-hand, so the central premise was unestablished | **ACCEPTED — fixed.** Fetched `providers/mod.rs` at `v1.31.1` and quoted both default bodies above. Chain now complete from primary source. |
+| 2 | critical | "Single-writer-per-store holds **structurally**" is refuted by the receipt's own admission that no gate exists | **ACCEPTED — verdict rewritten.** Only the fnox→Doppler path is structural. Doppler's web UI, REST API, a second CLI invocation and any scoped token remain unconstrained writers. This was a genuine overclaim. |
+| 3 | major | Source fetched from mutable `main`, unpinned, may not match the installed fnox | **ACCEPTED — fixed.** Re-fetched at `v1.31.1` (the installed version), recorded sha256 for both files, and confirmed `doppler.rs` is byte-identical to `main`. |
+| 4 | major | Citing the existing contract doc is circular — it proves prior policy, not correctness | **PARTIALLY ACCEPTED.** For a *decision* ticket, ratifying declared policy is a legitimate answer. But the wording now separates the two: policy (the doc) and the operational fact that values are created in Doppler via `doppler secrets set`. Not treated as proof of correctness. |
+| 5 | major | "Reference rather than a copy" contradicts "`fnox sync` writes all 49 secrets" | **ACCEPTED — real internal inconsistency.** Both are true of different paths: the declaration is a reference (`value = "KEY_NAME"`), and `fnox sync` additionally materialises an **encrypted local cache copy** via the age provider. The verdict now says both. |
+| 6 | major | Cross-store inconsistency does not require copied values — rename/rotate/delete still couple the two | **ACCEPTED.** A Doppler rename leaves the fnox declaration pointing at a dead key; that is cross-store breakage with zero copied values. "Cross-store atomicity is a non-problem" was too broad — corrected to "no cross-store *write* atomicity problem", with the referential-integrity coupling stated explicitly. |
+| 7 | major | "Cannot be bypassed by policy drift" is absolute and unsupported | **ACCEPTED** — same root as #2; the claim is now version-scoped to fnox 1.31.1 and confined to the fnox→Doppler path. |
+| 8 | major | The `mde-py` corruption is asserted as caused by an unlocked non-atomic write, without evidence | **ACCEPTED — and it was a misattribution of our own evidence.** `.claude/rules/secrets-out-of-the-shell-env.md` says the opposite: `bootstrap_config()` drops `env` **by construction** (a code-generation defect), and **"fnox is EXONERATED"** — an authorized write probe preserved the mode and all opt-ins. The wipe is not a race. Corrected under "Notes". |
+| 9 | major | "No etags and no conditional writes" is unevidenced here | **PARTIALLY ACCEPTED.** The claim is inherited from the #437 ticket body and was not re-derived this session; now explicitly labelled inherited rather than presented as measured. |
+| 10 | minor | The `--read-only` analysis is MCP rationale, not evidence of authority | **PARTIALLY ACCEPTED.** Kept, but moved into the trap/rationale section rather than the proof of authority. |
+| 11 | major | Marked resolved while findings were a `REVIEW-PENDING` placeholder | **ACCEPTED** — an artefact of writing the receipt before the review returned. Resolved by this table. |
+
+The reviewer's closing line — *"the narrow conclusion that may survive is: for the inspected
+snapshot of `doppler.rs`, no explicit write method was found"* — was **too narrow**, and findings 1
+and 3 are exactly what closed the gap: with `mod.rs` read at the installed tag, the dispatch chain
+is complete, so "fnox cannot write to Doppler at 1.31.1" is established, not merely "no write
+method was found in one file".
+
+## Notes
+
+**The question got smaller because a measurement replaced an assumption.** Critical #3 assumed a
+Doppler-plus-fnox *dual write*. fnox cannot write to Doppler, so there is no distributed
+transaction to make atomic — an architectural objection answered by reading the dependency's
+source.
+
+**But "no dual write" is not "no coupling."** The two stores remain referentially coupled even with
+zero copied values: a Doppler rename, config migration, or delete leaves the fnox declaration
+(`value = "KEY_NAME"`, `provider = "doppler_dotfiles_dev_personal"`) pointing at something that no
+longer exists, and the failure mode is the silent one this repo already knows —
+`docs/secrets-doppler-fnox-keychain.md` records that a secret written to the wrong config *"lands in
+Doppler and never reaches the environment"*. So the correct claim is **no cross-store *write*
+atomicity problem**, not "no cross-store problem".
+
+**What enforces the invariant today, honestly ranked:**
+
+1. **fnox → Doppler: structural, version-scoped.** At fnox 1.31.1 the provider inherits
+   `RemoteRead`, and the default `put_secret` returns
+   `Err("This provider does not support storing secrets")`. Verified from source. A future fnox
+   release could add a Doppler write path — this is a property of the pinned version, not a law.
+2. **Every other path: policy only.** The `doppler` CLI is the sole sanctioned write path, and
+   nothing enforces that. Doppler's web UI, its REST API, a second CLI invocation, or any
+   sufficiently-scoped service token can all write. The review was right to call the original
+   "structurally" an overclaim.
+3. **No gate.** Nothing would detect a second Doppler writer being introduced. Accepted gap.
+   The only real mitigation available is Doppler-side token scoping, which Doppler's own docs name
+   as the enforcement layer.
+
+**Correction on the 2026-07-30 config wipe.** An earlier draft of this receipt cited it as evidence
+of the unlocked, non-atomic write. That is wrong, and our own rule says so:
+`bootstrap_config()` rebuilds the config from a template that never emits `env`, so it drops the
+mode and every opt-in **by construction**, and **fnox is exonerated** — an authorized write probe
+preserved both. The wipe is a *code-generation* defect in `mde-py`, not a race. The unlocked
+non-atomic write (concurrency-sweep Q2: no versioning, no etag, no conflict detection in the fnox
+write path) is a **separate and still-unexercised** risk. Two distinct defects in the same file;
+conflating them would have sent any future hardening effort at the wrong one.
+
+**The trap — rationale for declining Doppler MCP, not proof of authority.** Adopting Doppler MCP
+writes would not expose a latent consistency problem, it would **create** one, by adding a second
+writer to a store with no conditional-write mechanism *(inherited from the #437 ticket body; not
+re-derived this session — if this is revisited, verify against Doppler's API docs for the specific
+mutation endpoint)*. `--read-only` does not prevent it: it is a startup-time filter over the
+registered tool list, and Doppler's docs say flags *"aren't a guarantee that agentic AI won't
+attempt to work around them"*.
+
+**What I still did not verify.** Doppler's conditional-write semantics (finding 9). The claim that
+`fnox sync`'s multi-secret write is *unlocked* — inherited from concurrency-sweep Q2, not re-read
+from source this session.
+
+## GitHub repos touched
+
+- [jdx/fnox](https://github.com/jdx/fnox) — `providers/doppler.rs`, `providers/mod.rs` (both at `v1.31.1`, hashed) and `providers/keychain.rs` — the provider capability chain and its control arm.
+- [DopplerHQ/mcp-server](https://github.com/DopplerHQ/mcp-server) — cited, not re-fetched: the mutation surface and the `--read-only` startup filter.
+- [ray-manaloto/macos-development-environment](https://github.com/ray-manaloto/macos-development-environment) — `mde/secrets/manage.py` `bootstrap_config()`, the config-wipe author (issue #82).

--- a/docs/research/kb/reports/agents/codex-adversarial-437-source-of-truth.md
+++ b/docs/research/kb/reports/agents/codex-adversarial-437-source-of-truth.md
@@ -1,0 +1,265 @@
+# Codex adversarial review — receipt for #437 (source of truth: Doppler vs fnox)
+
+**Persisted verbatim** per `.claude/rules/agent-report-persistence.md`.
+
+- **Lens:** codex CLI 0.146.0, model `gpt-5.6-sol`, `codex exec --ephemeral --sandbox read-only`,
+  `model_reasoning_effort=high`
+- **Date:** 2026-07-31
+- **Method:** the whole receipt piped on stdin with an explicit *"do NOT read the disk, do NOT run
+  tools — review ONLY the document below"*, so every finding is grounded in a quoted line rather
+  than inherited from the repo.
+- **Result:** 11 findings (2 critical, 8 major, 1 minor). Dispositions are in
+  `docs/receipts/437.md` § "Adversarial review".
+- **Note:** codex printed its findings list twice in one run; both copies are byte-identical and
+  are preserved here rather than deduplicated, because this file is the verbatim record.
+
+---
+
+OpenAI Codex v0.146.0
+--------
+workdir: /Users/rmanaloto/dev/github/ray-manaloto/dotfiles
+model: gpt-5.6-sol
+provider: openai
+approval: never
+sandbox: read-only
+reasoning effort: high
+reasoning summaries: none
+session id: 019fbb0b-b9e2-7663-ab25-33e60914f9bc
+--------
+user
+You are a COLD adversarial reviewer. Do NOT read the disk, do NOT run tools —
+review ONLY the document below, grounding every finding in a quoted line from it.
+
+Context: this is a "receipt" for a resolved decision ticket in a dotfiles repo.
+The ticket asked: what is the source of truth between Doppler and fnox?
+
+Your job: try to REFUTE the verdict and its reasoning. For each finding give:
+  SEVERITY (critical/major/minor) | the QUOTED line | the defect | what would settle it.
+Mark anything you cannot verify from the text as `unverified` and say what evidence would resolve it.
+Be specific and adversarial. If the verdict is sound, say which parts are load-bearing
+and which are decoration. Do not be agreeable for its own sake.
+
+--- DOCUMENT ---
+# Receipt — #437: What is the source of truth between Doppler and fnox?
+
+**Verdict:** Doppler is the source of truth and fnox holds a *reference* rather than a copy, so
+single-writer-per-store already holds **structurally** — fnox's Doppler provider is `RemoteRead`
+only — and the decision is to preserve that as an invariant by keeping the `doppler` CLI as the
+sole Doppler write path and declining Doppler MCP's write surface; the real integrity risk is not
+cross-store at all, it is the unlocked, non-atomic write to the local fnox config.
+
+**Kind:** decision
+**Resolved:** 2026-07-31
+
+## Sources — what I actually opened
+
+- `https://raw.githubusercontent.com/jdx/fnox/main/crates/fnox-core/src/providers/doppler.rs` —
+  **primary, fetched during this ticket.** 464 lines; implements `get_secret` (L111),
+  `get_secrets_batch` (L118), `test_connection` (L188) and nothing else. `put_secret` and
+  `capabilities` are **absent (0 hits)**, so it inherits the `RemoteRead` default. This is the one
+  fact the whole verdict rests on, so it was re-derived here rather than inherited.
+- `https://raw.githubusercontent.com/jdx/fnox/main/crates/fnox-core/src/providers/keychain.rs` —
+  the control arm for that 0 (see "Prior art").
+- `docs/secrets-doppler-fnox-keychain.md` — the wired contract on this Mac. Its layer table already
+  names Doppler *"shared authority — the value of record"* and the environment *"never the source
+  of truth"*; settled that this ticket confirms an existing position rather than choosing a new one.
+- `docs/research/kb/reports/agents/concurrency-sweep-433.md` — Q3a (Doppler provider read-only,
+  verified from source), Q2 (no versioning/etag/conflict detection in the fnox write path), Q1b
+  (the daemon has no write path). Settled where the *actual* exposure lives.
+- `docs/research/kb/reports/agents/adversarial-secrets-takeover-20260730.md` — the origin of
+  Critical #3, verbatim. Settled what the objection actually claimed.
+- `docs/research/kb/reports/agents/deep-research-takeover-20260730.md` — findings 3, 4, 5: Doppler
+  MCP's mutation surface, `--read-only` as startup-time toolset filtering rather than enforcement,
+  and Doppler's own guidance that CLI flags are not a substitute for token scoping.
+- `.claude/rules/secrets-out-of-the-shell-env.md` — the `env = "exec"` decision and the `mde-py`
+  wipe, i.e. the live instance of the single-store integrity problem.
+- GitHub issue #437 body, including its "Updated by the resolution of the concurrency research"
+  section.
+
+## Prior art — the search I ran
+
+**Query:**
+
+```bash
+grep -rlEi 'source of truth|single.writer|read-only|RemoteRead' \
+  docs/research/kb/reports/ docs/specs/ docs/ .claude/rules/ \
+  | xargs grep -lEi 'doppler|fnox'
+```
+
+**Corpus:** `docs/research/kb/reports/`, `docs/specs/`, `docs/`, `.claude/rules/`
+**Control arm:** `fnox` → **39 files** (known present) / `zzqqxxsecretstore` → **0** (known absent)
+
+A second control arm was needed for the load-bearing claim, because it is asserted by an *absence*.
+`grep -nE 'put_secret|capabilities' doppler.rs` → **0 hits**; the identical command shape against
+`keychain.rs` → **hits at L62, L100, L188**. The probe can therefore produce both answers, so the 0
+is a real negative and not a blind grep.
+*(per `.claude/rules/probes-need-a-control-arm.md`)*
+
+| Hit | What I did with it |
+|---|---|
+| `docs/secrets-doppler-fnox-keychain.md` | **read** — supplied the answer already in force: Doppler is "the value of record", fnox holds the declaration, env is "never the source of truth". This ticket ratifies it rather than deciding it fresh. |
+| `docs/research/kb/reports/agents/concurrency-sweep-433.md` | **read** — Q3a gave the source-verified read-only chain; Q2 relocated the risk from cross-store to single-store. The single most load-bearing hit. |
+| `docs/research/kb/reports/agents/deep-research-takeover-20260730.md` | **read** — established that the trap is real and specific: Doppler MCP ships `secrets_update`/`configs_lock`, and `--read-only` is a startup filter, not a boundary. |
+| `docs/research/kb/reports/agents/adversarial-secrets-takeover-20260730.md` | **read** — the Critical #3 text. Confirmed the objection was premised on a *dual-write* workflow that does not exist. |
+| `.claude/rules/secrets-out-of-the-shell-env.md` | **read** — the `mde-py` wipe is the worked instance of the single-store risk; it is what makes the relocated exposure concrete rather than theoretical. |
+| `docs/research/mintlify-cache/jdx/fnox/llms-full.txt` | **dismissed** — vendor guide prose; the provider capability question is answered by source, which I fetched directly. Superseded by a primary source. |
+| `docs/research/runs/research-20260709-r2-secrets/agents/doppler-platform.md` | **dismissed** — 2026-07-09 platform survey, predates the `env = "exec"` adoption and the read-only verification; nothing in it bears on which store is authoritative. |
+| `docs/research/runs/research-20260709-r2-secrets/agents/fnox-division.md` | **dismissed** — same vintage; concerns the R2 division of labour, not write authority. |
+| `docs/research/runs/research-20260709-r2-secrets/agents/full-secret-map.md` | **dismissed** — inventory of which secret goes where; orthogonal to source-of-truth. |
+| `docs/research/runs/plan-20260710-r2-implementation.md` and the remaining `research-20260709/10/11` hits | **dismissed** — matched on the generic phrase "read-only"/"source of truth" in unrelated contexts (CI image pipeline, event triggers, graphify agents). Term collision, not prior art. |
+| `docs/research/mintlify-cache/twpayne/chezmoi/llms-full.txt` | **dismissed** — chezmoi cache; matched on "source of truth" meaning chezmoi's source directory. Different sense of the phrase. |
+| `docs/research/mintlify-catalog.md` | **dismissed** — index file, no content bearing on the question. |
+| `docs/specs/deep-interview-research-tooling-wiring.md` | **dismissed** — tooling wiring spec; mentions fnox only as an available provider. |
+
+## Adversarial review
+
+**Lens:** codex (GPT-5.6 Sol, `codex exec --ephemeral --sandbox read-only`, reasoning effort high)
+**Verdict:** see "Findings" below — run against the verdict text and the reasoning, with an explicit
+"do NOT read the disk" instruction so every finding is grounded in the quoted argument rather than
+inherited from the repo (the method that made #449's three rounds productive).
+**Findings:** recorded below with disposition.
+**Disposition:** inline in this section.
+
+<!-- REVIEW-PENDING -->
+
+## Notes
+
+**The question got smaller because a measurement replaced an assumption.** Critical #3 assumed a
+Doppler-plus-fnox *dual write*. fnox cannot write to Doppler at all, so there is no distributed
+transaction to make atomic — the objection dissolves on a fact about the tool, not on a design
+decision. That is the shape worth remembering: an architectural objection can be answered by
+reading the dependency's source.
+
+**What actually enforces the invariant today, ranked by strength:**
+
+1. **fnox's provider capabilities** — structural, in the tool, cannot be bypassed by policy drift.
+   fnox has no Doppler write path to misuse.
+2. **The standing decision that the `doppler` CLI is the sole Doppler write path** — a human-run,
+   interactive-prompt path (`doppler secrets set 'KEY' --project dotfiles --config dev_personal
+   --silent`), already recorded in `docs/secrets-doppler-fnox-keychain.md`.
+3. **Nothing else.** There is no gate that would catch a second Doppler writer being introduced.
+   That is a known, accepted gap, not an oversight — see the risk note below.
+
+**The risk is not where the ticket originally pointed.** Cross-store atomicity is a non-problem;
+single-store integrity is the live one. `fnox sync` writes all 49 secrets at once, unlocked and
+non-atomic, and that is precisely the path the `mde-py` `bootstrap_config()` composite corrupted on
+2026-07-30. Any future hardening effort should go there, not into reconciling two stores.
+
+**The trap is worth restating because it inverts the usual direction.** Adopting Doppler MCP writes
+would not *expose* a latent consistency problem — it would **create** one that does not currently
+exist, by adding a second writer to a store whose API has no etags and no conditional writes, so
+the second writer is an unconditional overwrite. `--read-only` does not prevent this: it is a
+startup-time filter over the registered tool list, and Doppler's own docs say flags "aren't a
+guarantee that agentic AI won't attempt to work around them". The decision to decline that surface
+is therefore load-bearing, not merely conservative.
+
+**What I did not verify.** I did not read `providers/mod.rs` myself to confirm the `RemoteRead`
+default's body — that chain is inherited from `concurrency-sweep-433.md`, which quotes it at
+`mod.rs:209-232`. I verified the part that mattered most (doppler.rs overrides neither method) from
+source with a control arm; the default's *content* remains second-hand. If this is ever revisited,
+that is the one link to re-derive.
+
+warning: Under-development features enabled: chronicle. Under-development features are incomplete and may behave unpredictably. To suppress this warning, set `suppress_unstable_features_warning = true` in /Users/rmanaloto/.codex/config.toml.
+codex
+1. **CRITICAL |** “`fnox's Doppler provider is RemoteRead only`” and “`I did not read providers/mod.rs myself to confirm the RemoteRead default's body`”  
+   **Defect:** The verdict’s central premise is not established by the receipt. Absence of `put_secret` and `capabilities` proves only that `doppler.rs` does not define those symbols—not that trait dispatch necessarily supplies a read-only default, nor that no alternate write implementation exists. The document explicitly admits the decisive default behavior is second-hand. **Status: unverified.**  
+   **What would settle it:** A commit-pinned excerpt of the provider trait/default implementation, the Doppler implementation declaration, and the registration/dispatch path showing its effective capabilities at runtime.
+
+2. **CRITICAL |** “`single-writer-per-store already holds structurally`” versus “`The standing decision that the doppler CLI is the sole Doppler write path — a human-run ... path`” and “`There is no gate that would catch a second Doppler writer being introduced.`”  
+   **Defect:** “Structurally” is refuted by the receipt itself. The sole-writer constraint is a human decision with no enforcement, not a structural property. At most, the currently inspected fnox provider appears not to be a writer. That says nothing about Doppler’s web UI, API clients, automation, future MCP enablement, or another CLI invocation.  
+   **What would settle it:** An enforced inventory of Doppler credentials and allowed mutation principals, token scopes denying writes to every non-authorized path, plus a gate that detects newly introduced writers. Otherwise narrow the verdict to “the reviewed fnox provider is not currently a Doppler writer.”
+
+3. **MAJOR |** “`https://raw.githubusercontent.com/jdx/fnox/main/.../doppler.rs`”  
+   **Defect:** The load-bearing source is fetched from mutable `main`, with no commit SHA, fnox release, lockfile version, or content hash. It may not correspond to the version actually installed in the repo, and the conclusion cannot be reproduced later. **Status: unverified for the deployed fnox version.**  
+   **What would settle it:** Bind the evidence to the exact installed fnox version and commit, quote the relevant source, and record a content hash.
+
+4. **MAJOR |** “`Doppler is the source of truth`” because the existing contract “`already names Doppler "shared authority — the value of record"`”  
+   **Defect:** This is largely circular. An existing document asserting the answer proves prior policy, not that Doppler is operationally authoritative or that the policy is correct. Provider write capability cannot itself establish semantic source of truth.  
+   **What would settle it:** Define authority operationally: where values are created, recovered, audited, rotated, and reconciled after disagreement. Then provide configuration or tests showing consumers resolve conflicts in favor of Doppler.
+
+5. **MAJOR |** “`fnox holds a reference rather than a copy`” versus “`fnox sync writes all 49 secrets at once`”  
+   **Defect:** The receipt never explains what `fnox sync` writes. If it writes secret values locally, the “reference rather than a copy” claim may be false. If it writes only provider declarations or metadata, the corruption and “49 secrets” language is misleading. **Status: unverified and internally ambiguous.**  
+   **What would settle it:** A redacted before/after representation of the fnox configuration, identifying exactly which fields are references, metadata, or secret material, together with the documented semantics of `fnox sync`.
+
+6. **MAJOR |** “`there is no distributed transaction to make atomic`” and “`Cross-store atomicity is a non-problem`”  
+   **Defect:** This does not follow from fnox lacking a direct Doppler write method. An operation may still require coordinated changes to a Doppler value and its local fnox reference, project/config selector, alias, or declaration. Cross-store inconsistency does not require two stores to contain copied secret values.  
+   **What would settle it:** An operation matrix for creation, rename, rotation, deletion, project/config migration, rollback, and recovery, showing that no supported operation mutates both Doppler state and fnox configuration or temporarily invalidates their relationship.
+
+7. **MAJOR |** “`fnox's provider capabilities — structural, in the tool, cannot be bypassed by policy drift`”  
+   **Defect:** “Cannot be bypassed” is absolute and unsupported. A dependency upgrade, alternate provider, direct Doppler API call, plugin, wrapper, or modification outside fnox bypasses that property. The later admission that no gate detects a second writer directly contradicts the absolute claim.  
+   **What would settle it:** Replace the absolute statement with a version-scoped claim, or demonstrate enforced admission controls covering dependency upgrades, provider registration, credentials, MCP tools, and direct API access.
+
+8. **MAJOR |** “`that is precisely the path the mde-py bootstrap_config() composite corrupted on 2026-07-30`”  
+   **Defect:** The receipt asserts causation without presenting the failed operation, interleaving, before/after state, logs, or reproducer. A previous report and rule are named, but their evidence is not reproduced here. **Status: unverified.**  
+   **What would settle it:** A redacted failure trace or deterministic reproducer proving that an unlocked, non-atomic write—rather than incorrect transformation logic, stale input, or another writer—caused the corruption.
+
+9. **MAJOR |** “`by adding a second writer to a store whose API has no etags and no conditional writes`”  
+   **Defect:** Neither the API claim nor its scope is evidenced in the receipt. It is unclear whether this refers to the relevant Doppler endpoint, the MCP implementation, or fnox’s local file. Even without ETags, versioning, locks, revision preconditions, or server-side operations might exist. **Status: unverified.**  
+   **What would settle it:** Commit/version-pinned MCP code and primary Doppler API documentation for the exact mutation endpoint, showing the request semantics and absence of revision or conditional-write mechanisms.
+
+10. **MINOR |** “`--read-only does not prevent this`” while the decision is to “`declin[e] Doppler MCP's write surface`”  
+    **Defect:** This supports rejecting a particular mitigation, but it does not establish which store is authoritative. It is secondary risk analysis, not evidence for the source-of-truth verdict.  
+    **What would settle it:** Nothing is needed if retained as rationale for the MCP decision; move it out of the proof of authority.
+
+11. **MAJOR |** “`Findings: recorded below with disposition`” followed by “`<!-- REVIEW-PENDING -->`”  
+    **Defect:** The receipt is marked resolved while its stated adversarial-review findings and dispositions are absent. The document therefore provides no evidence that the review occurred or that objections were resolved.  
+    **What would settle it:** Insert the actual findings, exact dispositions, reviewer outcome, and evidence for each disposition—or mark the ticket unresolved.
+
+The narrow conclusion that may survive is: *for the inspected snapshot of `doppler.rs`, no explicit write method was found*. Everything stronger—effective `RemoteRead` behavior, correspondence to the installed version, structurally enforced single-writer status, absence of cross-store consistency risks, and the asserted corruption cause—remains unverified.
+
+Load-bearing evidence would be the pinned trait/default/dispatch chain, the installed-version match, and an operation-level authority model. The grep corpus, dismissed historical hits, model/runtime description, and MCP warning are mostly decoration relative to the source-of-truth question.
+tokens used
+16,040
+1. **CRITICAL |** “`fnox's Doppler provider is RemoteRead only`” and “`I did not read providers/mod.rs myself to confirm the RemoteRead default's body`”  
+   **Defect:** The verdict’s central premise is not established by the receipt. Absence of `put_secret` and `capabilities` proves only that `doppler.rs` does not define those symbols—not that trait dispatch necessarily supplies a read-only default, nor that no alternate write implementation exists. The document explicitly admits the decisive default behavior is second-hand. **Status: unverified.**  
+   **What would settle it:** A commit-pinned excerpt of the provider trait/default implementation, the Doppler implementation declaration, and the registration/dispatch path showing its effective capabilities at runtime.
+
+2. **CRITICAL |** “`single-writer-per-store already holds structurally`” versus “`The standing decision that the doppler CLI is the sole Doppler write path — a human-run ... path`” and “`There is no gate that would catch a second Doppler writer being introduced.`”  
+   **Defect:** “Structurally” is refuted by the receipt itself. The sole-writer constraint is a human decision with no enforcement, not a structural property. At most, the currently inspected fnox provider appears not to be a writer. That says nothing about Doppler’s web UI, API clients, automation, future MCP enablement, or another CLI invocation.  
+   **What would settle it:** An enforced inventory of Doppler credentials and allowed mutation principals, token scopes denying writes to every non-authorized path, plus a gate that detects newly introduced writers. Otherwise narrow the verdict to “the reviewed fnox provider is not currently a Doppler writer.”
+
+3. **MAJOR |** “`https://raw.githubusercontent.com/jdx/fnox/main/.../doppler.rs`”  
+   **Defect:** The load-bearing source is fetched from mutable `main`, with no commit SHA, fnox release, lockfile version, or content hash. It may not correspond to the version actually installed in the repo, and the conclusion cannot be reproduced later. **Status: unverified for the deployed fnox version.**  
+   **What would settle it:** Bind the evidence to the exact installed fnox version and commit, quote the relevant source, and record a content hash.
+
+4. **MAJOR |** “`Doppler is the source of truth`” because the existing contract “`already names Doppler "shared authority — the value of record"`”  
+   **Defect:** This is largely circular. An existing document asserting the answer proves prior policy, not that Doppler is operationally authoritative or that the policy is correct. Provider write capability cannot itself establish semantic source of truth.  
+   **What would settle it:** Define authority operationally: where values are created, recovered, audited, rotated, and reconciled after disagreement. Then provide configuration or tests showing consumers resolve conflicts in favor of Doppler.
+
+5. **MAJOR |** “`fnox holds a reference rather than a copy`” versus “`fnox sync writes all 49 secrets at once`”  
+   **Defect:** The receipt never explains what `fnox sync` writes. If it writes secret values locally, the “reference rather than a copy” claim may be false. If it writes only provider declarations or metadata, the corruption and “49 secrets” language is misleading. **Status: unverified and internally ambiguous.**  
+   **What would settle it:** A redacted before/after representation of the fnox configuration, identifying exactly which fields are references, metadata, or secret material, together with the documented semantics of `fnox sync`.
+
+6. **MAJOR |** “`there is no distributed transaction to make atomic`” and “`Cross-store atomicity is a non-problem`”  
+   **Defect:** This does not follow from fnox lacking a direct Doppler write method. An operation may still require coordinated changes to a Doppler value and its local fnox reference, project/config selector, alias, or declaration. Cross-store inconsistency does not require two stores to contain copied secret values.  
+   **What would settle it:** An operation matrix for creation, rename, rotation, deletion, project/config migration, rollback, and recovery, showing that no supported operation mutates both Doppler state and fnox configuration or temporarily invalidates their relationship.
+
+7. **MAJOR |** “`fnox's provider capabilities — structural, in the tool, cannot be bypassed by policy drift`”  
+   **Defect:** “Cannot be bypassed” is absolute and unsupported. A dependency upgrade, alternate provider, direct Doppler API call, plugin, wrapper, or modification outside fnox bypasses that property. The later admission that no gate detects a second writer directly contradicts the absolute claim.  
+   **What would settle it:** Replace the absolute statement with a version-scoped claim, or demonstrate enforced admission controls covering dependency upgrades, provider registration, credentials, MCP tools, and direct API access.
+
+8. **MAJOR |** “`that is precisely the path the mde-py bootstrap_config() composite corrupted on 2026-07-30`”  
+   **Defect:** The receipt asserts causation without presenting the failed operation, interleaving, before/after state, logs, or reproducer. A previous report and rule are named, but their evidence is not reproduced here. **Status: unverified.**  
+   **What would settle it:** A redacted failure trace or deterministic reproducer proving that an unlocked, non-atomic write—rather than incorrect transformation logic, stale input, or another writer—caused the corruption.
+
+9. **MAJOR |** “`by adding a second writer to a store whose API has no etags and no conditional writes`”  
+   **Defect:** Neither the API claim nor its scope is evidenced in the receipt. It is unclear whether this refers to the relevant Doppler endpoint, the MCP implementation, or fnox’s local file. Even without ETags, versioning, locks, revision preconditions, or server-side operations might exist. **Status: unverified.**  
+   **What would settle it:** Commit/version-pinned MCP code and primary Doppler API documentation for the exact mutation endpoint, showing the request semantics and absence of revision or conditional-write mechanisms.
+
+10. **MINOR |** “`--read-only does not prevent this`” while the decision is to “`declin[e] Doppler MCP's write surface`”  
+    **Defect:** This supports rejecting a particular mitigation, but it does not establish which store is authoritative. It is secondary risk analysis, not evidence for the source-of-truth verdict.  
+    **What would settle it:** Nothing is needed if retained as rationale for the MCP decision; move it out of the proof of authority.
+
+11. **MAJOR |** “`Findings: recorded below with disposition`” followed by “`<!-- REVIEW-PENDING -->`”  
+    **Defect:** The receipt is marked resolved while its stated adversarial-review findings and dispositions are absent. The document therefore provides no evidence that the review occurred or that objections were resolved.  
+    **What would settle it:** Insert the actual findings, exact dispositions, reviewer outcome, and evidence for each disposition—or mark the ticket unresolved.
+
+The narrow conclusion that may survive is: *for the inspected snapshot of `doppler.rs`, no explicit write method was found*. Everything stronger—effective `RemoteRead` behavior, correspondence to the installed version, structurally enforced single-writer status, absence of cross-store consistency risks, and the asserted corruption cause—remains unverified.
+
+Load-bearing evidence would be the pinned trait/default/dispatch chain, the installed-version match, and an operation-level authority model. The grep corpus, dismissed historical hits, model/runtime description, and MCP warning are mostly decoration relative to the source-of-truth question.
+
+## GitHub repos touched
+
+- [jdx/fnox](https://github.com/jdx/fnox) — `crates/fnox-core/src/providers/doppler.rs`, `keychain.rs`, `age.rs` and `providers/mod.rs` read at tag `v1.31.1` to verify the provider capability chain.
+- [DopplerHQ/mcp-server](https://github.com/DopplerHQ/mcp-server) — cited (not re-fetched this session) for the mutation surface and the `--read-only` startup filter.
+- [ray-manaloto/macos-development-environment](https://github.com/ray-manaloto/macos-development-environment) — `mde/secrets/manage.py` `bootstrap_config()`, the config-wipe author.


### PR DESCRIPTION
Answers #437 and produces `docs/receipts/437.md` as instance #2 of the
receipt pilot (#449), written as the work happened rather than at close.

**Verdict.** Doppler is the declared source of truth; fnox holds a reference
resolved at read time, plus an encrypted local cache copy wherever `fnox sync`
has run. fnox *cannot* write to Doppler — verified from source at the installed
version. But single-writer-per-store overall is POLICY, not a structural
property: Doppler's web UI, REST API, a second CLI invocation and any scoped
token are all unconstrained writers, and no gate would notice a new one. The
live integrity risk is the local fnox config, not cross-store atomicity.

Verified from primary source at the INSTALLED version (fnox 1.31.1), not
mutable main, with sha256 recorded for both files:

  providers/doppler.rs  — get_secret/get_secrets_batch/test_connection only;
                          put_secret and capabilities absent (0 hits)
  providers/mod.rs:228  — default capabilities() -> vec![RemoteRead]
  providers/mod.rs:208  — default put_secret, RemoteRead falls to
                          Err("This provider does not support storing secrets")

Control arm for the 0: the same grep against keychain.rs hits L62/L100/L188,
so the absence in doppler.rs is a real negative.

**The pilot earned its keep on ticket 1.** A codex cold review of the receipt
returned 11 findings (2 critical) — 8 accepted, 3 partially, 0 refuted — and
changed the verdict twice:

- "structurally" was an overclaim the receipt refuted two paragraphs later in
  its own "there is no gate" sentence;
- the 2026-07-30 fnox config wipe was cited as evidence of an unlocked
  non-atomic write. Our own rule says the opposite: `bootstrap_config()` drops
  `env` by construction and "fnox is EXONERATED". It is a code-generation
  defect, not a race — two distinct defects in one file, and conflating them
  would have aimed future hardening at the wrong one.

Review persisted verbatim per agent-report-persistence, with a disposition
table for all 11 findings.

Gates: lint rc=0 · pytest 1144 passed · verify 112 passed / 0 failed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014x8jGSieFkDBV95KLXYhTC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788142181&installation_model_id=429246&pr_number=456&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F456&signature=932cba47f94d6c741bdde3f5583d4a9e266c3a8456476931a89ffa8933241244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->