### PR TITLE
feat(secrets): declare AGE_PRIVATE_KEY — the three stores are now in sync

### DIFF
--- a/doctor.toml
+++ b/doctor.toml
@@ -37,6 +37,7 @@ env = true
 # Names are not secrets. Adding or removing an entry here is a deliberate change
 # to what this host carries, and belongs in a reviewed diff.
 env_true = [
+    "AGE_PRIVATE_KEY",
     "AUTH_TOKEN",
     "AWS_ACCESS_KEY_ID",
     "AWS_DEFAULT_REGION",


### PR DESCRIPTION
Completes the sync half of the goal. AGE_PRIVATE_KEY existed in Doppler and the
keychain but had no fnox declaration, so no fnox mechanism could inject it and
the three stores disagreed by exactly one entry.

Declared doppler-primary with NO age sync block: it IS the age key, so an
age-encrypted copy of it would be unreadable without itself. Deliberately not
keychain-primary either — an item created by `security` lacks fnox on its ACL,
and fnox resolves every declaration on EVERY shell prompt, so that read blocks
on a GUI dialog forever (190 stuck processes, 2026-08-02).

Two earlier attempts auto-rolled-back on a resolution timeout. The cause was not
the declaration: the `doppler` CLI stores its token in the macOS keychain and was
blocking on an authorization dialog, so any live Doppler read hung. With that
entry removed the CLI falls through to DOPPLER_TOKEN from the environment —
which the env=true flip now guarantees is present in every shell — and resolves
in 0.2s with no keychain involvement at all.

Measured: `fnox export` 50/50 (0.24-0.60s), fresh interactive shell carries all
50 with AGE_PRIVATE_KEY set and a bogus control absent, doctor[fnox-baseline]
PASS against the widened 50-name set.

TRADE-OFF, recorded rather than buried: shell startup went ~1.7s -> ~2.5-2.9s.
AGE_PRIVATE_KEY has no local age cache (it cannot), so every new shell pays a
live Doppler round-trip for it. If that cost is not worth the third store being
in sync, removing the declaration restores the faster startup.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014x8jGSieFkDBV95KLXYhTC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788310771&installation_model_id=429246&pr_number=506&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F506&signature=857b8ca6d8733223aae1b1c06555cf4549c68fd6dcbe0cb8d4b7c5d4b7a6faf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->