### PR TITLE
docs(receipts): the pilot is judged — stop describing it as in flight

### DIFF
--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -76,14 +76,18 @@ Used by `/wayfinder`. The **map** is a single issue with **child** issues as tic
   map's sub-issues / task list), drop any with an open blocker
   (`issue_dependencies_summary.blocked_by > 0`) or an assignee; first in map order wins.
 - **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
-- **Receipt** (pilot, from #449): a `wayfinder:*` ticket carries a hand-written
+- **Receipt** (standing practice since #449): a `wayfinder:*` ticket carries a hand-written
   **`docs/receipts/<n>.md`**, copied from `docs/receipts/TEMPLATE.md` and filled **as you work, not
   at close** — sources actually opened, the prior-art search with its control arm, the adversarial
-  review result. Running for the next **three** wayfinder tickets, then judged. **There is no tool
-  and no gate, deliberately**: three adversarial review rounds killed the automation (42 findings,
-  0 refuted) because only the prior-art search is machine-verifiable, and even then only that *a*
-  query ran. Design of record + the 42 reasons: `docs/specs/ticket-bound-receipts.md` (⛔ NOT FOR
-  BUILD). Worked example: `docs/receipts/449.md`.
+  review result. **There is no tool and no gate, deliberately**: three adversarial review rounds
+  killed the automation (42 findings, 0 refuted) because only the prior-art search is
+  machine-verifiable, and even then only that *a* query ran. Design of record + the 42 reasons:
+  `docs/specs/ticket-bound-receipts.md` (⛔ NOT FOR BUILD). Worked example: `docs/receipts/449.md`.
+  **The three-ticket pilot (#437, #438, #440) ran and was judged on 2026-08-01 — verdict: keep the
+  practice, still build nothing** (§12). 87 findings across 4 receipts, **1 refuted**: read as the
+  receipts being under-defended rather than the reviewer calibrated, so **if a review finding can be
+  settled by running something, run it before writing the disposition**. Even a control-arm verifier
+  would have *passed* #440's real failure, because the query ran and returned nothing.
 - **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a
   context pointer to the map's Decisions-so-far. The verdict goes in the **comment**; the evidence
   stays in the **receipt**, linked — they carry different content, never mirrored.

--- a/docs/receipts/TEMPLATE.md
+++ b/docs/receipts/TEMPLATE.md
@@ -2,8 +2,10 @@
 
 **Hand-written. There is no tool, and that is deliberate** — see
 `docs/specs/ticket-bound-receipts.md` § "Decision". Three adversarial review rounds killed the
-automation spine; this template is the pilot that runs in its place, on the next three
-`wayfinder:*` tickets, to find out which fields are worth anything before anything is built.
+automation spine, and the three-ticket pilot that ran in its place (#437, #438, #440) was **judged
+on 2026-08-01**: keep the practice, **still build nothing** (§12). This template carries the pilot's
+three edits — `Kind` dropped, the control arm promoted to a required field, the one-sentence Verdict
+cap dropped. **Use it for every `wayfinder:*` ticket.**
 
 **Fill it as you work, not at resolution time.** A receipt written from memory at close is the
 failure mode the whole exercise exists to catch. This is the same discipline


### PR DESCRIPTION
Doc sync for #462. Two places still said the receipt pilot was "running for
the next three wayfinder tickets, then judged". It ran (#437, #438, #440) and
was judged on 2026-08-01.

- docs/issue-tracker.md: the receipt is a STANDING practice, not a pilot.
  Records the verdict (keep the practice, build nothing), the 87/1 tally and
  what it means, and the settle-it-by-running rule.
- docs/receipts/TEMPLATE.md: header now states the pilot is judged and names
  the three edits the template carries, instead of announcing a pilot that
  has finished.

Neither gate could catch this — lint and agnix check structure, not whether
prose still describes a completed process as in flight.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014x8jGSieFkDBV95KLXYhTC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788212106&installation_model_id=429246&pr_number=463&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F463&signature=5d503ad1cefecc8cd5ce49d380ba6de776b84dff412ce1ae42a5ff73fdc15c3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->