### PR TITLE
docs(receipts): pilot verdict — 87 findings, 1 refuted, and still no build

### DIFF
--- a/docs/receipts/TEMPLATE.md
+++ b/docs/receipts/TEMPLATE.md
@@ -9,6 +9,11 @@ automation spine; this template is the pilot that runs in its place, on the next
 failure mode the whole exercise exists to catch. This is the same discipline
 `.claude/rules/notepad-enforcement.md` already requires.
 
+**If a review finding can be settled by running something, run it before writing the disposition.**
+Across the pilot's 87 findings exactly one was refuted, and it is the only one settled by a probe
+rather than by argument — the probe also produced a better measurement than the claim it defended.
+See § 12.5 of `docs/specs/ticket-bound-receipts.md`.
+
 Delete this header block when you copy it. Delete nothing else — **an empty section is an answer**,
 and "none" written down is worth more than a section quietly removed.
 
@@ -16,9 +21,10 @@ and "none" written down is worth more than a section quietly removed.
 
 # Receipt — #<n>: <ticket title>
 
-**Verdict:** <one sentence — the answer. This exact text goes in the resolution comment.>
+**Verdict:** <the answer, stated so a reader who opens only this line is not misled. Keep it as
+short as the truth allows, and no shorter — the pilot's four verdicts all needed their conditions
+attached, so a length cap was dropped rather than kept and ignored.>
 
-**Kind:** research | decision | task | none-required
 **Resolved:** <YYYY-MM-DD>
 
 ## Sources — what I actually opened
@@ -36,9 +42,20 @@ visible on the page.>
 
 **Query:** `<the actual command or search terms>`
 **Corpus:** `docs/research/kb/reports/`, `docs/specs/`, …
-**Control arm:** `<a term known present> → N hits` / `<a term known absent> → 0`
-*(per `.claude/rules/probes-need-a-control-arm.md` — a 0-result search is not an answer until a
-control has run)*
+
+### Control arm — REQUIRED, and run it before you believe any result
+
+**Known-present term:** `<term>` → **N** hits
+**Known-absent term:** `<term>` → **0** hits
+
+Both lines, with real numbers, or the search below is not evidence
+(`.claude/rules/probes-need-a-control-arm.md`).
+
+**This is the field that has earned its place.** In #440 the whole search was *broken* — zsh does
+not word-split an unquoted variable, so the corpus collapsed to one nonexistent path, `2>/dev/null`
+ate the error, and every query returned 0. A thin search and a blind one look identical; only this
+field tells them apart. If the known-present arm returns 0, **your probe is broken, not the world** —
+fix it and re-run before writing anything below.
 
 | Hit | What I did with it |
 |---|---|

--- a/docs/specs/ticket-bound-receipts.md
+++ b/docs/specs/ticket-bound-receipts.md
@@ -518,3 +518,141 @@ available to lift from — with their findings attached.
 - [ray-manaloto/knowledge-base](https://github.com/ray-manaloto/knowledge-base) — the
   `sources/agent-harness-docs/docs/claude-code/hooks.md` mirror behind the `permissionDecisionReason`
   and `SubagentStart` claims.
+
+---
+
+## 12. Pilot verdict — from data, 2026-08-01
+
+The pilot ran as §"The pilot" specified: three `wayfinder:*` tickets after this one — **#437, #438,
+#440** — each with a hand-written receipt. Four receipts exist in total; #449 is instance #1 and is
+this spec's own.
+
+| receipt | bytes | review findings | disposition | prior-art rows |
+|---|---|---|---|---|
+| `449.md` (#1) | 7,084 | 42, over 3 rounds | 42 accepted, **0 refuted** | 6 |
+| `437.md` (#2) | 14,217 | 11 (2 crit) | 8 acc / 3 partial / **0 refuted** | 13 |
+| `438.md` (#3) | 29,980 | 14 (2 crit) | 11 acc / 3 partial / **0 refuted** | 14 |
+| `440.md` (#4) | 21,201 | 20 (2 crit) | 13 acc / 6 partial / **1 refuted** | 9 |
+| **total** | | **87** | **1 refuted (1.1%)** | |
+
+### 1. Which fields were real, which became ritual?
+
+**Real, and the highest-value field in all four: the adversarial review.** It was never once
+clean, and it changed the *recommendation* — not the wording — in #437, #438 and #440. In #440 it
+did so twice: it moved the gate from the `[hooks]` key to the unscoped command, and it demolished
+the "permanently kill" framing by pointing out that a warn-only host check prevents nothing.
+
+**Real, and specifically the DISMISSAL column: prior art.** Its value is not the hit list, it is
+the written reason each hit did not apply. #438: **10 of 10** non-zero upstream hits were term
+collisions. #440: **6 of 7** non-zero hits were collisions on "hook" (devcontainer lifecycle,
+Claude Code). Without the column, "9 hits found" reads as coverage; with it, the reader can see
+most of them were noise.
+
+**Real, and the only field that has ever caught its own section lying: the control arm.** In #440
+the prior-art search was not thin, it was **broken** — zsh does not word-split an unquoted
+variable, so the corpus list collapsed to one nonexistent path, `2>/dev/null` ate the error, and
+every query returned 0. The control arm (`chezmoi` → 0 files, when it should be 51) is the only
+reason this was caught rather than published as "no prior art exists".
+
+**Ritual: `Kind`.** Four receipts, one observed value (`decision`). A field with no variance
+carries no information.
+
+**Ritual: `Resolved`.** Derivable from the close event.
+
+**Drifting toward ritual: `Sources`.** 9, 9, 9, 11 bullets. Three consecutive receipts landing on
+exactly nine is the shape of a habit-count rather than a measurement.
+
+**Not honoured once: the "one sentence" verdict.** 0 of 4 complied; every verdict grew into a
+paragraph, because the honest answer to a grilling ticket has conditions attached. Either drop the
+constraint or stop pretending it exists.
+
+### 2. Did anyone read a receipt after the ticket closed?
+
+**Yes — three times, and each read changed something.** #437's receipt was re-read during #438, and
+its finding-8 correction is what let that session recognise it had repeated the same misattribution.
+This session re-read #438's receipt and map line for the `lease.rs` facts, and #437's 13-row
+prior-art table to calibrate this one.
+
+**The honest limit: every reader has been the same author, in an adjacent session on the same map.**
+There is no evidence a receipt has been read by anyone outside the work that produced it. The field
+is proven useful for *continuity*, not yet for *audit*.
+
+### 3. Did query drift actually happen?
+
+**Yes in #438 — and something worse in #440.** #438's review objected that four queries do not
+establish absence; nine more were run and the objection was correct. #440 did not drift at all: its
+search was **broken**, returning 0 for every query for a reason that had nothing to do with the
+query text.
+
+That is the pilot's sharpest design conclusion. **The query is not the thing worth checking; the
+control arm is.** A drifted query returns too few real hits. A broken probe returns zero and looks
+identical to a clean corpus. Only the control arm distinguishes them.
+
+**The same failure then happened while writing this section, which is the strongest evidence in the
+pilot that it is not a one-off.** Committing §12 tripped hk's `typos` step on two hyphenated
+prefixes in the text above. Checking the file by hand said *clean* — twice over, for two
+independent reasons: `typos --diff` emits **nothing** when a correction is ambiguous (the offending
+prefix had two candidate expansions, so there was no single diff to print), and the `rc=0` read back
+was `head`'s, not `typos`'. Two display bounds stacked, in a probe written by someone who had spent
+the session documenting display bounds. The rule that catches it is mechanical, not attentional:
+**never read an exit code through a pipe, and never accept a clean result from a checker without
+seeding a failure it must catch.**
+
+*(Writing this paragraph tripped the same step a third time — quoting the offending token, even
+inside backticks, is still an occurrence of it. Hence the periphrasis.)*
+
+### 4. What did writing it by hand cost?
+
+Roughly **half a session** per ticket, consistently, across #438 and #440.
+
+But the honest finding is that **this cost cannot be separated from the cost of doing the ticket
+well.** The review *is* the answer-finding step, not a write-up step — in #440 it produced two of
+the three substantive corrections, and the third came from re-running a probe *because* a finding
+demanded it. So the receipt cannot be cost-justified as a distinct artifact, and any future
+proposal that frames it as "documentation overhead" has modelled it wrongly.
+
+### 5. The 0-refuted question this pilot was asked to answer
+
+The ticket-2 handoff asked whether 0 refutations meant the review was well-calibrated or the
+receipts were under-defended. With #440 the tally is **87 findings, 1 refuted — 1.1%**.
+
+**The receipts are under-defended.** A reviewer that survives 99% of its claims against a written
+artifact is not evidence of a supernatural reviewer; it is evidence the artifact is written with
+less rigour than the review applies to it.
+
+The corrective is visible in the one refutation. #440's finding #9 (the `--platform` result rests
+on unproved comma-parsing) was **settled by running an arm, not by arguing** — and the arm both
+refuted the finding and produced a *better* measurement than the original, showing per-platform
+behaviour the first probe had missed entirely. Every other finding across four receipts was
+disposed of by reasoning.
+
+**Process change, worth more than any field: when a review finding is empirically settleable, run
+the probe before disposing of it.** One of 87 dispositions did this, and it is the only one that
+reversed.
+
+### 6. What gets automated
+
+**Still nothing.** The pilot does not overturn the 2026-07-31 decision; it narrows what a future
+build could justify.
+
+- The **review** is the value, and it is already a single CLI call. What cannot be automated is the
+  **disposition**, which is judgement — and the disposition is where the value lands.
+- The **control arm** is the one field that is both machine-checkable and empirically load-bearing
+  (it caught a broken probe in 1 of 4 receipts). But round 3 already established that a verifier can
+  only prove *a* query ran, and #440's failure was a query that *did* run and returned nothing. A
+  verifier would have passed it. **So even the strongest candidate would not have caught the
+  pilot's one real miss.**
+
+That is the pilot's answer to §425 "Build order": **do not start it.**
+
+### 7. Three edits to `TEMPLATE.md`, and nothing else
+
+1. **Drop `Kind`** — no variance across four instances.
+2. **Promote the control arm to a required field of its own**, with both arms' counts stated, out of
+   its current parenthetical under Prior art. It is the only field that has caught its own section
+   lying.
+3. **Drop the "one sentence" constraint on Verdict** — 0 of 4 complied, and the non-compliance was
+   correct each time.
+
+Plus one line in the template's header, which is a process rule rather than a field: *if a review
+finding can be settled by running something, run it before writing the disposition.*


### PR DESCRIPTION
Closes out the three-ticket receipt pilot (#437, #438, #440; #449 is
instance #1). Answers §"The pilot"'s four questions from data, and applies
the three template edits the data supports.

Verdict: do NOT start the build in §9. The pilot narrows rather than
overturns the 2026-07-31 decision.

What the data says:

- The adversarial review is the highest-value field in all four receipts. It
  was never once clean and it changed the RECOMMENDATION (not the wording) in
  #437, #438 and #440.
- The prior-art DISMISSAL column is what carries the value, not the hit list:
  10/10 (#438) and 6/7 (#440) non-zero hits were term collisions.
- 87 findings across four receipts, 1 refuted (1.1%). Read as the receipts
  being under-defended, not the reviewer being calibrated — and the single
  refutation is the only disposition settled by running a probe rather than
  by arguing. That is now a template rule.
- `Kind` is ritual (one observed value in four). The one-sentence Verdict cap
  was honoured 0/4 times, correctly each time.

Template edits: drop `Kind`; promote the control arm to a required field with
both arms' counts; drop the one-sentence cap; add the settle-it-by-running rule.

The control arm earned promotion twice over. In #440 it caught a prior-art
search that was not thin but BROKEN (zsh does not word-split an unquoted
variable; `2>/dev/null` ate the error; every query returned 0). Then writing
that very paragraph tripped hk's typos step three times — `--diff` prints
nothing when a correction is ambiguous, and the `rc=0` I read back was
`head`'s, not `typos`'. Recorded in §12.3, periphrasis and all.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014x8jGSieFkDBV95KLXYhTC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788210601&installation_model_id=429246&pr_number=462&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F462&signature=3ed9a19c26fd2761da3d847dcceb853cade0b486d9776d8ebcc3ea0555dc4359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->