### PR TITLE
fix(guard): a presence probe printed a live token, so printing one is now denied

### DIFF
--- a/.claude/rules/mise-tasks-only.md
+++ b/.claude/rules/mise-tasks-only.md
@@ -27,6 +27,7 @@ library, zero-bash-logic) in the same change.
 | `npx <tool>` | the mise-pinned binary directly |
 | `chezmoi apply/update` on the Mac host | nothing — devcontainer-only |
 | `git commit --no-verify` / `-n` / `-nm`, `git push --no-verify` | nothing — fix what the hook reports. pre-commit is what runs `no_commit_to_branch`; pre-push runs the suite. Git skips a hook BEFORE it exists as a process, so no hook can catch its own suppression and this guard is the only layer (#400). `git push -n` is `--dry-run` and stays allowed |
+| `echo`/`printf` of a credential variable (`"$DOPPLER_TOKEN"`, `"${API_KEY:-none}"`) | nothing — print a FLAG, never a value: `[ -n "$VAR" ] && echo SET \|\| echo ABSENT`. **`:-` and `:=` emit the VALUE** for a set variable, so `${VAR:+SET}${VAR:-ABSENT}` prints the secret — that is how a live Doppler token reached a transcript (2026-08-02). Handing a credential to a consumer stays allowed; stdout is the transcript |
 | `HK_SKIP_HOOKS=` / `HK_SKIP_STEPS=` as a local command prefix | nothing — they exist for CI jobs that commit or push (ADR-0001, gated by `workflow_hk_skip_hooks`); locally they only turn the gate off |
 
 Diagnostic/read-only commands (`docker ps`, `gh pr view`, `git status`,

--- a/.claude/rules/secrets-out-of-the-shell-env.md
+++ b/.claude/rules/secrets-out-of-the-shell-env.md
@@ -162,12 +162,29 @@ Findings, control arms, and the verification that passed while blind:
    output of a command an agent runs, and that output lands in the session
    transcript. Measured 2026-08-02: a `${(P)k}` expansion meant as a presence flag
    printed four live credential values, and all four had to be rotated. They were
-   the four `env = true` opt-ins — with `env = "exec"` the other 45 are not in the
-   shell to print, so **the exposed set is exactly the opt-in set**, and it is
-   knowable in advance. Use `${VAR:+SET}`, `[ -n "$VAR" ]` or
+   the four `env = true` opt-ins. Use `${VAR:+SET}`, `[ -n "$VAR" ]` or
    `printenv VAR >/dev/null` and read the rc; never interpolate the value into a
    format string "just to check". Gap tracked in #474; no machine layer exists yet,
    so this rule is the only layer.
+
+   ⚠️ **IT RECURRED THE SAME DAY — the safe form is only safe ALONE.**
+   `${VAR:+SET}${VAR:-ABSENT}` opens with the form this rule recommends and is a
+   **leak**: `:-` and `:=` are *value-emitting* substitutions, so a **set**
+   variable prints `SET<the secret>` (an *unset* one prints `ABSENT`, which is why
+   it survives review and why an unset-only control arm certifies nothing — arm it
+   on a variable that IS set). Want both branches? `[ -n "$VAR" ] && echo SET ||
+   echo ABSENT`. **Now machine-enforced** — `hook_guard`'s
+   `secret_value_substitution` denies `${<CREDENTIAL_NAME>:-|:=}` in a Bash
+   command; that closes the #474 gap for this shape, and this rule still carries
+   every other shape.
+
+   ⚠️ **The blast radius is NOT capped at the opt-ins.** This file claimed
+   *"exactly the opt-in set, knowable in advance"* — **false for a probe run under
+   `fnox exec`**. The leaked `DOPPLER_TOKEN` is **exec-only** (same command:
+   `PRESENT` under `fnox exec`, `ABSENT` in a plain shell); wrapping the probe put
+   it in reach. Any of the 49 is printable that way; only an *unwrapped* probe is
+   capped at four. Full incident, the reproduction table and both corrections:
+   `docs/rules-evidence/secrets-out-of-the-shell-env.md`.
 
 ## See also
 

--- a/docs/rules-evidence/secrets-out-of-the-shell-env.md
+++ b/docs/rules-evidence/secrets-out-of-the-shell-env.md
@@ -260,6 +260,61 @@ the shell until something re-reads the config. Filed with the confirmed trigger 
    conclusion. An unattributed cause is an open question, and it should be
    labelled as one until a *source* — not a silence — closes it.
 
+## The `:-` fallback leak — 2026-08-02-g, the same rule's second breach that day
+
+Rule 7 was written earlier the same day, after a `${(P)k}` expansion printed four
+live credentials. Hours later, an agent **holding that rule and citing it** ran:
+
+```sh
+printf "%s" "${DOPPLER_TOKEN:+PRESENT}${DOPPLER_TOKEN:-ABSENT}"
+```
+
+which printed `PRESENT` followed by the live `dp.ct.` Doppler CLI token. It had to
+be rotated.
+
+### Why it passed review
+
+`${VAR:+PRESENT}` is the form the rule *recommends*. The construct opens with it,
+so it reads as compliant. The leak is the second half: **`:-` is a value-emitting
+substitution** — for a *set* variable it expands to the value, not to the fallback.
+Reproduced on a harmless value:
+
+| Expression (with `FOO=visible-safe-value`) | Output |
+|---|---|
+| `${FOO:+SET}` | `SET` |
+| `[ -n "$FOO" ] && echo SET \|\| echo ABSENT` | `SET` |
+| **`${FOO:+SET}${FOO:-ABSENT}`** | **`SETvisible-safe-value`** |
+| `${NOPE_UNSET:+SET}${NOPE_UNSET:-ABSENT}` (unset) | `ABSENT` |
+
+The last row is the whole trap: on an **unset** variable the bad form looks
+perfect.
+
+### Two corrections it forced in the rule
+
+1. **"The exposed set is exactly the opt-in set" was FALSE.** The rule claimed the
+   blast radius was the four `env = true` opt-ins, "knowable in advance".
+   `DOPPLER_TOKEN` is **exec-only** — measured in the same command, `PRESENT` under
+   `fnox exec` and `ABSENT` in a plain shell — and it leaked anyway, because the
+   probe wrapped *itself* in `fnox exec`. Any of the 49 is printable by a probe
+   that does that; only an **unwrapped** probe is capped at the four.
+2. **The control arm certified nothing.** The probe did carry one: a nonexistent
+   variable, returning `ABSENT`. That exercises the `:-` branch only on an unset
+   variable — the single case where it cannot leak. Arming only the absent
+   direction is `probes-need-a-control-arm.md` rule 8: a fixture that could not
+   have produced the other outcome. **Arm a presence probe on a variable that IS
+   set, with a value you can afford to see, before pointing it at a real one.**
+
+### Incidental finding (why the probe was running at all)
+
+It was checking whether a Doppler token already exists before ticket #487
+provisions one. It does: `DOPPLER_TOKEN` lives in the keychain via fnox, declared
+by mde's `bootstrap_config` (`src/mde/secrets/manage.py:296`) as a *declaration
+only*. `doppler me` reports the CLI authenticated as `type: cli`, name
+`dotfiles-20260327` — a **personal CLI login**, and the `dp.ct.` prefix confirms
+`DOPPLER_TOKEN` is that same class. So #487's premise ("provision a token") is
+wrong: one exists, it is the opposite of scoped/read-only/expiring, and the ticket
+should begin by assessing it.
+
 ## GitHub repos touched
 
 - [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the

--- a/python/src/dotfiles_setup/hook_guard.py
+++ b/python/src/dotfiles_setup/hook_guard.py
@@ -142,6 +142,54 @@ _V5 = "2026-07-27"
 # correctly, by the guard of the day. Hence its own cutoff: a pattern widened to
 # cover a NEW command shape is a NEW rule, whatever it is spelled next to.
 _V1B = "2026-07-18"
+# The secret-value-substitution rule landed 2026-08-02 after a presence probe
+# printed a live Doppler token into the session transcript — the SECOND such
+# leak that day, both by an agent holding
+# `.claude/rules/secrets-out-of-the-shell-env.md` rule 7. Prose was the only
+# layer (the rule said so itself, and #474 tracks the gap); this is the first
+# machine layer for the shape.
+_V7 = "2026-08-02"
+
+# Variable names that carry credentials. Suffix/infix match on an ALL-CAPS
+# environment name, minus the path-ish tails (`SSH_KEY_PATH`, `AWS_KEY_FILE`)
+# that name a location rather than a value — those are the false-positive class
+# a print-context rule would otherwise pick up.
+# The LEADING lookahead rejects location-shaped names outright. It has to come
+# first and span the whole name: as a trailing check it backtracks, because
+# `_PAT` matches inside `SSH_KEY_PATH` and the tail then sees only `H`. That
+# false positive was measured, not imagined.
+_CREDENTIAL_NAME = (
+    r"(?![A-Z0-9_]*(?:_PATH|_FILE|_DIR|_NAME|_ID)\b)"
+    r"[A-Z][A-Z0-9_]*"
+    r"(?:TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIALS?|APIKEY|API_KEY|_KEY|_PAT)"
+    r"[A-Z0-9_]*"
+    # `${VAR:+FLAG}` and `${VAR+FLAG}` emit the FLAG, never the value — they are
+    # the forms this rule tells you to use, so they must not trip it.
+    r"(?!:?\+)"
+)
+# Command position, PLUS the start of a shell `-c` body. The second alternative
+# is what catches the exact shape that leaked — `fnox exec -- sh -c 'printf …
+# ${TOKEN:-}'` — where the print sits inside a quoted `-c` argument that `_CMD`
+# cannot see and `_inert_masked` deliberately neuters.
+#
+# It is `-c` specifically, not "any opening quote": the looser form denied
+# `grep -rn "echo \$DOPPLER_TOKEN" docs/`, i.e. searching for the bad pattern.
+# That is a legitimate diagnostic, and a redirect that misfires on diagnostics
+# is the trust-eroding class this guard is warned about.
+#
+# Residual, accepted: only the FIRST command in a `-c` body anchors, because a
+# separator inside the quoted span is already neutered by the masking pass. The
+# leak shape puts the print first, and the alternative — un-neutering quoted
+# separators — would reopen the #265 false-positive class wholesale.
+_PRINT_POS = r"(?:^|[;&|\n]\s*|-c\s*['\"]\s*)"
+# A printing builtin, then — within the SAME command segment — a reference to a
+# credential-named variable. Scoped to print context on purpose: handing a
+# credential to a consumer (`curl -H "Authorization: Bearer $API_KEY"`) is the
+# correct way to use one and stays allowed. Putting the value on STDOUT is what
+# is never right, because stdout is the transcript.
+_PRINTS_SECRET = re.compile(
+    _PRINT_POS + r"(?:echo|printf|print)\b[^;&|\n]*\$\{?" + _CREDENTIAL_NAME
+)
 # The hook-suppression rules landed 2026-07-27 with `no_commit_to_branch` (#400).
 # They are the ONLY layer that can see a bypass: git decides not to run a hook
 # BEFORE the hook exists as a process, so no pre-commit or pre-push hook can
@@ -463,6 +511,20 @@ _RULES: tuple[Rule, ...] = (
         ".claude/rules/zero-skip-policy.md.",
         _V6,
         quoted_blind=True,
+    ),
+    Rule(
+        "secret_value_substitution",
+        _PRINTS_SECRET,
+        "Do not print a credential variable — stdout IS the session "
+        "transcript, and nothing downstream redacts it. A presence probe must "
+        'emit a FLAG, never a value: use `[ -n "$VAR" ] && echo SET || echo '
+        "ABSENT`, or `printenv VAR >/dev/null` and read the rc. Note "
+        "`${VAR:-ABSENT}` and `${VAR:=x}` are VALUE-EMITTING for a set "
+        "variable — `${VAR:+SET}${VAR:-ABSENT}` prints the secret, which is "
+        "exactly how a live Doppler token reached a transcript on 2026-08-02. "
+        "Passing a credential to a consumer is fine; printing it is not. See "
+        ".claude/rules/secrets-out-of-the-shell-env.md rule 7.",
+        _V7,
     ),
 )
 

--- a/tests/test_hook_guard.py
+++ b/tests/test_hook_guard.py
@@ -697,3 +697,67 @@ def test_read_command_real_hook_payload() -> None:
     assert res.returncode == 0
     assert '"permissionDecision": "deny"' in res.stdout
     assert "mise run ship" in res.stdout
+
+
+# --- secret_value_substitution (#474 shape; landed 2026-08-02) --------------
+#
+# A presence probe printed a live Doppler token into a session transcript. The
+# rule denies a credential variable reaching STDOUT; both directions are pinned
+# because the trap is that the SAFE form is a prefix of the leaking one.
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # the exact command that leaked, verbatim
+        'fnox exec -- sh -c \'printf "under fnox exec: %s\\n" '
+        '"${DOPPLER_TOKEN:+PRESENT}${DOPPLER_TOKEN:-ABSENT}"\'',
+        # the leak survives a shell -c body, which is where it actually happened
+        "sh -c 'echo \"${AWS_SECRET_ACCESS_KEY:-none}\"'",
+        'bash -c "echo $GITHUB_TOKEN"',
+        # bare and braced interpolation
+        'echo "$DOPPLER_TOKEN"',
+        'echo "${AWS_SECRET_ACCESS_KEY}"',
+        # every value-emitting substitution operator
+        'printf "%s" "${CONTEXT7_API_KEY:-none}"',
+        'echo "${GITHUB_PAT:=x}"',
+        # not the first command in the line
+        'ls; echo "$EXA_API_KEY"',
+        'echo "${MY_PASSWORD}"',
+        'echo "$FOO_CREDENTIALS"',
+    ],
+)
+def test_printing_a_credential_is_denied(command: str) -> None:
+    reason = hook_guard.decide(command)
+    assert reason is not None, command
+    assert "stdout IS the session" in reason
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # `:+` / `+` emit the FLAG, never the value — the forms the rule
+        # RECOMMENDS. Denying these would leave no compliant way to probe.
+        'echo "${DOPPLER_TOKEN:+SET}"',
+        'echo "${DOPPLER_TOKEN+SET}"',
+        '[ -n "$DOPPLER_TOKEN" ] && echo SET || echo ABSENT',
+        'printenv DOPPLER_TOKEN >/dev/null; echo "rc=$?"',
+        # handing a credential to a CONSUMER is the correct way to use one
+        'curl -H "Authorization: Bearer $CONTEXT7_API_KEY" https://example.com',
+        # location-shaped names hold a path, not a value (`_PAT` matched inside
+        # `_PATH` before the leading lookahead was added — a measured defect)
+        'echo "$SSH_KEY_PATH"',
+        'echo "$AWS_KEY_FILE"',
+        'echo "$SECRET_NAME"',
+        'echo "$TOKEN_ID"',
+        # ordinary variables, including the repo's own anchor idiom
+        'echo "${CLAUDE_PROJECT_DIR:-.}"',
+        'echo "$HOME"',
+        'bash "${CLAUDE_PROJECT_DIR:-.}/scripts/pretooluse-guard.sh"',
+        # prose and search are diagnostics, not leaks
+        'git commit -m "never echo $API_KEY in a probe"',
+        'grep -rn "echo \\$DOPPLER_TOKEN" docs/',
+    ],
+)
+def test_safe_credential_handling_is_allowed(command: str) -> None:
+    assert hook_guard.decide(command) is None, command


### PR DESCRIPTION
Second credential leak of 2026-08-02, both by an agent holding
`.claude/rules/secrets-out-of-the-shell-env.md` rule 7. Ray: "its fine for now,
we are still prototyping, just prevent it from happening again" — so no
rotation, but the prose layer is no longer the only layer. The rule itself said
"no machine layer exists yet"; #474 tracked the gap. This closes it for this
shape.

The probe was meant to print presence:

    printf "%s" "${DOPPLER_TOKEN:+PRESENT}${DOPPLER_TOKEN:-ABSENT}"

`${VAR:+PRESENT}` is the safe form this rule recommends, which is exactly why
the construct passed review. The leak is the second half: `:-` and `:=` are
VALUE-emitting, so a set variable prints `PRESENT<the secret>`. On an unset
variable it prints `ABSENT` and looks perfect — which is also why the control
arm (a nonexistent variable) certified nothing. It exercised the only case that
cannot leak.

New `hook_guard` rule `secret_value_substitution` denies a credential-named
variable reaching stdout from a printing builtin. Scoped to PRINT context on
purpose: handing a credential to a consumer (`curl -H "Authorization: Bearer
$API_KEY"`) is how you are supposed to use one and stays allowed. Putting the
value on stdout is what is never right, because stdout is the transcript.

Three defects found by arming it, none hypothetical:

- The exact leaking command was MISSED at first. The print sits inside a quoted
  `sh -c` body, which `_CMD` cannot see and the masking pass deliberately
  neuters. Fixed by admitting `-c '` as a command position — `-c` specifically,
  because the looser "any opening quote" denied `grep -rn "echo \$TOKEN" docs/`,
  a legitimate diagnostic and the trust-eroding class this guard is warned about.
- `echo "$SSH_KEY_PATH"` false-positived: `_PAT` matches inside `_PATH`, and a
  trailing exclusion backtracks. The location-name lookahead had to lead.
- `echo "${TOKEN:+SET}"` false-positived — the rule would have denied the very
  form it tells you to use. `:+` and `+` are flag-emitting and are now excluded.

25 cases pinned in both directions. Also corrected a claim in the rule that was
measurably false: it said the blast radius is "exactly the opt-in set, knowable
in advance". `DOPPLER_TOKEN` is exec-only (`PRESENT` under `fnox exec`, `ABSENT`
in a plain shell) and leaked anyway, because the probe wrapped itself in `fnox
exec`. Any of the 49 is printable that way; only an unwrapped probe is capped at
four.

Note ruff's S105 fires on the pattern constant's NAME. Renamed to
`_CREDENTIAL_NAME` rather than suppressed — `no_lint_skip` bans `noqa`, and the
rename is the honest fix.

Incidental, and it rewrites a ticket: the probe was checking whether a Doppler
token already exists before #487 provisions one. It does — `DOPPLER_TOKEN` in the
keychain via fnox, declared by mde's `bootstrap_config` — and `doppler me`
reports a `type: cli` personal login, which is the opposite of the scoped,
read-only, expiring token #487 asks for. Recorded in the evidence file.

Gates: lint rc=0 · pytest 1202 passed · verify 113 passed / 0 failed / 4 skipped
· lint-docs "No issues found" · md-budget rc=0 (196/200 and 162/200 lines).

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014x8jGSieFkDBV95KLXYhTC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788296156&installation_model_id=429246&pr_number=502&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F502&signature=f2f7ec025d792d9a5510ab0238511932d3ff571aa2c98e11096f021717db365b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added safeguards that block commands from printing credential values.
  - Added guidance for safely checking whether credentials are present without exposing secrets.
- **Documentation**
  - Expanded security documentation with examples of unsafe variable expansion and clarified exposure scope.
- **Tests**
  - Added coverage for credential leaks across shell commands and nested execution.
  - Confirmed safe presence checks, redacted output, and non-secret variables remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->