### PR TITLE
fix(agents): the report path was an option, so it lost to the cheap one

### DIFF
--- a/.claude/agents/staleness-auditor.md
+++ b/.claude/agents/staleness-auditor.md
@@ -37,17 +37,27 @@ Five shapes, all drawn from real finds in this repo. Look for these by name:
 
 ### 1. Persist findings incrementally, to disk, as you go
 
-Write your report file **before** you have finished auditing, and update it after
-each finding. Not at the end.
+**Your first action, before you read a single audited file, is to create the
+tracked report** at `docs/research/kb/reports/agents/staleness-auditor-<scope>.md`
+— a title and a ground-truth line are enough to start. Rewrite it after every
+finding. Not at the end, and not once you "have something worth writing."
 
-- Report: `docs/research/kb/reports/agents/staleness-auditor-<scope>.md` (tracked).
-- Running condensed findings: append to `.agent/notepad.md`.
+That file is the deliverable. `.agent/notepad.md` is **gitignored**, so an append
+there is a scratch note, not persistence — it is a **supplement to** the tracked
+report, never a substitute for it. Append to it too if it helps you think.
 
 Two agents in the 2026-08-03 run held everything in memory, died on an auth error
 around the 40-minute mark, and left **nothing**. A third survived only because it
 appended as it went. An agent that dies having written 7 of 12 findings leaves 7;
-one planning to write at the end leaves 0. Append with a shell heredoc rather than
-rewriting a large file.
+one planning to write at the end leaves 0.
+
+⚠️ **This agent's own first run failed exactly here, which is why the wording is
+now an order rather than a list.** It persisted diligently — to the notepad only —
+and never created the tracked report, so the one artifact that survives a clone had
+to be written by the caller after the fact. An earlier draft of this section
+offered the two paths as co-equal bullets; presented with a cheap option and a
+durable one, the agent took the cheap one. Delivering the report in your final
+message does **not** discharge this: a message is not a file.
 
 ### 2. Deliver before you go idle
 

--- a/docs/research/kb/reports/agents/staleness-auditor-secrets-prose.md
+++ b/docs/research/kb/reports/agents/staleness-auditor-secrets-prose.md
@@ -1,0 +1,99 @@
+# Staleness audit — secrets-prose (2026-08-03)
+
+> Persisted verbatim at receipt per `.claude/rules/agent-report-persistence.md`.
+> Producer: `staleness-auditor` agent (`model: opus`), first run — a smoke test of
+> `.claude/agents/staleness-auditor.md` (PR #512). The agent delivered by message
+> and did **not** write this file itself; the caller persisted it. See the
+> "Caller's verification" section appended at the end.
+
+**Ground truth used** (measured this host, no values printed): fnox **1.32.0**; `fnox config-files` → only `~/.config/fnox/config.toml`; `fnox list` = **50** secrets (49 doppler + 1 keychain); config line 2 = bare global `env = true` plus **50** inline per-secret `env = true`; **49** `sync = {` blocks; `AGE_PRIVATE_KEY` declared, doppler-primary, **no** sync block; `doctor.toml` `[fnox] env = true` + `env_true = [50 names]` incl. `AGE_PRIVATE_KEY`.
+
+⚠️ **Read finding 2 first — it changes what you think is already fixed.**
+
+| # | Verdict | Anchor | Claim | Probe + control arm |
+|---|---|---|---|---|
+| 1 | **CONFIRMED-STALE (P0)** | `.claude/rules/secrets-out-of-the-shell-env.md:43` | "Both entries were deleted … `gh:github.com` / `doppler-cli`" | `security find-generic-password -s 'gh:github.com'` → **rc=0 PRESENT**, cdat=mdat=`20260717`; `-s doppler-cli` → rc=44; control `-s krendlo-absent-9931` → rc=44 same error |
+| 2 | **CONFIRMED-STALE** | `.claude/rules/…:123-125` | gate #4 is "`clean_env()` … strips `__MISE_DIFF`" | `clean_env` → 0 production call sites; control `without_env_diff` → `graphify.py:18,52`, `graph_bakeoff.py:60,152`; control `ZANDRUP_KEEVIL_4471` → 0 |
+| 3 | **CONFIRMED-STALE** | `docs/secrets-doppler-fnox-keychain.md:28-61` | "Since 2026-07-27 this config is globally `env = "exec"`" + "**Four are**" | config line 2 = `env = true`; 50 inline `env = true`; 0 occurrences of `env = "exec"` |
+| 4 | **CONFIRMED-STALE** | `docs/…keychain.md:204` | step-3 comment "`present here + absent in step 4 == env="exec"`" | contradicted by the file's own rewritten table 14 lines later (`:224-229`) |
+| 5 | **CONFIRMED-STALE** | `docs/…keychain.md:21`, `:90` | "49 secrets"; table "per-secret `env = true` \| **3**" | `fnox list` → 50 rows; 50 inline `env = true`. `:90` also contradicts `:43` ("Four are") |
+| 6 | **REFUTED** | `docs/…keychain.md:72`, `:110`, `:91`, `:320` | mde-py off PATH · 3 `FNOX_*` vars · 49 sync blocks · `fnox scan` unused | `which mde-py` rc=1 (control `which fnox` rc=0); `env \| grep -c '^FNOX_'` → 3; 49 `sync = {`; `fnox scan` → 0 wiring (control `gitleaks` → 14) |
+
+## 1 — `gh:github.com` was never deleted (P0, two routes)
+
+> `.claude/rules/secrets-out-of-the-shell-env.md:43` — "Both entries were deleted (`security delete-generic-password -s 'gh:github.com'` / `-s 'doppler-cli'`) and both now fall through to their ENV token."
+
+**Falsifier:** if either service still resolves in the login keychain, "both were deleted" is false.
+
+```
+gh:github.com    PRESENT created=20260717014126Z modified=20260717014126Z
+mde-fnox         PRESENT created=20260329091057Z acct=AUTH_TOKEN
+doppler-cli      ABSENT rc=44
+CONTROL absent   ABSENT rc=44   (identical error text — probe discriminates)
+```
+
+`cdat == mdat == 2026-07-17` — **predating the claimed 2026-08-02 deletion, and unmodified since**. So it was not deleted-and-recreated; it was never deleted.
+
+**Second route** (`gh auth status`, rc=0 in <25s from this non-GUI process):
+
+```
+✓ Logged in to github.com account sortakool (GITHUB_TOKEN)     ← Active account: true
+✓ Logged in to github.com account sortakool (…/gh/hosts.yml)   ← Active account: false
+```
+
+The two routes agree and refine each other: gh *does* use the ENV token, but **because `GITHUB_TOKEN` takes precedence**, not because the keychain entry is gone. The rule's conclusion is accidentally right; its stated mechanism is false, and **the hazard it documents — a keychain-backed `gh` wedging a background process on an unanswerable auth dialog — is unmitigated, not mitigated.** Half of a security remediation is recorded as complete.
+
+Proposed replacement for `:43-45`:
+
+> The `doppler-cli` entry was deleted (`security delete-generic-password -s 'doppler-cli'`) and `doppler` now falls through to its ENV token. ⚠️ **`gh:github.com` is still in the keychain** (created 2026-07-17, unmodified) — `gh` reaches for `GITHUB_TOKEN` first, so the entry is currently dormant rather than removed, and the hang hazard returns the moment that env token is absent.
+
+I did **not** delete it — that is your call, and it is outward-facing on your credential store.
+
+## 2 — gate #4, and the fix that is on no shipping branch
+
+> `.claude/rules/…:123-125` — "4. **`clean_env()`** … strips `__MISE_DIFF` and the credential-bearing names from processes this repo spawns"
+
+`clean_env` appears only at its own `def` (`child_env.py:60`) and two docstrings (`:19`, `:79`), plus `tests/test_child_env.py`. Zero production callers. Control arm, identical command shape: `without_env_diff` → 4 real production hits. This is the exact defect the rule convicts `betterleaks` of two entries above.
+
+**The correction already exists** — `c9ac656` rewrites this block to name `without_env_diff()` — but:
+
+```
+c9ac656  not-in-HEAD  not-in-main   docs(rule): gate #4 named a function with zero call sites
+78a30be  not-in-HEAD  not-in-main   fix(doctor,guard): two live defects the env=true reversal exposed
+dc3f4e2  not-in-HEAD  not-in-main   docs: correct fnox/Doppler/keychain claims an agent audit found stale
+46c8178  not-in-HEAD  not-in-main   feat(secrets): declare AGE_PRIVATE_KEY — three stores in sync
+```
+
+**Disagreeing with the brief:** you said "#507, #509, #510 touched both files, so some claims may already be corrected." Partly. `docs/secrets-doppler-fnox-keychain.md` is byte-identical between HEAD and `feat/age-private-key-in-baseline`, so `dc3f4e2`'s doc edits *did* ship. But `c9ac656`'s rule edits did **not** — the 43-line branch delta is exactly that commit. So **`.claude/rules/secrets-out-of-the-shell-env.md` on `main` still carries the stale gate #4**, plus the two live defects `78a30be` fixes. Those four commits are stranded on a local branch. That is the highest-leverage item here and it is invisible from this branch alone.
+
+## 3-5 — the doc still teaches the retired posture
+
+`docs/secrets-doppler-fnox-keychain.md:31-49` presents `env = "exec"` as current, marks it "**(ours)**" in the mode table, and names four opt-ins. Reality is global `env = true` + 50 inline overrides. The file's own correction sits at `:218-229` — **190 lines below the false claim**, so a reader following the document top-to-bottom acts on the retired posture first. `:204`'s inline comment contradicts the corrected table 14 lines later. `:21` says 49 secrets (now 50); `:90` says 3 per-secret opt-ins while `:43` says four — an inconsistency that predates the reversal.
+
+The rule already flags this at `:161-162` ("read it as history until it is rewritten"), so it is known — but "until it is rewritten" has not happened, and the doc carries no banner. Minimum fix: a reversal banner at `:28` before the mode table, and delete the `env="exec"` clause from `:204`.
+
+## Re-verified before reporting
+
+Re-read at write-up time, immediately before this message: `git rev-parse HEAD` → `b208400` (unchanged), branch `feat/staleness-auditor-agent`, `git status` clean; `.claude/rules/…:123-125` and `:40-45`; `docs/…:31-35`, `:43-44`; `doctor.toml [fnox]`. Nothing had moved.
+
+**Two probe self-corrections, both mine, both the same class:** `grep '^AGE_PRIVATE_KEY'` returned 0 because `fnox list` indents rows with a leading space; and my `^env = true$` regex returned 0 because config line 2 carries a trailing comment. Both would have produced confident false findings ("AGE_PRIVATE_KEY undeclared", "no global env setting"). Corrected before reporting — the global `env = true` **is** there, so the brief's ground truth is right and my first reading was not.
+
+**Not settled:** the rule's "fnox reads a keychain secret in 0.03s" (`:37`) and "190 stuck processes, load 13.5" (`:41`) are inherited measurements I did not re-derive — timing them risks reading a value. Treat as unverified-inherited.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the audited files, git topology, `doctor.toml`, `child_env.py`
+- [ray-manaloto/macos-development-environment](https://github.com/ray-manaloto/macos-development-environment) — referenced as issue #82 (the `bootstrap_config()` wipe); not re-probed this run
+
+---
+
+## Caller's verification (appended 2026-08-03, not part of the agent's report)
+
+Recorded here rather than trimmed from the report above, per rule 2 (verbatim).
+
+Findings independently re-probed by the caller are annotated in the session
+handoff. One correction to the agent's finding 2 wording: the four commits are
+**not** "stranded on a local branch" — they are pushed, on PR **#510**, which is
+OPEN with auto-merge armed and `mergeState: DIRTY` since `main` advanced. The
+substance stands: they are not on `main`, so `main` still carries the stale
+gate #4 and the two live defects.


### PR DESCRIPTION
The staleness-auditor's first real run (a smoke test on the fnox/Doppler
secrets prose) passed all four protocol lessons and found a live P0, but
persisted only to `.agent/notepad.md` — which is gitignored. It never created
`docs/research/kb/reports/agents/staleness-auditor-<scope>.md`, so the one
artifact that survives a clone had to be written by the caller afterwards.

The definition caused that. It listed the tracked report and the notepad as
two co-equal bullets; offered a cheap path and a durable one, the agent took
the cheap one. Creating the tracked file is now the stated first action —
before reading any audited file — with the notepad demoted to a supplement,
and an explicit note that delivering the report in a message does not
discharge the requirement, because a message is not a file.

Also commits that first report verbatim, per rule 1 of
`.claude/rules/agent-report-persistence.md`. Its headline finding is
independently re-probed and holds: the `gh:github.com` keychain entry was
never deleted (rc=0, cdat=mdat=20260717, against a fresh absent control),
so the rule recording that remediation as complete is half wrong and the
background-process hang hazard is unmitigated. The caller's correction to
the agent's git-topology wording is appended rather than edited in.

Gates: lint rc=0 · lint-docs *No issues found* · pytest 1210 passed ·
verify 113 passed / 0 failed / 4 skipped.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XesaNXHz4CxEkdK5RQXoBd

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788331037&installation_model_id=429246&pr_number=513&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F513&signature=0c6c58de7ce20791b63ea4f731f50ee02b8472a77a3e7ef6d1718a3b85e799de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified staleness-audit procedures, requiring tracked reports to be created before reviewing files and updated after each finding.
  * Distinguished tracked reports from supplemental scratch notes and clarified that final messages cannot replace reports.
  * Added an audit report covering secrets, keychain state, environment configuration, documentation inconsistencies, and verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->