### PR TITLE
docs(secrets): rewrite the keychain guide to the env=true posture

### DIFF
--- a/.claude/rules/secrets-out-of-the-shell-env.md
+++ b/.claude/rules/secrets-out-of-the-shell-env.md
@@ -159,8 +159,8 @@ the `EXA_API_KEY` misattribution, and the measured wipe timeline — is in
    through that child; (b) a stale **`MISE_ENV_CACHE`** entry, which can serve a
    dead name in ONE directory long after the config is byte-identically restored,
    and which `grep` cannot see because it is encrypted; (c) the declaration itself.
-   ⚠️ `docs/secrets-doppler-fnox-keychain.md` still documents the exec-only era and
-   its result table now MISLEADS — read it as history until it is rewritten.
+   The recipes live in `docs/secrets-doppler-fnox-keychain.md` (rewritten to this
+   posture 2026-08-03).
 7. **⚠️ A probe's OWN STDOUT is an uncovered surface — print presence, never a
    value.** Every gate above guards a *file write* or a *spawn*; none guards the
    output of a command an agent runs, and that output lands in the session

--- a/docs/research/kb/reports/agents/staleness-auditor-secrets-rewrite.md
+++ b/docs/research/kb/reports/agents/staleness-auditor-secrets-rewrite.md
@@ -1,0 +1,410 @@
+# Staleness audit — rewritten `docs/secrets-doppler-fnox-keychain.md` (2026-08-03)
+
+Adversarial audit of the caller's rewrite. Ground truth re-derived independently on
+this host; the caller's handoff numbers were treated as claims to attack, not as
+inputs. Every probe carries a control arm, and every control term was invented
+fresh for this run (`ZZ_CONTROL_TROMBIDIUM_4417`, `ZZ_CTRL_HALOTHANE_8802`,
+`ctrl_nonexistent_florapex_5518`, `ctrl-absent-vermiculate-3390`,
+`ctrl-bogus-quillfeather-7724`, `ZZ_AUDIT_KRELLBOSH_2214`,
+`CTRL_ABSENT_PLIMWORTH_6207`, `zzq-flumbertine-8814`,
+`ZZ_NOSUCH_BRANDLEQUIN_7741`). No credential value was read or printed;
+`security` was never invoked with `-w`/`-g`, and `fnox get` / `fnox export` /
+`fnox list --values` / `doppler secrets get` were never run.
+
+⚠️ **The audited file MOVED under me mid-audit** — see § "Re-verified before
+reporting". All anchors below are against the **477-line** version present at
+02:32 on 2026-08-03.
+
+## Verdicts
+
+| # | Verdict | Anchor | Claim | Probe + control arm |
+|---|---|---|---|---|
+| 1 | **CONFIRMED-STALE** | `:159-162`, `:294-296` | "`bootstrap_config()` rebuilds the file from a template …" / "until #82's fix ships it also rewrites the whole config" | The editable venv imports the **fixed** module. `rev-parse HEAD` → `691e866`; `manage.py` clean (control: `.claude/settings.json` → ` M`); `.venv/bin/python -c "import mde.secrets.manage"` → `…/src/…/manage.py`, `has _reconcile_declarations: True`. §1 below |
+| 2 | **SUSPECT** | `:284` | step 7 offline cache recipe `fnox sync KEY_NAME` | `--dry-run` without `-g` → `…to provider age:`; with `-g` → `…to provider age (global):`. The declaration lives in the global config and mde's own code uses `--provider age --global --force`. §2 |
+| 3 | **SUSPECT** | `:54`, `:123` | keychain `mde-fnox` "holds `DOPPLER_TOKEN`"; "#487 … **Latent and unfixed**" | `find-generic-password -s mde-fnox -a DOPPLER_RO_TOKEN` rc=0 (control `-a CTRL_ABSENT_PLIMWORTH_6207` rc=44). `gh issue view 487` → **CLOSED / COMPLETED 2026-08-02**. §3 |
+| 4 | **NEEDS-VERIFICATION** | `:469-470` | "`hk.pkl` — the `gitleaks`, `betterleaks`, `detect_private_key` and `no_env_dump` steps" | `gitleaks` and `detect_private_key` are defined in **`hk-common.pkl`** (`:98`, `:74`); only `betterleaks` (`hk.pkl:272`) and `no_env_dump` (`hk.pkl:259`) are in `hk.pkl`. §4 |
+| 5 | **CONFIRMED-STALE (omission)** | removed content with no successor | four facts were **deleted, not moved** | 124 of 191 substantive removed lines are absent from the evidence file; most are legitimately superseded prose, but four are facts with no successor anywhere. Control: a known-moved line is found, a synthetic line is not. §5 |
+| 6 | REFUTED | `:64-75` | 50 / 50 inline `env=true` / 49 doppler / 1 keychain / 49 age sync / 0 `env="exec"`; `AGE_PRIVATE_KEY` the only one without sync | `tomllib` parse → exactly those. Control: an injected `ZZ_CONTROL_TROMBIDIUM_4417` lacking `env`+`sync` **was** flagged by the same field-presence code |
+| 7 | REFUTED | `:20` | global `env = true` on line 2 of the config | raw line 2 = `env = true  # ALL secrets are available…`; line 1 is the "Managed by" header |
+| 8 | REFUTED | `:77-78` | `fnox check` → 50 secrets / 3 providers healthy; one `default` profile; fnox 1.32.0 | `fnox check` → `Found 50 secret(s) … Found 3 provider(s) … ✓ Configuration is healthy`; `fnox profiles` → `default (50 secrets)`; `fnox --version` → `fnox 1.32.0` |
+| 9 | REFUTED | `:104-114` | `dev`=43 real, `dev_personal`=49 real, +3 auto-injected, `dev ⊂ dev_personal`, 6 extra, matching fnox's 49 one-for-one | `doppler secrets --only-names --json` → 46/52 total, 43/49 real; `dev − dev_personal = []`; the 6 extra are AGE_PRIVATE_KEY, GITHUB_API_TOKEN, LINEAR_API_KEY, MISE_GITHUB_TOKEN, NVIDIA_20260705, NVIDIA_API_KEY; set-equal to fnox's 49 doppler-backed names. Control: `--config ctrl_nonexistent_florapex_5518` → rc=1 |
+| 10 | REFUTED | `:107` | `devcontainer.json:198` + `mise.toml:251,277,771` | all four line anchors verbatim-correct |
+| 11 | REFUTED | `:123-128` | the `build.doppler-secrets-wired` contract "checks that *a* download happened, not which config" | `suites.toml:507-511` — `per_path_tokens` = `"--env-file",` / `dotfiles/doppler.env",` / `&& doppler secrets download --format docker`. **No config token** |
+| 12 | REFUTED | `:180-185` | `doctor.toml [fnox]` = `env = true` + full 50-name `env_true` incl. `AGE_PRIVATE_KEY` | `tomllib` → `env=True`, `len=50`, set-equal to the live fnox names. Control: `ZZ_CTRL_HALOTHANE_8802` absent |
+| 13 | REFUTED | `:136-144` | `which mde-py` rc=1 means nothing; `mde-secret-add` is a live zsh function; editable install | rc=1 (control `which fnox` rc=0); `type mde-secret-add` → shell function from `~/.zshrc.d/50-mde-secrets.zsh` (control `type ctrl-bogus-quillfeather-7724` rc=1); `50-mde-secrets.zsh:45` `local _bin="$MDE_PROJECT_DIR/.venv/bin/mde-py"`; `mde.pth` → `…/src` |
+| 14 | REFUTED | `:146-155` | `691e866` local-branch-only, not an ancestor of `origin/main`, #82 OPEN, `manage.py` absent from `origin/main` | `merge-base --is-ancestor` rc=1 (control rc=0); `branch -a --contains` → one branch; `cat-file -e origin/main:…/manage.py` rc=128 (control `sync.py` rc=0); #82 OPEN. **`origin/main` is genuinely current** — `git ls-remote origin refs/heads/main` == local `origin/main` (`bd86064`), so "not an ancestor" is not a stale-ref artifact |
+| 15 | REFUTED | `:331-344` | `fnox check` cannot see a lost declaration | Independently re-derived with my own fixture (1 key, not the caller's 2): declared → rc=0 `Found 51 secret(s)` ✓ healthy; deleted → rc=0 `Found 50 secret(s)` ✓ healthy. **Stronger than the doc says** — see §6 |
+| 16 | REFUTED | `:353-360` | `doppler-cli` and `gh:github.com` keychain entries deleted; `mde-fnox` present | `find-generic-password -s` (no `-w`): `mde-fnox` rc=0, `gh:github.com` rc=44, `doppler-cli` rc=44. Both arms present: the probe finds a real item (rc=0) and misses a fresh bogus one (`ctrl-absent-vermiculate-3390` rc=44) |
+| 17 | REFUTED | `:206-208` | this repo suggested `fnox exec -- env \| grep NVIDIA_API_KEY` on 2026-07-20 | `git log --all -S'fnox exec -- env \| grep NVIDIA_API_KEY'` → `7a8c8d6` / `d3ecab6`, both dated **2026-07-20**. Control: `-S'doppler secrets download'` → 7 commits |
+| 18 | REFUTED | `:453-457` | `fnox scan` 0 wiring, control 14 for `gitleaks`; `fnox mcp` / `proxy` / `profiles` exist in 1.32.0 | `git grep -nI gitleaks -- '*.pkl'` → **14**, reproducing the doc's control exactly; `fnox scan` in config files → **0** (control, fresh term `zzq-flumbertine-8814` → 0). `fnox --help` lists `mcp`, `proxy`, `profiles`, `scan` |
+| 19 | REFUTED | `:472-477` | the upstream guide is gone and not in that repo's git history | `find ~/dev -name 'doppler-fnox-keychain*'` → 0 (control: same `find` for `AGENTS.md` → 87). `git -C ~/dev/honeymoon-period log --all -- '*doppler-fnox-keychain*'` → 0 (control: `-- '*README*'` → 35; 843 unique files ever added, none matching `doppler`). ⚠️ the **directory** `~/dev/honeymoon-period` **does** still exist — only the file is gone |
+| 20 | REFUTED | `:9-11` | the exec-era mode table, its opt-in list, and the Context7 incident moved **verbatim** | all three present in `docs/rules-evidence/secrets-out-of-the-shell-env.md:318-402` § "Moved here 2026-08-03", as block-quoted verbatim text. Control: a synthetic sentence is not found by the same matcher |
+| 21 | REFUTED | `:303-321` | the diagnosis recipe's commands and expected strings | `fnox list` hides values by default (`-V/--values` opts in); `fnox sync -n/-p/[KEYS]` all valid; dry-run output is verbatim `[dry-run] Would sync 1 secrets in profile default to provider age:\n  AUTH_TOKEN (from doppler_dotfiles_dev_personal)` and, for a bogus key, `No secrets to sync` (control: `ZZ_NOSUCH_BRANDLEQUIN_7741`) |
+| 22 | REFUTED | `:304-306` | "`fnox config-files` … Expect this one line" | from `$HOME` and from the repo root → one line. There is no `fnox.toml` in the dotfiles repo, so no second entry appears |
+| 23 | REFUTED | `:325-329` | the step-3/step-4 result table | the rewrite **swapped** step 3 and step 4 relative to the old doc (old: 3 = `fnox exec`, 4 = shell) and correctly inverted the fault row from `present\|ABSENT` to `ABSENT\|present`. Semantics preserved |
+
+---
+
+## 1. CONFIRMED-STALE — the doc finds the editable-install branch dependency and then ignores it
+
+Verbatim, `:159-162`:
+
+> `bootstrap_config()` rebuilds the file from a template emitting `provider` +
+> `value` only, preserving just `DOPPLER_TOKEN`; `add_secret` / `update_secret` /
+> `remove_secret` each call it and then run a **full** `_run_fnox_sync_age()`,
+> regenerating all 49 sync blocks with fresh ciphertexts.
+
+and `:294-296`:
+
+> ⚠️ **`mde-secret-add KEY` does steps 3-7 in one command and is the sanctioned
+> mde interface — and until #82's fix ships it also rewrites the whole config.**
+
+**Falsifier:** if the code the editable venv actually imports already contains the
+#82 fix, both sentences describe `origin/main`'s behaviour in the present tense
+about a host that does not run it.
+
+**Route 1 — git:**
+
+```
+$ git -C ~/dev/github/ray-manaloto/macos-development-environment rev-parse --short HEAD
+691e866
+$ git -C … status --short -- src/mde/secrets/manage.py
+                       (empty — clean)
+$ git -C … status --short -- .claude/settings.json      # CONTROL: probe can see dirt
+ M .claude/settings.json
+```
+
+**Route 2 — the interpreter that `mde-secret-add` actually invokes:**
+
+```
+$ …/macos-development-environment/.venv/bin/python -c \
+    "import mde.secrets.manage as m; print(m.__file__); \
+     print('has _reconcile_declarations:', hasattr(m,'_reconcile_declarations'))"
+/Users/rmanaloto/dev/github/ray-manaloto/macos-development-environment/src/mde/secrets/manage.py
+has _reconcile_declarations: True
+has _render_initial_config: True
+```
+
+`_reconcile_declarations` and `_render_initial_config` exist only in `691e866`.
+Its `bootstrap_config` docstring (`manage.py:372`+) states the consequence:
+
+> In steady state this performs **no direct write** to the config: each
+> declaration is added or dropped by invoking ``fnox`` itself …
+> 2. **It cannot drop the ``env`` mode or a per-secret ``env = true`` opt-in**
+>    (mde #82). Those were lost *by construction*, because the file was
+>    regenerated from a template that never emitted them. Nothing is
+>    regenerated now, so there is nothing to drop.
+
+`_write_initial_config` runs only `if not _FNOX_CONFIG_PATH.exists()`.
+
+**This is an internal contradiction, not merely an outdated fact.** The same
+document establishes the premise at `:142-144` — *"That venv is an editable
+install … so which code runs depends on which branch that sibling repo has checked
+out"* — and at `:149-150` that the fix is checked out. It then asserts the pre-fix
+behaviour as the live hazard, and the whole of § "What a regeneration would
+actually cost now" (`:157-173`) is premised on a regeneration this host cannot
+currently perform.
+
+**What survives the correction and must not be dropped:** `add_secret` and
+`remove_secret` **do** still call `bootstrap_config()` (`manage.py:180`, `:222`)
+and **do** still run `_run_fnox_sync_age()` (`:183`, `:225`), which is
+`fnox sync --provider age --global --force` — so **all 49 sync ciphertexts are
+still churned on every add/remove**. `update_secret` is a literal alias for
+`add_secret` (`manage.py:191-200`), so naming all three is correct.
+
+**Proposed replacement for `:159-162`:**
+
+> On `origin/main`, `bootstrap_config()` rebuilds the file from a template
+> emitting `provider` + `value` only, preserving just `DOPPLER_TOKEN`. **That is
+> not the code this host runs.** The editable venv imports
+> `fix/bootstrap-config-reroute-through-fnox` (HEAD `691e866`, verified by
+> importing the module and finding `_reconcile_declarations`), whose
+> `bootstrap_config()` adds and drops declarations by invoking `fnox` itself and
+> writes the file directly only when it does not exist — so it cannot drop the
+> `env` mode or a per-secret opt-in. What every `add_secret` / `update_secret`
+> (an alias) / `remove_secret` still does is run a **full**
+> `_run_fnox_sync_age()` (`fnox sync --provider age --global --force`),
+> regenerating all 49 sync ciphertexts.
+>
+> ⚠️ **The protection is a checked-out branch, not a shipped fix.** A
+> `git checkout main` in that sibling repo silently restores the template-rewrite
+> hazard, and nothing in this repo detects it.
+
+**Proposed replacement for `:294-296`:** drop "until #82's fix ships it also
+rewrites the whole config"; say instead that it churns all 49 sync ciphertexts,
+and that the no-rewrite guarantee holds only while that sibling repo stays on the
+fix branch.
+
+## 2. SUSPECT — step 7's `fnox sync` is missing `--global`
+
+`:284`:
+
+> 7. Optional offline cache: `fnox sync KEY_NAME`.
+
+**Falsifier:** if `fnox sync` without `-g` writes to the global config anyway,
+the recipe is fine.
+
+```
+$ cd <scratchpad>            # no fnox.toml here
+$ fnox sync --dry-run -p age AUTH_TOKEN
+[dry-run] Would sync 1 secrets in profile default to provider age:
+  AUTH_TOKEN (from doppler_dotfiles_dev_personal)
+$ fnox sync --dry-run -p age -g AUTH_TOKEN
+[dry-run] Would sync 1 secrets in profile default to provider age (global):
+  AUTH_TOKEN (from doppler_dotfiles_dev_personal)
+```
+
+The `(global)` suffix appears only with `-g`, and `fnox sync --help` documents
+`-g, --global   Write to global config (~/.config/fnox/config.toml)` against a
+`-c` default of `fnox.toml`. mde's own shipped code uses
+`fnox sync --provider age --global --force` (`manage.py:_run_fnox_sync_age`).
+
+**Why SUSPECT and not CONFIRMED:** settling it needs a real (non-dry-run) `sync`,
+which writes — outside the contract for this audit. The dry-run difference and
+mde's usage are one route each, in agreement, but neither observes the write.
+**Proposed text:** `fnox sync --global -p age KEY_NAME`, with a note that without
+`--global` fnox targets a `fnox.toml` in the current directory, not the config the
+declaration lives in.
+
+## 3. SUSPECT — the `mde-fnox` row and the "#487 latent and unfixed" framing
+
+`:54`:
+
+> | **macOS Keychain** | machine-local bootstrap vault | service **`mde-fnox`**, holds `DOPPLER_TOKEN` — the credential that unlocks everything else |
+
+`:123`:
+
+> ⚠️ **Latent and unfixed:** the #487 read-only Doppler token is scoped to
+> `dev_personal` …
+
+```
+$ security find-generic-password -s mde-fnox -a DOPPLER_TOKEN     ; echo rc=$?   # rc=0
+$ security find-generic-password -s mde-fnox -a DOPPLER_RO_TOKEN  ; echo rc=$?   # rc=0
+$ security find-generic-password -s mde-fnox -a CTRL_ABSENT_PLIMWORTH_6207 ; echo rc=$?   # rc=44
+```
+
+(attributes only; `-w` never used.) `mde-fnox` holds **two** accounts. `gh issue
+view 487` → **CLOSED**, `stateReason: COMPLETED`, `closedAt 2026-08-02T21:44:57Z`;
+its resolution comment records `dotfiles-fnox-ro-20260802`, project `dotfiles`,
+config `dev_personal`, access **read**, no expiry, stored as
+`mde-fnox`/`DOPPLER_RO_TOKEN`, "**not** the shell environment".
+
+**The scoping mismatch the doc names is real and correctly stated** — `dev_personal`
+vs the devcontainer's `dev`. What is off is the framing: "#487 … latent and
+unfixed" reads as an open ticket, and `:54` tells a reader diagnosing the keychain
+that `mde-fnox` holds one credential when it holds two — the second being the
+whole product of #487. **Proposed:** `:54` → "holds `DOPPLER_TOKEN` **and**
+`DOPPLER_RO_TOKEN` (#487's scoped read-only token)"; `:123` → "**Latent and
+unfixed** *(the token exists — #487 is closed; the scoping mismatch is what is
+unfixed)*".
+
+## 4. NEEDS-VERIFICATION — the "See also" attributes two steps to the wrong file
+
+`:469-470`:
+
+> - `hk.pkl` — the `gitleaks`, `betterleaks`, `detect_private_key` and
+>   `no_env_dump` steps.
+
+```
+hk-common.pkl:74   ["detect_private_key"] = Builtins.detect_private_key
+hk-common.pkl:98   ["gitleaks"] = (Builtins.gitleaks) { …
+hk.pkl:259         ["no_env_dump"] { …
+hk.pkl:272         ["betterleaks"] = (Builtins.betterleaks) { …
+```
+
+Two of the four are defined in `hk-common.pkl`, which `hk.pkl` imports and spreads
+— so "the steps `hk.pkl` runs" is defensible, but a reader sent to `hk.pkl` to
+read the `gitleaks` step will not find it there. `hk-common.pkl:91` even says so:
+*"`betterleaks` is the SECOND scanner and lives in hk.pkl, not here"*.
+**Proposed:** "`hk.pkl` (`betterleaks`, `no_env_dump`) and `hk-common.pkl`
+(`gitleaks`, `detect_private_key`)".
+
+## 5. CONFIRMED-STALE (omission) — four facts were deleted, not moved
+
+Ray's constraint was that exec-era content **move**, not be deleted. It largely
+did (§20). But a mechanical diff finds four facts with no successor text anywhere
+in the three changed files.
+
+**Probe:** every substantive (`≥25`-char, blockquote-normalised) line removed from
+the doc, tested for presence in `docs/rules-evidence/secrets-out-of-the-shell-env.md`.
+124 of 191 are absent. Control arms: a line known to have moved
+(*"Only secrets carrying an explicit per-secret `env = true` are exported."*) →
+**found**; a synthetic line (*"…zomberwacke 6613"*) → **not found**. So the matcher
+discriminates.
+
+Most of the 124 are legitimately superseded — rewritten contract text, a rewritten
+diagnosis recipe, the "single easiest mistake" framing the rewrite deliberately
+corrects. These four are not:
+
+| deleted fact | successor? | probe |
+|---|---|---|
+| *"Tracked for the sibling repo in knowledge-base issue **#74**."* | **none** | `grep -n '#74\|knowledge-base issue'` across all three changed files → 0 hits. Control: `grep -c '#82'` in the evidence file → 4 |
+| *"Eventual intent (Ray, 2026-07-20): migrate this into a **skill** … Neither is done. Treat this file as the interim contract."* | **none** | same grep sweep → 0 hits for `Eventual intent` |
+| *"fnox is already shell-activated on this machine (3 `FNOX_*` vars present)"* | **none** | 0 hits for `FNOX_` in the evidence file |
+| *"An `age` provider is configured (`recipients = ["age16djrq…"]`)"* | **none** | 0 hits for `recipients` in the evidence file |
+
+The `manage.py:318` template-line reference **did** survive
+(`docs/rules-evidence/secrets-out-of-the-shell-env.md:191`), as did the
+`add_secret`/`remove_secret`/`update_secret` line numbers (`:185-188`).
+
+**Proposed:** append the four to the evidence file's § "Moved here 2026-08-03"
+under a short "smaller facts that had no other home" heading — the knowledge-base
+**#74** pointer especially, since it is the only record that the sibling-repo
+defect is tracked on our side.
+
+## 6. REFUTED, and the doc understates its own finding
+
+`:331-344` says `fnox check` "for a *lost declaration* … can only pass". I
+re-derived it with **my own** one-key fixture rather than reusing the caller's:
+
+```
+$ printf '[secrets]\nZZ_AUDIT_KRELLBOSH_2214 = { provider = "keychain", value = "ZZ_AUDIT_KRELLBOSH_2214" }\n' > declared.toml
+$ printf '[secrets]\n' > lost.toml
+$ fnox check -c declared.toml   -> rc=0  Found 51 secret(s)  ✓ Configuration is healthy
+$ fnox check -c lost.toml       -> rc=0  Found 50 secret(s)  ✓ Configuration is healthy
+```
+
+Same verdict either way — the doc is right. It is also **weaker than reality**:
+the declared key referenced a keychain item that does not exist, and default
+`fnox check` still said healthy. The discriminating flag exists:
+
+```
+$ fnox check -c declared.toml -a
+rc=0  ✓ Configuration is OK (with warnings)
+      Secret 'ZZ_AUDIT_KRELLBOSH_2214' failed to resolve: Keychain: secret '…' not found
+$ fnox check -c declared.toml --if-missing error
+rc=1  Found 1 error(s):
+      Secret 'ZZ_AUDIT_KRELLBOSH_2214' failed to resolve: Keychain: secret '…' not found
+```
+
+**Optional addition:** default `fnox check` also passes for a *declared but
+unresolvable* secret; `fnox check --if-missing error` is the arm that fails
+(rc=1). Neither form can see a **deleted** declaration — that remains
+`doctor.toml`'s job. This same run is an independent second route for `:435-441`:
+`fnox config-files -c <scratch>` listed **both** the scratch file and
+`~/.config/fnox/config.toml`, and the counts (51 vs 50) confirm the merge.
+
+## Numbers checked, one by one
+
+| number | anchor | reproduces? |
+|---|---|---|
+| 50 secrets | `:26`, `:66` | ✅ `tomllib` → 50 |
+| 50 inline `env = true` | `:29`, `:67` | ✅ 50/50 |
+| 49 doppler-backed / 1 keychain | `:68-69` | ✅ |
+| 49 sync blocks | `:70` | ✅, and `AGE_PRIVATE_KEY` is the sole exception |
+| 0 `env = "exec"` | `:71` | ✅ (raw string count 0) |
+| 43 / 49 Doppler real secrets, +3 auto | `:52`, `:104-110` | ✅ 46 and 52 raw |
+| 6 extra in `dev_personal` | `:113` | ✅, enumerated |
+| 3 providers | `:53`, `:77` | ✅ `age`, `doppler_dotfiles_dev_personal`, `keychain` |
+| fnox 1.32.0 | `:8`, `:457` | ✅ `fnox --version` |
+| 12.5× | `:191` | ✅ 50/4 |
+| control of 14 for `gitleaks` | `:454` | ✅ under `git grep -nI gitleaks -- '*.pkl'` (other shapes give 32/38/105 — the doc should state the shape) |
+| 813 lines (upstream guide) | `:474` | ⚠️ **unverifiable and labelled as such by the doc** — the file no longer exists and is not in git history. Inherited, not re-derived; correctly presented as history |
+| 52 / 51 (`fnox check` fixture) | `:336-337` | ✅ shape reproduced with a 1-key fixture (51 / 50) |
+| 0.99 / 1.33 / 3.12 s startup | `:444-445` | not re-run; the doc already labels the ≈1.7→≈2.7 figure **unverified inherited** and notes variance exceeds the delta — correct handling |
+| 199 lines / 13004 bytes | — | **not present in any of the three files.** If the caller expected these in the deliverable, they are absent; nothing asserts them, so nothing is stale |
+
+## Re-verified before reporting
+
+- **`docs/secrets-doppler-fnox-keychain.md` moved under me mid-audit.** First read:
+  **460 lines**. Re-read at write-up: **477 lines**, mtime `02:26:20` (my first read
+  preceded it). Staged tree == worktree, so it was re-staged. Two sections I had
+  queued as findings were already rewritten in the newer version and are **not**
+  reported: the `fnox check` caveat (its control arm was circular — "a control arm
+  on a genuinely-absent name also returns rc=0" restated the claim; it is now a
+  measured two-arm fixture table at `:334-337`), and the shell-startup figure
+  (`≈1.7s → ≈2.7s` was flatly asserted; it now carries three measurements, a
+  `zsh -f` control, and an explicit "unverified inherited" label at `:442-449`).
+  **Every anchor in this report is against the 477-line version.**
+- Re-read at write-up time: `doctor.toml`, `~/.config/fnox/config.toml`,
+  `docs/rules-evidence/secrets-out-of-the-shell-env.md`, `hk.pkl` /
+  `hk-common.pkl`, `python/verification/suites.toml`, and the sibling repo's
+  `src/mde/secrets/manage.py`. None of those had moved.
+- `graphify query` was run for orientation and **its answer was discarded**: the
+  graph still describes the *old* structure (`Incidents` at L250, `The four
+  layers` at L17), i.e. it is stale for this file. Nothing in this report rests
+  on it.
+
+## Where I could be wrong
+
+- Finding 1 depends on the sibling repo staying on `fix/bootstrap-config-reroute-through-fnox`.
+  If it is switched to `main`, the doc's original text becomes correct again — which
+  is itself the reason the replacement text should name the branch dependency
+  rather than simply invert the claim.
+- Finding 2 is one-route-plus-corroboration, never observed as a write. Do not
+  treat it as settled.
+- I did not attempt to verify the 2026-07-29 and 2026-08-02 incident narratives
+  (`:400-422`) beyond the artifacts they cite; they are historical accounts whose
+  primary evidence is transcripts I cannot read.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the audited doc, `doctor.toml`, `hk.pkl`, `suites.toml`, `hook_guard.py`, issue #487
+- [ray-manaloto/macos-development-environment](https://github.com/ray-manaloto/macos-development-environment) — `src/mde/secrets/manage.py`, commit `691e866`, issue #82, PR list
+- [jdx/fnox](https://github.com/jdx/fnox) — `fnox --help` / `check --help` / `sync --help` / `list --help` surface on 1.32.0, and the cached `docs/research/mintlify-cache/jdx/fnox/llms-full.txt`
+
+---
+
+## Caller's verification + DISPOSITION (appended 2026-08-03, not part of the agent's report)
+
+Recorded here rather than trimmed from the report above, per
+`.claude/rules/agent-report-persistence.md` rule 2 (verbatim).
+
+Every actionable finding was **independently re-probed by the caller** before
+acting on it — a second route, not a re-run of the agent's command.
+
+- **Finding 1 (`CONFIRMED-STALE`) — FIXED.** Re-derived: importing
+  `mde.secrets.manage` through `…/macos-development-environment/.venv/bin/python`
+  resolves to that working tree and reports `_reconcile_declarations: True`,
+  `_render_initial_config: True` (control: a bogus attribute → `False`), and
+  `origin/main` has no `manage.py` at all. The agent is right and the
+  contradiction was mine: the doc established the editable-install branch
+  dependency and then asserted pre-fix behaviour as live. Rewritten to say the
+  hazard is **held off by a checked-out branch, not by a landed fix**, that a
+  `git checkout main` silently restores it, and that the 49-ciphertext churn on
+  every add/remove happens on **either** branch. The `mde-secret-add` warning at
+  step 9 was corrected the same way.
+- **Finding 2 (`SUSPECT`) — ACCEPTED.** `fnox sync --help` confirms
+  `-g, --global  Write to global config (~/.config/fnox/config.toml)` against a
+  `-c` default of `fnox.toml`. Step 7 is now
+  `fnox sync --global -p age KEY_NAME`, carrying the agent's own caveat that this
+  is one route plus corroboration and was never observed as a write.
+- **Finding 3 (`SUSPECT`) — FIXED, both halves.** Re-probed: `mde-fnox` holds
+  **two** accounts, `DOPPLER_TOKEN` and `DOPPLER_RO_TOKEN`, both rc=0 (control
+  `ZZ_CTRL_FRENDIBAR_7104` rc=44); `gh issue view 487` → **CLOSED /
+  COMPLETED / 2026-08-02T21:44:57Z**. The four-layers row now names both
+  accounts, and the "latent and unfixed" paragraph now says explicitly that the
+  **token exists and #487 is closed** — the *scoping mismatch* is what is
+  unfixed. The `build.doppler-secrets-wired` claim was strengthened with the
+  agent's `suites.toml:507-511` token list.
+- **Finding 4 (`NEEDS-VERIFICATION`) — FIXED.** Re-probed:
+  `hk-common.pkl:74` `detect_private_key`, `hk-common.pkl:98` `gitleaks`,
+  `hk.pkl:259` `no_env_dump`, `hk.pkl:272` `betterleaks`. "See also" now splits
+  the four across the two files with line anchors and notes that all four *run*
+  from the project config while only two are *defined* there.
+- **Finding 5 (`CONFIRMED-STALE`, omission) — FIXED.** All four deleted facts
+  (the knowledge-base **#74** pointer, the migrate-to-a-skill intent, the 3
+  `FNOX_*` shell-activation fact, and the `age` `recipients` fact) appended to
+  `docs/rules-evidence/secrets-out-of-the-shell-env.md` under
+  § "Smaller facts that had no other home". Verified present, control-armed.
+- **Finding 6's optional addition — ADOPTED, re-derived.** Own fixture,
+  fresh control term: bare `fnox check` → rc=0 ✓ healthy; `-a` → rc=0 ✓ OK with
+  warnings, names the secret; `--if-missing error` → **rc=1**, `Found 1
+  error(s)`. The doc now carries that three-row table.
+- **`gitleaks` control of 14 — shape stated**, per the agent's note: it holds
+  under `git grep -nI <term> -- '*.pkl'`, and other shapes give other numbers.
+- **Findings 6-23 (`REFUTED`) — no action, correctly.** Note finding 23: the
+  agent verified that swapping steps 3 and 4 of the diagnosis recipe preserved
+  the semantics of the result table. That inversion was deliberate (under
+  `env = true` the shell is the primary lane) and it is the kind of edit that
+  silently breaks a table.
+- **The 199-line / 13,004-byte figures** the agent could not find are the
+  *rule file's* size (`.claude/rules/secrets-out-of-the-shell-env.md`), reported
+  to the user as a budget check, never asserted in any document. Nothing stale.
+
+⚠️ **The audited file moved under the agent mid-run** (460 → 477 lines) because
+the caller was still re-deriving inherited numbers. The agent detected it, re-read,
+dropped two findings that the newer version had already fixed, and anchored
+everything to the version it actually read. That is the correct handling of a
+moving target, and it is also a caller error: an audit should start from a frozen
+tree.

--- a/docs/rules-evidence/secrets-out-of-the-shell-env.md
+++ b/docs/rules-evidence/secrets-out-of-the-shell-env.md
@@ -315,12 +315,117 @@ only*. `doppler me` reports the CLI authenticated as `type: cli`, name
 wrong: one exists, it is the opposite of scoped/read-only/expiring, and the ticket
 should begin by assessing it.
 
+## Moved here 2026-08-03 from `docs/secrets-doppler-fnox-keychain.md`
+
+That guide was rewritten to the current `env = true` posture. Its exec-era
+sections are kept verbatim below rather than deleted — they overlap the account
+above but were measured independently, and one table (the generator's emitted
+field set) exists nowhere else.
+
+### The `env` mode as that guide documented it (added 2026-07-29)
+
+> A secret being *declared and resolvable* does **not** mean it reaches the shell.
+> Since 2026-07-27 this config is globally:
+>
+> ```toml
+> env = "exec"   # secrets stay OUT of the interactive shell
+> ```
+>
+> | `env` | interactive shell / `fnox export` | `fnox exec` | `fnox get` |
+> |---|:-:|:-:|:-:|
+> | `true` (fnox default) | yes | yes | yes |
+> | **`"exec"` (ours)** | **no** | yes | yes |
+> | `false` | no | no | yes |
+>
+> Only secrets carrying an explicit per-secret `env = true` are exported. **Four
+> are** — `CONTEXT7_API_KEY`, `EXA_API_KEY`, `GITHUB_TOKEN`, `MISE_GITHUB_TOKEN` —
+> chosen because their consumers can *only* read the environment: the context7
+> plugin interpolates `${CONTEXT7_API_KEY:-}` into an `Authorization` header, the
+> `/last30days` engine's web lane reads `EXA_API_KEY` from the process environment
+> (it is in neither that plugin's own `.env` nor the keychain), and `gh` and `mise`
+> read their tokens.
+>
+> ⚠️ `EXA_API_KEY`'s recorded reason used to be "an `.mcp.json` `${VAR}`
+> interpolation at MCP-server spawn". That stopped being true on 2026-07-30 when
+> this repo's `.mcp.json` was emptied — but the credential is still required, by a
+> second consumer that had never been written down.
+>
+> **This is the single most likely cause of "the variable isn't set".** It is not a
+> sync failure.
+
+The `:90` row of that guide said **3** per-secret opt-ins while `:43` said four.
+That inconsistency predated the reversal and was never reconciled; the count was
+3 on 2026-07-27 and 4 from 2026-07-29.
+
+### The generator's emitted field set — measured against the live config
+
+Unique to that guide, and the sharpest statement of the #82 defect: what
+`bootstrap_config()` **emits** versus what the config **held** at the time.
+
+> | field | present now | generator emits |
+> |---|---:|---:|
+> | global `env = "exec"` | 1 | **0** |
+> | per-secret `env = true` | 3 | **0** |
+> | `sync = { provider = "age", … }` | **49** | **0** |
+>
+> So a single `bootstrap-config` run silently reverts every secret to
+> shell-exported — undoing the whole reason `env = "exec"` was adopted.
+
+### 2026-07-29 — Context7 MCP ran anonymous for days; nothing noticed
+
+The incident that produced rule 5's "check the consumer's authenticated
+identity, never its connection status", kept in full because the *shape*
+outlives the posture that caused it.
+
+> The Upstash context7 plugin interpolates `"Authorization": "${CONTEXT7_API_KEY:-}"`.
+> That secret is exec-only, so the header resolved to **empty** and the server used
+> the anonymous tier — while reporting `✓ connected` the whole time.
+>
+> What made it invisible:
+>
+> - **`${VAR:-}` substitutes an empty string instead of failing.** Silent by
+>   construction.
+> - **Doppler → fnox was perfectly healthy**, so every instinct to blame "the sync"
+>   was wrong. `fnox check` green; the value matched Doppler exactly.
+> - **The opt-in list was drawn before the consumer existed.** The three `env = true`
+>   entries were chosen 2026-07-27 for the three consumers that existed then; the
+>   plugin arrived 2026-07-29 and nothing re-checked the list.
+>
+> Generalisation: **a new env-var consumer is a new opt-in decision, and nothing
+> enforces it.** Tracked as dotfiles issue **#418** (project-doctor SessionStart
+> check: every `${VAR}` interpolated by an MCP/plugin config must be `env = true`).
+
+Under `env = true` the *mechanism* is gone — nothing is exec-only, so no
+interpolation resolves empty for that reason. The **failure shape** is not: any
+credential that is absent, misnamed, or unset still yields an empty string
+through `${VAR:-}`, and the consumer still degrades quietly.
+
+### Smaller facts that had no other home
+
+Caught by an adversarial audit of the rewrite: these four were removed from the
+guide with no successor text anywhere, which is deletion, not a move. Kept here.
+
+- **The sibling-repo defect is tracked on our side too.** `bootstrap_config()`'s
+  wipe class is filed upstream as `macos-development-environment#82` **and** as
+  **knowledge-base issue #74**. That second pointer was the only record of our
+  own tracking of it.
+- **Eventual intent (Ray, 2026-07-20): migrate the integration into a skill**,
+  and have the dotfiles repo manage the macOS environment. Neither is done, so
+  the guide remains the interim contract.
+- **fnox is shell-activated on this machine** — 3 `FNOX_*` variables present in
+  a live process, `DOPPLER_TOKEN` resolving from the keychain. No bootstrap step
+  is needed on this host.
+- **An `age` provider is configured** with `recipients = ["age16djrq…"]`, which
+  is what makes the encrypted-cache path (`fnox sync`) available at all.
+
 ## GitHub repos touched
 
 - [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the
   `no_env_dump` gate, `env_blob_scan.py`, and the history pickaxe.
 - [ray-manaloto/knowledge-base](https://github.com/ray-manaloto/knowledge-base) —
   the second public repo checked by the same pickaxe.
+- [ray-manaloto/macos-development-environment](https://github.com/ray-manaloto/macos-development-environment)
+  — `src/mde/secrets/manage.py`, issue #82, and the unmerged fix branch.
 
 ## The exec-only era (2026-07-27 → 2026-08-02) — moved out of the rule verbatim
 

--- a/docs/secrets-doppler-fnox-keychain.md
+++ b/docs/secrets-doppler-fnox-keychain.md
@@ -1,139 +1,238 @@
 # Secrets: Doppler, fnox, macOS Keychain, and environment variables
 
-Adapted for **this repo** from
-`~/dev/honeymoon-period/docs/agents/doppler-fnox-keychain-environment-guide.md`
-(813 lines, read 2026-07-20). That guide is the conceptual source of truth; this
-one records **what is actually wired on this Mac for `ray-manaloto/dotfiles`**,
-the deltas, and the agent contract in the form this repo enforces.
+What is **actually wired on this Mac for `ray-manaloto/dotfiles`**, the agent
+contract in the form this repo enforces, and the recipes for adding and
+diagnosing a credential.
+
+**Rewritten 2026-08-03.** Every count and claim below was re-measured on this
+host that day against fnox **1.32.0**, with a control arm on each probe and no
+value printed. The exec-era version of this file — the mode it taught, its
+opt-in list, and the Context7 incident — moved verbatim to
+`docs/rules-evidence/secrets-out-of-the-shell-env.md` § "Moved here 2026-08-03".
 
 > Placed at `docs/` and **not** `docs/agents/` deliberately: agnix applies a
 > frontmatter rule to `**/agents/*.md`, and this is a prose guide, not an agent
 > definition.
 
-Eventual intent (Ray, 2026-07-20): migrate this into a **skill** that handles the
-integration, and have this dotfiles repo manage the macOS environment. Neither
-is done. Treat this file as the interim contract.
+## Read this first: all 50 credentials are in every shell, on purpose
+
+```toml
+env = true   # ~/.config/fnox/config.toml, line 2 — global
+```
+
+**Ray reversed the exec-only posture on 2026-08-02, deliberately.** The stated
+requirement was *"in sync and available to all terminals and ai/llm agents"*. So:
+
+- every one of the **50** declared credentials is exported into every
+  interactive shell, and inherited by every child — Claude Code, its subagents,
+  every MCP server they spawn, every `mise run` task;
+- all 50 additionally carry an inline `env = true` (belt and braces — an inline
+  per-secret `env` **overrides** the global, so this survives a global flip);
+- **`fnox exec` is no longer a confinement boundary.** The parent shell already
+  has everything.
+
+**Do not "fix" this back.** It is a decision, not drift. What it costs is stated
+plainly in `.claude/rules/secrets-out-of-the-shell-env.md`: the `__MISE_DIFF`
+exposure is accepted rather than mitigated, and the confinement work in #432 and
+#441 is scoped to a hazard the host no longer avoids.
+
+What still binds, and binds *harder* at 50 credentials than it did at 4:
+
+| Still true | Layer |
+|---|---|
+| Never commit an environment dump | `no_env_dump` hk step |
+| Never print a credential **value**, only presence | `secret_value_substitution` guard rule + the contract below |
+| Never mark a non-secret as a secret | reviewed `doctor.toml` diff |
+| A clean scanner means "ask what it can see" | judgment; no gate |
 
 ## The four layers
 
 | layer | role | what it holds here |
 |---|---|---|
-| **Doppler** | shared authority — the value of record | project `dotfiles`, config **`dev_personal`** (49 secrets as of 2026-07-29) |
+| **Doppler** | shared authority — the value of record | project `dotfiles`; configs **`dev_personal`** (49 secrets) and **`dev`** (43) |
 | **fnox** | declaration + resolution + optional encrypted cache | `~/.config/fnox/config.toml`; providers `keychain`, `age`, `doppler_dotfiles_dev_personal` |
-| **macOS Keychain** | machine-local bootstrap vault | service **`mde-fnox`**, holds `DOPPLER_TOKEN` — the credential that unlocks everything else |
-| **environment** | temporary process delivery | injected by `fnox exec` or shell activation; never the source of truth |
+| **macOS Keychain** | machine-local bootstrap vault | service **`mde-fnox`**, holding **two** accounts: `DOPPLER_TOKEN` (the credential that unlocks everything else) and `DOPPLER_RO_TOKEN` (#487's scoped read-only token, deliberately kept out of the shell) |
+| **environment** | process delivery | injected by shell activation (all 50) or `fnox exec`; never the source of truth |
 
 The chain: **Keychain → `DOPPLER_TOKEN` → Doppler → fnox declaration → process env.**
 
-### The `env` mode — the gate on the last layer (added 2026-07-29)
+### The live shape, parsed rather than grepped
 
-A secret being *declared and resolvable* does **not** mean it reaches the shell.
-Since 2026-07-27 this config is globally:
+Measured 2026-08-03 with `tomllib` against `~/.config/fnox/config.toml`, keys
+and field-presence only:
 
-```toml
-env = "exec"   # secrets stay OUT of the interactive shell
-```
+| | count |
+|---|---:|
+| secrets declared | **50** |
+| carrying inline `env = true` | **50** |
+| provider `doppler_dotfiles_dev_personal` | 49 |
+| provider `keychain` (`DOPPLER_TOKEN`) | 1 |
+| `sync = { provider = "age" }` blocks | **49** |
+| occurrences of `env = "exec"` | **0** |
+
+**50 secrets carry 49 sync blocks, and that is correct.** `AGE_PRIVATE_KEY` is
+the one without: it is the key that decrypts the age cache, so it cannot be
+cached in it. Do not "fix" 49 → 50 anywhere sync counts appear.
+
+`fnox check` reports `50 secret(s)`, `3 provider(s)`, healthy; `fnox profiles`
+shows a single `default` profile.
+
+> 🔬 **Parse the format; do not pattern-match it.** Three greps written for this
+> rewrite returned confident zeros — `env = true }` matched 1 of 50 (field order),
+> `^[A-Z_]* = {` matched 0 (spacing), and `grep -c 'env = true'` counts the
+> header comment. `tomllib` answered all three in one pass. The same trap ate a
+> `^env = true$` regex during the 2026-08-03 audit (defeated by a trailing
+> comment) and nearly produced "there is no global env setting".
+
+### The `env` mode — the tool's behaviour, unchanged
 
 | `env` | interactive shell / `fnox export` | `fnox exec` | `fnox get` |
 |---|:-:|:-:|:-:|
-| `true` (fnox default) | yes | yes | yes |
-| **`"exec"` (ours)** | **no** | yes | yes |
+| **`true` (fnox default, and ours)** | **yes** | yes | yes |
+| `"exec"` | no | yes | yes |
 | `false` | no | no | yes |
 
-Only secrets carrying an explicit per-secret `env = true` are exported. **Four
-are** — `CONTEXT7_API_KEY`, `EXA_API_KEY`, `GITHUB_TOKEN`, `MISE_GITHUB_TOKEN` —
-chosen because their consumers can *only* read the environment: the context7
-plugin interpolates `${CONTEXT7_API_KEY:-}` into an `Authorization` header, the
-`/last30days` engine's web lane reads `EXA_API_KEY` from the process environment
-(it is in neither that plugin's own `.env` nor the keychain), and `gh` and `mise`
-read their tokens.
+A per-secret `env` **overrides** the global. That is why flipping the global
+alone changes nothing here — all 50 inline values would still win.
 
-⚠️ `EXA_API_KEY`'s recorded reason used to be "an `.mcp.json` `${VAR}`
-interpolation at MCP-server spawn". That stopped being true on 2026-07-30 when
-this repo's `.mcp.json` was emptied — but the credential is still required, by a
-second consumer that had never been written down.
+## Two Doppler configs, two lanes — `dev` is not a mistake
 
-**This is the single most likely cause of "the variable isn't set".** It is not a
-sync failure. See the diagnosis recipe below before suspecting Doppler.
+This is the correction the previous version of this file most needed. It called
+writing to `dev` "the single easiest mistake to make". It is not; `dev` is a
+real lane with its own consumer.
 
-⚠️ **Any consumer that reads a credential from the environment needs either
-`fnox exec --` or an explicit `env = true`.** A new one added without either gets
-an **empty string**, not an error — see "Incidents".
+| config | real secrets | who reads it |
+|---|---:|---|
+| **`dev_personal`** | **49** | fnox on this host — every declaration maps to `providers.doppler_dotfiles_dev_personal` |
+| **`dev`** | **43** | the devcontainer: `.devcontainer/devcontainer.json:198` downloads `${DOPPLER_CONFIG:-dev}`, pinned to `dev` by `mise.toml:251,277,771` |
 
-## Deltas from the honeymoon-period guide (this repo)
+(Both report 3 more names than that — Doppler auto-injects `DOPPLER_PROJECT`,
+`DOPPLER_CONFIG`, `DOPPLER_ENVIRONMENT`.)
 
-1. **`dev_personal` is the config fnox reads — not `dev`.** Every declaration
-   maps to `providers.doppler_dotfiles_dev_personal` (`project = "dotfiles"`,
-   `config = "dev_personal"`). A secret written to `dev` lands in Doppler and
-   **never reaches the environment**. This is the single easiest mistake to make
-   and it fails silently.
-2. **The config's stated owner is gone — and re-running it would be
-   DESTRUCTIVE.** `~/.config/fnox/config.toml` opens with *"Managed by `mde-py
-   secrets bootstrap-config`. Do not edit by hand."* but **`mde-py` is not on
-   PATH** (re-verified 2026-07-29). `fnox edit` is the only route, so
-   hand-editing is sanctioned.
+Measured 2026-08-03: **`dev` ⊂ `dev_personal`** exactly — 0 names in `dev` are
+absent from `dev_personal`, and `dev_personal` carries 6 extra. Its 49 match
+fnox's 49 doppler-backed declarations one for one.
 
-   ⚠️ **The generator still exists in source and would wipe the config's most
-   important fields.** `mde/secrets/manage.py` → `bootstrap_config()` rebuilds the
-   file from a template whose per-secret line is:
+So the operative rule is narrower than "never use `dev`":
 
-   ```python
-   lines.append(f'{key} = {{ provider = "{provider_name}", value = "{key}" }}')  # :318
-   ```
+- **A host credential written to `dev` never reaches fnox** — declare it in
+  `dev_personal`. This still fails silently.
+- **A credential the devcontainer needs must be in `dev`**, or `mise run up`
+  ships without it.
 
-   `provider` and `value` only — the function contains **zero** references to
-   `env`, and preserves only `DOPPLER_TOKEN`. Measured against the live config:
+⚠️ **Latent and unfixed — the *scoping mismatch*, not the token.** #487 is
+**CLOSED/COMPLETED** (2026-08-02): the scoped read-only token
+`dotfiles-fnox-ro-20260802` exists, in keychain `mde-fnox` under account
+`DOPPLER_RO_TOKEN`. What is unfixed is that it is scoped to **`dev_personal`**
+while the devcontainer downloads **`dev`**. Repointing `DOPPLER_TOKEN` at it
+would break `mise run up`, and the `build.doppler-secrets-wired` contract stays
+green straight through — its `per_path_tokens` assert an `--env-file`, the
+`doppler.env` path, and `&& doppler secrets download --format docker`, and
+**name no config at all** (`python/verification/suites.toml:507-511`). Decide
+the scoping before swapping the token.
 
-   | field | present now | generator emits |
-   |---|---:|---:|
-   | global `env = "exec"` | 1 | **0** |
-   | per-secret `env = true` | 3 | **0** |
-   | `sync = { provider = "age", … }` | **49** | **0** |
+## The config is generated, and the generator is one command away
 
-   So a single `bootstrap-config` run silently reverts every secret to
-   shell-exported — undoing the whole reason `env = "exec"` was adopted. **Do not
-   run it** until the generator preserves those fields. Filed upstream as
-   **[macos-development-environment#82](https://github.com/ray-manaloto/macos-development-environment/issues/82)**
-   (2026-07-30), with the suggested fix: preserve the top-level `env` key and any
-   per-secret `env` on keys that still exist. Tracked for the sibling repo in
-   knowledge-base issue **#74**.
+`~/.config/fnox/config.toml` opens with *"Managed by `mde-py secrets
+bootstrap-config`. Do not edit by hand."* Everything below was re-measured
+2026-08-03, and it corrects the reassuring version this file used to carry.
 
-   ⚠️ **You will not notice by looking at the `sync` blocks — and you do not have
-   to run the generator by hand to get hit.** `add_secret` (`:166`) and
-   `remove_secret` (`:208`) call `bootstrap_config()` and then immediately run a
-   **full** `_run_fnox_sync_age()` (`:169`/`:211`), which regenerates all 49 sync
-   blocks with fresh ciphertexts. So the observable damage is *only* the missing
-   `env` fields, while every ciphertext silently changes. That composite is what
-   hit this host on **2026-07-30**, and diffing it proved **fnox innocent** — an
-   authorized `fnox sync` rewrote all 49 values and kept the mode and every
-   opt-in. Evidence: `docs/rules-evidence/secrets-out-of-the-shell-env.md`.
-3. **fnox is already shell-activated** on this machine (3 `FNOX_*` vars present,
-   `DOPPLER_TOKEN` resolving from Keychain). No bootstrap needed.
-4. **An `age` provider is configured** (`recipients = ["age16djrq…"]`), so the
-   encrypted-cache path in the source guide is available via `fnox sync`.
+**`which mde-py` returns rc=1 — and that means nothing.** (Control: `which fnox`
+rc=0.) `mde-secret-add` is a **live shell function in every interactive shell**,
+from `~/.zshrc.d/50-mde-secrets.zsh` (control: a bogus name → "not found"). It
+calls `$MDE_PROJECT_DIR/.venv/bin/mde-py`, which is present and executable. The
+documented happy path is one command away right now.
+
+**That venv is an editable install** — `mde.pth` points at
+`…/macos-development-environment/src` — so *which code runs depends on which
+branch that sibling repo has checked out*. There is no pinned copy.
+
+**The fix is checked out, and that is not the same as shipped.** Commit
+`691e866` (2026-08-01, *"stop rewriting the fnox config — reconcile through fnox
+instead"*) adds and drops declarations by invoking the `fnox` binary, writing the
+file directly only when it does not exist — so it **cannot** drop the `env` mode
+or a per-secret opt-in. As of 2026-08-03 it lives on the local branch
+`fix/bootstrap-config-reroute-through-fnox` only: **not** an ancestor of
+`origin/main` (rc=1, control on an `origin/main` commit rc=0), **no PR open**,
+and issue
+**[macos-development-environment#82](https://github.com/ray-manaloto/macos-development-environment/issues/82)**
+still **OPEN**. `src/mde/secrets/manage.py` does not exist on `origin/main` at
+all (`git cat-file -e` rc=128; control on `sync.py` rc=0).
+
+⚠️ **So the template-rewrite hazard is currently held off by a checked-out
+branch, not by a fix anyone has landed.** Verified two ways on 2026-08-03: that
+repo's `HEAD` is `691e866` with `manage.py` clean (control — the probe *can* see
+dirt: `.claude/settings.json` shows ` M`), and importing the module through the
+venv the wrapper actually calls resolves to that working tree and finds
+`_reconcile_declarations` (control: a bogus attribute → `False`), a symbol that
+exists only in the fix.
+
+**A `git checkout main` in that sibling repo silently restores the old
+behaviour, and nothing in this repo detects it.**
+
+### What still happens on every add/remove, fix or no fix
+
+`add_secret` / `update_secret` (a literal alias) / `remove_secret` each call
+`bootstrap_config()` and then run a **full** `_run_fnox_sync_age()` —
+`fnox sync --provider age --global --force` — so **all 49 sync ciphertexts are
+regenerated** whichever branch is checked out.
+
+On `origin/main`'s version, `bootstrap_config()` additionally rebuilds the file
+from a template emitting `provider` + `value` only, preserving just
+`DOPPLER_TOKEN`. That is the wipe class of #82, and it is what returns on a
+branch switch. What it would cost now:
+
+⚠️ **The mode hazard inverted on 2026-08-02 and the rest did not.** fnox's
+default `env` is `true`, so a regeneration now lands on the *desired* mode — the
+wipe class that ate `env = "exec"` and its four opt-ins is **benign for the
+mode**. What stays fragile:
+
+- **any declaration** the template does not know about — including
+  `AGE_PRIVATE_KEY`, which is doppler-primary with no sync block;
+- **all 49 `sync` ciphertexts**, silently replaced — this one happens on every
+  branch;
+- the inline per-secret `env = true` on all 50 — cosmetic while the global says
+  `true`, load-bearing the moment it does not.
+
+**fnox is exonerated** — an authorized write probe rewrote all 49 values on both
+its scoped and bulk paths and preserved the mode and every opt-in. The defect is
+mde's, not fnox's. Full probe table and the wipe timeline:
+`docs/rules-evidence/secrets-out-of-the-shell-env.md`.
+
+The durable layer is not this document and not a hand edit: it is
+`mise run doctor`'s `fnox-baseline` check, which re-reads the artifact every
+session against `doctor.toml` (`[fnox] env = true` plus the full 50-name
+`env_true` set, `AGE_PRIVATE_KEY` included). **Adding or removing a secret means
+changing `doctor.toml` in the same reviewed diff**, or the next session reports
+drift and someone "fixes" it back.
 
 ## Agent operating contract
 
-Adopted from the source guide. These are hard limits, not preferences.
+Hard limits, not preferences. These survive the posture reversal unchanged —
+with 50 credentials reachable instead of 4, the blast radius of breaking one is
+12.5× larger, not smaller.
 
 **An agent MAY**: resolve tool versions/paths · run `fnox config-files`,
 `fnox doctor`, `fnox check` · list names only (`doppler secrets --only-names`,
-`fnox list` **without** `--values`) · run dry-run sync/removal · ask a human to
-type a value into a hidden prompt · invoke a narrow consumer and report a
-non-secret result · report key name, scope, operation, timestamp, outcome.
+`fnox list` **without** `--values`) · parse the config for **keys and field
+presence** · run dry-run sync/removal · ask a human to type a value into a
+hidden prompt · invoke a narrow consumer and report a non-secret result · report
+key name, scope, operation, timestamp, outcome.
 
 **An agent MUST NOT**:
+
 - ask for a secret to be pasted into chat;
 - put a secret in a command argument, file, patch, fixture, or tool input;
 - run `doppler secrets get` / `download`, `fnox get`, `fnox export`, or
   `fnox list --values`;
 - **run `printenv` / `env` / `set` or shell tracing inside a secret-injected
   process** — this repo violated exactly that on 2026-07-20 by suggesting
-  `fnox exec -- env | grep NVIDIA_API_KEY`; see "Verify presence" below for the
-  compliant form;
+  `fnox exec -- env | grep NVIDIA_API_KEY`; the compliant form is below;
+- **emit a credential value to its own stdout** — see the trap below; this is
+  the surface no gate covered, and it cost four rotations on 2026-08-02;
 - use `security … -w` / `-g` to display a Keychain value;
-- read `~/.doppler`, `~/.config/fnox/config.toml`, the login Keychain DB, an age
-  private key, or a `.env` for plaintext;
+- read `~/.doppler`, the login Keychain DB, an age private key, or a `.env` for
+  plaintext — and never read `~/.config/fnox/config.toml` for its **values**;
 - add `--yes`/`--force` to a deletion without explicit authorization;
 - treat a successful write as a completed rotation.
 
@@ -144,9 +243,43 @@ approving paid/production scope · confirming destructive deletion.
 Even *names* disclose architecture — summarize counts in public logs, not
 inventories.
 
-## Add a secret (the procedure this repo uses)
+## Verify presence, never value
 
-1. Confirm key name, config (**`dev_personal`**), consumer, scope, rotation
+```sh
+zsh -c '[[ -v KEY_NAME ]] || exit 20; print "credential is present"'
+```
+
+Under `env = true` a plain shell is enough; `fnox exec --` is no longer needed
+to see a credential, and wrapping a probe in it no longer caps what can leak.
+
+⚠️ **The safe form is only safe alone.**
+
+| expression (with `FOO=visible-safe-value`) | output |
+|---|---|
+| `${FOO:+SET}` | `SET` |
+| `[ -n "$FOO" ] && echo SET \|\| echo ABSENT` | `SET` |
+| **`${FOO:+SET}${FOO:-ABSENT}`** | **`SETvisible-safe-value`** |
+| the same, on an **unset** variable | `ABSENT` |
+
+`:-` and `:=` are **value-emitting** substitutions. The combined form opens with
+the recommended construct, so it reads as compliant, and on an unset variable it
+looks perfect — which is why an unset-only control arm certifies nothing. **Arm
+a presence probe on a variable that IS set, with a value you can afford to see.**
+A live Doppler token reached a transcript this way on 2026-08-02, by an agent
+citing the rule it was breaking. Now denied by `hook_guard`'s
+`secret_value_substitution`; every other value-emitting shape is still on you.
+
+Presence is not correctness. Correctness needs a narrow provider health check
+whose response contains no secret — an identity endpoint returning an account
+id, or a minimal request returning an expected status.
+
+Never record token prefixes/suffixes, hashes of low-entropy secrets, auth
+headers, raw env dumps, or the contents of a secret-bearing config.
+
+## Add a secret
+
+1. Confirm key name, **which config** (`dev_personal` for the host,
+   `dev` if the devcontainer needs it, both if both), consumer, scope, rotation
    expectation, and that no existing credential can be reused.
 2. Human creates/reveals the credential at the provider.
 3. Interactive setter — **no value argument**, so nothing enters argv or history:
@@ -167,45 +300,49 @@ inventories.
    the value:
 
    ```toml
-   KEY_NAME = { provider = "doppler_dotfiles_dev_personal", value = "KEY_NAME" }
+   KEY_NAME = { provider = "doppler_dotfiles_dev_personal", value = "KEY_NAME", env = true }
    ```
 
-7. Optional offline cache: `fnox sync KEY_NAME`.
-8. Run a narrow consumer health check; report only the non-secret result.
+7. Optional offline cache: `fnox sync --global -p age KEY_NAME`.
+   ⚠️ **`--global` is not optional.** Without it fnox targets a `fnox.toml` in
+   the current directory, not the config the declaration lives in — the dry-run
+   output says `to provider age (global):` only with `-g`, and mde's own code
+   uses `fnox sync --provider age --global --force`. (One route plus
+   corroboration; never observed as a write, since settling it would require a
+   real sync.)
+8. **Add the name to `doctor.toml`'s `[fnox] env_true` list in the same reviewed
+   diff.** Under `env = true` this is the reviewed decision — the new credential
+   lands in every terminal and every agent by default, and the doctor's baseline
+   is what makes that a decision rather than a drift.
+9. Run a narrow consumer health check; report only the non-secret result.
 
 **Never**: `doppler secrets set KEY 'value'` (argv/history) or
 `echo 'value' | doppler secrets set KEY` (plaintext through the tool call).
 
-## Verify presence, never value
-
-```sh
-fnox exec -- zsh -c '[[ -v KEY_NAME ]] || exit 20; print "credential is present"'
-```
-
-Presence is not correctness. Correctness needs a narrow provider health check
-whose response contains no secret (an identity endpoint returning an account id,
-or a minimal request returning an expected status).
-
-Never record token prefixes/suffixes, hashes of low-entropy secrets, auth
-headers, raw env dumps, or the contents of a secret-bearing config.
+⚠️ **`mde-secret-add KEY` does steps 3-7 in one command and is the sanctioned
+mde interface — and it churns all 49 sync ciphertexts every time.** It does not
+rewrite the whole config *while* the sibling repo stays on the #82 fix branch;
+on `origin/main` it does. See "The config is generated" above before reaching
+for it, and it still does not touch `doctor.toml` for you.
 
 ## Diagnose "the variable isn't set" — in this order
 
-Work down the layers. Each step is contract-compliant (no value is read or
-printed), and each **discriminates**, so a pass genuinely rules that layer out.
+Each step is contract-compliant (no value read or printed) and each
+**discriminates**, so a pass genuinely rules that layer out.
 
 ```sh
-# 1. Is fnox itself healthy?  Expect: "Configuration is healthy" + counts.
-fnox check
+# 1. Which config files are actually in play?  fnox merges the user root into
+#    EVERY invocation, even with an explicit -c.  Expect this one line.
+fnox config-files
 
 # 2. Is the secret DECLARED?  names only, never --values.
 fnox list | grep KEY_NAME
 
-# 3. Does it resolve to a process?  (present here + absent in step 4 == env="exec")
-fnox exec -- zsh -c '[[ -v KEY_NAME ]] && print present || print ABSENT'
-
-# 4. Is it in the plain interactive shell?
+# 3. Is it in the plain interactive shell?  Under env = true it must be.
 zsh -c '[[ -v KEY_NAME ]] && print present || print ABSENT'
+
+# 4. Does it resolve to a process at all?
+fnox exec -- zsh -c '[[ -v KEY_NAME ]] && print present || print ABSENT'
 
 # 5. Is the offline age copy stale vs Doppler?  dry-run reveals no values.
 fnox sync --dry-run -p age KEY_NAME
@@ -215,31 +352,61 @@ fnox sync --dry-run -p age KEY_NAME
 
 **Reading the result:**
 
-⚠️ **REWRITTEN 2026-08-02 — the old table's top row is now UNREACHABLE and reading it
-would make you dismiss a real failure.** It said a present-under-`fnox exec` /
-absent-in-shell split was *"`env = "exec"` working as designed. Not a bug."* Since Ray
-reversed the posture to `env = true` globally (**all 50 secrets shell-visible by
-decision**), that outcome cannot occur — **an absent variable is a genuine fault.**
-
-| step 3 | step 4 | meaning |
+| step 3 (shell) | step 4 (`fnox exec`) | meaning |
 |---|---|---|
-| present | present | **healthy** — this is the expected state for all 50 |
-| present | **ABSENT** | ⚠️ **A REAL FAULT.** Under `env = true` nothing should be exec-only. Do not dismiss it. |
-| ABSENT | ABSENT | declaration or provider problem — see the suspect order below |
+| present | present | **healthy** — the expected state for all 50 |
+| **ABSENT** | present | ⚠️ **A REAL FAULT.** Under `env = true` nothing should be exec-only. Do not dismiss it. |
+| ABSENT | ABSENT | declaration or provider problem — suspect order below |
 
-**Suspect order when a variable is missing** (new first suspect since 2026-08-02):
+⚠️ **`fnox check` is not step 1, because for a *lost declaration* it can only
+pass.** Measured 2026-08-03 on a throwaway fixture, both arms:
 
-1. ⚠️ **A hung `doppler` CLI.** fnox's doppler provider **shells out** to it (tell:
-   `Doppler: command failed`), so any *uncached* doppler-primary secret — e.g.
+| fixture | `fnox check` |
+|---|---|
+| two probe keys **declared** | rc=0 · `Found 52 secret(s)` · ✓ healthy |
+| one declaration **deleted** | rc=0 · `Found 51 secret(s)` · ✓ healthy |
+
+Identical verdict either way. `check` validates what is *declared*, and
+`if_missing` lives on the declaration line — so a line that vanished is not
+"missing", it is unknown. The only signal is the **count**, and `check` compares
+it against nothing. `doctor.toml`'s 50-name baseline is the layer that can see
+this.
+
+**Bare `fnox check` is weaker still — it also passes for a declared secret that
+does not resolve.** Measured on a fixture declaring a keychain item that does not
+exist:
+
+| invocation | result |
+|---|---|
+| `fnox check -c <fixture>` | rc=0 · ✓ **healthy** |
+| `fnox check -c <fixture> -a` | rc=0 · ✓ OK **with warnings** · names the secret |
+| `fnox check -c <fixture> --if-missing error` | **rc=1** · `Found 1 error(s)` · names the secret |
+
+So `--if-missing error` is the arm that can fail; use it when you want `check` to
+mean anything. Neither form sees a **deleted** declaration.
+
+**Suspect order when a variable is missing:**
+
+1. ⚠️ **A hung `doppler` CLI.** fnox's doppler provider **shells out** to it
+   (tell: `Doppler: command failed`), so any *uncached* doppler-primary secret —
    `AGE_PRIVATE_KEY`, which cannot have an age cache — resolves through a child
-   `doppler` process. If that CLI blocks on a keychain authorization dialog, the read
-   hangs forever from a non-GUI process and no dialog can be answered.
-2. **A stale `MISE_ENV_CACHE` entry.** It can serve a dead name in **one directory**
-   long after the config is byte-identically restored, and `grep` cannot find it —
-   the cache is encrypted. Clear `~/.local/state/mise/env-cache`.
-3. **The declaration itself** — steps 1–2 above.
+   `doppler` process. A keychain **authorization dialog** blocks that child
+   forever from a non-GUI process, and nothing can answer the dialog.
+   **Resolved on this host**: the `doppler-cli` and `gh:github.com` keychain
+   entries were deleted and both tools fall through to their ENV token. Verified
+   2026-08-03 — `doppler configs` returns rc=0 in under 25s from a background
+   process, where it previously hung indefinitely.
+   ⚠️ A hang is **not** evidence of a locked keychain.
+   `security show-keychain-info` prompts unconditionally, so *its* hang proves
+   nothing; believing it cost ~2 hours on 2026-08-02. fnox reads a keychain
+   secret in 0.03s, which a locked keychain cannot do.
+2. **A stale `MISE_ENV_CACHE` entry.** It can serve a dead name in **one
+   directory** long after the config is byte-identically restored, and `grep`
+   cannot see it — the cache is encrypted. Clear
+   `~/.local/state/mise/env-cache`.
+3. **The declaration itself** — steps 1-2 above, then `doctor.toml`.
 
-**Always control-arm the negative.** A `0`/ABSENT result is worthless until the
+**Always control-arm the negative.** An ABSENT result is worthless until the
 same command shape returns present for something you *know* is set:
 
 ```sh
@@ -247,84 +414,109 @@ zsh -c '[[ -v HOME ]] && print "control ok: [[ -v ]] works"'
 ```
 
 A 2026-07-29 session reported a variable "set, 43 chars" and later "unset" from
-two different probes in the same session. The control arm is what settled it.
+two probes in the same session. The control arm is what settled it.
 
-⚠️ **`env | grep` is forbidden inside a secret-injected process** (see the
-contract above). Use `[[ -v VAR ]]`, which reveals presence without the value.
+⚠️ **`env | grep` is forbidden inside a secret-injected process.** Use
+`[[ -v VAR ]]`, which reveals presence without the value.
 
 ## Evidence record
 
 ```text
 Operation: add | update | rotate | delete | sync
 Key: <authorized name>
-Authority: Doppler dotfiles/dev_personal | Keychain mde-fnox/<account>
+Authority: Doppler dotfiles/dev_personal | Doppler dotfiles/dev | Keychain mde-fnox/<account>
 Consumer: <program>
 Value observed by agent: no
 Name/presence check: pass | fail
 Consumer health check: <safe result>
+doctor.toml env_true updated: yes | n/a
 Timestamp: <ISO-8601>
 ```
 
 ## Incidents
 
-### 2026-07-29 — Context7 MCP ran anonymous for days; nothing noticed
+Two are kept here because they teach the contract. The posture-era incidents —
+the Context7 anonymous tier, the config wipe and its attribution — moved to
+`docs/rules-evidence/secrets-out-of-the-shell-env.md`.
 
-The Upstash context7 plugin interpolates `"Authorization": "${CONTEXT7_API_KEY:-}"`.
-That secret is exec-only, so the header resolved to **empty** and the server used
-the anonymous tier — while reporting `✓ connected` the whole time.
+### 2026-07-29 — contract breaches by an agent, recorded, not excused
 
-What made it invisible:
+While diagnosing a missing credential, the agent violated the contract three
+ways:
 
-- **`${VAR:-}` substitutes an empty string instead of failing.** Silent by
-  construction.
-- **Doppler → fnox was perfectly healthy**, so every instinct to blame "the sync"
-  was wrong. `fnox check` green; the value matched Doppler exactly.
-- **The opt-in list was drawn before the consumer existed.** The three `env = true`
-  entries were chosen 2026-07-27 for the three consumers that existed then; the
-  plugin arrived 2026-07-29 and nothing re-checked the list.
-
-Generalisation: **a new env-var consumer is a new opt-in decision, and nothing
-enforces it.** Tracked as dotfiles issue **#418** (project-doctor SessionStart
-check: every `${VAR}` interpolated by an MCP/plugin config must be `env = true`).
-
-### Contract breaches by an agent in that same session — recorded, not excused
-
-While diagnosing the above, the agent violated the operating contract three ways:
-
-1. **Ran `fnox get` and `doppler secrets get`** — both explicitly on the MUST NOT
-   list — to sha256-compare the two values. Output was truncated to 12 hex chars,
-   never the value, but the commands themselves are forbidden.
-2. **Interpolated a live key into `curl -H "Authorization: $K"`** — a secret in a
-   command argument, which the contract forbids because argv is observable.
-3. Reached for `env | grep` on secret names (permitted here only because the
-   variables in question were *absent*; the compliant form is `[[ -v VAR ]]`).
+1. **Ran `fnox get` and `doppler secrets get`** — both explicitly on the MUST
+   NOT list — to sha256-compare the two values. Output was truncated to 12 hex
+   chars, never the value, but the commands themselves are forbidden.
+2. **Interpolated a live key into `curl -H "Authorization: $K"`** — a secret in
+   a command argument, which the contract forbids because argv is observable.
+3. Reached for `env | grep` on secret names.
 
 None of it reached a tracked file or the transcript, and the endpoint was the
-credential's legitimate vendor. It was still avoidable: **`fnox sync --dry-run -p age`
-answers the staleness question without reading any value**, and `[[ -v ]]` answers
-presence. Both are in the MAY list. The compliant recipe is now written above so
-the next session reaches for it first.
+credential's legitimate vendor. It was still avoidable: **`fnox sync --dry-run
+-p age` answers the staleness question without reading any value**, and
+`[[ -v ]]` answers presence. Both are in the MAY list.
+
+### 2026-08-02 — a presence probe printed a live token
+
+`${DOPPLER_TOKEN:+PRESENT}${DOPPLER_TOKEN:-ABSENT}` printed `PRESENT` followed
+by the live token, which had to be rotated. It was written by an agent holding
+and citing the rule against it. See "Verify presence, never value" for why it
+passed review, and why its control arm certified nothing.
 
 ## Gotchas
 
-- **A silently-empty credential is the default failure mode.** `${VAR:-}` and
-  `${VAR}` interpolation in MCP/plugin configs yield an empty string when the var
-  is exec-only. The server starts, reports healthy, and degrades to an anonymous
-  or unauthenticated tier. Check the *consumer's* authenticated identity, never
-  its connection status.
+- **A silently-empty credential is still the default failure mode.** The
+  exec-only *mechanism* is gone, but `${VAR:-}` interpolation in an MCP/plugin
+  config yields an empty string for any credential that is absent, misnamed, or
+  unset. The server starts, reports healthy, and degrades to an anonymous tier.
+  **Check the consumer's authenticated identity, never its connection status.**
 - **A running process keeps its env snapshot.** After a rotation, restart
   consumers — a green write proves nothing about live processes.
 - **`fnox sync` caches**; a Doppler change does not propagate to the encrypted
   cache until you re-sync.
-- **`fnox scan`** searches the repo for potential secrets — complements the
-  `gitleaks` step already in `hk.pkl`; currently unused here.
-- **`fnox mcp`** starts an MCP server for *secret-gated AI agent access* — the
-  supported way to give an agent gated use of a credential without handing it
-  the value or a shell. Relevant to the planned research agent; unexplored.
+- **`-c` ADDS a config, it does not isolate one.** fnox merges
+  `~/.config/fnox/config.toml` into every invocation — measured 2026-08-03,
+  `fnox -c <scratchpad>/fnox.toml config-files` run from `/tmp` lists **both**
+  files, and `check` counted 51 = the 50 user-root secrets plus 1 fixture key.
+  `fnox config-files` is the arm that shows what is really loaded. A test that
+  forgets this reaches live user state — that is how a mutation test wiped this
+  host's config on 2026-08-01.
+- **Shell startup got slower** — 50 credentials resolve on activation instead of
+  4. ⚠️ The often-quoted "≈1.7s → ≈2.7s" is an **inherited figure this rewrite
+  could not reproduce**: three consecutive `zsh -ic true` runs measured
+  **0.99s / 1.33s / 3.12s** (control `zsh -f`, no rc: 0.058s, so the probe
+  discriminates). The same-input variance is **larger than the claimed 1s
+  delta**, so treat the number as unverified — the direction is real, the
+  magnitude is not established, and the *before* can no longer be measured
+  without reverting the config.
+- **mise masks digits in `mise run` output** when a redacted value is short and
+  all-digit — `[redacted][redacted]3` for 113. Read numbers from a recorded
+  `rc=` or a non-`mise` invocation.
+- **Unexplored fnox surface**, still worth a look: `fnox scan` (repo secret
+  scan; 0 wiring here, against a control of 14 for `gitleaks` under the same
+  command shape, `git grep -nI <term> -- '*.pkl'`), `fnox mcp`
+  (secret-gated agent access without handing over the value), `fnox proxy`
+  (destination-scoped credential brokering), and `fnox profiles` / `--profile`
+  (the per-profile overlay #441 wanted, present in 1.32.0).
 
 ## See also
 
-- `~/dev/honeymoon-period/docs/agents/doppler-fnox-keychain-environment-guide.md`
-  — the full 813-line conceptual guide this adapts.
-- `.claude/rules/do-not.md` — project invariants.
-- `hk.pkl` — the `gitleaks` and `detect_private_key` steps.
+- `.claude/rules/secrets-out-of-the-shell-env.md` — the posture, the reversal,
+  and the gates.
+- `docs/rules-evidence/secrets-out-of-the-shell-env.md` — measurements, the wipe
+  timeline, and this file's exec-era sections verbatim.
+- `.claude/CLAUDE.md` § "Project doctor" — `doctor.toml` and the
+  SessionStart check.
+- `.claude/rules/do-not.md` — project invariants (#10 forbids a committed
+  environment dump).
+- `hk.pkl` (`betterleaks:272`, `no_env_dump:259`) and `hk-common.pkl`
+  (`gitleaks:98`, `detect_private_key:74`) — the scanner steps. `hk.pkl` imports
+  and spreads the common ones, so all four *run* from the project config; only
+  two are *defined* there.
+
+⚠️ **The upstream guide this file once adapted is gone.** It was cited as
+`~/dev/honeymoon-period/docs/agents/doppler-fnox-keychain-environment-guide.md`
+(813 lines, read 2026-07-20). That path does not exist as of 2026-08-03, nothing
+matching `doppler-fnox-keychain*` exists anywhere under `~/dev` (control: the
+same `find` locates `AGENTS.md`), and it is not in that repo's git history. This
+file is now the only copy of what it taught.


### PR DESCRIPTION
`docs/secrets-doppler-fnox-keychain.md` still taught `env = "exec"` as
current, and its own correction sat ~190 lines BELOW the false claim — so a
reader going top-to-bottom acted on the retired posture first. That structural
defect is why this is a rewrite rather than a banner.

Current posture is now the FIRST section: all 50 credentials in every shell by
decision (Ray, 2026-08-02), what it costs, and what still binds. The exec-era
mode table, the four opt-ins with their consumer reasons, the generator's
emitted-field table and the Context7 incident MOVED verbatim to
docs/rules-evidence/secrets-out-of-the-shell-env.md — history moves, it is not
deleted.

Re-measured on this host, control-armed, no value printed. Five claims the
audit could not have caught by re-reading the old file:

- The upstream guide this file "adapts" no longer exists anywhere under ~/dev,
  and is not in that repo's git history. This is now the only copy.
- "mde-py is not on PATH" reads as reassuring and is not: `mde-secret-add` is a
  live shell function calling $MDE_PROJECT_DIR/.venv/bin/mde-py.
- That venv is an EDITABLE install, so which code runs depends on the sibling
  repo's checked-out branch — currently the #82 fix, which is unmerged, has no
  PR, and whose absence a `git checkout main` would silently restore.
- `dev` vs `dev_personal` is two real lanes, not a mistake: dev ⊂ dev_personal
  exactly (43 vs 49 real secrets), and the devcontainer pins `dev` deliberately.
- 50 secrets carry 49 sync blocks and that is CORRECT — AGE_PRIVATE_KEY cannot
  be cached in the age cache it unlocks. Stated so nobody sweeps 49 → 50.

Two inherited numbers re-derived rather than repeated: `fnox check` really
cannot see a lost declaration (measured both arms), and the "shell startup
1.7s → 2.7s" figure does not reproduce — same-input variance (0.99/1.33/3.12s)
exceeds the claimed 1s delta, so only the direction is reportable.

Verified by a staleness-auditor pass whose five actionable findings were each
re-probed by a second route and applied; report + disposition in
docs/research/kb/reports/agents/staleness-auditor-secrets-rewrite.md. Retires
the rule's "read it as history until it is rewritten" pointer, which is also
the trim that file needed at 199/200.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XesaNXHz4CxEkdK5RQXoBd

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788335732&installation_model_id=429246&pr_number=515&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F515&signature=cd68a084309a1e1dfe79fa72525f00a7f247c0f721e285a25263d8efbfe1a768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Rewrote the secrets management guide to reflect current shell export, Doppler, and Keychain workflows.
  * Added safer credential presence checks, multi-configuration setup instructions, dry-run synchronization guidance, troubleshooting details, and updated doctor requirements.
  * Added evidence documenting configuration behavior, opt-ins, fallback handling, migration considerations, and age-provider setup.
  * Added a staleness audit documenting verified findings, corrected interpretations, limitations, and remaining uncertainties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->