### PR TITLE
docs(448): mise is the destination — chezmoi holds through the takeover

### DIFF
--- a/docs/receipts/448.md
+++ b/docs/receipts/448.md
@@ -1,0 +1,226 @@
+# Receipt — #448: chezmoi or `mise bootstrap dotfiles` — which tool owns this Mac's dotfiles?
+
+**Verdict:** **mise `bootstrap dotfiles` is the destination; chezmoi holds the Mac through the
+takeover (#431).** This is a directional decision on *timing*, not a tie and not a capability
+verdict — **no capability blocker survived measurement.** `promptBoolOnce`, which the 2026-07-10
+research called a hard, no-known-workaround blocker, is superseded by #439's own decision to move
+`.ssh`/`.gnupg` onto the OS branch; `mode = "template"` covers every fact our templates use
+(`os()`/`arch()`/`env`/`exec()`/`read_file()`, plus `is exists` for chezmoi's `stat`);
+`mise.macos-arm64.toml` / `mise.linux.toml` replace `.chezmoiignore`'s OS gate; and `mode = "copy"`
+preserves 0600, so `private_` is covered too. All measured on the installed binary, both arms.
+
+**I had this verdict pointing the other way until the adversarial review.** My load-bearing claim
+was that the OS gate cannot be declared in-repo, because `auto_env` is unreadable from a project
+`.miserc.toml`. That much is true — but findings 2 and 3 pointed out I had only tested implicit CLI
+discovery. A **repo-owned mise task** carrying `env = { MISE_AUTO_ENV = "true" }` enables platform
+environments: `MAC_ONLY` **1** hit through the task, **0** with the env removed. Since this repo
+already hook-enforces `mise run <task>` as the only entrypoint for canonical workflows, the
+activation is repo-owned by construction. **mise does eliminate #436's wrong-target class.**
+
+What actually defers it is blast radius and maturity, both unglamorous: 13 targets plus the CI
+`chezmoi managed` gate, `hook_guard`'s apply-deny rules, `doctor.toml`, the `chezmoi-check` skill and
+`scripts/check-chezmoi-templates.sh` all move at once — while #431 is mid-flight and the merged tree
+is not yet settled. Migrating the tool *and* merging two source trees changes two variables
+simultaneously. And the surface renamed itself again in the installed release (`mise dotfiles` is now
+deprecated in favour of `mise bootstrap dotfiles`), the fourth rename in ~7 weeks.
+
+**Consequence for #436: NOT moot, but its lifetime is now bounded — build the cheap version.** The
+wrong-target guard is still needed because chezmoi still runs through the takeover, so #436 proceeds.
+But it should be scoped as a guard with a scheduled end, not a permanent fixture.
+
+**Re-evaluation trigger — after #431 lands, then any one of:** (a) `auto_env` defaults on (mise
+**2027.6.0**), removing the bare-invocation hazard entirely; (b) `mise bootstrap dotfiles` goes one
+full release cycle without a command rename; (c) a `home/**` change lands that chezmoi makes
+awkward. Not a date, and no longer a conjunction — with the capability question closed, any one of
+these is enough.
+
+**Resolved:** 2026-08-01
+
+## Sources — what I actually opened
+
+- `https://raw.githubusercontent.com/jdx/mise/v2026.8.0/docs/dotfiles.md` — the four modes, `exclude`,
+  `unapply`, conflict rules, and `status --missing` as the CI gate. Fetched at the **installed tag**,
+  not `main`, so it describes the binary I probed.
+- `.../v2026.8.0/docs/templates.md` — the function list (`exec`, `read_file`, `arch`, `os`,
+  `os_family`, `num_cpus`) and the `is dir` / `is file` / `is exists` tests. Settled that there is no
+  `osRelease.id` and no `stat`, and that `exec()`/`is exists` cover both.
+- `.../v2026.8.0/docs/configuration.md` + `.../docs/configuration/environments.md` — platform
+  environments (`mise.linux.toml`, `mise.macos-arm64.toml`), their precedence, and the `auto_env`
+  rollout schedule (off until 2027.6.0, warns from 2026.12.0).
+- `home/.chezmoi.toml.tmpl`, `.chezmoiignore`, `.chezmoidata.yaml`, `.chezmoiexternal.toml`,
+  `.chezmoiremove`, `.chezmoitemplates/env` + all 9 `.tmpl` — the six chezmoi mechanisms actually in
+  use, and what each template really references.
+- `../macos-development-environment/home/**` — the tree the takeover imports. This is the tree the
+  decision applies to, and it is not the one the ticket measured.
+- `.devcontainer/Dockerfile:127` + `.devcontainer/mise-system.toml:142` — where `[bootstrap.packages]`
+  actually lives.
+- `docs/research/runs/research-20260710-r3-mise-dotfiles/report.md` (+ its 3 agent reports) — the
+  prior decision on this exact question. See "Prior art".
+- GitHub issues #434, #439 (both CLOSED) — their verdict comments; #434's C1 is load-bearing below.
+
+## Prior art — the search I ran
+
+**Query:** `graphify query "the 13-target chezmoi allow-list gate and the dotfile target collision
+inventory"`, then `git grep -ln 'chezmoi' -- python/ hk.pkl doctor.toml python/verification/
+.github/workflows/` and `git ls-files 'home/**'` counts.
+**Corpus:** `docs/research/runs/`, `docs/research/kb/reports/`, `docs/specs/`, the tracked tree,
+GitHub issues.
+
+### Control arm — REQUIRED, and run it before you believe any result
+
+**Known-present term:** `dot_` in `git ls-files 'home/**'` → **10** hits
+**Known-absent term:** `encrypted_` in the same corpus → **0** hits
+
+Both arms with real numbers, so absence readings below are answers rather than blindness. Every
+probe in this receipt carries its own arm; the ones that changed a conclusion are named inline.
+
+| Hit | What I did with it |
+|---|---|
+| `docs/research/runs/research-20260710-r3-mise-dotfiles/report.md` | **read — it inverted the framing.** A full 3-angle research run already answered this question on 2026-07-10 with "NEITHER — keep chezmoi", on the strength of `promptBoolOnce` as a *hard, no-known-workaround blocker*. **#448 does not cite it.** I re-derived its blocker rather than inheriting it, and it is dead (below). It also left 4 standing uncertainties; I closed 3 by measurement. |
+| `.../agents/mise-dotfiles-caps.md`, `chezmoi-parity.md`, `coexist-migrate.md` | read — the per-mechanism gap table. Its rankings still hold except where re-measured here. |
+| GitHub #434 verdict comment | **read — C1 is decisive and I would have missed it.** `chezmoi --source=dotfiles/home managed` → **rc=1**, `map has no entry for key "is_personal"`. dotfiles' chezmoi source **cannot be evaluated on this Mac today**, and the verification recipe in its own `.chezmoiignore:50` is a probe that can only fail. |
+| GitHub #439 verdict comment | read — the 13-target linux allow-list and the decision to retire `is_personal`. Confirms the retirement is **decided but not shipped** (the tree still has it), which is why my consumer count below is of the live tree. |
+| `.claude/skills/chezmoi-check/SKILL.md`, `scripts/check-chezmoi-templates.sh` | read — chezmoi-shaped machinery that a tool change would orphan. Counted into the migration blast radius, not otherwise decision-bearing. |
+| `python/src/dotfiles_setup/hook_guard.py`, `.github/workflows/ci.yml`, `doctor.toml` | dismissed for the capability question, counted for cost — they are chezmoi-shaped but each has a named mise counterpart (`status --missing` replaces the CI introspection gate). |
+
+## Measurements that changed the answer
+
+All against **mise 2026.8.0 macos-arm64 (2026-08-01)** — newer than the 2026.7.18 the previous
+handoff measured. Fixture: throwaway config in the scratchpad with absolute targets; the real `~`
+was never written.
+
+| # | Question | Result | Control arm |
+|---|---|---|---|
+| 1 | Is `promptBoolOnce` still a blocker? | **No — but not for the reason I first wrote (findings 5–7).** Today: `is_dev_computer`, `is_darwin`, `is_ci` have **0** consumers each; `is_personal` has 1 (`.chezmoiignore:24`) gating `.ssh/config` + `.gnupg/**`, which are **0** entries in today's tree. But the takeover **imports `private_dot_ssh/config`**, which would revive it. What actually kills it is #439's decision to move `.ssh`/`.gnupg` onto the `ne darwin` branch — an OS fact, which mise has. "Zero consumers today" was never sufficient on its own. | `.platforms` → **1** real consumer (`pixi.toml.tmpl:5`), so the consumer grep finds live ones. `ssh\|gnupg` in source paths → 0 vs `mise` → 1. |
+| 2 | Does `mode = "template"` have the depth our 9 templates need? | **Yes**, with one correction (findings 9–10). Rendered `os()`=macos, `arch()`=arm64, `env.HOME`. `exec(command='mise activate zsh')` renders the real activation script — **19** `hook-env` markers — but it is **not byte-identical** to running it directly (6390 vs 6472 chars), because `exec()` renders in a different process context. Functionally equivalent to `{{ output … }}`, which is context-dependent the same way; "direct equivalent" was too strong, and the earlier byte-count proved nothing on its own. | Rendered vs itself → equal; rendered vs `src/gitconfig` → not equal. Apply-state arm separately: `status --missing` **rc=1** before, **rc=0** after. |
+| 3 | Does mise replace chezmoi's `stat "/.dockerenv"` for existence tests? | **Yes** — the `is exists` test. Existence only; no metadata/type/ownership parity is claimed (finding 17). `/.dockerenv` → NO on this Mac host, **PRESENT inside the running container**. | `/etc/hosts` → YES, `/no/such/path/xyz` → OK, and in-container a bogus path → absent. |
+| 4 | Can a platform env gate a `[dotfiles]` entry per-OS? | **Yes on this host.** With `MISE_AUTO_ENV=true` on macos-arm64: `MAC_ONLY` **1** hit, `LINUX_ONLY` **0**. A "hit" = the entry appearing as a row in `mise bootstrap dotfiles status`, i.e. discovered and evaluated (finding 23). | With `auto_env` off: **0 / 0** — the platform files are inert, so the ON result is the setting, not the filenames. **Bound, stated (finding 1):** the linux positive arm was not run — no linux mise host was available. What is proven is that the mechanism selects by platform, not that `mise.linux.toml` loads on linux. |
+| 5 | Can `auto_env` be enabled by something this repo owns? | **Yes — and this reversed the verdict (findings 2–3).** Implicit discovery: a project-root `.miserc.toml` **and** `miserc.toml` are both unread (`MAC_ONLY` **0**; `settings get auto_env` → *"not set"* with the file present). But a **tracked mise task** with `env = { MISE_AUTO_ENV = "true" }` works: `MAC_ONLY` **1**. | Same task with the env replaced by an inert var → `MAC_ONLY` **0**. And for the implicit arm, `MISE_AUTO_ENV=true` on the same command → **1** / `settings get` → `true`. Both arms on both routes. |
+| 6 | Does the devcontainer set any of the 5 non-`stat` `$remote` signals? | **No — 0 of 5**, and `/.dockerenv` is **present** in the container, so it is genuinely load-bearing. Closes a 2026-07-10 open question. | Re-run after finding 16: the *same regex shape* against `PATH=` → **1**, `HOME=` → **1**, `BOGUSVAR_XYZ=` → **0**. The original "69 env vars total" arm did not test the filter and was not sufficient. |
+| 7 | Is #434's C1 still true today, or was I repeating it? | **Re-derived, not inherited (finding 20).** `chezmoi --source=./home managed` → **rc=1**, `map has no entry for key "is_personal"` — dotfiles' chezmoi source still cannot be evaluated on this Mac. | mde's source through the identical command → **rc=0**, 20 targets. The probe discriminates. (#434 reported 11 targets for mde; it passed `--include=files,symlinks` and I did not — a scope difference, not drift.) |
+| 8 | Does mise preserve `private_`'s 0600? | **Yes (finding 19 refuted).** `mode = "copy"` of a 0600 source → target **600**. ⚠️ But **git stores only the executable bit**, so a 0600 source cannot survive a clone — chezmoi encodes the mode in the *filename*, which is the part mise has no equivalent for. Net: an explicit `chmod` step, not a blocker. | 0644 source → target **644**, so the copy reflects the source rather than defaulting. |
+
+### Two rows of the ticket's "already established, do not re-derive" table are wrong
+
+Both are wrong by being scoped to today's dotfiles tree rather than to the post-takeover merged
+tree — which is what a tool decision inside #431 actually governs.
+
+- *"`home/**` has **0** `run_*` scripts, so both documented reasons to prefer chezmoi are measurably
+  absent."* The **merged** tree has **2** (`mde/.chezmoiscripts/run_onchange_*`) and **1**
+  `private_` file (`private_dot_ssh/config`, whose 0600 semantics mise has no equivalent for).
+  `encrypted_` stays **0** in both trees. Counts run over both repos with the same command shape.
+  *This cuts toward mise, not away from it:* both scripts are `brew bundle` and
+  `mise install`/`reshim` — precisely what `[bootstrap.packages]` and the `bootstrap` task do
+  natively. mise **removes** that machinery. Only `private_` is a real loss, and it is one file.
+- *"`[bootstrap.packages]` is **already** in our `mise.toml`; we are already partly on mise
+  bootstrap; `[dotfiles]` is the same file."* **It is not in `mise.toml`.** It lives in
+  `.devcontainer/mise-system.toml:142`, `COPY`'d to `/usr/local/share/mise/config.toml` in the image
+  (`Dockerfile:127`) — the container's **apt** list, not host machine setup. Verified three routes:
+  `git grep -ln '^\[bootstrap'` → that file only; host `mise bootstrap status` → `tools` rows only;
+  `mise config ls` → **0** hits for `mise-system.toml` against a control of **1** for `mise.toml`.
+  Adopting `[dotfiles]` on the host means opening a **new** surface, not extending an existing one.
+
+## The four things this decision had to settle
+
+1. **Which tool, and does the devcontainer follow?** chezmoi through the takeover, then mise; the
+   devcontainer follows in both eras. Recorded for the migration: mise's natural split is *better*
+   than chezmoi's here — host entries in the tracked `mise.toml`, container-only entries in the
+   image-only `mise-system.toml` (verified: **0** hits for `mise-system.toml` in host `mise config
+   ls` against a control of **1** for `mise.toml`), so that direction needs no gate at all. Only the
+   **Mac-only** direction (`Brewfile.tmpl`, `private_dot_ssh/config`) needs the platform-env gate.
+2. **Do #439's 13-target gate and #434's inventory survive?** **They survive because chezmoi
+   survives — but "unchanged" was wrong (findings 13–14).** Both were derived *before* the takeover
+   merges mde's tree; the takeover adds targets (`private_dot_ssh/config`, `~/Brewfile`,
+   `.gitignore_global`, `.oh-my-zsh/**`, `.zprofile.d/**`, `.zshrc.d/**`), so **both must be re-run
+   against the merged tree as part of #431** regardless of which tool wins. That is a takeover task,
+   not a tool-decision task. Also correcting myself: `status --missing` would **not** have replaced
+   #439's gate (finding 12) — it detects drift on *declared* entries and is blind to an
+   unauthorized fourteenth target, which is precisely the leak the allow-list exists to catch. The
+   mise-era equivalent is still a set-equality gate, just over `[dotfiles]` keys instead of
+   `chezmoi managed` output.
+3. **What does `mise bootstrap`'s wider surface mean for the takeover's scope?** It reaches well past
+   dotfiles — 11 ordered steps incl. `[bootstrap.repos]`, `macos.defaults`, `launchd.agents`,
+   `[bootstrap.user].login_shell`. That is an argument for adopting it **later and deliberately**,
+   not as a side effect of a dotfiles migration: several of those steps have no incumbent at all, so
+   they are additive scope rather than a swap.
+4. **Is templating depth genuinely equivalent?** For our files, **yes** — and the question is smaller
+   than it looks. **Two of the nine `.tmpl` files contain zero `{{ }}`** (`dot_config/mise/config.toml.tmpl`,
+   `pyproject.toml.tmpl`); they are templates in filename only. The whole live surface is 16
+   expressions across 7 files, and the only fact without a first-class mise equivalent is
+   `.chezmoi.osRelease.id` (4 branches), reachable via `exec()`.
+
+## Adversarial review
+
+**Lens:** codex-reviewer (`codex exec --ephemeral --sandbox read-only`, reasoning effort high, one round)
+**Verdict:** needs-attention — **it changed the verdict**
+**Findings:** 26 — verbatim at
+`docs/research/kb/reports/agents/codex-adversarial-448-chezmoi-vs-mise-dotfiles.md`
+**Disposition:** 3 refuted by probe, 23 accepted; every acceptance is reflected in the text above.
+
+**Settled by running something, not by arguing** (the template's rule, and the only way to earn a
+refutation):
+
+| # | Claim | Probe | Outcome |
+|---|---|---|---|
+| 2, 3 | "Testing two filenames does not prove no repo-owned mechanism can set `MISE_AUTO_ENV`" | tracked mise task with `env = { MISE_AUTO_ENV = "true" }` → `MAC_ONLY` 1; inert env → 0 | **CONFIRMED — reversed the verdict.** The reviewer was right and I was wrong on the load-bearing point. |
+| 19 | "The private-file loss is asserted rather than established" | `mode = "copy"` of a 0600 source → target 600; 0644 control → 644 | **REFUTED** — mise preserves the mode. The residual (git can't ship 0600) is now stated, and is smaller than the original claim. |
+| 20 | "The decisive chezmoi failure is inherited, not re-derived" | ran `chezmoi --source=./home managed` → rc=1, same error; mde control → rc=0 | **REFUTED** — it was re-derived. |
+| 16 | "69 env vars does not arm the negative for five particular signals" | same regex shape vs `PATH=`→1, `HOME=`→1, `BOGUSVAR_XYZ=`→0 | **CONFIRMED** — my arm tested the wrong link. Re-armed; conclusion held. |
+| 15 | "`/.dockerenv` measured on the host, concluded about the container" | checked inside the running container → PRESENT | **CONFIRMED** — now measured where it matters. |
+| 9, 10 | "A byte count does not prove semantic equivalence" | rendered vs direct `mise activate zsh`: 19 hook-env markers but **not** byte-identical | **CONFIRMED** — "direct equivalent" softened to functionally equivalent, with the difference stated. |
+
+Accepted without a probe, and the text corrected: **1** (no linux positive arm — bound now stated),
+**5–7** (zero-consumers-today was insufficient; the real killer is #439's OS-branch decision), **8**
+(no merged-tree template inventory — scoped as takeover work), **11** (`osRelease.id` via `exec()`
+is reachable, not tested — labelled), **12–14** (`status --missing` ≠ allow-list; #439/#434 must be
+re-run against the merged tree), **17** (`is exists` is existence only), **18** (the two
+`run_onchange` scripts are dismissed on *purpose*, not on measured behavioural equivalence —
+migration work, not decision evidence), **21** (13-target figure is inherited and pre-takeover),
+**22** (the corpus-level control arm does not license unrelated negatives — each probe now carries
+its own), **23** (defined what a "hit" means), **24–25** (the rename argument is weak on its own and
+the trigger was over-conjunctive — both fixed; the trigger is now a disjunction).
+
+**Finding 26 is the one that mattered most and is accepted in full.** It said the evidence supports
+"do not migrate during #431", not "chezmoi wins ownership". It does, and the verdict now says so.
+
+## Notes
+
+- **Read `docs/research/runs/research-20260710-r3-mise-dotfiles/` before re-opening this.** It is the
+  prior decision and #448's body does not reference it. Three of its four standing uncertainties are
+  now closed (config-level conditional omission → answered a *better* way, by platform environments;
+  the `$remote` env signals → 0 of 5; no empirical apply had ever been run → now run). The fourth
+  (an `executable_` equivalent) stays open and stays low-stakes.
+- **Its `os_family()` correction still stands and is now moot** — `os_family()` does collapse
+  darwin+linux into `unix`, but platform environments make the string branch unnecessary.
+- **The failure directions differ, and mise's is the safer one** (finding 4 accepted — I had called
+  them the same risk class). chezmoi's wrong `sourceDir` applies the *wrong* files; an inert
+  `auto_env` applies *nothing*. Destructive misapplication and safe non-application are not
+  equivalent, and pretending they were is what propped up the original verdict.
+- **The one hazard the migration must guard:** until `auto_env` defaults on in **2027.6.0**, a bare
+  `mise bootstrap dotfiles apply` — not routed through the repo task — silently ignores every
+  `mise.<platform>.toml`. It fails toward applying nothing, and `mise-tasks-only.md` is already
+  hook-enforced, so the guard is a `hook_guard` redirect rule, not new machinery. mise warns about
+  this itself from **2026.12.0**.
+- **Process slip, recorded rather than hidden:** I used `docker exec` for the in-container
+  `/.dockerenv` check. `do-not.md` #3 names `exec` among the devcontainer-lifecycle verbs reserved
+  for `@devcontainers/cli`. It was a read-only one-liner with no lifecycle effect, but the rule does
+  not carve that out — `devcontainer exec` was the correct call.
+- **A migration is not cheap even after the capability question closes**: 13 targets, the CI
+  `chezmoi managed` gate, `hook_guard`'s apply-deny rules, `doctor.toml` assertions, the
+  `chezmoi-check` skill, `scripts/check-chezmoi-templates.sh`, and #439's allow-list gate. Sequence
+  it after #431, never inside it.
+- **Not done deliberately:** no prototype branch (the evidence bar said probe the installed release,
+  and `prototype/432-secrets-cli-shape` is already an unmerged branch to keep alive); no changes to
+  `home/**`; #436 left open and unscoped-here.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — this repo; `home/**`,
+  `.devcontainer/`, `mise.toml`, prior research runs, issues #431/#434/#436/#439/#448.
+- [jdx/mise](https://github.com/jdx/mise) — the subject; `docs/dotfiles.md`, `docs/templates.md`,
+  `docs/configuration.md`, `docs/configuration/environments.md` read at tag `v2026.8.0`, and the
+  installed binary probed directly.
+- [ray-manaloto/macos-development-environment](https://github.com/ray-manaloto/macos-development-environment)
+  — the tree the takeover imports; `home/**` counted for `run_*`, `private_`, `encrypted_`.
+- [twpayne/chezmoi](https://github.com/twpayne/chezmoi) — the incumbent; behaviour taken from the
+  live tree and the #434/#439 probes rather than re-fetched docs.

--- a/docs/research/kb/reports/agents/codex-adversarial-448-chezmoi-vs-mise-dotfiles.md
+++ b/docs/research/kb/reports/agents/codex-adversarial-448-chezmoi-vs-mise-dotfiles.md
@@ -1,0 +1,77 @@
+1. **HIGH — The OS-gate probe never tests the second OS, so it cannot establish a per-OS gate.**  
+   Attacks table row 4: “`MAC_ONLY` **1** hit, `LINUX_ONLY` **0**” was measured only on macOS; toggling `auto_env` is a feature-control arm, not a Linux positive arm.
+
+2. **HIGH — Testing two filenames does not prove that `auto_env` cannot be enabled by any repository-owned mechanism.**  
+   Attacks table row 5 and the verdict: “A project-root `.miserc.toml` and `miserc.toml` both…” excludes committed task environments, wrapper tasks, hooks, or another supported local configuration layer that could set `MISE_AUTO_ENV=true`.
+
+3. **HIGH — A committed mise task with an explicit environment could eliminate the user-level pointer even if automatic direct invocation cannot.**  
+   Attacks: “`auto_env` is read only from a user-level… So mise does not eliminate #436’s untracked-user-level-pointer class.” The evidence addresses implicit CLI discovery, not whether the repository can own the supported bootstrap entrypoint and its environment.
+
+4. **HIGH — The document equates two materially different failure classes after admitting they have opposite failure directions.**  
+   Attacks: “it trades a wrong-target failure for a silently-inert-gate failure in the same untracked layer” versus “chezmoi’s wrong `sourceDir` applies the wrong files; an inert `auto_env` applies nothing.” Shared configuration location does not make destructive misapplication and safe non-application the same risk class.
+
+5. **HIGH — `promptBoolOnce` is declared dead using the pre-takeover tree even though the decision explicitly governs the post-takeover tree.**  
+   Attacks table row 1: “`is_dev_computer`: **0** consumers…” and the earlier scope rule: “The merged tree… is what a tool decision inside #431 actually governs.”
+
+6. **HIGH — The document’s own takeover inventory revives the supposedly dead `is_personal` use case.**  
+   Attacks table row 1: “`.ssh/config` + `.gnupg/**` — **0** such entries exist” versus the later statement that the merged tree contains `private_dot_ssh/config`. Zero consumers today does not establish zero consumers after the imminent import.
+
+7. **HIGH — “Retirement is decided” is not evidence that the blocker is absent during the migration being evaluated.**  
+   Attacks: “Confirms the retirement is **decided but not shipped**” followed by “I re-derived its blocker… and it is dead.” An unshipped removal cannot support a present-tense capability conclusion.
+
+8. **HIGH — The template-equivalence analysis appears to measure only the current repo’s nine templates, repeating the ticket’s alleged wrong-tree error.**  
+   Attacks: “For our files, **yes**… Two of the nine `.tmpl` files…” No corresponding merged-tree template inventory or render is presented.
+
+9. **HIGH — The `exec()` measurement cannot discriminate semantic equivalence from merely producing bytes.**  
+   Attacks table row 2: `exec(command='mise activate zsh \| wc -c')` → **6391**, called “a direct equivalent.” A nonzero byte count does not prove correct shell interpretation, correct activation text, correct environment, or equality with chezmoi’s output.
+
+10. **HIGH — The control arm for the template probe tests apply/status behavior, not template-function correctness.**  
+    Attacks table row 2: “`status` → `missing` ×2 before, `applied` ×2 after.” That proves files transitioned state; it does not validate `os()`, `arch()`, `env`, or `exec()` outputs.
+
+11. **HIGH — The claimed `osRelease.id` replacement is unmeasured, so the conclusion of full template equivalence exceeds the evidence.**  
+    Attacks: “the only fact without a first-class mise equivalent is `.chezmoi.osRelease.id`… reachable via `exec()`.” Reachability is not a tested implementation, especially across four branches and two operating systems.
+
+12. **HIGH — `status --missing` does not replace an allow-list gate.**  
+    Attacks: “#439’s gate would have been replaced by `mise bootstrap dotfiles status --missing`.” Missing-file detection cannot prove that only 13 authorized targets are configured; an accidental fourteenth target may be perfectly applied and therefore invisible to that gate.
+
+13. **HIGH — The claim that the 13-target allow-list survives “unchanged” conflicts with the acknowledged incoming target.**  
+    Attacks: “#439’s 13-target allow-list gate… survive unchanged” versus the merged tree’s `private_dot_ssh/config`. The document never demonstrates that the imported target is already among the 13 or intentionally excluded.
+
+14. **HIGH — The collision inventory cannot survive unchanged without being rerun against the merged tree.**  
+    Attacks: “#434’s collision inventory also survive[s] unchanged.” A takeover importing another repository’s target tree changes the collision domain by definition.
+
+15. **HIGH — The `/.dockerenv` probe measures the Mac host while making a conclusion about the devcontainer.**  
+    Attacks table row 3: “`/.dockerenv` → NO on this Mac host” and row 6: “So `/.dockerenv` is load-bearing.” The document never reports evaluating `is exists` inside the container where the file is expected to matter.
+
+16. **MEDIUM — Counting 69 container environment variables does not arm the negative for five particular signals.**  
+    Attacks table row 6: “`docker inspect`… reports **69** env vars total, so the inspection works.” A total count does not validate the name-selection filter; a known-present variable passed through the identical filter was required.
+
+17. **MEDIUM — “`is exists` replaces `stat`” is broader than the measurement.**  
+    Attacks table row 3: “Does mise replace chezmoi’s `stat`? **Yes**.” The probe establishes boolean existence only; it does not establish parity with any metadata, type, ownership, or permission properties available from `stat`.
+
+18. **HIGH — The two takeover scripts are dismissed without measuring behavioral equivalence.**  
+    Attacks: “both scripts are `brew bundle` and `mise install`/`reshim` — precisely what `[bootstrap.packages]` and the `bootstrap` task do natively.” No comparison covers triggers, ordering, conditional execution, idempotence, failure handling, or `run_onchange` semantics.
+
+19. **MEDIUM — The private-file loss is asserted rather than established.**  
+    Attacks: “`private_dot_ssh/config`, whose 0600 semantics mise has no equivalent for.” The document presents no permission-mode probe or documentation result showing that mise cannot preserve or enforce 0600 through another repository-owned mechanism.
+
+20. **HIGH — The supposedly decisive chezmoi failure is inherited from an issue comment, not re-derived.**  
+    Attacks the #434 row: “C1 is decisive… `chezmoi --source=dotfiles/home managed` → **rc=1**.” This contradicts “I re-derived its blocker rather than inheriting it”; the current receipt supplies no fresh run, current configuration fingerprint, or proof that the quoted state has not drifted.
+
+21. **MEDIUM — The 13-target figure is also inherited while being treated as current post-takeover scope.**  
+    Attacks the #439 row and consequence: “read — the 13-target linux allow-list…” The receipt does not enumerate or recount those targets after incorporating the second repository.
+
+22. **MEDIUM — The global known-present/known-absent check cannot validate unrelated negative probes.**  
+    Attacks: “Both arms with real numbers, so absence readings below are answers rather than blindness.” A `git ls-files` test for `dot_` and `encrypted_` says nothing about correctness of later consumer greps, Docker filters, mise configuration lookup, or OS selection.
+
+23. **MEDIUM — Several “hit” measurements are not auditable because the observable is undefined.**  
+    Attacks rows 4–5: “`MAC_ONLY` **1** hit” and “`LINUX_ONLY` **0**.” The document does not say whether a hit means configuration discovery, planned action, target creation, command output, or text occurrence; those outcomes support different conclusions.
+
+24. **LOW — Command renaming is used as a migration blocker without evidence that it affects configuration compatibility.**  
+    Attacks the verdict: “surface renaming itself again… not a foundation to migrate 13 targets onto.” A deprecated command alias may be cosmetic; no probe shows broken configuration, behavior, or automation.
+
+25. **MEDIUM — The re-evaluation rule is arbitrary and over-conjunctive.**  
+    Attacks: “all three, not a date” and “one full release cycle without a command rename.” No evidence establishes that all three conditions are necessary, that one release cycle predicts stability, or that a repository-owned gate could not permit earlier migration.
+
+26. **HIGH — The evidence supports deferring migration, not the stated tool-ownership verdict.**  
+    Attacks the overall verdict. The document says mise’s capability gaps are closed or dead, its host/container split is better, its failure direction is safer, and it removes two scripts. What remains is takeover timing, migration cost, an untested repository-owned activation alternative, and command maturity. That supports “do not migrate during #431; prototype the repository-owned gate afterward,” not the stronger conclusion that chezmoi wins the ownership decision or that #436 must proceed unchanged.


### PR DESCRIPTION
Resolves #448. No capability blocker survived measurement against the
installed mise 2026.8.0: `mode = "template"` covers every fact our nine
templates use, `is exists` replaces chezmoi's `stat`, platform
environments replace `.chezmoiignore`'s OS gate, and `mode = "copy"`
preserves 0600. The 2026-07-10 research's hard blocker (`promptBoolOnce`)
is superseded by #439's own decision to move `.ssh`/`.gnupg` onto the OS
branch.

The verdict pointed the other way until the adversarial review. I had
claimed the OS gate cannot be declared in-repo, having tested only
implicit discovery: a project `.miserc.toml` really is unread, but a
tracked mise task carrying `env = { MISE_AUTO_ENV = "true" }` enables
platform environments (MAC_ONLY 1 via the task, 0 with an inert env).
mise does eliminate #436's wrong-target class.

What defers it is blast radius and maturity, not capability — 13 targets
plus the CI gate, hook_guard, doctor.toml, the chezmoi-check skill and
check-chezmoi-templates.sh all move at once, while #431 is mid-flight.

Also corrects two rows of the ticket's "do not re-derive" table, both
scoped to the pre-takeover tree: the merged tree has 2 `run_onchange`
scripts and 1 `private_` file (not 0), and `[bootstrap.packages]` lives
in `.devcontainer/mise-system.toml`, not `mise.toml`.

Codex review: 26 findings, 3 refuted by probe, 23 accepted.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014x8jGSieFkDBV95KLXYhTC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788214298&installation_model_id=429246&pr_number=464&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F464&signature=95b3e03193dfcd1cf641becb4346dbc511c109f3d3eb452fca7b21c88a933929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a research record comparing the current dotfiles management approach with a potential migration path.
  - Documented compatibility measurements across templating, environments, containers, permissions, file modes, and merged configuration results.
  - Captured migration risks, required safeguards, review findings, re-evaluation criteria, and explicitly out-of-scope work.
  - Added an adversarial review identifying evidence gaps and clarifying that migration should be deferred pending further validation and prototyping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->