### PR TITLE
docs(receipt): #487 — the token existed, and it was the opposite of the ticket's title

### DIFF
--- a/docs/receipts/487.md
+++ b/docs/receipts/487.md
@@ -1,0 +1,175 @@
+# Receipt — #487: Provision a scoped, read-only, expiring Doppler service token
+
+**Verdict:** **A scoped read-only token now exists and is verified; the credential the ticket assumed
+had to be created already existed and was the opposite of its title.** `dotfiles-20260327` is a
+personal CLI login reaching **4 projects / 16 configs / ~162 secrets**, **read/write**, with **no
+expiry**. Minted alongside it: `dotfiles-fnox-ro-20260802` — `dotfiles`/`dev_personal`, `read`, no
+`--max-age` (Ray's call), stored in the macOS keychain as `mde-fnox`/`DOPPLER_RO_TOKEN`. Doppler
+token scoping is **per-config, not per-secret**, so the answer to the ticket's fourth sub-question is
+that **no single-writer enforcement is purchasable at secret granularity**. ⚠️ **The adoption lever
+is not what the map assumed** — fnox authenticates to Doppler via the ambient `doppler login`
+session, so the `DOPPLER_TOKEN` *secret* is inert for fnox's own resolution and repointing it would
+narrow nothing; the lever is the provider block's `token` field, which lives in a **generated** file.
+Adoption is therefore **not done** and is graduated as its own ticket.
+
+**Resolved:** 2026-08-02
+
+## Sources — what I actually opened
+
+- `doppler configs tokens create --help` (CLI v3.76.1, installed) — the primary source for scoping
+  granularity: *"Create a service token **for a config**"*, `--access read|read/write` (**read is
+  the default**), `--max-age`. Settles sub-question 4 without a doc fetch.
+- `doppler me --help` / `doppler secrets --help` — confirmed `me` prints a **truncated token
+  preview**, never the value, and that `--only-names` exists, so the whole assessment could run
+  without ever requesting a secret value (`.claude/rules/secrets-out-of-the-shell-env.md` rule 7).
+- `~/.config/fnox/config.toml` — provider blocks and declaration shape only, values redacted at the
+  point of reading. Established `[providers.doppler_dotfiles_dev_personal]` = project `dotfiles`,
+  config `dev_personal`, **no `token` key**.
+- `docs/research/runs/research-20260709-r2-secrets/agents/doppler-platform.md` — the 2026-07-09
+  platform sweep; its token-type table and free-tier limits.
+- [#437](https://github.com/ray-manaloto/dotfiles/issues/437) (via the map body) — fnox's Doppler
+  provider is `RemoteRead`, i.e. fnox **cannot write to Doppler**.
+
+**Live doc fetch not required:** the CLI's own `--help` is the primary source for the surface being
+assessed, and the cached corpus already carried the plan-gating table. Step 0 of
+`.claude/rules/research-doc-sources.md` was checked first and **missed** — `doppler` is absent from
+`docs/research/mintlify-catalog.md` (control arm: 16 `github.com` entries match, so the grep works).
+
+## Prior art — the search I ran
+
+**Query:** `grep -rlniE 'service token|token scop|--max-age|configs tokens|read-only token' docs/receipts docs/specs docs/research .claude/rules`
+**Corpus:** `docs/receipts/`, `docs/specs/`, `docs/research/`, `.claude/rules/`
+
+### Control arm — REQUIRED, and run it before you believe any result
+
+**Known-present term:** `Doppler` → **47** files
+**Known-absent term:** `flimberquax9` → **0** files
+
+Paths written **literally**, not via a shell variable — zsh does not word-split `$var`, and that is
+exactly how #440's search silently collapsed to one nonexistent path.
+
+| Hit | What I did with it |
+|---|---|
+| `docs/research/runs/research-20260709-r2-secrets/agents/doppler-platform.md` | **read — decisive.** Its token-type table independently confirms every CLI-derived finding (CLI token = *"user, whole workplace"*; service token = *"ONE project+config, read-only by default … ephemeral variant with `--max-age`"*) and adds what the CLI cannot show: **service accounts and OIDC are Team/Enterprise-only**, so on the free Developer plan the project+config service token is *the only* non-interactive primitive. Free tier: **50 service tokens, 5 CLI tokens/user**. ⚠️ **One row of it is stale against measurement** — its recommendation names `dotfiles/dev` as the scope target; the live fnox provider block says **`dev_personal`**. Measurement wins. |
+| `docs/receipts/437.md` | read — confirms fnox's provider is read-only from source, which is why `--access read` covers 100% of fnox's need. |
+| `docs/specs/secrets-takeover.md` | read — the spec consumes this decision; it does not pre-empt it. |
+| `docs/research/kb/reports/agents/codex-adversarial-437-source-of-truth.md` | read — the adversarial pass on #437; its single-writer analysis is what makes token scoping the only remaining enforcement lever, i.e. the reason this ticket exists. |
+| `docs/research/kb/reports/agents/deep-research-takeover-20260730.md` | read — takeover framing; no token-provisioning content beyond what #437 settled. |
+| `docs/research/runs/research-20260709-r2-secrets/report.md` · `agents/alternatives.md` · `agents/fnox-division.md` · `agents/full-secret-map.md` | read — same 2026-07-09 run as `doppler-platform.md`; the token content is consolidated there, these add store-comparison and secret-inventory context only. |
+| `docs/research/runs/research-20260709-r2-synthesis/report.md` · `research-20260709-r2-release-mining/{report.md,agents/fnox-secrets.md,agents/mise-core.md}` · `research-20260709-r2-web-env/report.md` | read — the web-env one carries the live caveat that a web session must hold `DOPPLER_TOKEN` as a **plaintext env var**, which is an argument *for* a scoped token but is out of this ticket's scope (headless consumers, not this Mac). Release-mining hits are fnox/mise version archaeology, not token surface. |
+| `docs/research/mintlify-cache/jdx/fnox/llms-full.txt` · `twpayne/chezmoi/llms-full.txt` | dismissed — matched on `read-only`/`service` in unrelated prose (chezmoi has no Doppler token surface at all; fnox's doc hit is its provider table, already superseded by the source-level finding in #437). |
+| `docs/research/runs/research-20260707-gha-shipland-enforcement/deep-research-raw.json` | dismissed — raw research JSON about GHA merge enforcement; the match is on `service` in an unrelated GitHub-API context. |
+
+## Measurements — every probe with its control arm
+
+| # | Probe | Result | Control arm |
+|---|---|---|---|
+| 1 | `doppler me` | `dotfiles-20260327`, type **`cli`**, workplace `ray-manaloto`, created **2026-03-27**, preview `dp.ct…d7dbpj` | — (identity, not a claim) |
+| 2 | Is `DOPPLER_TOKEN` the same credential as the ambient CLI login? | **Yes** — plain shell, `fnox exec`, and `fnox exec … --no-read-env` all return slug `b48d98a7-…` | ⚠️ Those three arms **do not discriminate on their own.** Armed with a bogus `DOPPLER_TOKEN`: → `Invalid Auth token`, **rc=1**; real → **rc=0**. That proves the env var *is* read, which is what makes arm 2's agreement meaningful. |
+| 3 | Reach | **4 projects × 4 configs = 16 configs**, ~**162** real secrets (`dotfiles/dev` 43, `dotfiles/dev_personal` **49**, `example-project` 20, `spendcli` 2, `spend-sentry` 48) | stg/prd configs return exactly the **3 Doppler built-ins** (`DOPPLER_{PROJECT,CONFIG,ENVIRONMENT}`), so the low counts are real emptiness, not a truncated read. Names only — `--only-names`, never a value. |
+| 4 | Expiry | **None exposed.** `doppler me --json` keys: `workplace.{name,slug}`, `type`, `token_preview`, `slug`, `created_at`, `name`, `last_seen_at` | Service tokens render an **`EXPIRES AT`** column, so the field exists in the product — its absence here is a property of the token type, not of the reader. |
+| 5 | Do any service tokens already exist? | **Zero**, across all 16 configs | bogus config → **rc=1** *"Could not find requested config"*; real config → **rc=0** + empty table. So the zero is the world. ⚠️ My reader was mildly broken first: `--json` emits literal `null` (not `[]`) for an empty list, so `jq length` gave `null`. The **table** form is the armed reader. |
+| 6 | fnox's Doppler surface | **exactly one config** — `[providers.doppler_dotfiles_dev_personal]` = `dotfiles`/`dev_personal`; no `token` key in the block | — (direct read of the declaration) |
+| 7 | Declaration structure | 49 declarations = **48 doppler-primary + 1 keychain**; every one carries an `age` **sync** block. `DOPPLER_TOKEN` itself is the keychain one (line 21) — it *cannot* live in Doppler | 49 age + 48 doppler + 1 keychain = **98 across 49 declarations** ✓, and the inline-table count is **49** ✓. Fresh known-absent arm `provider = "quorbix"` → **0**. |
+| 8 | Does the read path hit Doppler? | **No.** `fnox exec` resolves all 49 in **0.02–0.05s** | A single known-network call (`doppler secrets --only-names`) takes **0.11–0.81s** on the same host. ⚠️ This establishes *not-network*, **not the mechanism** — whether that is the `age` sync copy or `MISE_ENV_CACHE` is [#488](https://github.com/ray-manaloto/dotfiles/issues/488) / [#471](https://github.com/ray-manaloto/dotfiles/issues/471) territory, deliberately not claimed here. |
+
+### Two of my own probes were broken, and the control arms are what caught them
+
+⚠️ **A probe that could only pass.** Extracting a secret name with `cut -d' ' -f1` left the trailing
+`=` (the config uses `KEY= {` spacing), so the test became `[ -n "$AUTH_TOKEN=" ]` — **non-empty by
+construction**, printing `RESOLVED` in every arm. The tell was both arms agreeing. Fixed with
+`sed -E 's/ *=.*//'` plus a negative control (`$KRUNDLEVAX_NOPE_71` → **EMPTY**) so the probe
+demonstrably discriminates before any result was believed.
+
+⚠️ **A pipe ate an exit code.** `doppler me | head` returned **rc=0 on an authentication failure** —
+that was `head`'s rc (`feedback_pipe_kills_exit_code`). Unpiped and file-captured: bogus **rc=1**,
+real **rc=0**. Every rc in the table above is unpiped.
+
+## Provisioning — what was actually done, and its arms
+
+Ray's decision at the fork: **mint read-only, no `--max-age`**; then *"macos keychain and fnox need
+to have all the keys/secrets from `dotfiles/dev_personal`"*.
+
+| # | Action | Result | Control arm |
+|---|---|---|---|
+| 9 | Mint `dotfiles-fnox-ro-20260802` | slug `4115d261-4ece-4498-9d7a-2a0ecac69050`, `dotfiles`/`dev_personal`, ACCESS **read**, **EXPIRES AT blank**, 63 bytes, prefix `dp.st.` (service) vs the CLI login's `dp.ct.` | `dotfiles/dev` still lists **zero** tokens, so the new row is scoped where intended |
+| 10 | **The write arm the ticket demanded** | read in-scope **rc=0** (52 names) · **write in-scope rc=1** *"You do not have write access to this config's secrets"* | Three further arms give **distinct** messages — other config, other project, and bogus token (*"Invalid Auth token"*). Five distinct signatures ⇒ the rejection is about **access**, not auth or scope. Cleanup check: the probe secret is **absent**, so nothing was written. |
+| 11 | Store in keychain (`mde-fnox`/`DOPPLER_RO_TOKEN`) | round-trips at 63 bytes, `dp.st.` | an absent account name → **rc=44**, so the reader discriminates. Value never printed: `--plain` → 0600 scratchpad → keychain → scratch **shredded**. |
+| 12 | Three-way set comparison | fnox **49** · Doppler **49** · keychain **47**, overlap(fnox,Doppler) **48** | `comm` overlap counts printed alongside both differences, so an empty difference is distinguishable from a broken join |
+| 13 | Mirror the 6 Doppler-only secrets into keychain | all 6 stored rc=0; keychain **47 → 54** (+6, +`DOPPLER_RO_TOKEN`); **zero** now missing | Every value verified **by digest**, not by trusting rc. Control: `AUTH_TOKEN` — a pre-existing entry I never wrote — also matches Doppler, so the comparator works on untouched data. |
+
+**The fnox ↔ Doppler difference is structural, not drift.** `DOPPLER_TOKEN` is in fnox but not
+Doppler because it *unlocks* Doppler; `AGE_PRIVATE_KEY` was in Doppler but not fnox because it
+*unlocks* the age cache. **Each store holds the other's key** — that is the bootstrap chain, and it
+is why neither difference should ever be "fixed" by a set-equality gate without an encoded exception.
+
+⚠️ **`security find-generic-password -w` returns HEX for a multi-line value.** `AGE_PRIVATE_KEY`
+read back as **377** bytes against Doppler's **188** (≈2×+1). Not corruption — an encoding artifact
+of the retrieval path, confirmed by hex-decoding to a matching digest. **Any consumer reading that
+entry must hex-decode it**; the other five are plain.
+
+### Two more of my own probes were broken
+
+⚠️ **A keychain reader that found 47 records and printed 0 names.** `grep -A1` on `svce` never sees
+`acct`, which sorts far earlier in a dump record. *A count of 47 with zero names should have been the
+tell immediately* — instead the first pass reported an empty list. Rewritten as an awk record-scanner
+and armed by confirming the first names are real.
+
+⚠️ **A digest comparator that said MISMATCH on all six.** 6/6 failing is the same shape as "both arms
+agree" — it accuses the probe, not the world. Cause: the Doppler side was piped into `shasum`
+(keeping the trailing newline) while the keychain side went through `$(…)` (which strips it).
+Re-run with consistent capture, all six matched. The comparator was itself armed (`a` vs `b` →
+MISMATCH) so it was known to be capable of both answers.
+
+## Adversarial review
+
+**Lens:** none
+**Verdict:** not-run
+**Findings:** —
+**Disposition:** —
+
+**Not run:** this ticket ships **no code** — its output is a provisioned credential plus a fact
+table, and every row above is settled by a control-armed probe rather than by argument. ⚠️ **This is
+now the fourth `lens: none` in a row** (#445, #446, #460, #487), which `docs/issue-tracker.md`
+flags explicitly as a streak worth noticing rather than continuing by default. Recorded as a known
+weakness of this receipt, not defended: the claim most exposed by the absence of a cold lens is the
+**inferred** auth path in the Notes below, which is the one finding here not settled by measurement.
+
+## Notes
+
+⚠️ **The one claim here not settled by measurement — read it as an inference.** fnox's documented
+token resolution order is (1) provider `token` field → (2) `FNOX_DOPPLER_TOKEN` → (3)
+`DOPPLER_TOKEN` → (4) **interactive `doppler login` session**. This Mac's provider block has no
+`token` key (measured) and neither env var is present in fnox's own process, so by that order fnox
+authenticates via the **ambient CLI login**. I could not close the loop: `fnox sync --dry-run` does
+**not** contact Doppler — armed both ways, a real and a bogus `FNOX_DOPPLER_TOKEN` produced an
+**identical rc=0 plan** — so the auth call was never exercised. Proving it needs a real, mutating
+sync, which was out of scope. **Consequence if the inference holds:** repointing the `DOPPLER_TOKEN`
+secret narrows nothing, and the adoption lever is the provider `token` field.
+
+**Why adoption was not performed.** That lever lives in `~/.config/fnox/config.toml`, which is
+**generated** — `bootstrap_config()` rewrites it and drops whatever it does not re-emit, the same
+class that ate `env = "exec"` and all four opt-ins on 2026-07-30. Hand-adding `token = …` there is a
+patch with a half-life, so it is a decision about where the declaration should durably live, not a
+mechanical edit. **Graduated as its own ticket** rather than resolved here.
+
+**Why no `--max-age`, recorded so it is not re-litigated as an oversight.** Expiry was the third
+property the ticket asked for and was deliberately declined: nothing on this host reports a dead
+provider loudly. #460 measured `fnox check` as a probe that can only pass, and probe 8 shows reads
+never touch Doppler — so an expired token surfaces only at `fnox sync`, on a path with no gate.
+Expiry without a rotation mechanism converts a scoping win into a silent-failure risk.
+
+**The CLI login cannot be retired by this ticket.** The write path is the `doppler` CLI driven by a
+human (`mde-secret-add`), which needs read/write. So scoping only ever narrows *fnox's lane*. The
+leaked 2026-08-02 token is that same workplace-wide CLI login; it remains **unrotated by Ray's
+explicit decision** (*"its fine for now, we are still prototyping"*), and this receipt does not
+reopen it — it only makes revocation *possible later* without re-deciding anything.
+
+**What to re-check if this is revisited.** The free-tier limits (50 service tokens, 5 CLI tokens/user,
+no service accounts, no OIDC) come from a **2026-07-09** artifact — re-verify against
+<https://www.doppler.com/pricing> before relying on the plan gating, which is the one load-bearing
+claim here not re-derived from the installed CLI.
+
+**Not investigated, deliberately.** Whether the *other* three projects (`example-project`, `spendcli`,
+`spend-sentry`) should be in this workplace at all. They widen the CLI login's blast radius
+materially, but they are not this repo's business and not this map's destination.


### PR DESCRIPTION
The ticket asked to provision a scoped, read-only, expiring Doppler token. One
already existed: `dotfiles-20260327`, a personal CLI login reaching 4 projects /
16 configs / ~162 secrets, read/write, no expiry.

Minted beside it: `dotfiles-fnox-ro-20260802` (dotfiles/dev_personal, read, no
--max-age by decision), stored at keychain mde-fnox/DOPPLER_RO_TOKEN. The write
arm the ticket demanded ran and was REJECTED, across five arms with five distinct
signatures, so the rejection is about access rather than auth or scope.

Scoping bottoms out at per project+config, not per-secret, so no single-writer
enforcement is purchasable at secret granularity — which bounds #437's finding
that token scoping was the only remaining mechanism.

Adoption is deliberately not done: fnox's resolution order ends at the ambient
`doppler login` session, so the DOPPLER_TOKEN secret is inert for fnox's own
resolution and repointing it narrows nothing. The lever is the provider `token`
field, which lives in the generated config bootstrap_config() rewrites — a
decision, not an edit. Graduated as #503.

Side finding, fixed: 6 secrets were in Doppler but missing from the keychain
(incl. AGE_PRIVATE_KEY); mirrored in and verified by digest, 47 -> 54. The
fnox <-> Doppler difference is structural and must not be "fixed" — each store
holds the other's bootstrap key.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014x8jGSieFkDBV95KLXYhTC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788299379&installation_model_id=429246&pr_number=504&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F504&signature=2206c641d74eb5a1217ca2968fceb33bd86c37433975832e904bca355208d494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->