### PR TITLE
docs(report): record the disposition of the first staleness audit

### DIFF
--- a/docs/research/kb/reports/agents/staleness-auditor-secrets-prose.md
+++ b/docs/research/kb/reports/agents/staleness-auditor-secrets-prose.md
@@ -93,7 +93,31 @@ Recorded here rather than trimmed from the report above, per rule 2 (verbatim).
 
 Findings independently re-probed by the caller are annotated in the session
 handoff. One correction to the agent's finding 2 wording: the four commits are
-**not** "stranded on a local branch" — they are pushed, on PR **#510**, which is
+**not** "stranded on a local branch" — they are pushed, on PR **#510**, which was
 OPEN with auto-merge armed and `mergeState: DIRTY` since `main` advanced. The
-substance stands: they are not on `main`, so `main` still carries the stale
+substance stands: they were not on `main`, so `main` still carried the stale
 gate #4 and the two live defects.
+
+### DISPOSITION (2026-08-03, Ray approved all three follow-ups)
+
+- **Finding 1 — RESOLVED.** `gh:github.com` deleted with
+  `security delete-generic-password`. Control-armed both directions: before rc=0
+  → after **rc=44**, while `mde-fnox` stayed rc=0 (so the probe had not gone
+  blind) and a fresh absent term returned rc=44. `gh auth status` still rc=0 via
+  `GITHUB_TOKEN`, and a **file-based** fallback the report did not note also
+  survives at `~/.config/gh/hosts.yml` — so the entry was a third copy, and
+  deleting it costs no re-login. The audited claim at
+  `.claude/rules/secrets-out-of-the-shell-env.md:43` ("both entries were
+  deleted … both now fall through to their ENV token") is **true as of this
+  change**, so it needs no edit.
+- **Finding 2 — RESOLVED.** `main` merged into the branch; #510 went
+  `DIRTY` → `BLOCKED` (conflict cleared, awaiting checks). ⚠️ The first merge
+  attempt was **not a merge** — a `check_conventional_commit` rejection cleared
+  `MERGE_HEAD`, so the retry landed as a single-parent commit carrying main's
+  contents without its lineage, and GitHub kept reporting `DIRTY`. Caught by two
+  probes disagreeing (`git merge-base --is-ancestor` said no while the PR head
+  *was* the commit); `git rev-list --parents -n1` settled it. Redone as a real
+  two-parent merge, verified `main-is-ancestor rc=0` with the inverse as control.
+- **Findings 3-5 — still open.** `docs/secrets-doppler-fnox-keychain.md` has not
+  been rewritten; the reversal banner and the `:204` fix are unshipped.
+- **Finding 6 (`REFUTED`) — no action, correctly.**


### PR DESCRIPTION
The report was committed with its P0 open ("I did not delete it — that is
your call"). All three follow-ups were then approved and two are done, so the
tracked artifact now asserts a state that no longer holds — the precise
staleness class the agent exists to catch, in the agent's own output.

Appends a DISPOSITION section rather than editing the findings, per rule 2 of
`agent-report-persistence.md` (verbatim; annotating decisions inline is
encouraged, trimming evidence is not).

Records two things the report could not know. The `gh` keychain entry was a
THIRD copy — a file-based fallback survives at `~/.config/gh/hosts.yml` — so
deleting it costs no re-login, which the report's "that is your call" framing
implied was at stake. And the first merge that unblocked #510 was not a merge
at all: a conventional-commit rejection cleared MERGE_HEAD, the retry landed
single-parent, and GitHub went on reporting DIRTY until two probes disagreed
and `git rev-list --parents` settled it.

Findings 3-5 remain open — `docs/secrets-doppler-fnox-keychain.md` still
teaches the retired posture.

Gates: lint rc=0 · lint-docs *No issues found* · pytest 1210 passed ·
verify 113 passed / 0 failed / 4 skipped.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XesaNXHz4CxEkdK5RQXoBd

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788331599&installation_model_id=429246&pr_number=514&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F514&signature=83cbe993a4917fc9e0b18ed2dc518e2347a646ea35876087e93334166046be56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->