### PR TITLE
docs(receipts): a published control term stops being a control

### DIFF
--- a/.claude/rules/probes-need-a-control-arm.md
+++ b/.claude/rules/probes-need-a-control-arm.md
@@ -88,6 +88,12 @@ Full case tables — five false negatives, five cross-check disagreements:
    you KNOW is present in the same corpus with the same command shape. If that
    also returns 0, the probe is broken — not the world. Worked cases:
    `docs/rules-evidence/probes-need-a-control-arm.md`.
+
+   **Invent the known-absent term FRESH every time — writing one down destroys
+   it.** A control string published in a report or receipt is now IN the corpus,
+   so the next run's "absent" arm returns hits and the probe silently stops
+   discriminating. Measured 2026-08-01: `zzqqxx`, the arm three prior receipts
+   all used, returned **5 files** — three of them those receipts.
 4. **A redirect/timeout/parse-error is not a "no".** HTTP 301/000, a `jq` miss,
    an empty `grep` — distinguish "answered no" from "never asked".
 5. **Say which arm you ran.** When reporting a probe result, state the control:

--- a/docs/receipts/TEMPLATE.md
+++ b/docs/receipts/TEMPLATE.md
@@ -59,6 +59,16 @@ ate the error, and every query returned 0. A thin search and a blind one look id
 field tells them apart. If the known-present arm returns 0, **your probe is broken, not the world** —
 fix it and re-run before writing anything below.
 
+⚠️ **Invent a FRESH known-absent string each time — never reuse the last receipt's.** Writing one
+down publishes it into the corpus, so it stops being absent. Measured in #436: `zzqqxx`, the arm
+#437/#438/#440 all used, now returns **5 hits** — three of them those very receipts. A control term
+that the control arm itself created is a coin with one face.
+
+⚠️ **Arm the READER, not just the corpus.** The probe's own parsing is a component you depend on and
+it fails silently. In #436 a probe read the wrong attribute off a result object, printed **0
+findings** for a host carrying **2 live errors**, and that clean number was written into a draft
+before the control arm caught it. If a probe reports "nothing found", prove it can report something.
+
 | Hit | What I did with it |
 |---|---|
 | `path` | read — <what it changed> **or** dismissed — <why it does not apply> |

--- a/docs/specs/ticket-bound-receipts.md
+++ b/docs/specs/ticket-bound-receipts.md
@@ -546,6 +546,28 @@ this spec's own.
 > refuted**. This does not reopen §12's build/no-build verdict — the automation the pilot rejected
 > would still not have caught any of the three.
 
+> **Second post-pilot data point, 2026-08-01 — and it cuts against the refutation-rate story.**
+> `436.md` (#6): **14 findings (4 critical), 12 accepted / 2 partial / 0 refuted**, under the same
+> settle-it-by-running rule that produced #448's 11.5%. Running total: **127 findings, 4 refuted
+> (3.1%)**. One receipt does not establish a rate, and the honest reading is that **#448's 11.5% is
+> not yet a trend** — n=2 either side of the template edit.
+>
+> What *did* repeat is the more valuable signal: **the review reversed the verdict outright for the
+> second consecutive receipt.** The draft had dropped two of the ticket's seven prior decisions as
+> over-investment, citing #440's "host tier is detection only" — which is about the host **mise**
+> config and says nothing about chezmoi hooks. The reviewer caught the misapplication, and the
+> probes it prompted found **three more live bypasses in the shipped guard** than the ticket had
+> ever recorded (`-S` / `--source` / `--config` are chezmoi *global* flags, so they precede the
+> subcommand and escape a command-anchored regex). So the pattern worth tracking is not the
+> refutation rate but **how often the review changes the recommendation**: 5 of 6 receipts now.
+>
+> Two process defects surfaced that no field currently catches. **A published control term stops
+> being a control** — `zzqqxx`, the known-absent arm of #437/#438/#440, now returns 5 hits *because
+> those receipts wrote it down*; the template should not name a fixed string. And **the probe's own
+> reader is an unarmed component**: a probe here read the wrong attribute off a result object and
+> reported "0 findings" for a host carrying 2 live errors, and that clean number was written down
+> before the control arm caught it.
+
 ### 1. Which fields were real, which became ritual?
 
 **Real, and the highest-value field in all four: the adversarial review.** It was never once


### PR DESCRIPTION
Two process defects surfaced while answering #436 that no receipt field
caught, plus the second post-pilot data point.

`zzqqxx` — the known-absent control arm that receipts #437, #438 and #440
all used — now returns 5 files, three of them those very receipts. Writing
a control string down publishes it into the corpus, so the next run's
"absent" arm silently stops discriminating. The template and
probes-need-a-control-arm.md now require a fresh string every time.

And the probe's own READER is an unarmed component: a probe here read
`getattr(r,"issues")` where the field is `.findings`, printed 0 findings
for a host carrying 2 live errors, and that clean number reached a draft
before the control arm caught it.

Receipt tally: 436.md is instance #6 — 14 findings (4 critical),
12 accepted / 2 partial / 0 refuted. Running total 127 findings, 4 refuted
(3.1%). #448's 11.5% is NOT yet a trend, n=2 either side of the template
edit; the signal that does repeat is that the review changed the
recommendation in 5 of 6 receipts, reversing the verdict outright for the
second consecutive time.

Gates: lint rc=0 · lint-docs rc=0 · pytest 1144 passed · verify 112/0.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014x8jGSieFkDBV95KLXYhTC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788224551&installation_model_id=429246&pr_number=468&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F468&signature=577ba082d5ece99635fd5785ddda2f7d4b1a289c1ccd74d3a4cfa362a9d9ac9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated probe and receipt guidance to require newly generated control terms for each validation.
  * Added checks confirming that probe readers can detect findings and documented silent parsing failures.
  * Expanded receipt 436 with a second post-pilot data point: 127 findings, 4 refutations (3.1%), and a second consecutive verdict reversal.
  * Documented three additional guard bypasses and two process defects affecting control-term isolation and result interpretation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->