### PR TITLE
docs(receipts): #441 — fnox has the agent overlay, and this Mac cannot reach it

### DIFF
--- a/docs/receipts/441.md
+++ b/docs/receipts/441.md
@@ -1,0 +1,504 @@
+# Receipt — #441: Do fnox Composable Profiles give us an agent profile?
+
+**Verdict:** **fnox has exactly the overlay the ticket describes — and this Mac cannot use it.** Two
+different profile mechanisms exist at the **installed fnox 1.32.0** (not the 1.31.1 every prior
+ticket measured), and the ticket conflates them. `[profiles.X]` accepts exactly four keys —
+`leases`, `providers`, `default_provider`, `secrets` — so it carries **no** `[mcp]` or `[proxy]`.
+But `fnox.<profile>.toml`, a per-profile **config file**, is a full config and **does** carry them:
+measured, `proxy rules -P agent` returns the rule declared in `fnox.agent.toml` while the default
+profile errors *"No `[proxy]` configuration found"*. Two measurements kill it for us anyway: the
+profile-file mechanism is **project-config-only** — `config.agent.toml` and `fnox.agent.toml` in the
+global config dir are both **ignored** (control: the global `config.toml` itself loads fine) — and
+this Mac's 49 secrets live in the global `~/.config/fnox/config.toml`; and it is **mutually
+exclusive with confinement**, because its secrets merge into the *default* profile, so
+`-P agent --no-defaults` empties the environment **completely**, profile file included.
+⇒ **Adopt `[profiles.agent.secrets]` + `--no-defaults`** — scoping only, no channel allowlist, which
+is the one combination reachable from our config shape. Profile scoping is real on **both** channels:
+measured against a live `fnox mcp` server over stdio, `get_secret` under `-P agent --no-defaults`
+**denies** a top-level-only name and returns the profile one (controls: a nowhere-name is denied in
+all four arms; the rows differ across profiles).
+
+⚠️ **A cold review refuted this receipt's strongest claim, and it was right.** An earlier draft said
+`fnox proxy run` catches fnox's silent fail-open. It does not: that result came from a fixture whose
+rule table referenced a top-only *and* a profile-only secret, so **every** single-profile scope was
+forced to fail. Re-run against the design actually proposed — the rule names a secret the profile
+duplicates from top level — a **missing profile starts cleanly, rc=0**. What the proxy really does is
+cap the injected set at the **rule table**, profile-independently: with a missing profile the child
+still received only the one ruled placeholder, while plain `exec` handed it the other two secrets
+raw. That is a ceiling, not a gate, and it is still worth having — for a different reason than
+claimed.
+
+Three corrections to inherited claims stand: **`--no-defaults` alone is sufficient for confinement**
+(a missing profile then yields **0** secrets, not 49 — #435's "needs both" is wrong on the exposure
+axis, though right if read as "delivers the intended set"); **`FNOX_NO_DEFAULTS` exists**, giving the
+same confinement with no CLI flag; and **`--write-profile` is now required, not defaulted**, when a
+stack is composed. The cost the ticket does not anticipate: no reference form exists, so every
+per-secret binding the agent may reach is **duplicated** into the profile — a new silent-drift axis
+#435's baseline does not cover. **None of this is a boundary against an adversarial same-uid agent**,
+and nothing here should be read as one.
+
+**Resolved:** 2026-08-02
+
+## Sources — what I actually opened
+
+Third-party tool decision ⇒ the tool's own docs and the installed binary are both here (#449's miss).
+
+- `fnox 1.32.0` binary at `~/.local/share/mise/installs/fnox/latest/fnox` — **the authority for every
+  measured row below**; `--help`, `exec --help`, `proxy --help`, `proxy run --help`, `mcp --help`,
+  `profiles --help` gave the flag and command surface, and its TOML validator gave every vocabulary.
+- `github.com/jdx/fnox` → `docs/guide/profiles.md` (fetched to `.agent/kb/raw/fnox-guide-profiles.md`)
+  — overlay stack, inheritance, `--write-profile`; **never mentions `--no-defaults`**, so the guide
+  alone would teach an unconfined profile.
+- `github.com/jdx/fnox` → `docs/guide/proxy.md` (`.agent/kb/raw/fnox-guide-proxy.md`) — the
+  credential-proxy model, its `fnox proxy run -- codex` / `-- claude` examples, egress modes, and its
+  own "not yet an operating-system sandbox" limit.
+- `github.com/jdx/fnox` → `docs/guide/mcp.md` (`.agent/kb/raw/fnox-guide-mcp.md`) — `[mcp] tools` /
+  `[mcp] secrets` semantics, batch-vs-on-demand resolution, output redaction.
+- `github.com/jdx/fnox` → `docs/reference/configuration.md`, `docs/reference/environment.md`
+  (`.agent/kb/raw/fnox-reference-*.md`) — the top-level table list, `[proxy]` fields, and the
+  **`FNOX_NO_DEFAULTS`** env var that `--help` does not advertise.
+- Issue **#435** (closed, no receipt — predates the practice) — the 1.31.1 baseline this receipt
+  re-derives, and the two constraints it handed to #441.
+- Issue **#432** — the CLI-not-MCP decision that makes `[mcp]` moot for us, and the "exec does not
+  confine" measurement.
+- Map issue **#431** — the SCOPED-READ exposure model this ticket is load-bearing for.
+- `~/.config/fnox/config.toml` — **read-only**, for the live shape only (sha256 verified unchanged
+  before and after every probe).
+
+**Why the local mintlify cache was not the source:** `docs/research/mintlify-cache/jdx/fnox/` is
+dated **2026-07-02** and predates both composable profiles (1.31.0, 2026-07-17) and the proxy —
+`proxy` → **0** hits against a control of `profile` → **190**. `https://www.mintlify.com/jdx/fnox/llms.txt`
+now returns **HTTP 410**, so the chain's step 1 is dead for this repo and step 0 was stale; the fetch
+fell through to `raw` GitHub contents, as `feedback_mintlify_cache_stale` says it must.
+
+## Prior art — the search I ran
+
+**Query:** `rg --hidden -c '<term>'` over the corpus, then a second route,
+`git grep -lI -- '<term>'` over the whole tracked tree.
+**Corpus:** `docs/research/kb`, `docs/specs`, `docs/receipts`, `docs/research/runs`, `.claude/rules`,
+`.claude/skills`, `docs/rules-evidence` (**237 files**, enumerated per-directory before searching —
+each was non-empty, so no leg of the corpus was silently unreachable).
+
+### Control arm — REQUIRED, and run it before you believe any result
+
+**Known-present term:** `fnox` → **612** hits in **34** files
+**Known-absent term:** `vmqkzt4b` → **0** hits · second absent arm `zblthq9r` → **0** hits
+
+Both invented fresh for this receipt. `zzqqxx` was **not** reused — #436 measured it back up to 5
+hits, three of them the receipts that published it.
+
+⚠️ **The corpus arm caught a real bound.** `no-defaults` returned **0** in the corpus, which I did not
+believe, so I re-ran by a second route: `git grep` found it in **1** tracked file — outside all seven
+corpus directories. `Composable` likewise: corpus **0**, tracked tree **2**. The corpus was too
+narrow, and only the cross-check said so.
+
+| Hit | What I did with it |
+|---|---|
+| `docs/research/mintlify-cache/jdx/fnox/llms-full.txt` (`--no-defaults`, 6 lines) | **read** — and it is the miss that matters: line 5837 documents `FNOX_NO_DEFAULTS` as *"Equivalent to passing `--no-defaults` on every command"*. That env var was **in this repo since 2026-07-02** and #435 concluded confinement was call-site-only without it. Prior art existed and was not read. |
+| `docs/research/runs/research-20260709-r2-release-mining/agents/fnox-secrets.md` (`FNOX_PROFILE`, 2 lines) | **read** — 2026-07-09 release mining; names per-profile switching and "optional MCP/exec-only scoping for AI CLIs" as a *gain*, but predates composable profiles and the proxy. Confirms the direction, adds no measurement. |
+| `docs/research/kb/raw/src-mlx-README.md`, `docs/research/trail/findings/define-consensus-2026-03-28.yaml` (`Composable`) | **dismissed** — unrelated senses of the word (an ML library; a 2026-03 consensus note). |
+| 8 files matching `placeholder` (`docs/receipts/437.md`, `docs/specs/deep-interview-…md`, 6 others) | **dismissed** — all are "placeholder" in the ordinary sense (a TODO, a stub value). None concerns credential brokering. |
+| `fnox proxy`, `[proxy]`, `proxy.rules`, `agent profile`, `FNOX_NO_DEFAULTS`, `write-profile` | **0 hits by both routes**, against the `fnox` → 62-tracked-files control. Genuinely no prior art: the credential proxy has never been recorded in this repo. |
+
+## Measurements
+
+All arms at **fnox 1.32.0**, in a sandbox: `FNOX_CONFIG_DIR=<scratch>` plus an explicit `-c`.
+**Isolation was armed before anything else** — with `FNOX_CONFIG_DIR` set, `fnox config-files` lists
+only the sandbox file; the control arm (unset) lists `~/.config/fnox/config.toml` too. The live
+config's sha256 was `c0f1de72…` before the first probe and `c0f1de72…` after the last. Session
+2026-08-01 wiped the live config with a test that skipped this step.
+
+### A. `[profiles.X]` vocabulary — the literal question
+
+Probe: write the key, run `fnox list`, read the validator.
+
+| Key under `[profiles.agent…]` | rc | Result |
+|---|---|---|
+| `.secrets` | 0 | **valid** ← control |
+| `.providers` | 1 | **valid** (rc=1 is `missing field recipients`, i.e. it parsed) ← control |
+| `default_provider` | 0 | **valid** ← control |
+| `.leases` | 1 | **valid** (rc=1 is `missing field type`) ← control |
+| **`.mcp`** | 1 | **rejected** — `unknown field 'mcp', expected one of leases, providers, default_provider, secrets` |
+| **`.proxy`** | 1 | **rejected**, same list |
+| `if_missing` | 1 | **rejected**, same list |
+| `env` | 1 | **rejected**, same list |
+| `no_defaults` | 1 | **rejected**, same list |
+| bogus `wjtpz9v` / `qhvbnrz7` | 1 | **rejected**, same list ← control |
+| top-level `[mcp] secrets`+`tools` | 0 | valid ← control: the table is real, just not profile-scoped |
+| top-level `[proxy] egress` | 0 | valid ← control |
+| top-level bogus `qhvbnrz7` | 1 | rejected, with the 13-key top-level list ← control |
+
+**Identical to #435's 1.31.1 reading — re-derived, not inherited.** The `if_missing` row is a genuine
+doc error: `reference/configuration.md:507` shows `[profiles.PROFILE_NAME] if_missing = "error"` and
+the binary refuses it. ⚠️ **The `[proxy]` row is NOT a doc error, and an earlier draft of this
+receipt said it was.** `reference/configuration.md:222-225`'s *"a nearer, profile-specific, or local
+config defines `[proxy]`"* means a profile **config file**, not `[profiles.X.proxy]` — see § G, where
+that mechanism is measured and does carry `[proxy]`. The cold review guessed this before the probe
+did.
+
+### B. What is injected into the child's environment
+
+Probe: `fnox … exec -- sh -c 'env | grep …'`. ⚠️ **This measures environment injection, not
+reachability.** It cannot see `fnox get`, `as_file` temp files, daemon-cache reads, provider access,
+or a child re-invoking `fnox` itself — all of which remain open to anything running as this uid.
+Read every row as "names injected", never as "everything the agent can reach".
+
+| Arm | n | Names |
+|---|:-:|---|
+| no fnox at all | **0** | — ← control (probe floor) |
+| default profile | **2** | `SHARED`(top), `TOP_ONLY` ← control |
+| `-P agent` | 3 | `AGENT_ONLY`, `SHARED=agent-shared` (**value** measured — top's is `top-shared`, so later wins), `TOP_ONLY` |
+| `-P agent --no-defaults` | 2 | `AGENT_ONLY`, `SHARED`(agent) |
+| `-P empty --no-defaults` | **0** | — (the floor is reachable) |
+| `-P agent,other` | 4 | overlay stack merges both profiles **and** top |
+| `-P agent,other --no-defaults` | 3 | both profiles, no top |
+| **`-P <nonexistent>`** | **2** | **rc=0, stderr 0 bytes** — #435's fail-open, re-derived at 1.32.0 |
+| **`-P <nonexistent> --no-defaults`** | **0** | rc=0 — **confinement holds** |
+
+⚠️ **This corrects the constraint #435 handed to #441 and #432 — on one axis, and it matters which.**
+#435 concluded confinement needs the profile to exist **and** `--no-defaults`. Read as *exposure*
+("does a missing profile leak the 49?"), that is **wrong**: `--no-defaults` alone caps injection at
+zero. Read as *delivery* ("does the caller get the intended authorized set?"), it is **right** — a
+missing profile silently supplies none, rc=0. Both readings are legitimate and the sentence does not
+distinguish them, so state the axis whenever citing it. The failure mode inverts from "leaks 49" to
+"silently supplies none", which is the better one to be left holding but still a silent failure.
+
+**And `--no-defaults` is only a cap on the injection path.** It does not stop the same process from
+running `fnox get`, or `fnox exec` with no flags at all.
+
+`fnox list` and `fnox export` honour `--no-defaults` identically, so the CLI's `list` verb (#432)
+shows the confined set.
+
+### C. `FNOX_NO_DEFAULTS` — the env var `--help` does not advertise
+
+Only `--non-interactive` carries an `[env: …]` tag in `--help`; `--no-defaults` does not. It exists
+anyway, in `reference/environment.md`. Absence from `--help` is a search bound, again.
+
+Config for this arm was a **two-name** file (`TOP_ONLY` top-level, `AGENT_ONLY` in the profile) — not
+§ B's three-name file; the totals are not comparable across sections, which the cold review caught.
+
+| Value | Names in scope (of 2) | |
+|---|:-:|---|
+| `true`, `1`, `TRUE`, `yes` | 1 | **confined** |
+| `false`, `0`, `off`, `no`, `""` | 2 | top-level merged |
+
+A real boolean parse — **no presence-trap**, which is worth stating because the shape invites one.
+`FNOX_PROFILE=agent` + `FNOX_NO_DEFAULTS=true` reproduces the same injection cap **with no CLI flag**.
+
+### D. `fnox proxy` — the surface no prior ticket recorded, and the claim the review killed
+
+`proxy rules` (the listing) is not filtered by `-P` when `[proxy]` sits in the **base** config:
+byte-identical output under `<default>`, `-P agent`, `-P agent --no-defaults`, and a nonexistent
+profile. (§ G shows it *is* profile-conditional when `[proxy]` is declared in a profile **file**.)
+
+⚠️ **First fixture — and it was rigged, though not on purpose.** Rules referenced a top-only
+*and* a profile-only secret, so **every** single-profile scope necessarily lacked one and startup
+could only ever reject it. Six arms, six rc=1s, and an earlier draft read that as "the proxy catches
+fnox's fail-open". A probe that can only produce one answer is not evidence, and this one produced a
+verdict.
+
+**Second fixture — the design actually proposed.** Top level holds three secrets (standing in for
+the 49); `[profiles.agent.secrets]` **duplicates** one of them (`GH_TOKEN`); the single rule names
+that one:
+
+| `fnox … proxy run -- <child>` | rc | Child environment |
+|---|:-:|---|
+| `-P agent --no-defaults` | **0** | `GH_TOKEN=fnox_proxy_b2a8e5f5…` |
+| `-P agent` | **0** | `GH_TOKEN=fnox_proxy_938017b7…` |
+| `<default>` | **0** | `GH_TOKEN=fnox_proxy_697c4c61…` |
+| **`-P <nonexistent>`** | **0** | `GH_TOKEN=fnox_proxy_416f7a0a…` — **starts cleanly; the proxy does NOT catch the fail-open** |
+| `-P <nonexistent> --no-defaults` | **1** | `Proxy rule references unknown secret 'GH_TOKEN'` |
+
+Controls: real values were `gh-top-real` / `gh-agent-real`; **neither appears in any arm**. And the
+`exec` comparison is where the value is:
+
+| Same missing profile, no `--no-defaults` | Child receives |
+|---|---|
+| `fnox proxy run` | `GH_TOKEN=<placeholder>` — **nothing else** |
+| `fnox exec` (control) | `AWS_SECRET=aws-top-real EXA_KEY=exa-top-real` — **raw** |
+
+**So the proxy is a ceiling, not a gate.** Its injected set is `rule table ∩ resolvable scope`, and
+the rule table caps it *regardless of which profile is active*. A missing profile widens resolution
+but cannot widen what the proxied child gets. rc=1 arrives only when a rule becomes unsatisfiable —
+which, with `--no-defaults`, is exactly the misconfiguration you want loud.
+
+Two further arms decide what the tier is worth:
+
+| Arm | Result |
+|---|---|
+| a profile secret with **no** proxy rule (`UNRULED`) | **not injected at all** under `proxy run`; control — plain `exec` injects it **raw** (`UNRULED=unruled-real-value`) |
+| `env = false` **+** a proxy rule (fnox's own documented agent pattern) | child gets the **placeholder** and works; control — plain `exec` gives the child **nothing** |
+| `egress` unset, rules present | `proxy rules` prints `egress: Strict`; control — the same file with `egress = "permissive"` prints `Permissive`, so the field is being read |
+
+⚠️ **"Withholds values" means one thing only: the child's environment does not contain them.** No live
+request was made, so header substitution, an allowed vs rejected destination, and the CA path are all
+**unverified**; process memory, config access and same-uid re-invocation are untested and, by fnox's
+own warning, unprotected.
+
+**The client-compatibility surface is wider than "does it honour `HTTPS_PROXY`".** Measured on the
+child: `proxy run` sets `http_proxy`/`https_proxy`/`all_proxy`/`no_proxy` in **both** cases, plus
+per-runtime CA pointers to one ephemeral `fnox-proxy-ca-*.pem` — `NODE_EXTRA_CA_CERTS`,
+`NODE_USE_ENV_PROXY=1`, `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`,
+`CARGO_HTTP_CAINFO`, `DENO_CERT`. Control: the same child under plain `exec` matched **5** names, all
+ambient (`MISE_ENV_CACHE`, the uv/XDG/zsh cache dirs), i.e. none of the above. Node, Python, curl,
+git, cargo and deno are covered **by name**.
+
+fnox states its own residual, unprompted, on every run:
+`WARN … fnox proxy does not sandbox the child process yet; same-user code may bypass the proxy`.
+That is verbatim the pivotal question #431 lists as unanswered — **and fnox is the first vendor
+found attempting it at all**, which updates that map item's "no vendor attempting it".
+
+### E. The cost the ticket does not anticipate
+
+Under `--no-defaults`, top-level is dropped **wholesale** — including `import`.
+
+| Arm | Result |
+|---|---|
+| `[profiles.agent.secrets] WANT = { secret = "TOP" }` | **rc=1** — `unknown field 'secret'` |
+| `WANT = "TOP"` (bare alias) | **rc=1** — `invalid type: string, expected struct SecretConfig` |
+| duplicate the full binding | **rc=0** ← control |
+| top-level `import = [...]` under `-P agent` | imported secret present |
+| top-level `import = [...]` under `-P agent --no-defaults` | imported secret **gone** |
+
+A `SecretConfig` accepts `description`, `if_missing`, `default`, `provider`, `value`, `env`,
+`as_file`, `json_path`, `line`, `sync`, `daemon_cache` — **no reference form**. So every secret the
+agent may reach has its **per-secret binding duplicated** into `[profiles.agent.secrets]`. Rotate a
+Doppler path top-level and the agent copy keeps the old one, **silently** — precisely #435's
+*assert-iff-drift-is-silent* trigger, on an axis its 5-axis baseline does not have.
+
+Scope this precisely: it is the **per-secret binding** that duplicates. A profile carries its own
+`providers` and `default_provider` (A), so the *provider* blocks need not be repeated, and § G shows
+a profile **config file** is a further composition route — one that turns out to be unavailable here
+for other reasons.
+
+Also measured: `fnox profiles` prints **merged** counts (an empty profile reports `2 secrets` when
+top-level holds 2) — it cannot separate profile from default membership, so it is not a confinement
+audit on its own, though it would still catch a gross change against a known baseline. And
+`[mcp] secrets = ["<typo>"]` naming a nonexistent secret passes `fnox list` at **rc=0** (control: a
+bogus top-level key is rc=1) — that shows only that *`list`* does not check the reference; whether
+the MCP server checks it at startup or on request is untested.
+
+### F. MCP runtime scoping — measured, not inferred
+
+The "a profile scopes both channels" claim was asserted from docs in an earlier draft and the cold
+review was right to call it unmeasured. Probe: drive a live `fnox … mcp` server over stdio
+(`initialize` → `tools/list` → `tools/call get_secret`), config = `TOP_ONLY` top-level,
+`AGENT_ONLY` in `[profiles.agent.secrets]`.
+
+| Active profile | `TOP_ONLY` | `AGENT_ONLY` | `qhvbnrz7_nowhere` |
+|---|---|---|---|
+| `<default>` | **resolved** | denied | denied ← control |
+| `-P agent` | resolved | **resolved** | denied |
+| **`-P agent --no-defaults`** | **denied** | resolved | denied |
+| `-P <nonexistent>` | resolved | denied | denied |
+
+The nowhere-name is denied in all four rows (the server *can* say no) and the rows differ from each
+other (it *can* say yes), so the probe discriminates. **MCP resolution follows the active profile and
+honours `--no-defaults`**, and it fails open to top level on a missing profile exactly as `exec` does.
+
+### G. The mechanism the ticket was actually describing — `fnox.<profile>.toml`
+
+`[profiles.X]` is not fnox's only profile construct. `fnox.<profile>.toml` is a **per-profile config
+file**, loaded when that profile is active, whose content is a full top-level config — so it *can*
+carry `[mcp]` and `[proxy]`. Measured in a clean tree (control: no ancestor `fnox.toml` above the
+test root, checked explicitly — the first pass was contaminated by a parent config and `config-files`
+showed `fnox.toml` twice):
+
+| Arm | Result |
+|---|---|
+| `config-files <default>` | `fnox.toml` ← control |
+| `config-files -P agent` | `fnox.toml` **`fnox.agent.toml`** |
+| `config-files -P <nonexistent>` | `fnox.toml` ← control |
+| `proxy rules -P agent` | **the rule declared in `fnox.agent.toml`** |
+| `proxy rules <default>` | **rc=1** `No [proxy] configuration found` ← control: the rule table really is profile-conditional here |
+| `exec -P agent` | `PF_ONLY=pf-real TOP_ONLY=top-real` |
+| **`exec -P agent --no-defaults`** | **completely empty — the profile file's own secret is dropped too** |
+
+**Two facts kill it for this Mac, in opposite ways.**
+
+1. **It is mutually exclusive with confinement.** A profile file's secrets land in the *default*
+   profile's table (fnox's reference says so at `:625`, and the empty row above measures it), so
+   `--no-defaults` — which keeps only `[profiles.<name>.secrets]` — discards them along with
+   everything else. You can have the channel overlay **or** confinement, never both.
+2. **It is project-config-only.** With the 49 secrets' shape reproduced — a global config dir, no
+   project `fnox.toml` anywhere — neither `config.agent.toml` nor `fnox.agent.toml` beside
+   `config.toml` is loaded: `config-files -P agent` lists **only `config.toml`**, and neither
+   profile-file secret is injected. Control: `GTOP` from the global `config.toml` **is** injected in
+   both arms, so the global config is genuinely being read.
+
+So the ticket's literal question has the answer **"fnox does have that overlay, and we cannot reach
+it"** — not "fnox does not have it", which is what an earlier draft concluded from `[profiles.X]`
+alone.
+
+### H. What `--no-defaults` does **not** remove
+
+Probe: export `INHERITED_SHELL_VAR=inherited-real-value` into the parent shell, then read it in the
+child.
+
+| Child launched by | Sees the inherited raw value? |
+|---|---|
+| plain `sh` | yes ← control |
+| `fnox exec -P agent --no-defaults` | **yes** |
+| `fnox proxy run -P agent` | **yes** |
+
+Neither surface strips the ambient environment. So the four `env = true` opt-ins, which are in the
+interactive shell **by design**, are inherited straight through both the confined `exec` and the
+proxy. This is not a residual the profile leaves untouched — it is a channel that runs *around* every
+mechanism in this receipt.
+
+### I. Live state today
+
+`fnox profiles` → **`default (49 secrets)` only**. The config declares `[profiles.*]` **0** times,
+`[mcp]` **0**, `[proxy]` **0**, `env` **1** (control: `[secrets]` → 1). `if_missing` is still **0** —
+#435's hand-set line has not been applied. So #441 creates the first profile this host will have.
+
+## The decision
+
+**0. What this is and is not.** Everything below reduces the **ambient blast radius** of a
+cooperating agent lane. **None of it is a boundary against an adversarial agent** on this uid: such a
+process can invoke `fnox exec` with no flags, unset `FNOX_NO_DEFAULTS`, call `fnox get`, or bypass
+the proxy — fnox says the last one itself, on every run. Read every clause as "what a lane gets by
+default", never as "what an attacker cannot get". That is not a caveat on the decision; it is its
+scope.
+
+**1. Yes to an `agent` profile — as a `[profiles.agent.secrets]` overlay.** Not because it is the
+only construct (`fnox.<profile>.toml` is the other, and it is the one the ticket describes), but
+because it is the only one **reachable from our config shape** that also composes with
+`--no-defaults` (G). It scopes **both** channels — CLI and MCP resolution both follow the active
+profile and both honour `--no-defaults` (B, F). A profile also carries `providers`,
+`default_provider` and `leases`; "secret-set overlay" is shorthand for what we use, not the schema.
+
+**2. What it contains:** an **explicit, additive** `[profiles.agent.secrets]`, empty at creation and
+grown one entry at a time as an agent lane demonstrably needs a credential — **not** a subset carved
+out of the 49. Each entry is a **duplicated per-secret binding** (E), each defaults to `env = false`,
+and `dotfiles` **asserts** the set, never writes it (#435's ownership rule, unchanged). The assertion
+mechanism is not new work: #435 already decided the `doctor.toml` axis *"profile names + exact
+membership"*. **What #441 adds to it is the duplication axis** — the profile copy of a binding must
+be checked against its top-level original, because nothing else will notice them diverging.
+
+**3. How it is activated:** at the call site, by `dotfiles-secrets`, as **`-P agent --no-defaults`**,
+with `FNOX_NO_DEFAULTS=true` declared in the invoking **mise task's `env`** so the safe default is
+tracked in the repo rather than remembered. Never `FNOX_PROFILE=agent` alone — that is the arm that
+fails open. To be exact about what that buys: a mise task's `env` is **still a call-site mechanism**,
+not an fnox invariant, and it does not reach a direct `fnox` invocation. It does not answer #435's
+"config structurally cannot assert confinement" — that stands. It moves the default from *the caller
+remembers* to *the repo declares*, which is the only improvement measured to exist.
+
+**4. `fnox proxy run` is adopted as a second tier — as a CEILING on what a lane is handed, not as a
+gate.** For any credential an agent must *use* but never *read*: `env = false` plus a `[proxy.rules]`
+entry. Measured: the child receives a placeholder, un-ruled secrets are not injected at all, and that
+cap holds **even when the active profile is wrong or missing** (D) — which is precisely where
+`exec` hands over everything raw. It does **not** catch fnox's fail-open; the earlier draft said it
+did and the cold review refuted that. Adoption is sequenced into **#432's CLI**, not built here.
+
+**5. The rule table, not the profile, is the proxy's exposure set.** With `[proxy]` in the base
+config the table is global (D); via a profile file it is profile-conditional but unreachable for us
+(G). So per-lane narrowing must come from the **rule table's** design — one union of rules serves
+every lane, and adding a rule widens every lane at once. That is a real constraint on #432's shape
+and it is not solved by the profile.
+
+**6. Named residuals, not argued away.**
+- The proxy is **not a sandbox** — fnox says so on every run. Same-uid bypass stands, and #431's
+  pivotal question stays open.
+- "Withholds values" is measured **only** as "absent from the child's environment". No live request
+  was made: header substitution, allowed vs rejected destinations, and the CA path are unverified.
+  That is #432's first probe before committing to the tier.
+- Protocol surface: **HTTPS/443 only**, exact domains (no wildcards), header substitution only,
+  `Content-Length` bodies (chunked rejected), 10 MiB cap, HTTP/1.1 upstream, `http://` rejected.
+  Env-var coverage is *not* the weak point (D).
+- **Inherited environment defeats all of it** (H). The four `env = true` opt-ins sit in the
+  interactive shell and pass straight through both `exec --no-defaults` and `proxy run`. Any agent
+  started from that shell has them regardless of profile. This is the largest unclosed hole and it
+  is not addressed by anything in this ticket.
+- `fnox list`/`exec`/`export`/MCP were measured; `fnox get`, `as_file` temp files, the daemon cache
+  and provider access were **not**.
+- The duplication axis (E) is new silent drift and belongs in #435's baseline.
+
+## Adversarial review
+
+**Lens:** codex-reviewer (`codex exec --ephemeral --sandbox read-only`, reasoning effort high, cold —
+no disk access, told to refute by default)
+**Verdict:** **needs-attention — it reversed the receipt's headline claim.**
+**Findings:** **22** (5 critical, 15 major, 2 minor) — persisted verbatim to
+`docs/research/kb/reports/agents/codex-adversarial-441-fnox-agent-profile.md`
+**Disposition:** **17 accepted · 3 refuted by probe · 2 partial.** Four findings were settled by
+running something rather than by argument, and two of those **changed the verdict** (F2/F3 killed the
+proxy fail-open claim; F6 found the mechanism the ticket was actually asking about).
+
+| # | Sev | Claim | Disposition |
+|---|---|---|---|
+| 1 | crit | Not an enforceable boundary against a same-uid agent | **accepted** — decision 0 added; the whole answer is now framed as blast-radius reduction |
+| **2** | crit | The proxy fail-closed fixture forced its own result | **accepted, verdict-changing** — re-ran with a satisfiable rule table (D); `-P <missing>` → **rc=0**. The claim is withdrawn |
+| **3** | crit | The fixture does not model the proposed design | **accepted, verdict-changing** — the realistic fixture is now the one reported |
+| 4 | crit | "Scopes both CLI and MCP" was unmeasured | **accepted → closed by probe** — § F drives a live `fnox mcp` over stdio; the claim holds, now with arms |
+| 5 | major | "Secret-set overlay only" contradicts the 4-key list | **accepted** — decision 1 now says a profile also carries `providers`/`default_provider`/`leases` |
+| **6** | major | Nested-key rejection does not exhaust "profiles" | **accepted, verdict-changing** — § G: `fnox.<profile>.toml` **does** carry `[mcp]`/`[proxy]`. The literal answer flips from "fnox has no such overlay" to "it has one we cannot reach" |
+| 7 | major | The doc contradiction is not established | **accepted** — and the reviewer's guess was right: `:222`'s "profile-specific config" is the profile **file**. The `[proxy]` half of the contradiction is withdrawn; the `if_missing` half survives |
+| 8 | major | The #435 rebuttal changes what confinement means | **accepted** — § B now states both readings and which axis each is right on |
+| 9 | major | The `exec` probe measures injection, not reachability | **accepted** — § B relabelled and the unmeasured channels enumerated |
+| 10 | major | No inherited-environment control | **accepted → closed by probe** — § H; the inherited value survives **both** surfaces, which makes the residual worse than stated, not better |
+| 11 | minor | "later wins" not measured by a name count | **refuted by probe** — the raw output carried values: `-P agent` → `SHARED=agent-shared` against a top-level `top-shared`. Table now shows the value |
+| 12 | major | The `FNOX_NO_DEFAULTS` counts contradict § B | **accepted** — different, smaller config; § C now says so. The inconsistency was in the review prompt |
+| 13 | major | A mise `env` var is not a structural answer | **accepted** — decision 3 now says #435's structural claim stands |
+| 14 | crit | The env grep does not prove value confidentiality | **accepted** — § D and decision 6 scope "withholds" to the child's environment |
+| 15 | major | `env = false` promoted beyond its controls | **accepted** — it controls injection, not authorization |
+| 16 | major | The global rule table, not the profile, governs proxy exposure | **accepted** — promoted to decision 5, a constraint handed to #432 |
+| 17 | major | The duplication conclusion is not exhaustive | **partial** — narrowed to the **per-secret binding** (providers are profile-carried), and § G tests the config-file route the reviewer named. Within those two routes the conclusion holds |
+| 18 | major | "dotfiles ASSERTS the set" shows no mechanism | **partial** — the mechanism is #435's existing `doctor.toml` axis, now cited; the *new* duplication axis is named as this ticket's addition |
+| 19 | major | The MCP typo control is aimed at the wrong phase | **accepted** — restated as "`fnox list` does not reject it"; the real validation phase is untested |
+| 20 | minor | "useless as a confinement audit" is too absolute | **accepted** — softened to "not an audit on its own" |
+| 21 | major | The Strict default has no measurement | **refuted by probe** — the arm existed and the prompt omitted its output: `egress` unset → `egress: Strict`; control with `egress = "permissive"` → `Permissive` |
+| 22 | major | "Only measured surface" is unsupported exclusivity | **refuted in part, accepted in substance** — F4's probe now supplies the MCP comparison the finding said was missing, but F2/F3 remove the claim anyway, so the sentence is gone |
+
+**The reviewer's overall verdict — *"the publication does not establish enforceable agent
+confinement; its central proxy result is fixture-induced"* — is upheld on both counts.** The first is
+answered by scoping the decision (0); the second by re-measuring and withdrawing the claim.
+
+## Notes
+
+- **The version moved under the map.** Every prior ticket measured fnox **1.31.1**; the host runs
+  **1.32.0**. Nothing in #435's vocabulary changed, but `proxy`, `--write-profile` and the
+  `--if-missing` flag all arrived in between, and the first of those changes this ticket's answer.
+  Re-check the installed version at the top of any fnox ticket.
+- **`--write-profile` makes #441's own body stale.** The body says writes "target the **last active
+  profile** by default". At 1.32.0 a composed stack is **rc=1**: *"Multiple profiles are active
+  (agent,other). Specify `--write-profile <NAME>`"*. It defaults only when exactly one profile is
+  active. Harmless here (#432: the agent cannot write) but the body should not be quoted forward.
+- **Dead end:** `fnox proxy run` refuses to start with *"No providers configured"* even when every
+  secret is a plain `default =`. Declaring any provider satisfies it. Cost me one probe round; the
+  first battery reported four uninformative rc=1s that looked like a scoping result and were not.
+- **The expensive lesson, and it is the same one twice.** Both times a fixture was built to *show*
+  the thing rather than to *test* it. The proxy fixture referenced a top-only and a profile-only
+  secret, so no scope could satisfy it and every arm returned rc=1 — six arms, one possible answer.
+  The profile-file fixture was run inside a tree whose parent held a `fnox.toml`, so `config-files`
+  printed the same file twice and a stray secret leaked in. Neither error is caught by adding control
+  *arms*; both are caught by asking **"could this fixture have produced the other result?"** before
+  reading the output. The first was found by an adversarial reviewer, the second only because that
+  finding forced a re-run.
+- **Not attempted:** an end-to-end `proxy run` against a real HTTPS endpoint. Everything above is
+  startup-time resolution and child-environment inspection. Whether substitution actually lands in
+  the `authorization` header on a live request is **unverified** and is #432's probe to run.
+- **Not attempted:** `fnox get`, `as_file`, the daemon cache, and provider-level access under a
+  profile. Named in decision 6 rather than quietly omitted.
+- **Docs were read from `main`, not the `v1.32.0` tag** (`13e2a7bb`). The review was right that this
+  is unpinned. It changed nothing here — the one surviving doc/binary conflict (`if_missing`) and the
+  one withdrawn (`[proxy]`) were both resolved by probing the installed binary, which is the
+  authority either way — but pin the tag if a future ticket rests on doc wording alone.
+- If this is revisited: the two doc errors (profile-level `[proxy]` and `if_missing`) are worth an
+  upstream issue on `jdx/fnox`, and were **not** filed — consistent with #438's lane-1 handling.
+- **Found in passing, outside this ticket's question, and taken to the map:** `MISE_ENV_CACHE=1` is
+  **live in this Mac's shell right now** — `printenv` → `1` and `__MISE_ENV_CACHE_KEY` is set
+  (control: a bogus variable name → absent, so the probe discriminates). #431 lists it under "Not yet
+  specified" as an exposure surface *the model has not accounted for*; it is not hypothetical, it is
+  on. It is set by **`~/.zprofile.d/macos-dev-env.zsh`** (mde's `home/dot_zprofile.d/macos-dev-env.zsh`),
+  which is the very file #431 lists *separately* as the first unmanaged-but-load-bearing host file —
+  so those two open items are **one item**. This repo's own 2026-07-09 research already recorded that
+  the flag caches secrets **encrypted on disk** with a documented staleness trap.
+
+## GitHub repos touched
+
+- [jdx/fnox](https://github.com/jdx/fnox) — the tool under decision; `docs/guide/{profiles,proxy,mcp}.md`
+  and `docs/reference/{configuration,environment}.md` read from `main`, and the installed 1.32.0
+  binary probed directly.
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — this repo; issues #431, #432,
+  #435, #441 and the receipt corpus.

--- a/docs/research/kb/reports/agents/codex-adversarial-441-fnox-agent-profile.md
+++ b/docs/research/kb/reports/agents/codex-adversarial-441-fnox-agent-profile.md
@@ -1,0 +1,100 @@
+# Codex cold adversarial review — #441 (fnox Composable Profiles → agent profile)
+
+**Lens:** `codex exec --ephemeral --sandbox read-only -c model_reasoning_effort=high` (GPT-5.6 Sol).
+**Date:** 2026-08-02. **Mode:** cold — the prompt forbade reading disk or loading skills;
+everything the reviewer saw is in the prompt, and it was told to REFUTE by default.
+**Result:** 22 findings. Disposition table lives in `docs/receipts/441.md`.
+
+Verbatim below. Do not normalise (`agent-report-persistence.md`).
+
+---
+
+1. **Critical — The proposal does not confine an adversarial same-UID agent.**  
+   **Attack:** “Activation: at the call site by our CLI as `-P agent --no-defaults`…” and “The tier that withholds values is `fnox proxy run`…”  
+   **Why:** The context already establishes that an agent choosing its own command can invoke unrestricted `fnox exec`. It can also unset `FNOX_NO_DEFAULTS`, bypass the wrapper, or launch another fnox process. The proxy’s own warning explicitly says same-user code may bypass it. These are convenience defaults, not an enforceable secret boundary.
+
+2. **Critical — The proxy fail-closed experiment is constructed so every tested scope must fail.**  
+   **Attack:** The D configuration has disjoint `TOP_TOKEN` and `AGENT_TOKEN` secrets while global proxy rules reference **both**, followed by “a wrong or missing profile cannot silently widen scope.”  
+   **Why:** Every tested single-profile scope necessarily lacks at least one globally referenced secret, so startup validation can only reject it. There is no control where the same rule table is valid under both a narrow and a broad scope. The experiment proves that unresolved rules abort startup, not that wrong profiles cannot widen scope.
+
+3. **Critical — The proxy experiment does not model the proposed deployment.**  
+   **Attack:** D uses `TOP_TOKEN` and `AGENT_TOKEN`, while decision 2 proposes duplicating the same top-level bindings into `[profiles.agent.secrets]`.  
+   **Why:** In the real design, the default table contains all 49 names and the profile repeats selected names. A missing profile without `--no-defaults` may therefore satisfy every agent proxy rule from the top-level bindings and start successfully. The deliberately disjoint test names conceal that case.
+
+4. **Critical — “Scopes BOTH the CLI and MCP channels” is wholly unmeasured.**  
+   **Attack:** “It is the right unit because it is the only fnox construct that scopes BOTH the CLI and MCP channels at once.”  
+   **Why:** No MCP server was started, no MCP request was made, and no profile-dependent MCP result was measured. Parsing a top-level `[mcp]` table and measuring `exec` cannot establish MCP runtime scoping.
+
+5. **Major — The decision contradicts the vocabulary result.**  
+   **Attack:** “a profile is a secret-set overlay only; it cannot carry `[mcp]` or `[proxy]`.”  
+   **Why:** A’s own accepted-key list includes `leases`, `providers`, and `default_provider` in addition to `secrets`. The evidence supports “cannot directly nest `mcp` or `proxy` under `[profiles.X]` in this schema,” not “secret-set overlay only.”
+
+6. **Major — Rejection of nested keys does not exhaust “Composable Profiles.”**  
+   **Attack:** “the only thing a profile can be.”  
+   **Why:** The probes test only keys nested directly under `[profiles.agent]`. They do not test profile-specific config files, config layering, imports containing profile sections, command-specific composition, or any other meaning of “profile-specific.” The universal conclusion exceeds the tested syntax.
+
+7. **Major — The alleged documentation contradiction is not established.**  
+   **Attack:** “this CONTRADICTS fnox’s own `docs/reference/configuration.md`…”  
+   **Why:** No documentation version or commit is tied to installed fnox 1.32.0, and the quoted phrase “profile-specific … config” may describe a profile-specific config source rather than `[profiles.X.proxy]`. Without surrounding semantics and version provenance, this is not a demonstrated binary-versus-documentation contradiction.
+
+8. **Major — The rebuttal of #435 changes the meaning of confinement.**  
+   **Attack:** “#435 is WRONG on the confinement axis: `--no-defaults` ALONE is sufficient for confinement.”  
+   **Why:** A missing profile plus `--no-defaults` yields an empty environment, not the intended authorized set. If #435 required both bounded exposure and successful activation of the intended profile, the new result does not refute it. It only shows that `--no-defaults` bounds this particular injection path even when activation silently fails.
+
+9. **Major — The `exec` probe measures environment-name injection, not secret confinement.**  
+   **Attack:** “What is in scope (method: … `env | grep` … count names).”  
+   **Why:** This cannot observe direct fnox retrieval, inherited environment variables, files produced through `as_file`, daemon/cache access, provider access, or subprocesses launching fnox again. “Injected environment names” is the supported conclusion; “what is in scope” is materially broader.
+
+10. **Major — The missing inherited-environment control invalidates application to the stated live setup.**  
+    **Attack:** “no fnox at all | 0” and the residual “the 4 `env = true` opt-ins remain in the interactive shell untouched by any profile.”  
+    **Why:** The real agent process may inherit those four raw values. No arm preloaded them and checked whether `exec` or `proxy run` preserves or removes them. A zero-variable scratch-shell floor does not model the deployment, and merely listing this as a residual does not reconcile it with claims of withholding.
+
+11. **Minor — “SHARED(agent — later wins)” was not measured by the stated method.**  
+    **Attack:** “`-P agent` | 3 | `AGENT_ONLY, SHARED(agent — later wins), TOP_ONLY`.”  
+    **Why:** The method counts variable names only. Since both layers use the same name, it cannot determine which value won without inspecting the value.
+
+12. **Major — The `FNOX_NO_DEFAULTS` count is internally inconsistent or selectively reported.**  
+    **Attack:** “Measured (same config as B, `-P agent`, 2 possible names): `true`… → 1 name… `false`… → 2.”  
+    **Why:** B’s same merged configuration has three distinct names and its confined configuration has two. If only two discriminator names were counted, that restriction must be stated; otherwise the reported totals contradict B and do not prove complete scope.
+
+13. **Major — A mise environment variable does not answer the structural-config claim.**  
+    **Attack:** “partially answering #435’s ‘config structurally cannot assert confinement’.”  
+    **Why:** A mise task’s `env` table is another call-site mechanism. It is not an fnox configuration invariant and does not apply to direct invocations. Tracking a bypassable caller default does not partially make confinement structurally assertable.
+
+14. **Critical — The environment grep does not prove that proxy “actually withholds values.”**  
+    **Attack:** “grep count of each in every child environment = 0” and “it — not the profile — is what actually withholds values.”  
+    **Why:** This proves only that those literal values were absent from the printed environment. No approved request, disallowed request, CA/proxy path, header substitution, process inspection, config access, or same-user bypass was tested. The proxy warning directly limits the conclusion to injection behavior, not value confidentiality.
+
+15. **Major — `env = false` is being promoted beyond what its controls establish.**  
+    **Attack:** “`env = false` + a `[proxy.rules]` entry” is “the tier that withholds values.”  
+    **Why:** The controls show that plain `exec` omits the variable and `proxy run` supplies a placeholder. They do not show that an agent cannot retrieve the secret through fnox’s other CLI operations or bypass the proxy. `env = false` controls automatic environment injection, not authorization to the secret.
+
+16. **Major — Global proxy rules undermine the claim that the profile is the governing unit.**  
+    **Attack:** “Yes to an `agent` profile… It is the right unit” alongside “`[proxy]` is global so the rule table cannot differ per profile.”  
+    **Why:** Under `proxy run`, the global rule table determines which names may be exposed as placeholders. A union of rules for multiple consumers can either make narrower profiles unusable or expose additional rule-backed names whenever a broader scope satisfies them. The evidence points to the global rule table—not the profile—as the effective proxy exposure set.
+
+17. **Major — The duplication conclusion is not exhaustive.**  
+    **Attack:** “So every agent-reachable secret’s provider binding must be DUPLICATED into the profile.”  
+    **Why:** Two guessed alias syntaxes and one top-level-import case do not exclude imported profile sections, generated configuration, shared/default providers, separate profile-specific config sources, or other composition mechanisms. The accepted fields also include `providers` and `default_provider`, which weakens the claim that every complete provider binding must be repeated per secret.
+
+18. **Major — “dotfiles ASSERTS the set” has no demonstrated assertion mechanism.**  
+    **Attack:** “dotfiles ASSERTS the set, never writes it.”  
+    **Why:** No proposed validator, expected-set comparison, or failing test is shown. The answer itself says `fnox profiles` reports merged counts and MCP secret typos pass `fnox list`; those observations make an assertion mechanism necessary but do not supply one.
+
+19. **Major — The MCP typo control is aimed at the wrong validation phase.**  
+    **Attack:** “`[mcp] secrets = ["<typo>"]` … is rc=0, unvalidated (control: a bogus top-level key is rc=1).”  
+    **Why:** A schema validator rejecting unknown keys is not a control for referential-integrity validation of secret names. The name may be checked when the MCP server starts or when the secret is requested. The evidence supports only “`fnox list` does not reject this reference.”
+
+20. **Minor — “`fnox profiles` … is useless as a confinement audit” is too absolute.**  
+    **Attack:** “so it is useless as a confinement audit.”  
+    **Why:** A merged count cannot independently distinguish default from profile secrets, but it can still detect some unexpected changes when compared against a known configuration. The measurement shows insufficiency as a standalone audit, not uselessness.
+
+21. **Major — The default-to-Strict claim has no stated measurement.**  
+    **Attack:** “`egress` unset with rules present defaults to `Strict`.”  
+    **Why:** No command output, behavioral network probe, rejected destination, accepted destination, or comparison with an explicit non-Strict setting is provided. This conclusion appears without an evidentiary arm.
+
+22. **Major — “Only measured fnox surface” is unsupported exclusivity.**  
+    **Attack:** “`fnox proxy run` is the only measured fnox surface where a wrong or missing profile cannot silently widen scope.”  
+    **Why:** MCP runtime was not measured, direct secret-retrieval commands were not compared, and proxy’s apparent safety came from an unsatisfiable global-rule fixture. Neither “only” nor “cannot” follows.
+
+**Overall verdict:** The publication does not establish enforceable agent confinement; its central proxy result is fixture-induced, MCP scoping is unmeasured, and the proposed call-site controls remain freely bypassable by the same agent they are supposed to constrain.


### PR DESCRIPTION
Answers #441 (wayfinder:grilling) on the INSTALLED fnox 1.32.0, not the 1.31.1
every prior ticket measured.

`[profiles.X]` accepts exactly leases/providers/default_provider/secrets, so it
carries no `[mcp]` or `[proxy]`. But `fnox.<profile>.toml` — a per-profile config
file — does: `proxy rules -P agent` returns its rule while the default profile
errors "No [proxy] configuration found". Two measurements make it unusable here:
it is project-config-only (both profile-file names are ignored in the global
config dir, where this Mac's 49 secrets live), and it is mutually exclusive with
`--no-defaults`, which empties the environment completely, profile file included.

Adopted: `[profiles.agent.secrets]` + `--no-defaults` — scoping only. Profile
scoping is real on both channels; MCP was measured by driving a live `fnox mcp`
over stdio rather than inferred from docs.

A codex cold review returned 22 findings and reversed the headline. An earlier
draft claimed `fnox proxy run` catches fnox's silent fail-open; that came from a
fixture whose rule table no single profile could satisfy, so every arm was forced
to rc=1. Re-run against the design actually proposed, a missing profile starts
cleanly at rc=0. The proxy is a ceiling — it caps the injected set at the rule
table regardless of profile — not a gate. Disposition: 17 accepted, 3 refuted by
probe, 2 partial.

Corrections to inherited claims: `--no-defaults` alone suffices for confinement
(#435 is right only on the delivery axis); `FNOX_NO_DEFAULTS` exists;
`--write-profile` is required, not defaulted. New cost: no reference form, so
every per-secret binding duplicates into the profile — silent drift #435's
baseline does not cover. Inherited environment defeats all of it: the four
`env = true` opt-ins pass through both `exec --no-defaults` and `proxy run`.

Gates: lint rc=0 · lint-docs rc=0 · pytest rc=0 · verify rc=0.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014x8jGSieFkDBV95KLXYhTC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788226867&installation_model_id=429246&pr_number=469&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F469&signature=f94ca5174a300d0e86cb01c1915a716ac96747db558718a770d956495f9b8928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->