### PR TITLE
docs(receipts-spec): the lens has been off three receipts running, and it cost something

### DIFF
--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -85,7 +85,8 @@ Used by `/wayfinder`. The **map** is a single issue with **child** issues as tic
   `docs/specs/ticket-bound-receipts.md` (⛔ NOT FOR BUILD). Worked example: `docs/receipts/449.md`.
   **The three-ticket pilot (#437, #438, #440) ran and was judged on 2026-08-01 — verdict: keep the
   practice, still build nothing** (§12). Across the **7 reviewed** receipts: **149 findings, 7
-  refuted (4.7%)** — #445 and #446 ran `lens: none` and sit outside that denominator. The pilot's
+  refuted (4.7%)** — #445, #446 and #460 ran `lens: none` and sit outside that denominator, and they
+  are the **three most recently resolved**, so the lens has now been off three in a row. The pilot's
   first 4 were 87/1, read as the receipts being under-defended, so the template gained **if a review
   finding can be settled by running something, run it before writing the disposition** — and #448,
   the first receipt written under that rule, went **3 refuted of 26**, every one settled by a probe.

--- a/docs/specs/ticket-bound-receipts.md
+++ b/docs/specs/ticket-bound-receipts.md
@@ -651,6 +651,36 @@ this spec's own.
 > receipts corrected their ticket's premise. If a sixth field is ever added, that is the candidate;
 > the pilot's §7 conclusion (three edits and nothing else) still stands until then.
 
+> **Sixth post-pilot data point, 2026-08-02 — a receipt about control arms shipped an unmeasured
+> number, and no field caught it.** `460.md` (#10) also ran `lens: none`, so the reviewed denominator
+> is again unchanged at **149 findings, 7 refuted (4.7%)** across **7** receipts. But 445, 446 and
+> 460 are the **three most recently resolved**, so the review lens has now been off **three in a
+> row** — the fifth data point's "two of the last three" is now a trend, not a blip, and §1's claim
+> that the fields are "the whole apparatus" on an unreviewed receipt is carrying more weight each
+> time.
+>
+> It did not hold here. The receipt's own **Adversarial review** section claimed "the sixth
+> consecutive `lens: none`" — a number written from memory, never measured, in the one field whose
+> job is to describe the receipt practice itself. It is the **third** of ten (445, 446, 460).
+> Nothing caught it: not the control-arm field (which governs the prior-art search, not prose
+> elsewhere in the document), not lint, not the author. It **merged**, and needed a second PR (#482)
+> to correct on `main`.
+>
+> Two things follow. First, **the control-arm discipline is scoped to one field and the rest of the
+> receipt is unguarded** — a receipt is mostly prose, and prose carries numbers. The fifth data point
+> concluded that "only the arm that *runs* was load-bearing"; this one narrows it further, to only
+> the arm that runs *in the field that has one*. Second, and worse for the no-review verdict: this is
+> exactly the defect class a cold reviewer finds cheaply — an unsourced count is visible without any
+> session context. Three consecutive unreviewed receipts is how it got through.
+>
+> That is not an argument to reinstate the lens by default (§12 judged the cost honestly), but it is
+> the first measured cost of *not* running it, and it should be weighed the next time `lens: none` is
+> chosen for a receipt that makes claims about the practice. #460 also corrected its own ticket's
+> premise — the body records fnox **v1.31.1** as installed where the live binary is **v1.32.0** —
+> which adds to the premise-correction pattern the fifth data point named; deliberately **not**
+> restated as a new count here, since inventing an unverified figure is the very thing this entry
+> exists to record.
+
 ### 1. Which fields were real, which became ritual?
 
 **Real, and the highest-value field in all four: the adversarial review.** It was never once


### PR DESCRIPTION
Sixth post-pilot data point. `460.md` also ran `lens: none`, so the reviewed
denominator is unchanged again at 149 findings / 7 refuted across 7 receipts —
but 445, 446 and 460 are the three most recently resolved, so the review lens
has now been off three in a row.

The interesting part is that the fields did not carry it. The receipt's own
adversarial-review section claimed "the sixth consecutive `lens: none`" — a
number written from memory, never measured, in the one field whose job is to
describe the receipt practice. It is the third of ten. Nothing caught it: not
the control-arm field (which governs the prior-art search, not prose elsewhere),
not lint, not the author. It merged, and needed a second PR to correct on main.

So the control-arm discipline is scoped to one field while a receipt is mostly
prose, and prose carries numbers. And an unsourced count is exactly what a cold
reviewer finds cheaply, without any session context — three consecutive
unreviewed receipts is how it got through. Not an argument to reinstate the lens
by default, but the first measured cost of not running it.

`docs/issue-tracker.md`: the `lens: none` set was stale at "#445 and #446".

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014x8jGSieFkDBV95KLXYhTC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788276280&installation_model_id=429246&pr_number=484&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F484&signature=949042ff282d0e45bb33dee2356df2f54ae1f2462d5fda52985ef792b734db91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Wayfinding receipt statistics to reflect three consecutive `lens: none` receipts, including resolved ticket 460.
  * Added a sixth post-pilot data point documenting the correction associated with receipt 460.
  * Clarified that control-arm validation covers prior-art fields only, and that broader receipt prose and numerical claims may require additional review.
  * Documented the corrected ticket premise without adding an unverified aggregate count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->