### PR TITLE
docs(wayfinder): the spec was hand-written in place of /to-spec, and the map was never done

### DIFF
--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -16,6 +16,32 @@ Adapted from the `setup-matt-pocock-skills` seed template. Consumed by
 > `/setup-matt-pocock-skills`** — it also edits the root `CLAUDE.md`, which the
 > `claude_md_import_stub` hk step rejects (that file must be byte-exactly `@AGENTS.md\n`).
 
+## ⚠️ The protocol's own verbs are USER-INVOKED ONLY — name the command, never hand-roll it
+
+The chain is **`/wayfinder` → `/to-spec` → `/to-tickets` → `/triage` / `/implement`**. Every verb in
+it carries `disable-model-invocation: true`, so **an agent cannot invoke any of them.** Measured
+2026-08-02 across all 17 `skills/engineering/*` — the **9** with that flag are *exactly* the 9 absent
+from the agent's invocable skill list, against **8** present with it off:
+
+| User-invoked only (agent CANNOT call) | Agent-invocable |
+|---|---|
+| `wayfinder` · `to-spec` · `to-tickets` · `triage` · `implement` · `ask-matt` · `grill-with-docs` · `improve-codebase-architecture` · `setup-matt-pocock-skills` | `research` · `prototype` · `grilling`¹ · `domain-modeling` · `tdd` · `code-review` · `codebase-design` · `diagnosing-bugs` · `resolving-merge-conflicts` |
+
+¹ `grilling` lives under `skills/productivity/`, not `skills/engineering/`.
+
+**When the next step in the protocol is one of the left column: STOP, tell the human which command
+to type, and do not produce its output by hand.** Hand-rolling a protocol verb is a
+[`use-tool-builtins.md`](../.claude/rules/use-tool-builtins.md) violation, and it silently drops
+whatever that skill's process adds — `to-spec` alone contributes a **seam sketch checked with the
+user**, **User Stories**, **Testing Decisions**, and a standing *"do NOT include specific file paths
+or code snippets — they go stale fast"*.
+
+**Why this is written down:** on 2026-08-02 a session reached the edge of #431's map, felt the pull
+to *"just write the spec"* — which `wayfinder`'s own **Plan, don't do** section names as the signal
+to **hand off** — and hand-wrote `docs/specs/secrets-takeover.md` instead of saying "run
+`/to-spec`". The unreachable verb is the mechanism: the correct next action was invisible from the
+agent's side, so it substituted its own. See `.claude/rules/use-tool-builtins.md`.
+
 ## ⚠️ Repo-specific: PR creation is guard-denied
 
 **`gh pr create` is DENIED by this repo's PreToolUse guard** (`hook_guard.py`, rule `"gh pr create"`).
@@ -98,6 +124,14 @@ Used by `/wayfinder`. The **map** is a single issue with **child** issues as tic
 - **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a
   context pointer to the map's Decisions-so-far. The verdict goes in the **comment**; the evidence
   stays in the **receipt**, linked — they carry different content, never mirrored.
+- ⚠️ **An empty ticket queue is NOT the map's done-condition.** Done is *"nothing left to decide
+  before someone goes and does the thing"*, and resolving a ticket is supposed to **graduate** any
+  fog it made specifiable into fresh tickets (`wayfinder` step 5). So a map with **zero open
+  children and a full "Not yet specified"** has not finished — the frontier stalled, because
+  graduation stopped happening. Apply wayfinder's own test to every fog item before declaring done:
+  **ticket it when the question is already sharp, even if blocked**; leave it as fog only when you
+  cannot yet phrase it that precisely. Observed on #431, 2026-08-02: queue empty, **19** fog items,
+  at least three of them sharp enough to ticket that day.
 
 ### Prerequisites — all verified live on 2026-07-15
 

--- a/docs/specs/secrets-takeover.md
+++ b/docs/specs/secrets-takeover.md
@@ -16,6 +16,31 @@ Nothing assembles them. That is this file's whole job.
 **This spec is a planning artifact.** No code ships from it. Each step becomes ordinary work with
 its own PR and its own gates.
 
+> ## ⚠️ STATUS — this is an INPUT to `/to-spec`, not its output (corrected 2026-08-02)
+>
+> This file was hand-written. The protocol is **`/wayfinder` → `/to-spec` → `/to-tickets` →
+> `/implement`** (`docs/issue-tracker.md`), and `/to-spec` is **user-invoked only** — so the session
+> that reached the edge of #431's map substituted its own document for the skill's. What that
+> dropped, concretely: `/to-spec`'s **seam sketch checked with the user**, its **User Stories** and
+> **Testing Decisions** sections, and its standing *"do NOT include specific file paths or code
+> snippets — they go stale fast"* (which **A2 below actively contradicts**).
+>
+> **Two things follow, and neither is optional:**
+>
+> 1. **The map is not done, so `/to-spec` is not yet due.** `wayfinder`'s done-condition is
+>    *"nothing left to decide"*, and resolving a ticket must **graduate** newly-sharp fog into fresh
+>    tickets. #431 has **zero open children and 19 fog items** — the frontier stalled. Sharp items
+>    become `wayfinder:<type>` tickets **before** any spec is written.
+> 2. **A6 is superseded for sharp items.** "Name every open item as open in the spec" is the wrong
+>    instrument under wayfinder: a fog item you can phrase precisely is a **ticket**, not a spec
+>    bullet. § 5 stays as the classification work-product, but it is a *triage input* for
+>    graduation, not the resting place.
+>
+> What survives unchanged: the assembled decisions (§§ 1–4), the evidence index (§ 8), and the
+> `NEW` decisions in § 6 — those are real work, and `/to-spec` should consume them.
+> Publishing to `docs/specs/` rather than a tracker issue is **not** part of the error: #431's Notes
+> says *"Specs here are persistent… we do not adopt the disposable-spec habit."*
+
 **Resolution decreases with distance** (approved 2026-08-02). Phases 1–2 carry PR-sized steps;
 phases 3–4 carry the transition, its exit gate and its open items, and are deepened when their
 preconditions come near. That is deliberate: #448 records `mise dotfiles` → `mise bootstrap
@@ -90,6 +115,12 @@ Resolving them is explicitly out of scope — the lock is *name them as open*. O
 failure.
 
 *Fails when:* an open item is absent, or unclassified, or quietly answered.
+
+⚠️ **SUPERSEDED IN PART (2026-08-02) — see the STATUS banner.** Under `wayfinder`, a fog item you can
+**phrase precisely** is a **ticket**, not a spec bullet, *"even if it's blocked and you can't act on
+it yet."* So A6's classification is the right *triage*, and the wrong *destination* for the sharp
+ones. § 5 stands as the work-product; the sharp rows graduate to `wayfinder:<type>` child issues
+before `/to-spec` runs.
 
 ### A7 — Rollback per transition
 


### PR DESCRIPTION
Ray, at clear-prep: "shouldn't we have run /to-spec?" Yes. And the answer
exposed a larger miss than the one asked about.

docs/issue-tracker.md names the chain /wayfinder -> /to-spec -> /to-tickets ->
/triage, and wayfinder's own "Plan, don't do" section says the pull to just do
the work is the signal to HAND OFF. The prior PR hand-wrote the spec instead.
That is use-tool-builtins.md violated in its exact shape, and it silently
dropped what the skill contributes: a seam sketch checked with the user, User
Stories, Testing Decisions, and a standing "do NOT include specific file paths
or code snippets" — which the spec's own A2 requires on every step.

The root cause is mechanical, which is why it needed writing down rather than
just fixing. Measured across all 17 skills/engineering/*: the 9 carrying
disable-model-invocation: true are EXACTLY the 9 absent from the agent's
invocable list, against 8 present with the flag off. An agent cannot call
/to-spec. The correct next action was invisible from its side, so it
substituted its own — nothing errored, no gate fired, the absence just read as
"there is no tool for this". docs/issue-tracker.md now carries that table and
the instruction: when the next step is one of those verbs, STOP and name the
command.

The larger miss: an empty ticket queue is not wayfinder's done-condition. Fog
is meant to GRADUATE into tickets on each resolution; #431 has 0 open children
and 19 fog items, so the frontier stalled — graduation stopped, not the fog.
Applying wayfinder's own test (ticket it when the question is already sharp,
even if blocked) to all 19: roughly 13 are ticketable today, 2 already have
issues, 1 is resolved, 1 became work, 1 is out of scope. Essentially none was
genuinely too vague. The section had become a backlog. So the spec's A6 —
"name every open item as open" — is the right triage and the wrong
destination, and it is marked superseded for sharp items.

The spec keeps its place as an INPUT to /to-spec rather than being reverted:
the assembled decisions and the evidence index are real work the skill should
consume. Publishing to docs/specs/ was never part of the error — #431's Notes
says specs here are persistent.

Gates: lint rc=0 · lint-docs rc=0 (agnix --strict, no issues found). Both
#431 body edits verified round-trip byte-identical (44199 = 44199).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014x8jGSieFkDBV95KLXYhTC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788286969&installation_model_id=429246&pr_number=486&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F486&signature=352c1b6704393e54ef09c05b4930d1282d50a683e2f3df60d9ad91472070505a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that protocol commands must be explicitly invoked and documented the required command workflow.
  - Added guidance that unresolved “fog” items must be converted into tickets before specification or implementation.
  - Clarified that an empty ticket queue does not necessarily indicate completion.
  - Added a status banner distinguishing source inputs from command outputs and documenting superseded triage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->