### PR TITLE
feat(hooks): the ask standard drifted three times, so it stops being markdown-only

### DIFF
--- a/.claude/rules/clarify-before-acting.md
+++ b/.claude/rules/clarify-before-acting.md
@@ -5,6 +5,12 @@ hard to reverse, ask clarifying questions (via `AskUserQuestion`) and
 keep asking across rounds until you are confident what to do. Do not
 guess and proceed.
 
+**Whenever you need input, use the `AskUserQuestion` TOOL — never options
+in prose.** This is the *mechanism* rule and it is unconditional: it holds
+even when nothing is ambiguous and the ask is just "which of these two"
+or "please run X". Options in a message are not a question the harness
+can answer; they cost the user a round-trip.
+
 ## Why this rule exists
 
 Session 2026-06-29: the user asked for hk-hang prevention and explicitly
@@ -22,9 +28,28 @@ avoided shipping the wrong thing.
    the action is hard to undo (deletes, pushes, merges, external/
    outward-facing effects), resolve it with the user first.
 
-2. **Recommend, don't just enumerate.** Lead with the option you'd pick,
-   marked `(Recommended)`, and give the trade-offs. A question is a
-   proposal to confirm, not a blank survey.
+2. **Recommend, don't just enumerate — with citations and both sides.**
+   A question is a proposal to confirm, not a blank survey. Every ask
+   carries all three (Ray, 2026-08-02), and **the first three are
+   machine-enforced** by `dotfiles_setup.ask_quality` (below):
+
+   - **A recommendation.** On a single-select question, the option you'd
+     pick is **first** and its label ends `(Recommended)`; no other
+     option claims it. (Multi-select is exempt — "recommended" is
+     incoherent when the user picks several.)
+   - **Pros and cons.** Every option's description carries `PRO:` and
+     `CON:`. An option with no stated downside is a recommendation in
+     disguise.
+   - **A citation.** Ground the recommendation in something the user can
+     open: a `backticked/path`, a `#NNN` issue/PR ref, or a URL. Cite
+     what exists and **label it when thin** — if there is genuinely no
+     prior evidence, say so with the literal `[no prior evidence]`, and
+     treat needing that escape as a signal to go look first. Reaching
+     for it routinely defeats the gate rather than satisfying it.
+   - **Free-form is always available.** The harness adds "Other" to
+     every question, so never apologise for imperfect options or pad the
+     list to cover every case — offer the real choices and let the user
+     write past them.
 
 3. **Proceed directly on clear, low-risk, reversible tasks.** Do not
    manufacture questions for things with an obvious default or facts you
@@ -40,6 +65,27 @@ avoided shipping the wrong thing.
    rework. Don't stop at one question if the answer revealed new
    ambiguity.
 
+## The gate (and the half of this rule no gate can carry)
+
+`.claude/settings.json` wires `PreToolUse` matcher **`Bash|AskUserQuestion`**
+to `scripts/pretooluse-guard.sh`; `hook_guard.decide_payload` dispatches on
+`tool_name`, and `dotfiles_setup.ask_quality` **denies** an ask that is
+missing the recommendation, the `PRO:`/`CON:` trade-offs, or the citation.
+The deny is deterministic — it applies even in bypassPermissions mode — and
+its reason names what to fix. `hook selfcheck` (run by `ship`/`land`) drives
+both arms through the real wrapper, so the wiring cannot regress silently.
+
+**What no hook can see is an ask that never happened.** A gate can only judge
+the shape of a question you chose to ask; it is blind to the case this rule
+exists for — quietly guessing instead. That half is carried by rule 1 and by
+`feedback_clarify_before_acting`, and it is why this rule stays eager
+(behaviour-triggered; see `md-size-budgets.md` § "the trigger test").
+
+Why a gate at all for judgment-shaped guidance: the same standard has drifted
+**three times** (2026-06-29 → 2026-07-30-e → 2026-08-02), and
+`mise-tasks-only.md` records that markdown alone is "relying on the LLM, never
+the only layer".
+
 ## Applies to
 
 All non-trivial work: planning, multi-file changes, design choices,
@@ -50,5 +96,10 @@ under-determines what to build.
 
 - `do-not.md` — project invariants (some actions are never OK regardless
   of clarification).
+- `mise-tasks-only.md` — the sibling PreToolUse guard, and the enforcement-layer
+  doctrine this gate follows.
+- `probes-need-a-control-arm.md` — why the gate ships with a passing arm as
+  well as a failing one.
+- `python/src/dotfiles_setup/ask_quality.py` — the enforcer.
 - CLAUDE.md → `AGENTS.md` "Agent Instructions" — the policy index that
   references this rule.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,7 +28,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash",
+        "matcher": "Bash|AskUserQuestion",
         "hooks": [
           {
             "type": "command",

--- a/python/src/dotfiles_setup/ask_quality.py
+++ b/python/src/dotfiles_setup/ask_quality.py
@@ -1,0 +1,192 @@
+"""Quality gate for ``AskUserQuestion`` calls (PreToolUse).
+
+Ray's standing instruction (2026-08-02): *"always use the AskUserQuestion tool
+with recommendation based on cited research and pros/cons and the ability to
+answer as free form text if the multiple options are not sufficient"*.
+
+Three of those four are enforceable here; the fourth needs no enforcement:
+
+===============  ==========================================================
+Component        How it is carried
+===============  ==========================================================
+the TOOL         Not gateable — no hook can observe an ask that never
+                 happened. Carried by ``.claude/rules/clarify-before-acting``
+                 and the ``feedback_clarify_before_acting`` memory.
+recommendation   **Gated** — a single-select question leads with a
+                 ``(Recommended)`` option and no other option claims it.
+pros/cons        **Gated** — every option description carries ``PRO:``
+                 and ``CON:``.
+cited research   **Gated** — each question carries a citation marker (a
+                 backticked path, a ``#NNN`` issue ref, or a URL), or the
+                 explicit ``[no prior evidence]`` escape.
+free-form text   Nothing to enforce: the harness always offers "Other".
+===============  ==========================================================
+
+The escape exists because Ray ruled *"cite what exists; label it when thin"* —
+a recommendation must not be blocked for want of evidence, only for hiding that
+it has none. **If ``[no prior evidence]`` starts showing up routinely, the gate
+has been defeated rather than satisfied** — that was the named risk when the
+strictest tier was chosen, and it is a thing to audit, not a thing to reach for.
+
+Why a gate at all, when this is judgment-shaped: the same standard has now
+drifted three times (2026-06-29 → 2026-07-30-e → 2026-08-02), and
+``.claude/rules/mise-tasks-only.md`` records that markdown alone is "relying on
+the LLM, never the only layer". What a hook *can* see is the shape of an ask
+that did happen, so that is exactly what this checks — never whether asking was
+the right call.
+
+Deliberately NOT gated: whether the recommendation is *good*, whether the
+citation is *relevant*, or whether the cons are honest. Those are review, not
+lint.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+
+RECOMMENDED_MARKER = "(Recommended)"
+PRO_MARKER = "PRO:"
+CON_MARKER = "CON:"
+NO_EVIDENCE_ESCAPE = "[no prior evidence]"
+
+#: A backticked path-ish token (``hk.pkl``, ``.claude/rules/x.md``), a ``#NNN``
+#: issue reference, or a URL. Deliberately permissive: this pattern gates the
+#: ALLOW direction, so a false positive only weakens the gate, while a false
+#: negative would block a legitimate ask.
+_CITATION_RE = re.compile(r"`[^`\n]*[./][^`\n]*`|#\d+|https?://\S")
+
+_DOC = ".claude/rules/clarify-before-acting.md"
+
+
+# The payload is untrusted JSON, so every accessor takes ``object`` and narrows
+# on the way in. Annotating these as ``Mapping[str, object]`` does not type-check:
+# ``Mapping`` is INVARIANT in its key type, so ``isinstance(x, Mapping)`` narrows
+# only to ``Mapping[Unknown, object]`` and will not pass as a str-keyed mapping.
+# Taking ``object`` is also the more honest signature — nothing here has proved
+# the keys are strings.
+def _text(value: object) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _field(obj: object, key: str) -> object:
+    """One field of a JSON object, or None when ``obj`` is not one."""
+    return obj.get(key) if isinstance(obj, Mapping) else None
+
+
+def _options(question: object) -> list[object]:
+    raw = _field(question, "options")
+    if not isinstance(raw, Sequence) or isinstance(raw, str | bytes):
+        return []
+    return [opt for opt in raw if isinstance(opt, Mapping)]
+
+
+def _citation_corpus(question: object) -> str:
+    parts = [_text(_field(question, "question")), _text(_field(question, "header"))]
+    for opt in _options(question):
+        parts.append(_text(_field(opt, "description")))
+        parts.append(_text(_field(opt, "preview")))
+    return "\n".join(parts)
+
+
+def _check_question(index: int, question: object) -> list[str]:
+    """Violations for one question, as actionable sentences."""
+    where = f"question {index + 1}"
+    options = _options(question)
+    if not options:
+        # Nothing to judge — the tool's own schema requires 2-4 options, so an
+        # empty list means a shape this gate does not understand. Allow.
+        return []
+
+    out: list[str] = []
+
+    missing_desc = [
+        i + 1
+        for i, opt in enumerate(options)
+        if not _text(_field(opt, "description")).strip()
+    ]
+    if missing_desc:
+        out.append(
+            f"{where}: option(s) {missing_desc} have no description. "
+            "Every option must say what it means and what happens if chosen."
+        )
+
+    thin = [
+        i + 1
+        for i, opt in enumerate(options)
+        if _text(_field(opt, "description")).strip()
+        and not (
+            PRO_MARKER in _text(_field(opt, "description"))
+            and CON_MARKER in _text(_field(opt, "description"))
+        )
+    ]
+    if thin:
+        out.append(
+            f"{where}: option(s) {thin} give no trade-off. Each description must "
+            f"contain both {PRO_MARKER!r} and {CON_MARKER!r} — an option with no "
+            "stated downside is a recommendation in disguise."
+        )
+
+    if not _field(question, "multiSelect"):
+        labels = [_text(_field(opt, "label")) for opt in options]
+        claimed = [
+            i + 1 for i, label in enumerate(labels) if RECOMMENDED_MARKER in label
+        ]
+        if not claimed:
+            out.append(
+                f"{where}: no option is marked {RECOMMENDED_MARKER!r}. Lead with the "
+                "option you would pick — enumerating without recommending pushes the "
+                "judgment back onto the user."
+            )
+        elif claimed != [1]:
+            out.append(
+                f"{where}: {RECOMMENDED_MARKER!r} is on option(s) {claimed}; it "
+                "must be on exactly one option, and that option must be FIRST."
+            )
+
+    corpus = _citation_corpus(question)
+    if NO_EVIDENCE_ESCAPE not in corpus and not _CITATION_RE.search(corpus):
+        out.append(
+            f"{where}: no citation. Ground the recommendation in something readable — "
+            "a `backticked/path`, a #NNN issue/PR ref, or a URL. If there genuinely is "
+            f"no prior evidence, say so with the literal {NO_EVIDENCE_ESCAPE!r} "
+            "(and treat needing it as a signal to go look first)."
+        )
+
+    return out
+
+
+def find_violations(tool_input: Mapping[str, object]) -> list[str]:
+    """Every quality violation in an ``AskUserQuestion`` payload.
+
+    Args:
+        tool_input: The hook's ``tool_input`` object for the pending call.
+
+    Returns:
+        Actionable violation sentences; empty when the ask is compliant.
+        An unrecognised shape yields no violations — this gate must never
+        brick an ask it cannot parse.
+    """
+    questions = _field(tool_input, "questions")
+    if not isinstance(questions, Sequence) or isinstance(questions, str | bytes):
+        return []
+    out: list[str] = []
+    for index, question in enumerate(questions):
+        if isinstance(question, Mapping):
+            out.extend(_check_question(index, question))
+    return out
+
+
+def decide(tool_input: Mapping[str, object]) -> str | None:
+    """Deny reason for an ``AskUserQuestion`` call, or None to allow."""
+    violations = find_violations(tool_input)
+    if not violations:
+        return None
+    bullets = "\n".join(f"  - {v}" for v in violations)
+    return (
+        "This ask does not meet the project's AskUserQuestion standard "
+        f"(Ray, 2026-08-02; {_DOC}):\n"
+        f"{bullets}\n"
+        "Revise and re-ask — do NOT fall back to listing the options in prose, "
+        "which costs the user a round-trip and is what this standard exists to stop."
+    )

--- a/python/src/dotfiles_setup/hook_guard.py
+++ b/python/src/dotfiles_setup/hook_guard.py
@@ -21,6 +21,13 @@ untouched. This module also absorbs the two legacy shell guards (npx,
 chezmoi apply/update) which exited 1 — a NON-blocking code for
 PreToolUse; the intent was clearly to block, so consolidating here
 fixes them.
+
+It also dispatches ``AskUserQuestion`` to :mod:`dotfiles_setup.ask_quality`
+(the ask-quality standard, Ray 2026-08-02). One entrypoint for both tools
+rather than a second hook script, because a new ``scripts/*.sh`` would need
+its own ``bash_budget`` allowlist entry to carry logic that belongs in
+``python/`` anyway (``.claude/rules/zero-bash-logic.md``). The settings.json
+matcher is ``Bash|AskUserQuestion``; dispatch is on ``tool_name``.
 """
 
 from __future__ import annotations
@@ -31,6 +38,7 @@ import re
 import sys
 from dataclasses import dataclass
 
+from dotfiles_setup import ask_quality
 from dotfiles_setup.heredoc import HEREDOC_PATTERN, NUL_FILLER, blank_heredoc
 
 
@@ -662,24 +670,53 @@ def decide(command: str) -> str | None:
     return rule.reason if rule is not None else None
 
 
-def _read_command() -> str:
-    """Bash command from the hook stdin JSON (env-var fallback)."""
+def _read_payload() -> tuple[str, dict[str, object]]:
+    """``(tool_name, tool_input)`` from the hook stdin JSON (env-var fallback).
+
+    Returns:
+        The pending call's tool name (``""`` when the payload omits it, which
+        is the pre-dispatch shape every existing Bash test uses) and its
+        ``tool_input`` object.
+    """
     raw = sys.stdin.read() if not sys.stdin.isatty() else ""
     if raw:
         try:
             payload = json.loads(raw)
         except json.JSONDecodeError:
             payload = {}
+        if not isinstance(payload, dict):
+            payload = {}
         tool_input = payload.get("tool_input", payload)
-        if isinstance(tool_input, dict):
-            return str(tool_input.get("command", ""))
+        return (
+            str(payload.get("tool_name", "")),
+            tool_input if isinstance(tool_input, dict) else {},
+        )
     legacy = os.environ.get("CLAUDE_TOOL_INPUT", "")
     if legacy:
         try:
-            return str(json.loads(legacy).get("command", ""))
-        except json.JSONDecodeError, AttributeError:
-            return ""
-    return ""
+            parsed = json.loads(legacy)
+        except json.JSONDecodeError:
+            return "", {}
+        if isinstance(parsed, dict):
+            return str(parsed.get("tool_name", "")), parsed
+    return "", {}
+
+
+def _read_command() -> str:
+    """Bash command from the hook stdin JSON (env-var fallback)."""
+    return str(_read_payload()[1].get("command", ""))
+
+
+def decide_payload(tool_name: str, tool_input: dict[str, object]) -> str | None:
+    """Deny reason for a pending tool call, dispatched on ``tool_name``.
+
+    ``AskUserQuestion`` goes to the ask-quality standard; everything else is
+    treated as a Bash command (the historical shape — an absent ``tool_name``
+    must keep behaving exactly as it did before dispatch existed).
+    """
+    if tool_name == "AskUserQuestion":
+        return ask_quality.decide(tool_input)
+    return decide(str(tool_input.get("command", "")))
 
 
 def pretooluse_main() -> int:
@@ -689,7 +726,8 @@ def pretooluse_main() -> int:
     contract); a crash here would fail OPEN (hook errors do not block),
     which is the acceptable failure mode for a redirect guard.
     """
-    reason = decide(_read_command())
+    tool_name, tool_input = _read_payload()
+    reason = decide_payload(tool_name, tool_input)
     if reason is not None:
         sys.stdout.write(
             json.dumps(

--- a/python/src/dotfiles_setup/hook_selfcheck.py
+++ b/python/src/dotfiles_setup/hook_selfcheck.py
@@ -51,9 +51,17 @@ _WEB_SETUP = "scripts/web-setup.sh"
 _HOOK_SCRIPTS = (PRETOOLUSE_WRAPPER, _WEB_SETUP)
 
 # Each settings.json hook event -> (command substrings that MUST appear in its
-# wired command(s), required matcher or None). Keeps the project hooks from
+# wired command(s), required matchers or None). Keeps the project hooks from
 # silently drifting out of .claude/settings.json (the wiring the end-to-end
-# check then exercises). PreToolUse must stay scoped to Bash.
+# check then exercises).
+#
+# PreToolUse must stay scoped, and to BOTH tools it guards: `Bash` (the
+# mise-tasks-only redirects) and `AskUserQuestion` (the ask-quality standard,
+# Ray 2026-08-02 — see dotfiles_setup.ask_quality). Each is asserted
+# separately, because the matcher is one alternation string: a check that only
+# looked for "Bash" would keep passing if AskUserQuestion were dropped from it,
+# and the guard would go silently absent for that tool exactly as #343 did for
+# off-root Bash.
 #
 # SessionEnd runs the command-audit refine loop once per session (the recurring
 # half of mise-tasks-only enforcement). A matcher would SCOPE it to particular
@@ -67,8 +75,8 @@ _HOOK_SCRIPTS = (PRETOOLUSE_WRAPPER, _WEB_SETUP)
 # neither can disrupt a session; asserting them here is what keeps them from
 # quietly falling out of settings.json, which is the only place they are wired.
 _SESSION_END_REPORT = ".agent/command-audit.md"
-_SETTINGS_WIRING: tuple[tuple[str, tuple[str, ...], str | None], ...] = (
-    ("PreToolUse", (PRETOOLUSE_WRAPPER,), "Bash"),
+_SETTINGS_WIRING: tuple[tuple[str, tuple[str, ...], tuple[str, ...] | None], ...] = (
+    ("PreToolUse", (PRETOOLUSE_WRAPPER,), ("Bash", "AskUserQuestion")),
     (
         "SessionStart",
         (_WEB_SETUP, "CLAUDE_CODE_REMOTE", "run tool-currency-check", "run doctor"),
@@ -137,7 +145,7 @@ def check_settings_wiring(settings_path: Path) -> list[str]:
         settings = json.loads(settings_path.read_text())
     except (OSError, json.JSONDecodeError) as exc:
         return [f"could not read {settings_path}: {exc}"]
-    for event, required, matcher in _SETTINGS_WIRING:
+    for event, required, matchers in _SETTINGS_WIRING:
         entries = _event_entries(settings, event)
         if not entries:
             failures.append(f"settings.json has no {event} hook wired")
@@ -148,11 +156,12 @@ def check_settings_wiring(settings_path: Path) -> list[str]:
             for token in required
             if token not in joined
         )
-        if matcher is not None and not any(matcher in m for m, _ in entries):
-            failures.append(
-                f"settings.json {event} hook must be scoped with matcher "
-                f"{matcher!r} (tool events fire on every tool otherwise)"
-            )
+        failures.extend(
+            f"settings.json {event} hook must be scoped with matcher "
+            f"{matcher!r} (tool events fire on every tool otherwise)"
+            for matcher in matchers or ()
+            if not any(matcher in m for m, _ in entries)
+        )
     failures.extend(_unanchored_hooks(settings))
     return failures
 
@@ -224,7 +233,74 @@ def check_pretooluse_endtoend(project_root: Path) -> list[str]:
             f"pretooluse wrapper was not silent on the allowed command "
             f"{_ALLOWED_SAMPLE!r}: {allowed.stdout.strip()!r}"
         )
+    failures.extend(check_ask_quality_endtoend(project_root, wrapper))
     failures.extend(check_offroot_arm(project_root, wrapper))
+    return failures
+
+
+def _ask_payload(*, cited: bool) -> str:
+    """A single-select AskUserQuestion that differs ONLY in whether it cites.
+
+    Both arms are otherwise compliant (recommendation first, PRO:/CON: on every
+    option), so a difference in the wrapper's verdict can only come from the
+    citation rule — the control arm for the deny.
+    """
+    where = "per `mise.toml`" if cited else "which do you prefer"
+    return json.dumps(
+        {
+            "tool_name": "AskUserQuestion",
+            "tool_input": {
+                "questions": [
+                    {
+                        "question": f"Selfcheck probe — {where}?",
+                        "header": "Probe",
+                        "multiSelect": False,
+                        "options": [
+                            {
+                                "label": "A (Recommended)",
+                                "description": "PRO: a. CON: b.",
+                            },
+                            {"label": "B", "description": "PRO: c. CON: d."},
+                        ],
+                    }
+                ]
+            },
+        }
+    )
+
+
+def check_ask_quality_endtoend(project_root: Path, wrapper: str) -> list[str]:
+    """Drive the ask-quality gate through the REAL wrapper (deny + allow).
+
+    The wiring check proves ``AskUserQuestion`` is in the matcher; this proves
+    the guard actually decides on it. Without the allow arm the deny would be
+    indistinguishable from a gate that denies every ask.
+    """
+    failures: list[str] = []
+
+    denied = _run(["bash", wrapper], stdin=_ask_payload(cited=False), cwd=project_root)
+    if denied.returncode != 0:
+        failures.append(
+            f"pretooluse wrapper exited {denied.returncode} on a non-compliant "
+            f"AskUserQuestion (must exit 0): {denied.stderr.strip()}"
+        )
+    elif '"permissionDecision": "deny"' not in denied.stdout:
+        failures.append(
+            "pretooluse wrapper did not DENY an uncited AskUserQuestion — the "
+            f"ask-quality gate is not reachable. stdout={denied.stdout.strip()!r}"
+        )
+
+    allowed = _run(["bash", wrapper], stdin=_ask_payload(cited=True), cwd=project_root)
+    if allowed.returncode != 0:
+        failures.append(
+            f"pretooluse wrapper exited {allowed.returncode} on a compliant "
+            f"AskUserQuestion: {allowed.stderr.strip()}"
+        )
+    elif allowed.stdout.strip():
+        failures.append(
+            "pretooluse wrapper was not silent on a COMPLIANT AskUserQuestion — "
+            f"the gate denies every ask: {allowed.stdout.strip()!r}"
+        )
     return failures
 
 

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -1095,6 +1095,23 @@ tokens = [
 ]
 
 [[suite]]
+name = "workflow.ask-quality-enforcement"
+description = "The AskUserQuestion quality standard (Ray, 2026-08-02) must stay wired end-to-end: .claude/settings.json's PreToolUse matcher covers AskUserQuestion as well as Bash, hook_guard dispatches on tool_name into dotfiles_setup.ask_quality, that module enforces the three checkable components (a first-and-only `(Recommended)` option, `PRO:`/`CON:` in every option description, a citation marker or the explicit `[no prior evidence]` escape), hook_selfcheck drives BOTH arms through the real wrapper, and the rule doc states the standard. The matcher is one alternation string, which is the specific drift this pins: a wiring check that only looked for `Bash` would keep passing after AskUserQuestion were dropped from it, and the gate would go silently absent for that tool exactly as #343 did for off-root Bash. Both regressions were mutation-tested on 2026-08-02 and are caught by DIFFERENT checks — reverting the matcher fails settings-wiring, deleting the dispatch call site fails pretooluse-endtoend — so neither check can stand in for the other. What is deliberately NOT asserted anywhere: whether asking was the right call at all. No hook can observe an ask that never happened, so that half lives in the rule and the memory."
+category = "workflow"
+check_type = "static"
+handler = "require_tokens"
+paths_required = true
+paths = [
+    ".claude/settings.json",
+    "python/src/dotfiles_setup/ask_quality.py",
+    "python/src/dotfiles_setup/hook_guard.py",
+    "python/src/dotfiles_setup/hook_selfcheck.py",
+    "tests/test_ask_quality.py",
+    ".claude/rules/clarify-before-acting.md",
+]
+per_path_tokens = { ".claude/settings.json" = ['"matcher": "Bash|AskUserQuestion"'], "python/src/dotfiles_setup/ask_quality.py" = ['RECOMMENDED_MARKER = "(Recommended)"', 'NO_EVIDENCE_ESCAPE = "[no prior evidence]"', "def find_violations(", "_CITATION_RE = re.compile("],"python/src/dotfiles_setup/hook_guard.py" = ['if tool_name == "AskUserQuestion":', "return ask_quality.decide(tool_input)", "def decide_payload("], "python/src/dotfiles_setup/hook_selfcheck.py" = ['("Bash", "AskUserQuestion")', "def check_ask_quality_endtoend(", "def _ask_payload("], "tests/test_ask_quality.py" = ["def test_uncited_ask_is_denied(", "def test_compliant_ask_is_allowed(", "def test_cli_denies_a_noncompliant_ask(", "def test_cli_allows_a_compliant_ask(", "def test_dispatch_still_denies_a_guarded_bash_command("], ".claude/rules/clarify-before-acting.md" = ["`Bash|AskUserQuestion`", "[no prior evidence]", "python/src/dotfiles_setup/ask_quality.py"] }
+
+[[suite]]
 name = "workflow.mise-tasks-enforcement"
 description = "mise-tasks-only policy wiring: the PreToolUse Bash guard must stay wired end-to-end — .claude/settings.json invokes `bash scripts/pretooluse-guard.sh`, that fail-open wrapper execs `dotfiles-setup hook pretooluse`, the guard module + its tests exist, and the rule doc names the canonical task map. The wrapper adds one hop of indirection (web-brick fix: fail open when the Python>=3.14 interpreter is absent) — this contract asserts BOTH hops so neither drifts out of the chain. Also pins the #265 precision fix: rules run against `_inert_masked(command)`, never the raw string, so a separator inside a quoted span or a heredoc body cannot fake a command position. That masking is the MATCHER's only measured defect class — 2 of its 3 denials were quoting false positives, and a deny cancels the WHOLE compound command, so a wrong one silently skips the rest. (Scope matters: nothing has evaded the matcher, but #343 measured 125 commands bypassing the guard entirely by never reaching it — a relative hook path resolving against a sibling repo — which is why this contract now also pins the $CLAUDE_PROJECT_DIR anchoring and the foreign-cwd arm.) Pinned here because the masking lives one call away from the rules and a refactor that dropped it would restore every false positive while every rule test still passed."
 category = "workflow"

--- a/tests/test_ask_quality.py
+++ b/tests/test_ask_quality.py
@@ -1,0 +1,288 @@
+"""Tests for the AskUserQuestion quality gate.
+
+Every rule is tested in BOTH directions (`.claude/rules/probes-need-a-control-arm.md`):
+a payload that must be DENIED and the same payload, minimally repaired, that must
+be ALLOWED. A gate exercised only on compliant input is decoration.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+from dotfiles_setup import ask_quality
+from dotfiles_setup.hook_guard import decide_payload
+
+GOOD_DESC = "PRO: cheap and reversible. CON: leaves `hk.pkl` untouched."
+
+
+def question(**overrides: object) -> dict[str, object]:
+    """A fully compliant single-select question; override one field per test."""
+    base: dict[str, object] = {
+        "question": "Which lane owns this, per `.claude/rules/do-not.md`?",
+        "header": "Lane",
+        "multiSelect": False,
+        "options": [
+            {"label": "Keep it here (Recommended)", "description": GOOD_DESC},
+            {
+                "label": "Move it",
+                "description": "PRO: tidier. CON: a second place to drift.",
+            },
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+def uncited(**overrides: object) -> dict[str, object]:
+    """A question that is compliant except that nothing in it is cited.
+
+    Deliberately NOT built from ``question()``: the citation corpus spans the
+    question text AND every option description, so overriding only the question
+    text leaves ``hk.pkl`` in ``GOOD_DESC`` satisfying the check. Three tests
+    were silently passing for that reason before this helper existed.
+    """
+    base: dict[str, object] = {
+        "question": "Which one do you want?",
+        "header": "Pick",
+        "multiSelect": False,
+        "options": [
+            {"label": "A (Recommended)", "description": "PRO: fast. CON: rough."},
+            {"label": "B", "description": "PRO: tidy. CON: slow."},
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+def payload(*questions: dict[str, object]) -> dict[str, object]:
+    return {"questions": list(questions)}
+
+
+def test_uncited_helper_is_uncited_and_otherwise_compliant() -> None:
+    """Control arm for the helper itself: exactly one violation, the citation."""
+    (violation,) = ask_quality.find_violations(payload(uncited()))
+    assert "no citation" in violation
+
+
+# --- the ALLOW arm ----------------------------------------------------------
+
+
+def test_compliant_ask_is_allowed() -> None:
+    assert ask_quality.find_violations(payload(question())) == []
+    assert ask_quality.decide(payload(question())) is None
+
+
+def test_multiselect_needs_no_recommendation() -> None:
+    """A '(Recommended)' pick is incoherent when the user picks several."""
+    q = question(
+        multiSelect=True,
+        options=[
+            {"label": "Lint", "description": GOOD_DESC},
+            {"label": "Tests", "description": "PRO: catches regressions. CON: slow."},
+        ],
+    )
+    assert ask_quality.find_violations(payload(q)) == []
+
+
+@pytest.mark.parametrize(
+    "citation",
+    [
+        "see `.claude/rules/do-not.md`",
+        "see `hk.pkl`",
+        "closed by #431",
+        "https://github.com/ray-manaloto/dotfiles/issues/431",
+        f"{ask_quality.NO_EVIDENCE_ESCAPE} — nothing in the repo covers this",
+    ],
+)
+def test_every_accepted_citation_form(citation: str) -> None:
+    q = question(question=f"Which one? {citation}")
+    assert ask_quality.find_violations(payload(q)) == []
+
+
+def test_citation_may_live_in_an_option_description() -> None:
+    q = question(
+        question="Which one?",
+        options=[
+            {
+                "label": "A (Recommended)",
+                "description": "PRO: matches `mise.toml`. CON: slower.",
+            },
+            {"label": "B", "description": "PRO: fast. CON: undocumented."},
+        ],
+    )
+    assert ask_quality.find_violations(payload(q)) == []
+
+
+# --- the DENY arm -----------------------------------------------------------
+
+
+def test_no_recommendation_is_denied() -> None:
+    q = question(
+        options=[
+            {"label": "Keep it here", "description": GOOD_DESC},
+            {"label": "Move it", "description": "PRO: tidier. CON: drift."},
+        ]
+    )
+    (violation,) = ask_quality.find_violations(payload(q))
+    assert "no option is marked" in violation
+
+
+def test_recommendation_not_first_is_denied() -> None:
+    q = question(
+        options=[
+            {"label": "Move it", "description": GOOD_DESC},
+            {"label": "Keep it here (Recommended)", "description": "PRO: a. CON: b."},
+        ]
+    )
+    (violation,) = ask_quality.find_violations(payload(q))
+    assert "must be FIRST" in violation
+
+
+def test_two_recommendations_is_denied() -> None:
+    q = question(
+        options=[
+            {"label": "Keep it (Recommended)", "description": GOOD_DESC},
+            {"label": "Move it (Recommended)", "description": "PRO: a. CON: b."},
+        ]
+    )
+    (violation,) = ask_quality.find_violations(payload(q))
+    assert "exactly one option" in violation
+
+
+def test_missing_description_is_denied() -> None:
+    q = question(
+        options=[
+            {"label": "Keep it (Recommended)", "description": GOOD_DESC},
+            {"label": "Move it", "description": "   "},
+        ]
+    )
+    violations = ask_quality.find_violations(payload(q))
+    assert any("no description" in v for v in violations)
+
+
+@pytest.mark.parametrize(
+    "description",
+    [
+        "PRO: fast, and nothing else.",
+        "CON: slow, with no upside stated.",
+        "Just a flat claim.",
+    ],
+)
+def test_missing_pro_or_con_is_denied(description: str) -> None:
+    q = question(
+        options=[
+            {"label": "Keep it (Recommended)", "description": GOOD_DESC},
+            {"label": "Move it", "description": description},
+        ]
+    )
+    violations = ask_quality.find_violations(payload(q))
+    assert any("no trade-off" in v for v in violations)
+
+
+def test_uncited_ask_is_denied() -> None:
+    (violation,) = ask_quality.find_violations(payload(uncited()))
+    assert "no citation" in violation
+
+
+def test_a_bare_backticked_word_is_not_a_citation() -> None:
+    """`foo` names nothing readable; `foo.py` or `a/b` does."""
+    q = uncited(question="Which `one` do you want?")
+    assert any("no citation" in v for v in ask_quality.find_violations(payload(q)))
+
+
+def test_second_question_is_checked_too() -> None:
+    violations = ask_quality.find_violations(payload(question(), uncited()))
+    assert len(violations) == 1
+    assert violations[0].startswith("question 2:")
+
+
+def test_deny_reason_names_the_rule_and_forbids_the_prose_fallback() -> None:
+    reason = ask_quality.decide(payload(uncited()))
+    assert reason is not None
+    assert ".claude/rules/clarify-before-acting.md" in reason
+    assert "prose" in reason
+
+
+# --- shapes the gate must NOT brick ----------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tool_input",
+    [{}, {"questions": []}, {"questions": "not-a-list"}, {"questions": [None, 7]}],
+)
+def test_unparsable_shapes_are_allowed(tool_input: dict[str, object]) -> None:
+    assert ask_quality.find_violations(tool_input) == []
+
+
+def test_option_list_without_options_is_allowed() -> None:
+    assert ask_quality.find_violations(payload({"question": "hi", "options": []})) == []
+
+
+# --- dispatch: the Bash path must be untouched ------------------------------
+
+
+def test_dispatch_routes_askuserquestion_to_the_quality_gate() -> None:
+    reason = decide_payload("AskUserQuestion", payload(uncited()))
+    assert reason is not None
+    assert "AskUserQuestion standard" in reason
+
+
+def test_dispatch_allows_a_compliant_ask() -> None:
+    assert decide_payload("AskUserQuestion", payload(question())) is None
+
+
+def test_dispatch_still_denies_a_guarded_bash_command() -> None:
+    reason = decide_payload("Bash", {"command": "git commit --no-verify -m x"})
+    assert reason is not None
+
+
+def test_dispatch_without_a_tool_name_is_the_legacy_bash_path() -> None:
+    """Every pre-existing payload omits tool_name; it must behave as before."""
+    assert decide_payload("", {"command": "git commit --no-verify -m x"}) is not None
+    assert decide_payload("", {"command": "git status --short"}) is None
+
+
+def test_an_askuserquestion_payload_is_never_read_as_a_bash_command() -> None:
+    assert decide_payload("AskUserQuestion", payload(question())) is None
+
+
+# --- the wired CLI path (proves the module is reachable as the hook runs it) --
+
+
+#: The console-script entry point (`python/pyproject.toml` [project.scripts]),
+#: driven in a subprocess so the stdin-reading path the real hook uses is
+#: actually exercised — an in-process call cannot read stdin under pytest.
+_ENTRY = (
+    "import sys;"
+    "from dotfiles_setup.main import main;"
+    "sys.argv = ['dotfiles-setup'] + sys.argv[1:];"
+    "main()"
+)
+
+
+def _run_hook(payload_obj: dict[str, object]) -> str:
+    proc = subprocess.run(
+        [sys.executable, "-c", _ENTRY, "hook", "pretooluse"],
+        input=json.dumps(payload_obj),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout
+
+
+def test_cli_denies_a_noncompliant_ask() -> None:
+    out = _run_hook({"tool_name": "AskUserQuestion", "tool_input": payload(uncited())})
+    decision = json.loads(out)["hookSpecificOutput"]
+    assert decision["permissionDecision"] == "deny"
+    assert "AskUserQuestion standard" in decision["permissionDecisionReason"]
+
+
+def test_cli_allows_a_compliant_ask() -> None:
+    """The control arm for the test above: same path, same tool, no output."""
+    out = _run_hook({"tool_name": "AskUserQuestion", "tool_input": payload(question())})
+    assert out.strip() == ""

--- a/tests/test_hook_guard.py
+++ b/tests/test_hook_guard.py
@@ -144,7 +144,9 @@ def test_legitimate_commands_allowed(command: str) -> None:
 def test_pretooluse_emits_deny_json(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    monkeypatch.setattr(hook_guard, "_read_command", lambda: "gh pr create")
+    monkeypatch.setattr(
+        hook_guard, "_read_payload", lambda: ("Bash", {"command": "gh pr create"})
+    )
     assert hook_guard.pretooluse_main() == 0
     out = capsys.readouterr().out
     assert '"permissionDecision": "deny"' in out
@@ -154,7 +156,9 @@ def test_pretooluse_emits_deny_json(
 def test_pretooluse_silent_on_allowed(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    monkeypatch.setattr(hook_guard, "_read_command", lambda: "git status")
+    monkeypatch.setattr(
+        hook_guard, "_read_payload", lambda: ("Bash", {"command": "git status"})
+    )
     assert hook_guard.pretooluse_main() == 0
     assert capsys.readouterr().out == ""
 

--- a/tests/test_hook_selfcheck.py
+++ b/tests/test_hook_selfcheck.py
@@ -57,7 +57,10 @@ def _full_settings() -> dict:
     return {
         "hooks": {
             "PreToolUse": [
-                _hook("Bash", f"bash {_ANCHOR}/scripts/pretooluse-guard.sh")
+                _hook(
+                    "Bash|AskUserQuestion",
+                    f"bash {_ANCHOR}/scripts/pretooluse-guard.sh",
+                )
             ],
             "SessionStart": [
                 _hook(
@@ -97,6 +100,22 @@ def test_missing_matcher_fails(tmp_path: Path) -> None:
     settings["hooks"]["PreToolUse"] = [_hook(None, "bash scripts/pretooluse-guard.sh")]
     failures = _wiring(tmp_path, settings)
     assert any("PreToolUse" in f and "matcher" in f for f in failures)
+
+
+def test_partial_matcher_fails(tmp_path: Path) -> None:
+    """A matcher covering only SOME guarded tools must fail.
+
+    The realistic regression: someone reverts PreToolUse to ``"Bash"`` and the
+    ask-quality gate goes silently absent for AskUserQuestion. A check that
+    merely looked for ``"Bash"`` somewhere in the matcher would still pass.
+    """
+    settings = _full_settings()
+    settings["hooks"]["PreToolUse"] = [
+        _hook("Bash", f"bash {_ANCHOR}/scripts/pretooluse-guard.sh")
+    ]
+    failures = _wiring(tmp_path, settings)
+    assert any("AskUserQuestion" in f for f in failures)
+    assert not any("'Bash'" in f for f in failures)
 
 
 def test_wrong_command_fails(tmp_path: Path) -> None:


### PR DESCRIPTION
Ray, 2026-08-02: "always use the AskUserQuestion tool with recommendation based
on cited research and pros/cons and the ability to answer as free form text if
the multiple options are not sufficient" — and enforce it for future sessions.

The standard is not new; the enforcement is. It has been restated three times
(2026-06-29 → 2026-07-30-e → today), each time as prose, and each time it decayed.
`mise-tasks-only.md` already records the verdict on that shape: markdown alone is
"relying on the LLM, never the only layer".

So a PreToolUse gate now denies a non-compliant ask:

- `.claude/settings.json` matcher `Bash` → `Bash|AskUserQuestion`
- `hook_guard.decide_payload` dispatches on `tool_name`; `_read_command` becomes
  `_read_payload` and the absent-tool_name path stays byte-identical in behaviour
  to the old Bash-only one
- `dotfiles_setup.ask_quality` denies an ask missing a first-and-only
  `(Recommended)` option, `PRO:`/`CON:` in every option description, or a
  citation marker (`backticked/path`, `#NNN`, URL — escape `[no prior evidence]`)

No new `scripts/*.sh`: reusing the existing fail-open wrapper keeps the logic in
`python/` where zero-bash-logic wants it, and costs no bash-budget entry.

The citation escape is deliberate — Ray ruled "cite what exists; label it when
thin", so a recommendation is never blocked for want of evidence, only for hiding
that it has none. If `[no prior evidence]` becomes routine the gate has been
defeated, not satisfied; that was the named risk when the strictest tier was chosen.

Both regressions are mutation-tested and caught by DIFFERENT checks, so neither
stands in for the other:

- revert the matcher to "Bash" → FAIL hook-selfcheck[settings-wiring]
- delete the dispatch call site → FAIL hook-selfcheck[pretooluse-endtoend]

What is deliberately NOT gated, and is stated in the module, the rule and the
contract: whether asking was the right call at all. No hook can observe an ask
that never happened, so the gate judges only the shape of one that did — the
failure that matters most stays with rule 1 and the memory.

Three defects found while building this, all mine: the existing selfcheck tests
patched `_read_command`, the seam I moved (updated, not worked around); three
"uncited" test fixtures were silently cited via `hk.pkl` in a shared description,
so they proved nothing until an `uncited()` helper with its own control arm
replaced them; and two contract tokens matched more than once, which `token_audit`
caught — bound to their single meaningful site per #394.

Gates: lint rc=0 · pytest 1177 passed · verify 113 passed / 0 failed / 4 skipped
· lint-docs "No issues found" · hook selfcheck 4/4 PASS.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014x8jGSieFkDBV95KLXYhTC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788290577&installation_model_id=429246&pr_number=500&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F500&signature=74f367c1fe161bb99f0168a799d4ab0eb01d773d75390ef77b79dcad0069a659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quality checks for clarification questions, including recommended options, PRO/CON trade-offs, and supporting evidence.
  * Added support for enforcing these checks on interactive questions and command requests.
  * Clarifying questions can explicitly indicate when no prior evidence is available.

* **Bug Fixes**
  * Improved enforcement coverage and deterministic handling of incomplete or non-compliant questions.

* **Tests**
  * Added comprehensive validation for compliant, rejected, malformed, and multi-question inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->