### PR TITLE
fix/487 retract unsupported timing claim

### DIFF
--- a/.claude/rules/secrets-out-of-the-shell-env.md
+++ b/.claude/rules/secrets-out-of-the-shell-env.md
@@ -1,11 +1,45 @@
-# Secrets Stay Out of the Shell Environment
+# Secrets in the Shell Environment
 
-A credential that lives in the interactive shell's environment is inherited by
-**every** child process — every agent, every CLI, every task — and travels in a
-form no secret scanner can read. Keep secrets out of the shell; inject them into
-the one process that needs them.
+⚠️ **REVERSED 2026-08-02 by Ray, deliberately.** All 49 credentials are now
+`env = true` — available in every terminal and inherited by every child process,
+including Claude Code, its subagents and any MCP server they spawn. The stated
+requirement was *"in sync and available to all terminals and ai/llm agents"*.
+This file is no longer "keep secrets out of the shell"; it is **the record of why
+that posture existed, what the reversal costs, and which parts still bind.**
 
-## What happened, and why no scanner caught it
+**Most of this rule survives the reversal, and rule 7 matters MORE.** What changed
+is one axis — where credentials live. What did not change: an environment dump is
+still unscannable and must never be committed (rule 1, gated by `no_env_dump`), a
+probe must still never print a value (rule 7, gated by `secret_value_substitution`),
+a non-secret must still not be marked secret (rule 3), and a clean scanner still
+means "ask what it can see" (rule 4). With 49 credentials in every child instead
+of 4, the blast radius of breaking any of those is **12× larger**, not smaller.
+
+**What the reversal costs, stated plainly rather than argued away:** the exposure
+[#470](https://github.com/ray-manaloto/dotfiles/issues/470) documents is now
+accepted, not mitigated; `__MISE_DIFF` again carries all 49 in a form no scanner
+reads; and the confinement work in
+[#432](https://github.com/ray-manaloto/dotfiles/issues/432) (SCOPED-READ) and
+[#441](https://github.com/ray-manaloto/dotfiles/issues/441) (agent profile) is
+scoped to a hazard the host no longer avoids. Those tickets need re-judging.
+
+**The tripwire moved, it did not go away.** `doctor.toml` now pins `env = true`
+plus the **full 49-name set**, so an addition, a removal or a *rename* is still
+caught in both directions (control-armed: a rename keeping the count at 49 is
+reported both ways). That also lands what
+[#460](https://github.com/ray-manaloto/dotfiles/issues/460) measured as the fix
+for the doctor's blind zone — 14 of 49 secrets previously sat past the deepest
+thing the baseline checked.
+
+⚠️ **Never declare a keychain-backed secret without putting fnox on the item's
+ACL.** fnox resolves every declaration on **every shell prompt**, and a keychain
+item created by `security add-generic-password` does not list fnox, so the read
+blocks on a GUI dialog forever. On 2026-08-02 that produced **190 stuck
+processes**, load 13.5, and a locked login keychain. Create with
+`-T <fnox real binary>` — noting the real path is version-pinned under
+`~/.local/share/mise/installs/fnox/<version>/`, so the grant breaks on upgrade.
+
+## What happened originally, and why no scanner caught it
 
 `fnox activate` exported 49 credentials into the login shell. mise records the
 environment delta in **`__MISE_DIFF`** (zlib + base64) so it can undo it on
@@ -22,86 +56,24 @@ code here at all (see [[use-tool-builtins]]), and it covers only the decode.
 Full incident, measurements and control arms:
 `docs/rules-evidence/secrets-out-of-the-shell-env.md`.
 
-## The source fix — fnox already ships it
+## The mechanism, and the generator that keeps eating it
 
-fnox **v1.30.0** (2026-07-09) added an exec-only env mode whose release notes
-name this exact threat: it keeps secrets out of the interactive shell *"where AI
-coding agents and other inherited processes would see them"*, while still
-injecting them into `fnox exec` subprocesses. fnox here is **1.31.1**, so it is
-available now.
+fnox's `env` setting has three values: `true` (default — shell, `exec` and `get`),
+`"exec"` (not the shell), `false` (`get` only). Per-secret `env` **overrides the
+global**, which is why flipping the global alone changes nothing.
 
-```toml
-# fnox.toml — one line flips the whole config to default-deny
-env = "exec"
+⚠️ **The config is GENERATED** — *"Managed by `mde-py secrets bootstrap-config`. Do
+not edit by hand."* `bootstrap_config()` rebuilds it from scratch and re-emits only
+`provider` + `value`, so it drops the global `env`, every per-secret override and
+every `sync` block **by construction**. Its trigger is the documented happy path:
+any `mde-secret-add` / `update` / `remove`. That is a real defect
+(`macos-development-environment#82`), **not** an fnox bug — an authorized write probe
+round-tripped fnox's own writers with the mode and all opt-ins preserved, on both the
+scoped and bulk paths. So any hand edit here is **a patch with a half-life**, and the
+durable layer is the doctor check that re-reads the artifact every session.
 
-[secrets]
-AWS_SECRET_ACCESS_KEY = { provider = "…" }              # exec-only
-SOME_PROMPT_VAR       = { provider = "…", env = true }  # explicit opt-back-in
-```
-
-| `env` | shell / `fnox export` | `fnox exec` | `fnox get` |
-|---|:-:|:-:|:-:|
-| `true` (default) | yes | yes | yes |
-| `"exec"` | **no** | yes | yes |
-| `false` | no | no | yes |
-
-With `env = "exec"` there is no delta for mise to record, so `__MISE_DIFF`
-stops carrying credentials at the source. Everything below is the net under
-that, not a substitute for it.
-
-The table above is the tool's **measured** behaviour on the pinned 1.31.1 (both
-arms probed), not a restatement of its release notes.
-
-**APPLIED 2026-07-27 by Ray; 4 opt-ins since 2026-07-30** — 45 of 49 exec-only.
-Four must stay `env = true` because this repo runs on them: the context7 plugin
-interpolates `CONTEXT7_API_KEY` into an `Authorization` header (exec-only made it
-an empty string and the server served an **anonymous tier while reporting
-connected**), `gh` reports its active account as the environment-authenticated
-one, `mise` rate-limits to 60/h without `MISE_GITHUB_TOKEN`, and the
-`/last30days` engine's web lane reads **`EXA_API_KEY` from the process
-environment**. Exec-only for those degrades tooling *silently*.
-
-⚠️ **`EXA_API_KEY`'s stated reason was wrong until 2026-07-30.** It read
-"`.mcp.json` interpolates it at MCP-server spawn" — true when written, false once
-that server was dropped. The credential is still needed, by a consumer nobody had
-recorded: it is **not** in `~/.config/last30days/.env` and **not** in the
-keychain, so last30days reads it straight from the shell (probed: present at
-length 36, against `AWS_SECRET_ACCESS_KEY` absent, so the check discriminates).
-**A reason that names one consumer is a claim that there is only one** — and that
-claim is what nearly dropped a live credential.
-
-⚠️ **AND IT DOES NOT STAY APPLIED.** Measured 2026-07-30: the config was rewritten
-~4h40m after the fix, losing the global `env` line **and all 4 opt-ins**, so all 49
-credentials were shell-visible again until `mise run doctor`'s `fnox-baseline`
-check caught it. **Diagnosed the same day.** `mde-py`'s `bootstrap_config()`
-rebuilds the file from scratch and never re-emits `env`, so it drops the mode and
-every opt-in **by construction**; the full `fnox sync` its callers run next
-(`add`/`update`/`remove_secret`) regenerates all 49 `sync` blocks. That composite
-matches the wipe exactly — the blocks *look* intact because every ciphertext in
-them was replaced. **fnox is EXONERATED**: an authorized write probe rewrote all
-49 values and preserved the mode and all 4 opt-ins, on both its scoped and bulk
-paths, and fnox's `env` is a real struct field its writers round-trip.
-
-⚠️ **The trigger is the DOCUMENTED HAPPY PATH.** It was `mde-secret-add
-LINEAR_API_KEY`, run by hand after an agent recommended it from the mde repo's own
-docs. So **every secret you add or update re-exposes all 49 credentials** until
-something re-reads the config — which is the whole job of `fnox-baseline`. Filed
-as `macos-development-environment#82`. Probe table, the timeline and the
-re-derived line refs: `docs/rules-evidence/secrets-out-of-the-shell-env.md`.
-
-⚠️ **The config is GENERATED** — *"Managed by `mde-py secrets bootstrap-config`.
-Do not edit by hand."* A hand edit is therefore **not a fix, it is a patch with a
-half-life**; the durable fix belongs upstream. There is no user-root local
-override to hide it in; that layer is project-scoped only. What makes the hand
-edit safe to rely on meanwhile is the check that re-reads the artifact every
-session, not the edit itself.
-
-This also fixed the `[redacted]` digit-masking: two fnox telemetry flags held
-one-character all-digit values and were marked redacted, so mise masked every
-digit in every `mise run` line. Never a mise bug — collateral from treating a
-non-secret as a secret. **It returns if `mde-py` re-bootstraps the config.**
-
-Findings, control arms, and the verification that passed while blind:
+The exec-only era's full adoption history — the mode table, the four opt-in reasons,
+the `EXA_API_KEY` misattribution, and the measured wipe timeline — is in
 `docs/rules-evidence/secrets-out-of-the-shell-env.md`.
 
 ## The gates that now exist in this repo
@@ -139,17 +111,26 @@ Findings, control arms, and the verification that passed while blind:
 1. **Never write an environment dump into a tracked file.** Not `env`, not
    `printenv`, not `export -p`, not a debug log that includes them. If you need
    one for diagnosis, write it to the scratchpad and delete it.
-2. **A secret belongs to a process, not to a shell.** Reach for `fnox exec --`
-   (or the tool's own credential flow) rather than exporting.
+2. ⚠️ **REVERSED — secrets now live in the shell by decision.** This rule used to
+   read *"a secret belongs to a process, not to a shell — reach for `fnox exec --`
+   rather than exporting."* That is no longer the posture (2026-08-02). The
+   consequence to internalise: `fnox exec` is no longer a confinement boundary,
+   because the parent shell already has everything. **Rules 1, 4 and 7 are now the
+   only things between 49 credentials and a transcript or a commit** — there is no
+   second line behind them any more.
 3. **Do not mark a non-secret as a secret.** Redaction is value-based, so a
    short or empty "secret" corrupts every log the tool writes.
 4. **When a scanner reports clean, ask what it can see.** Compression, encoding,
    and a path allowlist each turn "no findings" into "never looked".
-5. **A new env-var consumer is a new `env = true` decision.** With `env = "exec"`,
-   a config that interpolates `${VAR}` gets an **empty string**, not an error — the
-   tool starts, reports healthy, and silently drops to an anonymous tier (context7
-   MCP did exactly this, 2026-07-29). Check the consumer's authenticated
-   *identity*, never its connection status.
+5. **A new SECRET is now the reviewed decision — the old trap inverted.** Under
+   `env = "exec"` the hazard was a *consumer* silently getting an empty `${VAR}`
+   and dropping to an anonymous tier (context7 MCP, 2026-07-29) — so **check a
+   consumer's authenticated identity, never its connection status** still holds
+   whenever anything is exec-only or absent. Under `env = true` that trap is gone
+   and the reviewed decision moves to the other end: **adding a secret to fnox now
+   puts it in every terminal and every agent by default**, so it must be added to
+   `doctor.toml`'s 49-name `env_true` set in the same reviewed diff, or the doctor
+   reports drift on the next session and someone "fixes" it back.
 6. **Diagnose by layer, and never run `fnox get` to do it.** A `-v` presence test
    under `fnox exec` (present) vs the same in a plain shell (absent) identifies
    `env = "exec"` on its own; `fnox sync --dry-run -p age VAR` answers staleness

--- a/docs/receipts/487.md
+++ b/docs/receipts/487.md
@@ -71,7 +71,35 @@ exactly how #440's search silently collapsed to one nonexistent path.
 | 5 | Do any service tokens already exist? | **Zero**, across all 16 configs | bogus config → **rc=1** *"Could not find requested config"*; real config → **rc=0** + empty table. So the zero is the world. ⚠️ My reader was mildly broken first: `--json` emits literal `null` (not `[]`) for an empty list, so `jq length` gave `null`. The **table** form is the armed reader. |
 | 6 | fnox's Doppler surface | **exactly one config** — `[providers.doppler_dotfiles_dev_personal]` = `dotfiles`/`dev_personal`; no `token` key in the block | — (direct read of the declaration) |
 | 7 | Declaration structure | 49 declarations = **48 doppler-primary + 1 keychain**; every one carries an `age` **sync** block. `DOPPLER_TOKEN` itself is the keychain one (line 21) — it *cannot* live in Doppler | 49 age + 48 doppler + 1 keychain = **98 across 49 declarations** ✓, and the inline-table count is **49** ✓. Fresh known-absent arm `provider = "quorbix"` → **0**. |
-| 8 | Does the read path hit Doppler? | **No.** `fnox exec` resolves all 49 in **0.02–0.05s** | A single known-network call (`doppler secrets --only-names`) takes **0.11–0.81s** on the same host. ⚠️ This establishes *not-network*, **not the mechanism** — whether that is the `age` sync copy or `MISE_ENV_CACHE` is [#488](https://github.com/ray-manaloto/dotfiles/issues/488) / [#471](https://github.com/ray-manaloto/dotfiles/issues/471) territory, deliberately not claimed here. |
+| 8 | ~~Does the read path hit Doppler?~~ | ⚠️ **RETRACTED 2026-08-02 — the probe measured nothing.** See below. | — |
+
+### ⚠️ RETRACTION — probe 8 measured nothing, and its conclusion travelled before it was checked
+
+**Retracted 2026-08-02, same day, by re-measurement.** Probe 8 originally read: *"Does the read path
+hit Doppler? **No.** `fnox exec` resolves all 49 in 0.02–0.05s"*, against a 0.11–0.81s network call.
+
+**The probe timed `fnox exec -- true`.** `true` consumes no secret, so that command need not resolve
+anything — the number was the cost of starting fnox, not of resolving 49 secrets. Re-timed against a
+command that actually reads a value (`fnox exec -- sh -c 'test -n "$AUTH_TOKEN"'`): **0.03s, 0.03s,
+0.88s**. A 29× spread across three runs of one command supports no conclusion about the read path at
+all, in either direction.
+
+**This is the failure mode this very receipt catalogues, committed one section below where it is
+described.** The three probes I did catch were caught because two arms *agreed* or N/N failed — a
+visible contradiction. This one produced a plausible number with no contradiction to notice, so
+nothing flagged it, and it propagated into the receipt, the resolution comment on #487, and the map's
+Decisions-so-far before re-measurement killed it. **A fast number is not a control arm.** The arm that
+was missing is trivial in hindsight: run the probe against a command that *cannot* need the thing
+being measured, and confirm the timing differs.
+
+**What is still true, and what is now open:** nothing else in this receipt depended on probe 8, and
+the `--max-age` decision is unaffected — it rested on #460's measured `fnox check` behaviour, not on
+timing. **Genuinely open again:** how fnox resolves the 48 doppler-primary secrets, and whether it
+ever touches the network on the read path. Compounding it, this host has **no age identity**
+(`FNOX_AGE_KEY` absent, control `GITHUB_TOKEN` SET; no `~/.config/fnox/age.txt`), and fnox's docs name
+exactly those as the age provider's decryption inputs — so it is not established that the 49
+`sync = { provider = "age" }` copies are readable here at all. That question belongs to
+[#488](https://github.com/ray-manaloto/dotfiles/issues/488).
 
 ### Two of my own probes were broken, and the control arms are what caught them
 
@@ -155,9 +183,13 @@ mechanical edit. **Graduated as its own ticket** rather than resolved here.
 
 **Why no `--max-age`, recorded so it is not re-litigated as an oversight.** Expiry was the third
 property the ticket asked for and was deliberately declined: nothing on this host reports a dead
-provider loudly. #460 measured `fnox check` as a probe that can only pass, and probe 8 shows reads
-never touch Doppler — so an expired token surfaces only at `fnox sync`, on a path with no gate.
-Expiry without a rotation mechanism converts a scoping win into a silent-failure risk.
+provider loudly — [#460](https://github.com/ray-manaloto/dotfiles/issues/460) measured `fnox check`
+as a probe that can only pass, so an expired token would surface late and quietly, on a path with no
+gate. Expiry without a rotation mechanism converts a scoping win into a silent-failure risk.
+⚠️ **The original wording of this paragraph also leaned on retracted probe 8** (*"reads never touch
+Doppler, so it surfaces only at `fnox sync`"*); that clause is withdrawn. The decision stands on
+#460's measurement alone, which is untouched by the retraction — but the *blast radius* of an expiry
+is now unknown rather than bounded, which if anything strengthens the choice.
 
 **The CLI login cannot be retired by this ticket.** The write path is the `doppler` CLI driven by a
 human (`mde-secret-add`), which needs read/write. So scoping only ever narrows *fnox's lane*. The

--- a/docs/rules-evidence/secrets-out-of-the-shell-env.md
+++ b/docs/rules-evidence/secrets-out-of-the-shell-env.md
@@ -321,3 +321,99 @@ should begin by assessing it.
   `no_env_dump` gate, `env_blob_scan.py`, and the history pickaxe.
 - [ray-manaloto/knowledge-base](https://github.com/ray-manaloto/knowledge-base) —
   the second public repo checked by the same pickaxe.
+
+## The exec-only era (2026-07-27 → 2026-08-02) — moved out of the rule verbatim
+
+Ray **reversed this posture on 2026-08-02**: all 49 credentials are now `env = true`,
+available in every terminal and to every agent. The section below is the adoption
+history of the exec-only mode it replaced, kept verbatim because the *mechanisms* it
+documents are still live — `bootstrap_config()` still regenerates the config, and the
+`fnox` env-mode table is still how the tool behaves.
+
+⚠️ **One thing inverts usefully:** fnox's default `env` is `true` and
+`bootstrap_config()` emits only `provider` + `value`, so a regeneration now lands on
+the *desired* state for the mode. The wipe class that ate `env = "exec"` and its four
+opt-ins is **benign for the mode** under the new posture; what stays fragile is any
+added declaration and the `sync` blocks.
+
+## The source fix — fnox already ships it
+
+fnox **v1.30.0** (2026-07-09) added an exec-only env mode whose release notes
+name this exact threat: it keeps secrets out of the interactive shell *"where AI
+coding agents and other inherited processes would see them"*, while still
+injecting them into `fnox exec` subprocesses. fnox here is **1.31.1**, so it is
+available now.
+
+```toml
+# fnox.toml — one line flips the whole config to default-deny
+env = "exec"
+
+[secrets]
+AWS_SECRET_ACCESS_KEY = { provider = "…" }              # exec-only
+SOME_PROMPT_VAR       = { provider = "…", env = true }  # explicit opt-back-in
+```
+
+| `env` | shell / `fnox export` | `fnox exec` | `fnox get` |
+|---|:-:|:-:|:-:|
+| `true` (default) | yes | yes | yes |
+| `"exec"` | **no** | yes | yes |
+| `false` | no | no | yes |
+
+With `env = "exec"` there is no delta for mise to record, so `__MISE_DIFF`
+stops carrying credentials at the source. Everything below is the net under
+that, not a substitute for it.
+
+The table above is the tool's **measured** behaviour on the pinned 1.31.1 (both
+arms probed), not a restatement of its release notes.
+
+**APPLIED 2026-07-27 by Ray; 4 opt-ins since 2026-07-30** — 45 of 49 exec-only.
+Four must stay `env = true` because this repo runs on them: the context7 plugin
+interpolates `CONTEXT7_API_KEY` into an `Authorization` header (exec-only made it
+an empty string and the server served an **anonymous tier while reporting
+connected**), `gh` reports its active account as the environment-authenticated
+one, `mise` rate-limits to 60/h without `MISE_GITHUB_TOKEN`, and the
+`/last30days` engine's web lane reads **`EXA_API_KEY` from the process
+environment**. Exec-only for those degrades tooling *silently*.
+
+⚠️ **`EXA_API_KEY`'s stated reason was wrong until 2026-07-30.** It read
+"`.mcp.json` interpolates it at MCP-server spawn" — true when written, false once
+that server was dropped. The credential is still needed, by a consumer nobody had
+recorded: it is **not** in `~/.config/last30days/.env` and **not** in the
+keychain, so last30days reads it straight from the shell (probed: present at
+length 36, against `AWS_SECRET_ACCESS_KEY` absent, so the check discriminates).
+**A reason that names one consumer is a claim that there is only one** — and that
+claim is what nearly dropped a live credential.
+
+⚠️ **AND IT DOES NOT STAY APPLIED.** Measured 2026-07-30: the config was rewritten
+~4h40m after the fix, losing the global `env` line **and all 4 opt-ins**, so all 49
+credentials were shell-visible again until `mise run doctor`'s `fnox-baseline`
+check caught it. **Diagnosed the same day.** `mde-py`'s `bootstrap_config()`
+rebuilds the file from scratch and never re-emits `env`, so it drops the mode and
+every opt-in **by construction**; the full `fnox sync` its callers run next
+(`add`/`update`/`remove_secret`) regenerates all 49 `sync` blocks. That composite
+matches the wipe exactly — the blocks *look* intact because every ciphertext in
+them was replaced. **fnox is EXONERATED**: an authorized write probe rewrote all
+49 values and preserved the mode and all 4 opt-ins, on both its scoped and bulk
+paths, and fnox's `env` is a real struct field its writers round-trip.
+
+⚠️ **The trigger is the DOCUMENTED HAPPY PATH.** It was `mde-secret-add
+LINEAR_API_KEY`, run by hand after an agent recommended it from the mde repo's own
+docs. So **every secret you add or update re-exposes all 49 credentials** until
+something re-reads the config — which is the whole job of `fnox-baseline`. Filed
+as `macos-development-environment#82`. Probe table, the timeline and the
+re-derived line refs: `docs/rules-evidence/secrets-out-of-the-shell-env.md`.
+
+⚠️ **The config is GENERATED** — *"Managed by `mde-py secrets bootstrap-config`.
+Do not edit by hand."* A hand edit is therefore **not a fix, it is a patch with a
+half-life**; the durable fix belongs upstream. There is no user-root local
+override to hide it in; that layer is project-scoped only. What makes the hand
+edit safe to rely on meanwhile is the check that re-reads the artifact every
+session, not the edit itself.
+
+This also fixed the `[redacted]` digit-masking: two fnox telemetry flags held
+one-character all-digit values and were marked redacted, so mise masked every
+digit in every `mise run` line. Never a mise bug — collateral from treating a
+non-secret as a secret. **It returns if `mde-py` re-bootstraps the config.**
+
+Findings, control arms, and the verification that passed while blind:
+`docs/rules-evidence/secrets-out-of-the-shell-env.md`.

--- a/doctor.toml
+++ b/doctor.toml
@@ -14,43 +14,78 @@
 # look inside the working tree.
 
 [fnox]
-# Global env mode. "exec" keeps credentials OUT of the interactive shell, so
-# they are not inherited by Claude Code, by any MCP server it spawns, or by any
-# agent — see `.claude/rules/secrets-out-of-the-shell-env.md`. The consequence
-# this baseline exists to police: with "exec", a config that interpolates
-# `${VAR}` gets an EMPTY STRING, not an error.
-env = "exec"
+# Global env mode. ⚠️ CHANGED 2026-08-02 (Ray): "exec" -> true.
+#
+# Every secret is now available in the interactive shell and is therefore
+# inherited by every child process — Claude Code, its subagents, and any MCP
+# server they spawn. That is the DELIBERATE, stated requirement ("available to
+# all terminals and ai/llm agents"), reversing the 2026-07-27 exec-only posture.
+# The accepted risk is written up in
+# `.claude/rules/secrets-out-of-the-shell-env.md`; this line is only the
+# tripwire that keeps the state intentional.
+env = true
 
-# The variables deliberately opted BACK IN to the shell (`env = true`), each
-# because something reads it from the environment at spawn time and degrades
-# SILENTLY without it:
+# With env = true the shell-visible set is EVERY declared secret, so this list
+# is the full 49-name set rather than a short opt-in list. Keeping it exhaustive
+# is what preserves the check's value: `_opt_in_findings` compares NAME SETS in
+# both directions, so a renamed, added or dropped secret is still caught — a
+# count would not catch a swap. This also lands what
+# https://github.com/ray-manaloto/dotfiles/issues/460 measured as the fix for
+# the doctor's blind zone: it found 14 of 49 secrets sat past the deepest thing
+# the baseline checked, so a truncating write could lose them silently.
 #
-#   CONTEXT7_API_KEY   the context7 PLUGIN's `.mcp.json` interpolates it into an
-#                      `Authorization` header as `${CONTEXT7_API_KEY:-}` — and
-#                      that default is the trap: exec-only made the header an
-#                      empty string, so the server reported connected and served
-#                      an anonymous tier for weeks. Added 2026-07-30 (#418).
-#   EXA_API_KEY        the `/last30days` engine's web lane reads it from the
-#                      PROCESS ENVIRONMENT. It is NOT in that plugin's own
-#                      `~/.config/last30days/.env` and NOT in the keychain, so
-#                      exec-only silently drops its web backend from exa to the
-#                      keyless floor. Re-derived 2026-07-30 when `.mcp.json`
-#                      stopped declaring the exa server: the OLD reason on this
-#                      line (".mcp.json interpolates it") is now false, but the
-#                      opt-in stays — a second consumer was always there.
-#   GITHUB_TOKEN       `gh` reports its active account as the environment-
-#                      authenticated one; every ship/land/automerge runs on it.
-#   MISE_GITHUB_TOKEN  mise's GitHub API calls (release lookups) rate-limit
-#                      to 60/h unauthenticated.
-#
-# Anything NOT listed here must stay exec-only. Adding a name is a decision to
-# widen the blast radius of a credential, so it belongs in a reviewed diff.
-# Measured after the change: `fnox export` names exactly these 4 of 49 secrets.
+# Names are not secrets. Adding or removing an entry here is a deliberate change
+# to what this host carries, and belongs in a reviewed diff.
 env_true = [
+    "AUTH_TOKEN",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_DEFAULT_REGION",
+    "AWS_REGION",
+    "AWS_SECRET_ACCESS_KEY",
+    "BRAVE_API_KEY",
+    "BSKY_APP_PASSWORD",
+    "BSKY_HANDLE",
     "CONTEXT7_API_KEY",
+    "CT0",
+    "DB_PASSWORD",
+    "DOPPLER_TOKEN",
     "EXA_API_KEY",
+    "GEMINI_API_KEY",
+    "GEMINI_TELEMETRY_ENABLED",
+    "GEMINI_TELEMETRY_LOG_PROMPTS",
+    "GEMINI_TELEMETRY_OTLP_ENDPOINT",
+    "GEMINI_TELEMETRY_OTLP_PROTOCOL",
+    "GEMINI_TELEMETRY_TARGET",
+    "GITHUB_API_TOKEN",
+    "GITHUB_MCP_PAT",
     "GITHUB_TOKEN",
+    "GOOGLE_CLIENT_ID",
+    "GOOGLE_CLIENT_SECRET",
+    "GRAFANA_PASSWORD",
+    "LANGSMITH_API_KEY",
+    "LANGSMITH_WORKSPACE_ID",
+    "LINEAR_API_KEY",
+    "LOKI_S3_ACCESS_KEY",
+    "LOKI_S3_BUCKET",
+    "LOKI_S3_SECRET_KEY",
+    "MIMIR_S3_ACCESS_KEY",
+    "MIMIR_S3_BUCKET",
+    "MIMIR_S3_SECRET_KEY",
     "MISE_GITHUB_TOKEN",
+    "NEXTAUTH_SECRET",
+    "NEXTAUTH_URL",
+    "NVIDIA_20260705",
+    "NVIDIA_API_KEY",
+    "OPENLIT_ENDPOINT",
+    "OPENLIT_UI_PASSWORD",
+    "OPENLIT_UI_USER",
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_PROTOCOL",
+    "SCRAPECREATORS_API_KEY",
+    "SKILLSMP_API_KEY",
+    "TEMPO_S3_ACCESS_KEY",
+    "TEMPO_S3_BUCKET",
+    "TEMPO_S3_SECRET_KEY",
 ]
 
 [mcp]

--- a/python/src/dotfiles_setup/doctor.py
+++ b/python/src/dotfiles_setup/doctor.py
@@ -536,11 +536,18 @@ def check_fnox_baseline(setup: Setup) -> list[str]:
     """The env mode and opt-in set must match the reviewed baseline.
 
     This is the ``bootstrap-config`` tripwire. That generator emits ``provider``
-    + ``value`` only, so a regeneration drops the global ``env = "exec"``, every
-    per-secret opt-in, and every ``sync`` block in one go — silently widening 46
-    credentials from exec-only to "in every child process". Checking the NAME
+    + ``value`` only, so a regeneration drops the global ``env``, every
+    per-secret override, and every ``sync`` block in one go. Checking the NAME
     SET rather than a count is deliberate: a swap keeps the count and is exactly
     the change worth catching.
+
+    .. note::
+       The posture this guarded was **reversed on 2026-08-02**: the baseline is
+       now ``env = true`` with the full 49-name set, because all credentials are
+       deliberately available to every terminal and agent. The check is unchanged
+       and still discriminates in both directions — what moved is the sanctioned
+       state, not the mechanism. See
+       ``.claude/rules/secrets-out-of-the-shell-env.md``.
     """
     expected = setup.fnox_baseline()
     if not expected:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -946,11 +946,24 @@ def test_every_check_function_is_actually_registered() -> None:
 
 
 def test_the_shipped_baseline_parses_and_declares_what_the_checks_read() -> None:
-    """A baseline missing a section makes its check silently cover nothing."""
+    """A baseline missing a section makes its check silently cover nothing.
+
+    The ``env`` value is pinned deliberately, so flipping the host's posture
+    cannot happen without a reviewed diff here as well. It was ``"exec"`` until
+    **2026-08-02**, when Ray reversed it to ``True`` — all credentials available
+    to every terminal and agent. See
+    ``.claude/rules/secrets-out-of-the-shell-env.md``.
+    """
     setup = doctor.collect(REPO_ROOT)
     fnox = setup.fnox_baseline()
-    assert fnox.get("env") == "exec"
-    assert isinstance(fnox.get("env_true"), list)
+    assert fnox.get("env") is True
+    opt_in = fnox.get("env_true")
+    assert isinstance(opt_in, list)
+    # Under ``env = true`` this list is the FULL shell-visible set, not a short
+    # opt-in list, and ``_opt_in_findings`` compares it as a SET in both
+    # directions. A duplicate would silently shrink what is actually compared.
+    assert opt_in, "env_true must not be empty — an empty set sanctions nothing"
+    assert len(opt_in) == len(set(opt_in)), "env_true has duplicate names"
     mcp = setup.mcp_baseline()
     assert mcp.get("scope_servers")
     assert isinstance(mcp.get("mutating_tools"), dict)
@@ -987,7 +1000,7 @@ def test_collect_reads_the_real_repo_without_touching_the_real_home(
     assert not setup.fnox.exists
 
     # The repo seam — positive evidence that REPO_ROOT was read.
-    assert setup.fnox_baseline().get("env") == "exec"
+    assert setup.fnox_baseline().get("env") is True
     assert setup.mcp_baseline().get("scope_servers")
 
     # Current declared state, pinned deliberately so a future reader does not


### PR DESCRIPTION
- **docs(receipt): retract #487's probe 8 — it timed a command that resolves nothing**
- **feat(secrets): all 49 credentials available to every terminal and agent**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788308777&installation_model_id=429246&pr_number=505&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F505&signature=85670577618e0380b1b7b439acc67d751d3a77fc2b177cf291346eb2d9bba404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Credentials are now available in interactive shells and inherited by child processes.
  * All declared credentials are included in the shell-visible credential set.

* **Documentation**
  * Updated security guidance, adoption history, and operational warnings to reflect the revised credential exposure model.
  * Clarified limitations around secret resolution, generated configuration, expiry behavior, and probe measurements.

* **Tests**
  * Updated baseline checks to validate the new environment configuration and complete credential set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->