### PR TITLE
docs(probes): a control arm verifies the PROBE, not that the FIXTURE admits both answers

### DIFF
--- a/.claude/rules/probes-need-a-control-arm.md
+++ b/.claude/rules/probes-need-a-control-arm.md
@@ -116,6 +116,18 @@ Full case tables — five false negatives, five cross-check disagreements:
    fact costs seconds and settles which side is broken. Disagreement is a
    finding, not noise — and the finding is usually your probe.
 
+8. **Arm the FIXTURE too: "could this setup have produced the other result?"**
+   Rules 1–7 verify the *probe* discriminates. They say nothing about whether
+   the *world you built for it* admits both answers — and a fully-armed probe on
+   a rigged fixture yields a confident wrong finding. Canonical case: a #441
+   fixture whose rule table named two secrets **no single profile could hold**,
+   so all six arms were forced to the same outcome; that outcome was published
+   as a finding and reversed once the fixture was rebuilt realistically. Ask the
+   question *before* reading the output, and prefer a fixture that mirrors the
+   real configuration over one that isolates the variable. A second case (a
+   parent-directory config the tool silently merged) and both re-runs:
+   `docs/rules-evidence/probes-need-a-control-arm.md`.
+
 ## Applies to
 
 Every probe whose answer you act on or report: shell one-liners, `find`/`grep`

--- a/docs/receipts/TEMPLATE.md
+++ b/docs/receipts/TEMPLATE.md
@@ -69,6 +69,15 @@ it fails silently. In #436 a probe read the wrong attribute off a result object,
 findings** for a host carrying **2 live errors**, and that clean number was written into a draft
 before the control arm caught it. If a probe reports "nothing found", prove it can report something.
 
+⚠️ **Ask "could this FIXTURE have produced the other result?" — control arms do not answer it.**
+A fixture can be fully armed and still worthless. #441 built one whose rule table referenced two
+secrets no single profile could hold, so **all six arms were forced to the same outcome**, and the
+draft published that outcome as a finding; re-run realistically it reversed. A second fixture in the
+same session ran inside a tree whose *parent* held a config file, which the tool silently merged.
+Both had working positive and negative controls. Controls prove the **probe** discriminates; only
+this question proves the **setup** admits both answers. Ask it before reading the output — neither
+instance was self-caught.
+
 | Hit | What I did with it |
 |---|---|
 | `path` | read — <what it changed> **or** dismissed — <why it does not apply> |

--- a/docs/rules-evidence/probes-need-a-control-arm.md
+++ b/docs/rules-evidence/probes-need-a-control-arm.md
@@ -115,10 +115,50 @@ it explicitly as unverified and inherited. And when the number ranks things, ask
 what the **noise floor** is — a difference smaller than the same-input variance is
 not a difference.
 
+## Rule 8 — two rigged fixtures in one session, both fully control-armed (#441, 2026-08-02)
+
+Rules 1–7 all target the **probe**. These two failures were in the **fixture**, and
+the existing arms could not see them: each probe genuinely discriminated, on a
+world that only ever allowed one answer.
+
+**Case 1 — the fixture no scope could satisfy.** Testing whether `fnox proxy run`
+is bound by the active profile, the config declared a top-level-only secret
+(`TOP_TOKEN`), a profile-only secret (`AGENT_TOKEN`), and `[[proxy.rules]]` for
+**both**. Every single-profile scope therefore lacked at least one ruled secret, so
+startup validation could only ever reject it: six arms, six `rc=1`, and the draft
+reported *"the proxy catches fnox's silent fail-open"*.
+
+Rebuilt to mirror the design actually proposed — top level holds the secrets, the
+profile **duplicates** one, and the rule names that one — a missing profile
+**starts cleanly at `rc=0`**. The real behaviour is the opposite of the finding:
+the proxy does not gate on the profile at all, it caps the injected set at the rule
+table. Caught by an adversarial reviewer, not by the session that built it.
+
+**Case 2 — the fixture with a parent.** Testing whether `fnox.<profile>.toml` is
+loaded, the sandbox sat inside a directory whose **parent** already held a
+`fnox.toml` from an earlier probe. fnox searches parent directories, so it silently
+merged both: `config-files` printed `fnox.toml` **twice** and a foreign secret
+appeared in the results. Surfaced only because case 1 forced a re-run; the clean
+re-run added an explicit ancestor check (`walk up from the test root, assert no
+fnox.toml`) as a fixture arm.
+
+**Why arms don't catch this.** A control arm answers *"can this probe report the
+other value?"* Both probes could. The unasked question is *"can this WORLD produce
+the other value?"* — and no amount of arming the probe reaches it. Two habits:
+
+- Ask it **before** reading the output. Afterwards, a result that confirms the
+  hypothesis reads as evidence rather than as a fixture artifact.
+- **Prefer a fixture that mirrors the real configuration** over one that cleanly
+  isolates the variable. Case 1's fixture was *better designed* as an experiment —
+  disjoint names, no confounds — and that is exactly what made it wrong: the real
+  system duplicates names across the two layers, which is the whole mechanism.
+
 ## GitHub repos touched
 
 - [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the probes,
   `hk.pkl`'s `no_grep_q_under_pipefail`, and the #289 base build.
+- [jdx/fnox](https://github.com/jdx/fnox) — the tool both rule-8 fixtures probed
+  (`fnox proxy run`, profile config files), at the installed v1.32.0.
 
 graphify's issue #959 and its `LM Studio` spelling are cited above as
 cross-check examples. Its upstream repo is deliberately **not** enumerated here:

--- a/docs/specs/ticket-bound-receipts.md
+++ b/docs/specs/ticket-bound-receipts.md
@@ -568,6 +568,34 @@ this spec's own.
 > reported "0 findings" for a host carrying 2 live errors, and that clean number was written down
 > before the control arm caught it.
 
+> **Third post-pilot data point, 2026-08-02 — the highest finding count yet, and the pattern held for
+> a third consecutive receipt.** `441.md` (#7): **22 findings (5 critical, 15 major, 2 minor), 17
+> accepted / 3 refuted by probe / 2 partial**. Running total: **149 findings, 7 refuted (4.7%)**.
+> Post-template-edit the rate is 6 refuted of 62 (9.7%) against the pilot's 1 of 87 (1.1%), which is
+> now n=3 either side and starting to look like a real effect rather than #448's single outlier —
+> though every refutation still comes from the same lever, **settling a finding by running something
+> instead of arguing**.
+>
+> **The review changed the recommendation for the third consecutive receipt — 6 of 7 overall**, and
+> this one did it twice. It killed the draft's headline claim (that `fnox proxy run` catches fnox's
+> silent fail-open) by identifying that the fixture's rule table referenced a top-only *and* a
+> profile-only secret, so **no** single profile could satisfy it and all six arms were forced to
+> rc=1; re-run realistically, a missing profile starts at rc=0. And it pointed at
+> `fnox.<profile>.toml`, a **second** profile mechanism the draft had never tested, which turned out
+> to be the thing the ticket was actually asking about — flipping the literal answer from "fnox has
+> no such overlay" to "fnox has it and we cannot reach it".
+>
+> **The process defect this receipt adds is not caught by any control-arm rule, including the ones
+> the last two receipts added.** Both of its bad fixtures were *armed* — each had working positive
+> and negative controls — and both were still worthless, because **a fixture built to demonstrate a
+> thing cannot test it**. The proxy fixture admitted only one outcome; the profile-file fixture ran
+> inside a tree whose parent held a `fnox.toml`, so the config search silently merged a foreign file.
+> Control arms verify that the *probe* can distinguish; they say nothing about whether the *fixture*
+> allows both answers. The question that catches this class — and it belongs in the template — is
+> **"could this fixture have produced the other result?"**, asked before reading the output. Neither
+> instance was self-caught: the first came from the reviewer, the second only surfaced because the
+> first forced a re-run.
+
 ### 1. Which fields were real, which became ritual?
 
 **Real, and the highest-value field in all four: the adversarial review.** It was never once


### PR DESCRIPTION
Adds rule 8 to probes-need-a-control-arm.md, from two rigged fixtures in one
session (#441) that were BOTH fully control-armed and both still worthless.

A `fnox proxy` fixture declared rules for a top-level-only and a profile-only
secret, so no single profile could satisfy both — six arms, six rc=1 — and that
outcome was published as "the proxy fails closed on a missing profile". Rebuilt
to mirror the real design (the profile duplicates a top-level secret), a missing
profile starts at rc=0: the opposite finding. A second fixture ran inside a tree
whose parent held a fnox.toml, which fnox silently merged; it surfaced only
because the first re-run forced a look.

Rules 1-7 all target the probe, and each of these probes genuinely discriminated.
The unasked question is whether the WORLD built for it admits both answers. Two
habits recorded: ask it before reading the output, and prefer a fixture that
mirrors the real configuration over one that cleanly isolates the variable — the
rigged fixture was the better-designed experiment, and that is what broke it.

Rule keeps the directive plus one canonical case; both worked cases go to
docs/rules-evidence/ (md-size-budgets.md's trimming lever). Template gains the
question as a required check alongside the existing control-arm fields.

ticket-bound-receipts.md gains the third post-pilot data point: 22 findings,
17 accepted / 3 refuted by probe / 2 partial. Running total 149 findings,
7 refuted (4.7%); the review changed the recommendation for the third
consecutive receipt, 6 of 7 overall.

Gates: lint rc=0 · lint-docs rc=0.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014x8jGSieFkDBV95KLXYhTC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788229067&installation_model_id=429246&pr_number=472&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F472&signature=e7e291a34dd6d84590ee2a7145c22e353d980745bac91bb1408948d3049bf9f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for designing reliable test fixtures that can produce both positive and negative outcomes.
  * Expanded review guidance to identify unrealistic, impossible, or inherited configurations that may distort results.
  * Documented corrective fixture designs and validation steps before interpreting probe findings.
  * Added a new evidence record covering recent findings, refutations, and recommendation reversals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->