### PR TITLE
docs(436): three layers replace the host-apply deny — codex reversed the verdict

### DIFF
--- a/docs/receipts/436.md
+++ b/docs/receipts/436.md
@@ -1,0 +1,257 @@
+# Receipt — #436: What replaces the host-apply deny rule when "chezmoi is devcontainer-only" reverses?
+
+**Verdict:** **Three layers, none sufficient alone — and the ticket's framing that a Claude deny
+rule was ever the guard is wrong.** Measured this session: `-S` / `--source` / `--config` are
+chezmoi **global** flags, so they may precede the subcommand, and the live guard therefore already
+allows `chezmoi --config=… apply`, `chezmoi -S /tmp/x apply` and `chezmoi --source=/tmp/x apply`
+(control arms: bare `chezmoi apply` and `chezmoi update` **deny**; `chezmoi diff` **allow**). A
+command-string regex **cannot bind the source**, so "what replaces the deny" cannot be answered with
+another regex.
+
+1. **Native chezmoi `[hooks].pre` on `apply` and `update` — the primary, and the ONLY
+   pre-execution binding available.** It reads `CHEZMOI_ARGS` and aborts when `--source`/`-S` names
+   anything but this repo. This is prior-session decision 6, which an earlier draft of this receipt
+   **dropped and the adversarial review restored** — see the disposition table.
+2. **The Claude guard keeps a rule, but retargeted: `init` and `update` denied, `apply` freed.**
+   `apply` is what the takeover legitimises. `update` is not — chezmoi's own help calls it *"Pull
+   and apply any changes"*, i.e. a `git pull --autostash --rebase` against the source tree, which
+   the host has no need for. This is a **new** `_RULES` entry (own `since`, own test), and it is
+   explicitly a **defence-in-depth spelling guard, not the binding** — it has the same global-flag
+   escape as the rule it replaces (simulated: `chezmoi init` → deny, `chezmoi --config=… init
+   --apply` → allow).
+3. **The `doctor.toml` axis #440 already owes**, carrying decision 7's **three** claims — a
+   **relative** `sourceDir`, `[hooks]` present and pointing into that source, `destDir` absent.
+   Relative, **not** a literal path: a committed literal fails in whichever of Mac or container it
+   was not written for, which is exactly why decision 4 was superseded by decision 7 in the first
+   place. Cadence is real — `.claude/settings.json:61-67` runs `mise run doctor` on SessionStart
+   (`startup|resume`).
+
+**Ordering — and the earlier draft had this dangerously wrong.** Not "both land before the
+takeover". The sequence is **keep the `apply` deny → move the source → verify → then flip the
+guard**. Freeing `apply` while the live `sourceDir` still points at `macos-development-environment`
+(it does, and that tree is in 3-file drift) opens precisely the window the old invariant existed to
+close.
+
+**Accepted residual, stated plainly rather than argued away:** `--config=/elsewhere` defeats layers
+1 and 3 together and **nothing available closes it**; path equality is not repository identity (the
+right directory can hold the wrong checkout, remote, revision, or dirty tree — this session's own
+drift evidence proves the two are different properties); and layer 3 is detection *after* an
+`init --apply` has already written. The guard **retires with chezmoi** (#448: `mise bootstrap
+dotfiles` is the destination), so this is a bounded-lifetime design — but "bounded" is a reason not
+to gold-plate, not a reason to leave the central hole open.
+
+⚠️ **The deny is already broken today, four ways**, independent of the reversal — and the host is in
+**real chezmoi drift right now** (3 files `MM`) with **nothing this repo runs** reporting it.
+
+**Resolved:** 2026-08-01
+
+## Sources — what I actually opened
+
+- `python/src/dotfiles_setup/hook_guard.py:187-195` — the live `Rule("chezmoi apply/update", …)`,
+  pattern `_CMD + r"chezmoi\s+(apply|update)\b"`.
+- `.claude/settings.json:17-18` (the deny) and `:61-67` (the SessionStart doctor wiring that makes
+  layer 3's cadence real).
+- `python/src/dotfiles_setup/eval_cases.py:97-98` and `tests/test_hook_guard.py:23-24,102` — **two
+  mechanical sites #436's own comment does not list.** Any retarget must move all four.
+- `chezmoi --help` (v2.71.1) — the global-flag block at `:95` (`-S, --source path`) and the
+  subcommand descriptions at `:13,18,23`. This is the source that refuted the writer/readers model.
+- `macos-development-environment/src/mde/validate/chezmoi.py` (**on mde `origin/main`**) —
+  `validate_chezmoi()` / `_check_sourcedir_not_default()`, the only `sourceDir` conformance check
+  that exists today, in the repo that currently *is* the `sourceDir`.
+- `docs/receipts/440.md:9,94-95,200-225` — the decisive prior art; see the table below.
+- `docs/receipts/448.md` + issue #448's verdict — the scheduled end that bounds this ticket.
+- `.devcontainer/scripts/on-create.sh:40-41` — `chezmoi init --apply --source="${WORKSPACE_FOLDER}"
+  --no-tty --force`, still verbatim. An `init` guard must stay unreachable from the lifecycle hook
+  (it is — hooks do not go through the Bash tool; decision 3).
+- `chezmoi` v2.71.1 — pinned in `.config/mise/conf.d/shared.toml:27`, installed, **and the latest
+  release** (`gh api repos/twpayne/chezmoi/releases/latest` → `v2.71.1`, 2026-07-20). Re-derived
+  this session, not inherited from #436's comment.
+
+## Prior art — the search I ran
+
+**Query:** `rg -il --hidden "sourceDir|source-bind|chezmoi init" docs/research/kb/reports docs/specs
+docs/receipts docs/rules-evidence .claude/rules`
+**Corpus:** `docs/research/kb/reports/`, `docs/specs/`, `docs/receipts/`, `docs/rules-evidence/`,
+`.claude/rules/`
+
+### Control arm
+
+**Known-present term:** `sourceDir` → **3** files
+**Known-absent term:** `qxzvbnm7743` → **0** files
+
+⚠️ **The control term this repo has been using is no longer absent.** `zzqqxx` — the known-absent
+arm of earlier receipts — now returns **5 files** (`docs/receipts/440.md`, `437.md`, `438.md`, and
+two agent reports), because prior sessions *wrote it into the receipts*. A published control term
+stops being a control. Hence the fresh string above.
+
+| Hit | What I did with it |
+|---|---|
+| `docs/receipts/440.md` | **read — decisive.** Its findings #2/#3 already established the enforceable condition as the **machine-checkable active `sourceDir`**, with "a `doctor.toml` axis on that covers the whole class". Layer 3 is therefore *not a new mechanism* — it is that axis, with decision 7's three claims attached. ⚠️ Its tier (c) (*"host-side, detection only … claiming a hard stop would be false"*) is about the **host mise config**, and an earlier draft of this receipt **misapplied it to chezmoi hooks** to justify dropping them. Review finding 2 caught that; #440 says nothing about hooks. |
+| `docs/research/kb/reports/agents/codex-adversarial-448-chezmoi-vs-mise-dotfiles.md` | read — supplies the risk asymmetry the whole ticket rests on: *"chezmoi's wrong `sourceDir` applies the **wrong files**; an inert `auto_env` applies **nothing**."* |
+| `docs/receipts/448.md` | read — the scheduled end (`:196` carries the same asymmetry). Frames the cost ceiling, and — per finding 2 — **not** a licence to drop a layer. |
+| `docs/specs/deep-interview-devcontainer-lifecycle.md` | read — `:104` documents the mid-session `devcontainer exec … chezmoi apply` workflow the current deny blocks (a real cost of the deny), and `:161` fixes the `onCreateCommand` form the retargeted rule must not break. |
+| `docs/specs/deep-interview-devcontainer-build-mise-chezmoi-resync.md` | read — `:139-141`, `:346-348` framed "which clone is the source" as a `chezmoi init --source` choice **executed by the user, not autopilot**, which is why `init` is guarded rather than banned. |
+| `docs/specs/deep-interview-docker-mise-system-config.md` | **dismissed** — `:79` is a one-line historical note that the deleted `install.sh` did post-create `chezmoi init + apply`. Nothing here bears on the guard. |
+
+## Probes — settled by running, not by argument
+
+Every probe has both arms. Three of them **reversed a result already written down**.
+
+### P1 — ⚠️ the live guard has FOUR escapes, not one, and three of them are `apply` itself
+
+Fed to the real `dotfiles-setup hook pretooluse` (from a script file, because a guard-denied
+*compound* command runs nothing):
+
+| Command | Decision |
+|---|---|
+| `chezmoi apply` | **deny** ← control arm |
+| `chezmoi update` | **deny** ← control arm |
+| `chezmoi --config=/tmp/x.toml apply` | **allow** |
+| `chezmoi -S /tmp/x apply` | **allow** |
+| `chezmoi --source=/tmp/x apply` | **allow** |
+| `chezmoi --config=/tmp/x.toml update` | **allow** |
+| `chezmoi diff` | **allow** ← control arm |
+| `chezmoi init --apply --source=/tmp/x --force` | **allow** |
+
+`chezmoi --help:95` lists `-S, --source path` in the **global** flag block, so it may legally
+precede the subcommand. **This is the finding that rewrote the verdict.** #436's comment said the
+deny "blocks a spelling"; it understates the case — the spelling it blocks is one of at least four,
+and the escapes are on `apply` itself, not only on `init`.
+
+The same defect is inherited by any replacement regex. Simulating the proposed `init` rule:
+`chezmoi init` → **would-deny** (control arm), `chezmoi --config=/tmp/x.toml init --apply` →
+**would-allow**, `chezmoi -S /tmp/x init` → **would-allow**. Hence layer 2 is labelled
+defence-in-depth and layer 1 carries the binding.
+
+### P2 — ⚠️ chezmoi's own help refutes the "guard the writer, not the readers" model
+
+| Subcommand | chezmoi's description |
+|---|---|
+| `apply` | "Update the destination directory to match the target state" |
+| `init` | "Setup the source directory **and** update the destination directory…" |
+| `update` | "Pull and apply any changes" |
+
+None of the three is a reader. `update` is a `git pull --autostash --rebase` against the source tree
+followed by an apply — it mutates source state. Prior-session decision 2 framed `apply`/`update` as
+readers that "merely obey" `sourceDir`; that is wrong as stated. The operative distinction is not
+writer-vs-reader but **what the takeover needs** (`apply`) versus what it does not (`update`).
+
+### P3 — mde's `sourceDir` check exists, and is narrower than this ticket needs
+
+`_check_sourcedir_not_default()` called directly with synthetic paths (pure function, no live state
+touched):
+
+| Arm | `sourceDir` | Findings |
+|---|---|---|
+| A | `~/.local/share/chezmoi` (the chezmoi default) | **1** |
+| B | `~/dev/github/ray-manaloto/dotfiles` (**wrong source, non-default**) | **0** |
+| C | `~/dev/github/ray-manaloto/macos-development-environment` (live) | **0** |
+
+Arm A proves the check can fire. **Arm B is the finding**: it tests "not the *default*", not "is
+*this* source". mde's check cannot answer #436's question, so layer 3 is still needed — but note
+finding 12: neither can a path-equality check prove repository *identity*.
+
+### P4 — ⚠️ MY OWN READER WAS THE BOUND, and it inverted the live result
+
+The first runs of P3 and P5 read `getattr(r, "issues") or getattr(r, "results")`. The field is
+`ValidationResult.findings`. Both were absent, so both printed **0**. Corrected:
+
+- control arm A: **0 → 1** (the check can fire at all — the entire basis of P3)
+- the live run: **0 → 2 ERRORS**
+
+An unarmed probe reported *"all clean"* for a host carrying two live errors, and the clean result
+was already written down. `.claude/rules/probes-need-a-control-arm.md` names this exact shape: arm
+the component you actually depend on — the **reader**, not just the corpus.
+
+### P5 — the host is in real chezmoi drift today, and nothing here reports it
+
+`validate_chezmoi()` on this host: `files_checked=1`, **2 `ERROR` findings** — `chezmoi.drift` and
+`chezmoi.timeout`. Cross-checked by a second route rather than believed:
+
+- **The drift is real.** `chezmoi status` → **3** files in `MM` (modified in source *and*
+  destination): `.config/mise/config.toml`, `.gitconfig`, `.zshrc`.
+- **The timeout is not.** `chezmoi doctor` completed here in **25s**, rc=0, 26 result lines, 2
+  warnings (both *"is a git working tree (dirty)"*) — against mde's **30s** limit. A 5s cushion on a
+  25s command is a flaky margin. That one is an mde defect, not a host defect.
+- **Nothing in this repo would surface either.** `doctor.toml` and
+  `python/src/dotfiles_setup/doctor.py` contain **0** chezmoi mentions (control arm: `fnox` → **3**
+  and **43** in the same two files, so the probe discriminates).
+
+### P6 — the site inventory in #436's own comment is incomplete
+
+Re-enumerated with `rg --hidden` (**without** `--hidden`, `rg` returns **0** hits under `.claude/**`
+— `feedback_fd_skips_hidden_dirs`, and it silently bounded the first sweep):
+
+- **Mechanical: 4, not 2.** `.claude/settings.json:17-18`, `hook_guard.py:187-195`, plus
+  `python/src/dotfiles_setup/eval_cases.py:97-98` and `tests/test_hook_guard.py:23-24,102`.
+- **Prose: 7, not 4.** The four it lists (`AGENTS.md:132`, `.claude/rules/mise-tasks-only.md:28`,
+  `.claude/rules/use-tool-builtins.md:55`, `.claude/skills/devcontainer-workflow/SKILL.md:68`) plus
+  `.claude/skills/tmux-extended-keys/SKILL.md:96`,
+  `docs/specs/deep-interview-devcontainer-lifecycle.md:148`, and
+  `docs/specs/deep-interview-research-tooling-wiring.md:74`.
+
+### Inherited, labelled, NOT re-derived
+
+The chezmoi `[hooks]` mechanics that layer 1 rests on — a failing pre-hook **aborts** the command
+(3 arms), hooks run under `--dry-run`, and a hook **can see `--source` via `CHEZMOI_ARGS`** (2
+arms) — were measured by the 2026-07-31 session on this same pinned v2.71.1. They are **not**
+re-derived here: doing so requires writing a `[hooks]` block into the live user config, which is out
+of bounds. Treat them as prior measurements with their arms recorded on the ticket, not as this
+session's findings.
+
+## Adversarial review
+
+**Lens:** codex-reviewer (`codex exec --ephemeral --sandbox read-only`, reasoning effort high, cold
+— given the text only, instructed not to read disk)
+**Verdict:** **needs-attention — it reversed the verdict**
+**Findings:** **14** (4 critical, 8 major, 2 minor) — full report at
+`docs/research/kb/reports/agents/codex-adversarial-436-host-apply-deny-replacement.md`
+**Disposition:** 12 accepted, 2 partial, **0 refuted**.
+
+| # | Sev | Claim | Disposition |
+|---|---|---|---|
+| 1 | crit | `apply --source=/wrong` never touches the configured `sourceDir`, so the doctor axis cannot see it | **accepted — decisive.** Confirmed: `-S/--source` is a *global* flag (`chezmoi --help:95`). This is the hole that restores layer 1. |
+| 2 | major | None of the four reasons for dropping hooks holds | **accepted.** #440's "detection only" is about the host **mise** config, not hooks; novelty bears on cost not correctness; "cannot protect `init`" means *insufficient alone*; `--config=` limits coverage rather than nullifying it. "Four independent reasons, any one sufficient" was indefensible. |
+| 3 | major | Dropping decision 7 discards `[hooks]`-present and `destDir`-absent without evaluating them | **accepted.** Both restored; `destDir` controls where `apply` writes and is an independent threat. |
+| 4 | major | "Equality with the expected source" has no portable definition across Mac and container | **accepted — and it re-introduced a defect already retired.** Decision 4 was superseded by decision 7 for exactly this reason. Layer 3 asserts a **relative** `sourceDir`. |
+| 5 | crit | The residual list accepts away the central failure mode; "typo not attack" is a threat-model switch | **accepted.** Rewritten: layer 1 now covers `--source`; what remains residual is named without excuse. |
+| 6 | crit | The evidence contradicts the verdict, and freeing `apply` pre-takeover opens an unsafe window | **accepted.** Ordering corrected to keep-deny → move-source → verify → flip. |
+| 7 | major | "Writer vs readers" is materially false — `apply` writes, `update` pulls then applies | **accepted**, and confirmed from chezmoi's own help (P2). `update` stays denied. |
+| 8 | crit | The replacement regex is bypassed by `chezmoi --config=… init` | **accepted, and understated.** Probed: `--config=`, `-S`, and `--source=` bypass it, and they bypass the **existing** rule too (P1). Layer 2 is demoted to defence-in-depth. |
+| 9 | major | `init` is not the only writer of `sourceDir` | **accepted.** Independently corroborated: mde's own code comments describe *"the template bug that caused repeated breakage"* — a non-`init` regeneration dropping `sourceDir`, which has already happened more than once. |
+| 10 | major | Detection is not prevention; no cadence specified | **partial.** Cadence **refuted** — `.claude/settings.json:61-67` runs doctor on SessionStart (`startup\|resume`), so "within one session" holds. "Too late for `init --apply`" **accepted** and now stated. |
+| 11 | major | The deployment order is unsafe and internally unresolved | **accepted** — merged with 6. |
+| 12 | major | Path equality does not prove repository identity | **accepted.** Named in the residual list; this session's own 3-file drift is the demonstration. |
+| 13 | minor | "Nothing new is built" minimises real implementation work | **accepted.** That phrasing is gone. |
+| 14 | minor | Repo/live evidence is unverifiable from the supplied text | **partial — expected by construction.** The review was deliberately cold and disk-blind; every such claim carries its command and both arms above. |
+
+## Notes
+
+- **What this ticket does NOT do.** It ships no code. All three layers are #431 work
+  (`map #431 is planning-only`).
+- **Layer 2 is a new `_RULES` entry**, not a reword: its own `since` date and its own test row, per
+  `.claude/rules/mise-tasks-only.md` § "`since` dates COVERAGE". The `apply|update` entry is
+  **deleted**, and `apply` must move out of `.claude/settings.json`'s deny list as well.
+- **`AGENTS.md` is at 200/200 lines**, so its prose edit must be size-neutral. Seven prose sites, not
+  four (P6).
+- **Two live defects surfaced but NOT fixed here** (out of scope, recorded on the map): the host's
+  3-file chezmoi drift, and mde's 30s `chezmoi doctor` timeout sitting 5s above a 25s command. The
+  mde one belongs to the deferred mde session.
+- **Worth reconsidering when #431 plans layer 1:** the global-flag escape (P1) is not chezmoi's
+  fault or ours — it is what a command-string guard *is*. If a later session finds itself writing a
+  cleverer regex, that is the signal that it has picked the wrong layer.
+- **If this is revisited:** re-check whether #431's takeover has moved `sourceDir` off
+  `macos-development-environment`. Every measurement above was taken with the live `sourceDir`
+  **still pointing at mde** — the same condition #440 measured under, and the same condition that
+  made two rows of #448's own table wrong.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the guard, its tests and eval
+  cases, the prose sites, and the prior-art corpus.
+- [ray-manaloto/macos-development-environment](https://github.com/ray-manaloto/macos-development-environment) —
+  `src/mde/validate/chezmoi.py`, the only existing `sourceDir` conformance check; also the current
+  live `sourceDir`.
+- [twpayne/chezmoi](https://github.com/twpayne/chezmoi) — `chezmoi --help` on the pinned v2.71.1
+  (the global-flag block that rewrote the verdict); release currency check (`v2.71.1` is pinned,
+  installed, and latest).

--- a/docs/research/kb/reports/agents/codex-adversarial-436-host-apply-deny-replacement.md
+++ b/docs/research/kb/reports/agents/codex-adversarial-436-host-apply-deny-replacement.md
@@ -1,0 +1,54 @@
+# Codex cold adversarial review — #436 (what replaces the host-apply deny rule)
+
+**Lens:** `codex exec --ephemeral --sandbox read-only -c model_reasoning_effort=high`
+**Run:** 2026-08-01 · **Mode:** cold — given the receipt text only, instructed not to read disk
+**Result:** 14 findings (4 critical, 8 major, 2 minor). Disposition table: `docs/receipts/436.md`.
+
+Verbatim below. Nothing edited.
+
+---
+
+1. **Critical — Wrong: retargeting `apply|update` to `init` does not protect the stated source-binding threat.**  
+   `chezmoi apply --source=/wrong/tree` applies from a one-shot source without changing the configured `sourceDir`. The proposed doctor check will subsequently inspect the unchanged active configuration and report the expected source. The document acknowledges this path, then falsely claims the doctor catches its “resting-state result.”
+
+2. **Major — Wrong: none of the four reasons independently justifies dropping hooks.**  
+   The “detection only” conclusion means hooks are not universal, not that they provide no prevention; the document’s own measurements say a failing pre-hook aborts covered commands and can inspect `--source`. Novelty is irrelevant to correctness. Inability to protect `init` only means hooks need the complementary `init` guard. `--config=/elsewhere` is a real bypass, but it limits hook coverage rather than making protection of the default configuration worthless. The claimed “four independent reasons, any one sufficient” is indefensible.
+
+3. **Major — Wrong: “dropping decision 7” silently discards requirements rather than cleanly replacing them.**  
+   A stronger source-equality doctor check could supersede the earlier “relative `sourceDir`” claim. It does not replace verification that `[hooks]` exists or that `destDir` is absent. The document drops those claims without evaluating their threats—especially `destDir`, which controls where `apply` writes. This is neither a clean rename nor a justified retirement of the baseline.
+
+4. **Major — Unverifiable and underspecified: equality with “the expected source” has no portable definition here.**  
+   A committed literal path cannot represent both the Mac checkout and `${WORKSPACE_FOLDER}` in the devcontainer. A workable check would need a runtime-derived expected directory, explicit context-specific configuration, or repository-identity validation, plus normalization for relative paths, `~`, symlinks, and worktrees. The text neither defines that resolver nor establishes that `doctor.toml` can express it. Under the unconditional/no-context decision, the proposal may be impossible as stated.
+
+5. **Critical — Wrong: the residual-risk section accepts away the central failure mode.**  
+   A wrong `--source`, alternate `--config`, or mistaken `init --apply` is precisely how the wrong dotfiles get applied. Calling it a “typo, not an attack” is a threat-model switch: the old guard was protecting against dangerous agent or operator behavior, not merely hostile actors. Chezmoi confirmation is also not an adequate backstop for unattended or forced execution.
+
+6. **Critical — Wrong: the document’s evidence contradicts its verdict.**  
+   It reports that hooks abort before execution and see `--source`, then concludes no preventive control is available. It reports one-shot overrides but claims doctor detects all residual cases. It also says the active source still points to mde and is already in three-file drift, while requiring the `apply` deny to be removed before takeover. That creates an unsafe interval in exactly the state the old invariant was intended to contain.
+
+7. **Major — Wrong: the “writer versus readers” model is materially false.**  
+   `apply` writes destination files and may execute source-state scripts. `update` mutates the source state and then applies it; it is not merely a reader. The takeover’s need for host-side `apply` does not establish any need to permit `update`. Treating both identically expands authority without justification.
+
+8. **Critical — Wrong: the replacement remains a spelling guard with an obvious semantic bypass.**  
+   The proposed regex requires `chezmoi` to be immediately followed by `init`. A valid form such as `chezmoi --config=/elsewhere init --apply …` does not match `chezmoi\s+init\b`. The document notices that alternate configuration bypasses hooks but fails to apply the same observation to its new regex. Wrappers and executable-path variations create further bypasses unless `_CMD` performs semantic normalization, which is unverifiable from the text.
+
+9. **Major — Wrong: `init` is not the only mechanism capable of changing `sourceDir`.**  
+   Chezmoi configuration can be changed through configuration-editing commands or ordinary file edits. Template-backed configuration introduces another writer. At most, `init` is one important chezmoi-mediated writer; guarding that spelling does not guard the configuration invariant.
+
+10. **Major — Wrong: post-command detection is not a replacement for pre-command prevention.**  
+    Even when a wrong `init` persists its source and doctor later detects it, `init --apply` can already have modified the destination or executed scripts. No doctor cadence is specified, so “within one session” is unsupported as well as too late. The document turns a preventive control into an eventual alarm without acknowledging the reduction in safety.
+
+11. **Major — Wrong: the required deployment order is unsafe and internally unresolved.**  
+    Removing the old deny before takeover permits host application from the pre-takeover source. Changing the expected doctor value before takeover instead produces an intentional failure until the source moves. The receipt needs an atomic transition or explicit order—retain the old deny, establish the new source, verify it, then change the guard—not merely “both changes land before takeover.”
+
+12. **Major — Wrong: path equality alone does not prove that “THIS repo” is the source.**  
+    The expected directory can exist while containing the wrong checkout, remote, revision, or dirty content. The document’s own drift evidence demonstrates that correct location and correct source material are different properties. If the invariant is repository identity, literal path equality is an incomplete proxy.
+
+13. **Minor — Wrong: “nothing new is built” minimizes substantive implementation work.**  
+    A portable expected-source resolver, normalization rules, doctor integration, a new guard rule, evaluation cases, tests, and prose changes are not “one retarget.” Deferring their implementation to #431 does not make the design free.
+
+14. **Minor — Unverifiable: the repository and live-machine evidence cannot be confirmed from the supplied text.**  
+    The exact site counts, current drift, mde behavior, timing, pinned/latest release status, and cited receipt contents all depend on unseen repository or external state. They may be treated as reported observations for internal-consistency review, but not as independently established facts.
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the reviewed receipt and the guard it describes.


### PR DESCRIPTION
Answers #436. The ticket's framing that a Claude deny rule was ever the guard
does not survive measurement: `-S`/`--source`/`--config` are chezmoi GLOBAL
flags, so the live rule already allows `chezmoi --config=… apply`,
`chezmoi -S /tmp/x apply` and `chezmoi --source=/tmp/x apply` (control arms:
bare `apply`/`update` deny, `diff` allows). A command-string regex cannot bind
the source, so the replacement cannot be another regex.

Verdict — three layers, none sufficient alone:
  1. native chezmoi `[hooks].pre` on apply/update reading CHEZMOI_ARGS — the
     only pre-execution binding available (prior decision 6, RESTORED);
  2. the Claude rule retargeted to `init` + `update` with `apply` freed, and
     labelled defence-in-depth, not the binding;
  3. #440's `doctor.toml` axis on the active sourceDir, carrying decision 7's
     three claims — a RELATIVE sourceDir (a literal fails on Mac or container,
     which is why decision 4 was retired), `[hooks]` present, `destDir` absent.

Ordering corrected: keep the deny -> move the source -> verify -> then flip.
Freeing `apply` while sourceDir still points at mde opens the exact window the
invariant existed to close.

An earlier draft dropped decisions 6 and 7 as over-investment. The codex cold
review (14 findings, 4 critical, 12 accepted / 2 partial / 0 refuted) reversed
that, and the probes it prompted found three MORE live bypasses in the existing
guard than the ticket had recorded.

Also measured and recorded: the host is in real chezmoi drift now (3 files MM)
and nothing this repo runs reports it; mde's sourceDir check tests "not the
default", so a wrong non-default source scores 0; the site inventory is 4
mechanical + 7 prose, not 2 + 4; and the receipts' own known-absent control
term `zzqqxx` is no longer absent — prior receipts published it.

Gates: lint rc=0 · pytest 1144 passed · verify 112 passed/0 failed ·
lint-docs rc=0.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014x8jGSieFkDBV95KLXYhTC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788222448&installation_model_id=429246&pr_number=467&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F467&signature=90f5006575a4229d7948ba13deedcc9de3dfb67767a2cea50da2a380f7bdce62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->