### PR TITLE
docs(receipts): #446 — mde's gitconfig contributes nothing, and .tmux.conf stops being a template

### DIFF
--- a/docs/receipts/446.md
+++ b/docs/receipts/446.md
@@ -1,0 +1,294 @@
+# Receipt — #446: How do the remaining colliding targets merge — `.gitconfig`'s `excludesFile` and `safe.directory`, and `.tmux.conf`'s two shapes?
+
+**Verdict:** Neither target is really a merge. **`.gitconfig`** — mde's remainder contributes *nothing*
+to the merged file: `core.excludesFile` is redundant because git already reads
+`$XDG_CONFIG_HOME/git/ignore` natively, so `dot_gitignore_global` **moves to
+`home/dot_config/git/ignore`** and the key is dropped; all **8** `[safe] directory` entries are
+**inert on both machines** and are dropped; `[filter "lfs"]` is a byte-equivalent duplicate of the
+block dotfiles already has. So the merged `~/.gitconfig` is **dotfiles' existing behaviour-only file
+plus the `[user]` block #439 already decided** — `.gitconfig` stops being a collision.
+**`.tmux.conf`** — the merged file becomes a **plain file**, `home/dot_tmux.conf`: dotfiles' only
+templating is a powerline branch that is **dead on both machines**, so nothing is left to template.
+Content is mde's 49 lines minus its mde-repo-absolute `status-right`, plus dotfiles' `mode-keys vi`,
+`escape-time 10` and `-r -T prefix` pane binds.
+⚠️ **Scope correction: #446's premise under-enumerates.** It names "mde's other two gitconfig-only
+keys". mde's file has **four** remainder areas — the unnamed one is **`[credential]`** (4 sections),
+whose GCM path is **inverted for this Mac** and errors on every HTTPS credential lookup. It is
+dropped too, and that is the one decision here that extends #446's stated scope.
+**Net effect on #439's linux allow-list: 13 → 14 targets** (`+ .config/git/ignore`;
+`.tmux.conf` stays).
+
+**Resolved:** 2026-08-02
+
+## Sources — what I actually opened
+
+- `home/dot_gitconfig` — dotfiles' side: behaviour-only, 23 lines, no `[user]`, no `excludesFile`.
+- `macos-development-environment/home/dot_gitconfig.tmpl` — mde's side, 33 lines. Settled that the
+  remainder is **four** areas, not two, and that `[safe]` holds **8** `directory` entries, not one.
+- `home/dot_tmux.conf.tmpl` (21 lines) · `macos-development-environment/home/dot_tmux.conf`
+  (49 lines) — the two shapes; settled that the only overlap is the four pane binds.
+- `macos-development-environment/home/dot_gitignore_global` — 35 lines, 6 blocks; settled that the
+  content is not macOS-only (`.env`, `__pycache__`, `node_modules` matter in the container too).
+- **`.claude/skills/tmux-extended-keys/SKILL.md`** — this repo's own skill. It names
+  `home/dot_tmux.conf.tmpl` as the file to edit and prescribes `set -s extended-keys on` +
+  `set -as terminal-features 'xterm*:extkeys'`. **Those lines are in mde's copy (`:12-13`) and
+  absent from dotfiles'.** This is the authority for carrying them into the merged file.
+- **git's `core.excludesFile` / `safe.directory` semantics** — taken from git itself
+  (`git 2.50.1`, probed below) rather than restated from memory; `safe.directory` is the
+  CVE-2022-24765 ownership control, which is why an inert exception list is a net negative.
+- `home/dot_config/mise/config.toml.tmpl` — the linux **overlay** tier: ships **zellij**, no tmux.
+- `mise.toml:972-1000` (`[tasks.cc]`) — this repo's own launcher hard-refuses without tmux.
+- `docs/research/kb/reports/agents/kb-standalone-readiness.md` D5 — independent, earlier finding
+  that tmux comes from `~/.config/mise/config.toml`, i.e. #434 row 8.
+- `docs/receipts/448.md:132-135` — names `.gitignore_global` among the takeover-added targets whose
+  derivations must be re-run under #431.
+- `~/.tmux/plugins/tmux-sensible/sensible.tmux:82-88` — settled that tpm does **not** clobber our
+  values (see Notes).
+- GitHub issues **#446** (the question), **#439** (its parent verdict — the `[user]` derivation and
+  the 13-target allow-list), **#434** rows 10/11/13 (the inventory).
+
+## Prior art — the search I ran
+
+**Query:** `grep -rIln -E "excludesFile|gitignore_global" · "safe\.directory" · "tmux" ·
+"gcm-core|credential-manager|credential\.helper" · "dot_gitconfig"`
+**Corpus:** `docs/research/kb/reports` `docs/specs` `docs/receipts` `.claude/rules`
+`docs/rules-evidence` (44 + 10 + 9 + 23 + 17 files)
+
+### Control arm — REQUIRED, and run it before you believe any result
+
+**Known-present term:** `chezmoi` → **31** hits
+**Known-absent term:** `xqjfmoz42` → **0** hits
+
+⚠️ **The first run of this search FAILED its control arm — known-present returned 0** — and it
+failed for the *exact* reason `docs/receipts/TEMPLATE.md` warns about from #440: the corpus was held
+in an unquoted `$CORPUS`, and **zsh does not word-split an unquoted variable**, so the whole corpus
+collapsed to one nonexistent path. Every query returned 0 and looked like a clean "no prior art".
+Re-run with the five paths written out literally, the same queries return the five hits below. The
+warning is now a measured repeat, not a story.
+
+| Hit | What I did with it |
+|---|---|
+| `docs/receipts/448.md:132-135` | read — confirms `.gitignore_global` is a takeover-added target and that #431 must re-run two derivations against the merged tree. Consistent with moving it; does not decide the target path. |
+| `docs/research/kb/reports/agents/kb-standalone-readiness.md:62` (D5) | read — **cross-check**: independently establishes tmux comes from `~/.config/mise/config.toml`, not any repo pin, and that a missing tmux is a blocking preflight for `mise run cc`. Reached by a different route than my probe; they agree. |
+| `docs/receipts/436.md:189` | read — the pointer that led me to `.claude/skills/tmux-extended-keys/SKILL.md`, which turned out to be the decisive source for the tmux content. |
+| `docs/receipts/445.md:255` | read — explicitly defers the `.gitconfig`/`.tmux.conf` collisions to this ticket. Confirms scope, adds no facts. |
+| `docs/specs/deep-interview-…-resync.md:201` · `docs/specs/graphify-autonomous-queue.md` · the two `memory-curation-*` reports | dismissed — `tmux` appears only as a *session-detach mechanism* for agent workflows, unrelated to `~/.tmux.conf` content. |
+| `safe.directory` → **0 hits** · `gcm-core\|credential-manager\|credential\.helper` → **0 hits** · `dot_gitconfig` → **0 hits** | genuine zeroes, under the armed control above. Nothing in this repo has ever discussed the `[safe]` or `[credential]` blocks — which is consistent with #446 not knowing `[credential]` existed. |
+
+## The probes
+
+Every result below was run with its control arm. Where an arm is a *control*, it is labelled.
+
+### 1. `core.excludesFile` is redundant — git reads `~/.config/git/ignore` natively
+
+Isolated `HOME`, `XDG_CONFIG_HOME` unset, fresh repo. Leak check first:
+`git config --get core.excludesFile` → **rc=1** (nothing in the fixture sets it).
+
+| arm | setup | result |
+|---|---|---|
+| A *(control)* | no `~/.config/git/ignore` | `check-ignore probe.tmpfoo` → **rc=1**, not ignored |
+| B | `~/.config/git/ignore` = `*.tmpfoo` | **rc=0**, prints `…/.config/git/ignore:1:*.tmpfoo` |
+| C *(control)* | same file, non-matching name | **rc=1**, not ignored |
+
+**Fixture check — could this setup have produced the other result?** Yes: arm A and arm C are the
+same fixture yielding the opposite answer, and the leak check proves no `excludesFile` was in play.
+
+**Repeated inside the devcontainer**, because the path depends on `XDG_CONFIG_HOME`:
+
+| machine | `XDG_CONFIG_HOME` | resolved path | arms |
+|---|---|---|---|
+| Mac | `/Users/rmanaloto/.config` | `~/.config/git/ignore` | A/B/C as above |
+| devcontainer | **unset** → `$HOME/.config` | `/home/rmanaloto/.config/git/ignore` | B rc=0 (path printed), C rc=1, A rc=1 |
+
+Both machines resolve to the same chezmoi target, `dot_config/git/ignore`. The container probe file
+was created and removed inside the probe.
+
+### 2. All 8 `[safe] directory` entries are inert — on both machines
+
+Every listed path is owned by **uid 501 = me**; three of the eight (`$HOME`,
+`…/guilde-lite-tdd-sprint/backend`, `~/dev/tmp`) are **not git repositories at all**.
+
+| arm | command | result |
+|---|---|---|
+| 1 | listed repo, `GIT_CONFIG_GLOBAL=/dev/null` (list removed) | **rc=0** — the list is doing nothing |
+| 2 *(control)* | same + `GIT_TEST_ASSUME_DIFFERENT_OWNER=1` | **rc=128** `fatal: detected dubious ownership` — the probe *can* see the failure |
+| 3 *(control)* | forced different owner, **with** the real global config | **rc=0** — the list *does* work when the condition fires |
+| 4 *(control)* | forced different owner, a repo **not** on the list (`dotfiles`) | **rc=128** — list membership is the discriminator |
+
+Arms 2–4 are what make arm 1 readable: rc=0 is because ownership matches, not because the mechanism
+is broken or the probe is blind.
+
+**Container:** `/workspaces/dotfiles` and its `.git` are **uid 1000 = the container user**, so
+`git status` → **rc=0** with no `safe.directory` configured at all; the forced-different-owner
+control → **rc=128**. The bind mount does not create the condition `safe.directory` exists to
+excuse.
+
+### 3. The undocumented remainder: `[credential]`, and its arch branch is inverted
+
+mde renders `{{ if eq .chezmoi.arch "amd64" }}/usr/local{{ else }}/opt/homebrew{{ end }}`. This Mac
+is arm64, so it renders `/opt/homebrew/share/gcm-core/git-credential-manager`.
+
+| path | present? |
+|---|---|
+| `/opt/homebrew/share/gcm-core/git-credential-manager` *(what mde renders here)* | **ABSENT** |
+| `/usr/local/share/gcm-core/git-credential-manager` *(the amd64 branch)* | **PRESENT** |
+| `/usr/bin/git` *(control for the `-x` test)* | present |
+
+GCM is installed under `/usr/local` **on an arm64 Mac**, so the branch is backwards for the only
+machine that runs it. What that costs, probed in an isolated `HOME` against a bogus host with
+`GIT_TERMINAL_PROMPT=0` (stdout discarded — a probe's stdout is an uncovered surface,
+`secrets-out-of-the-shell-env.md` rule 7):
+
+| arm | helper | stderr |
+|---|---|---|
+| A *(control)* | none | `fatal: could not read Username …` only |
+| B | nonexistent path *(mde's live case)* | **`…: No such file or directory`** on every lookup, then the same fatal |
+| C *(control)* | a real binary that is not a helper (`/bin/echo`) | `warning: invalid credential line: get` — a **different** signature, so the probe tells "missing" from "present but wrong" |
+
+Non-fatal — git falls through to the next helper — but it prints an error on every HTTPS credential
+lookup. And **no HTTPS lookup is needed**: `dotfiles`, `knowledge-base` and
+`macos-development-environment` all use `git@github.com:` SSH remotes. Azure DevOps has **zero**
+real consumers (the only non-cache hits for `dev.azure.com` are mde's own gitconfig template, its
+worktree copy, and one mde doc; control: `chezmoi` → 563 files across both trees).
+
+### 4. `.gitconfig` is in live drift, and the drift is in that same block
+
+`chezmoi status` → exactly three `MM`: `.config/mise/config.toml`, `.gitconfig`, `.zshrc`.
+`chezmoi diff ~/.gitconfig` shows the difference is entirely inside `[credential]` — the live file
+has accreted **both** GCM paths plus a `helper =` reset in a different order.
+
+⚠️ **Probe-shape trap, caught by cross-check:** `chezmoi diff .gitconfig` (relative target) prints
+`chezmoi: .gitconfig: not managed` **and exits rc=0**, while `chezmoi status` lists it as managed
+and dirty. Two probes of one fact disagreed; the broken one was mine. `chezmoi diff ~/.gitconfig`
+(absolute) works. A relative path here is a silent false negative with a success exit code.
+
+### 5. `.tmux.conf` — the powerline branch is dead on both machines
+
+| machine | tmux | powerline-daemon | tpm |
+|---|---|---|---|
+| Mac | **3.7b** (mise) | **ABSENT** | present |
+| devcontainer | **ABSENT** | ABSENT | ABSENT |
+
+Controls: `git` resolves under the same `command -v` shape, so the ABSENTs are real; and grepping
+the same files for `powerline` → **0** while `tmux` → **1** (`~/.config/mise/config.toml:166`),
+so that 0 is an answer and not a broken probe.
+
+The container ships **zellij**, not tmux (`home/dot_config/mise/config.toml.tmpl:42`); tmux appears
+**0** times in `mise-system.toml`, `shared.toml` and the `Dockerfile`. So dotfiles' template has:
+
+- a **darwin** powerline arm guarded by `if-shell "command -v powerline-daemon"` — never true here;
+- **ubuntu/debian** and **fedora** arms — reached only where tmux does not exist.
+
+Every branch is inert. Removing them leaves 7 static lines, and **the file stops needing to be a
+template**.
+
+⚠️ tmux the *binary* comes from `~/.config/mise/config.toml` — **#434 row 8**, the file that goes
+**unmanaged** at takeover and is #440's subject. `mise run cc` refuses to launch without tmux. So the
+config file this ticket merges outlives the mechanism that installs the program that reads it, unless
+#440 lands first. (It is *drift* in that file, not source: `tmux` appears **0** times in mde's
+`dot_config/mise/config.toml.tmpl`; control `MDE_PROJECT_DIR` → found.)
+
+## The merged files
+
+### `home/dot_gitconfig.tmpl` — dotfiles' file, plus `[user]`
+
+Everything dotfiles has today, unchanged, plus the `[user]` block #439 derived from `gh api user`.
+From mde: **nothing**. `[filter "lfs"]` is already present with byte-identical values (same four
+keys, different order); `excludesFile`, `[safe]` and `[credential]` are all dropped per above.
+
+`.gitconfig` therefore **stops being a collision** — #434 row 10's "merging means dotfiles' config
+template must start emitting `data.git.*`" is the whole of it, and #439 already decided that.
+
+### `home/dot_config/git/ignore` — a plain file, both OSes
+
+mde's `dot_gitignore_global`, moved verbatim. Not OS-gated: the macOS block is inert noise on linux,
+while `.env`, `__pycache__`, `node_modules` and `*.log` matter in the container. **This adds a 14th
+target to #439's linux allow-list** — the set-equality gate will report a **DROP** on the missing
+entry unless the allow-list is updated in the same change. That is the gate working, and it is the
+one thing in this receipt that will fail loudly if forgotten.
+
+### `home/dot_tmux.conf` — a plain file, no longer templated
+
+mde's 49 lines are the base. Changes:
+
+- **drop** `status-right` — it shells out to
+  `$HOME/dev/github/ray-manaloto/macos-development-environment/scripts/status-dashboard.sh`, a path
+  that dies with the takeover. Leaving it would put a broken command in the status bar on every
+  redraw.
+- **keep** `set -s extended-keys on` + `set -as terminal-features 'xterm*:extkeys'` — mandated by
+  `.claude/skills/tmux-extended-keys/SKILL.md`, which names this exact source file.
+- **add** dotfiles' `set-window-option -g mode-keys vi` and `set-option -sg escape-time 10`.
+- **supersede** mde's four plain `bind h/j/k/l` with dotfiles' `bind-key -r -T prefix …` form
+  (`-r` makes them repeatable; same four panes).
+- **drop** the powerline branch entirely — no provider on either machine.
+- **keep** the tpm block. tpm is installed on the Mac; `run '~/.tmux/plugins/tpm/tpm'` is a no-op
+  where absent.
+
+**Stays on the linux allow-list, ungated.** The container has no tmux, so the file is inert there —
+but inert is not a leak: once `status-right` is dropped the file names no host path and no Mac-only
+program. Gating it on `ne darwin` would encode "the overlay currently ships zellij", which is a
+moving target, and #439's threat model is Mac *files* reaching the container (`private_dot_ssh`),
+not a dead config.
+
+## Adversarial review
+
+**Lens:** none
+**Verdict:** not-run
+**Findings:** 0 — n/a
+**Disposition:** n/a
+
+**Not run:** this is an inline main-session planning ticket with no code diff to review — the same
+shape as #445, whose receipt also recorded `lens: none` and which
+`docs/specs/ticket-bound-receipts.md` analyses. The falsifiable content here is the probe table, and
+every row of it carries its own control arm, which is the cheaper and more direct check.
+
+## Notes
+
+- **tpm does *not* clobber our settings — measured, because the naive reading says it does.**
+  `tmux-sensible` runs last (after `run '…/tpm'`) and would appear to overwrite `escape-time 10`
+  with `0`. It does not: `sensible.tmux:82` guards with
+  `if server_option_value_not_changed "escape-time" "500"`, i.e. it only sets a value still at
+  tmux's default. Same guard at `:87` for `history-limit` (mde's `100000` survives). No conflict to
+  resolve.
+- **What #446 got right and what it missed.** Right: `excludesFile`'s only referent is
+  `dot_gitignore_global`, and the two files are coupled. Missed: they are coupled *only* under the
+  assumption that a global ignore needs a config key — git's native path decouples them, so #434
+  row 11's "move-or-die **with** row 10" becomes a plain **move**, independent of row 10. Also
+  missed: `[safe]` is 8 entries and `[credential]` exists at all.
+- **The one decision beyond #446's stated scope** is dropping `[credential]`. It is recorded here
+  rather than deferred because nothing ships from a map ticket, so it is fully reversible — but it
+  is an auth surface, and if it should instead be carried (say, an HTTPS lane is planned), that is
+  a one-line reversal in a follow-up, not a re-run of this receipt. The native alternative if HTTPS
+  to GitHub is ever needed is `gh auth setup-git`, not a hardcoded absolute path
+  (`use-tool-builtins.md`); macOS's own `osxkeychain` is already effective today.
+- **Not decided here:** whether the merged tmux config should regain a `status-right` at all, and
+  what it would show (mde's was a live dashboard). Dropping it loses a feature; replacing it needs a
+  script that survives the takeover, which is a #431 task, not this one.
+- **Re-check if revisited:** whether `~/.config/mise/config.toml` still supplies tmux (it is drift,
+  not source — #440), and whether the linux overlay has gained tmux, which would make the tmux
+  config live on both machines and re-open the "does it stay a template" question.
+- **Fresh control string.** `xqjfmoz42` is now published in this file and is therefore **burnt** —
+  the next receipt must invent its own, per `probes-need-a-control-arm.md` rule 3.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — `home/dot_gitconfig`,
+  `home/dot_tmux.conf.tmpl`, `home/dot_config/mise/config.toml.tmpl`, `mise.toml [tasks.cc]`,
+  `.claude/skills/tmux-extended-keys/SKILL.md`, `.devcontainer/mise-system.toml`, the receipt and
+  report corpus; issues #434/#439/#446.
+- [ray-manaloto/macos-development-environment](https://github.com/ray-manaloto/macos-development-environment)
+  — `home/dot_gitconfig.tmpl`, `home/dot_gitignore_global`, `home/dot_tmux.conf`,
+  `home/dot_config/mise/config.toml.tmpl`.
+- [git/git](https://github.com/git/git) — `core.excludesFile` XDG default and `safe.directory`
+  ownership semantics, exercised directly against `git 2.50.1` rather than read.
+- [tmux-plugins/tmux-sensible](https://github.com/tmux-plugins/tmux-sensible) — `sensible.tmux`
+  `*_not_changed` guards, read from the locally installed plugin.
+
+<sub>Probes: `git check-ignore` in two isolated-`HOME` fixtures (Mac + devcontainer) with
+present/absent/non-matching arms; `git status` under `GIT_CONFIG_GLOBAL=/dev/null` and
+`GIT_TEST_ASSUME_DIFFERENT_OWNER=1` on listed and unlisted repos, both machines; `git credential
+fill` against `example.invalid` with `GIT_TERMINAL_PROMPT=0` and stdout discarded; `stat`/`test -x`
+on the eight `safe.directory` paths and both GCM paths; `chezmoi status` / `chezmoi diff` (read-only,
+no `apply`); `command -v` and `grep` sweeps with named controls; `devcontainer exec` for every
+container arm. No `chezmoi apply`, no writes to either repo's tracked tree; the container's
+`~/.config/git/ignore` probe file was created and removed within the probe.</sub>


### PR DESCRIPTION
Neither remaining colliding target is really a merge.

.gitconfig: `core.excludesFile` is redundant — git reads
`$XDG_CONFIG_HOME/git/ignore` natively (3 arms, both machines), so
`dot_gitignore_global` moves to `home/dot_config/git/ignore` and the key
dies. All 8 `[safe] directory` entries are inert on Mac AND container
(4-arm probe; every path is uid 501, the bind mount presents uid 1000).
`[filter "lfs"]` is a byte-equivalent duplicate. So the merged file is
dotfiles' behaviour-only config plus #439's `[user]` block, and
.gitconfig stops being a collision.

Scope correction: #446 names two remainder keys; there are four. The
unnamed one is `[credential]`, whose arch branch renders
/opt/homebrew/... on this arm64 Mac where only /usr/local/... exists —
an error on every HTTPS credential lookup, for remotes that are all SSH.

.tmux.conf: dotfiles' only templating is a powerline branch dead on both
machines (no powerline-daemon on the Mac, no tmux in the container —
the overlay ships zellij), so the merged file is plain. It carries
mde's extended-keys pair, which this repo's own tmux-extended-keys skill
already prescribes for a file that never received it.

Net: #439's linux allow-list goes 13 -> 14 (+ .config/git/ignore).

Gates: lint rc=0 · lint-docs rc=0 · pytest 1144 passed · verify 112
passed/0 failed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014x8jGSieFkDBV95KLXYhTC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788238347&installation_model_id=429246&pr_number=478&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F478&signature=b6f31fa2ea2b0de1b93c40bade93e9fec2fa212d20d2f96426f5e043371f2ad1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added receipt `#446` documenting the resolution of Git and tmux configuration conflicts.
  - Clarified retained settings, removed redundant or inactive configuration, and documented updated ignore-file handling.
  - Recorded compatibility details for extended keys, vi mode, pane controls, and TPM integration.
  - Updated the Linux target allow-list and included validation results, caveats, and affected repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->