### PR TITLE
docs(receipts): #445 — mise owns the edits, chezmoi owns only whole files

### DIFF
--- a/docs/receipts/445.md
+++ b/docs/receipts/445.md
@@ -1,0 +1,275 @@
+# Receipt — #445: What owns the shell-init chain after takeover — `~/.zshrc`, `~/.zprofile`, and the `.d` fragment loaders?
+
+**Verdict:** **mise owns the *edits*; chezmoi owns only the files it owns whole; `~/.zprofile` never
+becomes a chezmoi target.** The `.d` loader pattern **survives** — it is what lets the secrets
+fragment retire *with* its replacement rather than before it. Ray's standing rule decided the
+mechanism (*"always choose mise over chezmoi if mise provides the same features or can be adapted to
+mise"*), and mise 2026.8.0 does provide them: `[bootstrap.mise_shell_activate]` and `[dotfiles]`
+**edit entries** write marker-delimited blocks that are **idempotent by construction**, preserve
+every third-party installer append, create the file when absent, and ship an armed
+`status --missing` gate — all measured on the installed binary, both arms, in an isolated HOME.
+
+Four decisions, taken with Ray 2026-08-02: **starship on both machines** · **`~/.zprofile` gets a
+mise activation block, not a chezmoi entry** · **`~/.zshenv` stops being an `output` bake** · **keep
+the `.d` loader**.
+
+**One sequencing constraint dominates the whole answer.** chezmoi whole-file ownership and mise
+marker blocks in the *same* file fight forever — chezmoi's apply wipes the block, mise's apply
+re-adds it. mise defers to *mise's* `[dotfiles]`; **chezmoi has no reciprocal deference.** So through
+the chezmoi era (#448: chezmoi holds the Mac through #431) the loader lives **inside the chezmoi
+template**, and the mise-block form is the post-migration shape. Adopting the mise blocks early would
+be the one thing that breaks.
+
+**Resolved:** 2026-08-02
+
+## Sources — what I actually opened
+
+- `https://raw.githubusercontent.com/jdx/mise/v2026.8.0/docs/bootstrap/shell.md` — the
+  `[bootstrap.mise_shell_activate]` target table (`zprofile`→shims, `zshrc`→activate,
+  `zshenv`→shims-but-not-by-default), the marker format, and the four `state` values. Fetched at the
+  **installed tag**, not `main`, so it describes the binary probed. Byte-identical to `main` (`diff`
+  clean), so no drift either way.
+- `.../v2026.8.0/docs/dotfiles.md` — edit entries (`block` / `line` / templated `source`), the
+  `(path, id)` merge key, marker-as-ownership-record, and the conflict rules.
+- `.../v2026.8.0/docs/bootstrap.md` — the 13 ordered steps; step 4 is mise-shell-activate. Its worked
+  example is `zprofile = "shims"` + `zshrc = "activate"` + `fish = "activate"`.
+- `docs/research/mintlify-cache/twpayne/chezmoi/llms-full.txt` — the source-state attribute table
+  (`modify_`, `create_`, `exact_`), apply ordering, and `chezmoi_modify_manager` as third-party
+  prior art for the same problem.
+- `home/dot_zshrc.tmpl`, `home/dot_zshenv.tmpl`, `home/dot_profile.tmpl`, `home/.chezmoitemplates/env`,
+  `home/.chezmoiignore` — dotfiles' side of the chain.
+- `../macos-development-environment/home/dot_zshrc.tmpl`, `home/dot_zshrc.d/50-mde-secrets.zsh`,
+  `home/dot_zprofile.d/macos-dev-env.zsh`, `home/.chezmoiignore`, `home/.chezmoi.toml.tmpl` — mde's.
+- `~/.zprofile`, `~/.zshrc`, `~/.zshrc.d/`, `~/.zprofile.d/`, `~/.oh-my-zsh/lib/history.zsh` — the
+  live host chain. Read-only.
+- The running devcontainer `dotfiles-dotfiles-rmanaloto-273897ea-4444` — `~/.zshenv`, `~/.profile`,
+  `chezmoi managed`/`status`/`diff`. Read-only.
+- GitHub issues #439 (CLOSED — the leak model this ticket was blocked on), #434 (the merge
+  inventory), #471 (`MISE_ENV_CACHE`, this ticket's own input), `docs/receipts/448.md` (which tool
+  owns the Mac), `docs/receipts/441.md` (fnox scoping).
+
+## Prior art — the search I ran
+
+**Query:** `git grep -lI -- "<term>" docs .claude` for `zshrc.d`, `zprofile`, `oh-my-zsh`, `zshenv`,
+`starship`
+**Corpus:** `docs/` and `.claude/` of this repo (tracked tree), plus the mintlify cache under
+`docs/research/mintlify-cache/`.
+
+### Control arm
+
+**Known-present term:** `chezmoi` → **91** files
+**Known-absent term:** `wqfj8xrp` → **0** files
+
+Fresh string, never used as a control before this receipt — and now burned by appearing here.
+Second control arm on the mise cache specifically: `bootstrap` → **4** hits, `wqfj8xrp` → **0**,
+`mise_shell_activate` → **0**. Four hits for the whole bootstrap feature is what told me the cache
+was too stale to use, rather than that the feature did not exist.
+
+| Hit | What I did with it |
+|---|---|
+| `docs/research/runs/research-20260710-r3-mise-bootstrap/report.md` | **read — and it reversed one of my own conclusions.** It recommends *against* `[bootstrap.mise_shell_activate]`, on the ground that it would put "two declarative tools claiming ownership of the same line in the same file" as chezmoi's whole-file render. That reasoning is sound and **still binding for `~/.zshrc`** — but it was scoped to *chezmoi-owned rc files*, and `~/.zprofile` is owned by nobody. The prior "no" does not reach the file this ticket is actually about. |
+| `docs/receipts/448.md` | read — supplied the era rule (mise is the destination, chezmoi holds through #431), the re-evaluation triggers, and the practice of fetching docs at the **installed tag**. Its list of takeover-added targets already names `.zprofile.d/**` and `.zshrc.d/**` and says #439's gate must be re-run against the merged tree. |
+| `docs/receipts/441.md` | read — its §Notes established that `MISE_ENV_CACHE=1` comes from `~/.zprofile.d/macos-dev-env.zsh`, i.e. that #431's "unmanaged load-bearing host file" and its "unaccounted exposure surface" are one item. That is why this ticket had to decide the *file*, not just the loader. |
+| `docs/research/runs/research-20260710-r3-mise-dotfiles/agents/chezmoi-parity.md` | read — independently documents that `.chezmoitemplates/env` bakes `mise activate` output at apply time via `output`. Two routes to the same fact, derived three weeks apart. |
+| `docs/research/runs/research-20260710-r3-mise-dotfiles/agents/coexist-migrate.md` | read — costed the `.chezmoitemplates/env` fragment as "low cost, two call sites" to replace. Confirms the `.zshenv` change is cheap; does not address that the bake is non-reproducible. |
+| `docs/rules-evidence/secrets-out-of-the-shell-env.md` | read — its consumer sweep covered `~/.zshrc` and `~/.zprofile` and explicitly bounded itself to *declared* consumers. Relevant because the secrets fragment is the one `.zshrc.d` entry with a retirement constraint. |
+| `docs/specs/deep-interview-devcontainer-build-mise-chezmoi-resync.md` | dismissed — its `zshenv` mention is an inventory line in a spec about container build/resync, superseded by the current tree (it lists `AGENTS.md.tmpl`/`CODEX.md.tmpl` templates that no longer exist). |
+| `docs/maestro/plans/archive/2026-03-22-reproducible-dotfiles-impl-plan.md` | dismissed — archived March plan, predates both the devcontainer host-user migration and the mde merge. |
+| `docs/research/mintlify-cache/jdx/mise/llms-full.txt` | dismissed as a source, **used as a measurement**: 0 hits for `mise_shell_activate` against 4 for `bootstrap` proved the cache (2026-07-02) predates the whole feature. Refetched live instead. |
+| `docs/research/mintlify-cache/devcontainers/**`, `starship/starship/**`, `mintlify-catalog*.md`, `.claude/skills/mintlify/SKILL.md`, `docs/research/runs/research-20260709-r2-*` | dismissed — `starship` matches there are catalog/tooling bookkeeping, not statements about this repo's shell chain. |
+
+## Adversarial review
+
+**Lens:** none
+**Verdict:** not-run
+**Findings:** 0
+**Disposition:** n/a
+
+**Not run:** the session's remaining budget went to the credential-exposure incident below and to
+re-deriving two claims I had already reported wrongly. A cold review is the right next step on the
+*implementation* diff — this receipt decides a shape, and the four decisions in it were taken
+interactively with Ray rather than argued from a draft. Recorded as not-run rather than quietly
+omitted.
+
+## The answer
+
+### 1. `~/.zprofile` — mise block, and it stays otherwise unowned
+
+`~/.zprofile` is a **third-party installer accretion target**: JetBrains Toolbox, `brew shellenv`,
+OrbStack (commented), Obsidian, and the Antigravity CLI installer have each appended to it. The same
+is true of `~/.zshrc` — `chezmoi diff .zshrc` on this host shows drift that is **100% installer
+appends** ("Added by Antigravity CLI installer", "Added by Antigravity IDE"), nothing hand-authored.
+That, not oversight, is why `chezmoi managed` lists `.zprofile.d/macos-dev-env.zsh` but not
+`.zprofile`: **mde ships a fragment into a directory read by a file it does not manage.**
+
+Whole-file ownership is therefore the wrong shape, and measurably so — a plain chezmoi entry wipes
+every append (§ Probes, P1 arm B). What is needed is block ownership, and mise has it:
+
+```toml
+[bootstrap.mise_shell_activate]
+zprofile = "shims"     # eval "$(mise activate zsh --shims)"
+zshrc    = "activate"  # eval "$(mise activate zsh)"
+```
+
+This is mise's own worked example, and it is exactly the two-layer setup this Mac already runs by
+hand (`~/.zprofile.d/macos-dev-env.zsh:84` does `mise activate zsh --shims`; dotfiles'
+`dot_zshrc.tmpl:53` does `mise activate zsh`). The rest of `~/.zprofile` stays unmanaged — correct,
+because the rest of it belongs to installers.
+
+**What happens to `~/.zprofile.d/macos-dev-env.zsh` (90 lines).** It splits three ways, and only the
+first is settled here:
+
+| Content | Destination |
+|---|---|
+| pre-mise PATH (`~/.local/bin`, mise `bin`/`shims`) + `mise activate --shims` | `[bootstrap.mise_shell_activate] zprofile = "shims"` — **settled** |
+| `XDG_*`, `ZSH_*`, `HISTFILE`, `MDE_PLATFORM`, `UV_CACHE_DIR`, `GOBIN` | a `[dotfiles]` block edit on `~/.zprofile` (measured working, P7). **Not** mise `[env]`: that only applies once mise is activated, and some of these are read *before* activation. |
+| `MISE_ENV_CACHE=1`, `FNOX_CONFIG_DIR`, `FNOX_AGE_KEY_FILE`, `SOPS_AGE_KEY_FILE` | **deferred to [#471](https://github.com/ray-manaloto/dotfiles/issues/471)** — the cache flag's fate is that ticket's, and the fnox paths move with it. |
+
+### 2. `~/.zshrc` — dotfiles' template, starship, and the loader inside it
+
+Ray chose **starship on both machines**. The two machines already differ today (host = oh-my-zsh
+`robbyrussell`, container = starship), and `~/.config/starship.toml` sits on the host as a 5,122-byte
+**orphan** — managed by nothing, initialized by nothing. Adopting dotfiles' `.zshrc` gives it an
+owner and makes the two machines identical.
+
+Consequences, named so they are not discovered later:
+
+- **mde's `~/.oh-my-zsh/custom/aliases.zsh` needs a home.** It becomes a `~/.zshrc.d/` fragment. This
+  is the loader earning its place on day one.
+- **The omz `git` / `gh` / `mise` plugins are lost.** The `mise` plugin only added completions, and
+  dotfiles already fetches `_mise` completions via `.chezmoiexternal.toml`.
+- **History is safe.** mde's `.zprofile.d` sets `HISTFILE=$ZSH_DATA_DIR/history`; dotfiles'
+  `dot_zshrc.tmpl:3` sets `$HOME/.zsh_history`. Measured with `HISTFILE` cleared from the parent,
+  **all three shell kinds resolve to `~/.zsh_history`**, which holds 283 KB, while
+  `~/.local/share/zsh/` is **empty**. The XDG line is inert; nothing gets orphaned. I had this
+  written up as a migration hazard until I measured it.
+
+**The loader stays, and during the chezmoi era it lives in the template**, not in a mise block —
+see the sequencing constraint in the Verdict. mde's loader form is already correct and is adopted
+verbatim: the `(N)` nullglob qualifier makes an absent or empty `~/.zshrc.d` a no-op, which is what
+makes the same `.zshrc` safe in the container.
+
+### 3. `~/.zshenv` — stop baking, or don't ship one
+
+`home/dot_zshenv.tmpl` is `{{ template "env" (dict "SHELL" "zsh") }}` →
+`home/.chezmoitemplates/env` = `{{ output "mise" "activate" .SHELL }}`. `output` shells out **at
+apply time**, so the file's content is a function of the applying process's environment, not of the
+source tree. Measured (P4): 149 lines / 38 `unset`s on this Mac, 87 / 21 in the container, 88 / 0
+from a shell with `__MISE_DIFF` cleared. The mechanism is that **`chezmoi` runs as a mise shim**, so
+its `output` subprocess inherits `__MISE_DIFF` + `__MISE_SHIM` that the parent shell does not have.
+
+Ray chose the literal `eval "$(mise activate zsh)"` over the bake — and the mise decision delivers
+exactly that, because `[bootstrap.mise_shell_activate]` writes that literal line into a marker block.
+So `dot_zshenv.tmpl` is **retired**, not rewritten: with `zprofile = "shims"` and
+`zshrc = "activate"` there is nothing left for `~/.zshenv` to do on the Mac.
+
+mise's own doc reaches the same conclusion independently and says why: *"Shims stay out of `zshenv`
+by default — `zshenv` is supported when configured explicitly, but shell shortcuts do not write it
+because zsh reads it for every invocation, including scripts."* The `zsh = true` shortcut expands to
+`zprofile` + `zshrc` and deliberately not `zshenv`.
+
+**This is a live defect, not only a takeover risk.** The container's `~/.zshenv` carries 21 baked
+`unset`s today and `~/.profile` carries 23. They are harmless — the rendered file ends with a live
+`_mise_hook` call that re-derives the environment, and the four fnox `env = true` credentials were
+measured **still set** after sourcing the real rendered file — but the files are not reproducible
+from the repo, and `chezmoi cat` reproduces the stale content byte-for-byte (`cmp` → IDENTICAL)
+rather than re-deriving it.
+
+### 4. What stops Mac fragments loading in the devcontainer
+
+Two layers, neither of them the loader:
+
+1. **`.chezmoiignore`** gains a `{{ if ne .chezmoi.os "darwin" }}` branch covering `.zshrc.d/**` and
+   `.zprofile.d/**` — the idiom #439 chose, applied to the new targets.
+2. **#439's set-equality allow-list gate**, widened. #448 already records that the 13-target
+   allow-list and #434's inventory must be **re-derived against the merged tree**; `.zshrc.d/**` and
+   `.zprofile.d/**` are named there as takeover-added targets. A leaked fragment is a fourteenth
+   target, which is precisely what the gate catches and what `status --missing` alone cannot.
+
+The loader itself needs no guard: `*.zsh(N)` on an absent directory is a no-op, and the container has
+no `~/.zshrc.d` at all. The container also has **no `~/.zprofile`** and a `/bin/bash` login shell, so
+the `zprofile` half of the mise config is darwin-only by construction.
+
+### 5. The secrets fragment keeps its constraint
+
+`~/.zshrc.d/50-mde-secrets.zsh` retires **with** its replacement, never before — #431's Notes, and
+this ticket does not relax it. Its `eval "$(fnox activate zsh)"` is what populates the interactive
+shell, and #441's `[profiles.agent.secrets]` + `--no-defaults` decision is a **call-site** mechanism
+for agent invocations, not a replacement for the interactive shell's activation. So the fragment
+survives the takeover; only its *home* changes (mde's source tree → dotfiles'). Its `mde-secret-*`
+wrappers and `MDE_PROJECT_DIR` resolution are mde-repo concerns and move with the mde branch.
+
+## Probes
+
+Every probe below is read-only against the host except P6–P8, which write only inside an isolated
+scratch `HOME`. The real `~/.zprofile` and `~/.zshrc` were sha256-fingerprinted before and after
+every write probe and were **identical every time**.
+
+| # | Probe | Arms | Result |
+|---|---|---|---|
+| P1 | chezmoi `modify_` vs a plain entry, same destination file carrying an installer append | `modify_dot_testrc` / `dot_plainrc` | `modify_` **preserves** the append and adds a block; plain **wipes** it. Both rc=0. |
+| P2 | naive `modify_` idempotency | 3 renders | **2** managed blocks. A strip-then-emit `awk` version → **1**, pass2 == pass3 (fixed point). |
+| P3 | `modify_` against a **missing** destination | control: `ls` confirms absent | empty stdin, file created with the block only, rc=0 |
+| P4 | `{{ output "mise" "activate" zsh }}` determinism | live shell / `env -u __MISE_DIFF` | **38** vs **0** `unset` lines (149 vs 88 total). Container: 21 / 87. Mechanism: chezmoi is a mise shim, so its subprocess has `__MISE_DIFF`+`__MISE_SHIM` the parent shell lacks (`mise activate zsh` → 0 unsets in the shell, 21 through `chezmoi execute-template`). |
+| P5 | installed versions, re-checked first | — | chezmoi **v2.71.1**, mise **2026.8.0**; `mise bootstrap --help` lists step 4 mise-shell-activate |
+| P6 | `[bootstrap.mise_shell_activate] apply` ×2, isolated HOME | fixture seeded with 3 installer appends | #1 writes both blocks; #2 → "all edits are applied". Toolbox=1, Obsidian=2, brew=1 all preserved. `~/.zshrc` **created** although absent. |
+| P7 | `[dotfiles]` edit entries (`"~/.zshrc/fragment-loader"`, `"~/.zprofile/xdg"`) | apply ×2 | both converge; second run idempotent; nothing else in either file touched |
+| P8 | `status --missing` as a gate | converged / block deleted / re-applied | **rc=0 / rc=1 / rc=0** |
+| P9 | HISTFILE resolution | login+interactive, interactive, login, each with `HISTFILE` cleared | all three → `~/.zsh_history` (283 KB); `~/.local/share/zsh/` empty |
+| P10 | host chezmoi state | `managed`, `status`, `diff .zshrc` | `.zprofile` **not** managed; 3 files `MM`; `.zshrc` drift is 100% installer appends |
+| P11 | container chezmoi state | perturb `~/.bashrc` → restore | `MM .bashrc` then clean — the status probe discriminates |
+
+**Fixture arming — "could this setup have produced the other result?"** P1's two arms differ *only*
+in the source-entry prefix against a byte-identical destination, so both outcomes were reachable.
+P6's fixture deliberately **mirrors the real `~/.zprofile`** (installer appends, mid-file `brew`
+line) rather than isolating the variable with an empty file — an empty fixture would have made
+"preserved" and "wiped" indistinguishable. P8's mutation is the realistic one: deleting the managed
+block is what a whole-file `chezmoi apply` would actually do, not a rename or a typo.
+
+## Notes
+
+- ⚠️ **I published two claims before cross-checking them, and both were wrong.** I told Ray the
+  `.zshenv` bake was a credential-stripping **blocker** — it is not; the rendered file ends with a
+  live `_mise_hook` that re-derives the environment, and all four fnox opt-ins were measured still
+  set. And I read `status --missing` as rc=0 in both directions and nearly filed the gate as broken —
+  my helper piped mise through `grep -v`, so I was reading grep's exit code
+  (`feedback_pipe_kills_exit_code`, self-inflicted, in a session whose own receipt template warns
+  about it). Both corrected in place. The pattern is the same one rule 7 of
+  `probes-need-a-control-arm.md` names: **cross-check a surprise before you report it.**
+- ⚠️ **Credential exposure, 2026-08-02.** A probe of mine printed the **values** of `GITHUB_TOKEN`,
+  `MISE_GITHUB_TOKEN`, `EXA_API_KEY` and `CONTEXT7_API_KEY` to stdout — `${(P)k}` in a format string
+  where a presence flag was intended. They are in this session's transcript JSONL. Nothing reached a
+  tracked file (the scratch render was checked: 0 value matches, then deleted). Ray was told
+  immediately and asked to rotate all four. Unrelated and pre-existing: `.agent/notepad.md` line 1703
+  holds a `ghp_` from an earlier session — gitignored, never committed, still sitting in the tree.
+- **The mintlify cache is unusable for mise's bootstrap surface** (2026-07-02; `mise_shell_activate`
+  → 0 hits against `bootstrap` → 4). Fetch live at the installed tag:
+  `https://raw.githubusercontent.com/jdx/mise/v2026.8.0/docs/<path>.md`, which round-tripped
+  byte-identical to `main` for both files read here. Raw copies in
+  `.agent/kb/raw/mise-{bootstrap,bootstrap-shell,dotfiles}.md` (gitignored, re-fetchable).
+- **The prior "no" on `[bootstrap.mise_shell_activate]` was correctly scoped and is still correctly
+  scoped.** `research-20260710-r3-mise-bootstrap` rejected it for *chezmoi-owned* rc files. That
+  rejection is what produces this ticket's sequencing constraint; it is not overturned. If someone
+  later reads that report and concludes mise blocks are banned outright, this is the paragraph that
+  says otherwise — and the file it was never about is `~/.zprofile`.
+- **Not decided here:** `MISE_ENV_CACHE`'s fate (#471), the `.gitconfig`/`.tmux.conf` collisions
+  (#446), and whether `[bootstrap.user].login_shell` should pin `/bin/zsh` on the Mac. The last one
+  is genuinely new surface — nothing sets the host login shell declaratively today — and belongs to
+  the takeover ticket, not to this one.
+
+## GitHub repos touched
+
+- [jdx/mise](https://github.com/jdx/mise) — `docs/bootstrap.md`, `docs/bootstrap/shell.md`,
+  `docs/dotfiles.md` at tag `v2026.8.0`; and the installed binary, probed directly.
+- [twpayne/chezmoi](https://github.com/twpayne/chezmoi) — source-state attributes (`modify_`,
+  `create_`, `exact_`), apply ordering, marker/partial-file options; read from the local mintlify
+  cache and probed on the installed v2.71.1.
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — `home/**`, the receipts and
+  research corpus, issues #431/#434/#439/#445/#448/#471.
+- [ray-manaloto/macos-development-environment](https://github.com/ray-manaloto/macos-development-environment)
+  — `home/dot_zshrc.tmpl`, `home/dot_zshrc.d/50-mde-secrets.zsh`,
+  `home/dot_zprofile.d/macos-dev-env.zsh`, `home/.chezmoiignore`, `home/.chezmoi.toml.tmpl`.
+- [VorpalBlade/chezmoi_modify_manager](https://github.com/VorpalBlade/chezmoi_modify_manager) —
+  named in chezmoi's own docs as third-party prior art for owning part of a file; noted, not adopted.
+- [ohmyzsh/ohmyzsh](https://github.com/ohmyzsh/ohmyzsh) — `lib/history.zsh` on the host, to settle
+  who sets `HISTFILE`.


### PR DESCRIPTION
`~/.zprofile` and `~/.zshrc` are third-party installer accretion targets
(`chezmoi diff .zshrc` drift is 100% installer appends), so whole-file
ownership is the wrong shape. Per Ray's standing rule — prefer mise where
mise provides the same feature — the mechanism is mise 2026.8.0's
`[bootstrap.mise_shell_activate]` plus `[dotfiles]` edit entries: marker
blocks, idempotent by construction, every append preserved, armed
`status --missing` gate. Measured in an isolated HOME; the real files were
sha256-identical before and after every write probe.

The `.d` loader survives, and one constraint decides sequencing: chezmoi
whole-file ownership and a mise block in the same file fight forever, and
chezmoi has no reciprocal deference. So through the chezmoi era (#448) the
loader lives in the template; the mise block is the post-migration shape.

Also records a live defect: `dot_zshenv.tmpl`'s `{{ output "mise" "activate" }}`
bake is a function of the applying process (chezmoi runs as a mise shim, so it
inherits __MISE_DIFF) — 38 unsets here, 21 in the container, 0 from a clean
shell. Harmless at runtime, but not reproducible from the repo.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014x8jGSieFkDBV95KLXYhTC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788231323&installation_model_id=429246&pr_number=473&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F473&signature=9dbcc301954623745f5fb5d89dfd77218a7aea49ed41750ec60cfe7ac7adc767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->