### PR TITLE
docs(research): the answer was on this disk, and the chain never pointed there

### DIFF
--- a/.claude/rules/clarify-before-acting.md
+++ b/.claude/rules/clarify-before-acting.md
@@ -75,6 +75,16 @@ The deny is deterministic — it applies even in bypassPermissions mode — and
 its reason names what to fix. `hook selfcheck` (run by `ship`/`land`) drives
 both arms through the real wrapper, so the wiring cannot regress silently.
 
+**Confirmed against the vendor docs and a live probe (2026-08-02)**, not
+assumed: `AskUserQuestion` is a documented PreToolUse matcher value
+(`$CC/hooks.md:1394`); hooks reload from `settings.json` **without a
+restart** (`$CC/settings.md:177`); and a `deny` **prevents the call** while
+its reason is **shown to Claude** (`$CC/hooks.md:1544`) — so a rejected ask costs the user
+nothing and tells the agent exactly what to revise. The probe: an
+otherwise-compliant ask minus its citation was denied through the wired path,
+naming that one rule. `$CC` is the knowledge-base's offline claude-code doc
+tree — see `research-doc-sources.md` step 00 for the path.
+
 **What no hook can see is an ask that never happened.** A gate can only judge
 the shape of a question you chose to ask; it is blind to the case this rule
 exists for — quietly guessing instead. That half is carried by rule 1 and by

--- a/.claude/rules/research-doc-sources.md
+++ b/.claude/rules/research-doc-sources.md
@@ -8,6 +8,40 @@ worked.
 
 ## The chain
 
+00. **For AGENT-HARNESS behaviour, grep the knowledge-base's offline sources
+    FIRST.** `~/dev/github/ray-manaloto/knowledge-base/sources/` holds **36
+    source trees / 6,446 markdown files** (measured 2026-08-02), including
+    `agent-harness-docs/docs/{claude-code,codex,cursor,opencode,pi}` — the
+    **vendor's own docs**, on disk, greppable, zero round-trips.
+
+    ```bash
+    KB=~/dev/github/ray-manaloto/knowledge-base/sources
+    CC=$KB/agent-harness-docs/docs/claude-code   # cited as `$CC/...` elsewhere
+    grep -rn "<topic>" "$CC/"
+    ```
+
+    **This is where every question about how the harness itself behaves is
+    answered** — hook events and their matcher values, settings precedence and
+    reload semantics, tool input schemas, permission modes, the SDK surface.
+    Anything of the form *"does Claude Code do X"* is a **step-00 question**,
+    and reaching the web for it is a step you already had cheaper.
+
+    ⚠️ **Why this is step 00 and not a footnote.** It was in this chain
+    **nowhere** until 2026-08-02 (control-armed: `agent-harness-docs` → **0**
+    hits across `.claude/rules/`, `.claude/skills/` and `AGENTS.md`, against
+    `mintlify-cache` → 2 files, so the probe discriminates). The measured cost:
+    a session shipped a PreToolUse gate and **reported "unproven — I don't know
+    if the harness fires PreToolUse for `AskUserQuestion`, or whether a
+    mid-session `settings.json` edit is picked up"**. Both were sitting on this
+    disk. `$CC/hooks.md:1394` **names
+    `AskUserQuestion`** in the PreToolUse matcher list; `$CC/settings.md:177`
+    states hooks reload **without a restart**. An
+    unanswered question is expensive; an unanswered question whose answer you
+    already have locally is pure loss.
+
+    Step 0 below is a *different* corpus — mintlify docs for third-party
+    libraries. Neither substitutes for the other.
+
 0. **Grep the local cache first.** Every repo in
    `docs/research/mintlify-catalog.md` has both `llms.txt` and
    `llms-full.txt` pre-fetched under

--- a/python/src/dotfiles_setup/ask_quality.py
+++ b/python/src/dotfiles_setup/ask_quality.py
@@ -38,6 +38,40 @@ the right call.
 Deliberately NOT gated: whether the recommendation is *good*, whether the
 citation is *relevant*, or whether the cons are honest. Those are review, not
 lint.
+
+Harness contract — every line below is from the vendor's own docs, on disk in the
+knowledge-base's offline claude-code tree, cited here as ``$CC`` (see
+``.claude/rules/research-doc-sources.md`` step 00 for the path), and confirmed by
+a live probe on 2026-08-02:
+
+- ``$CC/hooks.md:1394`` lists ``AskUserQuestion`` **by name** among PreToolUse
+  matcher values, and ``$CC/hooks.md:246`` states the matcher runs against
+  ``tool_name``. So the dispatch in :func:`hook_guard.decide_payload` is the
+  documented seam, not a guess.
+- ``$CC/settings.md:177``: Claude Code watches settings files and reloads them,
+  and *"this includes ``permissions``, ``hooks``"* — so a matcher edit takes
+  effect **without a restart**. (``$CC/hooks.md:616`` says the same for hooks
+  specifically.) The gate went live in the session that wrote it.
+- ``$CC/hooks.md:1544`` PreToolUse decision control: ``"deny"`` **prevents the tool
+  call**, and ``permissionDecisionReason`` for a deny is *"shown to Claude"*.
+  That is what makes this gate usable rather than merely obstructive — the
+  reason below is the revision instruction, and the user never sees the
+  rejected ask.
+- The payload shape this module reads (``questions[].question`` / ``header`` /
+  ``multiSelect`` / ``options[].label`` / ``description`` / ``preview``) is the
+  documented one: ``$CC/hooks.md:1523`` and
+  ``$CC/agent-sdk__python.md:2560``.
+
+⚠️ ``$CC/hooks.md:1529``'s own example option is ``{"label": "React"}`` — no
+description — so the vendor's illustrative snippet would fail this gate. That is
+fine and deliberate: the SDK schema documents ``description`` as a plain ``str``
+(not optional), and this is a project standard that is stricter than the tool's
+minimum. Do not "fix" the gate to match the snippet.
+
+**Live probe, 2026-08-02** — an otherwise-compliant ask with the citation
+removed was DENIED through the real wired path, the reason naming exactly that
+one rule (so the recommendation and PRO:/CON: checks passed in the same run) and
+the question never reaching the user. Both arms in one call.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Ray: "you should be using the graphify query tools and the offline sources from
the knowledge-base repo".

Last commit shipped the AskUserQuestion gate and reported an unproven link — I
did not know whether the harness fires PreToolUse for `AskUserQuestion`, or
whether a mid-session settings.json edit is picked up without a restart. Both
answers were already on this machine, in the vendor's own docs.

Root cause is mechanical, not a lapse of attention: `research-doc-sources.md`'s
preference chain named ONLY `docs/research/mintlify-cache/`. The knowledge-base's
`sources/` tree appeared in the chain NOWHERE — control-armed, `agent-harness-docs`
returns 0 hits across `.claude/rules/`, `.claude/skills/` and `AGENTS.md` while
`mintlify-cache` returns 2 files, so the probe discriminates and the absence is
real. That corpus is 36 source trees / 6,446 markdown files, including
`agent-harness-docs/docs/{claude-code,codex,cursor,opencode,pi}`.

So it becomes step 00 of the chain: anything of the form "does Claude Code do X"
is a step-00 question, and reaching past it is a step you already had cheaper.

What the docs settled, now recorded in `ask_quality.py` and the rule:

- `$CC/hooks.md:1394` lists `AskUserQuestion` BY NAME among PreToolUse matcher
  values, and `:246` states the matcher runs against `tool_name` — so the
  dispatch seam is documented, not guessed.
- `$CC/settings.md:177`: settings reload covers `permissions` and `hooks`, so the
  matcher edit took effect WITHOUT a restart. The gate went live in the session
  that wrote it.
- `$CC/hooks.md:1544`: a `deny` PREVENTS the tool call and its reason is "shown to
  Claude". That dissolved my stated reason for not probing — a blocked ask never
  reaches the user at all.
- The payload shape the module parses is the documented one (`$CC/hooks.md:1523`,
  `$CC/agent-sdk__python.md:2560`), so the parser is pinned to a spec.

Then probed it live: an otherwise-compliant ask minus its citation was DENIED
through the real wired path, the reason naming exactly that one rule — so the
recommendation and PRO:/CON: checks passed in the same call, and the user never
saw it. Both arms in one call.

Also noted: `$CC/hooks.md:1529`'s own example option carries no description and
would fail this gate. Deliberate — the SDK schema types `description` as a plain
`str`, and this is a project standard stricter than the tool's minimum.

External citations are written `$CC/...` because `doc_refs` resolves a bare
`` `settings.md` `` as a repo path and fails; `_NON_PATH_CHARS` includes `$`, so the
alias both disqualifies the false ref and reads better than an absolute path
repeated eleven times. The one `CC=` definition lives in the chain's code block.

Gates: lint rc=0 · pytest 1177 passed · verify 113 passed / 0 failed / 4 skipped
· lint-docs "No issues found" · hook selfcheck 4/4 PASS.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014x8jGSieFkDBV95KLXYhTC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788293432&installation_model_id=429246&pr_number=501&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F501&signature=72d2340a7662a25c0ab455c9ad5b0bb74c282024e8903916607cb3e36df789da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->