### PR TITLE
docs(receipts): #460 — this repo owns no fnox writer, so the mitigation is detection

### DIFF
--- a/docs/receipts/460.md
+++ b/docs/receipts/460.md
@@ -1,0 +1,216 @@
+# Receipt — #460: fnox config writes are unlocked and non-atomic — the two-tier guard, tracked locally
+
+**Verdict:** Scoped to what **this repo** can do, the answer is **detection, not prevention** — and
+only one of the three candidate mitigations is worth building. **(1) "Serialize our own call sites"
+is N/A**: this repo invokes the `fnox` binary **zero** times (control-armed), so there are no call
+sites to serialize; every writer lives in `macos-development-environment`. **(2) "Detect a truncated
+config" is already done for every shape that yields empty or invalid TOML** — `check_fnox_baseline`
+catches all of them today. **(3) Extending `doctor.toml` with the full secret NAME SET is the one
+mitigation with durable value**, because it catches the *persistent* damage class (a lost update
+silently dropping a secret) rather than the transient one, and it closes (2)'s single residual hole
+for free. That hole is measured, not hypothetical: on the live config **14 of 49 secrets sit past
+the deepest thing the doctor checks**, and a loss confined to them reports **zero findings**. The
+native tool cannot substitute — `fnox check` is a probe that **can only pass** for this class, by
+construction. **No code ships from this ticket** (decide-first); the implementation is the
+follow-up named under "Notes".
+
+**Resolved:** 2026-08-02
+
+## Sources — what I actually opened
+
+- `python/src/dotfiles_setup/doctor.py` — `read_fnox` (L210), `check_fnox_baseline` (L535),
+  `_opt_in_findings` (L570). Settled exactly which drift shapes are covered today.
+- `doctor.toml` `[fnox]` — the reviewed baseline: `env = "exec"` plus the 4-name `env_true` set.
+  Settled that the baseline declares **4 of 49** secret names, and nothing about the other 45.
+- `~/.config/fnox/config.toml` — **layout only, no values read or printed.** Settled the blind-zone
+  size: 49 secrets in inline-table form, deepest opt-in at ordinal 34/49.
+- `fnox --help`, `fnox check --help`, `fnox doctor --help`, `fnox list --help` (live binary,
+  **v1.32.0**) — settled the use-tool-builtins gate.
+- `docs/research/mintlify-cache/jdx/fnox/llms-full.txt` — fnox's own docs. Settled that no native
+  locking/integrity feature exists for `config.toml`, and disposed of one apparent contradiction.
+- `docs/research/kb/reports/agents/concurrency-sweep-433.md` — the source-level sweep that
+  established the defect. Settled the two damage classes and that its scope was fnox's source,
+  not this repo's call sites.
+- `docs/receipts/438.md`, `docs/receipts/437.md` — the upstream patch design and the misattribution
+  correction.
+
+## Prior art — the search I ran
+
+**Query:** `grep -rlEi 'flock|lost update|atomic write|non-atomic|read-modify-write' docs/research/kb/reports docs/specs docs/receipts docs/rules-evidence`
+**Corpus:** `docs/research/kb/reports/`, `docs/specs/`, `docs/receipts/`, `docs/rules-evidence/`
+
+Corpus paths written **literally**, not via a shell variable — zsh does not word-split an unquoted
+`$var`, which is what broke #440's search and nearly broke #446's.
+
+### Control arm — REQUIRED, and run it before you believe any result
+
+**Known-present term:** `fnox` → **17** hits
+**Known-absent term:** `qvnzt8w` → **0** hits
+
+Fresh known-absent string. `zzqqxx` and `xqjfmoz42` are both **burnt** — published in earlier
+receipts, so they are now in the corpus.
+
+**Could this fixture have produced the other result?** Asked before reading output, twice, and it
+paid twice. (a) My first `check_fnox_baseline` fixture emitted **invalid TOML** — the intact arm
+FAILED, which is impossible for a healthy config, so the renderer was wrong, not the check. (b) My
+layout probe's own regex assumed `[secrets.NAME]` headers; the real file uses inline tables, so it
+matched **0 of 49** and every derived line number was `None`. Both were caught by an in-probe
+control (`headers matched == secrets`), not by inspection. (c) The `fnox check` fixture's control
+was `fnox config-files`, and it caught the **#441 trap live**: fnox silently merged
+`~/.config/fnox/config.toml` into the isolated fixture (98 secrets = 49 fixture + 49 real).
+
+| Hit | What I did with it |
+|---|---|
+| `docs/research/kb/reports/agents/concurrency-sweep-433.md` | **read** — the load-bearing prior art. Q2 establishes both damage classes from source: a **silent lost update** (last writer wins, no versioning/etag/conflict detection) and, because `fs::write` truncates in place, a **reader observing a half-written TOML**. Names "an agent and a human" as the concurrent pair. Its scope is fnox's source, **not** this repo's call sites — so the mitigation-1 finding below is new, not a restatement. |
+| `docs/receipts/438.md` | **read** — the upstream two-tier patch design. Confirms the design is complete and that Ray ruled out an upstream issue/PR, which is what makes #460 local-only. Not re-derived. |
+| `docs/receipts/437.md` | **read** — row 8 corrects a misattribution: the `mde-py` config wipe is a **code-generation** defect, not a race, and "fnox is EXONERATED". Kept me from folding the wipe into this ticket's damage model; they are separate causes with the same-looking result. |
+| `docs/research/kb/reports/agents/codex-adversarial-438-flock-replacement.md` | **read** — its CRITICAL finding is that a guard inside the write *function* starts too late for some callers. That is the tier A/B split already in #460's body; it constrains the **upstream** patch, not a local mitigation. |
+| `docs/research/kb/reports/agents/currency-review-rev2.md` | **read — same defect class, different owner.** OPEN-5: `save_current` writes non-atomically and `load_previous` swallows the parse error, so a truncated state file is indistinguishable from "first ever run". That is `kb_setup.currency` in the **knowledge-base** repo, not this one. Recorded under "Notes"; out of scope here. |
+| `docs/research/kb/reports/agents/adversarial-secrets-takeover-20260730.md` | **dismissed** — its flock finding is about the *takeover design's* proposed lock, a different artifact from fnox's config path. |
+| `docs/specs/second-brain-design.md` | **dismissed** — flock mentioned as a property of an upstream dependency (#1059) that makes fan-out safe. No bearing on fnox. |
+| `docs/specs/research-nudge-hooks.md` | **dismissed** — non-atomic *statusline state file*. Different artifact; its concurrency measurement (61 of 92 hours had ≥2 sessions active) is a useful reachability data point, noted below. |
+| `docs/research/kb/reports/agents/graphify-embedding-archaeology.md` | **dismissed** — an atomic-write comment in graphify's own writer. Different tool. |
+| `docs/research/mintlify-cache/jdx/fnox/llms-full.txt:3714` | **read — an apparent contradiction, resolved.** "Atomic writes protect against corruption" appears to refute #438's source reading. It does not: it sits inside the **KeePass provider** accordion and describes the `.kdbx` database file, not `config.toml`. Worth recording because the line is greppable and reads like a config guarantee out of context. |
+
+## The measurements
+
+### 1. This repo invokes `fnox` zero times — so there is nothing to serialize
+
+```
+git grep -nIE '"fnox"|^ *fnox |run = .*fnox|\$\(fnox' -- python/src scripts/ mise.toml .config/ .claude/settings.json .claude/hooks
+```
+
+**3 hits, none an invocation** — all in `doctor.py`: a dict key (L185), a path literal (L355), a
+local variable (L548). Control arms, identical shape and corpus: `chezmoi` → **3**, `docker` →
+**37**. Both non-zero, so the pattern does find real invocations; the zero is the world, not the
+probe.
+
+⇒ **Mitigation (1) is inapplicable.** The writers are `mde-secret-add` / `mde-py bootstrap_config`
+in `macos-development-environment`. This repo is a **pure reader** of the fnox config, exactly once
+per session, via the SessionStart doctor hook.
+
+### 2. What `check_fnox_baseline` sees today — six arms
+
+Fixture mirrors the real configuration rather than isolating the variable: 49 inline-table secrets
+under one `[secrets]` header, `env = "exec"` at the root, a `sync` block per secret, and the four
+sanctioned opt-ins at the **same ordinals the live file has** (9, 12, 21, 34 of 49). Every path
+under a `TemporaryDirectory`; no real config read or written.
+
+| Arm | Config state | Result |
+|---|---|---|
+| A | intact, 49/49 | **PASS**, 0 findings — *control: the check can pass* |
+| B | wipe-shaped (no `env` line, no `sync`) | FAIL, 3 findings — *control: the check can fail* |
+| C | **empty file** (`File::create` truncate-to-zero window) | FAIL, 2 findings — **caught** |
+| D | torn mid-line (invalid TOML) | FAIL, 1 finding — **caught** |
+| E | **tail lost, 35/49, all 4 opt-ins intact** | **PASS, 0 findings — FALSE PASS** |
+| F | tail lost, 22/49, 3 of 4 opt-ins | FAIL, 1 finding — caught, but **only by luck**: an opt-in happened to be in the lost tail |
+
+Arms C and D are why mitigation (2) is largely already done. **Arm E is the whole residual gap**,
+and F shows the existing coverage is incidental rather than designed — it depends on where the loss
+lands relative to four names out of forty-nine.
+
+**Blind zone, measured on the live config** (layout only): 49 secrets, 70 lines, one inline table
+per line; deepest sanctioned opt-in at **ordinal 34/49, line 55 of 70**. So **14 secrets sit past
+the last thing the doctor checks**, and any loss confined to them is arm E.
+
+### 3. `fnox check` cannot detect this class — by construction
+
+The use-tool-builtins gate: before proposing custom code, check whether the tool already does it.
+`fnox check` — *"Check if all required secrets are defined and configured"* — sounds like exactly
+the right built-in. It is not, because **`if_missing` is declared per-secret inside the same file
+that loses the secret**. A dropped line drops its own requirement, so nothing is left to be missing.
+
+| Arm | `fnox check` rc | Output |
+|---|---|---|
+| intact, 49 secrets | **0** | `✓ Configuration is healthy` |
+| lost, 35 secrets | **0** | `✓ Configuration is healthy` |
+| control: secret with unknown provider | **0** | `✓ Configuration is OK (with warnings)` |
+
+It does not discriminate the two arms — and the control shows it returns **rc=0 even on a real
+defect**, so it never fails at all. Two further reasons not to build on it: `fnox config-files`
+proved it **silently merges `~/.config/fnox/config.toml`** into any invocation, so its
+`Found N secret(s)` count is contaminated (98, not 49); and the doctor already parses the file
+directly, which is cheaper and unambiguous. No other subcommand covers it — the full command list
+was enumerated from the live binary, and there is no `verify`, `fsck`, or integrity command.
+fnox's own docs likewise carry no locking/integrity feature for `config.toml`.
+
+### 4. The proposed mitigation, armed both directions
+
+Prototyped in the scratchpad only — **nothing ships from this ticket.** Both candidates were run
+against the intact arm (must pass), the tail-lost arm (must fail), and a renamed-secret arm.
+
+| Candidate | intact | tail-lost 35/49 | one secret renamed |
+|---|---|---|---|
+| **name set** (`[fnox] secrets = [...49 names]`) | PASS | **FAIL — caught**, `14 declared secret/s GONE` | **FAIL — caught** |
+| count floor (`min_secrets = 49`) | PASS | FAIL — caught | **PASS — missed** |
+
+The name set wins, and it wins for the reason `check_fnox_baseline`'s own docstring already gives
+about the opt-in set: *"Checking the NAME SET rather than a count is deliberate: a swap keeps the
+count and is exactly the change worth catching."* Applying the same rule to all 49 rather than 4 is
+a widening of an existing decision, not a new mechanism.
+
+**Secret names are not secrets** — four are already in `doctor.toml` in plain text, and the file's
+whole purpose is to declare setup facts in a reviewed diff.
+
+## Adversarial review
+
+**Lens:** none
+**Verdict:** not-run
+**Findings:** 0 — n/a
+**Disposition:** n/a
+
+**Not run:** this is an inline main-session planning ticket that ships no code, and its four claims
+are each settled by a control-armed probe in this receipt rather than by argument — the shape a
+cold reviewer adds least to. Recorded here rather than omitted, per the template, and it is the
+sixth consecutive `lens: none` data point for `docs/specs/ticket-bound-receipts.md`.
+
+## Notes
+
+**Why detection and not prevention.** #460's headline is "unlocked and non-atomic", but this repo
+owns neither writer nor lock. What it owns is the ability to **notice the damage**. Of the two
+damage classes the #433 sweep established, they are not equally worth local effort:
+
+- a **torn read** (reader concurrent with a writer) is transient and self-healing — the doctor runs
+  once per session and always exits 0, so a missed one is recovered on the next session, and arms
+  C and D show the two shapes that reach the parser are already caught;
+- a **lost update** is durable. It presents as arm E, it never heals, and nothing on this host
+  would ever report it.
+
+So the mitigation is aimed at the lost update, and closing arm E is a by-product.
+
+**Reachability is not theoretical.** The #433 sweep names "an agent and a human" as the concurrent
+pair, and this host has both: `.claude/rules/secrets-out-of-the-shell-env.md` records that the
+2026-07-30 config wipe was triggered by a hand-run `mde-secret-add` **an agent recommended**. The
+adjacent statusline research measured **61 of 92 hours (66%) with ≥2 Claude Code sessions active**
+on this Mac, so concurrent agent activity is the normal case, not the edge.
+
+**Follow-up ticket (the code, shipped separately).** Add `secrets = [...]` to `doctor.toml`'s
+`[fnox]` section and a `check_fnox_secret_set` alongside `check_fnox_baseline`, reporting both
+directions (declared-but-gone, present-but-undeclared) with tests binding both arms. Cost to
+accept: every legitimate add or remove then needs a `doctor.toml` diff. That is the doctor's
+existing stated doctrine — *"Changing your setup means changing `doctor.toml` in a reviewed diff"* —
+not a new tax, and it is the same trade already taken for the four opt-ins.
+
+**Version drift in the ticket body.** #460 records fnox **v1.31.1** as installed; the live binary
+is **v1.32.0**. The analysis is unaffected — the body already scopes itself to both and states the
+write path is unchanged in 1.32.0 — but the "installed" label is now stale.
+
+**Same defect class, different owner.** `kb_setup.currency`'s `save_current` (knowledge-base repo)
+writes state non-atomically while `load_previous` swallows the parse error, making a truncated file
+indistinguishable from a first run. Not this repo, not this ticket — recorded so the pairing is not
+rediscovered from scratch.
+
+**Do not re-derive.** The three probe scripts were scratchpad-only and are gone. Every number above
+is transcribed with its control arm; re-running is cheap if a claim is doubted, but nothing here
+depends on a surviving fixture.
+
+## GitHub repos touched
+
+- [jdx/fnox](https://github.com/jdx/fnox) — the config write path under analysis; docs cache and
+  the live v1.32.0 binary's command surface.
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — this repo: the doctor, its
+  baseline, and the call-site enumeration.
+- [ray-manaloto/knowledge-base](https://github.com/ray-manaloto/knowledge-base) — `kb_setup.currency`,
+  named only as the same-class adjacent finding.
+- [ray-manaloto/macos-development-environment](https://github.com/ray-manaloto/macos-development-environment) —
+  where every fnox writer this repo is exposed to actually lives.


### PR DESCRIPTION
`fnox`'s config write path is an unlocked, non-atomic read-modify-write. Scoped
to what THIS repo can do about a writer it does not own, three candidate
mitigations were evaluated and only one survives.

- Serializing our own call sites is N/A: this repo invokes the `fnox` binary
  ZERO times (3 grep hits, all non-invocations in doctor.py; control arms
  chezmoi=3, docker=37 prove the shape finds invocations). Every writer lives
  in macos-development-environment. This repo is a pure reader.
- Truncation detection is already done for both shapes that reach the parser:
  an empty file and a torn mid-line file each produce findings today.
- The residual hole is a loss landing on a line boundary past the deepest
  sanctioned opt-in. Measured on the live config: 14 of 49 secrets sit past it,
  and a loss confined to them reports ZERO findings.

Extending `doctor.toml` with the full secret NAME SET closes it, and matters
mainly because it catches the durable damage class — a lost update — not just
the transient torn read. Prototyped and armed both ways; a count floor misses a
renamed secret, which is the argument `check_fnox_baseline`'s own docstring
already makes for the opt-in set.

`fnox check` cannot substitute: `if_missing` lives per-secret in the same file,
so a dropped secret drops its own requirement. Measured intact-49 and lost-35
both rc=0 "healthy", with a control showing it returns rc=0 even on a real
defect.

No code ships from this ticket — the implementation is a named follow-up.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014x8jGSieFkDBV95KLXYhTC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788242460&installation_model_id=429246&pr_number=481&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F481&signature=54994e3bb4e241ed3cd2cf14622894a3ed67b598f8086fb358ad615c12f320ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added receipt `#460` documenting configuration validation findings and testing results.
  * Recorded limitations in detecting certain truncated configurations and recommended declaring the complete secret name set in a follow-up.
  * Included supporting references, measurements, scope notes, and review status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->