### PR TITLE
docs(438): flock replacement — the sentinel is already in-tree, the gap is placement

### DIFF
--- a/docs/receipts/438.md
+++ b/docs/receipts/438.md
@@ -1,0 +1,306 @@
+# Receipt — #438: What replaces the flock design, given the dead-inode problem?
+
+**Verdict:** Nothing replaces `flock` — the dead-inode bug is a property of locking the file you
+then rename over, and fnox already ships the right answer in `lease.rs` (a stable sidecar sentinel
+locked with `flock(2)`, plus temp-write→`fs::rename`); so the decision is to apply that pattern in
+**two tiers upstream** — inside the three self-contained `*_source` writers, but at the *command*
+boundary for `Config::save`, whose read happens in the CLI dispatcher — **and** to fix the one
+writer upstream can never reach, `mde-py`'s `bootstrap_config()`, which rewrites the config with a
+raw `Path.write_text()` across a Doppler network call, preferably by routing it through `fnox`
+rather than by re-implementing the lock in Python.
+
+**Kind:** decision
+**Resolved:** 2026-08-01
+
+## Sources — what I actually opened
+
+Everything below was read from a fresh `--depth 1` clone at a **tag**, not mutable `main` — the
+correction ticket 1 earned. Two tags, because the installed version and the current release differ:
+
+- **`jdx/fnox` @ `v1.31.1`** (`df4e159eff92fe1ac648facd26987e31a132b17f`, 2026-07-24) — **the
+  installed fnox** (`fnox --version` → `fnox 1.31.1`).
+  File bytes are pinned by that commit, so — unlike ticket 1, where files were fetched
+  individually over HTTP — no per-file digest is needed here.
+  - `crates/fnox-core/src/lease.rs` — the pattern, quoted below.
+  - `crates/fnox-core/src/config.rs` — the four unguarded writers.
+  - `src/daemon.rs` — the `Request` enum.
+  - `src/commands/{set,remove,sync,import,reencrypt,init,encrypt,decrypt,provider/add,provider/remove}.rs`
+    — the caller side, read to establish **where each transaction's read happens**. This is what
+    the review's critical #1 turned on, and it changed the recommendation.
+- **`jdx/fnox` @ `v1.32.0`** (`13e2a7bbc6af47423ef0b614291ced536a539c90`, released
+  **2026-08-01T10:51:01Z — the day this ticket was resolved**), *"Credential proxy, process
+  replacement, and Azure App Configuration"*. Read to answer "has upstream already fixed this?"
+  **It has not.** `config.rs` gained 241 lines, all config-discovery / `load_import`; the four
+  `fs::write` calls and the zero locks are unchanged, and the `fslock` call-site set is
+  byte-for-byte identical to 1.31.1. Also re-read `providers/doppler.rs` here (see prior art).
+- **`fslock` 0.2.1 crate source**, downloaded from `static.crates.io` and verified
+  `sha256:04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb` — **byte-identical to
+  the checksum in fnox's `Cargo.lock`**, so this is the exact code fnox builds. `src/unix.rs:322`
+  settles the interop question (below).
+- **`ray-manaloto/macos-development-environment` `src/mde/secrets/manage.py`** — the decisive
+  source, and the one nobody had opened. `bootstrap_config()` at L247–324.
+- `docs/research/kb/reports/agents/concurrency-sweep-433.md` — the inherited sweep. Two of its
+  enumerations are corrected below.
+- `docs/research/kb/reports/agents/adversarial-secrets-takeover-20260730.md` L26–52 — Critical #2
+  verbatim, the origin of this ticket. Read in full rather than via the ticket's paraphrase, which
+  mattered: it makes *two* claims and the title carries only one.
+- `.devcontainer/devcontainer.json` L93–98 — the mount inventory, read to settle the
+  cross-boundary bound rather than assert it.
+- `jdx/mise` `src/lock_file.rs` and `DopplerHQ/cli` `pkg/utils/io.go` — cited from the sweep as
+  precedent, **not** re-fetched this session. Labelled inherited, per rule 6 of
+  `probes-need-a-control-arm.md`, and load-bearing on nothing here.
+- GitHub issue #438's body, including its "Updated by the resolution of the concurrency research".
+
+## Prior art — the search I ran
+
+### Arm 1 — this repo
+
+**Query:**
+
+```bash
+grep -rn -Ei 'flock|fslock|O_EXCL|dead inode|sentinel|atomic (write|replace|rename)|lost update' \
+  docs/ .claude/rules/ python/
+```
+
+**Corpus:** `docs/`, `.claude/rules/`, `python/`
+**Control arm:** `fnox` → **47 files** (known present) / `zzqqxxlockstore` → **0** (known absent)
+
+| Hit | What I did with it |
+|---|---|
+| `docs/research/kb/reports/agents/adversarial-secrets-takeover-20260730.md` | **read — most load-bearing hit.** The origin. Critical #2 makes **two** claims and this ticket's title carries only the first. See "Notes". |
+| `docs/research/kb/reports/agents/concurrency-sweep-433.md` | **read** — the mechanism and the call-site claims. **Two of its enumerations are wrong**; corrected below. |
+| `docs/receipts/437.md` | **read** — the sibling receipt. Supplied the "fnox cannot write Doppler" premise; **re-derived here rather than inherited** (review finding 5). |
+| `docs/research/kb/reports/agents/codex-adversarial-437-source-of-truth.md` | **read** — finding 8's correction (the wipe is codegen, not a race) is exactly the trap this receipt then walked into anyway. See finding 2's disposition. |
+| `docs/specs/second-brain-design.md:121` | **read** — in-repo precedent: a prior design accepted an upstream component *because* it was already `flock`-serialized, so "no new single-writer machinery" was needed. Same reasoning shape, opposite outcome — there the upstream lock existed. |
+| `docs/research/kb/reports/agents/graphify-embedding-archaeology.md:696` | **read** — in-repo atomic-write precedent (*"a crash/ENOSPC mid-write must not truncate a good graph.json"*). temp+rename is already a pattern this repo applies to its own state. |
+| `docs/specs/research-nudge-hooks.md:226` | **read** — a third in-repo instance of the same defect class ("statusline state unscoped / non-atomic"). Evidence the class recurs here; no mechanism to borrow. |
+| `docs/rules-evidence/*`, `docs/research/runs/research-20260709-*`, `-20260710-*`, `-20260711-*`, `plan-20260710-r2-implementation.md`, `python/src/dotfiles_setup/{p2996_hash,image,apt_repo}.py`, `python/verification/suites.toml`, `docs/research/gha-workflow-optimization.md` | **dismissed — term collision on "sentinel".** In every one it means a *Dockerfile hash-boundary comment* (`BASE_HASH_BEGIN/END`) or a bootstrap marker file, not a lock. ~40 of the 65 file hits are this single collision. |
+| `docs/research/mintlify-cache/**`, `docs/research/trail/**`, `docs/adr/0001-*`, `docs/triage-labels.md`, `python/src/dotfiles_setup/lock_{integrity,refresh}.py`, `.claude/rules/tool-currency-and-native-first.md` | **dismissed — "lock" in the dependency-pinning sense** (`mise.lock`, "lock file maintenance", Renovate lockfile PRs). Nothing to do with mutual exclusion. |
+
+### Arm 2 — upstream, re-run and then widened
+
+The sweep's negative was 2026-07-30. A release shipped since, so I re-ran it; the review (finding
+6) then correctly objected that four narrow queries do not establish absence, so I widened it.
+
+**Query:** `gh api -X GET search/issues -f q='repo:jdx/fnox <term>' --jq '.total_count'`
+**Control arm:** `secret` → **234** · `secret in:title` → **43** · `zzqqxxww` → **0**
+
+| Query | Count | After reading every item |
+|---|---:|---|
+| `"lost update"` | 2 | **both false positives** — a Renovate `@anthropic-ai/claude-code` bump (#625) and the KeePass provider PR (#123). |
+| `save_secret_to_source` | 6 | **all false positives** — TOML comment/format preservation (#223, #268, #467), profile composition (#605), config-hierarchy fixes (#107, #122). |
+| `concurrent in:title` | 1 | false positive — #180, provider **batch-fetch** concurrency. |
+| `overwrite in:title` | 1 | false positive — #309, a sync *cache field*, not a file race. |
+| `race` · `clobber` · `data loss` · `serialization` · `flock` · `locking` · `truncated` · `config write lock` · `atomic` (all `in:title`) | **0** each | real zeros against the 43-hit title-scoped control. |
+
+**No upstream issue, PR or discussion raises concurrent config writes — as of the day v1.32.0
+shipped**, across 13 queries this session plus the sweep's 6. Scope bound, kept from the sweep:
+this is a negative about the GitHub trackers, not about jdx's Discord.
+
+Counting was never enough — **10 of 10 non-zero hits were term collisions**, the same ratio ticket
+1 found, and the reason the dismissal column exists.
+
+## Adversarial review
+
+**Lens:** codex CLI / `gpt-5.6-sol`, `codex exec --ephemeral --sandbox read-only`,
+`model_reasoning_effort=high`, whole document on stdin with *"do NOT read the disk"*
+**Verdict:** needs-attention — **the review changed the recommendation, not just its wording**
+**Findings:** 14 (2 critical, 10 major, 2 minor) — verbatim in
+`docs/research/kb/reports/agents/codex-adversarial-438-flock-replacement.md`
+**Disposition:** **11 accepted, 3 partially accepted, 0 refuted.**
+
+| # | Sev | Claim | Disposition |
+|---|---|---|---|
+| 1 | critical | Guarding the four `config.rs` *write functions* starts the lock too late — two callers can both read before either locks | **ACCEPTED — and verified from source; the recommendation is now two-tier.** `encrypt.rs:16` and `decrypt.rs:18` take `mut config: Config` **already loaded by the dispatcher**; `provider/add.rs:75` and `provider/remove.rs:47` call `Config::load` in the caller, 13–230 lines before the save. For those five, a guard inside `Config::save` is unambiguously too late. The three `*_source` functions *do* read and write internally (`config.rs:969→1025`, `1047→1077`, `1101→1157`), so for them an internal guard is correct. The single-tier recommendation was wrong. |
+| 2 | critical | "The only observed incident lives in lane 2" contradicts "did not measure the race" — and the one wipe was corrected to codegen, not a race | **ACCEPTED — and this is a REPEAT of ticket 1's finding 8, by me, in the receipt that documents it.** No lost-update incident has been observed. Corrected to *"the only identified high-risk writer"*. See "Notes". |
+| 3 | major | The "11 writers" inventory commits the enumeration error the receipt accuses its own source of | **ACCEPTED.** Relabelled **"known application call sites reachable on this host"**, with the method stated (grep of the four function names across `src/` + `crates/`; grep of mde's Python for direct writes and `fnox` subprocess calls). Editors, `chezmoi`, and future agents are outside it by construction — which is the point of the advisory-lock caveat, not a hole in it. |
+| 4 | major | A shared pathname does not make a Rust lock and a Python lock interoperate | **ACCEPTED — measured, and it is now a stated contract.** `fslock` 0.2.1 `src/unix.rs:322` is `libc::flock(fd, LOCK_EX)` — BSD `flock(2)`, in the crate whose sha256 matches fnox's `Cargo.lock`. So the Python side **must** use `fcntl.flock`, **never** `fcntl.lockf`: `lockf` is a POSIX record lock and the two families do not interact. Without this measurement, lane 2 would have looked correct and silently protected nothing. |
+| 5 | major | The "single-store" bound that justifies rejecting CAS is inherited from #437, not established here | **ACCEPTED — re-derived at the current release.** `providers/doppler.rs` @ **v1.32.0** implements `get_secret`/`get_secrets_batch`/`test_connection` and nothing else; control arm `keychain.rs` @ the same tag shows `put_secret` at L62/L188 and `capabilities` at L100, so the probe returns both answers. No longer inherited. |
+| 6 | major | "Nobody has raised" rests on four narrow queries and omits obvious vocabulary | **ACCEPTED — nine more queries run** (`race`, `concurrent`, `clobber`, `overwrite`, `data loss`, `serialization`, `flock`, `locking`, `truncated`, title-scoped), two non-zero, both false positives on reading. Claim retained but now bounded to the GitHub trackers. |
+| 7 | major | The daemon is dismissed for being *absent*, which is not the same as being *unsuitable* | **PARTIALLY ACCEPTED.** The logical objection is right and the rejection is re-grounded: a daemon is **opt-in and per-user**, so it inherits the same voluntary-participation problem *and* additionally requires every third-party writer (`mde-py`) to speak a private socket protocol instead of calling one libc function. It is strictly worse than a lockfile **as a design**, independent of the implementation cost. The absence is now cited as availability, not as the reason. |
+| 8 | major | "Mandatory" / "no upstream change can *ever* reach it" overstates — the Python writer could be removed rather than locked | **ACCEPTED, and it improved the answer.** Eliminating the writer is now the **preferred** form of lane 2: route `bootstrap_config()` through `fnox set`/`fnox sync` so it inherits the upstream guard, and re-implement the lock in Python only if that proves infeasible. Fewer writers beats more locks. The unconditional wording is withdrawn. |
+| 9 | major | "The correct pattern … solved" claims more than the excerpt shows; `mode(0o600)` governs creation only | **PARTIALLY ACCEPTED.** "Correct" is narrowed to *correct for the inode problem*, which is what this ticket asks. Three residual weaknesses in `lease.rs` are now recorded as things the upstream patch should **improve rather than copy**: no `fsync` before rename (so it is crash-*consistent*, not crash-*durable*), a **fixed** tmp path (`.toml.tmp`) that a crashed run can leave behind, and `OpenOptions::mode()` applying only at creation — so a stale tmp file is reused with its old mode. Not refutations of the choice; genuine gaps in the reference implementation. |
+| 10 | major | "Genuinely eliminates lost updates" holds only if every writer cooperates, which the receipt says is unenforced | **ACCEPTED — qualified everywhere** to *cooperating writers*. |
+| 11 | major | The local "minimum fix" never states when the lock is acquired, so the network-spanning stale read may survive it | **ACCEPTED — and it exposed a better shape.** Acquiring before `_read_existing_config` and holding through the rename is correct but would hold an exclusive lock across a multi-second Doppler round-trip. The right order is **fetch → lock → re-read → merge → write → unlock**, which keeps the critical section local and short. Specified below. |
+| 12 | major | CAS is rejected partly because the TOML has no version field, but CAS can use a content hash | **PARTIALLY ACCEPTED.** The version-field reason is **withdrawn** — a content hash or `(mtime, size, ino)` triple works. CAS is not inferior, it is *complementary*: a lock prevents races between cooperating writers, a compare-before-write **detects** a bypassing one. A cheap hash check is now recommended as an adjunct in lane 2. Locking remains the primary mechanism because CAS alone cannot prevent torn reads. |
+| 13 | minor | Appending `.lock` still collides, and path aliasing yields different sentinels for one target | **ACCEPTED.** The contract now requires `std::fs::canonicalize` on the config path before deriving the sidecar, and reserves the `.lock` suffix in that directory. |
+| 14 | minor | The devcontainer exclusion is asserted, not shown | **ACCEPTED — verified from `.devcontainer/devcontainer.json:93-98.`** Exactly three binds: the workspace, `~/.local/state/dotfiles`, and the ssh-auth socket; `$HOME` is a **named volume**, not a host bind. No mount covers `~/.config`, so the host config is genuinely unreachable from the container. Residual, now stated: the container ships its **own** fnox (`mise-runtime.lock` pins v1.29.0) writing a *different* config inside that volume. |
+
+## The decision
+
+### Mechanism: a stable sidecar sentinel — which is `flock`, correctly targeted
+
+The ticket's framing ("what *replaces* flock") contains the error. `flock(2)` is not the broken
+part; **locking a file you are about to `rename(2)` over** is. The fix is to lock something whose
+inode is never replaced — and fnox already does exactly that, at `lease.rs:89-103` @ `v1.31.1`,
+with a doc comment stating the reasoning in the same terms the adversarial review used:
+
+```rust
+/// Locks a separate `.lock` sentinel file rather than the data file itself,
+/// because `save()` uses atomic rename which replaces the data file's inode.
+/// Locking the data file directly would break mutual exclusion: after rename,
+/// new processes would lock the new inode while the old process holds the old one.
+pub fn lock(project_dir: &Path) -> Result<LedgerLockGuard> {
+    let ledger_path = Self::ledger_path(project_dir);
+    let lock_path = ledger_path.with_extension("lock");
+    let lock = xx::fslock::FSLock::new(&lock_path).lock() …
+```
+
+…paired with a `save()` that writes `path.with_extension("toml.tmp")` at `0o600` and `fs::rename`s
+it into place (`lease.rs:153-183`). Sentinel lock for lost updates, temp+rename for torn reads.
+
+**The primitive underneath is `flock(2)`, measured not assumed.** `fslock` 0.2.1 `src/unix.rs:322`
+is `libc::flock(fd, libc::LOCK_EX)`, in the crate whose checksum matches fnox's `Cargo.lock`. That
+is the interop contract for anything else that locks the same file.
+
+### The alternatives the ticket listed, and why they lose
+
+| Candidate | Verdict |
+|---|---|
+| **Stable sidecar sentinel + temp-write→rename** | **CHOSEN.** Kernel-backed release on process death, so no stale-lock heuristics; already implemented, commented and shipped in the same crate. |
+| Lock the config file itself | The dead-inode bug — *if* you also rename. If you don't rename, you keep torn reads instead. It fails one half whichever way you take it. |
+| `O_EXCL` exclusive-create sentinel | Rejected. `O_EXCL` has **no kernel-backed release**: a writer that crashes or is `SIGKILL`ed leaves a lock indistinguishable from a live one, needing PID-liveness or timeout heuristics — new failure modes in a path whose whole job is not losing data. |
+| fnox's daemon socket as the serialisation point | Rejected **on design**, not merely on availability. It is opt-in and per-user, so it carries the same voluntary-participation weakness as a lock, *and* additionally obliges every third-party writer to speak a private socket protocol rather than call one libc function. (It is also unavailable: `Request` at `src/daemon.rs` admits only `ResolveBatch`/`ResolveOne`/`Status`/`Clear`/`Shutdown`, **byte-identical at v1.31.1 and v1.32.0**.) |
+| CAS / content-hash compare-before-write | **Not rejected — demoted to an adjunct.** It cannot prevent torn reads and needs a retry loop, so it is not the primary mechanism; but it *detects* a clobber by a writer that took no lock, which locking cannot. Recommended as a cheap guard in lane 2. |
+| Versioning / operation IDs / a transaction (the reviewer's original counter-proposal) | Rejected **for this scope**. It was proposed for a *distributed* Doppler+fnox update that does not exist — re-derived at v1.32.0, fnox's Doppler provider implements only `get_secret`/`get_secrets_batch`/`test_connection`. |
+
+### Where to apply it: two tiers upstream, plus one writer upstream cannot reach
+
+Known application call sites reachable on this host, for `~/.config/fnox/config.toml`. **Method:**
+grep of the four `config.rs` write-function names across `src/` and `crates/` at both tags, plus a
+grep of `mde`'s Python for direct writes to the config path and for `fnox` subprocess invocations.
+This is a call-site inventory, **not** a proof that no other writer exists — an editor, `chezmoi`,
+or a future agent is outside it by construction, which is what makes the advisory-lock caveat load-
+bearing rather than decorative.
+
+| Writer | Path to the file | Where its read happens | Guard placement |
+|---|---|---|---|
+| `fnox set` | `set.rs:323` → `save_secret_to_source` | **inside** the fn (`config.rs:969`) | **Tier A** — guard inside the fn |
+| `fnox remove` | `remove.rs:97` → `remove_secret_from_source` | inside (`:1047`) | Tier A |
+| `fnox sync` (incl. via `mde-py` `sync.py:27`, `manage.py:74`), `import`, `reencrypt` | `sync.rs:301`, `import.rs:258`, `reencrypt.rs:316` → `save_secrets_to_source` | inside (`:1101`) | Tier A |
+| `fnox encrypt` / `decrypt` | `encrypt.rs:78`, `decrypt.rs:132` → `Config::save` | **in the CLI dispatcher** — `run(&self, cli, mut config: Config)` | **Tier B** — guard at the command boundary; an internal guard is too late |
+| `fnox provider add` / `provider remove` | `provider/add.rs:307`, `provider/remove.rs:60` → `Config::save` | **in the caller** (`add.rs:75`, `remove.rs:47`) | Tier B |
+| `fnox init` | `init.rs:67` → `Config::save` | none — builds a fresh `Config` | atomicity only; no read to protect |
+| **`mde-py secrets bootstrap-config`** (fired by the documented `mde-secret-add` happy path) | **`manage.py:322` — `Path.write_text()`, direct Python, no fnox process involved** | `manage.py:265`, **with a Doppler network call at `:304` before the write** | **Lane 2 — structurally unreachable from upstream** |
+
+**Lane 1 — upstream PR to `jdx/fnox`.** Two tiers as above, plus converting all four `fs::write`
+calls to temp+rename. No new dependency: `xx`'s `fslock` is already a `fnox-core` dep
+(`Cargo.toml:103`, `crates/fnox-core/Cargo.toml:67`), and the pattern is precedented twice by the
+same author (`lease.rs`; `mise/src/lock_file.rs`). It should **improve on** `lease.rs` rather than
+copy it — `fsync` before rename, a randomised tmp suffix, and an explicit `chmod` after write, per
+finding 9.
+
+**Lane 2 — the `mde-py` writer, preferably eliminated rather than locked.** In order of preference:
+
+1. **Route `bootstrap_config()` through `fnox` itself** (`fnox set` / `fnox sync` per declaration,
+   or a `fnox`-side bulk verb) so it inherits lane 1's guard and stops being a writer at all. This
+   is the better fix and it is what the review's finding 8 surfaced.
+2. If that is infeasible, take the same sidecar lock from Python — **`fcntl.flock(fd, LOCK_EX)`,
+   never `fcntl.lockf`** — in the order **fetch → lock → re-read → merge → write via temp+rename →
+   unlock**, so the critical section stays local and the multi-second Doppler round-trip happens
+   *outside* it. Acquiring before `_read_existing_config` and holding through the network call
+   would be correct but would block every other writer for seconds.
+3. Either way, add a **compare-before-write**: hash the file content read at step 3 and re-check it
+   immediately before the rename. That is the only thing here that can *detect* a writer which took
+   no lock.
+
+### The lock path is an interop contract, so pin it now
+
+Lanes 1 and 2 compose only if both take the same lock on the same file with the same primitive:
+
+- **Path:** `std::fs::canonicalize(config_path)` then **append** `".lock"` — e.g.
+  `~/.config/fnox/config.toml.lock`. Canonicalisation first, so symlinked, relative and
+  case-varied spellings converge on one sentinel (finding 13). Append rather than
+  `Path::with_extension("lock")`, which *replaces* the extension (`config.toml` → `config.lock`)
+  and is more likely to collide with a real file. The `.lock` suffix is reserved in that directory.
+- **Primitive:** `flock(2)` `LOCK_EX`, on both sides. Measured, not assumed.
+- A sidecar rather than a state-dir hash because a third-party writer can derive it from the config
+  path alone, with no knowledge of fnox's internal layout — which is precisely lane 2's situation.
+
+## Notes
+
+### The ticket's title carries only half of the finding it came from
+
+Critical #2 of the takeover review makes **two** claims. The title carries the dead-inode one,
+which is the easy half and already solved in-tree. The other half is the hard one:
+
+> *"The lock coordinates only callers that voluntarily acquire that exact lock. It is bypassed by:
+> `fnox set` · `mde-secret-*` · Any direct file edit or regeneration · mise or chezmoi applying the
+> file · Another agent implementation …"*
+
+That list reads as hypothetical. **It is not — one of its items is live and measured.**
+`mde-secret-*` really does bypass, really does rewrite the whole file with raw Python, and really
+is the documented happy path. Answering only the titled question would have produced a correct
+mechanism aimed at a writer set that excludes the one most likely to lose data.
+
+### I repeated ticket 1's own headline mistake, in the receipt that documents it
+
+The first draft of this receipt said *"lane 2 is where the only observed incident lives."* There is
+no observed incident. The 2026-07-30 config wipe was a **code-generation** defect —
+`bootstrap_config()` never emits `env`, so it drops the mode by construction — and
+`.claude/rules/secrets-out-of-the-shell-env.md` says in bold that **fnox is exonerated**. That is
+finding 8 of ticket 1's review, recorded in `docs/receipts/437.md`, which I read *this session* and
+listed three sections above.
+
+Ticket 1's lesson was *"citing a document you have read is not citing what it says."* This is the
+same error one layer up: **knowing that a correction exists is not the same as applying it.** The
+lost update here is derived from source — unguarded read → parse → whole-document `fs::write` — and
+has never been observed. Only a cold reviewer with no memory of the correction caught it.
+
+### Two corrections to the inherited sweep, both enumeration misses
+
+`concurrency-sweep-433.md` is otherwise well-evidenced, and both errors are the same kind — a list
+asserted from one search shape rather than enumerated.
+
+1. **"It has exactly two callers, both on the read/exec path"** — false at *both* tags. Grepping
+   `LeaseLedger::lock` (not just `fslock`) returns **five** command-level call sites: `exec.rs`,
+   `get.rs`, **and `commands/lease.rs:293`, `:422`, `:517`** — the last three being `lock` → `load`
+   → mutate → `save`, i.e. **writes**. This *strengthens* the recommendation: the guard is already
+   applied to the exact read-modify-write shape `config.rs` needs, at the transaction boundary.
+2. **The config-side writer list is 10 command call sites, not 4.** The sweep tabulated the four
+   `config.rs` *functions* and named callers for three, leaving `Config::save`'s five unlisted:
+   `init.rs:67`, `encrypt.rs:78`, `decrypt.rs:132`, `provider/add.rs:307` (`:320` @ v1.32.0),
+   `provider/remove.rs:60`. Those five are precisely the Tier B cases where guarding the write
+   function would not have worked — so this omission was not cosmetic.
+
+Neither changes the sweep's conclusion. Both change the size and the *shape* of the upstream patch.
+
+### What I deliberately did not do
+
+- **Did not re-derive `mise/src/lock_file.rs` or Doppler's `io.go`.** Inherited from the sweep and
+  labelled as such; supporting precedent, load-bearing on nothing. The decision stands on
+  `lease.rs` and `fslock`, both read at pinned versions.
+- **Did not act upstream.** Ray's call at resolution (2026-08-01): **lane 1 is tracked in dotfiles
+  only** — no `jdx/fnox` issue, no PR. The two-tier guard design above is the ticket's content, and
+  it stays ours until someone decides to spend it. **Lane 2 is being implemented now**, in
+  `macos-development-environment`. So the asymmetry is deliberate: we fix the writer we own and
+  record — without filing — the fix for the one we don't.
+- **Did not build a reproducer.** The lost update is derived from source, not observed — see above.
+  A deterministic two-process reproducer is the honest next control arm and the natural first
+  artifact of lane 1.
+
+### Bounds worth carrying
+
+- `flock` is **advisory**, and that is not a defect being tolerated quietly: it is why lane 2 exists
+  and why the compare-before-write adjunct is recommended. Among **cooperating** writers, mutual
+  exclusion plus atomic replace eliminates both lost updates and torn reads. Against a bypassing
+  writer it eliminates neither, and **no gate would notice a new one** — the same honest admission
+  ticket 1 had to make about Doppler's writers.
+- **The devcontainer is not a cross-boundary concern for this file**, verified from
+  `.devcontainer/devcontainer.json:93-98`: three binds (workspace, `~/.local/state/dotfiles`,
+  ssh-auth socket) and `$HOME` as a named volume — nothing covers `~/.config`. The container ships
+  its own fnox (`mise-runtime.lock` pins v1.29.0) writing a *different* config inside that volume.
+  A *project* `fnox.toml` in the bind-mounted workspace **would** cross the boundary, and a sidecar
+  lock handles that better than a state-dir lock (the state dirs differ; the mounted filesystem
+  does not).
+- Everything above is scoped to **v1.31.1 (installed)** and **v1.32.0 (current)**. A release adding
+  a Doppler write path or a daemon write op invalidates two rows of the alternatives table.
+
+## GitHub repos touched
+
+- [jdx/fnox](https://github.com/jdx/fnox) — read `crates/fnox-core/src/lease.rs`, `config.rs`, `providers/{doppler,keychain,mod}.rs`, `src/daemon.rs`, all ten `src/commands/*` write callers, and `Cargo.toml`/`Cargo.lock`, at **both** `v1.31.1` and `v1.32.0` (each a `--depth 1` clone at the tag, commit recorded); re-ran the issue/PR sweep with 13 queries and a control arm.
+- [brunoczim/fslock](https://github.com/brunoczim/fslock) — crate `0.2.1` source, checksum-matched to fnox's `Cargo.lock`; `src/unix.rs:322` established that the primitive is `flock(2)`, which is the whole interop contract.
+- [ray-manaloto/macos-development-environment](https://github.com/ray-manaloto/macos-development-environment) — `src/mde/secrets/manage.py` `bootstrap_config()`, the writer no upstream fix can reach; plus `secrets/sync.py`, `lib/secrets.py`, `secrets/validate_parity.py` for the CLI-invocation inventory.
+- [jdx/mise](https://github.com/jdx/mise) — `src/lock_file.rs` as same-author precedent, **inherited from the #433 sweep, not re-fetched this session**.
+- [DopplerHQ/cli](https://github.com/DopplerHQ/cli) — `pkg/utils/io.go` (temp+rename), likewise inherited and not re-read.
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the commissioning repo; ticket #438, map #431, and the prior-art corpus.

--- a/docs/research/kb/reports/agents/codex-adversarial-438-flock-replacement.md
+++ b/docs/research/kb/reports/agents/codex-adversarial-438-flock-replacement.md
@@ -1,0 +1,81 @@
+# Codex cold adversarial review — receipt for #438 (flock replacement / dead inode)
+
+**Lens:** codex CLI / `gpt-5.6-sol`, `codex exec --ephemeral --sandbox read-only`, `model_reasoning_effort=high`
+**Input:** `docs/receipts/438.md` in full on stdin, with an explicit *"do NOT read the disk"* constraint.
+**Date:** 2026-08-01
+
+> Persisted **verbatim** at receipt, per `.claude/rules/agent-report-persistence.md`. Dispositions live in `docs/receipts/438.md`, not here.
+
+---
+
+1. **CRITICAL — The proposed upstream lock may begin too late to prevent lost updates.**  
+   **Quoted text:** “wrap the four `config.rs` write functions in a `LedgerLockGuard`-shaped guard” and “`lock` → `load` → mutate → `save` sequences … the exact read-modify-write shape `config.rs` needs.”  
+   **Why it fails:** Locking only a write/save function does not prevent two callers from loading the same old state before either acquires the lock. The document praises `lease.rs` specifically for locking before `load`, but does not establish that each proposed `config.rs` guard would encompass the caller’s complete load→mutate→save transaction. Consequently, “covers 10 of the 11 writers” does not follow.  
+   **WHAT WOULD SETTLE IT:** For every caller, show the read and mutation boundaries and prove that the same guard is acquired before the read and held through the final rename; otherwise place the guard at the transaction-level call sites.
+
+2. **CRITICAL — The claimed observed incident contradicts the document’s own evidence boundary.**  
+   **Quoted text:** “Lane 2 is where the only observed incident lives,” “one of its items is live and measured,” and later: “Did not measure the race… The lost update is derived from source … not observed.”  
+   **Why it fails:** The document moves from a source-derived possibility to an “observed incident” without presenting an observation. It also notes that a prior wipe was corrected to “codegen, not a race,” which further undermines attribution of an incident to this concurrency defect. A direct writer is observed in source; a lost-update incident is not.  
+   **WHAT WOULD SETTLE IT:** An incident record or deterministic trace showing two overlapping operations, the stale read, and the resulting overwrite—or revise the claim to “the only identified high-risk writer.”
+
+3. **MAJOR — The “11 writers” inventory repeats the enumeration error the document criticizes.**  
+   **Quoted text:** “Measured writer inventory …” and “Covers 10 of the 11 writers.”  
+   **Why it fails:** No exhaustive search method for writers is shown. The table enumerates selected command call sites and one Python writer, while the document itself names direct edits, regeneration, mise, chezmoi, and other agents as additional writers. It later admits “no gate would notice a new one.” Thus 11 is neither a complete writer count nor a stable denominator; it also conflates command-level callers with distinct writers.  
+   **WHAT WOULD SETTLE IT:** Define “writer” precisely, show a complete write-sink/call-graph search across every in-scope repository and execution mechanism, and either include external writers or explicitly label the table “known application call sites.”
+
+4. **MAJOR — A shared pathname alone is insufficient to make the Rust and Python locks interoperate.**  
+   **Quoted text:** “Lanes 1 and 2 only compose if both take the same lock.”  
+   **Why it fails:** Using the same file is necessary, but not sufficient. Different APIs can apply non-interacting lock classes or differing shared/exclusive, descriptor-inheritance, and open-file semantics. The local implementation is only described as taking “the same sidecar lock”; no Python primitive or compatibility contract is specified.  
+   **WHAT WOULD SETTLE IT:** Specify the exact OS locking primitive and exclusive-lock semantics in both implementations, then provide a cross-process Rust↔Python contention test, including crash and descriptor-inheritance cases.
+
+5. **MAJOR — The single-store bound used to reject CAS is inherited, not established here.**  
+   **Quoted text:** “`docs/receipts/437.md` … supplies the ‘fnox cannot write Doppler’ premise that bounds this ticket to a single-store problem” and “CAS … was proposed for a distributed Doppler+fnox update that #437 established does not exist.”  
+   **Why it fails:** This is a load-bearing premise imported from another document whose evidence is not reproduced. The current receipt’s rejection of CAS changes if that bound is false, and the receipt later expressly admits that a new Doppler write path would invalidate its reasoning.  
+   **WHAT WOULD SETTLE IT:** Include the current-version provider/write call graph or behavioral evidence proving that neither fnox nor any covered workflow writes Doppler.
+
+6. **MAJOR — “Nobody has raised” is not supported by the upstream search.**  
+   **Quoted text:** “Nobody has raised concurrent config writes upstream.”  
+   **Why it fails:** Four narrow queries do not establish absence. The search omits obvious vocabulary such as `race`, `concurrent`, `flock`, `locking`, `overwrite`, `data loss`, `clobber`, and `serialization`, and does not establish coverage of discussions or reports outside GitHub issues/PRs. The positive and negative controls test query operation, not semantic completeness.  
+   **WHAT WOULD SETTLE IT:** Run and disclose a broader synonym set over all relevant upstream channels, or narrow the conclusion to “none found by these four queries.”
+
+7. **MAJOR — The daemon alternative is rejected from an enum that does not prove routing behavior.**  
+   **Quoted text:** “`Request` … admits only `ResolveBatch`/…/`Shutdown` … `fnox set` does not route through it.”  
+   **Why it fails:** The request variants show the visible protocol surface, but do not by themselves prove every `fnox set` path or exclude use of an existing generic operation. More importantly, “not available today” does not establish that the daemon is an unsuitable replacement design; it only establishes that implementation work would be required.  
+   **WHAT WOULD SETTLE IT:** Show the `fnox set` call graph or runtime trace, and evaluate the effort and failure properties of adding a daemon mutation operation rather than dismissing it solely because it is absent.
+
+8. **MAJOR — “Local is mandatory” and “no upstream change can ever reach it” overstate the design constraint.**  
+   **Quoted text:** “the local one is not optional,” “no fnox-side lock can ever reach,” and “no upstream change can serialise it.”  
+   **Why it fails:** This follows only if the direct Python writer must remain. Other designs could remove that writer, route it through fnox, expose a supported transaction API, or change ownership of the config. The document establishes that the proposed fnox-internal patch alone cannot govern the current raw `Path.write_text()` call—not that a local lock implementation is universally mandatory.  
+   **WHAT WOULD SETTLE IT:** State the constraint that the Python direct-write architecture is fixed, or compare elimination/rerouting alternatives and show why they are infeasible.
+
+9. **MAJOR — The “correct pattern” is asserted beyond the properties actually demonstrated.**  
+   **Quoted text:** “fnox already ships the correct pattern,” “temp+rename for torn reads: … solved,” and “at `0o600`.”  
+   **Why it fails:** The excerpt proves only the intended lock-path rationale. It does not show `FSLock`’s actual platform semantics, whether rename is same-filesystem and atomic under every supported filesystem, crash durability, directory syncing, or error cleanup. `OpenOptions::mode(0o600)` ordinarily controls creation permissions, not necessarily an already-existing stale temp file, so the final file’s mode is not established from the description.  
+   **WHAT WOULD SETTLE IT:** Show the complete open/write/flush/rename/error path and `FSLock` implementation or authoritative contract, plus tests for contention, process death, stale temp files, permissions, and crash recovery.
+
+10. **MAJOR — The document claims full elimination despite admitting uncoordinated writers.**  
+    **Quoted text:** “mutual exclusion plus atomic replace genuinely eliminates both lost updates and torn reads” versus “Any future writer that does not take the lock is invisible to both lanes.”  
+    **Why it fails:** The first claim is true only under an all-writers-cooperate bound. The document has not proved that bound and explicitly says it is unenforced. Atomic replacement can protect readers from partial replacement, but advisory locking cannot eliminate lost updates from bypassing writers.  
+    **WHAT WOULD SETTLE IT:** Qualify the claim to cooperating writers and add a mechanism that discovers or blocks bypass writers if system-wide elimination is intended.
+
+11. **MAJOR — The local “minimum fix” does not explicitly cover the stale read it identifies.**  
+    **Quoted text:** “read at `:265`, `doppler_list_secrets()` at `:304`, write at `:322`” and “Minimum fix: take the same sidecar lock and write via temp+rename.”  
+    **Why it fails:** If “take the lock” occurs only around the final write, the network-spanning stale read remains and the lost update persists. The document never states the acquisition point or lock lifetime, despite that being the central correctness requirement.  
+    **WHAT WOULD SETTLE IT:** Require acquisition before `_read_existing_config` and retention through the successful rename, with a test that blocks a competing fnox mutation during that entire interval.
+
+12. **MAJOR — The rejection of CAS does not follow from the reasons supplied.**  
+    **Quoted text:** “It would also need a version field the TOML schema has not got.”  
+    **Why it fails:** CAS need not use an embedded schema field; it can compare content hashes, file identity, metadata, or a sidecar generation. The absence of a TOML version field therefore does not rule it out. Single-host locking may still be the simpler choice, but that comparative conclusion is asserted rather than demonstrated.  
+    **WHAT WOULD SETTLE IT:** Compare concrete CAS implementations and failure modes against the proposed lock, then reject them on measured complexity or unmet requirements.
+
+13. **MINOR — Appending `.lock` does not resolve the collision or identity problem claimed.**  
+    **Quoted text:** “`with_extension("lock")` … risks colliding with a real user file; the upstream patch should append.”  
+    **Why it fails:** `config.toml.lock` can also collide with a real file. Moreover, deriving locks from path strings can yield different sentinels for symlinked, relative, case-varied, or otherwise aliased paths to the same target.  
+    **WHAT WOULD SETTLE IT:** Define the sidecar namespace as reserved, specify canonical path resolution and symlink policy, and test that all supported path spellings converge on one lock.
+
+14. **MINOR — The devcontainer exclusion is asserted rather than demonstrated.**  
+    **Quoted text:** “The devcontainer is not a cross-boundary concern for this file.”  
+    **Why it fails:** Separate home volumes do not prove that the host file is never bind-mounted, forwarded, regenerated, or accessed through another configured path. The conclusion depends on runtime configuration not shown in the document.  
+    **WHAT WOULD SETTLE IT:** Provide the relevant mount/config inventory or qualify the statement to the currently inspected configuration.
+
+**Overall verdict: needs-attention.** The sidecar-lock direction is plausible, but the receipt does not yet prove that either proposed guard encloses complete transactions, that the two languages’ locks interoperate, or that its writer inventory and incident claims are sound.


### PR DESCRIPTION
#438 asked what replaces flock given that locking a file you then rename over
leaves the lock on a dead inode. Nothing replaces it: the bug is the target, not
the primitive, and fnox already ships the right pattern in lease.rs (stable
sidecar sentinel over flock(2) + temp-write→fs::rename), with a doc comment
naming the dead-inode reasoning verbatim.

Verified at BOTH the installed tag (v1.31.1) and v1.32.0, which shipped the day
this was resolved — the config write path is unchanged in the new release, so
the finding is not stale.

Three things the inherited sweep had wrong or missing:

- "exactly two callers, both read-path" is five, three of them WRITES
  (commands/lease.rs:293/422/517). The guard is already applied to the exact
  read-modify-write shape config.rs needs.
- the config-side writer list is 10 command call sites, not 4 — Config::save's
  five callers were never enumerated.
- mde-py's bootstrap_config() writes the fnox config with a raw Python
  Path.write_text(), NOT through the fnox binary, holding its stale read across
  a Doppler network call. No upstream lock can ever reach it.

Codex cold review returned 14 findings (2 critical); 11 accepted, 3 partial,
0 refuted, and it changed the recommendation rather than its wording. Its
critical #1 — that guarding the write FUNCTION starts the lock too late for the
five callers whose read happens in the dispatcher — is confirmed from source and
is why the recommendation is now two-tier. Review persisted verbatim.

Gates: lint rc=0 · pytest 1144 passed · verify 112 passed / 0 failed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014x8jGSieFkDBV95KLXYhTC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788203014&installation_model_id=429246&pr_number=459&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F459&signature=2cec81fa88a467e1d54071698cf0ba451e1d178d5b287ab212be6137d299da3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a decision record documenting the configuration locking and atomic-write approach.
  - Documented interoperability guidance for Python and Rust-based configuration writers.
  - Added an adversarial review covering design assumptions, locking gaps, filesystem guarantees, stale reads, and compare-before-write validation.
  - Recorded supporting research, rejected alternatives, implementation boundaries, and areas requiring further evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->