### PR TITLE
fix(guard): block writes to the default branch, and repair the dev opt-out

### DIFF
--- a/.claude/rules/do-not.md
+++ b/.claude/rules/do-not.md
@@ -42,16 +42,28 @@ in this repo. Control arms and case history for each entry:
    fails our size gate either way. Run any `graphify <platform> install` in a
    **throwaway directory outside this repo**, never here.
 
-9. **Do NOT commit onto the default branch — branch FIRST.** Create the branch
-   *before* the commit, then `mise run ship`. It has happened twice, the second
-   time straight after `mise run land` (which **leaves you on `main`**).
-   Recovery is `git branch <new> && git reset --hard origin/main`.
+9. **Do NOT commit — or WRITE — onto the default branch. Branch FIRST.** Create
+   the branch *before* the first edit, then `mise run ship`. It has happened
+   three times, twice straight after `mise run land` (which **leaves you on
+   `main`**). Recovery is `git branch <new> && git reset --hard origin/main`;
+   uncommitted work carries across a `git checkout -b` untouched.
 
-   Machine-enforced (#400) in three layers: hk's `no_commit_to_branch` in the
-   **pre-commit** hook, the PreToolUse guard denying `--no-verify` / `git commit
-   -n` / a `HK_SKIP_HOOKS=` prefix (**no git hook can catch those** — git skips
-   the hook before it exists as a process), and a repository **ruleset requiring
-   a PR for `main`** — the only layer an agent cannot skip.
+   ⚠️ **"Don't commit" was too late a gate.** On 2026-08-03 a whole session's
+   work — including two sub-agent reports — accumulated on `main` and nothing
+   said a word, because **hk is a git-hook system and never sees a write**. It
+   would only have fired at the commit. Ray's standing instruction is therefore
+   *"all work should be on a branch that can be on a PR"*, enforced *whenever
+   anything is modified*.
+
+   Machine-enforced (#400) in four layers, earliest first: the **PreToolUse
+   `branch_guard`** denying `Edit`/`Write`/`NotebookEdit` on a repo file while
+   on the default branch (git-ignored paths and anything outside the repo stay
+   allowed, so `.agent/`, `mise.local.toml` and the scratchpad are unaffected);
+   hk's `no_commit_to_branch` in the **pre-commit** hook; the PreToolUse guard
+   denying `--no-verify` / `git commit -n` / a `HK_SKIP_HOOKS=` prefix (**no git
+   hook can catch those** — git skips the hook before it exists as a process);
+   and a repository **ruleset requiring a PR for `main`** — the only layer an
+   agent cannot skip.
 
 10. **Do NOT write an environment dump into a tracked file.** Not `env`, not
     `printenv`, not `export -p`, not a debug log carrying them. The interactive

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,7 +28,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash|AskUserQuestion",
+        "matcher": "Bash|AskUserQuestion|Edit|Write|NotebookEdit",
         "hooks": [
           {
             "type": "command",

--- a/.devcontainer/AGENTS.md
+++ b/.devcontainer/AGENTS.md
@@ -48,17 +48,17 @@ spec), not a bootstrap shell wrapper:
 service token needed inside the container.
 
 Doppler project/config defaults (`dotfiles`/`dev_personal`) come from
-`mise.toml [tasks.up].env` (`:251`, `:277`, `:771`). Override per-clone via
-`mise.local.toml`: `[tasks.up] env = { DOPPLER_CONFIG = "dev" }`.
+`mise.toml [tasks.up].env` (`:251`, `:277`, `:771`), templated
+`{{ env.DOPPLER_CONFIG | default(value='dev_personal') }}`. Override per-clone
+via a top-level `[env]` block in `mise.local.toml` — `DOPPLER_CONFIG = "dev"` —
+**never** by redefining `[tasks.up]`, which replaces the whole task and strips
+its `run` body (`mise.local.toml.example:9-13`).
 
-**Aligned onto `dev_personal` 2026-08-03.** `dev` (43) was a strict subset of
-`dev_personal` (49) — measured, 0 names in `dev` absent from `dev_personal`. The
-6 extras all have host-side consumers (fnox's age key, the mise/renovate token
-aliases, an NVIDIA benchmark key), so the container never used them; what the
-split cost was a second name set that **nothing asserts** — `doctor.toml` models
-`dev_personal` only, and `build.doppler-secrets-wired` names no config at all.
-The accepted trade-off is that `AGE_PRIVATE_KEY` — the key that decrypts the
-fnox age cache — now reaches the container's `--env-file`.
+**Aligned onto `dev_personal` 2026-08-03** (`dev` was a strict subset; its 6
+extras are all host-side). ⚠️ Accepted cost: `AGE_PRIVATE_KEY`, which decrypts
+the fnox age cache, now reaches the container's `--env-file`. Rationale,
+measurements and the still-open contract gap:
+`docs/secrets-doppler-fnox-keychain.md` § "One config".
 
 Future: migrate to mise-env-fnox with doppler provider inside the
 container for runtime secret resolution (#83).

--- a/docs/research/kb/reports/agents/code-review-522-spec.md
+++ b/docs/research/kb/reports/agents/code-review-522-spec.md
@@ -1,0 +1,87 @@
+# Code review — SPEC axis — commit `5bce39f` (PR #522)
+
+Diff: `git diff a7eecc2...HEAD` — 4 files, +84/-35.
+Spec: scratchpad `spec-522.md` (handoff `.agent/plans/session-2026-08-03-e.md` + the
+user's AskUserQuestion decision, which superseded the "do not arrive with a patch"
+clause).
+
+**Verdict: the diff faithfully implements the chosen option. One real defect (D1),
+one nit. No scope creep.**
+
+## Verified anchors
+
+| Spec claim | Probe | Result |
+|---|---|---|
+| `mise.toml:251,277,771` → `dev_personal` | tree-wide `grep -rn DOPPLER_CONFIG` | ✅ all three; no `= "dev"` survives |
+| `devcontainer.json` fallback also changed | same grep | ✅ `${DOPPLER_CONFIG:-dev_personal}` at `:201` (was `:198`). **The pin/fallback disagreement hazard does not exist anywhere** |
+| `suites.toml` unchanged, gap not overclaimed | `git diff -- python/verification/suites.toml` → empty; prose reads "⚠️ **The contract still names no config, and that gap is unchanged.**" | ✅ correctly states the gap remains; no overclaim |
+| `LINEAR_API_KEY` / `NVIDIA_20260705` retained, wrong finding retracted | grep | ✅ neither removed; docs:127 now reads "**other projects on this host** (Ray, 2026-08-03)". `grep "no consumer\|unused credential"` → rc=1 (control: `AGE_PRIVATE_KEY` in same file → hit) |
+| `AGE_PRIVATE_KEY` cost recorded | read | ✅ three places: commit body ("Accepted cost, decided knowingly"), docs § "The accepted cost, stated rather than argued away", `.devcontainer/AGENTS.md` |
+| `AGENTS.md:52` inversion complete | read | ✅ override now `DOPPLER_CONFIG = "dev"` (was `dev_personal`) |
+| fnox 0 lines in image | `grep -c fnox mise-system.toml Dockerfile` → 0,0; **control** `-E "\bgh\b\|\buv\b\|\bpython\b"` → 4,8 | ✅ probe discriminates |
+| mise token precedence | `mintlify-cache/jdx/mise/llms-full.txt:4004-4008` | ✅ verbatim: 1 `MISE_GITHUB_TOKEN`, 2 `GITHUB_API_TOKEN`, 3 `GITHUB_TOKEN` |
+| Consumer citations | `renovate_dryrun.py:98,99` ✅ · `graph_bakeoff.py:618` (`env_key: NVIDIA_API_KEY`) ✅ · `Dockerfile:311,564` (`export MISE_GITHUB_TOKEN="$GITHUB_TOKEN"`) ✅ · `on-create.sh:54` (`mise install -y`) ✅ · `mise.toml:615` (`[tasks.renovate-dryrun]`) ✅ | all land |
+
+## (a) Missing / partial
+
+**M1 (partial, low).** The chosen option's PRO said the #487 RO token becomes
+"trivial" to repoint. Not done — correctly, it was outside the option's text, and the
+prose labels it "Stated as unblocked, **not as verified**". Honest, not a gap.
+
+No gate was added. The user explicitly rejected "Keep split, add the missing gate",
+so its absence is faithful, and the prose does not pretend otherwise.
+
+## (b) Scope creep
+
+**None.** All three files beyond `mise.toml` are necessary completion:
+
+- `devcontainer.json:201` — the load-bearing one. Left at `:-dev`, a clone invoking
+  `devcontainer up` without the mise task env would silently download the OLD config.
+  Changing only `mise.toml:251,277,771` would have created exactly the hazard the
+  brief asked about.
+- `devcontainer.json:69` + `.devcontainer/AGENTS.md:50-52` — both stated
+  `DOPPLER_CONFIG=dev` and documented the override in the **opposite** direction; the
+  diff falsifies them.
+- `docs/secrets-doppler-fnox-keychain.md` (the largest hunk) — its table asserted
+  "`dev` → the devcontainer". Untouched, the repo's own secrets doc would contradict
+  the code. Necessary.
+
+## (c) Implemented but wrong
+
+**D1 — MEDIUM: the documented per-clone opt-out does not work, and the diff
+propagated it.** Commit body: *"`dev` is retained as a per-clone opt-out via
+mise.local.toml."* Both edited docs spell it:
+
+> `.devcontainer/AGENTS.md:52` — ``Override per-clone via `mise.local.toml`: `[tasks.up] env = { DOPPLER_CONFIG = "dev" }`.``
+> `docs/secrets-doppler-fnox-keychain.md:108` — same form.
+
+`mise.local.toml.example` forbids exactly this, verified on mise 2026.7.0:
+
+> "WARNING: do NOT override by redefining a task (`[tasks.up]`, …). A `[tasks.<name>]`
+> block in mise.local.toml **REPLACES the whole task** — it strips the task's `run`
+> body, so `mise run up` silently becomes a no-op. Use `[env]` only."
+
+`mise.toml:242-244` says the same. And the `[env]` escape hatch is unavailable here:
+`BASE_IMAGE` / `DEVCONTAINER_SSH_PORT` are templated `{{ env.VAR | default(...) }}`,
+but `DOPPLER_CONFIG` is a **literal**, so an `[env]` value is ignored. There is
+therefore *no* working opt-out. Pre-existing (the old text said the same with
+`dev_personal`), but this commit makes it load-bearing and edited both lines without
+fixing it. Fix: template `DOPPLER_CONFIG` like its siblings and add it to
+`mise.local.toml.example`'s "Overridable vars" list — which the diff also leaves
+un-updated.
+
+**N1 — nit.** The docs' control-arm citation "(control: gh/uv/python → 15)" measures
+**12** by my grep shape (4 + 8). The arm fired non-zero, so the probe discriminates
+and the claim stands; the number is imprecise.
+
+## Spec checklist item 1 (the investigation)
+
+Delivered in the commit body + the docs § "The 6 extras" table: all 6 names, a
+consumer each, safe enumeration (`--only-names` counts only; no value in the diff or
+message). Not persisted as a standalone agent artifact, but it was the main session's
+own work, so `agent-report-persistence.md` does not bind.
+
+## GitHub repos touched
+
+- [jdx/mise](https://github.com/jdx/mise) — GitHub-token priority table, read from the
+  local `docs/research/mintlify-cache/jdx/mise/llms-full.txt` (no network).

--- a/docs/research/kb/reports/agents/code-review-522-standards.md
+++ b/docs/research/kb/reports/agents/code-review-522-standards.md
@@ -1,0 +1,160 @@
+# Code review — #522 `5bce39f`, STANDARDS axis
+
+Diff: `git diff a7eecc2...HEAD` — 4 files, +84/-35.
+`.devcontainer/AGENTS.md`, `.devcontainer/devcontainer.json`,
+`docs/secrets-doppler-fnox-keychain.md`, `mise.toml`.
+
+Tooling already green (lint rc=0, pytest 1210, verify 113, lint-docs); nothing
+below duplicates a check that ran.
+
+---
+
+## HARD VIOLATIONS
+
+### H1 — The documented opt-out is the exact anti-pattern `mise.local.toml.example` forbids, and it has no working alternative
+
+The diff prescribes, in two places:
+
+`.devcontainer/AGENTS.md:52`
+```
+`mise.local.toml`: `[tasks.up] env = { DOPPLER_CONFIG = "dev" }`.
+```
+`docs/secrets-doppler-fnox-keychain.md:108` (a NEW line)
+```
+| **`dev`** | **43** | nothing, by default. Retained as a per-clone opt-out via
+`mise.local.toml` `[tasks.up] env = { DOPPLER_CONFIG = "dev" }` |
+```
+
+`mise.local.toml.example` says the opposite, in capitals:
+
+> **WARNING: do NOT override by redefining a task (`[tasks.up]`,
+> `[tasks.dev-rebuild]`, …). A `[tasks.<name>]` block in mise.local.toml
+> REPLACES the whole task — it strips the task's `run` body, so `mise run up`
+> silently becomes a no-op.** mise task tables do NOT deep-merge (verified on
+> mise 2026.7.0). Use `[env]` only. See `feedback_mise_local_toml_replaces_task`.
+
+`mise.toml:240-250` — the comment block **immediately above the line this diff
+edits** — repeats it and explains the fix: `BASE_IMAGE` and
+`DEVCONTAINER_SSH_PORT` are written as `{{ env.VAR | default(value='…') }}`
+precisely "so a per-clone gitignored mise.local.toml `[env]` … overrides them
+WITHOUT redefining the task."
+
+`DOPPLER_CONFIG = "dev_personal"` is a **bare literal**, not templated. So the
+sanctioned `[env]` route does not work either (a task-scoped `env` literal beats
+a config-level `[env]`), and the prescribed `[tasks.up]` route no-ops
+`mise run up`. **The opt-out this diff leans on has no working mechanism at
+all.**
+
+This is not inherited breakage the diff merely passed through: the shape existed
+before, but the diff *promotes* it — `dev`'s entire remaining justification
+("Retained as a per-clone opt-out") now rests on it, and the "Add a secret"
+section (`:349-352`) was rewritten to point at it too.
+
+**Fix:** template it like its two neighbours —
+`DOPPLER_CONFIG = "{{ env.DOPPLER_CONFIG | default(value='dev_personal') }}"` in
+all three `mise.toml` sites (`:251`, `:277`, `:771`), add `DOPPLER_CONFIG` to
+`mise.local.toml.example`'s "Overridable vars" list, and change both prose sites
+to `[env]`.
+
+### H2 — The commit invalidated one of its own citations
+
+`docs/secrets-doppler-fnox-keychain.md:107` cites
+`` `.devcontainer/devcontainer.json:198` ``. The diff added 3 lines to that
+file's header comment, so `initializeCommand` moved to **201**; line 198 is now
+`"forwardPorts": [2222],`.
+
+Control-armed — every *other* line citation in the diff resolves, so the probe
+discriminates: `renovate_dryrun.py:98,99` ✓ (`GITHUB_API_TOKEN`,
+`MISE_GITHUB_TOKEN`), `Dockerfile:311,564` ✓ (`export
+MISE_GITHUB_TOKEN="$GITHUB_TOKEN"`), `mise.toml:615` ✓
+(`[tasks.renovate-dryrun]`), `graph_bakeoff.py:618` ✓ (`"env_key":
+"NVIDIA_API_KEY"`), `on-create.sh:54` ✓ (`mise install -y`),
+`suites.toml:507-511` ✓, `mise.toml:251,277,771` ✓. 7 of 8 correct, 1 broken by
+this commit.
+
+Nothing catches it: `hk.pkl:448` `doc_refs` globs
+`AGENTS.md`/`**/AGENTS.md`/`.claude/rules/*.md`/`.claude/skills/**/*.md` —
+`docs/*.md` is outside it, and it validates path existence, not line numbers.
+
+---
+
+## JUDGEMENT CALLS
+
+### J1 — Shotgun Surgery, and it is real, not tool-forced
+
+One fact ("which Doppler config") is written in **6** places:
+`mise.toml:251`, `:277`, `:771`, `devcontainer.json:201`'s
+`${DOPPLER_CONFIG:-dev_personal}` fallback, plus the `:69` comment and two prose
+docs. The three `mise.toml` literals are *not* forced — `BASE_IMAGE` and
+`DEVCONTAINER_SSH_PORT` are duplicated across the same tasks too, but they at
+least route through one templated default. Fixing H1 collapses the override
+surface to one place and makes the JSON fallback the single literal.
+
+### J2 — Duplicated prose: the same rationale narrative, three times
+
+The "43 ⊂ 49, the 6 extras are host-side, the accepted cost is `AGE_PRIVATE_KEY`"
+argument is written at three different lengths: `.devcontainer/AGENTS.md:53-61`
+(9 lines), `devcontainer.json:69-74` (6 lines), and
+`docs/secrets-doppler-fnox-keychain.md:117-150` (the full version). The repo's
+own remedy is documented — `md-size-budgets.md`: "move reference content to a
+sibling doc and **link it by path**". The two short copies should be one
+sentence plus a link to the doc.
+
+### J3 — `.devcontainer/AGENTS.md` headroom is now 5.6%
+
+11,334 B against agnix AGM-003's hard 12,000-char ceiling — **666 B left**, and
+this diff spent ~640 B of it. `md-size-budgets.md` calls AGM-003 the binding
+constraint for an `AGENTS.md` ("Both must pass; for an `AGENTS.md`, AGM-003 binds
+first"). J2's fix is also the fix here.
+
+### J4 — The smoke probe cannot tell which config was downloaded
+
+The diff states the gap honestly for the contract
+(`suites.toml:507-511` "name no config at all … A wrong `DOPPLER_CONFIG` stays
+green"), but the same blindness sits in `scripts/devcontainer-smoke.sh:59`, which
+the diff did not touch:
+
+```sh
+doppler_count=$(env | grep -cE "^(DOPPLER_PROJECT|DOPPLER_CONFIG|DOPPLER_ENVIRONMENT|EXA_API_KEY|GITHUB_TOKEN|BRAVE_API_KEY|GEMINI_API_KEY)=" || true)
+```
+
+Every one of those 7 canaries is in **both** configs (`dev` ⊂ `dev_personal`), so
+the tier-3 probe passes identically under either — `probes-need-a-control-arm.md`
+rule 1/8: it is armed for "no secrets" but has only one face for "wrong config".
+A `dev_personal`-only canary (`NVIDIA_API_KEY`, or a `DOPPLER_CONFIG` value
+assert) would make it discriminate, at near-zero cost, and would be the one thing
+that actually pins the 6 duplicated literals in J1 together.
+
+### J5 — A named-but-unticketed deferred gap
+
+`zero-skip-policy.md` rule 4: an approved deferral gets "a GitHub Issue … with
+the full context". The rewritten section states the contract gap is "unchanged"
+and that the `DOPPLER_TOKEN` swap is "**Stated as unblocked, not as verified**" —
+both correctly hedged, neither carrying an issue number. Compare the surrounding
+prose, which cites `#83`, `#487` freely.
+
+---
+
+## Not findings (checked, clean)
+
+- **`doctor.toml` untouched** — I checked whether `.claude/CLAUDE.md`'s "changing
+  your setup means changing `doctor.toml` in a reviewed diff" binds. It does not:
+  `doctor.toml` pins the fnox `env_true` 50-name set, which is unchanged, and it
+  has never modelled `DOPPLER_CONFIG` (grep: 0 hits; control `DOPPLER_TOKEN` → 1
+  at `:52`). The diff's own claim that "`doctor.toml` models `dev_personal` only"
+  is accurate in that indirect sense.
+- **Evidence discipline in the new prose is good** — the two-route control arm on
+  mise's token priority (cached `llms-full.txt:4004-4008` **and** live
+  `jdx/mise:src/env.rs:591`, with a bogus-var control), the `fnox` → "0 lines,
+  control gh/uv/python → 15" arm, and the explicit "decided knowingly … Do not
+  'fix' it back" all satisfy `probes-need-a-control-arm.md` rules 5 and 6. The
+  section that admits the file "has now been wrong about `dev` twice in opposite
+  directions" is the correct handling per `verify-before-advancing.md`'s
+  provenance note.
+- No baseline smell beyond J1/J2 applies — there is no code here to carry
+  Feature Envy, Primitive Obsession or Repeated Switches.
+
+## GitHub repos touched
+
+- [jdx/mise](https://github.com/jdx/mise) — cited in the diff as `src/env.rs:591`
+  for the GitHub-token priority chain; verified only as a citation, not fetched.

--- a/docs/secrets-doppler-fnox-keychain.md
+++ b/docs/secrets-doppler-fnox-keychain.md
@@ -104,8 +104,8 @@ superseded — the lane existed, but **nothing in it was ever container-specific
 
 | config | real secrets | who reads it |
 |---|---:|---|
-| **`dev_personal`** | **49** | **everything** — fnox on this host (every declaration maps to `providers.doppler_dotfiles_dev_personal`) **and** the devcontainer (`.devcontainer/devcontainer.json:198` downloads `${DOPPLER_CONFIG:-dev_personal}`, pinned by `mise.toml:251,277,771`) |
-| **`dev`** | **43** | nothing, by default. Retained as a per-clone opt-out via `mise.local.toml` `[tasks.up] env = { DOPPLER_CONFIG = "dev" }` |
+| **`dev_personal`** | **49** | **everything** — fnox on this host (every declaration maps to `providers.doppler_dotfiles_dev_personal`) **and** the devcontainer (`.devcontainer/devcontainer.json` `initializeCommand` downloads `${DOPPLER_CONFIG:-dev_personal}`, pinned by `mise.toml:251,277,771`) |
+| **`dev`** | **43** | nothing, by default. Retained as a per-clone opt-out: a top-level `[env] DOPPLER_CONFIG = "dev"` in `mise.local.toml` (**never** a `[tasks.up]` block — that replaces the whole task) |
 
 (Both report 3 more names than that — Doppler auto-injects `DOPPLER_PROJECT`,
 `DOPPLER_CONFIG`, `DOPPLER_ENVIRONMENT`.)

--- a/mise.local.toml.example
+++ b/mise.local.toml.example
@@ -20,9 +20,13 @@
 #     recovering.
 #   - BASE_IMAGE — pin to a specific tag/SHA for reproducible rebuilds.
 #     Default ghcr.io/ray-manaloto/dotfiles-devcontainer:dev.
+#   - DOPPLER_CONFIG — which Doppler config the devcontainer downloads.
+#     Default dev_personal (aligned 2026-08-03, PR #522); set to "dev" for the
+#     43-secret subset that omits AGE_PRIVATE_KEY and the host-only tokens.
 #
 # DO NOT check in mise.local.toml; it is gitignored by design.
 
 [env]
 DEVCONTAINER_SSH_PORT = "4444"
 # BASE_IMAGE = "ghcr.io/ray-manaloto/dotfiles-devcontainer:<sha>"
+# DOPPLER_CONFIG = "dev"

--- a/mise.toml
+++ b/mise.toml
@@ -248,7 +248,7 @@ description = "Bring the devcontainer up via the official @devcontainers/cli (Ma
 # it would silently ignore a mise.local.toml `[env]` override. The default
 # keeps these TASK-scoped (no global leak of BASE_IMAGE / the amd64
 # platform into unrelated subprocesses) unless the user opts in.
-env = { BASE_IMAGE = "{{ env.BASE_IMAGE | default(value='ghcr.io/ray-manaloto/dotfiles-devcontainer:dev') }}", DOCKER_DEFAULT_PLATFORM = "linux/amd64/v2", DEVCONTAINER_SSH_PORT = "{{ env.DEVCONTAINER_SSH_PORT | default(value='4444') }}", DOPPLER_PROJECT = "dotfiles", DOPPLER_CONFIG = "dev_personal" }
+env = { BASE_IMAGE = "{{ env.BASE_IMAGE | default(value='ghcr.io/ray-manaloto/dotfiles-devcontainer:dev') }}", DOCKER_DEFAULT_PLATFORM = "linux/amd64/v2", DEVCONTAINER_SSH_PORT = "{{ env.DEVCONTAINER_SSH_PORT | default(value='4444') }}", DOPPLER_PROJECT = "dotfiles", DOPPLER_CONFIG = "{{ env.DOPPLER_CONFIG | default(value='dev_personal') }}" }
 run = '''
 set -euo pipefail
 # v6 collision guard: compute an 8-char hash of $PWD so sibling clones
@@ -274,7 +274,7 @@ description = "Force a full rebuild + re-pull of :dev (lifecycle hooks fire)"
 # the host-user overlay without cached layers. Lifecycle hooks
 # (initializeCommand → onCreateCommand → postCreateCommand) all fire.
 # BASE_IMAGE + DEVCONTAINER_SSH_PORT templated for per-clone override — see the up task.
-env = { BASE_IMAGE = "{{ env.BASE_IMAGE | default(value='ghcr.io/ray-manaloto/dotfiles-devcontainer:dev') }}", DOCKER_DEFAULT_PLATFORM = "linux/amd64/v2", DEVCONTAINER_SSH_PORT = "{{ env.DEVCONTAINER_SSH_PORT | default(value='4444') }}", DOPPLER_PROJECT = "dotfiles", DOPPLER_CONFIG = "dev_personal" }
+env = { BASE_IMAGE = "{{ env.BASE_IMAGE | default(value='ghcr.io/ray-manaloto/dotfiles-devcontainer:dev') }}", DOCKER_DEFAULT_PLATFORM = "linux/amd64/v2", DEVCONTAINER_SSH_PORT = "{{ env.DEVCONTAINER_SSH_PORT | default(value='4444') }}", DOPPLER_PROJECT = "dotfiles", DOPPLER_CONFIG = "{{ env.DOPPLER_CONFIG | default(value='dev_personal') }}" }
 run = '''
 set -euo pipefail
 DEVCONTAINER_WORKSPACE_HASH="$(scripts/workspace-hash.sh)"
@@ -768,7 +768,7 @@ echo "OK: R1 inbound ssh ${USER}@localhost -p ${port} works"
 
 [tasks.verify-secrets]
 description = "S1: doppler env file exists and contains secrets"
-env = { DOPPLER_PROJECT = "dotfiles", DOPPLER_CONFIG = "dev_personal" }
+env = { DOPPLER_PROJECT = "dotfiles", DOPPLER_CONFIG = "{{ env.DOPPLER_CONFIG | default(value='dev_personal') }}" }
 run = '''
 set -euo pipefail
 envfile="${HOME}/.local/state/dotfiles/doppler.env"

--- a/python/src/dotfiles_setup/branch_guard.py
+++ b/python/src/dotfiles_setup/branch_guard.py
@@ -1,0 +1,169 @@
+"""Deny repo-file modifications made while sitting on the default branch.
+
+``do-not.md`` #9 already says "do NOT commit onto the default branch — branch
+FIRST", and it is enforced at *commit* time by hk's ``no_commit_to_branch``.
+That layer is blind to the failure this module closes: **work accumulating on
+``main`` before any commit is attempted**.
+
+Session 2026-08-03-f produced it. ``mise run land`` leaves you on ``main``; two
+sub-agents then wrote their reports straight into the working tree there, and
+nothing said a word — the tree simply grew untracked files on the default
+branch. It only becomes visible when something tries to commit, which is far too
+late if the intervening work was expensive. Ray's instruction: *"all work should
+be on a branch that can be on a pr"*, enforced *"whenever anything is modified on
+the repo"*.
+
+So this fires on ``Edit`` / ``Write`` / ``NotebookEdit`` — the moment a file is
+about to change, not the moment it is about to be committed.
+
+**What it deliberately ALLOWS**, because a guard that blocks these gets switched
+off (``mise-tasks-only.md``: "a redirect that misfires on legitimate diagnostics
+erodes trust in the guard"):
+
+- anything **outside the repo** — the auto-memory dir, the session scratchpad;
+- anything **git-ignored** — ``.agent/``, ``graphify-out/``, ``mise.local.toml``;
+  these are machine-local by construction and can never go on a PR;
+- everything, when **not on the default branch** (the normal case).
+
+Like its siblings it fails **OPEN**: any error resolving git state allows the
+call. A crashed guard must not brick every edit.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# Branches treated as protected when the remote's default cannot be resolved.
+# `main` first: this repo's default (`AGENTS.md` — "Main branch (you will
+# usually use this for PRs): main").
+_FALLBACK_DEFAULTS = ("main", "master")
+
+_TOOLS = frozenset({"Edit", "Write", "NotebookEdit"})
+
+_REASON = (
+    "You are on the default branch ({branch}) and about to modify {path}.\n"
+    "All work belongs on a branch that can become a PR — branch FIRST, then edit.\n"
+    "\n"
+    "    git checkout -b <type>/<slug>\n"
+    "\n"
+    "Then re-run this edit and ship with `mise run ship`.\n"
+    "This is `.claude/rules/do-not.md` #9. `mise run land` leaves you on the "
+    "default branch, which is how work ends up here unnoticed.\n"
+    "Writes outside the repo and to git-ignored paths (.agent/, the scratchpad) "
+    "are NOT affected by this guard."
+)
+
+
+def _git(args: list[str], cwd: Path) -> str | None:
+    """Run a read-only git command, returning stripped stdout or None."""
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except OSError, subprocess.SubprocessError:
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip()
+
+
+def repo_root(start: Path) -> Path | None:
+    """Absolute root of the git worktree containing ``start``, or None.
+
+    ``start`` routinely does NOT exist yet — a Write creating a new file, often
+    inside a directory that does not exist either. So walk up to the first
+    ancestor that IS a directory before asking git; running git with a
+    nonexistent cwd just errors, and the guard would then fail open on exactly
+    the case it was built for (caught by
+    ``test_denies_a_new_untracked_file_on_default_branch``).
+    """
+    probe = start if start.is_dir() else start.parent
+    while not probe.is_dir():
+        parent = probe.parent
+        if parent == probe:  # reached the filesystem root
+            return None
+        probe = parent
+    out = _git(["rev-parse", "--show-toplevel"], probe)
+    return Path(out).resolve() if out else None
+
+
+def default_branch(root: Path) -> tuple[str, ...]:
+    """Protected branch names for ``root``.
+
+    Prefers the remote's advertised default; falls back to the conventional
+    pair so the guard still works in a clone with no ``origin/HEAD`` ref.
+    """
+    out = _git(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], root)
+    if out and "/" in out:
+        return (out.split("/", 1)[1],)
+    return _FALLBACK_DEFAULTS
+
+
+def is_ignored(path: Path, root: Path) -> bool:
+    """True when git ignores ``path`` (so it can never reach a PR)."""
+    try:
+        proc = subprocess.run(
+            ["git", "check-ignore", "-q", "--", str(path)],
+            cwd=root,
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+    except OSError, subprocess.SubprocessError:
+        return False
+    return proc.returncode == 0
+
+
+def _target(tool_input: dict[str, object]) -> Path | None:
+    """The file a tool call is about to modify, absolute — or None."""
+    raw = tool_input.get("file_path") or tool_input.get("notebook_path")
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        return Path(raw).expanduser().resolve()
+    except OSError, RuntimeError:
+        return None
+
+
+def _protected(target: Path) -> tuple[Path, str] | None:
+    """``(root, branch)`` when ``target`` sits in a repo on its default branch.
+
+    None means "not our business": outside any repo (the scratchpad, the
+    auto-memory dir), or on a feature branch, or on a detached HEAD — which is
+    not a branch anyone ships from.
+    """
+    root = repo_root(target)
+    if root is None or not target.is_relative_to(root):
+        return None
+    branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], root)
+    if branch is None or branch == "HEAD" or branch not in default_branch(root):
+        return None
+    return root, branch
+
+
+def decide(tool_input: dict[str, object]) -> str | None:
+    """Deny reason for an Edit/Write/NotebookEdit, or None to allow.
+
+    Fails OPEN — every unresolvable step returns None.
+    """
+    target = _target(tool_input)
+    if target is None:
+        return None
+    found = _protected(target)
+    if found is None:
+        return None
+    root, branch = found
+    if is_ignored(target, root):
+        return None
+    return _REASON.format(branch=branch, path=target.relative_to(root))
+
+
+def handles(tool_name: str) -> bool:
+    """True when ``tool_name`` is a file-modifying tool this guard covers."""
+    return tool_name in _TOOLS

--- a/python/src/dotfiles_setup/hook_guard.py
+++ b/python/src/dotfiles_setup/hook_guard.py
@@ -38,7 +38,7 @@ import re
 import sys
 from dataclasses import dataclass
 
-from dotfiles_setup import ask_quality
+from dotfiles_setup import ask_quality, branch_guard
 from dotfiles_setup.heredoc import HEREDOC_PATTERN, NUL_FILLER, blank_heredoc
 
 
@@ -783,12 +783,15 @@ def _read_command() -> str:
 def decide_payload(tool_name: str, tool_input: dict[str, object]) -> str | None:
     """Deny reason for a pending tool call, dispatched on ``tool_name``.
 
-    ``AskUserQuestion`` goes to the ask-quality standard; everything else is
-    treated as a Bash command (the historical shape — an absent ``tool_name``
-    must keep behaving exactly as it did before dispatch existed).
+    ``AskUserQuestion`` goes to the ask-quality standard; the file-modifying
+    tools go to the default-branch guard; everything else is treated as a Bash
+    command (the historical shape — an absent ``tool_name`` must keep behaving
+    exactly as it did before dispatch existed).
     """
     if tool_name == "AskUserQuestion":
         return ask_quality.decide(tool_input)
+    if branch_guard.handles(tool_name):
+        return branch_guard.decide(tool_input)
     return decide(str(tool_input.get("command", "")))
 
 

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -1109,7 +1109,7 @@ paths = [
     "tests/test_ask_quality.py",
     ".claude/rules/clarify-before-acting.md",
 ]
-per_path_tokens = { ".claude/settings.json" = ['"matcher": "Bash|AskUserQuestion"'], "python/src/dotfiles_setup/ask_quality.py" = ['RECOMMENDED_MARKER = "(Recommended)"', 'NO_EVIDENCE_ESCAPE = "[no prior evidence]"', "def find_violations(", "_CITATION_RE = re.compile("],"python/src/dotfiles_setup/hook_guard.py" = ['if tool_name == "AskUserQuestion":', "return ask_quality.decide(tool_input)", "def decide_payload("], "python/src/dotfiles_setup/hook_selfcheck.py" = ['("Bash", "AskUserQuestion")', "def check_ask_quality_endtoend(", "def _ask_payload("], "tests/test_ask_quality.py" = ["def test_uncited_ask_is_denied(", "def test_compliant_ask_is_allowed(", "def test_cli_denies_a_noncompliant_ask(", "def test_cli_allows_a_compliant_ask(", "def test_dispatch_still_denies_a_guarded_bash_command("], ".claude/rules/clarify-before-acting.md" = ["`Bash|AskUserQuestion`", "[no prior evidence]", "python/src/dotfiles_setup/ask_quality.py"] }
+per_path_tokens = { ".claude/settings.json" = ['"matcher": "Bash|AskUserQuestion|Edit|Write|NotebookEdit"'], "python/src/dotfiles_setup/ask_quality.py" = ['RECOMMENDED_MARKER = "(Recommended)"', 'NO_EVIDENCE_ESCAPE = "[no prior evidence]"', "def find_violations(", "_CITATION_RE = re.compile("],"python/src/dotfiles_setup/hook_guard.py" = ['if tool_name == "AskUserQuestion":', "return ask_quality.decide(tool_input)", "def decide_payload("], "python/src/dotfiles_setup/hook_selfcheck.py" = ['("Bash", "AskUserQuestion")', "def check_ask_quality_endtoend(", "def _ask_payload("], "tests/test_ask_quality.py" = ["def test_uncited_ask_is_denied(", "def test_compliant_ask_is_allowed(", "def test_cli_denies_a_noncompliant_ask(", "def test_cli_allows_a_compliant_ask(", "def test_dispatch_still_denies_a_guarded_bash_command("], ".claude/rules/clarify-before-acting.md" = ["`Bash|AskUserQuestion`", "[no prior evidence]", "python/src/dotfiles_setup/ask_quality.py"] }
 
 [[suite]]
 name = "workflow.mise-tasks-enforcement"
@@ -1775,3 +1775,19 @@ per_path_tokens = { "python/src/dotfiles_setup/pr.py" = [
     "FAIL  ship: git push rc={push_rc}",
     "gh pr view rc={view.returncode}",
 ] }
+
+[[suite]]
+name = "workflow.branch-write-guard-wiring"
+description = "All work belongs on a branch that can become a PR (do-not.md #9), enforced at the moment a file CHANGES rather than the moment it is committed. hk's `no_commit_to_branch` (hk.pkl) already covers the commit, but hk is a git-hook system and never sees a write — so work can pile up on the default branch invisibly until something finally tries to commit. That is exactly what happened in session 2026-08-03-f: `mise run land` left the session on `main` and two sub-agents wrote their reports into the working tree there, unremarked. This contract pins the write-time layer end-to-end: the settings.json matcher must still name the file-modifying tools (a matcher that silently loses `Edit|Write` disables the guard while every unit test keeps passing — the #343 shape), `decide_payload` must still ROUTE to the module, the module must keep the two fail-open escapes that stop it blocking legitimate writes (git-ignored paths and paths outside the repo), and the nonexistent-ancestor walk must survive, because without it a Write creating a file in a new directory fails open on precisely the case the guard exists for."
+category = "workflow"
+check_type = "static"
+handler = "require_tokens"
+paths_required = true
+paths = [
+    ".claude/settings.json",
+    "python/src/dotfiles_setup/hook_guard.py",
+    "python/src/dotfiles_setup/branch_guard.py",
+    "tests/test_branch_guard.py",
+    ".claude/rules/do-not.md",
+]
+per_path_tokens = { ".claude/settings.json" = ['"matcher": "Bash|AskUserQuestion|Edit|Write|NotebookEdit"'], "python/src/dotfiles_setup/hook_guard.py" = ["if branch_guard.handles(tool_name):", "return branch_guard.decide(tool_input)"], "python/src/dotfiles_setup/branch_guard.py" = ["def decide(", "def handles(", "if is_ignored(target, root):", "while not probe.is_dir():", '_FALLBACK_DEFAULTS = ("main", "master")'], "tests/test_branch_guard.py" = ["def test_denies_a_new_untracked_file_on_default_branch(", "def test_allows_same_file_on_a_feature_branch(", "def test_allows_gitignored_paths_on_default_branch(", "def test_allows_paths_outside_any_repo(", "def test_dispatch_routes_edit_to_the_branch_guard("], ".claude/rules/do-not.md" = ["Branch FIRST", "denying `Edit`/`Write`/`NotebookEdit` on a repo file"] }

--- a/tests/test_branch_guard.py
+++ b/tests/test_branch_guard.py
@@ -1,0 +1,144 @@
+"""Tests for the default-branch write guard.
+
+Every test builds a **real git repo** rather than mocking git. The fixture is
+the thing most likely to lie here (``probes-need-a-control-arm.md`` rule 8:
+"could this setup have produced the other result?"), and a mocked
+``rev-parse`` would prove only that the mock returns what it was told to.
+
+Each behaviour is asserted in BOTH directions — a guard verified only on the
+deny path is a check that can only pass.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+from dotfiles_setup import branch_guard, hook_guard
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _run(args: list[str], cwd: Path) -> None:
+    subprocess.run(args, cwd=cwd, check=True, capture_output=True)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A real git repo on `main`, with a .gitignore and one commit."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    _run(["git", "init", "-b", "main"], root)
+    _run(["git", "config", "user.email", "t@example.com"], root)
+    _run(["git", "config", "user.name", "T"], root)
+    (root / ".gitignore").write_text(".agent/\nmise.local.toml\n")
+    (root / "tracked.md").write_text("hello\n")
+    _run(["git", "add", "-A"], root)
+    _run(["git", "commit", "-m", "init"], root)
+    (root / ".agent").mkdir()
+    return root
+
+
+def test_denies_tracked_file_on_default_branch(repo: Path) -> None:
+    """The headline case: real work, on main, must be refused."""
+    reason = branch_guard.decide({"file_path": str(repo / "tracked.md")})
+    assert reason is not None
+    assert "default branch" in reason
+    assert "git checkout -b" in reason
+    assert "tracked.md" in reason
+
+
+def test_denies_a_new_untracked_file_on_default_branch(repo: Path) -> None:
+    """The exact 2026-08-03-f failure: agent reports written to main.
+
+    The file does not exist yet and is not tracked — but it is not ignored
+    either, so it is work that belongs on a branch.
+    """
+    reason = branch_guard.decide({"file_path": str(repo / "docs" / "report.md")})
+    assert reason is not None
+
+
+def test_allows_same_file_on_a_feature_branch(repo: Path) -> None:
+    """CONTROL ARM for the deny above — only the branch differs."""
+    _run(["git", "checkout", "-b", "feat/x"], repo)
+    assert branch_guard.decide({"file_path": str(repo / "tracked.md")}) is None
+
+
+def test_allows_gitignored_paths_on_default_branch(repo: Path) -> None:
+    """`.agent/` and friends can never reach a PR, so they are never blocked."""
+    assert (
+        branch_guard.decide({"file_path": str(repo / ".agent" / "notepad.md")}) is None
+    )
+    assert branch_guard.decide({"file_path": str(repo / "mise.local.toml")}) is None
+
+
+def test_allows_paths_outside_any_repo(tmp_path: Path) -> None:
+    """The auto-memory dir and the session scratchpad must stay writable."""
+    outside = tmp_path / "not-a-repo"
+    outside.mkdir()
+    assert branch_guard.decide({"file_path": str(outside / "MEMORY.md")}) is None
+
+
+def test_allows_when_detached_head(repo: Path) -> None:
+    """A detached HEAD is not a branch anyone ships from."""
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    _run(["git", "checkout", sha], repo)
+    assert branch_guard.decide({"file_path": str(repo / "tracked.md")}) is None
+
+
+def test_allows_master_as_well_as_main(tmp_path: Path) -> None:
+    """The fallback pair covers a `master`-default clone."""
+    root = tmp_path / "old"
+    root.mkdir()
+    _run(["git", "init", "-b", "master"], root)
+    _run(["git", "config", "user.email", "t@example.com"], root)
+    _run(["git", "config", "user.name", "T"], root)
+    (root / "f.md").write_text("x\n")
+    _run(["git", "add", "-A"], root)
+    _run(["git", "commit", "-m", "i"], root)
+    assert branch_guard.decide({"file_path": str(root / "f.md")}) is not None
+
+
+def test_allows_missing_or_malformed_input() -> None:
+    """Fails OPEN — a payload without a path must never block."""
+    assert branch_guard.decide({}) is None
+    assert branch_guard.decide({"file_path": ""}) is None
+    assert branch_guard.decide({"file_path": 42}) is None
+
+
+def test_notebook_path_is_honoured(repo: Path) -> None:
+    """NotebookEdit carries `notebook_path`, not `file_path`."""
+    assert branch_guard.decide({"notebook_path": str(repo / "nb.ipynb")}) is not None
+
+
+def test_handles_covers_exactly_the_file_modifying_tools() -> None:
+    """Both arms: the covered set, and a tool that must NOT route here."""
+    for name in ("Edit", "Write", "NotebookEdit"):
+        assert branch_guard.handles(name)
+    for name in ("Bash", "AskUserQuestion", "Read", "Grep"):
+        assert not branch_guard.handles(name)
+
+
+def test_dispatch_routes_edit_to_the_branch_guard(repo: Path) -> None:
+    """The WIRING, not just the module — `decide_payload` must reach it.
+
+    Without this, the guard could be perfect and never called; that is the
+    #343 fail-open shape.
+    """
+    reason = hook_guard.decide_payload("Write", {"file_path": str(repo / "tracked.md")})
+    assert reason is not None
+    assert "default branch" in reason
+
+
+def test_dispatch_still_treats_bash_as_a_command() -> None:
+    """CONTROL ARM: adding the branch guard must not swallow Bash rules."""
+    assert hook_guard.decide_payload("Bash", {"command": "git status"}) is None
+    assert hook_guard.decide_payload("Bash", {"command": "git commit --no-verify -m x"})


### PR DESCRIPTION
Two-axis code review of #522 (`/mattpocock-skills:code-review`) found a real
defect, and the session that shipped #522 exposed a gap in do-not.md #9.

## H1/D1 — the documented `dev` opt-out had no working mechanism

#522 documented, in two places, `mise.local.toml` `[tasks.up] env = {
DOPPLER_CONFIG = "dev" }`. `mise.local.toml.example:9-13` forbids exactly
that: a `[tasks.<name>]` block REPLACES the whole task and strips its `run`
body. The `[env]` escape hatch did not work either, because DOPPLER_CONFIG
was a bare literal while its siblings BASE_IMAGE / DEVCONTAINER_SSH_PORT are
templated. Both axes found this independently.

Proven, both arms, before and after:
  before: DOPPLER_CONFIG=zzq_probe_value -> config=dev_personal  (IGNORED)
  after:  DOPPLER_CONFIG=zzq_probe_value -> config=zzq_probe_value
  control (no override, after)            -> config=dev_personal

Fix: template DOPPLER_CONFIG at mise.toml:251,277,771, add it to
mise.local.toml.example's overridables, and correct both prose sites to
`[env]`.

## H2 — #522 invalidated its own citation

It cited `.devcontainer/devcontainer.json:198` while adding 3 lines to that
file, moving initializeCommand to :201. Replaced with a line-free reference.
(7 of the other 8 citations resolved, so the probe discriminated.)

## The branch guard — a NEW layer, at write time

hk's `no_commit_to_branch` already blocks a COMMIT on main, but hk is a
git-hook system and never sees a write. So a whole session's work — including
two sub-agent reports — accumulated on `main` unremarked; `mise run land`
leaves you there. Ray: "all work should be on a branch that can be on a pr",
enforced "whenever anything is modified on the repo".

PreToolUse now denies Edit/Write/NotebookEdit on a repo file while on the
default branch. Deliberately allows git-ignored paths (.agent/,
mise.local.toml) and anything outside the repo (auto-memory, scratchpad) —
a guard that blocks those gets switched off.

Verified through the REAL wrapper, three arms: Write on main -> deny;
same file on a feature branch -> allow; `git commit --no-verify` -> still
denies, so no regression to the existing Bash rules.

My own test caught a hole first: a Write into a not-yet-existing directory
ran git with a nonexistent cwd, errored, and failed OPEN — precisely the
case the guard exists for. Fixed by walking up to the first existing
ancestor; test_denies_a_new_untracked_file_on_default_branch pins it.

Also: J2/J3 — trimmed the duplicated rationale out of .devcontainer/AGENTS.md
and linked it, recovering AGM-003 headroom 454 -> 738 B.

Gates: lint rc=0 · pytest 1222 passed · verify 114 passed 0 failed ·
lint-docs no issues.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XesaNXHz4CxEkdK5RQXoBd

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788381552&installation_model_id=429246&pr_number=523&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F523&signature=84c0ebc6c8214687e7fb8047a1317275c51733120f8ac36250d36a2c8af8ff62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added safeguards that prevent file edits on the repository’s default branch, requiring work on a separate branch first.
  - Protection covers standard file and notebook edits while allowing ignored files, detached repositories, and paths outside repositories.

- **Documentation**
  - Clarified secret configuration defaults and per-clone overrides.
  - Updated development-container guidance and added code-review documentation.

- **Tests**
  - Added coverage for branch protection, configuration behavior, and hook routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->