### PR TITLE
docs(receipts-spec): the control-arm field did a reviewer's job, and a printed warning did not

### DIFF
--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -84,12 +84,16 @@ Used by `/wayfinder`. The **map** is a single issue with **child** issues as tic
   machine-verifiable, and even then only that *a* query ran. Design of record + the 42 reasons:
   `docs/specs/ticket-bound-receipts.md` (⛔ NOT FOR BUILD). Worked example: `docs/receipts/449.md`.
   **The three-ticket pilot (#437, #438, #440) ran and was judged on 2026-08-01 — verdict: keep the
-  practice, still build nothing** (§12). Across 5 receipts: **113 findings, 4 refuted**. The pilot's
+  practice, still build nothing** (§12). Across the **7 reviewed** receipts: **149 findings, 7
+  refuted (4.7%)** — #445 and #446 ran `lens: none` and sit outside that denominator. The pilot's
   first 4 were 87/1, read as the receipts being under-defended, so the template gained **if a review
   finding can be settled by running something, run it before writing the disposition** — and #448,
   the first receipt written under that rule, went **3 refuted of 26**, every one settled by a probe.
-  It also had the review **reverse the verdict outright**. Even a control-arm verifier would have
-  *passed* #440's real failure, because the query ran and returned nothing.
+  It also had the review **reverse the verdict outright**. A *machine* control-arm verifier would
+  still have **passed** #440's real failure, because the query ran and returned nothing — but the
+  **human** arm catches it: in #446 the known-present term returned 0, which is the only reason a
+  broken search did not become the receipt. On an unreviewed receipt the fields are the whole
+  apparatus.
 - **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a
   context pointer to the map's Decisions-so-far. The verdict goes in the **comment**; the evidence
   stays in the **receipt**, linked — they carry different content, never mirrored.

--- a/docs/specs/ticket-bound-receipts.md
+++ b/docs/specs/ticket-bound-receipts.md
@@ -622,6 +622,35 @@ this spec's own.
 > here only because it is the second consecutive receipt whose worst moment came from the probe
 > apparatus rather than from the reasoning.
 
+> **Fifth post-pilot data point, 2026-08-02 — the control-arm field did a reviewer's job, and that is
+> the first time any field has.** `446.md` (#9) also ran `lens: none`, so the reviewed denominator
+> stays **149 findings, 7 refuted (4.7%)** across **7** receipts, and two of the last three receipts
+> are now unreviewed. The trend that matters is elsewhere.
+>
+> §1 argued the control arm is the field that has earned its place, and #440 was the evidence: a
+> search broken by zsh's non-word-splitting of an unquoted `$CORPUS`, with `2>/dev/null` eating the
+> error. **It happened again here, in a session that had #440's warning printed in the very template
+> being filled in** — the known-present arm returned **0**, the query set returned a clean-looking
+> "no prior art", and the arm is the only reason that did not become the receipt. Re-run with literal
+> paths, the same queries surfaced five hits, one of which
+> (`.claude/skills/tmux-extended-keys/SKILL.md`, reached via `436.md`) turned out to be the decisive
+> source for half the verdict and is now [#479](https://github.com/ray-manaloto/dotfiles/issues/479).
+>
+> Two readings follow, and both are uncomfortable. The useful one: **a required field caught a defect
+> the author could not see, which is precisely what §1 claimed adversarial review was for** — so on
+> an unreviewed receipt the fields are not ritual, they are the whole apparatus. The other: **a
+> warning printed in the template did not prevent the mistake it describes.** Documentation of a
+> footgun is not a guard against it; only the arm that *runs* was load-bearing. That is an argument
+> for [#337](https://github.com/ray-manaloto/dotfiles/issues/337) (machine-enforce "a 0-result grep
+> is not an answer") rather than for more prose, and it is now a durable memory
+> (`feedback_zsh_no_word_splitting`) rather than a fourth burial inside a session note.
+>
+> One field-shaped gap, recorded not fixed: the receipt's **Sources** list is where a *premise
+> correction* surfaced — #446 named two remainder keys and its subject file had four — but no field
+> asks "does the ticket's own framing survive contact with the artifact?". Three of the last five
+> receipts corrected their ticket's premise. If a sixth field is ever added, that is the candidate;
+> the pilot's §7 conclusion (three edits and nothing else) still stands until then.
+
 ### 1. Which fields were real, which became ritual?
 
 **Real, and the highest-value field in all four: the adversarial review.** It was never once


### PR DESCRIPTION
Fifth post-pilot data point. #446 also ran `lens: none`, so the reviewed
denominator is unchanged at 149 findings / 7 refuted (4.7%) across 7
receipts — the finding is elsewhere.

zsh's non-word-splitting of an unquoted $CORPUS broke #446's prior-art
search exactly as it broke #440's, in a session with #440's warning
printed in the very template being filled in. The known-present arm
returned 0, which is the only reason a broken search did not become the
receipt. Re-run with literal paths it surfaced five hits, one of which
became #479.

Two readings: on an unreviewed receipt the required fields are the whole
apparatus, not ritual — and documentation of a footgun is not a guard
against it, which argues for #337 rather than more prose.

Also corrects a stale count in docs/issue-tracker.md (it read "5
receipts: 113 findings, 4 refuted" against the spec's 149/7 across 7),
and sharpens the control-arm sentence: a machine verifier would still
pass #440's failure, but the human arm caught the same class in #446.

Gates: lint rc=0 · lint-docs rc=0.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014x8jGSieFkDBV95KLXYhTC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788241239&installation_model_id=429246&pr_number=480&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F480&signature=85f53ee5ec62ceebf5bcf0a4ec46cf85aacd139ef9d0407e6b0d9a47f189f701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->