### PR TITLE
docs(secrets): knowledge-base #74 is closed — update the two pointers that said otherwise

### DIFF
--- a/docs/rules-evidence/secrets-out-of-the-shell-env.md
+++ b/docs/rules-evidence/secrets-out-of-the-shell-env.md
@@ -278,8 +278,10 @@ the shell until something re-reads the config. Filed with the confirmed trigger 
 > (merged `716b17d`) — `bootstrap_config()` now reconciles through `fnox` itself, so
 > there is no template to drop a field from. Everything above is the record of the
 > incident as it stood, kept verbatim; the current account is
-> `docs/secrets-doppler-fnox-keychain.md` § "The config is generated". ⚠️ The sibling
-> tracker **knowledge-base #74 is still OPEN** and now describes a fixed upstream.
+> `docs/secrets-doppler-fnox-keychain.md` § "The config is generated". The sibling
+> tracker **knowledge-base #74 was CLOSED 2026-08-03** with its evidence comment — it
+> described a fixed upstream, and its "prefer `fnox exec --`" recommendation was the
+> inverse of the chosen posture.
 
 **The durable lessons:**
 
@@ -443,7 +445,8 @@ guide with no successor text anywhere, which is deletion, not a move. Kept here.
 - **The sibling-repo defect is tracked on our side too.** `bootstrap_config()`'s
   wipe class is filed upstream as `macos-development-environment#82` **and** as
   **knowledge-base issue #74**. That second pointer was the only record of our
-  own tracking of it.
+  own tracking of it. *[2026-08-03: both are now CLOSED — #82 by mde #83
+  (`716b17d`), KB #74 with an evidence comment.]*
 - **Eventual intent (Ray, 2026-07-20): migrate the integration into a skill**,
   and have the dotfiles repo manage the macOS environment. Neither is done, so
   the guide remains the interim contract.


### PR DESCRIPTION
Follow-up to #520. The audit's own report noted that
docs/rules-evidence/secrets-out-of-the-shell-env.md was "the only place that
flags KB #74 as open" — closing it made both pointers stale in the same turn.

- `:281` — the #82 status block now records #74 as CLOSED 2026-08-03 with its
  evidence comment, and why (its "prefer `fnox exec --`" recommendation was the
  inverse of the deliberate `env = true` posture).
- `:447` — one dated bracket on the archaeology entry; the surrounding record
  stays verbatim.

Found by grepping for the SHAPE rather than the spelling: `knowledge-base#74`
and `KB #74` matched only the report, while the real wording was
`knowledge-base #74` / `knowledge-base issue #74`.

Gates: lint rc=0 · lint-docs rc=0.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XesaNXHz4CxEkdK5RQXoBd

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788375205&installation_model_id=429246&pr_number=521&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F521&signature=900e8f7c8e69e432d7778ea3bca609866690c6b1cac2d53c6c2bcb1925e56873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->