### PR TITLE
docs(secrets): #82 is fixed and merged — rewrite the section that said otherwise

### DIFF
--- a/.claude/rules/secrets-out-of-the-shell-env.md
+++ b/.claude/rules/secrets-out-of-the-shell-env.md
@@ -79,14 +79,14 @@ fnox's `env` setting has three values: `true` (default — shell, `exec` and `ge
 global**, which is why flipping the global alone changes nothing.
 
 ⚠️ **The config is GENERATED** — *"Managed by `mde-py secrets bootstrap-config`. Do
-not edit by hand."* `bootstrap_config()` rebuilds it from scratch and re-emits only
-`provider` + `value`, so it drops the global `env`, every per-secret override and
-every `sync` block **by construction**. Its trigger is the documented happy path:
-any `mde-secret-add` / `update` / `remove`. That is a real defect
-(`macos-development-environment#82`), **not** an fnox bug — an authorized write probe
-round-tripped fnox's own writers with the mode and all opt-ins preserved, on both the
-scoped and bulk paths. So any hand edit here is **a patch with a half-life**, and the
-durable layer is the doctor check that re-reads the artifact every session.
+not edit by hand."* `bootstrap_config()` used to rebuild it re-emitting only `provider`
++ `value`, dropping the global `env`, every per-secret override and every `sync` block
+**by construction**, on the documented `mde-secret-add` / `update` / `remove` path.
+✅ **FIXED 2026-08-03** — `macos-development-environment#82` CLOSED, #83 merged as
+`716b17d`: declarations are added and removed by invoking `fnox` itself, so there is no
+template left to drop a field from. fnox was never at fault. What SURVIVES the fix: every
+add/remove still churns all 49 `sync` ciphertexts, and one stale local branch still
+carries the pre-fix code — so the durable layer is still the doctor check, not a hand edit.
 
 The exec-only era's full adoption history — the mode table, the four opt-in reasons,
 the `EXA_API_KEY` misattribution, and the measured wipe timeline — is in

--- a/docs/rules-evidence/secrets-out-of-the-shell-env.md
+++ b/docs/rules-evidence/secrets-out-of-the-shell-env.md
@@ -246,6 +246,14 @@ happened. So **every secret added or updated re-exposes all 49 credentials** to
 the shell until something re-reads the config. Filed with the confirmed trigger as
 [macos-development-environment#82](https://github.com/ray-manaloto/macos-development-environment/issues/82).
 
+> **Status, 2026-08-03: #82 is CLOSED**, fixed by
+> [#83](https://github.com/ray-manaloto/macos-development-environment/pull/83)
+> (merged `716b17d`) — `bootstrap_config()` now reconciles through `fnox` itself, so
+> there is no template to drop a field from. Everything above is the record of the
+> incident as it stood, kept verbatim; the current account is
+> `docs/secrets-doppler-fnox-keychain.md` § "The config is generated". ⚠️ The sibling
+> tracker **knowledge-base #74 is still OPEN** and now describes a fixed upstream.
+
 **The durable lessons:**
 
 1. "APPLIED 2026-07-27 by Ray" was recorded as settled and nothing re-read the

--- a/docs/secrets-doppler-fnox-keychain.md
+++ b/docs/secrets-doppler-fnox-keychain.md
@@ -135,7 +135,8 @@ the scoping before swapping the token.
 
 `~/.config/fnox/config.toml` opens with *"Managed by `mde-py secrets
 bootstrap-config`. Do not edit by hand."* Everything below was re-measured
-2026-08-03, and it corrects the reassuring version this file used to carry.
+2026-08-03 **after mde #83 merged**, and it supersedes two earlier accounts this
+file carried — see "How this section was wrong twice" at the end.
 
 **`which mde-py` returns rc=1 — and that means nothing.** (Control: `which fnox`
 rc=0.) `mde-secret-add` is a **live shell function in every interactive shell**,
@@ -145,64 +146,56 @@ documented happy path is one command away right now.
 
 **That venv is an editable install** — `mde.pth` points at
 `…/macos-development-environment/src` — so *which code runs depends on which
-branch that sibling repo has checked out*. There is no pinned copy.
+branch that sibling repo has checked out*. There is no pinned copy. That is why
+this section talks about branches at all, and it is still true after the fix.
 
-**The fix is checked out, and that is not the same as shipped.** Commit
-`691e866` (2026-08-01, *"stop rewriting the fnox config — reconcile through fnox
-instead"*) adds and drops declarations by invoking the `fnox` binary, writing the
-file directly only when it does not exist — so it **cannot** drop the `env` mode
-or a per-secret opt-in. As of 2026-08-03 it lives on the local branch
-`fix/bootstrap-config-reroute-through-fnox` only: **not** an ancestor of
-`origin/main` (rc=1, control on an `origin/main` commit rc=0), **no PR open**,
-and issue
-**[macos-development-environment#82](https://github.com/ray-manaloto/macos-development-environment/issues/82)**
-still **OPEN**.
+### The fix is shipped — `main` is now the safe place to be
 
-⚠️ **So the template-rewrite hazard is currently held off by a checked-out
-branch, not by a fix anyone has landed.** Verified two ways on 2026-08-03: that
-repo's `HEAD` is `691e866` with `manage.py` clean (control — the probe *can* see
-dirt: `.claude/settings.json` shows ` M`), and importing the module through the
-venv the wrapper actually calls resolves to that working tree and finds
-`_reconcile_declarations` (control: a bogus attribute → `False`), a symbol that
-exists only in the fix.
+[macos-development-environment#82](https://github.com/ray-manaloto/macos-development-environment/issues/82)
+is **CLOSED** (2026-08-03T08:55:50Z), fixed by
+[#83](https://github.com/ray-manaloto/macos-development-environment/pull/83),
+squash-merged as **`716b17d`** on `main`. The fix (`691e866`, *"stop rewriting
+the fnox config — reconcile through fnox instead"*) adds and drops declarations
+by invoking the `fnox` binary, writing the file directly only when it does not
+exist — so it **cannot** drop the `env` mode or a per-secret opt-in.
 
-### Which branch you land on decides which failure you get
+Re-derived on `origin/main`, control-armed: `git ls-tree -r --name-only
+origin/main -- src/mde/secrets/manage.py` → **1** row (control `README.md` → 1),
+and `git show origin/main:<path> | grep -c _reconcile_declarations` → **2**
+(control, a bogus symbol → **0**). `_reconcile_declarations` exists only in the
+fix, so its presence on `origin/main` is the fix's presence.
 
-`src/mde/secrets/manage.py` is on **neither** `main` **nor** `origin/main` — the
-whole CRUD wrapper arrived in `7bf7a55`, which was never merged. Three
-independent routes, each control-armed: `git ls-tree -r --name-only <ref> --
-<path>` → **0** rows for both (control `README.md` → 1); `git log <ref> --
-<path>` → **0** commits for both (control, the fix branch → 2); and
-`git show <ref>:<path> | grep` → 0. Counted across every local and remote ref,
-**64 branches carry `manage.py` WITHOUT the fix and exactly 1 carries it with**.
+### The residual hazard is one stale local branch
 
-| you check out | `mde-secret-add` does |
+Across all **45** local and remote-tracking refs in that clone, exactly **4**
+carry `src/mde/secrets/manage.py` at all:
+
+| ref | `mde-secret-add` does |
 |---|---|
-| `fix/bootstrap-config-reroute-through-fnox` (today) | reconciles through `fnox`; cannot drop the mode or an opt-in |
-| any of the **64** other branches carrying `manage.py` | the #82 template rewrite — **silent**, and the hazard this section describes |
-| `main` / `origin/main` | **fails loudly** — `mde/secrets/__init__.py:76` imports `manage` lazily inside the call, so the module is simply absent |
+| `origin/main` · `origin/HEAD` | reconciles through `fnox`; **cannot** drop the mode or an opt-in |
+| local `fix/bootstrap-config-reroute-through-fnox` (upstream deleted on merge) | same code — it *is* `691e866` |
+| local `feat/secrets-crud-architecture-a` | ⚠️ **the pre-fix template rewrite — silent.** The only remaining carrier |
+| every other ref (41) | **fails loudly** — `mde/secrets/__init__.py:76` imports `manage` lazily inside the call, so the module is simply absent |
 
-**Nothing in this repo detects which of those three you are on.**
+**Nothing in this repo detects which of those you are on**, so the residual risk
+is real but now narrow: delete `feat/secrets-crud-architecture-a` and it is zero.
 
-> ⚠️ **This table replaces a wrong claim shipped in #515**, which said the
-> pre-fix code was "on `origin/main`" and that `git checkout main` silently
-> restores the hazard. It does not — that checkout breaks the tool instead. The
-> probe that produced the error was `git cat-file -e <ref>:<path>`, which
-> **returned rc=128 and rc=0 for the same ref minutes apart**; `ls-tree` and
-> `git log -- <path>` agreed with each other and with `git show | grep`, so the
-> odd one out was the probe. When two routes disagree, one of them is broken —
-> and it is usually the probe, not the world.
+⚠️ **Do not carry the "64 pre-fix branches" figure forward.** It was true when
+measured, against a ref set holding ~40 stale remote-tracking branches; a
+`git fetch --prune` on 2026-08-03 removed them, and the count is **1** now. An
+inherited number is not a measurement — re-derive it or label it.
 
 ### What still happens on every add/remove, on any branch that HAS the wrapper
 
 `add_secret` / `update_secret` (a literal alias) / `remove_secret` each call
 `bootstrap_config()` and then run a **full** `_run_fnox_sync_age()` —
 `fnox sync --provider age --global --force` — so **all 49 sync ciphertexts are
-regenerated** on the fix branch and on the 64 pre-fix branches alike.
+regenerated**, on `main` and on the stale pre-fix branch alike. #83 changed
+`bootstrap_config`; it did not change the sync, so this survives the fix.
 
-On those 64, `bootstrap_config()` additionally rebuilds the file from a template
-emitting `provider` + `value` only, preserving just `DOPPLER_TOKEN`. That is the
-wipe class of #82. What it would cost now:
+On the one pre-fix branch, `bootstrap_config()` additionally rebuilds the file
+from a template emitting `provider` + `value` only, preserving just
+`DOPPLER_TOKEN`. That is the wipe class of #82. What it would cost now:
 
 ⚠️ **The mode hazard inverted on 2026-08-02 and the rest did not.** fnox's
 default `env` is `true`, so a regeneration now lands on the *desired* mode — the
@@ -212,14 +205,32 @@ mode**. What stays fragile:
 - **any declaration** the template does not know about — including
   `AGE_PRIVATE_KEY`, which is doppler-primary with no sync block;
 - **all 49 `sync` ciphertexts**, silently replaced — this one happens on every
-  branch;
+  branch, fixed or not, because the fix changed `bootstrap_config`, not the sync;
 - the inline per-secret `env = true` on all 50 — cosmetic while the global says
   `true`, load-bearing the moment it does not.
 
 **fnox is exonerated** — an authorized write probe rewrote all 49 values on both
-its scoped and bulk paths and preserved the mode and every opt-in. The defect is
-mde's, not fnox's. Full probe table and the wipe timeline:
+its scoped and bulk paths and preserved the mode and every opt-in. The defect was
+mde's, not fnox's, and #83 removed it at the source: there is no template to drop
+a field from any more. Full probe table and the wipe timeline:
 `docs/rules-evidence/secrets-out-of-the-shell-env.md`.
+
+### How this section was wrong twice
+
+Both errors are cheap to repeat, so they are recorded rather than deleted.
+
+1. **#515 claimed the pre-fix code was "on `origin/main`"** and that a
+   `git checkout main` silently restored the hazard. It did not — at the time
+   that checkout *broke* the tool instead, because `manage.py` was absent from
+   `main` entirely. The probe behind it was `git cat-file -e <ref>:<path>`, which
+   **returned rc=128 and rc=0 for the same ref minutes apart**; `ls-tree`,
+   `git log -- <path>` and `git show | grep` all agreed with each other. When two
+   routes disagree, one is broken — usually the probe, not the world. Corrected
+   in #516.
+2. **#516's replacement went stale in one day**, because it described a fix held
+   off by a *checked-out branch* and #83 then merged it to `main`. A claim about
+   where code lives has a shelf life measured in merges; state the ref and the
+   date, and re-derive before relying on it.
 
 The durable layer is not this document and not a hand edit: it is
 `mise run doctor`'s `fnox-baseline` check, which re-reads the artifact every
@@ -342,11 +353,11 @@ headers, raw env dumps, or the contents of a secret-bearing config.
 `echo 'value' | doppler secrets set KEY` (plaintext through the tool call).
 
 ⚠️ **`mde-secret-add KEY` does steps 3-7 in one command and is the sanctioned
-mde interface — and it churns all 49 sync ciphertexts every time.** It does not
-rewrite the whole config *while* the sibling repo stays on the #82 fix branch;
-on any of the 64 pre-fix branches it does, and on either `main` it fails on
-import instead. See "The config is generated" above before reaching for it, and
-it still does not touch `doctor.toml` for you.
+mde interface — and it churns all 49 sync ciphertexts every time.** Since #83
+merged it no longer rewrites the whole config on `main` or on any current
+branch; the one stale local branch that still would is named in "The residual
+hazard is one stale local branch" above. It still does not touch `doctor.toml`
+for you.
 
 ## Diagnose "the variable isn't set" — in this order
 


### PR DESCRIPTION
mde #83 merged as `716b17d` and issue #82 closed 2026-08-03T08:55:50Z, which
invalidated the account this repo shipped one day earlier in #516. The direction
of the error was the dangerous one: the prose told a future session that
`git checkout main` in that clone RESTORES the config-wipe hazard. As of today
`main` is the only place carrying the fix.

Rewritten rather than patched, because a section written as a live hazard and
then edited to past tense is exactly the structural defect #515 set out to
remove.

## docs/secrets-doppler-fnox-keychain.md § "The config is generated"

- "The fix is shipped" replaces "the fix is checked out, and that is not the same
  as shipped". Re-derived on `origin/main`, control-armed: `ls-tree` -> 1 row
  (control `README.md` -> 1) and `grep -c _reconcile_declarations` -> 2 (control,
  a bogus symbol -> 0). That symbol exists only in the fix, so its presence on
  `origin/main` IS the fix's presence.
- The branch table collapses. Across all 45 local and remote-tracking refs,
  exactly 4 carry `manage.py`: `origin/main` + `origin/HEAD` + the local (now
  upstream-deleted) fix branch have the fix; ONE stale local branch,
  `feat/secrets-crud-architecture-a`, is the last pre-fix carrier. Delete it and
  the residual risk is zero.
- "64 pre-fix branches" is explicitly retired IN PLACE rather than silently
  dropped. It was true when measured, against a ref set holding ~40 stale
  remote-tracking branches that a `git fetch --prune` removed today. An inherited
  number is not a measurement.
- New "How this section was wrong twice" keeps both failures instead of deleting
  them: #515's `git cat-file -e` probe that returned rc=128 and rc=0 for the same
  ref minutes apart, and #516's correct-but-one-day-shelf-life replacement. A
  claim about where code lives expires on the next merge.
- The sync-churn paragraph now says what SURVIVES the fix: #83 changed
  `bootstrap_config`, not `_run_fnox_sync_age`, so all 49 ciphertexts are still
  regenerated on every add/remove, on `main` too.

## .claude/rules/secrets-out-of-the-shell-env.md

The generated-config warning said "That is a real defect" in the present tense.
It is now marked FIXED with the closing refs, and states the two things that
survive the fix (the sync churn, the one stale branch) so the rule still earns
its eager bytes. Held at 199/200 lines.

## docs/rules-evidence/secrets-out-of-the-shell-env.md

Archaeology is NOT rewritten — it records what was true when written. One dated
status block added after the #82 filing, pointing at the current account and
flagging that the sibling tracker knowledge-base #74 is still OPEN while now
describing a fixed upstream.

Receipts under `docs/receipts/` and the persisted agent reports under
`docs/research/kb/` are deliberately untouched for the same reason.

Gates: `mise run lint` rc=0 · `mise run lint-docs` "No issues found" rc=0.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XesaNXHz4CxEkdK5RQXoBd

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788360863&installation_model_id=429246&pr_number=519&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F519&signature=d7ca03cb257939fe6f1653b95aa719c99bbf23233e0f54d06061387b66227bd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration history and troubleshooting guidance to reflect the latest reconciliation behavior.
  * Clarified that declaration changes are handled without dropping existing configuration fields.
  * Documented remaining ciphertext churn during synchronization and the need to update certain local files manually.
  * Revised guidance on default environment handling and corrected historical references.
  * Added current status for related issues, fixes, and known stale branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->