### PR TITLE
research/secrets cli direction

### DIFF
--- a/docs/research/kb/artifacts/README.md
+++ b/docs/research/kb/artifacts/README.md
@@ -1,0 +1,27 @@
+# Secrets-CLI decision artifacts — session 2026-08-03/04
+
+Published Artifact pages, with their sources preserved here. The pages live on
+claude.ai; these `.html` files are the sources they were published from. To
+update a page from a later session, pass its URL as the Artifact tool's `url`
+parameter — otherwise a new URL is minted.
+
+| Artifact | URL | What it holds |
+|---|---|---|
+| `secrets-cli-proposals.html` | https://claude.ai/code/artifact/d484504f-4d8f-49fe-8765-97deb1138a28 | Five proposals, the measured evidence matrix with per-cell provenance, mise-native capabilities, the four resolution lanes |
+| `secrets-cli-architecture.html` | https://claude.ai/code/artifact/94961fff-d5b1-4805-a67d-3740fe2b5e86 | Four-layer target architecture, the five drift seams, CRUD as sequence diagrams |
+| `secrets-fnox-entrypoint.html` | https://claude.ai/code/artifact/73dcd549-55c7-4e52-b430-4a5a3fdd5082 | fnox as sole integration point — the three leaks, CRUD flows, the Rust-vs-Python build fork |
+| `fnox-doppler-write.html` | https://claude.ai/code/artifact/5df65a33-ac72-4bde-baf5-8ad34631fe50 | Whether Doppler write support exists upstream, the four edits to add it, the cleartext-write defect |
+| `shell-activation.html` | https://claude.ai/code/artifact/e569d38b-c5d8-42cb-a6f0-ebeb0be73344 | Five candidates to replace the mde shell fragment, six hazards, mise `[dotfiles]` |
+
+## Known-stale content
+
+`secrets-cli-architecture.html` draws Create/Delete routing the **write**
+through fnox. That has never been how this host works — writes go via the
+Doppler CLI, and fnox cannot write to Doppler at all. Fix before citing that
+diagram.
+
+## Backing agent reports
+
+`../reports/agents/` — `secrets-backend-{infisical,sops-age,bitwarden-sm}.md`,
+`fnox-{write-surface,sdk-config,export-exec,shell-activation}.md`,
+`mise-shell-activation.md`.

--- a/docs/research/kb/artifacts/fnox-doppler-write.html
+++ b/docs/research/kb/artifacts/fnox-doppler-write.html
@@ -1,0 +1,330 @@
+<title>Implementing Doppler writes in fnox</title>
+
+<style>
+  :root {
+    --ground:#EDEEF0; --surface:#FFFFFF; --sunk:#E3E5E9; --ink:#16181C;
+    --muted:#676D78; --hair:#CFD3D9; --accent:#A97A3D; --accent-w:#F0E4D2;
+    --good:#2E7D5B; --bad:#B3402F; --warn:#8A6A1F;
+    --good-w:#DCEDE5; --bad-w:#F6DED9; --warn-w:#F1E7CE;
+    --f-display: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    --f-body: Georgia, "Iowan Old Style", "Times New Roman", serif;
+    --f-mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
+    --col: 68ch;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root { --ground:#111317; --surface:#191C21; --sunk:#0C0E11; --ink:#E6E8EC;
+      --muted:#8E95A1; --hair:#2C3138; --accent:#D4A468; --accent-w:#33281A;
+      --good:#4FA57E; --bad:#D9705E; --warn:#C9A24D;
+      --good-w:#16281F; --bad-w:#2E1A16; --warn-w:#2A2213; }
+  }
+  :root[data-theme="dark"] { --ground:#111317; --surface:#191C21; --sunk:#0C0E11; --ink:#E6E8EC;
+    --muted:#8E95A1; --hair:#2C3138; --accent:#D4A468; --accent-w:#33281A;
+    --good:#4FA57E; --bad:#D9705E; --warn:#C9A24D;
+    --good-w:#16281F; --bad-w:#2E1A16; --warn-w:#2A2213; }
+  :root[data-theme="light"] { --ground:#EDEEF0; --surface:#FFFFFF; --sunk:#E3E5E9; --ink:#16181C;
+    --muted:#676D78; --hair:#CFD3D9; --accent:#A97A3D; --accent-w:#F0E4D2;
+    --good:#2E7D5B; --bad:#B3402F; --warn:#8A6A1F;
+    --good-w:#DCEDE5; --bad-w:#F6DED9; --warn-w:#F1E7CE; }
+
+  body { background:var(--ground); color:var(--ink); font-family:var(--f-body);
+         font-size:17px; line-height:1.62; -webkit-font-smoothing:antialiased; }
+  .wrap { max-width:1180px; margin:0 auto;
+          padding:clamp(2rem,5vw,4.5rem) clamp(1.1rem,4vw,2.5rem) 6rem;
+          display:flex; flex-direction:column; gap:3.5rem; }
+  .col { max-width:var(--col); }
+  .lbl { font-family:var(--f-mono); font-size:0.7rem; letter-spacing:0.16em;
+         text-transform:uppercase; color:var(--muted); }
+  h1,h2,h3 { font-family:var(--f-display); text-wrap:balance; line-height:1.15; letter-spacing:-0.02em; }
+  h1 { font-size:clamp(2rem,5vw,3.1rem); font-weight:700; margin:0.4rem 0 0; }
+  h2 { font-size:clamp(1.35rem,3vw,1.75rem); font-weight:650; margin:0; }
+  h3 { font-size:1rem; font-weight:650; margin:0 0 0.15rem; letter-spacing:-0.01em; }
+  p { margin:0 0 1rem; } p:last-child { margin-bottom:0; }
+  code { font-family:var(--f-mono); font-size:0.87em; background:var(--sunk);
+         padding:0.1em 0.36em; border-radius:3px; word-break:break-word; }
+  pre { background:var(--sunk); border:1px solid var(--hair); border-left:3px solid var(--accent);
+        border-radius:4px; padding:0.9rem 1rem; overflow-x:auto; margin:0;
+        font-family:var(--f-mono); font-size:0.78rem; line-height:1.55; }
+  pre code { background:none; padding:0; font-size:inherit; }
+  pre.bad { border-left-color:var(--bad); }
+  pre.good { border-left-color:var(--good); }
+  header .rule { height:3px; width:68px; background:var(--accent); margin-bottom:1.6rem; }
+  header .sub { color:var(--muted); font-size:1.02rem; margin-top:1.2rem; }
+  section { display:flex; flex-direction:column; gap:1.4rem; }
+  .head { display:flex; flex-direction:column; gap:0.5rem; }
+
+  .chip { display:inline-block; font-family:var(--f-mono); font-size:0.63rem;
+          letter-spacing:0.11em; text-transform:uppercase; padding:0.26em 0.55em;
+          border-radius:3px; white-space:nowrap; font-weight:600; }
+  .c-good{background:var(--good-w);color:var(--good);} .c-bad{background:var(--bad-w);color:var(--bad);}
+  .c-warn{background:var(--warn-w);color:var(--warn);} .c-flat{background:var(--sunk);color:var(--muted);}
+
+  .tablewrap { overflow-x:auto; border:1px solid var(--hair); border-radius:6px; background:var(--surface); }
+  table { border-collapse:collapse; width:100%; min-width:760px; }
+  th,td { text-align:left; padding:0.7rem 0.85rem; border-bottom:1px solid var(--hair);
+          vertical-align:top; font-size:0.86rem; line-height:1.45; }
+  thead th { font-family:var(--f-mono); font-size:0.66rem; letter-spacing:0.1em;
+             text-transform:uppercase; color:var(--muted); font-weight:600; background:var(--sunk); }
+  tbody th { font-family:var(--f-display); font-weight:650; font-size:0.82rem; width:200px; }
+  tbody tr:last-child th, tbody tr:last-child td { border-bottom:none; }
+
+  /* sequence */
+  .seq { background:var(--surface); border:1px solid var(--hair); border-radius:6px;
+         padding:1.1rem 1.2rem 1.4rem; overflow-x:auto; }
+  .seq .cmd { font-family:var(--f-mono); font-size:0.78rem; background:var(--sunk);
+              padding:0.5rem 0.7rem; border-radius:4px; border-left:2px solid var(--accent);
+              margin-bottom:1.1rem; display:inline-block; white-space:nowrap; }
+  .seq-inner { min-width:700px; }
+  .seq-head { display:grid; grid-template-columns:repeat(5,1fr);
+              padding-bottom:0.6rem; border-bottom:1px solid var(--hair); margin-bottom:0.2rem; }
+  .seq-head span { font-family:var(--f-mono); font-size:0.66rem; letter-spacing:0.06em;
+                   text-align:center; color:var(--muted); font-weight:600; }
+  .seq-head span.owner { color:var(--accent); }
+  .seq-body { position:relative; padding-top:0.5rem; }
+  .rails { position:absolute; inset:0; display:grid; grid-template-columns:repeat(5,1fr); pointer-events:none; }
+  .rails i { background:linear-gradient(var(--hair),var(--hair)) center/1px 100% no-repeat; }
+  .step { position:relative; display:grid; grid-template-columns:repeat(10,1fr);
+          align-items:center; min-height:2.55rem; }
+  .bar { grid-column:var(--gc); position:relative; height:2px; background:var(--accent);
+         align-self:center; margin-top:0.55rem; }
+  .bar .t { position:absolute; left:0; right:0; bottom:6px; text-align:center;
+            font-size:0.76rem; line-height:1.3; color:var(--ink); white-space:nowrap; }
+  .bar::after { content:""; position:absolute; top:-4px; width:0; height:0;
+                border-top:5px solid transparent; border-bottom:5px solid transparent; }
+  .bar.r::after { right:-1px; border-left:8px solid var(--accent); }
+  .bar.l::after { left:-1px; border-right:8px solid var(--accent); }
+  .bar.dim { background:var(--muted); }
+  .bar.dim::after { border-left-color:var(--muted); border-right-color:var(--muted); }
+  .bar.dim .t { color:var(--muted); }
+  .bar.warn { background:var(--bad); }
+  .bar.warn::after { border-left-color:var(--bad); border-right-color:var(--bad); }
+  .bar.warn .t { color:var(--bad); font-weight:600; }
+  .bar.ok { background:var(--good); }
+  .bar.ok::after { border-left-color:var(--good); border-right-color:var(--good); }
+  .self { grid-column:var(--gc); align-self:center; margin-top:0.3rem;
+          border:1px solid var(--hair); border-left:2px solid var(--accent);
+          background:var(--ground); border-radius:3px; padding:0.24rem 0.4rem;
+          font-size:0.73rem; text-align:center; line-height:1.25; }
+  .self.warn { border-left-color:var(--bad); color:var(--bad); font-weight:600; }
+  .self.ok { border-left-color:var(--good); }
+  .stepno { position:absolute; left:-0.1rem; top:0.85rem; font-family:var(--f-mono);
+            font-size:0.62rem; color:var(--accent); font-weight:700; }
+  .seq .note { font-size:0.83rem; color:var(--muted); margin-top:1rem; line-height:1.5; }
+
+  .work { display:flex; flex-direction:column; gap:1.1rem; }
+  .item { background:var(--surface); border:1px solid var(--hair); border-radius:6px; padding:1.25rem;
+          display:flex; flex-direction:column; gap:0.75rem; }
+  .item .top { display:flex; justify-content:space-between; align-items:flex-start; gap:1rem; flex-wrap:wrap; }
+  .item .where { font-family:var(--f-mono); font-size:0.72rem; color:var(--muted); }
+
+  .callout { background:var(--surface); border:1px solid var(--hair);
+             border-left:3px solid var(--accent); border-radius:4px;
+             padding:1.15rem 1.3rem; font-size:0.94rem; }
+  .callout.alarm { border-left-color:var(--bad); }
+  .callout .lbl { display:block; margin-bottom:0.5rem; }
+
+  footer { border-top:1px solid var(--hair); padding-top:1.5rem; font-size:0.8rem;
+           color:var(--muted); font-family:var(--f-mono); line-height:1.7; }
+  @media (prefers-reduced-motion:reduce){ *{animation:none!important;transition:none!important;} }
+</style>
+
+<div class="wrap">
+
+  <header class="col">
+    <div class="rule"></div>
+    <span class="lbl">Upstream change · jdx/fnox · read at 1.32.0</span>
+    <h1>Teaching fnox to write to Doppler</h1>
+    <p class="sub">It does not exist yet, anywhere I can see. It is also small — the provider already shells out to the Doppler CLI, so the write is one more subcommand. Here is exactly what changes, and the separate defect found while looking.</p>
+  </header>
+
+  <!-- DOES IT EXIST -->
+  <section>
+    <div class="head col">
+      <span class="lbl">First question</span>
+      <h2>Does an implementation already exist?</h2>
+      <p>Four routes checked. Three say no; the fourth could not be checked at all, and that is stated rather than glossed.</p>
+    </div>
+
+    <div class="tablewrap">
+      <table>
+        <thead><tr><th scope="col">Route</th><th scope="col">Result</th><th scope="col">Confidence</th></tr></thead>
+        <tbody>
+          <tr>
+            <th scope="row">Unreleased on <code>main</code>?</th>
+            <td><code>main</code> and <code>v1.32.0</code> return the <strong>identical blob sha</strong> for <code>doppler.rs</code> — <code>4c99bb1…</code>. There is no newer implementation waiting to ship.</td>
+            <td><span class="chip c-good">Certain</span></td>
+          </tr>
+          <tr>
+            <th scope="row">In the original provider PR?</th>
+            <td><strong>#376 "feat(provider): add Doppler secrets manager provider"</strong>, merged, added <code>src/providers/doppler.rs</code> at <strong>+464 lines</strong>. Its patch mentions <code>put_secret</code> and <code>fn capabilities</code> <strong>zero times</strong>. Writes were never implemented, not removed later.</td>
+            <td><span class="chip c-good">Certain</span></td>
+          </tr>
+          <tr>
+            <th scope="row">Any other PR?</th>
+            <td>Ten PRs mention Doppler; the only provider-shaped ones are #376 itself and unrelated additions (azure-ac, FOKS, proxy, daemon). None adds a write path.</td>
+            <td><span class="chip c-good">Good</span> — control arm: the same query route returned 3 recent PRs, so the search discriminates</td>
+          </tr>
+          <tr>
+            <th scope="row">In any of the 97 forks?</th>
+            <td><strong>Unknown.</strong> GitHub code search is unavailable on this token — and the control arm for it also returned zero, so that probe is blind rather than empty-handed. I cannot claim no fork has it.</td>
+            <td><span class="chip c-bad">Not checked</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- THE DEFECT -->
+  <section>
+    <div class="head col">
+      <span class="lbl">Found while looking</span>
+      <h2>A separate defect, and it is the more urgent one</h2>
+    </div>
+
+    <div class="callout alarm col">
+      <p>The <code>Provider</code> trait's default <code>put_secret</code> already handles read-only providers correctly — it returns <code>Err("This provider does not support storing secrets")</code>. So fnox <em>knows</em> the right answer.</p>
+      <p style="margin:0"><strong><code>set.rs</code> never asks it.</strong> The dispatch checks for the two writer capabilities, and a read-only provider falls into an <code>else</code> that yields <code>(None, None)</code> — <code>put_secret</code> is not called, so the trait's error never fires. Further down, <code>(None, None)</code> plus a named provider lands in a branch that writes <strong>the raw value</strong> into the config file.</p>
+    </div>
+
+    <pre class="bad"><code>// crates/.../commands/set.rs — the dispatch
+} else {
+    // Not an encryption or remote storage provider
+    (None, None)          // &lt;- put_secret never called
+}
+
+// ...and further down, where that (None, None) lands:
+} else if provider_name_to_use.is_some() {
+    // Provider specified or default provider available
+    // (but not an encryption/remote provider)
+    secret_config.set_value(Some(value.clone()));   // &lt;- CLEARTEXT into fnox.toml
+}</code></pre>
+
+    <div class="callout col">
+      <span class="lbl">Why this matters more than the feature</span>
+      <p style="margin:0">The feature's absence is a limitation you can route around. This is a <strong>silent</strong> failure that plaintexts a credential to disk while appearing to succeed — and it applies to all six read-only providers, not just Doppler. The fix is small and independent: make that <code>else</code> call <code>put_secret</code> (or return its error) instead of yielding <code>(None, None)</code>. <span class="chip c-warn">Read from source, not executed — confirm in a throwaway <code>FNOX_CONFIG_DIR</code> before filing</span></p>
+    </div>
+  </section>
+
+  <!-- BEFORE / AFTER -->
+  <section>
+    <div class="head col">
+      <span class="lbl">Behaviour</span>
+      <h2>What changes, as a flow</h2>
+    </div>
+
+    <div class="seq">
+      <h3>Today <span class="chip c-bad">writes cleartext</span></h3>
+      <div class="cmd">fnox set STRIPE_API_KEY --provider doppler</div>
+      <div class="seq-inner">
+        <div class="seq-head"><span>you</span><span class="owner">fnox set</span><span>provider trait</span><span>doppler CLI</span><span>fnox.toml</span></div>
+        <div class="seq-body">
+          <div class="rails"><i></i><i></i><i></i><i></i><i></i></div>
+          <div class="step"><span class="stepno">1</span><div class="bar r" style="--gc:2/4"><span class="t">value on stdin</span></div></div>
+          <div class="step"><span class="stepno">2</span><div class="bar r dim" style="--gc:4/6"><span class="t">capabilities() → RemoteRead (the default)</span></div></div>
+          <div class="step"><span class="stepno">3</span><div class="self warn" style="--gc:3/5">neither writer branch matches → (None, None)</div></div>
+          <div class="step"><span class="stepno">4</span><div class="bar warn r" style="--gc:6/8"><span class="t">✗ doppler secrets set never runs</span></div></div>
+          <div class="step"><span class="stepno">5</span><div class="bar warn r" style="--gc:4/10"><span class="t">raw value written to disk, rc=0</span></div></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="seq">
+      <h3>After <span class="chip c-good">writes through</span></h3>
+      <div class="cmd">fnox set STRIPE_API_KEY --provider doppler</div>
+      <div class="seq-inner">
+        <div class="seq-head"><span>you</span><span class="owner">fnox set</span><span>provider trait</span><span>doppler CLI</span><span>fnox.toml</span></div>
+        <div class="seq-body">
+          <div class="rails"><i></i><i></i><i></i><i></i><i></i></div>
+          <div class="step"><span class="stepno">1</span><div class="bar r" style="--gc:2/4"><span class="t">value on stdin</span></div></div>
+          <div class="step"><span class="stepno">2</span><div class="bar r dim" style="--gc:4/6"><span class="t">capabilities() → RemoteStorage</span></div></div>
+          <div class="step"><span class="stepno">3</span><div class="bar ok r" style="--gc:4/8"><span class="t">put_secret → doppler secrets set, value on STDIN</span></div></div>
+          <div class="step"><span class="stepno">4</span><div class="bar ok l" style="--gc:4/8"><span class="t">returns the key name, never the value</span></div></div>
+          <div class="step"><span class="stepno">5</span><div class="bar ok r" style="--gc:4/10"><span class="t">only a reference written to disk</span></div></div>
+        </div>
+      </div>
+      <p class="note">The whole difference is step 2. Once <code>capabilities()</code> returns <code>RemoteStorage</code>, <code>set.rs</code>'s existing dispatch routes to <code>put_secret</code> on its own — no change needed there for the feature.</p>
+    </div>
+  </section>
+
+  <!-- THE WORK -->
+  <section>
+    <div class="head col">
+      <span class="lbl">The change</span>
+      <h2>Four edits, one of them the real work</h2>
+      <p>All in <code>crates/fnox-core/src/providers/doppler.rs</code> unless noted. The provider is 464 lines today and already shells out to the Doppler CLI, so nothing new has to be invented.</p>
+    </div>
+
+    <div class="work">
+
+      <article class="item">
+        <div class="top"><h3>1 · Let the command helper carry stdin</h3><span class="chip c-warn">The real work</span></div>
+        <p class="where">doppler.rs — <code>execute_doppler_command</code></p>
+        <p>The helper hardcodes <code>cmd.stdin(std::process::Stdio::null())</code>, because every existing call is a read. A write has to pass the value <em>somehow</em>, and it must not be argv — <code>fnox set</code>'s own help warns that argv leaks to shell history and <code>ps</code>, and that applies just as much to the <code>doppler</code> child process it spawns.</p>
+        <pre><code>// today
+cmd.stdin(std::process::Stdio::null());
+
+// needed: an optional payload, piped and written to the child
+cmd.stdin(match stdin_payload {
+    Some(_) =&gt; Stdio::piped(),
+    None    =&gt; Stdio::null(),
+});</code></pre>
+        <p style="margin:0">This is the only edit that touches shared code and the only one that can regress existing reads, so it wants its own test.</p>
+      </article>
+
+      <article class="item">
+        <div class="top"><h3>2 · Declare the capability</h3><span class="chip c-flat">3 lines</span></div>
+        <p class="where">doppler.rs — <code>impl Provider for DopplerProvider</code></p>
+        <pre class="good"><code>fn capabilities(&amp;self) -&gt; Vec&lt;ProviderCapability&gt; {
+    vec![ProviderCapability::RemoteStorage]
+}</code></pre>
+        <p style="margin:0">This single addition is what flips <code>set.rs</code>'s dispatch from the cleartext branch to the <code>put_secret</code> branch.</p>
+      </article>
+
+      <article class="item">
+        <div class="top"><h3>3 · Implement the write</h3><span class="chip c-flat">~15 lines</span></div>
+        <p class="where">doppler.rs — same impl block</p>
+        <pre class="good"><code>async fn put_secret(&amp;self, key: &amp;str, value: &amp;str) -&gt; Result&lt;String&gt; {
+    // project/config flags are added by build_common_args()
+    self.execute_doppler_command_with_stdin(
+        &amp;["secrets", "set", key],
+        value,           // on stdin, never argv
+        Some(key),
+    ).await?;
+    Ok(key.to_string())  // config stores the REFERENCE, not the value
+}</code></pre>
+        <p style="margin:0">Returning the key name rather than the value is what makes the config hold a reference. That contract is already documented on the trait: <em>"Remote storage providers: store remotely and return the key name."</em></p>
+      </article>
+
+      <article class="item">
+        <div class="top"><h3>4 · Docs and the schema</h3><span class="chip c-flat">small</span></div>
+        <p class="where">docs/providers/doppler.md · docs/public/schema.json</p>
+        <p style="margin:0">#376 shipped 250 lines of provider docs and 23 of schema. A write path needs the <code>fnox set --provider doppler</code> example that <code>bitwarden-sm.md:140</code> already has and <code>doppler.md</code> conspicuously lacks — that absence is currently the clearest signal to a reader that writes are unsupported.</p>
+      </article>
+
+    </div>
+
+    <div class="callout col">
+      <span class="lbl">Also worth doing, separately</span>
+      <p style="margin:0">Fix the <code>set.rs</code> fall-through so the other five read-only providers error instead of plaintexting. It is a different change with a different risk profile, and bundling it with a feature makes both harder to review. Two PRs, not one.</p>
+    </div>
+  </section>
+
+  <!-- COST -->
+  <section>
+    <div class="head col">
+      <span class="lbl">What it costs you</span>
+      <h2>The part that is not code</h2>
+    </div>
+    <div class="callout alarm col">
+      <p><strong>You cannot ask first.</strong> <code>jdx/fnox</code> has GitHub Issues <em>disabled</em>. There is no way to propose the change, check whether writes were deliberately withheld, or find out if a maintainer already has an opinion. Every contribution there is speculative by construction.</p>
+      <p><strong>Your CLI cannot depend on it until it ships.</strong> Merge, then release, then your pin moves — on someone else's timeline. If the CLI is blocking on this, you have coupled your schedule to an upstream you cannot even file against.</p>
+      <p style="margin:0"><strong>There is a hedge.</strong> Doppler writes are one subcommand of the Doppler CLI. The CLI can shell out to <code>doppler secrets set</code> directly today, ship now, and drop that path later if the PR lands. That keeps the contribution valuable without making it load-bearing.</p>
+    </div>
+  </section>
+
+  <footer class="col">
+    Read at fnox 1.32.0 · main and v1.32.0 identical for doppler.rs (blob 4c99bb1…) · v1.32.1 not yet tagged<br>
+    Verified here: the trait's put_secret default · set.rs's dispatch and fall-through · execute_doppler_command's null stdin · PR #376's file list<br>
+    Not verified: the cleartext write by execution · whether any of the 97 forks implements it (code search blind on this token, control arm also returned zero)
+  </footer>
+
+</div>

--- a/docs/research/kb/artifacts/secrets-cli-architecture.html
+++ b/docs/research/kb/artifacts/secrets-cli-architecture.html
@@ -1,0 +1,444 @@
+<title>Secrets CLI — target architecture and CRUD</title>
+
+<style>
+  :root {
+    --ground:#EDEEF0; --surface:#FFFFFF; --sunk:#E3E5E9; --ink:#16181C;
+    --muted:#676D78; --hair:#CFD3D9; --accent:#A97A3D; --accent-w:#F0E4D2;
+    --good:#2E7D5B; --bad:#B3402F; --warn:#8A6A1F;
+    --good-w:#DCEDE5; --bad-w:#F6DED9; --warn-w:#F1E7CE;
+    --f-display: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    --f-body: Georgia, "Iowan Old Style", "Times New Roman", serif;
+    --f-mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
+    --col: 68ch;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --ground:#111317; --surface:#191C21; --sunk:#0C0E11; --ink:#E6E8EC;
+      --muted:#8E95A1; --hair:#2C3138; --accent:#D4A468; --accent-w:#33281A;
+      --good:#4FA57E; --bad:#D9705E; --warn:#C9A24D;
+      --good-w:#16281F; --bad-w:#2E1A16; --warn-w:#2A2213;
+    }
+  }
+  :root[data-theme="dark"] {
+    --ground:#111317; --surface:#191C21; --sunk:#0C0E11; --ink:#E6E8EC;
+    --muted:#8E95A1; --hair:#2C3138; --accent:#D4A468; --accent-w:#33281A;
+    --good:#4FA57E; --bad:#D9705E; --warn:#C9A24D;
+    --good-w:#16281F; --bad-w:#2E1A16; --warn-w:#2A2213;
+  }
+  :root[data-theme="light"] {
+    --ground:#EDEEF0; --surface:#FFFFFF; --sunk:#E3E5E9; --ink:#16181C;
+    --muted:#676D78; --hair:#CFD3D9; --accent:#A97A3D; --accent-w:#F0E4D2;
+    --good:#2E7D5B; --bad:#B3402F; --warn:#8A6A1F;
+    --good-w:#DCEDE5; --bad-w:#F6DED9; --warn-w:#F1E7CE;
+  }
+
+  body { background:var(--ground); color:var(--ink); font-family:var(--f-body);
+         font-size:17px; line-height:1.62; -webkit-font-smoothing:antialiased; }
+  .wrap { max-width:1180px; margin:0 auto;
+          padding:clamp(2rem,5vw,4.5rem) clamp(1.1rem,4vw,2.5rem) 6rem;
+          display:flex; flex-direction:column; gap:3.5rem; }
+  .col { max-width:var(--col); }
+  .lbl { font-family:var(--f-mono); font-size:0.7rem; letter-spacing:0.16em;
+         text-transform:uppercase; color:var(--muted); }
+  h1,h2,h3 { font-family:var(--f-display); text-wrap:balance; line-height:1.15; letter-spacing:-0.02em; }
+  h1 { font-size:clamp(2rem,5vw,3.1rem); font-weight:700; margin:0.4rem 0 0; }
+  h2 { font-size:clamp(1.35rem,3vw,1.75rem); font-weight:650; margin:0; }
+  h3 { font-size:1rem; font-weight:650; margin:0; letter-spacing:-0.01em; }
+  p { margin:0 0 1rem; } p:last-child { margin-bottom:0; }
+  code { font-family:var(--f-mono); font-size:0.87em; background:var(--sunk);
+         padding:0.1em 0.36em; border-radius:3px; word-break:break-word; }
+  a { color:var(--accent); }
+  a:focus-visible, summary:focus-visible { outline:2px solid var(--accent); outline-offset:3px; }
+  header .rule { height:3px; width:68px; background:var(--accent); margin-bottom:1.6rem; }
+  header .sub { color:var(--muted); font-size:1.02rem; margin-top:1.2rem; }
+  section { display:flex; flex-direction:column; gap:1.4rem; }
+  .head { display:flex; flex-direction:column; gap:0.5rem; }
+
+  .chip { display:inline-block; font-family:var(--f-mono); font-size:0.63rem;
+          letter-spacing:0.11em; text-transform:uppercase; padding:0.26em 0.55em;
+          border-radius:3px; white-space:nowrap; font-weight:600; }
+  .c-good{background:var(--good-w);color:var(--good);} .c-bad{background:var(--bad-w);color:var(--bad);}
+  .c-warn{background:var(--warn-w);color:var(--warn);} .c-flat{background:var(--sunk);color:var(--muted);}
+
+  /* stack diagram */
+  .stack { background:var(--surface); border:1px solid var(--hair); border-radius:6px;
+           padding:clamp(1rem,3vw,1.9rem); overflow-x:auto; }
+  .layers { display:flex; flex-direction:column; gap:0.5rem; min-width:560px; }
+  .layer { display:grid; grid-template-columns:120px 210px 1fr; gap:1rem; align-items:baseline;
+           padding:0.8rem 1rem; background:var(--ground); border:1px solid var(--hair);
+           border-left:3px solid var(--accent); border-radius:4px; }
+  .layer .role { font-family:var(--f-mono); font-size:0.62rem; letter-spacing:0.11em;
+                 text-transform:uppercase; color:var(--muted); }
+  .layer .who { font-family:var(--f-mono); font-size:0.8rem; font-weight:600; }
+  .layer .what { font-size:0.87rem; color:var(--muted); line-height:1.45; }
+  .layer.trust { border-left-color:var(--bad); }
+  .layer.entry { border-left-color:var(--accent); background:var(--accent-w); }
+  .layer.entry .what { color:var(--ink); }
+  .tick { font-family:var(--f-mono); font-size:0.7rem; color:var(--muted); padding-left:1rem; }
+
+  /* seams table */
+  .tablewrap { overflow-x:auto; border:1px solid var(--hair); border-radius:6px; background:var(--surface); }
+  table { border-collapse:collapse; width:100%; min-width:820px; }
+  th,td { text-align:left; padding:0.7rem 0.85rem; border-bottom:1px solid var(--hair);
+          vertical-align:top; font-size:0.86rem; line-height:1.45; }
+  thead th { font-family:var(--f-mono); font-size:0.66rem; letter-spacing:0.1em;
+             text-transform:uppercase; color:var(--muted); font-weight:600; background:var(--sunk); }
+  tbody th { font-family:var(--f-display); font-weight:650; font-size:0.82rem; width:170px; }
+  tbody tr:last-child th, tbody tr:last-child td { border-bottom:none; }
+
+  /* workflows */
+  .flows { display:grid; gap:1.1rem; grid-template-columns:repeat(auto-fit,minmax(330px,1fr)); }
+  .flow { background:var(--surface); border:1px solid var(--hair); border-radius:6px;
+          padding:1.25rem; display:flex; flex-direction:column; gap:0.9rem; }
+  .flow .cmd { font-family:var(--f-mono); font-size:0.78rem; background:var(--sunk);
+               padding:0.5rem 0.7rem; border-radius:4px; border-left:2px solid var(--accent);
+               overflow-x:auto; white-space:nowrap; }
+  ol.steps { margin:0; padding-left:0; list-style:none; counter-reset:s;
+             display:flex; flex-direction:column; gap:0.55rem; }
+  ol.steps li { counter-increment:s; display:grid; grid-template-columns:1.5rem 1fr;
+                gap:0.6rem; font-size:0.87rem; line-height:1.45; }
+  ol.steps li::before { content:counter(s); font-family:var(--f-mono); font-size:0.68rem;
+                        color:var(--accent); font-weight:700; padding-top:0.22em; }
+  ol.steps li .comp { font-family:var(--f-mono); font-size:0.74rem; color:var(--muted); }
+
+  /* ---- sequence diagrams ---- */
+  .seq { background:var(--surface); border:1px solid var(--hair); border-radius:6px;
+         padding:1.1rem 1.2rem 1.4rem; overflow-x:auto; }
+  .seq .cmd { font-family:var(--f-mono); font-size:0.78rem; background:var(--sunk);
+              padding:0.5rem 0.7rem; border-radius:4px; border-left:2px solid var(--accent);
+              margin-bottom:1.1rem; display:inline-block; white-space:nowrap; }
+  .seq-inner { min-width:760px; }
+  .seq-head { display:grid; grid-template-columns:repeat(7,1fr); gap:0;
+              padding-bottom:0.6rem; border-bottom:1px solid var(--hair); margin-bottom:0.2rem; }
+  .seq-head span { font-family:var(--f-mono); font-size:0.66rem; letter-spacing:0.06em;
+                   text-align:center; color:var(--muted); font-weight:600; }
+  .seq-head span.owner { color:var(--accent); }
+  .seq-body { position:relative; padding-top:0.5rem; }
+  .rails { position:absolute; inset:0; display:grid; grid-template-columns:repeat(7,1fr);
+           pointer-events:none; }
+  .rails i { background:linear-gradient(var(--hair),var(--hair)) center/1px 100% no-repeat; }
+  .step { position:relative; display:grid; grid-template-columns:repeat(14,1fr);
+          align-items:center; min-height:2.55rem; }
+  .bar { grid-column:var(--gc); position:relative; height:2px; background:var(--accent);
+         align-self:center; margin-top:0.55rem; }
+  .bar .t { position:absolute; left:0; right:0; bottom:6px; text-align:center;
+            font-size:0.76rem; line-height:1.3; color:var(--ink); white-space:nowrap; }
+  .bar::after { content:""; position:absolute; top:-4px; width:0; height:0;
+                border-top:5px solid transparent; border-bottom:5px solid transparent; }
+  .bar.r::after { right:-1px; border-left:8px solid var(--accent); }
+  .bar.l::after { left:-1px; border-right:8px solid var(--accent); }
+  .bar.dim { background:var(--muted); }
+  .bar.dim::after { border-left-color:var(--muted); border-right-color:var(--muted); }
+  .bar.dim .t { color:var(--muted); }
+  .bar.warn { background:var(--bad); }
+  .bar.warn::after { border-left-color:var(--bad); border-right-color:var(--bad); }
+  .self { grid-column:var(--gc); align-self:center; margin-top:0.3rem;
+          border:1px solid var(--hair); border-left:2px solid var(--accent);
+          background:var(--ground); border-radius:3px; padding:0.24rem 0.4rem;
+          font-size:0.73rem; text-align:center; line-height:1.25; }
+  .stepno { position:absolute; left:-0.1rem; top:0.85rem; font-family:var(--f-mono);
+            font-size:0.62rem; color:var(--accent); font-weight:700; }
+  .seq .note { font-size:0.83rem; color:var(--muted); margin-top:1rem; line-height:1.5; }
+  .seq h3 { margin-bottom:0.15rem; }
+
+  .callout { background:var(--surface); border:1px solid var(--hair);
+             border-left:3px solid var(--accent); border-radius:4px;
+             padding:1.15rem 1.3rem; font-size:0.94rem; }
+  .callout.alarm { border-left-color:var(--bad); }
+  .callout .lbl { display:block; margin-bottom:0.5rem; }
+
+  footer { border-top:1px solid var(--hair); padding-top:1.5rem; font-size:0.8rem;
+           color:var(--muted); font-family:var(--f-mono); line-height:1.7; }
+
+  @media (prefers-reduced-motion:reduce){ *{animation:none!important;transition:none!important;} }
+  @media (max-width:620px){ .layer{grid-template-columns:1fr;gap:0.3rem;} }
+</style>
+
+<div class="wrap">
+
+  <header class="col">
+    <div class="rule"></div>
+    <span class="lbl">Target architecture · companion to the proposals brief</span>
+    <h1>One entrypoint, four layers, five seams</h1>
+    <p class="sub">The ideal setup for keeping mise, fnox, Doppler and the macOS keychain in sync — and the CRUD workflows the CLI owns. Not a description of what runs today.</p>
+  </header>
+
+  <!-- CORRECTION -->
+  <section>
+    <div class="callout alarm col">
+      <span class="lbl">First, a correction that changes the shape</span>
+      <p><strong>Doppler cannot sync to the macOS keychain.</strong> Its 20+ syncs are cloud targets — AWS Secrets Manager, GCP Secret Manager, Vercel, Netlify, Heroku, Kubernetes, GitHub Actions, Docker, Render, Fly.io, Cloudflare. The keychain is a local resource and is not among them; the CLI's help never mentions it. <span class="chip c-flat">Control arm: <code>secrets</code> → 3 hits, same grep</span></p>
+      <p style="margin:0">That is the more useful answer, because it forces the real question: <em>what is the keychain for?</em> And the answer is that its job should be <strong>much smaller than a sync target</strong> — it holds the one credential that cannot come from the cloud, because you need it to reach the cloud. Exactly one secret, never synced, never mirrored. Today's setup already does this by accident: the keychain holds <code>DOPPLER_TOKEN</code> and nothing else.</p>
+    </div>
+  </section>
+
+  <!-- LAYERS -->
+  <section>
+    <div class="head col">
+      <span class="lbl">Components</span>
+      <h2>The four layers, and where the CLI sits</h2>
+      <p>Each layer does one thing that no other layer should. The CLI is not a fifth layer — it is the <em>entrypoint</em> that drives the others, which is why it spans them rather than sitting on top.</p>
+    </div>
+
+    <div class="stack">
+      <div class="layers">
+        <div class="layer trust">
+          <span class="role">Root of trust</span>
+          <span class="who">macOS keychain</span>
+          <span class="what"><strong>Exactly one secret:</strong> the Doppler service token. Never synced, never mirrored, never in a file. On a new Mac this is the only thing a human types, and everything else follows from it.</span>
+        </div>
+        <div class="tick">│ authenticates</div>
+
+        <div class="layer">
+          <span class="role">Source of truth</span>
+          <span class="who">Doppler cloud</span>
+          <span class="what">All 50 values. The only durable copy — this is what survives the Mac being lost. Free tier. Swappable for Infisical via one fnox provider line, since fnox speaks both.</span>
+        </div>
+        <div class="tick">│ resolves</div>
+
+        <div class="layer">
+          <span class="role">Resolution</span>
+          <span class="who">fnox</span>
+          <span class="what">Multi-backend read + declaration. 23 providers, so the store underneath is a config choice rather than an architecture. Owns <em>which</em> secrets exist and where each one lives.</span>
+        </div>
+        <div class="tick">│ exports to</div>
+
+        <div class="layer">
+          <span class="role">Injection</span>
+          <span class="who">mise</span>
+          <span class="what">Per-project environment, scoped by directory. Native sops/age decryption, native redaction. Every consuming project is a mise project, so this layer is free and already installed.</span>
+        </div>
+        <div class="tick">│ consumed by</div>
+
+        <div class="layer">
+          <span class="role">Consumers</span>
+          <span class="who">shell · devcontainer · agents</span>
+          <span class="what">Get whatever their project scopes. Not 50 by default — a subset, because the scope is the project's mise config rather than the login shell.</span>
+        </div>
+
+        <div class="tick" style="padding-top:0.6rem">└─ driven end-to-end by ─┐</div>
+
+        <div class="layer entry">
+          <span class="role">Entrypoint</span>
+          <span class="who">the CLI / SDK</span>
+          <span class="what">Owns <strong>origination and reconciliation</strong> — the two jobs no layer above provides. Adds and rotates secrets, keeps the layers agreeing, bootstraps a new machine, and is what the Claude Code plugin wraps.</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- SEAMS -->
+  <section>
+    <div class="head col">
+      <span class="lbl">Where things drift</span>
+      <h2>Five seams — and nothing owns them today</h2>
+      <p>"Keeping them in sync" is not one problem. It is five, each with its own failure and its own detection. This table is the actual specification for the CLI's reconcile command.</p>
+    </div>
+
+    <div class="tablewrap">
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">Seam</th>
+            <th scope="col">What drifts</th>
+            <th scope="col">How it shows up</th>
+            <th scope="col">Owner</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Doppler ↔ fnox</th>
+            <td>A secret exists in Doppler but is not declared in fnox, or a declaration points at a value that was deleted.</td>
+            <td>The first is <em>invisible</em> — you never learn the secret exists. The second fails at resolve time, or worse, resolves empty.</td>
+            <td><span class="chip c-bad">Nobody</span></td>
+          </tr>
+          <tr>
+            <th scope="row">fnox ↔ doctor.toml</th>
+            <td>The reviewed 50-name baseline stops matching the live declaration set.</td>
+            <td>Caught today by the SessionStart doctor — the one seam that already has a tripwire.</td>
+            <td><span class="chip c-good">doctor</span></td>
+          </tr>
+          <tr>
+            <th scope="row">Host ↔ devcontainer</th>
+            <td>Two independent resolution paths: fnox on the host, a `doppler download` env file in the container.</td>
+            <td>Silent. Nothing compares the two name sets, so a host-only secret simply is not there in the container.</td>
+            <td><span class="chip c-bad">Nobody</span></td>
+          </tr>
+          <tr>
+            <th scope="row">Keychain ↔ Doppler</th>
+            <td>The service token is revoked, expired, or was never minted on this machine.</td>
+            <td>Everything below it fails at once. Recovery needs a human and a browser — by design, since it is the root of trust.</td>
+            <td><span class="chip c-warn">Manual</span></td>
+          </tr>
+          <tr>
+            <th scope="row">Project ↔ what it needs</th>
+            <td>A project's mise scope omits a secret its code reads, or carries ones it does not.</td>
+            <td>The first is a runtime failure. The second is silent over-exposure — the thing scoping was supposed to prevent.</td>
+            <td><span class="chip c-bad">Nobody</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="callout col">
+      <span class="lbl">The finding in that table</span>
+      <p style="margin:0">Three of five seams have no owner, and the two silent ones — host/devcontainer and project/needs — are exactly the failures you cannot notice by working normally. <strong>That is the CLI's real justification</strong>, and it is a much better one than the fail-open clause it replaces: reconciliation is work no existing tool does, because no existing tool can see across all four layers at once.</p>
+    </div>
+  </section>
+
+  <!-- CRUD -->
+  <section>
+    <div class="head col">
+      <span class="lbl">Workflows</span>
+      <h2>CRUD, end to end</h2>
+      <p>Each verb is a sequence <em>between</em> components — the CLI drives, the other four do the work. Order matters in every one of these, and the arrows are where the design decisions actually live.</p>
+    </div>
+
+    <!-- CREATE -->
+    <div class="seq">
+      <h3>Create</h3>
+      <div class="cmd">secrets add STRIPE_API_KEY --project payments</div>
+      <div class="seq-inner">
+        <div class="seq-head">
+          <span>you</span><span class="owner">CLI</span><span>keychain</span><span>Doppler</span><span>fnox</span><span>mise</span><span>project</span>
+        </div>
+        <div class="seq-body">
+          <div class="rails"><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+          <div class="step"><span class="stepno">1</span><div class="self" style="--gc:3/5">prompt on a TTY — never argv, never stdout</div></div>
+          <div class="step"><span class="stepno">2</span><div class="bar r" style="--gc:4/6"><span class="t">read DOPPLER_TOKEN</span></div></div>
+          <div class="step"><span class="stepno">3</span><div class="bar r" style="--gc:4/8"><span class="t">write the value — cloud becomes truth first</span></div></div>
+          <div class="step"><span class="stepno">4</span><div class="bar r" style="--gc:4/10"><span class="t">declare name + provider</span></div></div>
+          <div class="step"><span class="stepno">5</span><div class="bar r" style="--gc:4/12"><span class="t">add to the named project's [env] scope</span></div></div>
+          <div class="step"><span class="stepno">6</span><div class="self" style="--gc:3/5">doctor.toml diff — a human reviews the widened set</div></div>
+          <div class="step"><span class="stepno">7</span><div class="bar l dim" style="--gc:4/10"><span class="t">verify by resolving back — presence, not value</span></div></div>
+        </div>
+      </div>
+      <p class="note">Cloud first, declaration second, scope third. If step 4 fails you have an orphaned value you can still find; if the order were reversed you would have a declaration pointing at nothing.</p>
+    </div>
+
+    <!-- READ -->
+    <div class="seq">
+      <h3>Read</h3>
+      <div class="cmd">secrets ls · secrets status</div>
+      <div class="seq-inner">
+        <div class="seq-head">
+          <span>you</span><span class="owner">CLI</span><span>keychain</span><span>Doppler</span><span>fnox</span><span>mise</span><span>project</span>
+        </div>
+        <div class="seq-body">
+          <div class="rails"><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+          <div class="step"><span class="stepno">1</span><div class="bar r" style="--gc:4/10"><span class="t">list declared names + provenance</span></div></div>
+          <div class="step"><span class="stepno">2</span><div class="bar l dim" style="--gc:4/10"><span class="t">names only — no verb in this CLI prints a value</span></div></div>
+          <div class="step"><span class="stepno">3</span><div class="self" style="--gc:3/5">status answers “is it resolvable”, via exit code</div></div>
+          <div class="step"><span class="stepno">4</span><div class="bar r dim" style="--gc:12/14"><span class="t">values reach a process ONLY here, by injection</span></div></div>
+        </div>
+      </div>
+      <p class="note">Step 4 is the constraint drawn as a diagram: there is no path from a secret to your terminal. The CLI can tell you a secret exists and resolves; only mise or <code>fnox exec</code> can put its value anywhere.</p>
+    </div>
+
+    <!-- ROTATE -->
+    <div class="seq">
+      <h3>Rotate</h3>
+      <div class="cmd">secrets rotate STRIPE_API_KEY</div>
+      <div class="seq-inner">
+        <div class="seq-head">
+          <span>you</span><span class="owner">CLI</span><span>keychain</span><span>Doppler</span><span>fnox</span><span>mise</span><span>project</span>
+        </div>
+        <div class="seq-body">
+          <div class="rails"><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+          <div class="step"><span class="stepno">1</span><div class="self" style="--gc:3/5">prompt for the new value</div></div>
+          <div class="step"><span class="stepno">2</span><div class="bar r" style="--gc:4/8"><span class="t">overwrite — the new value is truth immediately</span></div></div>
+          <div class="step"><span class="stepno">3</span><div class="bar r" style="--gc:4/10"><span class="t">invalidate the resolution cache</span></div></div>
+          <div class="step"><span class="stepno">4</span><div class="bar r" style="--gc:4/12"><span class="t">clear the encrypted env cache</span></div></div>
+          <div class="step"><span class="stepno">5</span><div class="bar l dim" style="--gc:4/10"><span class="t">re-resolve and confirm, by presence</span></div></div>
+          <div class="step"><span class="stepno">6</span><div class="bar l dim" style="--gc:4/12"><span class="t">report every project that scopes it</span></div></div>
+        </div>
+      </div>
+      <p class="note">Step 4 exists because the mise env cache is encrypted — you cannot grep it to see whether a stale value is still being served, so it must be cleared rather than inspected. Step 6 gives you the blast radius <em>before</em> you revoke the old credential upstream.</p>
+    </div>
+
+    <!-- DELETE -->
+    <div class="seq">
+      <h3>Delete</h3>
+      <div class="cmd">secrets rm STRIPE_API_KEY</div>
+      <div class="seq-inner">
+        <div class="seq-head">
+          <span>you</span><span class="owner">CLI</span><span>keychain</span><span>Doppler</span><span>fnox</span><span>mise</span><span>project</span>
+        </div>
+        <div class="seq-body">
+          <div class="rails"><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+          <div class="step"><span class="stepno">1</span><div class="bar r" style="--gc:4/12"><span class="t">which projects still scope this?</span></div></div>
+          <div class="step"><span class="stepno">2</span><div class="bar l warn" style="--gc:4/12"><span class="t">refuse if any — unless --force</span></div></div>
+          <div class="step"><span class="stepno">3</span><div class="bar r" style="--gc:4/12"><span class="t">remove from every project scope</span></div></div>
+          <div class="step"><span class="stepno">4</span><div class="bar r" style="--gc:4/10"><span class="t">remove the declaration</span></div></div>
+          <div class="step"><span class="stepno">5</span><div class="bar r warn" style="--gc:4/8"><span class="t">delete from the cloud LAST</span></div></div>
+          <div class="step"><span class="stepno">6</span><div class="self" style="--gc:3/5">doctor.toml diff — the narrowed set</div></div>
+        </div>
+      </div>
+      <p class="note">Delete runs in the exact reverse of create, and for the same reason. The cloud value goes last so that a failure anywhere in steps 3-4 leaves the secret <em>recoverable</em> rather than orphaned — you can always re-declare something that still exists.</p>
+    </div>
+
+    <!-- RECONCILE -->
+    <div class="seq">
+      <h3>Reconcile — the verb the design hangs on</h3>
+      <div class="cmd">secrets reconcile [--fix]</div>
+      <div class="seq-inner">
+        <div class="seq-head">
+          <span>you</span><span class="owner">CLI</span><span>keychain</span><span>Doppler</span><span>fnox</span><span>mise</span><span>project</span>
+        </div>
+        <div class="seq-body">
+          <div class="rails"><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+          <div class="step"><span class="stepno">1</span><div class="bar r" style="--gc:4/8"><span class="t">list every name in the cloud</span></div></div>
+          <div class="step"><span class="stepno">2</span><div class="bar r" style="--gc:4/10"><span class="t">list every declaration</span></div></div>
+          <div class="step"><span class="stepno">3</span><div class="bar r" style="--gc:4/12"><span class="t">list every project scope</span></div></div>
+          <div class="step"><span class="stepno">4</span><div class="bar r" style="--gc:4/14"><span class="t">scan code for the names it actually references</span></div></div>
+          <div class="step"><span class="stepno">5</span><div class="self" style="--gc:3/5">diff all four against doctor.toml — report by name</div></div>
+          <div class="step"><span class="stepno">6</span><div class="self" style="--gc:3/5">exit nonzero on drift, so it can gate a commit</div></div>
+        </div>
+      </div>
+      <p class="note">This is the only verb that touches all four layers, which is exactly why nothing else can do its job. Steps 3 and 4 together close the seam nothing owns today: a project scoping a secret its code never reads is silent over-exposure, and a project reading one it does not scope is a runtime failure nobody predicted.</p>
+    </div>
+
+    <!-- BOOTSTRAP -->
+    <div class="seq">
+      <h3>Bootstrap a replacement Mac</h3>
+      <div class="cmd">secrets bootstrap</div>
+      <div class="seq-inner">
+        <div class="seq-head">
+          <span>you</span><span class="owner">CLI</span><span>keychain</span><span>Doppler</span><span>fnox</span><span>mise</span><span>project</span>
+        </div>
+        <div class="seq-body">
+          <div class="rails"><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+          <div class="step"><span class="stepno">1</span><div class="bar r" style="--gc:2/8"><span class="t">browser login, mint a service token</span></div></div>
+          <div class="step"><span class="stepno">2</span><div class="bar r" style="--gc:2/4"><span class="t">paste it once, on a TTY</span></div></div>
+          <div class="step"><span class="stepno">3</span><div class="bar r" style="--gc:4/6"><span class="t">store it — the only root-of-trust write there is</span></div></div>
+          <div class="step"><span class="stepno">4</span><div class="bar r" style="--gc:4/8"><span class="t">verify the token authenticates</span></div></div>
+          <div class="step"><span class="stepno">5</span><div class="bar l dim" style="--gc:8/10"><span class="t">fnox resolves all 50</span></div></div>
+          <div class="step"><span class="stepno">6</span><div class="bar l dim" style="--gc:10/12"><span class="t">mise injects per project</span></div></div>
+          <div class="step"><span class="stepno">7</span><div class="self" style="--gc:3/5">run reconcile to prove the machine matches the declared world</div></div>
+        </div>
+      </div>
+      <p class="note">Step 1 is the only manual step in the whole system, and it should stay manual — it is the one action that cannot be automated without storing a credential that would itself need protecting. Everything from step 5 down is automatic because the layers below only ever needed the token.</p>
+    </div>
+
+  </section>
+
+  <!-- CAVEATS -->
+  <section>
+    <div class="head col">
+      <span class="lbl">Known costs</span>
+      <h2>What this design owes you</h2>
+    </div>
+    <div class="callout col">
+      <p><strong>Writes are provider-specific.</strong> fnox's Infisical provider is read-through-fnox; writes go via <code>infisical secrets set</code>. So the create/rotate/delete paths need a small per-provider adapter — that is the one place the CLI cannot be a pure driver.</p>
+      <p><strong>mise's sops and age paths are experimental.</strong> mise's own docs say behaviour may change. Depending on them for encryption is a real bet, and worth taking only because the fallback — fnox resolving from the cloud — stays available.</p>
+      <p style="margin:0"><strong>Shell-wide availability goes away.</strong> Scoping by project is the point, but it means the current "all 50 in every terminal" behaviour ends. That was a deliberate decision on 2026-08-02, so reversing it here should be deliberate too, not a side effect.</p>
+    </div>
+  </section>
+
+  <footer class="col">
+    Probed this session: doppler v3.76.1 (no keychain mention; control <code>secrets</code> → 3) · fnox 1.32.0 (23 providers; fail-open confirmed, 2 arms) · mise 2026.8.1 (native sops + age + redaction)<br>
+    Companion brief: the five proposals and the evidence matrix<br>
+    Not yet exercised: mise sops/age round-trip · Infisical free-tier identity semantics
+  </footer>
+
+</div>

--- a/docs/research/kb/artifacts/secrets-cli-proposals.html
+++ b/docs/research/kb/artifacts/secrets-cli-proposals.html
@@ -1,0 +1,708 @@
+<title>Secrets CLI — four proposals</title>
+
+<style>
+  :root {
+    --ground:   #EDEEF0;
+    --surface:  #FFFFFF;
+    --sunk:     #E3E5E9;
+    --ink:      #16181C;
+    --muted:    #676D78;
+    --hair:     #CFD3D9;
+    --accent:   #A97A3D;
+    --accent-w: #F0E4D2;
+    --good:     #2E7D5B;
+    --bad:      #B3402F;
+    --warn:     #8A6A1F;
+    --good-w:   #DCEDE5;
+    --bad-w:    #F6DED9;
+    --warn-w:   #F1E7CE;
+
+    --f-display: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    --f-body: Georgia, "Iowan Old Style", "Times New Roman", serif;
+    --f-mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
+
+    --col: 68ch;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --ground:   #111317;
+      --surface:  #191C21;
+      --sunk:     #0C0E11;
+      --ink:      #E6E8EC;
+      --muted:    #8E95A1;
+      --hair:     #2C3138;
+      --accent:   #D4A468;
+      --accent-w: #33281A;
+      --good:     #4FA57E;
+      --bad:      #D9705E;
+      --warn:     #C9A24D;
+      --good-w:   #16281F;
+      --bad-w:    #2E1A16;
+      --warn-w:   #2A2213;
+    }
+  }
+
+  :root[data-theme="dark"] {
+    --ground:#111317; --surface:#191C21; --sunk:#0C0E11; --ink:#E6E8EC;
+    --muted:#8E95A1; --hair:#2C3138; --accent:#D4A468; --accent-w:#33281A;
+    --good:#4FA57E; --bad:#D9705E; --warn:#C9A24D;
+    --good-w:#16281F; --bad-w:#2E1A16; --warn-w:#2A2213;
+  }
+
+  :root[data-theme="light"] {
+    --ground:#EDEEF0; --surface:#FFFFFF; --sunk:#E3E5E9; --ink:#16181C;
+    --muted:#676D78; --hair:#CFD3D9; --accent:#A97A3D; --accent-w:#F0E4D2;
+    --good:#2E7D5B; --bad:#B3402F; --warn:#8A6A1F;
+    --good-w:#DCEDE5; --bad-w:#F6DED9; --warn-w:#F1E7CE;
+  }
+
+  body {
+    background: var(--ground);
+    color: var(--ink);
+    font-family: var(--f-body);
+    font-size: 17px;
+    line-height: 1.62;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap {
+    max-width: 1180px;
+    margin: 0 auto;
+    padding: clamp(2rem, 5vw, 4.5rem) clamp(1.1rem, 4vw, 2.5rem) 6rem;
+    display: flex;
+    flex-direction: column;
+    gap: 3.5rem;
+  }
+
+  .col { max-width: var(--col); }
+
+  .lbl {
+    font-family: var(--f-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+
+  h1, h2, h3 {
+    font-family: var(--f-display);
+    text-wrap: balance;
+    line-height: 1.15;
+    letter-spacing: -0.02em;
+  }
+  h1 { font-size: clamp(2rem, 5vw, 3.1rem); font-weight: 700; margin: 0.4rem 0 0; }
+  h2 { font-size: clamp(1.35rem, 3vw, 1.75rem); font-weight: 650; margin: 0; }
+  h3 { font-size: 1.05rem; font-weight: 650; margin: 0; letter-spacing: -0.01em; }
+
+  p { margin: 0 0 1rem; }
+  p:last-child { margin-bottom: 0; }
+  strong { font-weight: 700; }
+  code {
+    font-family: var(--f-mono);
+    font-size: 0.87em;
+    background: var(--sunk);
+    padding: 0.1em 0.36em;
+    border-radius: 3px;
+    word-break: break-word;
+  }
+  a { color: var(--accent); }
+  a:focus-visible, summary:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+  }
+
+  header .rule {
+    height: 3px;
+    width: 68px;
+    background: var(--accent);
+    margin-bottom: 1.6rem;
+  }
+  header .sub {
+    color: var(--muted);
+    font-size: 1.02rem;
+    margin-top: 1.2rem;
+  }
+
+  section { display: flex; flex-direction: column; gap: 1.4rem; }
+  .head { display: flex; flex-direction: column; gap: 0.5rem; }
+
+  /* ---- verdict chips ---- */
+  .chip {
+    display: inline-block;
+    font-family: var(--f-mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.11em;
+    text-transform: uppercase;
+    padding: 0.28em 0.6em;
+    border-radius: 3px;
+    white-space: nowrap;
+    font-weight: 600;
+  }
+  .c-good { background: var(--good-w); color: var(--good); }
+  .c-bad  { background: var(--bad-w);  color: var(--bad); }
+  .c-warn { background: var(--warn-w); color: var(--warn); }
+  .c-flat { background: var(--sunk);   color: var(--muted); }
+
+  /* ---- topology diagram ---- */
+  .topo {
+    background: var(--surface);
+    border: 1px solid var(--hair);
+    border-radius: 6px;
+    padding: clamp(1rem, 3vw, 1.9rem);
+    overflow-x: auto;
+  }
+  .flow { display: flex; flex-direction: column; gap: 0.45rem; min-width: 520px; }
+  .node {
+    display: grid;
+    grid-template-columns: 190px 1fr;
+    gap: 1rem;
+    align-items: baseline;
+    padding: 0.7rem 0.9rem;
+    background: var(--ground);
+    border: 1px solid var(--hair);
+    border-left: 3px solid var(--hair);
+    border-radius: 4px;
+  }
+  .node.key { border-left-color: var(--accent); }
+  .node.risk { border-left-color: var(--bad); }
+  .node.dead { border-left-color: var(--muted); opacity: 0.78; }
+  .node .n {
+    font-family: var(--f-mono);
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+  .node .d { font-size: 0.88rem; color: var(--muted); line-height: 1.45; }
+  .arrow {
+    font-family: var(--f-mono);
+    font-size: 0.72rem;
+    color: var(--muted);
+    padding-left: 0.9rem;
+    letter-spacing: 0.04em;
+  }
+  .branch {
+    margin-left: 2rem;
+    border-left: 1px dashed var(--hair);
+    padding-left: 1.1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+  }
+
+  /* ---- evidence matrix ---- */
+  .tablewrap {
+    overflow-x: auto;
+    border: 1px solid var(--hair);
+    border-radius: 6px;
+    background: var(--surface);
+  }
+  table { border-collapse: collapse; width: 100%; min-width: 900px; }
+  th, td {
+    text-align: left;
+    padding: 0.72rem 0.85rem;
+    border-bottom: 1px solid var(--hair);
+    vertical-align: top;
+    font-size: 0.86rem;
+    line-height: 1.45;
+  }
+  thead th {
+    font-family: var(--f-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--muted);
+    font-weight: 600;
+    background: var(--sunk);
+    position: sticky;
+    top: 0;
+  }
+  tbody th {
+    font-family: var(--f-display);
+    font-weight: 650;
+    font-size: 0.82rem;
+    width: 150px;
+    color: var(--ink);
+  }
+  tbody tr:last-child th, tbody tr:last-child td { border-bottom: none; }
+  .prov {
+    display: block;
+    font-family: var(--f-mono);
+    font-size: 0.63rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-top: 0.3rem;
+  }
+
+  /* ---- proposal cards ---- */
+  .props { display: grid; gap: 1.1rem; grid-template-columns: repeat(auto-fit, minmax(310px, 1fr)); }
+  .prop {
+    background: var(--surface);
+    border: 1px solid var(--hair);
+    border-radius: 6px;
+    padding: 1.3rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+  }
+  .prop.lead { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent); }
+  .prop .top { display: flex; justify-content: space-between; align-items: flex-start; gap: 0.8rem; }
+  .prop dl { margin: 0; display: flex; flex-direction: column; gap: 0.6rem; }
+  .prop dt {
+    font-family: var(--f-mono);
+    font-size: 0.63rem;
+    letter-spacing: 0.11em;
+    text-transform: uppercase;
+    color: var(--muted);
+    margin-bottom: 0.15rem;
+  }
+  .prop dd { margin: 0; font-size: 0.89rem; line-height: 1.5; }
+  .prop .cost {
+    font-family: var(--f-mono);
+    font-size: 0.72rem;
+    color: var(--muted);
+    border-top: 1px solid var(--hair);
+    padding-top: 0.7rem;
+    margin-top: auto;
+  }
+
+  /* ---- callout ---- */
+  .callout {
+    background: var(--surface);
+    border: 1px solid var(--hair);
+    border-left: 3px solid var(--accent);
+    border-radius: 4px;
+    padding: 1.15rem 1.3rem;
+    font-size: 0.94rem;
+  }
+  .callout.alarm { border-left-color: var(--bad); }
+  .callout .lbl { display: block; margin-bottom: 0.5rem; }
+
+  /* ---- open decisions ---- */
+  .qs { display: flex; flex-direction: column; gap: 0.6rem; }
+  details {
+    background: var(--surface);
+    border: 1px solid var(--hair);
+    border-radius: 5px;
+    padding: 0.85rem 1.1rem;
+  }
+  details[open] { border-color: var(--accent); }
+  summary {
+    cursor: pointer;
+    font-family: var(--f-display);
+    font-weight: 650;
+    font-size: 0.95rem;
+    display: flex;
+    gap: 0.7rem;
+    align-items: baseline;
+  }
+  summary::-webkit-details-marker { display: none; }
+  summary::before { content: "›"; color: var(--accent); font-size: 1.1rem; line-height: 1; }
+  details[open] summary::before { content: "⌄"; }
+  details .body { margin-top: 0.75rem; font-size: 0.9rem; color: var(--muted); line-height: 1.55; }
+  details .body strong { color: var(--ink); }
+
+  footer {
+    border-top: 1px solid var(--hair);
+    padding-top: 1.5rem;
+    font-size: 0.8rem;
+    color: var(--muted);
+    font-family: var(--f-mono);
+    line-height: 1.7;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    * { animation: none !important; transition: none !important; }
+  }
+  @media (max-width: 560px) {
+    .node { grid-template-columns: 1fr; gap: 0.25rem; }
+  }
+</style>
+
+<div class="wrap">
+
+  <header class="col">
+    <div class="rule"></div>
+    <span class="lbl">Decision brief · 2026-08-03 · branch research/secrets-cli-direction</span>
+    <h1>Four ways to build the secrets CLI</h1>
+    <p class="sub">What replaces what, what each proposal costs, and which claims were actually measured. Constraint as clarified: <strong>free cloud hosting of the data</strong> so losing this Mac loses nothing. Licence is a preference, not a gate.</p>
+  </header>
+
+  <!-- ============ CURRENT STATE ============ -->
+  <section>
+    <div class="head col">
+      <span class="lbl">Measured, not assumed</span>
+      <h2>What is actually running today</h2>
+      <p>Probed directly from <code>~/.config/fnox/config.toml</code> this session. The surprise is the direction of dependency: the age layer is a <em>read cache</em> bootstrapped from Doppler, not a backup.</p>
+    </div>
+
+    <div class="topo">
+      <div class="flow">
+        <div class="node key">
+          <span class="n">macOS keychain</span>
+          <span class="d">Holds exactly one secret: <code>DOPPLER_TOKEN</code>. Not the age key — that was the assumption, and it was wrong.</span>
+        </div>
+        <div class="arrow">│ authenticates</div>
+        <div class="node key">
+          <span class="n">Doppler cloud</span>
+          <span class="d">49 secrets, including <code>AGE_PRIVATE_KEY</code> itself. <strong>The only off-Mac copy of anything.</strong></span>
+        </div>
+        <div class="arrow">│ resolves</div>
+        <div class="node">
+          <span class="n">fnox 1.32.0</span>
+          <span class="d">Aggregates 3 providers. Writes an age-encrypted local cache — 49 ciphertexts, <strong>1 recipient</strong>. No <code>[profiles]</code> block, no <code>[proxy]</code> block: the confinement design was decided, never built.</span>
+        </div>
+        <div class="arrow">│ activated by</div>
+        <div class="node dead">
+          <span class="n">~/.zshrc.d/50-mde-secrets.zsh</span>
+          <span class="d">Runs <code>fnox activate zsh</code> via chpwd/precmd hooks. Owned by <code>macos-development-environment</code> — the repo now deprecated. This file is what puts 50 credentials in every shell, and it is orphaned.</span>
+        </div>
+        <div class="arrow">│ inherited by</div>
+        <div class="node risk">
+          <span class="n">every child process</span>
+          <span class="d">All 50 credentials, <code>env = true</code> on every one (inline, which beats the global). Claude Code, its subagents, every MCP server it spawns. Accepted by decision, 2026-08-02.</span>
+        </div>
+      </div>
+
+      <div class="branch" style="margin-top:1.1rem">
+        <span class="lbl">Second, independent path — does not touch fnox</span>
+        <div class="node">
+          <span class="n">devcontainer</span>
+          <span class="d"><code>doppler download</code> → <code>~/.local/state/dotfiles/doppler.env</code>, gated by <code>mise.toml:769</code>. A parallel resolution path that can silently drift from the host's.</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="callout col">
+      <span class="lbl">Consequence worth stating plainly</span>
+      <p style="margin:0">Swapping Doppler out without first adding a second age recipient would <strong>delete the durability layer</strong>, not preserve it. age fixes recipients at encrypt time, so a recovery key has to exist <em>before</em> the first secret is written, never after.</p>
+    </div>
+  </section>
+
+  <!-- ============ EVIDENCE ============ -->
+  <section>
+    <div class="head col">
+      <span class="lbl">Provenance labelled per cell</span>
+      <h2>What the research actually established</h2>
+      <p>Three agents against primary sources only. Every claim carries how it was verified — runtime-probed beats source-verified beats inherited, and one row below is none of those.</p>
+    </div>
+
+    <div class="tablewrap">
+      <table>
+        <thead>
+          <tr>
+            <th scope="col"></th>
+            <th scope="col">fnox + Doppler <span style="font-weight:400;text-transform:none;letter-spacing:0">(today)</span></th>
+            <th scope="col">Infisical</th>
+            <th scope="col">SOPS + age</th>
+            <th scope="col">Bitwarden SM</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Unknown scope</th>
+            <td><span class="chip c-bad">Fails open</span><br><strong>50</strong> secrets, <code>rc=0</code>, zero stderr — identical to the no-profile control.<span class="prov">Runtime-probed here on 1.32.0 · 2 arms · control returns 50, so it discriminates</span></td>
+            <td><span class="chip c-good">Refuses</span><br>Error propagates to <code>os.Exit(1)</code> before the child execs; backend raises <code>NotFoundError</code> unconditionally in both branches.<span class="prov">Source-verified · not probed</span></td>
+            <td><span class="chip c-good">Refuses</span><br>Structurally impossible to fail open — decrypt errors return before <code>ExecWithEnv</code>. Exits 2 / 128 / 128 / 1.<span class="prov">Runtime-probed · 6 arms · discriminates</span></td>
+            <td><span class="chip c-good">Refuses</span><br><code>run.rs:62-74</code> has no fallback branch, so a bad project id cannot widen to the org.<span class="prov">Source-verified · not probed</span></td>
+          </tr>
+          <tr>
+            <th scope="row">Offline</th>
+            <td>age cache, fully local.</td>
+            <td>Encrypted backup keyed in the OS keyring — but <strong>only on the logged-in-user branch</strong>. Machine identities hard-fail offline.<span class="prov">Source-verified</span></td>
+            <td><span class="chip c-good">Fully local</span> No network in the path at all.</td>
+            <td><span class="chip c-bad">None</span> State file caches auth tokens only. Service down = nonzero exit, no secrets.</td>
+          </tr>
+          <tr>
+            <th scope="row">Free cloud tier</th>
+            <td>Doppler free tier. Works today.</td>
+            <td>5 identities · 3 environments · unlimited projects.<span class="prov">Whether users count toward the 5 = UNVERIFIED — docs and pricing page do not cross-reference</span></td>
+            <td>A private git repo. Free, and no vendor.</td>
+            <td>2 users · 3 projects · 3 machine accounts · unlimited secrets.</td>
+          </tr>
+          <tr>
+            <th scope="row">Licence</th>
+            <td>Proprietary SaaS.</td>
+            <td>MIT with an <code>ee/</code> carve-out. Paywalled: versioning, point-in-time recovery, RBAC, rotation, audit logs.</td>
+            <td><span class="chip c-good">MPL-2.0 / BSD-3</span> LICENSE files read, not assumed.</td>
+            <td>Server AGPL-3.0, but <strong>the entire client stack is a bespoke EULA</strong> — <code>bws</code> and <code>bitwarden-sm</code> both.</td>
+          </tr>
+          <tr>
+            <th scope="row">Interactive shell</th>
+            <td><code>fnox activate zsh</code> — what you have now.</td>
+            <td>Not documented. <code>run -- $SHELL</code> is inference.<span class="prov">UNVERIFIED</span></td>
+            <td><span class="chip c-bad">None exists</span> No chpwd/precmd/eval form. 0 files, control <code>exec-env</code> → 2.</td>
+            <td>Not documented.</td>
+          </tr>
+          <tr>
+            <th scope="row">Per-command exec</th>
+            <td><code>fnox exec --</code></td>
+            <td><code>infisical run --</code> — parent env never mutated, so teardown is structural.</td>
+            <td><code>sops exec-env</code> — no teardown code; teardown is process lifetime. <code>exec-file</code> has real cleanup.</td>
+            <td><code>bws run --no-inherit-env</code> — can <code>env_clear()</code> the parent, strips its own token from the child.</td>
+          </tr>
+          <tr>
+            <th scope="row">Agent surface</th>
+            <td>None.</td>
+            <td><span class="chip c-good">Ships it</span> <code>agent-proxy run -- claude</code>, scrubs credential-shaped vars, brokers on the wire. Official MCP server. <code>.claude-plugin/marketplace.json</code>.</td>
+            <td><span class="chip c-flat">None</span> 0 hits, control → 8+ files.</td>
+            <td><code>agent-access</code> (Apache-2.0, <code>aac run</code>) — but targets the password vault, not Secrets Manager.</td>
+          </tr>
+          <tr>
+            <th scope="row">Self-host</th>
+            <td>n/a</td>
+            <td>Postgres + Redis, 2 cores / 4 GB / 20 GB.</td>
+            <td>n/a — files.</td>
+            <td>Enterprise-gated by licence file.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="callout col">
+      <span class="lbl">Re-derived, and it holds</span>
+      <p>The fnox fail-open figure arrived through a handoff and was the one cell nobody had measured. It has now been run here on 1.32.0 with both arms: the control (no profile) puts <strong>50</strong> secrets in the child at <code>rc=0</code>, and a nonexistent profile puts the <strong>same 50</strong> in at <code>rc=0</code> with zero stderr. The claim stands. The count was 49 in the handoff and is 50 today.</p>
+      <p style="margin:0">The correction that matters more: <strong>this defect is neutralised by your own ruling.</strong> Fail-open on a profile can only bite something that uses profiles, and you decided agents hold all 50 regardless. The strongest charge against fnox is one whose blast radius you have already accepted.</p>
+    </div>
+
+    <div class="callout col">
+      <span class="lbl">What I got wrong about fnox</span>
+      <p>fnox supports <strong>23 providers</strong> — including <code>infisical</code>, <code>bitwarden-sm</code>, <code>doppler</code>, <code>1password</code>, <code>vault</code>, <code>keychain</code>, <code>age</code> and the three cloud KMS/SM families. It is, already, the multi-backend CRUD proxy this project set out to build. Version 1.32.0 shipped 2026-08-01, and the changelog shows active profile work.</p>
+      <p style="margin:0">Two things I attributed to it are not its: the churn of all sync ciphertexts on every add/remove is <strong>mde's</strong> <code>_run_fnox_sync_age()</code>, which leaves when mde does; and the config-regeneration wipe class was closed upstream in mde#82, which exonerated fnox. Swapping its Doppler provider for Infisical is a config change, not a migration.</p>
+    </div>
+  </section>
+
+  <!-- ============ MISE REFRAME ============ -->
+  <section>
+    <div class="head col">
+      <span class="lbl">New constraint · changes the answer</span>
+      <h2>Every consumer is a mise project</h2>
+      <p>That is not just a distribution detail. mise <strong>2026.8.1</strong> already does most of this natively, which means the tool-builtins gate applies before any of the proposals below.</p>
+    </div>
+
+    <div class="topo">
+      <div class="flow">
+        <div class="node key">
+          <span class="n">mise reads sops natively</span>
+          <span class="d"><code>[env] _.file = ".env.json"</code> — age is the only supported backend; formats are <code>.env.json</code>, <code>.env.yaml</code>, <code>.env.toml</code>. Key resolution order is documented: <code>MISE_SOPS_AGE_KEY</code> → <code>..._FILE</code> → <code>SOPS_AGE_KEY_FILE</code> → <code>SOPS_AGE_KEY</code> → <code>~/.config/mise/age.txt</code>.</span>
+        </div>
+        <div class="node key">
+          <span class="n">mise has built-in age</span>
+          <span class="d"><code>mise set --age-encrypt --prompt DB_PASSWORD</code> stores ciphertext inline in <code>mise.toml</code>. <strong>No age CLI required.</strong> Defaults to your existing SSH key.</span>
+        </div>
+        <div class="node key">
+          <span class="n">--age-recipient is repeatable</span>
+          <span class="d">Plus <code>--age-ssh-recipient</code> and <code>--age-key-file</code>. This is precisely the multi-recipient recovery primitive that has to exist <em>before</em> the first secret is encrypted — available natively, today.</span>
+        </div>
+        <div class="node key">
+          <span class="n">Redaction is native</span>
+          <span class="d"><code>_.file = { path = ".env.json", redact = true }</code>, <code>mise env --redacted</code>. Direct-age values are <strong>always</strong> redacted. Partially answers the transcript-leak concern in #474.</span>
+        </div>
+        <div class="node risk">
+          <span class="n">fnox is NOT a mise feature</span>
+          <span class="d">Same author, but mise's docs are explicit: <em>"There is no direct integration between fnox and mise — you configure fnox independently, and it sets environment variables that mise picks up like any other variables in your shell."</em> It is recommended for <strong>team</strong> environments. You are one person.</span>
+        </div>
+        <div class="node dead">
+          <span class="n">Both paths are experimental</span>
+          <span class="d">mise's docs carry an explicit warning on each: <em>"Behavior may change in future releases."</em> That is a real cost, not a footnote.</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="callout col">
+      <span class="lbl">What this does to the build</span>
+      <p style="margin:0">Per-project injection, encryption, multi-recipient recovery and redaction are all <strong>already native</strong>. And because mise config is per-directory, scoping is <em>structural</em> rather than a flag a call site can forget — which is the open question in #492, answered for free. What mise does <strong>not</strong> give you is cloud durability beyond a git remote, cross-project CRUD, rotation across many projects, or the agent-scoping surface.</p>
+    </div>
+  </section>
+
+  <!-- ============ PROPOSALS ============ -->
+  <section>
+    <div class="head col">
+      <span class="lbl">Five options</span>
+      <h2>The proposals</h2>
+      <p>Not a sequence and not ranked by effort — each is a different bet about which component is the weak one. The verdict chips are judgments, and the reasoning behind each is stated so you can reject it.</p>
+    </div>
+
+    <div class="props">
+
+      <article class="prop lead">
+        <div class="top">
+          <h3>Lean on mise, build only the gap</h3>
+          <span class="chip c-good">Smallest real build</span>
+        </div>
+        <dl>
+          <div><dt>Components out</dt><dd>fnox, the mde shell fragment, most of the planned CLI.</dd></div>
+          <div><dt>Components in</dt><dd>mise's native sops/age env loading in each consuming project, plus a thin CRUD tool for origination and a cloud store for durability.</dd></div>
+          <div><dt>Why</dt><dd>Injection, encryption, multi-recipient recovery, redaction and directory-scoping are already native and free. Writing any of that ourselves is exactly what the tool-builtins rule forbids, and this repo's standing preference is mise wherever mise has the feature.</dd></div>
+          <div><dt>What breaks</dt><dd>Both mise features are experimental. Shell-wide availability becomes per-project, so anything relying on all 50 everywhere changes shape. Cloud durability still has to come from somewhere.</dd></div>
+        </dl>
+        <p class="cost">Cost: lowest build, highest dependence on an experimental feature.</p>
+      </article>
+
+      <article class="prop">
+        <div class="top">
+          <h3>Move to Infisical</h3>
+          <span class="chip c-good">Strongest fit</span>
+        </div>
+        <dl>
+          <div><dt>Components out</dt><dd>fnox, Doppler, the mde shell fragment, the age cache.</dd></div>
+          <div><dt>Components in</dt><dd><code>infisical</code> CLI + Infisical cloud. The CLI you build wraps it; the plugin wraps <code>agent-proxy</code>.</dd></div>
+          <div><dt>Why</dt><dd>It already ships the end state you described — agent credential scoping and a Claude Code plugin marketplace — so most of the build becomes adoption. Refuses on unknown scope. Has an offline cache.</dd></div>
+          <div><dt>What breaks</dt><dd>No documented shell-activate, so today's every-shell behaviour has no direct equivalent. Rotation, versioning and audit are paid. The 5-identity cap may bind sooner than it looks.</dd></div>
+        </dl>
+        <p class="cost">Cost: full migration of 50 secrets + the durable copy.</p>
+      </article>
+
+      <article class="prop">
+        <div class="top">
+          <h3>Drop fnox, keep Doppler</h3>
+          <span class="chip c-good">Lowest risk</span>
+        </div>
+        <dl>
+          <div><dt>Components out</dt><dd>fnox, the age cache, the mde shell fragment.</dd></div>
+          <div><dt>Components in</dt><dd>Your CLI wrapping <code>doppler</code> directly. Keychain keeps the bootstrap token.</dd></div>
+          <div><dt>Why</dt><dd>Every defect measured this session belongs to fnox, not Doppler. Doppler already satisfies free + cloud + durable, and <code>doppler run --</code> is the same injection shape everything else uses.</dd></div>
+          <div><dt>What breaks</dt><dd>Loses <code>fnox activate</code>; the shell-wide equivalent is a download piped into <code>eval</code>, which is exactly the shape that puts values on stdout. Loses the offline cache.</dd></div>
+        </dl>
+        <p class="cost">Cost: no data migration. Rewrites the shell integration.</p>
+      </article>
+
+      <article class="prop">
+        <div class="top">
+          <h3>SOPS + age</h3>
+          <span class="chip c-warn">Viable, narrow</span>
+        </div>
+        <dl>
+          <div><dt>Components out</dt><dd>fnox, Doppler, the keychain token.</dd></div>
+          <div><dt>Components in</dt><dd><code>sops</code> + <code>age</code> + a private git repo as the cloud.</dd></div>
+          <div><dt>Why</dt><dd>The only option with runtime-proven refusal on all six arms. Zero vendor. Rotation is O(recipients) not O(secrets) — much cheaper than churning 49 ciphertexts per change.</dd></div>
+          <div><dt>What breaks</dt><dd>No interactive-shell injection exists at all, so it cannot reproduce current behaviour. A second recipient must be created before the first secret is encrypted, or the durability requirement is not met.</dd></div>
+        </dl>
+        <p class="cost">Cost: full migration + a key-custody decision first.</p>
+      </article>
+
+      <article class="prop lead">
+        <div class="top">
+          <h3>Keep fnox, swap its provider</h3>
+          <span class="chip c-good">Least work, most reuse</span>
+        </div>
+        <dl>
+          <div><dt>Components out</dt><dd>The Doppler provider, if you want off it. The mde shell fragment either way.</dd></div>
+          <div><dt>Components in</dt><dd><code>[providers] infisical = { type = "infisical", project_id = "…", environment = "dev" }</code> — a config change, not a migration.</dd></div>
+          <div><dt>Why</dt><dd>fnox already <em>is</em> the multi-backend CRUD proxy, across 23 providers, current as of two days ago, by mise's author. Its one confirmed defect only bites profiles, which your ruling means nobody uses. Two other charges against it were mde's, not its.</dd></div>
+          <div><dt>What breaks</dt><dd>Nothing structural. You still own origination and the plugin, and you still need a shell-activate story once the mde fragment goes. Writes through the Infisical provider go via <code>infisical secrets set</code>, not fnox.</dd></div>
+        </dl>
+        <p class="cost">Cost: a config edit plus the origination layer.</p>
+      </article>
+
+    </div>
+  </section>
+
+  <!-- ============ WORKFLOWS ============ -->
+  <section>
+    <div class="head col">
+      <span class="lbl">Four lanes, four answers</span>
+      <h2>How a credential gets resolved</h2>
+      <p>The lanes are where the proposals actually differ. Note that today's second and fourth lanes are served by two unrelated mechanisms that nothing keeps in sync.</p>
+    </div>
+
+    <div class="tablewrap">
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">Lane</th>
+            <th scope="col">Today</th>
+            <th scope="col">Infisical</th>
+            <th scope="col">Doppler-direct</th>
+            <th scope="col">mise + age / sops</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Interactive shell</th>
+            <td>chpwd/precmd hooks export all 50.</td>
+            <td>No documented equivalent — open question.</td>
+            <td><code>doppler secrets download</code> → <code>eval</code>. Needs verifying; leaks to stdout.</td>
+            <td><span class="chip c-good">Native, per-project</span> <code>mise activate</code> already loads <code>[env]</code> per directory. Not shell-wide — <em>scoped</em>, which is arguably the better property.</td>
+          </tr>
+          <tr>
+            <th scope="row">Per-command</th>
+            <td><code>fnox exec --</code>, fails open on a bad profile.</td>
+            <td><code>infisical run --</code>, refuses.</td>
+            <td><code>doppler run --</code>.</td>
+            <td><code>sops exec-env</code>, refuses.</td>
+          </tr>
+          <tr>
+            <th scope="row">Devcontainer</th>
+            <td>Separate lane: <code>doppler download</code> to an env file. Never touches fnox.</td>
+            <td>Same CLI as the host — the two lanes collapse into one.</td>
+            <td>Unchanged, and now the same tool as the host.</td>
+            <td>Repo is already mounted; needs the key inside the container — one env var, <code>MISE_SOPS_AGE_KEY</code>.</td>
+          </tr>
+          <tr>
+            <th scope="row">AI agent</th>
+            <td>Inherits all 50 from the parent shell. Accepted by decision.</td>
+            <td><code>agent-proxy run -- claude</code> scrubs and brokers. Knows <code>~/.claude</code> by name.</td>
+            <td>Inherits, or you build the scrubbing yourself.</td>
+            <td>Inherits whatever the project scopes — which is a subset, not 50.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="callout alarm col">
+      <span class="lbl">The tension this surfaces</span>
+      <p style="margin:0">You ruled an hour ago that agents keep all 50 and confinement is dead. Infisical's <code>agent-proxy</code>, Bitwarden's <code>agent-access</code>, and a live July incident where an AI tool hoovered whole repos including SSH keys are three independent signals pointing the other way — all from the last month. That does not make the ruling wrong; it does mean the market is building the thing we decided not to need, and it is worth deciding again on purpose rather than by omission.</p>
+    </div>
+  </section>
+
+  <!-- ============ OPEN ============ -->
+  <section>
+    <div class="head col">
+      <span class="lbl">Unresolved</span>
+      <h2>What still has to be decided</h2>
+      <p>Each carries a recommended default, so silence resolves to something stated rather than something accidental.</p>
+    </div>
+
+    <div class="qs">
+      <details open>
+        <summary>What justifies the CLI at all now?</summary>
+        <div class="body">The spec calls converting fnox's fail-open into a refusal <em>"the CLI's whole job"</em> (<code>secrets-takeover.md:528-530</code>). With no profile in play nobody passes <code>-P</code>, so that never fires — and every candidate backend refuses natively anyway. <strong>Recommended default:</strong> the CLI's justification becomes CRUD ownership plus the plugin surface, and the refusal clause is struck from the spec rather than quietly inherited.</div>
+      </details>
+
+      <details>
+        <summary>Does the agent-proxy finding reopen the all-50 ruling?</summary>
+        <div class="body">Confinement was ruled dead when the only available mechanism was fnox profiles, which cannot un-inject what the shell already exported. A wire-level broker is a different mechanism with a different cost. <strong>Recommended default:</strong> the ruling stands for the shell, but agent-proxy is evaluated on its own merits rather than being ruled out by inheritance.</div>
+      </details>
+
+      <details>
+        <summary>#496 — wrap or reimplement?</summary>
+        <div class="body">The ticket asks about <em>resolution</em>, and resolution was never the problem — <code>fnox activate</code> works. What mde owns is <strong>origination</strong>: the config writer, the CRUD verbs, the shell fragment. <strong>Recommended default:</strong> rewrite #496 to ask "which tool do we wrap, and who owns origination", then answer it with whichever backend wins.</div>
+      </details>
+
+      <details>
+        <summary>#497 — which repo?</summary>
+        <div class="body">Own repo, <code>python/</code> under dotfiles, or the shared <code>uv</code> git-dep shape <code>kb_setup.currency</code> already proves in this org. <strong>Recommended default:</strong> defer — it is a cheap later refactor, and the ticket itself says it may be a follow-on.</div>
+      </details>
+
+      <details>
+        <summary>Re-derive the fnox fail-open number before it decides anything</summary>
+        <div class="body">It is inherited, not measured here, and it is load-bearing for the whole spec. <strong>Recommended default:</strong> run it with both arms — a known-good profile that succeeds, and the nonexistent one — and record the exit codes, before any proposal is chosen on its strength.</div>
+      </details>
+
+      <details>
+        <summary>#470's arithmetic is stale</summary>
+        <div class="body">It argues the hole is 4 secrets <em>"because <code>env = "exec"</code> keeps the other 45 out of the shell"</em>. That clause is retired; the number is 50, and the rest of the ticket's framing rests on the 4. <strong>Recommended default:</strong> correct the body before anyone builds against it.</div>
+      </details>
+    </div>
+  </section>
+
+  <footer class="col">
+    Evidence: docs/research/kb/reports/agents/secrets-backend-{infisical,sops-age,bitwarden-sm}.md<br>
+    mise facts: docs/research/mintlify-cache/jdx/mise/llms-full.txt (mise's own docs, local) + <code>mise settings</code> on 2026.8.1<br>
+    Probes this session: ~/.config/fnox/config.toml · mise.toml:769 · ~/.zshrc.d/50-mde-secrets.zsh<br>
+    Unverified and labelled as such: fnox fail-open (inherited) · Infisical identity semantics · Infisical + Bitwarden refusal (source-read, not run) · mise sops/age paths not yet exercised here
+  </footer>
+
+</div>

--- a/docs/research/kb/artifacts/secrets-fnox-entrypoint.html
+++ b/docs/research/kb/artifacts/secrets-fnox-entrypoint.html
@@ -1,0 +1,381 @@
+<title>fnox as the single entrypoint</title>
+
+<style>
+  :root {
+    --ground:#EDEEF0; --surface:#FFFFFF; --sunk:#E3E5E9; --ink:#16181C;
+    --muted:#676D78; --hair:#CFD3D9; --accent:#A97A3D; --accent-w:#F0E4D2;
+    --good:#2E7D5B; --bad:#B3402F; --warn:#8A6A1F;
+    --good-w:#DCEDE5; --bad-w:#F6DED9; --warn-w:#F1E7CE;
+    --f-display: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    --f-body: Georgia, "Iowan Old Style", "Times New Roman", serif;
+    --f-mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
+    --col: 68ch;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root { --ground:#111317; --surface:#191C21; --sunk:#0C0E11; --ink:#E6E8EC;
+      --muted:#8E95A1; --hair:#2C3138; --accent:#D4A468; --accent-w:#33281A;
+      --good:#4FA57E; --bad:#D9705E; --warn:#C9A24D;
+      --good-w:#16281F; --bad-w:#2E1A16; --warn-w:#2A2213; }
+  }
+  :root[data-theme="dark"] { --ground:#111317; --surface:#191C21; --sunk:#0C0E11; --ink:#E6E8EC;
+    --muted:#8E95A1; --hair:#2C3138; --accent:#D4A468; --accent-w:#33281A;
+    --good:#4FA57E; --bad:#D9705E; --warn:#C9A24D;
+    --good-w:#16281F; --bad-w:#2E1A16; --warn-w:#2A2213; }
+  :root[data-theme="light"] { --ground:#EDEEF0; --surface:#FFFFFF; --sunk:#E3E5E9; --ink:#16181C;
+    --muted:#676D78; --hair:#CFD3D9; --accent:#A97A3D; --accent-w:#F0E4D2;
+    --good:#2E7D5B; --bad:#B3402F; --warn:#8A6A1F;
+    --good-w:#DCEDE5; --bad-w:#F6DED9; --warn-w:#F1E7CE; }
+
+  body { background:var(--ground); color:var(--ink); font-family:var(--f-body);
+         font-size:17px; line-height:1.62; -webkit-font-smoothing:antialiased; }
+  .wrap { max-width:1180px; margin:0 auto;
+          padding:clamp(2rem,5vw,4.5rem) clamp(1.1rem,4vw,2.5rem) 6rem;
+          display:flex; flex-direction:column; gap:3.5rem; }
+  .col { max-width:var(--col); }
+  .lbl { font-family:var(--f-mono); font-size:0.7rem; letter-spacing:0.16em;
+         text-transform:uppercase; color:var(--muted); }
+  h1,h2,h3 { font-family:var(--f-display); text-wrap:balance; line-height:1.15; letter-spacing:-0.02em; }
+  h1 { font-size:clamp(2rem,5vw,3.1rem); font-weight:700; margin:0.4rem 0 0; }
+  h2 { font-size:clamp(1.35rem,3vw,1.75rem); font-weight:650; margin:0; }
+  h3 { font-size:1rem; font-weight:650; margin:0 0 0.15rem; letter-spacing:-0.01em; }
+  p { margin:0 0 1rem; } p:last-child { margin-bottom:0; }
+  code { font-family:var(--f-mono); font-size:0.87em; background:var(--sunk);
+         padding:0.1em 0.36em; border-radius:3px; word-break:break-word; }
+  a { color:var(--accent); }
+  a:focus-visible { outline:2px solid var(--accent); outline-offset:3px; }
+  header .rule { height:3px; width:68px; background:var(--accent); margin-bottom:1.6rem; }
+  header .sub { color:var(--muted); font-size:1.02rem; margin-top:1.2rem; }
+  section { display:flex; flex-direction:column; gap:1.4rem; }
+  .head { display:flex; flex-direction:column; gap:0.5rem; }
+
+  .chip { display:inline-block; font-family:var(--f-mono); font-size:0.63rem;
+          letter-spacing:0.11em; text-transform:uppercase; padding:0.26em 0.55em;
+          border-radius:3px; white-space:nowrap; font-weight:600; }
+  .c-good{background:var(--good-w);color:var(--good);} .c-bad{background:var(--bad-w);color:var(--bad);}
+  .c-warn{background:var(--warn-w);color:var(--warn);} .c-flat{background:var(--sunk);color:var(--muted);}
+
+  .stack { background:var(--surface); border:1px solid var(--hair); border-radius:6px;
+           padding:clamp(1rem,3vw,1.9rem); overflow-x:auto; }
+  .layers { display:flex; flex-direction:column; gap:0.5rem; min-width:560px; }
+  .layer { display:grid; grid-template-columns:130px 200px 1fr; gap:1rem; align-items:baseline;
+           padding:0.8rem 1rem; background:var(--ground); border:1px solid var(--hair);
+           border-left:3px solid var(--accent); border-radius:4px; }
+  .layer .role { font-family:var(--f-mono); font-size:0.62rem; letter-spacing:0.11em;
+                 text-transform:uppercase; color:var(--muted); }
+  .layer .who { font-family:var(--f-mono); font-size:0.8rem; font-weight:600; }
+  .layer .what { font-size:0.87rem; color:var(--muted); line-height:1.45; }
+  .layer.entry { border-left-color:var(--accent); background:var(--accent-w); }
+  .layer.entry .what { color:var(--ink); }
+  .layer.risk { border-left-color:var(--bad); }
+  .tick { font-family:var(--f-mono); font-size:0.7rem; color:var(--muted); padding-left:1rem; }
+
+  .tablewrap { overflow-x:auto; border:1px solid var(--hair); border-radius:6px; background:var(--surface); }
+  table { border-collapse:collapse; width:100%; min-width:820px; }
+  th,td { text-align:left; padding:0.7rem 0.85rem; border-bottom:1px solid var(--hair);
+          vertical-align:top; font-size:0.86rem; line-height:1.45; }
+  thead th { font-family:var(--f-mono); font-size:0.66rem; letter-spacing:0.1em;
+             text-transform:uppercase; color:var(--muted); font-weight:600; background:var(--sunk); }
+  tbody th { font-family:var(--f-display); font-weight:650; font-size:0.82rem; width:180px; }
+  tbody tr:last-child th, tbody tr:last-child td { border-bottom:none; }
+  .prov { display:block; font-family:var(--f-mono); font-size:0.63rem; letter-spacing:0.06em;
+          text-transform:uppercase; color:var(--muted); margin-top:0.3rem; }
+
+  /* sequence diagrams */
+  .seq { background:var(--surface); border:1px solid var(--hair); border-radius:6px;
+         padding:1.1rem 1.2rem 1.4rem; overflow-x:auto; }
+  .seq .cmd { font-family:var(--f-mono); font-size:0.78rem; background:var(--sunk);
+              padding:0.5rem 0.7rem; border-radius:4px; border-left:2px solid var(--accent);
+              margin-bottom:1.1rem; display:inline-block; white-space:nowrap; }
+  .seq-inner { min-width:780px; }
+  .seq-head { display:grid; grid-template-columns:repeat(7,1fr);
+              padding-bottom:0.6rem; border-bottom:1px solid var(--hair); margin-bottom:0.2rem; }
+  .seq-head span { font-family:var(--f-mono); font-size:0.66rem; letter-spacing:0.06em;
+                   text-align:center; color:var(--muted); font-weight:600; }
+  .seq-head span.owner { color:var(--accent); }
+  .seq-body { position:relative; padding-top:0.5rem; }
+  .rails { position:absolute; inset:0; display:grid; grid-template-columns:repeat(7,1fr); pointer-events:none; }
+  .rails i { background:linear-gradient(var(--hair),var(--hair)) center/1px 100% no-repeat; }
+  .step { position:relative; display:grid; grid-template-columns:repeat(14,1fr);
+          align-items:center; min-height:2.55rem; }
+  .bar { grid-column:var(--gc); position:relative; height:2px; background:var(--accent);
+         align-self:center; margin-top:0.55rem; }
+  .bar .t { position:absolute; left:0; right:0; bottom:6px; text-align:center;
+            font-size:0.76rem; line-height:1.3; color:var(--ink); white-space:nowrap; }
+  .bar::after { content:""; position:absolute; top:-4px; width:0; height:0;
+                border-top:5px solid transparent; border-bottom:5px solid transparent; }
+  .bar.r::after { right:-1px; border-left:8px solid var(--accent); }
+  .bar.l::after { left:-1px; border-right:8px solid var(--accent); }
+  .bar.dim { background:var(--muted); }
+  .bar.dim::after { border-left-color:var(--muted); border-right-color:var(--muted); }
+  .bar.dim .t { color:var(--muted); }
+  .bar.warn { background:var(--bad); }
+  .bar.warn::after { border-left-color:var(--bad); border-right-color:var(--bad); }
+  .bar.warn .t { color:var(--bad); font-weight:600; }
+  .bar.brk { background:repeating-linear-gradient(90deg,var(--bad) 0 6px,transparent 6px 11px); height:2px; }
+  .bar.brk::after { border-left-color:var(--bad); border-right-color:var(--bad); }
+  .bar.brk .t { color:var(--bad); font-weight:600; }
+  .self { grid-column:var(--gc); align-self:center; margin-top:0.3rem;
+          border:1px solid var(--hair); border-left:2px solid var(--accent);
+          background:var(--ground); border-radius:3px; padding:0.24rem 0.4rem;
+          font-size:0.73rem; text-align:center; line-height:1.25; }
+  .self.warn { border-left-color:var(--bad); }
+  .stepno { position:absolute; left:-0.1rem; top:0.85rem; font-family:var(--f-mono);
+            font-size:0.62rem; color:var(--accent); font-weight:700; }
+  .seq .note { font-size:0.83rem; color:var(--muted); margin-top:1rem; line-height:1.5; }
+
+  .callout { background:var(--surface); border:1px solid var(--hair);
+             border-left:3px solid var(--accent); border-radius:4px;
+             padding:1.15rem 1.3rem; font-size:0.94rem; }
+  .callout.alarm { border-left-color:var(--bad); }
+  .callout .lbl { display:block; margin-bottom:0.5rem; }
+
+  footer { border-top:1px solid var(--hair); padding-top:1.5rem; font-size:0.8rem;
+           color:var(--muted); font-family:var(--f-mono); line-height:1.7; }
+  @media (prefers-reduced-motion:reduce){ *{animation:none!important;transition:none!important;} }
+  @media (max-width:620px){ .layer{grid-template-columns:1fr;gap:0.3rem;} }
+</style>
+
+<div class="wrap">
+
+  <header class="col">
+    <div class="rule"></div>
+    <span class="lbl">Design variant · fnox as the sole integration point</span>
+    <h1>One entrypoint, and the three places it leaks</h1>
+    <p class="sub">The CLI talks only to fnox; fnox talks to everything else. It mostly works — and the exceptions are specific, findable, and decide the backend for you.</p>
+  </header>
+
+  <section>
+    <div class="callout col">
+      <span class="lbl">The verdict up front</span>
+      <p><strong>The design is sound and fnox was built for it</strong> — there is a real published library crate, <code>fnox-core</code> 1.32.0, described in its own source as the reusable engine and convenience API <em>for downstream consumers</em>. Writes work through <strong>17 of 23 providers</strong>.</p>
+      <p style="margin:0">But the invariant "the CLI only ever talks to fnox" breaks in exactly three places, and one of them is a silent plaintext write. Each is drawn below rather than described, because each one is an arrow that should not exist.</p>
+    </div>
+  </section>
+
+  <!-- LAYERS -->
+  <section>
+    <div class="head col">
+      <span class="lbl">Components</span>
+      <h2>What the stack collapses to</h2>
+      <p>Four integration points become one. mise stops being something the CLI drives and becomes just another consumer of fnox's output.</p>
+    </div>
+
+    <div class="stack">
+      <div class="layers">
+        <div class="layer entry">
+          <span class="role">Entrypoint</span>
+          <span class="who">your CLI / SDK</span>
+          <span class="what">Talks to <strong>fnox only</strong>. Adds the three things fnox cannot do for itself: validate a profile name, serialise concurrent writes, and verify after a rotation.</span>
+        </div>
+        <div class="tick">│ <code>fnox-core</code> if written in Rust · shelling out if not</div>
+
+        <div class="layer">
+          <span class="role">Everything</span>
+          <span class="who">fnox 1.32.0</span>
+          <span class="what">Resolution, declaration, encryption, profiles, scoping, export, exec, proxy. 23 providers, so the store underneath is a config line.</span>
+        </div>
+        <div class="tick">│ resolves through</div>
+
+        <div class="layer">
+          <span class="role">Bootstrap</span>
+          <span class="who">macOS keychain</span>
+          <span class="what">One credential, reached by fnox rather than by you. Writable through fnox — it is in the RemoteStorage class.</span>
+        </div>
+        <div class="layer">
+          <span class="role">Durability</span>
+          <span class="who">the cloud store</span>
+          <span class="what">Must be <strong>writable through fnox</strong> or the whole design fails on its first verb. That is a hard constraint on the backend choice, not a preference.</span>
+        </div>
+        <div class="tick">│ exported to</div>
+
+        <div class="layer">
+          <span class="role">Consumers</span>
+          <span class="who">mise · shell · agents</span>
+          <span class="what">Via <code>fnox activate</code> (shell inheritance) or <code>fnox exec</code> in a task. There <em>is</em> a <code>jdx/mise-env-fnox</code> plugin, but upstream says <em>"we do not recommend"</em> it and self-rates full feature support as <strong>No</strong>.</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- LEAKS -->
+  <section>
+    <div class="head col">
+      <span class="lbl">Where the invariant breaks</span>
+      <h2>Three leaks, all specific</h2>
+    </div>
+
+    <div class="tablewrap">
+      <table>
+        <thead>
+          <tr><th scope="col">Leak</th><th scope="col">What happens</th><th scope="col">Cost</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">Writing to a read-only provider</th>
+            <td>Five providers never implement <code>capabilities()</code> and so default to read-only: <strong>1password, bitwarden personal, doppler, infisical, proton-pass</strong> (plus azure-ac, read-only by declaration). <code>fnox set FOO bar --provider infisical</code> does <strong>not</strong> error — it falls through and writes the <strong>cleartext value into <code>fnox.toml</code></strong>.<span class="prov">source-read at set.rs:180-183 → :236-243 · not executed</span></td>
+            <td><span class="chip c-bad">Fatal to the design</span> Doppler and Infisical are both in this set.</td>
+          </tr>
+          <tr>
+            <th scope="row">Deleting a remote value</th>
+            <td>The <code>Provider</code> trait has <strong>no delete method at all</strong> — 0 hits, against a control of <code>fn put_secret</code> → 11 files. <code>fnox remove</code> drops the declaration and leaves the remote value in place.<span class="prov">source-verified · control-armed</span></td>
+            <td><span class="chip c-bad">Unavoidable</span> Delete always needs the vendor's own CLI.</td>
+          </tr>
+          <tr>
+            <th scope="row">Declaring a scope on disk</th>
+            <td><code>--no-defaults</code> is the scoping mechanism and it is <strong>CLI/env only</strong> — all 11 source lines across the settings are <code>sources.cli</code>/<code>sources.env</code>, <strong>zero</strong> <code>sources.config</code>.<span class="prov">source-verified · control-armed</span></td>
+            <td><span class="chip c-warn">Permanent</span> Scoping lives in your wrapper's flags. Anyone calling <code>fnox</code> directly gets all 50.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="callout alarm col">
+      <span class="lbl">What leak 1 does to the backend choice</span>
+      <p style="margin:0">A fnox-only entrypoint <strong>cannot use Doppler or Infisical</strong>. Reaching one integration point means moving to a RemoteStorage-class backend — <strong>Bitwarden Secrets Manager, Vault, AWS/GCP/Azure Secrets Manager, keepass, or password-store</strong>. Bitwarden SM is the only one of those that is both free-tier and cloud-hosted, which makes the single-entrypoint design and the Bitwarden decision the <em>same</em> decision.</p>
+    </div>
+  </section>
+
+  <!-- CRUD -->
+  <section>
+    <div class="head col">
+      <span class="lbl">Workflows</span>
+      <h2>CRUD through one integration point</h2>
+      <p>Red dashed arrows are the leaks — the calls that bypass fnox and break the invariant. Everything else goes through it.</p>
+    </div>
+
+    <!-- CREATE -->
+    <div class="seq">
+      <h3>Create</h3>
+      <div class="cmd">secrets add STRIPE_API_KEY --project payments</div>
+      <div class="seq-inner">
+        <div class="seq-head"><span>you</span><span class="owner">CLI</span><span>fnox</span><span>keychain</span><span>cloud store</span><span>mise</span><span>project</span></div>
+        <div class="seq-body">
+          <div class="rails"><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+          <div class="step"><span class="stepno">1</span><div class="self" style="--gc:3/5">prompt on a TTY</div></div>
+          <div class="step"><span class="stepno">2</span><div class="bar r" style="--gc:4/6"><span class="t">fnox profiles — validate the name FIRST</span></div></div>
+          <div class="step"><span class="stepno">3</span><div class="bar r" style="--gc:4/6"><span class="t">fnox set NAME — value on STDIN, never argv</span></div></div>
+          <div class="step"><span class="stepno">4</span><div class="bar r dim" style="--gc:6/8"><span class="t">resolve the bootstrap credential</span></div></div>
+          <div class="step"><span class="stepno">5</span><div class="bar r" style="--gc:6/10"><span class="t">put_secret — only if RemoteStorage class</span></div></div>
+          <div class="step"><span class="stepno">6</span><div class="self" style="--gc:5/7">write the declaration into the config</div></div>
+          <div class="step"><span class="stepno">7</span><div class="bar l dim" style="--gc:6/12"><span class="t">exported on the next prompt</span></div></div>
+        </div>
+      </div>
+      <p class="note">Step 2 is not ceremony. A mistyped profile is silently ignored by fnox, so the CLI must reject it before writing anything. Step 3 uses stdin because <code>fnox set</code>'s own help warns that argv leaks to shell history and <code>ps</code> — its input precedence is argv, then stdin when not a TTY, then a hidden prompt.</p>
+    </div>
+
+    <!-- CREATE FAILURE -->
+    <div class="seq">
+      <h3>Create — against a read-only provider <span class="chip c-bad">the silent one</span></h3>
+      <div class="cmd">secrets add STRIPE_API_KEY   # backend = doppler or infisical</div>
+      <div class="seq-inner">
+        <div class="seq-head"><span>you</span><span class="owner">CLI</span><span>fnox</span><span>keychain</span><span>cloud store</span><span>mise</span><span>project</span></div>
+        <div class="seq-body">
+          <div class="rails"><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+          <div class="step"><span class="stepno">1</span><div class="bar r" style="--gc:4/6"><span class="t">fnox set NAME</span></div></div>
+          <div class="step"><span class="stepno">2</span><div class="self warn" style="--gc:5/7">no capabilities() → falls through, no error raised</div></div>
+          <div class="step"><span class="stepno">3</span><div class="bar warn r" style="--gc:6/10"><span class="t">✗ put_secret never happens</span></div></div>
+          <div class="step"><span class="stepno">4</span><div class="self warn" style="--gc:5/7">CLEARTEXT value written into fnox.toml</div></div>
+          <div class="step"><span class="stepno">5</span><div class="bar brk r" style="--gc:4/10"><span class="t">the write you wanted needs the vendor CLI — invariant broken</span></div></div>
+        </div>
+      </div>
+      <p class="note">This is why leak 1 is fatal rather than annoying: it does not fail loudly and route you to the vendor CLI, it succeeds at the wrong thing. Source-read, not executed — worth confirming in a throwaway config before trusting either direction.</p>
+    </div>
+
+    <!-- READ -->
+    <div class="seq">
+      <h3>Read</h3>
+      <div class="cmd">secrets ls · secrets status</div>
+      <div class="seq-inner">
+        <div class="seq-head"><span>you</span><span class="owner">CLI</span><span>fnox</span><span>keychain</span><span>cloud store</span><span>mise</span><span>project</span></div>
+        <div class="seq-body">
+          <div class="rails"><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+          <div class="step"><span class="stepno">1</span><div class="bar r" style="--gc:4/6"><span class="t">fnox list — names only, NEVER -V</span></div></div>
+          <div class="step"><span class="stepno">2</span><div class="bar l dim" style="--gc:4/6"><span class="t">a human-formatted table, truncating by default</span></div></div>
+          <div class="step"><span class="stepno">3</span><div class="self" style="--gc:3/5">parse it — there is no --json on list</div></div>
+          <div class="step"><span class="stepno">4</span><div class="bar r dim" style="--gc:6/12"><span class="t">fnox export -f json — emits VALUES, injection only</span></div></div>
+          <div class="step"><span class="stepno">5</span><div class="bar r dim" style="--gc:12/14"><span class="t">values reach a process only here</span></div></div>
+        </div>
+      </div>
+      <p class="note">Step 3 is the tax on shelling out. Structured output exists on only four commands — <code>export</code>, <code>import</code>, <code>lease create</code>, <code>scan</code> — and <code>export</code> emits the values themselves. Everything a wrapper wants to <em>read</em> is a table. A Rust CLI on <code>fnox-core</code> skips this step entirely; a Python one cannot.</p>
+    </div>
+
+    <!-- ROTATE -->
+    <div class="seq">
+      <h3>Rotate</h3>
+      <div class="cmd">secrets rotate STRIPE_API_KEY</div>
+      <div class="seq-inner">
+        <div class="seq-head"><span>you</span><span class="owner">CLI</span><span>fnox</span><span>keychain</span><span>cloud store</span><span>mise</span><span>project</span></div>
+        <div class="seq-body">
+          <div class="rails"><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+          <div class="step"><span class="stepno">1</span><div class="self" style="--gc:3/5">prompt for the new value</div></div>
+          <div class="step"><span class="stepno">2</span><div class="bar r" style="--gc:4/6"><span class="t">fnox set — on stdin</span></div></div>
+          <div class="step"><span class="stepno">3</span><div class="bar r" style="--gc:6/10"><span class="t">put_secret — new value is truth</span></div></div>
+          <div class="step"><span class="stepno">4</span><div class="bar warn r" style="--gc:4/6"><span class="t">fnox daemon clear — MANDATORY, see below</span></div></div>
+          <div class="step"><span class="stepno">5</span><div class="bar r" style="--gc:4/6"><span class="t">fnox check — bypasses the cache by design</span></div></div>
+          <div class="step"><span class="stepno">6</span><div class="bar r dim" style="--gc:4/6"><span class="t">fnox sync KEY — never bare, or all 49 re-encrypt</span></div></div>
+        </div>
+      </div>
+      <p class="note">Step 4 is mandatory because fnox's daemon cache <strong>invalidates on fnox-side inputs only</strong> — config, profile, provider refs, <code>FNOX_*</code> vars. A rotation at the <em>remote</em> matches none of them, so a running daemon keeps serving the credential you just rotated away until the idle timeout, which upstream's own example sets to <strong>8h</strong>. Step 5 works because <code>fnox check</code> deliberately bypasses the cache, making it the only correct post-rotation probe. Step 6 is filtered because a bare <code>fnox sync</code> re-encrypts every entry — age is non-deterministic.</p>
+    </div>
+
+    <!-- DELETE -->
+    <div class="seq">
+      <h3>Delete <span class="chip c-bad">the invariant cannot hold</span></h3>
+      <div class="cmd">secrets rm STRIPE_API_KEY</div>
+      <div class="seq-inner">
+        <div class="seq-head"><span>you</span><span class="owner">CLI</span><span>fnox</span><span>keychain</span><span>cloud store</span><span>mise</span><span>project</span></div>
+        <div class="seq-body">
+          <div class="rails"><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+          <div class="step"><span class="stepno">1</span><div class="bar r" style="--gc:4/6"><span class="t">fnox list — who still scopes it?</span></div></div>
+          <div class="step"><span class="stepno">2</span><div class="self" style="--gc:3/5">refuse if any project does, unless forced</div></div>
+          <div class="step"><span class="stepno">3</span><div class="bar r" style="--gc:4/6"><span class="t">fnox remove — declaration only</span></div></div>
+          <div class="step"><span class="stepno">4</span><div class="bar brk r" style="--gc:4/10"><span class="t">remote delete: no Provider::delete exists — vendor CLI required</span></div></div>
+          <div class="step"><span class="stepno">5</span><div class="self warn" style="--gc:3/5">otherwise the value survives, undeclared and invisible</div></div>
+        </div>
+      </div>
+      <p class="note">fnox is <strong>CRU, not CRUD</strong>. Step 4 is the leak with no workaround: dropping the declaration without deleting the remote leaves a live credential that nothing lists and nobody rotates — strictly worse than not deleting at all. Any honest delete verb either shells out to the vendor, or refuses and tells you to.</p>
+    </div>
+
+    <!-- GUARD -->
+    <div class="seq">
+      <h3>The guard rail only your CLI can add</h3>
+      <div class="cmd">every command, before anything else</div>
+      <div class="seq-inner">
+        <div class="seq-head"><span>you</span><span class="owner">CLI</span><span>fnox</span><span>keychain</span><span>cloud store</span><span>mise</span><span>project</span></div>
+        <div class="seq-body">
+          <div class="rails"><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+          <div class="step"><span class="stepno">1</span><div class="bar r" style="--gc:4/6"><span class="t">fnox profiles — the ONLY detector that exists</span></div></div>
+          <div class="step"><span class="stepno">2</span><div class="bar l" style="--gc:4/6"><span class="t">the declared profile names</span></div></div>
+          <div class="step"><span class="stepno">3</span><div class="self warn" style="--gc:3/5">refuse an unknown name — exit nonzero</div></div>
+          <div class="step"><span class="stepno">4</span><div class="bar r" style="--gc:4/6"><span class="t">only now: -P name --no-defaults</span></div></div>
+        </div>
+      </div>
+      <p class="note">Measured on 1.32.0 against a fixture that <em>declares</em> a real profile, so the control is armed: <code>-P real</code> returned 52 names including the canary, <code>-P nope</code> returned 51 with only the top-level canary, both <code>rc=0</code>. Neither <code>--if-missing error</code> nor <code>fnox check -P nope</code> catches it — they address a different failure. <code>fnox profiles</code> is the only thing that can, which makes step 1 the single clearest justification for the CLI existing at all.</p>
+    </div>
+  </section>
+
+  <!-- BUILD -->
+  <section>
+    <div class="head col">
+      <span class="lbl">The build decision this forces</span>
+      <h2>Rust against the crate, or Python against tables</h2>
+    </div>
+    <div class="callout col">
+      <p><strong>Rust.</strong> <code>fnox-core</code> is published, real, and explicitly aimed at downstream consumers — <code>discover()</code>, <code>open()</code>, <code>with_profile(s)</code>, <code>with_no_defaults()</code>, <code>get()</code>, <code>list()</code>. Typed results, no parsing, no version-skew in output formatting. The cost is a Rust toolchain in a repo whose tooling is Python, and a language most of the surrounding code is not written in.</p>
+      <p style="margin:0"><strong>Python.</strong> Shell out and regex over human-formatted tables that truncate by default, with no <code>--json</code> on any command you need to read. There are <strong>no</strong> Python bindings — <code>pyo3</code> → 0 hits, control <code>clap</code> → 45. This works, and it breaks quietly the first time an output format shifts.</p>
+    </div>
+    <div class="callout col">
+      <span class="lbl">Two more things the CLI must own</span>
+      <p><strong>Serialising writes.</strong> All four config-write sites are bare truncating <code>fs::write</code> in a read-modify-write — no temp-and-rename, no locking. Concurrent <code>fnox set</code> loses updates.</p>
+      <p style="margin:0"><strong>Never letting a value reach a terminal.</strong> <code>fnox list -V</code> and <code>fnox export</code> both print values, and fnox has no mise-style <code>--redacted</code> — redaction exists only in <code>fnox mcp</code>, the proxy, <code>ci-redact</code> and <code>scan</code>. The wrapper is the only thing standing between those flags and your transcript.</p>
+    </div>
+  </section>
+
+  <footer class="col">
+    Evidence: docs/research/kb/reports/agents/fnox-{write-surface,sdk-config,export-exec}.md<br>
+    Source read at fnox 1.32.0 (released 2026-08-01) · probes run against isolated fixtures, never the live config<br>
+    Unverified by execution: the cleartext-write fall-through · the proxy's runtime behaviour (no live request made)<br>
+    Note: jdx/fnox has GitHub Issues DISABLED — an empty issue search there is absence of a venue, not absence of a problem
+  </footer>
+
+</div>

--- a/docs/research/kb/artifacts/shell-activation.html
+++ b/docs/research/kb/artifacts/shell-activation.html
@@ -1,0 +1,354 @@
+<title>Replacing the mde shell fragment</title>
+
+<style>
+  :root {
+    --ground:#EDEEF0; --surface:#FFFFFF; --sunk:#E3E5E9; --ink:#16181C;
+    --muted:#676D78; --hair:#CFD3D9; --accent:#A97A3D; --accent-w:#F0E4D2;
+    --good:#2E7D5B; --bad:#B3402F; --warn:#8A6A1F;
+    --good-w:#DCEDE5; --bad-w:#F6DED9; --warn-w:#F1E7CE;
+    --f-display: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    --f-body: Georgia, "Iowan Old Style", "Times New Roman", serif;
+    --f-mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
+    --col: 68ch;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root { --ground:#111317; --surface:#191C21; --sunk:#0C0E11; --ink:#E6E8EC;
+      --muted:#8E95A1; --hair:#2C3138; --accent:#D4A468; --accent-w:#33281A;
+      --good:#4FA57E; --bad:#D9705E; --warn:#C9A24D;
+      --good-w:#16281F; --bad-w:#2E1A16; --warn-w:#2A2213; }
+  }
+  :root[data-theme="dark"] { --ground:#111317; --surface:#191C21; --sunk:#0C0E11; --ink:#E6E8EC;
+    --muted:#8E95A1; --hair:#2C3138; --accent:#D4A468; --accent-w:#33281A;
+    --good:#4FA57E; --bad:#D9705E; --warn:#C9A24D;
+    --good-w:#16281F; --bad-w:#2E1A16; --warn-w:#2A2213; }
+  :root[data-theme="light"] { --ground:#EDEEF0; --surface:#FFFFFF; --sunk:#E3E5E9; --ink:#16181C;
+    --muted:#676D78; --hair:#CFD3D9; --accent:#A97A3D; --accent-w:#F0E4D2;
+    --good:#2E7D5B; --bad:#B3402F; --warn:#8A6A1F;
+    --good-w:#DCEDE5; --bad-w:#F6DED9; --warn-w:#F1E7CE; }
+
+  body { background:var(--ground); color:var(--ink); font-family:var(--f-body);
+         font-size:17px; line-height:1.62; -webkit-font-smoothing:antialiased; }
+  .wrap { max-width:1180px; margin:0 auto;
+          padding:clamp(2rem,5vw,4.5rem) clamp(1.1rem,4vw,2.5rem) 6rem;
+          display:flex; flex-direction:column; gap:3.5rem; }
+  .col { max-width:var(--col); }
+  .lbl { font-family:var(--f-mono); font-size:0.7rem; letter-spacing:0.16em;
+         text-transform:uppercase; color:var(--muted); }
+  h1,h2,h3 { font-family:var(--f-display); text-wrap:balance; line-height:1.15; letter-spacing:-0.02em; }
+  h1 { font-size:clamp(2rem,5vw,3.1rem); font-weight:700; margin:0.4rem 0 0; }
+  h2 { font-size:clamp(1.35rem,3vw,1.75rem); font-weight:650; margin:0; }
+  h3 { font-size:1rem; font-weight:650; margin:0 0 0.15rem; letter-spacing:-0.01em; }
+  p { margin:0 0 1rem; } p:last-child { margin-bottom:0; }
+  code { font-family:var(--f-mono); font-size:0.87em; background:var(--sunk);
+         padding:0.1em 0.36em; border-radius:3px; word-break:break-word; }
+  pre { background:var(--sunk); border:1px solid var(--hair); border-left:3px solid var(--accent);
+        border-radius:4px; padding:0.85rem 1rem; overflow-x:auto; margin:0;
+        font-family:var(--f-mono); font-size:0.78rem; line-height:1.55; }
+  pre code { background:none; padding:0; font-size:inherit; }
+  pre.bad { border-left-color:var(--bad); }
+  pre.good { border-left-color:var(--good); }
+  header .rule { height:3px; width:68px; background:var(--accent); margin-bottom:1.6rem; }
+  header .sub { color:var(--muted); font-size:1.02rem; margin-top:1.2rem; }
+  section { display:flex; flex-direction:column; gap:1.4rem; }
+  .head { display:flex; flex-direction:column; gap:0.5rem; }
+
+  .chip { display:inline-block; font-family:var(--f-mono); font-size:0.63rem;
+          letter-spacing:0.11em; text-transform:uppercase; padding:0.26em 0.55em;
+          border-radius:3px; white-space:nowrap; font-weight:600; }
+  .c-good{background:var(--good-w);color:var(--good);} .c-bad{background:var(--bad-w);color:var(--bad);}
+  .c-warn{background:var(--warn-w);color:var(--warn);} .c-flat{background:var(--sunk);color:var(--muted);}
+
+  .tablewrap { overflow-x:auto; border:1px solid var(--hair); border-radius:6px; background:var(--surface); }
+  table { border-collapse:collapse; width:100%; min-width:900px; }
+  th,td { text-align:left; padding:0.72rem 0.85rem; border-bottom:1px solid var(--hair);
+          vertical-align:top; font-size:0.86rem; line-height:1.45; }
+  thead th { font-family:var(--f-mono); font-size:0.66rem; letter-spacing:0.1em;
+             text-transform:uppercase; color:var(--muted); font-weight:600; background:var(--sunk); }
+  tbody th { font-family:var(--f-display); font-weight:650; font-size:0.82rem; width:210px; }
+  tbody tr:last-child th, tbody tr:last-child td { border-bottom:none; }
+  .prov { display:block; font-family:var(--f-mono); font-size:0.63rem; letter-spacing:0.06em;
+          text-transform:uppercase; color:var(--muted); margin-top:0.3rem; }
+
+  .seq { background:var(--surface); border:1px solid var(--hair); border-radius:6px;
+         padding:1.1rem 1.2rem 1.4rem; overflow-x:auto; }
+  .seq .cmd { font-family:var(--f-mono); font-size:0.78rem; background:var(--sunk);
+              padding:0.5rem 0.7rem; border-radius:4px; border-left:2px solid var(--accent);
+              margin-bottom:1.1rem; display:inline-block; white-space:nowrap; }
+  .seq-inner { min-width:700px; }
+  .seq-head { display:grid; grid-template-columns:repeat(5,1fr);
+              padding-bottom:0.6rem; border-bottom:1px solid var(--hair); margin-bottom:0.2rem; }
+  .seq-head span { font-family:var(--f-mono); font-size:0.66rem; letter-spacing:0.06em;
+                   text-align:center; color:var(--muted); font-weight:600; }
+  .seq-head span.owner { color:var(--accent); }
+  .seq-body { position:relative; padding-top:0.5rem; }
+  .rails { position:absolute; inset:0; display:grid; grid-template-columns:repeat(5,1fr); pointer-events:none; }
+  .rails i { background:linear-gradient(var(--hair),var(--hair)) center/1px 100% no-repeat; }
+  .step { position:relative; display:grid; grid-template-columns:repeat(10,1fr);
+          align-items:center; min-height:2.55rem; }
+  .bar { grid-column:var(--gc); position:relative; height:2px; background:var(--accent);
+         align-self:center; margin-top:0.55rem; }
+  .bar .t { position:absolute; left:0; right:0; bottom:6px; text-align:center;
+            font-size:0.76rem; line-height:1.3; color:var(--ink); white-space:nowrap; }
+  .bar::after { content:""; position:absolute; top:-4px; width:0; height:0;
+                border-top:5px solid transparent; border-bottom:5px solid transparent; }
+  .bar.r::after { right:-1px; border-left:8px solid var(--accent); }
+  .bar.l::after { left:-1px; border-right:8px solid var(--accent); }
+  .bar.dim { background:var(--muted); }
+  .bar.dim::after { border-left-color:var(--muted); border-right-color:var(--muted); }
+  .bar.dim .t { color:var(--muted); }
+  .bar.warn { background:var(--bad); }
+  .bar.warn::after { border-left-color:var(--bad); border-right-color:var(--bad); }
+  .bar.warn .t { color:var(--bad); font-weight:600; }
+  .bar.ok { background:var(--good); }
+  .bar.ok::after { border-left-color:var(--good); border-right-color:var(--good); }
+  .self { grid-column:var(--gc); align-self:center; margin-top:0.3rem;
+          border:1px solid var(--hair); border-left:2px solid var(--accent);
+          background:var(--ground); border-radius:3px; padding:0.24rem 0.4rem;
+          font-size:0.73rem; text-align:center; line-height:1.25; }
+  .self.warn { border-left-color:var(--bad); color:var(--bad); font-weight:600; }
+  .self.ok { border-left-color:var(--good); }
+  .stepno { position:absolute; left:-0.1rem; top:0.85rem; font-family:var(--f-mono);
+            font-size:0.62rem; color:var(--accent); font-weight:700; }
+  .seq .note { font-size:0.83rem; color:var(--muted); margin-top:1rem; line-height:1.5; }
+
+  .opts { display:flex; flex-direction:column; gap:1.1rem; }
+  .opt { background:var(--surface); border:1px solid var(--hair); border-radius:6px; padding:1.3rem;
+         display:flex; flex-direction:column; gap:0.8rem; }
+  .opt.lead { border-color:var(--accent); box-shadow:0 0 0 1px var(--accent); }
+  .opt .top { display:flex; justify-content:space-between; align-items:flex-start; gap:1rem; flex-wrap:wrap; }
+  .pc { display:grid; gap:0.5rem 1.4rem; grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); }
+  .pc div { font-size:0.88rem; line-height:1.5; }
+  .pc b { font-family:var(--f-mono); font-size:0.63rem; letter-spacing:0.11em;
+          text-transform:uppercase; display:block; margin-bottom:0.2rem; }
+  .pc .p b { color:var(--good); } .pc .c b { color:var(--bad); }
+
+  .callout { background:var(--surface); border:1px solid var(--hair);
+             border-left:3px solid var(--accent); border-radius:4px;
+             padding:1.15rem 1.3rem; font-size:0.94rem; }
+  .callout.alarm { border-left-color:var(--bad); }
+  .callout .lbl { display:block; margin-bottom:0.5rem; }
+
+  footer { border-top:1px solid var(--hair); padding-top:1.5rem; font-size:0.8rem;
+           color:var(--muted); font-family:var(--f-mono); line-height:1.7; }
+  @media (prefers-reduced-motion:reduce){ *{animation:none!important;transition:none!important;} }
+</style>
+
+<div class="wrap">
+
+  <header class="col">
+    <div class="rule"></div>
+    <span class="lbl">Blocking decision · retiring 50-mde-secrets.zsh</span>
+    <h1>What replaces the shell activation</h1>
+    <p class="sub">Retiring mde deletes the one file that loads your credentials. Five candidates, measured — and the two most obvious ones both turn out to be traps.</p>
+  </header>
+
+  <!-- ANSWER -->
+  <section>
+    <div class="callout col">
+      <span class="lbl">Both tools can do it — that was the question, and the answer is yes</span>
+      <p><strong>fnox can</strong>, two different ways, and <strong>mise can</strong> via a real global env source: <code>~/.config/mise/config.toml</code>'s <code>[env]</code> applies in <em>every</em> directory, not just from that directory down. Measured: 26 keys survive at <code>/tmp</code> under a sanitised <code>env -i</code>, with a 3/3 control arm.</p>
+      <p style="margin:0">But <strong>mise cannot replace fnox</strong> — only re-house the call. Its two native secret paths are both experimental and file-or-inline only, so using them means re-homing all 50 secrets out of fnox and Doppler. Every viable mise route still ends in <code>fnox export</code>.</p>
+    </div>
+  </section>
+
+  <!-- OPTIONS -->
+  <section>
+    <div class="head col">
+      <span class="lbl">Five candidates</span>
+      <h2>The options</h2>
+    </div>
+
+    <div class="opts">
+
+      <article class="opt lead">
+        <div class="top"><h3>B · <code>fnox export</code> once per shell</h3><span class="chip c-good">Recommended</span></div>
+        <pre class="good"><code># ~/.zshrc.d/50-dotfiles-secrets.zsh, owned by this repo
+eval "$(fnox export -f shell -P shell --no-defaults)"</code></pre>
+        <div class="pc">
+          <div class="p"><b>Pro</b>Scoping actually works here. Verified in an isolated fixture: the scoped arm yields only that profile's secrets, and <code>-P bogus --no-defaults</code> yields <strong>nothing</strong> — fail-closed, unlike every other path. Values round-trip byte-identical through <code>eval</code>, including spaces, quotes and <code>$</code>. Respects per-secret <code>env = false</code>/<code>"exec"</code>.</div>
+          <div class="p"><b>Pro</b>Resolves <strong>once per shell</strong>. No prompt hook at all, so it sidesteps the fnox/mise hook-ordering hazard entirely and cannot wedge a prompt.</div>
+          <div class="c"><b>Con</b>No auto-reload. Rotate a secret and existing shells keep the old value until you re-source or open a new one — <code>activate</code> would have picked it up on the next <code>cd</code>.</div>
+          <div class="c"><b>Con</b>Requires declaring a <code>shell</code> profile you do not have today; your config has <strong>zero</strong> <code>[profiles.*]</code> blocks. Deriving that subset is real work.</div>
+        </div>
+      </article>
+
+      <article class="opt">
+        <div class="top"><h3>A · Relocate <code>fnox activate</code> as-is</h3><span class="chip c-warn">Safest, unscoped</span></div>
+        <pre><code>eval "$(fnox activate zsh)"</code></pre>
+        <div class="pc">
+          <div class="p"><b>Pro</b>A one-line relocation of a mechanism that already works. Zero behaviour change, so it cannot break your morning, and it decouples retiring mde from settling the exposure model.</div>
+          <div class="p"><b>Pro</b>Auto-reloads on <code>cd</code> and on config change, which B does not.</div>
+          <div class="c"><b>Con</b><strong>Cannot be scoped, at all.</strong> <code>-P</code> and <code>--no-defaults</code> are accepted and silently discarded — <code>ActivateCommand</code> has only two fields and the hook is hardcoded. Writing <code>activate -P agent --no-defaults</code> reads as scoped in review and hands over all 50.</div>
+          <div class="c"><b>Con</b>Keeps a per-prompt hook, and its early exit fails on every <code>cd</code>, every config mtime change, and <strong>every new shell</strong>.</div>
+        </div>
+      </article>
+
+      <article class="opt">
+        <div class="top"><h3>C · mise <code>_.source</code> in the global config</h3><span class="chip c-warn">Works, adds moving parts</span></div>
+        <pre><code>[env]
+_.source = "/abs/path/to/load-secrets.sh"   # NEVER a bare `fnox` inside</code></pre>
+        <div class="pc">
+          <div class="p"><b>Pro</b><code>_.source</code> is the only command escape hatch in mise's <code>[env]</code>, it is not experimental, and mise's hook is <em>already installed</em> — so this removes a per-prompt hook rather than adding one. mise's hook also has a dedup fast-path fnox's lacks.</div>
+          <div class="c"><b>Con</b><strong>Reproduced fork bomb.</strong> A bare <code>fnox</code> inside <code>_.source</code> with mise shims on <code>PATH</code> re-enters through the shim: <strong>3,011 processes, load 17.9 → 28.4.</strong> Absolute path returns instantly. Same root cause as mde#75.</div>
+          <div class="c"><b>Con</b><code>env_cache = true</code> with a 1h TTL means <strong>decrypted secrets are cached to disk</strong> — a new exposure surface, and only visible via <code>mise settings --all</code>.</div>
+          <div class="c"><b>Con</b>Delivery through <code>_.source</code> is <strong>unverified end-to-end</strong> — the probing agent's shell lacked <code>AGE_PRIVATE_KEY</code>, so its test arm could never have passed. Needs a re-run in your real shell.</div>
+        </div>
+      </article>
+
+      <article class="opt">
+        <div class="top"><h3>D · mise-native sops or inline age</h3><span class="chip c-bad">Not now</span></div>
+        <div class="pc">
+          <div class="p"><b>Pro</b>Removes fnox from the shell path entirely and gives per-project scoping structurally, by directory.</div>
+          <div class="c"><b>Con</b>Means re-homing all 50 secrets out of fnox and Doppler into files — the migration you have twice declined, to reach the same place.</div>
+          <div class="c"><b>Con</b>Both paths are flagged <strong>experimental</strong> by mise, and direct age returns the <strong>ciphertext as-is</strong> when decryption fails rather than erroring — a silent wrong-value failure.</div>
+        </div>
+      </article>
+
+      <article class="opt">
+        <div class="top"><h3>E · the <code>mise-env-fnox</code> plugin</h3><span class="chip c-bad">No</span></div>
+        <div class="pc">
+          <div class="c"><b>Con</b>Last code change <strong>2026-02-21</strong>, <strong>0 releases</strong>, 7 open issues, 16 stars. Registered on this host but inert.</div>
+          <div class="c"><b>Con</b>Its own README says: <em>"I am not sure this plugin is a good idea… I would probably advise avoiding this."</em> fnox's docs warn it off too, as an "incomplete experiment". When both authors say no, that is the finding.</div>
+        </div>
+      </article>
+
+    </div>
+  </section>
+
+  <!-- FLOWS -->
+  <section>
+    <div class="head col">
+      <span class="lbl">What actually happens</span>
+      <h2>Shell startup, the two leading options</h2>
+      <p>The difference is not cosmetic — it is where the resolution happens and how often.</p>
+    </div>
+
+    <div class="seq">
+      <h3>A · <code>fnox activate</code> — a hook that re-resolves</h3>
+      <div class="cmd">eval "$(fnox activate zsh)"</div>
+      <div class="seq-inner">
+        <div class="seq-head"><span>you</span><span class="owner">rc fragment</span><span>fnox</span><span>providers</span><span>shell env</span></div>
+        <div class="seq-body">
+          <div class="rails"><i></i><i></i><i></i><i></i><i></i></div>
+          <div class="step"><span class="stepno">1</span><div class="bar r" style="--gc:4/6"><span class="t">emit hook code — no secrets yet</span></div></div>
+          <div class="step"><span class="stepno">2</span><div class="bar r" style="--gc:4/10"><span class="t">_fnox_hook into precmd_functions AND chpwd_functions</span></div></div>
+          <div class="step"><span class="stepno">3</span><div class="bar warn r" style="--gc:6/8"><span class="t">new shell → early exit FAILS → resolve all 50</span></div></div>
+          <div class="step"><span class="stepno">4</span><div class="self" style="--gc:5/7">steady prompt: should_exit_early → 0 bytes, ~2ms</div></div>
+          <div class="step"><span class="stepno">5</span><div class="bar warn r" style="--gc:6/8"><span class="t">every cd → resolve again</span></div></div>
+        </div>
+      </div>
+      <p class="note">Measured warm at <strong>11.78 ms</strong> against a <strong>9.57 ms</strong> bare <code>fnox --version</code> spawn floor — so the steady-state hook costs about 2 ms and is genuinely cheap. The cost lives in steps 3 and 5, which is why a hung provider CLI felt like it wedged "every prompt": it was every new shell and every <code>cd</code>.</p>
+    </div>
+
+    <div class="seq">
+      <h3>B · <code>fnox export</code> — resolve once, then nothing</h3>
+      <div class="cmd">eval "$(fnox export -f shell -P shell --no-defaults)"</div>
+      <div class="seq-inner">
+        <div class="seq-head"><span>you</span><span class="owner">rc fragment</span><span>fnox</span><span>providers</span><span>shell env</span></div>
+        <div class="seq-body">
+          <div class="rails"><i></i><i></i><i></i><i></i><i></i></div>
+          <div class="step"><span class="stepno">1</span><div class="bar r" style="--gc:4/6"><span class="t">export -f shell, scoped profile</span></div></div>
+          <div class="step"><span class="stepno">2</span><div class="bar r" style="--gc:6/8"><span class="t">resolve ONLY the profile's secrets — once</span></div></div>
+          <div class="step"><span class="stepno">3</span><div class="bar ok l" style="--gc:4/8"><span class="t">shell-quoted export lines</span></div></div>
+          <div class="step"><span class="stepno">4</span><div class="bar ok r" style="--gc:4/10"><span class="t">eval → the scoped set is in the shell</span></div></div>
+          <div class="step"><span class="stepno">5</span><div class="self ok" style="--gc:3/5">no hook registered — every later prompt costs zero</div></div>
+        </div>
+      </div>
+      <p class="note">Step 5 is the whole argument. No prompt hook means no per-<code>cd</code> re-resolution, no interaction with mise's hooks, and no path by which a hung provider can touch an already-running shell. The price is step 2 never repeating: a rotated secret needs a new shell.</p>
+    </div>
+  </section>
+
+  <!-- HAZARDS -->
+  <section>
+    <div class="head col">
+      <span class="lbl">Found while measuring</span>
+      <h2>Six hazards, four of them undocumented</h2>
+    </div>
+
+    <div class="tablewrap">
+      <table>
+        <thead><tr><th scope="col">Hazard</th><th scope="col">What happens</th><th scope="col">Status</th></tr></thead>
+        <tbody>
+          <tr><th scope="row"><code>_.source</code> fork bomb</th>
+            <td>A bare <code>fnox</code> inside <code>_.source</code> re-enters via mise's shim. <strong>3,011 processes, load 17.9 → 28.4.</strong> Absolute path returns instantly.</td>
+            <td><span class="chip c-bad">Reproduced</span></td></tr>
+          <tr><th scope="row"><code>activate</code> discards its flags</th>
+            <td><code>-P</code> and <code>--no-defaults</code> are accepted and ignored. <code>diff</code> of activate output with and without them is <strong>identical</strong>; control against <code>--no-hook-env</code> shows a 16-line diff, so the probe discriminates.</td>
+            <td><span class="chip c-bad">Verified</span></td></tr>
+          <tr><th scope="row">Hook ordering</th>
+            <td>fnox <strong>prepends</strong> to <code>precmd_functions</code>, so whichever tool is eval'd <em>last</em> runs <em>first</em>. fnox consults an existing env var before resolving, so mise-set names can win. And mise capturing fnox's exports is where <code>__MISE_DIFF</code>'s payload comes from.</td>
+            <td><span class="chip c-warn">Undocumented</span> control-armed: 0 hits for ordering terms against a working control</td></tr>
+          <tr><th scope="row">mise's unset preamble</th>
+            <td><code>mise activate</code> installs a preamble that will <code>unset</code> all 50 credentials — so ordering is not merely cosmetic.</td>
+            <td><span class="chip c-warn">Source-read</span></td></tr>
+          <tr><th scope="row">mise caches decrypted secrets to disk</th>
+            <td><code>env_cache = true</code>, TTL 1h, visible only via <code>mise settings --all</code>. Any mise-mediated route writes plaintext-equivalent material to disk.</td>
+            <td><span class="chip c-warn">Verified setting</span></td></tr>
+          <tr><th scope="row">age fails open on decrypt</th>
+            <td>mise's direct-age path returns the <strong>ciphertext as-is</strong> when decryption fails, rather than erroring — a consumer gets a wrong value instead of a failure.</td>
+            <td><span class="chip c-warn">Docs-stated</span></td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="callout alarm col">
+      <span class="lbl">A near-miss worth recording</span>
+      <p style="margin:0">The first measurement of mise's global env reported <strong>75 keys including <code>DOPPLER_TOKEN</code> and <code>AGE_PRIVATE_KEY</code></strong> — which would have "proved" mise was already serving your secrets. It was wrong: <code>mise env</code> <strong>echoes the ambient environment</strong>, and those values were inherited from fnox. Sanitised under <code>env -i</code>: <strong>0 of 4</strong>. The first control arm was itself broken, because <code>command -v mise</code> resolves to the shell <em>function</em> rather than the binary. Two layers of probe error, caught before it became a finding.</p>
+    </div>
+  </section>
+
+  <!-- WHO MANAGES THE FILE -->
+  <section>
+    <div class="head col">
+      <span class="lbl">And who manages the fragment itself</span>
+      <h2>mise manages dotfiles — natively, and well</h2>
+      <p><code>mise bootstrap dotfiles</code> is a full dotfile manager driven by a <code>[dotfiles]</code> config section, and it is step 3 of <code>mise bootstrap</code>. So the replacement fragment needs no chezmoi, which matches your earlier ruling that the CLI shouldn't.</p>
+    </div>
+
+    <div class="tablewrap">
+      <table>
+        <thead><tr><th scope="col">Capability</th><th scope="col">What it gives you here</th></tr></thead>
+        <tbody>
+          <tr><th scope="row"><code>mode = "symlink-each"</code></th>
+            <td>Walks a source <em>directory</em> and symlinks each file individually, with <code>exclude</code> globs. Exactly right for <code>~/.zshrc.d/</code> — repo-managed fragments and any unmanaged ones coexist, rather than the repo owning the whole directory.</td></tr>
+          <tr><th scope="row"><code>status --json --missing</code></th>
+            <td><strong>Exits 1 when anything is missing, differs, or its source is gone.</strong> That is a drift detector with a machine-readable output, for free — one of the seams I listed as unowned is natively covered for dotfiles.</td></tr>
+          <tr><th scope="row"><code>block</code> / <code>line</code> edits</th>
+            <td>Manages a marker-delimited block, or ensures a single exact line, inside a file mise does <em>not</em> own. So the <code>eval "$(…)"</code> line can be managed inside <code>~/.zshrc</code> without the repo taking over that file.</td></tr>
+          <tr><th scope="row"><code>apply --dry-run</code> · <code>unapply</code></th>
+            <td>Reversible with a preview. <code>unapply</code> deliberately refuses to remove modified or ambiguous files without <code>--force</code>, so it will not silently discard a hand-edit.</td></tr>
+          <tr><th scope="row"><code>add &lt;target&gt;</code></th>
+            <td>Seeds the source <em>from the live target</em>, so adopting the existing file is one command rather than a copy-and-hope.</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="callout alarm col">
+      <span class="lbl">How I nearly told you this didn't exist</span>
+      <p style="margin:0">My first probe grepped <code>mise --help</code> and the local docs cache, found <code>bootstrap</code>/<code>link</code>/<code>sync</code> and two irrelevant "dotfile" mentions, and concluded there was no such feature. <strong>Both control arms passed</strong> — <code>install</code> → 20 hits, <code>tasks</code> → 187 — so the probes were working. They were simply <em>aimed at the wrong surface</em>: top-level help does not list subcommands, and the docs cache is stale. A control arm proves your probe can see; it says nothing about whether you pointed it at the right thing.</p>
+    </div>
+  </section>
+
+  <!-- RECOMMENDATION -->
+  <section>
+    <div class="head col">
+      <span class="lbl">What I would do</span>
+      <h2>Recommendation</h2>
+    </div>
+    <div class="callout col">
+      <p><strong>Take A first, then B — and manage the file with <code>[dotfiles]</code>.</strong> Relocate <code>fnox activate zsh</code> into a repo-owned <code>~/.zshrc.d/</code> fragment today, declared in <code>[dotfiles]</code> with <code>mode = "symlink-each"</code>, and gate it with <code>mise bootstrap dotfiles status --missing</code>. It retires mde, which is the goal you actually stated, changes nothing about how your machine behaves, and needs no chezmoi.</p>
+      <p style="margin:0">Then move to B once a <code>shell</code> profile has been <em>derived</em> rather than guessed. B is the only option where scoping genuinely works and fails closed, and the only one with no prompt hook at all — but it needs a subset list you do not have yet, and the last time a credential's consumer was assumed instead of measured, the assumption was wrong.</p>
+    </div>
+    <div class="callout col">
+      <span class="lbl">Before B ships, one thing must be measured</span>
+      <p style="margin:0">Which secrets the shell actually needs. <code>reconcile</code>'s code-scan is exactly that measurement, which is an argument for building it before the scoping decision rather than after.</p>
+    </div>
+  </section>
+
+  <footer class="col">
+    Evidence: docs/research/kb/reports/agents/{fnox-shell-activation,mise-shell-activation}.md<br>
+    Measured at fnox 1.32.0 · mise 2026.8.1 · probes in isolated FNOX_CONFIG_DIR fixtures, since deleted<br>
+    Unverified: end-to-end delivery through mise <code>_.source</code> (probing shell lacked AGE_PRIVATE_KEY) · cold-path resolution cost against the live 50-secret config, deliberately not measured
+  </footer>
+
+</div>

--- a/docs/research/kb/decisions/secrets-cli-grilling-2026-08-04b.md
+++ b/docs/research/kb/decisions/secrets-cli-grilling-2026-08-04b.md
@@ -1,0 +1,180 @@
+# Grilling outcome — the secrets CLI, 2026-08-04
+
+Output of `/mattpocock-skills:grilling` against the direction set in
+`docs/specs/secrets-takeover.md` (STATUS 3) and the 2026-08-04 handoff. Six decisions taken,
+each grounded in a measurement made during the session rather than in the inherited record.
+
+**This is a planning artifact.** No code ships from it.
+
+---
+
+## 0. The requirement, in Ray's words
+
+> "Dev projects on the mac having a universal way to crud api keys secrets."
+
+That replaces "takeover" as the north star. Reconcile, scoping and CRUD ownership are all in
+service of it, not ends in themselves.
+
+---
+
+## 1. Decisions
+
+| # | Decision | Status |
+|---|---|---|
+| D1 | **Scoping = additive declaration + reconcile.** A project declares what it additionally needs; the CLI checks the declaration against reality. Scoping buys **zero confinement** — accepted, because confinement is already dead as a goal. | Settled |
+| D2 | **Declarations use fnox's native hierarchy** — committed `fnox.toml`, gitignored `fnox.local.toml`. Reconcile **reports** collisions rather than preventing them. No new declaration format. | Settled, contingent on D5 |
+| D3 | **Storage is the status quo.** Keychain holds exactly `DOPPLER_TOKEN`; Doppler CLI owns CRUD; the other 49 stay Doppler-sourced. | Settled |
+| D4 | **The highest-value verbs are rotate / classify / retire**, not create. See § 3. | Settled |
+| D5 | **"fnox stays" is PROVISIONAL, pending measurement.** Doppler CLI natively covers CRUD, per-directory scoping, an encrypted offline cache and shell env. `/prototype` decides. | Open |
+| D6 | **Language deferred** — and largely pre-decided. Rust's only genuine win is typed in-process `fnox-core`, which is **read-only**; if D5 removes fnox, that argument disappears entirely. | Open, low variance |
+
+## 2. Measurements that drove them
+
+All control-armed. Full working: `.agent/notepad.md`; agent reports under
+`docs/research/kb/reports/agents/`.
+
+### fnox has no subtraction primitive (⇒ D1)
+
+Throwaway project dir + `fnox list --sources`, six arms:
+
+| Arm | from global config | from project file |
+|---|---|---|
+| bare (control) | 50 | 1 |
+| `--no-defaults` | 50 | 1 |
+| `-c ./fnox.toml` | 50 | 1 |
+| `-P bogus` (fail-open, rc=0) | 50 | 1 |
+| `-P bogus --no-defaults` | 0 | 0 |
+| `FNOX_CONFIG_DIR=<empty>` | 0 | 1 |
+
+A project dir sees **51**. `--no-defaults` governs profile-vs-top-level merge, **not** the global
+config. Confirmed independently by fnox's own docs: *"Global config is always loaded, even when
+`root = true` … or `-c/--config` points at an explicit file"* (`guide/hierarchical-config.md:167`).
+
+### Overriding is designed, silent, and undiagnosable (⇒ D2)
+
+A project declaration **replaces** the global entry of the same name: 49 global + 1 local on
+collision vs 50 + 1 on the control, `rc=0`, **stderr 0 bytes**. There is no override-warning
+setting anywhere (`warn` → 5 hits in the config reference, all five `if_missing`; control
+`provider` → 73). Introspection is after-the-fact only: `fnox config-files`, `fnox list --sources`.
+
+This supersedes codex adversarial review finding **H1** (2026-04-08, quoted in
+`../macos-development-environment/fnox.toml`), which read designed behaviour as a defect. H1 is
+right about the mechanics and wrong about the verdict; its residual concern — a *committed* file
+silently repointing a *personal* global token — is answered by fnox's own committed/local split.
+
+### `fnox sync -p keychain` cannot be built (⇒ D3)
+
+`sync` re-encrypts with a **local encryption provider** and writes a `sync` field into the TOML
+(`config.rs:263`), not into a keystore. Targets must declare `ProviderCapability::Encryption` —
+exactly `age`, `yubikey`, `fido2`, `aws_kms`, `azure_kms`, `gcp_kms`, `plain`. Keychain declares
+only `RemoteStorage` (`keychain.rs:100-102`) and has no `encrypt()` override, so it falls to the
+trait default `Err("This provider does not support encryption")` (`mod.rs:195-200`; control:
+`age.rs:145` does declare it).
+
+Doppler cannot do it either, and structurally: `keychain` → **0** hits across
+`docs.doppler.com/llms.txt` (control `sync` → 24) and **0** across the whole CLI help tree
+(control `secrets` → 3). Its two sync families are *server-side push to a cloud endpoint* and
+*pull-based DIY syncs "with the Doppler CLI"* — neither can address a laptop keystore.
+
+Writing all 50 to the keychain **is** possible (`keychain.rs:188` `put_secret`) and was rejected
+on cost: 50 keychain reads per shell prompt and 50 ACL grants to re-apply on every fnox bump
+(`installs/fnox/latest` is a symlink → `./1.32.0`; five versions on disk since April), guarding the
+failure that produced **190 stuck processes** on 2026-08-02 — while buying ~no secrecy, because
+all 50 are already in every process by design under `env = true`.
+
+### fnox's unique feature is inert on this Mac (⇒ D5)
+
+Doppler CLI v3.76.1 natively provides CRUD, `--scope <dir>` per-directory config, an encrypted
+offline cache (`--fallback`, `--offline`, `--passphrase` — a functional equivalent of
+`fnox sync -p age`), child injection (`doppler run`), and shell-eval-able env
+(`secrets download --no-file --format env`).
+
+The one thing it lacks is an automatic chpwd/precmd hook. But **zero** project `fnox.toml` files
+exist in `dotfiles` or `knowledge-base`, the only one (mde's) declares no secrets, and
+`~/.doppler/.doppler.yaml` holds exactly **one** scope — `/`. No directory on this machine
+resolves a different secret set.
+
+Stated fairly, fnox *is* buying one real thing: `DOPPLER_TOKEN` sits in a keychain item with the
+fnox binary on its ACL, and the native `doppler login` item is the one that hung forever from
+background processes and was deleted on 2026-08-02. Any fnox-less design must re-solve that.
+
+### Rust buys read-only access (⇒ D6)
+
+`fnox-core` has **no `[lib]` section** ⇒ default `rlib` ⇒ Rust-only. `crate-type`, `cdylib`,
+`staticlib`, `no_mangle`, `wasm-bindgen`, `napi`, `uniffi`, `neon`, `cbindgen`, `pyo3` → **0 each**
+(control: `clap` 56, `async_trait` 68, `rmcp` 13). The 26 `extern "C"` are inbound libusb types.
+
+The public `Fnox` API is `discover / open / with_profile(s) / with_no_defaults / profile / config /
+get / list` — **no `set`**, by design; writes live in the binary's unpublished `commands` module.
+`fnox mcp` offers strictly fewer verbs than shelling out (stdio, tools-only, exactly `get_secret`
+and `exec`). Meanwhile `usage` — the jdx CLI generator — works for a **non-Rust** CLI, yielding
+completions for 5 shells, markdown docs, man pages, JSON and typed SDKs from hand-written KDL.
+
+## 3. Why rotate / classify / retire beat create (⇒ D4)
+
+From the consumption sweep (28 repos enumerated, 162 `.mcp.json`, `~/.claude.json`, `~/.config/`):
+
+**CONSUMED 25 · AMBIENT 4 · ALIAS 4 · ORPHAN 17.**
+
+- **Rotate** — one GitHub PAT lives under **four names**, and they are not aliases: mise documents
+  a *precedence chain* (`MISE_GITHUB_TOKEN` → `GITHUB_API_TOKEN` → `GITHUB_TOKEN`), plus
+  `GITHUB_MCP_PAT`. Rotating it today is four coordinated edits. There is **no documented rotate
+  procedure at all**, and a running fnox daemon serves the rotated-away value until idle timeout.
+- **Classify** — **19 of 50 are not secrets** (regions, buckets, endpoints, protocols, usernames,
+  handles, client IDs, booleans). `.claude/rules/secrets-out-of-the-shell-env.md` rule 3 forbids
+  this: value-based redaction means a short or empty "secret" corrupts every log the tool writes.
+- **Retire** — **17 orphans, 14 of them one dead project**: an S3-backed
+  Grafana/Loki/Mimir/Tempo/OpenLIT stack plus a NextAuth app. The surviving observability compose
+  uses local storage and reads only `GRAFANA_PASSWORD`. There is **no documented delete procedure**
+  either, and fnox is **CRU** — the `Provider` trait has no delete method at all.
+
+By contrast **create** is a documented 9-step runbook across four systems
+(`docs/secrets-doppler-fnox-keychain.md:347-397`), of which `mde-secret-add` already automates
+steps 3–7 — everything except `doctor.toml`.
+
+### One design already refuted before being built
+
+Only **1 of 50** secrets is interpolated into an MCP config; the other 49 arrive by **environment
+inheritance**. So a reconcile code-scan that greps for `${VAR}` would report **~49 false orphans**.
+The project-scope↔code seam needs a different mechanism than the spec assumed.
+
+## 4. What `/prototype` must settle
+
+1. `mise bootstrap dotfiles` — `symlink-each` against a fixture; does `status --json --missing`
+   really exit 1 on missing / differs / source-gone?
+2. `eval "$(fnox export -f shell -P shell --no-defaults)"` against a **real** declared profile —
+   zero `[profiles.*]` exist today, so one must be declared first.
+3. The cleartext-write defect — `fnox set … --provider doppler` in a throwaway `FNOX_CONFIG_DIR`,
+   both arms.
+4. **fnox-full vs fnox-less** — time `eval "$(doppler secrets download --no-file --format env
+   --fallback <enc>)"` cold and warm against the current fnox path, and confirm the
+   `DOPPLER_TOKEN` keychain-ACL story survives without fnox. **This decides D5, and D6 follows.**
+
+All four are safe with `FNOX_CONFIG_DIR` isolation and fake secrets. **Never print a value** —
+compare `value == name`.
+
+## 5. Probe corrections made during this session
+
+Recorded because each is a reusable trap, not to flagellate.
+
+- **A path-spelling bound produced a false negative.** The `-c ./fnox.toml` arm first read
+  `local=0` because the grep searched `q1-scope/fnox.toml` while fnox printed
+  `q1-scope/./fnox.toml` — the flag's `./` is embedded verbatim in the source column.
+- **A probe aimed at a directory with no source in it.** The first keychain-`encrypt()` check ran
+  against a scratch dir containing no fnox tree; its `age.rs` **control arm returned empty**, which
+  is the only reason it was caught. Re-run against the real clone: same verdict, right reason.
+- Agents caught three of their own: a lockfile `awk … {print; exit}` reporting the first of several
+  majors; `gh repo list --limit 200` returning exactly 200 against a true **623**; and a crates.io
+  sweep printing empty for all 9 crates due to a broken parser, with no control arm passed.
+- The consumption agent **refuted the belief it was handed** — "`MISE_GITHUB_TOKEN` and
+  `GITHUB_API_TOKEN` are aliases of `GITHUB_TOKEN`" is wrong as stated; they are three distinct
+  variables in a documented precedence chain.
+
+## GitHub repos touched
+
+- [jdx/fnox](https://github.com/jdx/fnox) — provider traits, `library.rs`, `mcp_server.rs`, config model, docs
+- [jdx/mise](https://github.com/jdx/mise) — GitHub-token precedence chain; crate stack comparison
+- [jdx/hk](https://github.com/jdx/hk) — crate stack comparison
+- [jdx/usage](https://github.com/jdx/usage) — CLI spec generator; non-Rust viability
+- [jdx/xx](https://github.com/jdx/xx) — jdx-owned utility crate in the shared stack
+- [DopplerHQ/cli](https://github.com/DopplerHQ/cli) — `run` / `secrets download` / `configure` surfaces (v3.76.1)

--- a/docs/research/kb/decisions/secrets-cli-grilling-2026-08-04b.md
+++ b/docs/research/kb/decisions/secrets-cli-grilling-2026-08-04b.md
@@ -22,18 +22,25 @@ service of it, not ends in themselves.
 | # | Decision | Status |
 |---|---|---|
 | D1 | **Scoping = additive declaration + reconcile.** A project declares what it additionally needs; the CLI checks the declaration against reality. Scoping buys **zero confinement** — accepted, because confinement is already dead as a goal. | Settled |
-| D2 | **Declarations use fnox's native hierarchy** — committed `fnox.toml`, gitignored `fnox.local.toml`. Reconcile **reports** collisions rather than preventing them. No new declaration format. | Settled, contingent on D5 |
+| D2 | ~~Declarations use fnox's native hierarchy~~ → **VOIDED BY D5.** The mechanism it chose (committed `fnox.toml` + gitignored `fnox.local.toml`) leaves with fnox. Its *intent* survives — a project records what it needs and reconcile reports drift — and its new home is `doppler setup --scope` plus whatever the CLI declares. **Re-decide in `/to-spec`.** | **Superseded** |
 | D3 | **Storage is the status quo.** Keychain holds exactly `DOPPLER_TOKEN`; Doppler CLI owns CRUD; the other 49 stay Doppler-sourced. | Settled |
 | D4 | **The highest-value verbs are rotate / classify / retire**, not create. See § 3. | Settled |
-| D5 | **"fnox stays" is PROVISIONAL, pending measurement.** Doppler CLI natively covers CRUD, per-directory scoping, an encrypted offline cache and shell env. `/prototype` decides. | Open |
-| D6 | **Language deferred** — and largely pre-decided. Rust's only genuine win is typed in-process `fnox-core`, which is **read-only**; if D5 removes fnox, that argument disappears entirely. | Open, low variance |
+| D5 | ~~"fnox stays" is PROVISIONAL~~ → **RESOLVED 2026-08-04: DROP FNOX.** The stack becomes **Doppler + macOS keychain**. See § 6. | **Settled** |
+| D6 | **Language deferred** — and largely pre-decided. Rust's only genuine win is typed in-process `fnox-core`, which is **read-only**; D5 removed fnox, so that argument is now moot entirely. | Open, near-zero variance |
 
 ## 2. Measurements that drove them
 
 All control-armed. Full working: `.agent/notepad.md`; agent reports under
 `docs/research/kb/reports/agents/`.
 
-### fnox has no subtraction primitive (⇒ D1)
+### fnox has no subtraction primitive (⇒ D1) — ⚠️ CORRECTED, see § 6
+
+> **This heading is wrong and is kept for the record.** `/prototype` claim 2 measured the opposite
+> against a fixture with a **real declared profile**: `-P shell --no-defaults` yields exactly the
+> profile's 2 secrets out of 52. The six arms below were run with **no profile declared** — and
+> zero `[profiles.*]` exist on this host — so the only outcome they could show was the degenerate
+> 0. fnox **has** a subtraction primitive; it is **profile-selected, not directory-selected**,
+> which is what D1 was actually about. D1 stands; this reason was too strong.
 
 Throwaway project dir + `fnox list --sources`, six arms:
 
@@ -178,3 +185,75 @@ Recorded because each is a reusable trap, not to flagellate.
 - [jdx/usage](https://github.com/jdx/usage) — CLI spec generator; non-Rust viability
 - [jdx/xx](https://github.com/jdx/xx) — jdx-owned utility crate in the shared stack
 - [DopplerHQ/cli](https://github.com/DopplerHQ/cli) — `run` / `secrets download` / `configure` surfaces (v3.76.1)
+
+---
+
+# 6. `/prototype` outcome — D5 RESOLVED: drop fnox (2026-08-04)
+
+Full harness, every arm and every control: branch **`prototype/secrets-cli-claims`**
+(`fce4a80`, `6a27014`, `719c175`), file `prototype/RESULTS.md`. Kept off this branch on purpose —
+throwaway code as a primary source, per the prototype skill's capture step.
+
+**Ray's decision: the stack becomes Doppler + macOS keychain.** This reverses the 2026-08-04
+"fnox stays" ruling, on measurement rather than argument.
+
+## What was measured
+
+| Question | Result |
+|---|---|
+| Does every terminal still get the secrets fnox-less? | **Yes — 49 of 50 in a clean shell, 0.117s offline.** Controls: empty env → 0, token-only → 1 |
+| The 50th? | `DOPPLER_TOKEN` itself — the bootstrap, from the keychain, not from Doppler |
+| Cost shape | fnox `hook-env` ~0.009s on **every prompt**; fnox-less ~0.117s **once per shell** |
+| Is the keychain ACL a one-time approval? | **Yes, and automatable — at CREATION only.** Creator is implicitly trusted; `-T /usr/bin/security` and `-A` both read with no prompt; an item trusting only the fnox binary **TIMEOUTs at 8s** behind a GUI dialog |
+| Can an existing ACL be amended non-interactively? | **No.** `set-generic-password-partition-list` prompts for the login keychain password; `-k` is deprecated and leaks it into argv ⇒ migrate by **delete-and-recreate** |
+| Per-project scoping without fnox? | **Yes.** `doppler setup --scope` is genuinely directory-bound — succeeds inside, fails outside, fails before setup |
+| Does `doppler setup` persist the token? | **No.** Key absent, length 0, while `DOPPLER_TOKEN` *was* set in the caller — so it could have |
+
+## Why this beats the incumbent, per axis
+
+- **Durability.** `-T` binds a binary PATH. fnox's is version-pinned (`installs/fnox/1.32.0/fnox`,
+  five versions since April) so its ACL breaks on every upgrade. **`/usr/bin/security` is
+  OS-stable** — an ACL granted to it never breaks.
+- **Scoping.** `doppler setup --scope` is directory-bound. fnox's `[profiles.*]` subtraction is
+  real (measured: `-P shell --no-defaults` → exactly 2 of 52) but **profile-selected, not
+  directory-selected**, and **zero profiles are declared** on this host.
+- **Simplicity.** Four moving parts (Doppler + fnox + age + keychain) become two. The CLI's write
+  path drops from **4 systems to 2**, which was most of its complexity.
+- **Churn.** The 49-ciphertext re-encrypt on every add/remove disappears with the age cache;
+  Doppler's `--fallback` is per-fetch.
+
+## What is given up, stated plainly
+
+22 unused providers; the age `sync` cache (replaced by Doppler `--fallback`); and profile
+subtraction. The CLI, not fnox, now owns local-cache correctness.
+
+## Carried forward as work
+
+- **The migration is delete-and-recreate** of the `mde-fnox` `DOPPLER_TOKEN` keychain item with
+  `-T /usr/bin/security`, plus a `doppler setup --scope` per project. Both scripted, no password
+  prompts. ⚠️ Register scopes with **resolved** paths — macOS `/var` is a symlink to
+  `/private/var`, and an unresolved scope silently never matches.
+- **Upstream defect to report** (claim 3): `fnox set --provider <doppler>` returns rc=0 and writes
+  the **plaintext value** into the config rather than writing through or refusing. Control arm
+  `age` writes ciphertext. `jdx/fnox` has Issues disabled ⇒ PR or discussion.
+- **D1's stated reason was too strong** — fnox *does* have a subtraction primitive; it is
+  profile-selected, not directory-selected. The decision stands, the justification is corrected.
+- **`mise bootstrap dotfiles` is confirmed usable** (claim 1): `symlink-each` applies and
+  `status --json --missing` exits 1 on missing, differs, dangling-symlink and source-dir-gone.
+
+## Probe discipline — five broken probes, all caught by their own controls
+
+Recorded because the hit rate is the point: a fixture that can only produce one answer is the
+default failure mode, not an unusual one.
+
+1. A grep bounded by **path spelling** (`q1-scope/fnox.toml` vs the printed `q1-scope/./fnox.toml`).
+2. A probe aimed at a **directory containing no source** — caught only because its control arm
+   returned empty.
+3. A `[dotfiles]` fixture whose keys mise rejected, leaving "no dotfiles configured" ⇒ **every arm
+   returned rc=0**; and a later one that removed source *and* target, which nearly shipped as a
+   mise defect that was not one.
+4. A claim-3 control (`plain`) that is **itself a cleartext store**, so both arms leaked and the
+   probe discriminated nothing.
+5. `zsh -f` **inherits the environment**, so a do-nothing control reported **47 of 50 set**; and a
+   `doppler secrets --only-names` parse reported 0 names while a download in the same run returned
+   49. Both discarded rather than published.

--- a/docs/research/kb/reports/agents/fnox-export-exec.md
+++ b/docs/research/kb/reports/agents/fnox-export-exec.md
@@ -1,0 +1,446 @@
+# fnox export / exec / activate surface + refusal semantics
+
+**Agent:** fnox-export-exec · **Date:** 2026-08-03 · **Local version:** fnox 1.32.0
+**Status:** COMPLETE.
+
+## TL;DR for the entrypoint decision
+
+1. **Profile selection is unverifiable at the call site.** An unknown or invalid
+   `-P` silently yields the top-level secret set at rc=0 — **always**, not only
+   when no profiles are declared (source + live positive control, Q4a). No
+   strictness flag covers it; `--if-missing error` and `fnox check` both return
+   0 on a typo'd profile. **A caller must validate against `fnox profiles`.**
+2. **Default resolution policy is fail-open** (`if_missing = "warn"`): an
+   unreachable provider or a deleted remote value ⇒ warning, rc=0, variable
+   unset. Set `--if-missing error` (or top-level `if_missing = "error"`) or the
+   entrypoint cannot tell "resolved" from "skipped".
+3. **`fnox export -f env|shell|json|yaml|toml` is the machine-readable surface**
+   (`--all` needed for `env=false`/`"exec"` secrets). There is **no `fnox env`**.
+4. **mise integration exists but upstream says don't use it** — the recommended
+   channels are shell inheritance via `activate`, or `fnox exec` inside a task.
+   No `_.file` output is documented.
+5. **No redaction on `exec`/`export` output** — redaction is MCP-, proxy-,
+   `ci-redact`- and `scan`-scoped only. No mise-style `--redacted`.
+6. **The daemon cache does not invalidate on remote rotation** — only on config/
+   env change, `daemon clear`/`stop`, or idle timeout (default example: 8h).
+
+
+Primary sources: `github.com/jdx/fnox` (source + `docs/` + CHANGELOG), local
+`fnox <cmd> --help` (authoritative for 1.32.0), `https://fnox.jdx.dev/**`.
+
+⚠️ No `fnox get` was ever run. No secret value printed. The user's real
+`~/.config/fnox/config.toml` was not modified.
+
+---
+
+## Q1. The export surface
+
+**There is no `fnox env` subcommand.** `fnox env --help` → `error: unrecognized
+subcommand 'env'`, rc=2 (local 1.32.0). The four surfaces are:
+
+| Command | What it does |
+|---|---|
+| `fnox activate [SHELL]` | *Prints* shell activation code (bash/zsh/fish/nu/pwsh) to stdout; you `eval` it. Does not itself load secrets. |
+| `fnox exec [-- CMD]` | Resolves secrets, injects as env vars, spawns CMD. `--replace` execs in fnox's own PID (signals, no leases, drops ambient `FNOX_AGE_KEY`/`FNOX_AGE_KEY_FILE`). |
+| `fnox export -f <fmt>` | **The machine-readable surface.** `--format env\|shell\|json\|yaml\|toml`, `-o FILE`, `--header`, `--all`, `-n/--dry-run`. |
+| `fnox proxy {rules,run}` | Destination-scoped credential brokering (Q3). |
+| `fnox hook-env` | Internal command the activate hooks call; `-s/--shell`. |
+
+`export` **is** a dotenv/JSON emitter: `-f env` gives `KEY=value`, `-f shell`
+gives `export KEY=value`, plus `json`/`yaml`/`toml` — any of which another tool
+can consume. ⚠️ `--all` is needed to include `env = false` / `env = "exec"`
+secrets, which are **excluded by default** (`fnox export --help`, 1.32.0).
+
+### What `activate` installs
+
+Source: `src/shell/zsh.rs:7-72`. `fnox activate zsh` emits, to stdout:
+
+1. `export FNOX_SHELL=zsh`
+2. A **`fnox()` shell function** wrapping the real binary. It exists so that
+   `fnox deactivate` and `fnox shell` are `eval`'d rather than run in a child
+   (`zsh.rs:26-28`); every other subcommand is exec'd plainly. ✅ Verified live
+   on this host — `type fnox` returns exactly this function, so activation is
+   in effect in this shell.
+3. `_fnox_hook()` → `eval "$(<exe> hook-env -s zsh)"`, wrapped in
+   `trap -- '' SIGINT` / `trap - SIGINT` (`zsh.rs:41-47`).
+4. Registration of `_fnox_hook` into **both** `precmd_functions` **and**
+   `chpwd_functions` (`zsh.rs:50-69`), each guarded against double-insert.
+
+⚠️ **`precmd` means the hook runs before EVERY PROMPT, not only on `cd`.** This
+is the mechanism behind the already-recorded incident that a hung `doppler` CLI
+wedges every shell prompt (`secrets-out-of-the-shell-env.md`): `hook-env` is on
+the interactive critical path, and `--if-missing`/provider latency is paid there.
+`--no-hook-env` suppresses items 3-4 (leaving only the wrapper) — it is
+documented "for testing".
+
+`deactivate` emits the inverse: it filters `_fnox_hook` out of both arrays
+(`zsh.rs:76-80`).
+
+## Q2. How mise would consume fnox
+
+⚠️ **Correction to the brief's premise.** fnox's side documents a *real* mise
+env plugin — it is not "no integration", it is an integration fnox tells you not
+to use. `docs/guide/mise-integration.md:7-11`:
+
+> ::: warning Experimental plugin
+> We do not recommend using fnox through the
+> [`jdx/mise-env-fnox`](https://github.com/jdx/mise-env-fnox) env plugin. It is
+> an incomplete experiment and does not track every fnox feature.
+
+The plugin wires in as `[env] _.fnox-env = { tools = true, profile = "..." }`
+(`mise-integration.md:61-63`), i.e. a mise **env plugin**, *not* `_.file`. It
+requires `tools = true` so it runs after mise puts the fnox binary on PATH
+(`:65-68`). Its own feature table concedes "Full fnox feature support: **No**"
+(`:183`).
+
+**The recommended channels are exactly two** (`mise-integration.md:3-5`, `:185`):
+
+1. **Shell integration** — `eval "$(fnox activate bash)"`; mise picks the vars up
+   as ordinary inherited shell vars. This is the shell-inheritance channel.
+2. **`fnox exec` inside a mise task** — `run = "fnox exec -- npm run dev"`
+   (`:36-41`). fnox keeps resolution, "so options such as `env = false`,
+   `as_file`, leases, profiles ... all work the same" (`:43-45`).
+
+There is **no `_.file`-compatible output documented for mise**. `fnox export -f
+env` produces a dotenv file that mise's `[env] _.file` could read, but nothing in
+fnox's docs proposes that pairing, and it would write plaintext secrets to disk.
+
+**Control arm (required by `probes-need-a-control-arm.md`):** the same grep
+method that returned the `_.file` absence returns hits for a term known present.
+
+```
+$ grep -rn '_\.file' docs/ src/ crates/     → 0 hits
+$ grep -rln 'mise'    docs/ src/ crates/    → 15 files   (control: discriminates)
+$ grep -rn '_\.fnox-env' docs/              → 7 hits     (control: the plugin form IS found)
+```
+
+So the `_.file` zero is a real negative, not a blind probe.
+
+## Q3. `fnox proxy`
+
+Source: `docs/guide/proxy.md`, `src/proxy.rs`. Two subcommands: `proxy rules`
+(show effective rules, **without resolving secrets** — `proxy.md:37-41`) and
+`proxy run -- CMD`.
+
+**Design intent** (`proxy.md:3-8`): the child gets *placeholders*, never real
+values; fnox substitutes the real credential only into approved HTTPS requests.
+Aimed explicitly at "AI agents and other untrusted or highly automated programs".
+
+`[[proxy.rules]]` fields (`proxy.md:25-31`): `secret`, `domain`, `header`,
+`methods`, `paths` (glob), optional `placeholder` (else a unique per-session one
+is generated — useful when an SDK validates credential format, `:34-35`).
+Rules "refer to secrets in the active profile" (`:12`) — so **Q4(a)'s silent
+profile fallback applies to the proxy's rule resolution too.**
+
+**Runtime sequence** (`proxy.md:51-63`), verbatim shape:
+
+1. Resolve secrets referenced by proxy rules + the provider auth secrets they
+   depend on.
+2. Start a **loopback-only HTTPS (CONNECT) proxy with an ephemeral CA**.
+3. Pass placeholders + standard proxy/CA env vars to the child.
+4. Verify upstream TLS, substitute a placeholder **only** when domain, method,
+   path **and** header all match.
+5. Replace reflected secret values in response headers/bodies with placeholders
+   (`src/proxy.rs:875-884` `redact_values`/`redact_string`/`redact_bytes`).
+6. Stop the proxy and delete the public CA file on child exit.
+
+CA private key and real values stay in fnox process memory (`:65`).
+
+**Egress modes** (`:67-80`): `egress = "strict"` is the **default** — destinations
+with no rule are **rejected**. `"permissive"` tunnels unmatched destinations
+without inspection or injection. Strict is recommended for agents.
+
+⚠️ **Documented limits** (`:82-93`) that decide whether this is usable as an
+entrypoint: header-only substitution; `http://` rejected; matched destinations
+must be **HTTPS on port 443**; HTTP/1.1 only; **chunked request bodies rejected**
+(`Content-Length` required); 10 MiB request/response cap; **domains are exact —
+no wildcards**; client must honor standard proxy/CA env vars.
+
+⚠️ **Stated non-guarantee** (`:101-105`): "The proxy is **not yet an
+operating-system sandbox**. A determined process running as the same user may
+bypass proxy environment variables, read accessible fnox configuration or
+provider state, or **invoke fnox directly**." Upstream's own advice is to run
+untrusted agents in a container/VM. Under this repo's `env = true` posture the
+parent shell already holds all 50 credentials, so the proxy confines nothing it
+inherits — it is only meaningful for a child launched from a *clean* env.
+
+Auditing (`audit = true`) logs method, domain, path and injected secret **names**
+through fnox tracing, and "never logs request headers, bodies, or secret values"
+(`:107-108`).
+
+**UNVERIFIED:** no live request was made through the proxy in this run either —
+I did not start `proxy run`, since doing so would resolve real credentials into
+a live broker on this host. The above is design-from-source/docs, as briefed.
+
+## Q4. Refusal semantics per command
+
+### (a) Unknown profile → SILENTLY IGNORED, ALWAYS. Root cause found.
+
+The prior session's measurement (`fnox exec -P <nonexistent>` → 50 secrets,
+rc=0, zero stderr) is **fully explained by source, and the answer is the worse
+of the two options the brief posed: the profile flag is ignored ALWAYS, not
+merely when no profiles are declared.**
+
+`crates/fnox-core/src/config.rs:1440-1444` — the entire profile overlay:
+
+```rust
+for profile in profiles.iter().filter(|p| *p != "default") {
+    if let Some(profile_config) = self.profiles.get(profile) {
+        secrets.extend(profile_config.secrets.clone());
+    }
+}
+```
+
+`self.profiles.get(profile)` returns `None` for an unknown name, the `if let`
+does not fire, and **there is no `else` branch** — no error, no warning, no
+counter. The loop is unconditional over whatever names were passed; whether or
+not *other* profiles are declared is never consulted. The base map was already
+set at `:1434-1438` to `self.secrets.clone()` (the top-level secrets), because
+`no_defaults` is false by default. Hence: full top-level set, zero overlay, rc=0.
+
+This is **structural, not a config artifact of this host.** A typo'd `-P`
+(`prodution`, `dev_personal` vs `dev-personal`) silently yields the top-level
+secret set on every command that takes `-P`.
+
+Two further silent degradations on the same path:
+
+- **Invalid profile names are dropped, then the list falls back to `default`.**
+  `normalize_profiles` (`config.rs:1335-1347`) filters on
+  `env::is_valid_profile_name` and then: `if profiles.is_empty() { vec!["default"] }`.
+  So `-P 'bad/name'` → the name is discarded → active profile becomes `default`.
+  No diagnostic.
+- **`--no-defaults` changes the failure shape, not the refusal.** With
+  `no_defaults` + a non-default profile, the base map starts empty
+  (`:1434-1438`), so an unknown profile yields **zero** secrets — still rc=0,
+  still silent. Safer (no wrong secrets) but equally unannounced.
+
+**No command validates profile existence anywhere in the codebase.** There is no
+`UnknownProfile` variant in `crates/fnox-core/src/error.rs` (its profile-related
+errors at `:123-235` are all *secret*- or *provider*-not-found-**in**-a-profile,
+which presuppose the profile). Control-armed grep:
+
+```
+$ grep -rn "Unknown profile|profile not found|UnknownProfile" src/ crates/   → 0 relevant hits
+$ grep -rn "Multiple profiles are active" src/ crates/                       → 1  (control: config.rs:1377, discriminates)
+```
+
+The only profile-shaped refusal in the whole tree is the **write** path:
+`resolve_write_profile` (`config.rs:1363-1381`) errors on an invalid
+`--write-profile` name or on multiple active profiles without one. Read paths
+(`exec`, `export`, `activate`/`hook-env`, `proxy`) have no equivalent.
+
+⇒ **For a fnox-only entrypoint this is the primary unsafe-failure surface:
+profile selection is unverifiable at the call site.** The only way to detect a
+typo'd profile is to compare the resolved *name set* against an expectation
+(`fnox list -P <p>` names, or `fnox profiles` for what is declared) — fnox will
+never tell you.
+
+### (b) Unreachable provider / (c) declared secret whose remote value is missing
+
+Governed by **`if_missing`, whose default is `warn` — i.e. continue, rc=0.**
+`docs/guide/missing-secrets.md:6-9`:
+
+> - **`error`** - Fail the command if a secret cannot be resolved (strictest)
+> - **`warn`** - Print a warning and continue (default)
+> - **`ignore`** - Silently skip missing secrets
+
+Precedence, highest first (`missing-secrets.md:11-20`): CLI `--if-missing` →
+`FNOX_IF_MISSING` → per-secret `if_missing` → top-level config `if_missing` →
+`FNOX_IF_MISSING_DEFAULT` → built-in `warn`.
+
+⚠️ **The default is fail-open for every read command.** A provider that is down,
+or a secret deleted upstream, produces a stderr warning and a **successful exit
+with that variable absent** — the consumer then sees an unset var, which is the
+"anonymous tier" trap already recorded in `secrets-out-of-the-shell-env.md`
+rule 5. A fnox-only entrypoint that does not pass `--if-missing error` (or set
+`if_missing = "error"` top-level) cannot distinguish "resolved" from "skipped".
+
+`--if-missing` is a **global** flag present on `exec`, `export`, `activate`,
+`hook-env`, `ci-redact` and `proxy` alike (verified in each `--help`, 1.32.0),
+so the strict mode is available uniformly.
+
+**An unreachable provider is governed by the same chain, not by a separate
+error path.** `handle_provider_error` (`secret_resolver.rs:348-379`) takes the
+resolved `IfMissing` and returns `Some(err)` only for `Error`; `Warn` logs and
+returns `None`, `Ignore` returns `None` silently. It is called on the provider
+failure paths at `:1119` and `:1157`. So "provider down" and "secret absent"
+collapse into one policy — **default `warn` ⇒ continue, rc=0, variable unset.**
+
+### Live probe (fixture-armed, control-armed) — 1.32.0 on this host
+
+Isolated fixture in a scratchpad dir, `provider = "plain"`. ⚠️ **First fixture
+was rigged** — I declared `provider = "plain"` without a `[providers.plain]`
+block, so both canaries silently vanished and every arm returned the same 50
+names. Rebuilt with the provider declared. (The failed fixture was itself an
+unplanned live demo of (b): *"Provider 'plain' not configured in profile
+'default'"* → **WARN, rc=0**.) `fnox config-files` confirms both the fixture and
+the user's global `~/.config/fnox/config.toml` load — hence the +50 baseline.
+Only NAMES and counts were ever printed; no value, no `fnox get`.
+
+**Arm A — profile handling.** The fixture declares a real profile (`real`), so
+it *can* distinguish "flag ignored always" from "flag ignored when no profiles
+exist":
+
+| Invocation | rc | names | canaries |
+|---|---|---|---|
+| `export` (baseline) | 0 | 51 | `TOPLEVEL_CANARY` |
+| `export -P real` **← positive control** | 0 | **52** | `TOPLEVEL_CANARY REAL_CANARY` |
+| `export -P nope` | **0** | 51 | `TOPLEVEL_CANARY` only |
+| `export -P real,nope` | 0 | 52 | both (unknown name in a stack is dropped) |
+| `export -P nope --no-defaults` | **0** | **0** | none |
+| `export -P 'bad/name'` | **0** | 51 | falls back to `default` |
+
+The positive control proves `-P` works when the profile exists ⇒ the `-P nope`
+result is a real silent fallback, not a dead flag.
+**⇒ The profile flag is ignored ALWAYS, exactly as the source predicts — not
+merely when no profiles are declared.** Source and probe agree.
+
+**Arm B — `if_missing`, both directions:**
+
+| Invocation | rc | names | stderr lines |
+|---|---|---|---|
+| `export` (default) | 0 | 51 | 2 |
+| `export --if-missing warn` | 0 | 51 | 2 (identical to default ⇒ default *is* `warn`) |
+| `export --if-missing ignore` | 0 | 51 | **0** |
+| `export --if-missing error` | **1** | 0 | 12 |
+| `exec --if-missing error -- true` | **1** | — | — |
+| `exec -- true` (default) | **0** | — | — |
+
+Both directions fire ⇒ the probe discriminates.
+
+### ⚠️ The composite finding: strict mode does NOT cover the profile gap
+
+| Invocation | rc |
+|---|---|
+| `export -P real --if-missing error` | 0 (52 names) |
+| **`export -P nope --if-missing error`** | **0** (51 names) |
+| `check -P real` | 0 |
+| **`check -P nope`** | **0** |
+
+**`--if-missing error` cannot catch a typo'd profile, and neither can `fnox
+check`.** The mechanism is exactly the source: an unknown profile's secrets are
+never *added* to the map, so there is nothing "missing" for the policy to judge —
+the two failure modes are orthogonal, and fnox ships a lever for only one.
+
+**The only detector is `fnox profiles`**, which enumerates declared profiles with
+counts (`default (51 secrets)` / `real (52 secrets)` in the fixture). A
+fnox-only entrypoint must validate its profile name against that list itself —
+**this is the one guard rail a caller has to build, because fnox has none.**
+
+## Q5. Redaction — **there is NO `--redacted` equivalent to mise's**
+
+Redaction in fnox 1.32.0 exists in exactly **four** places, none of which covers
+`exec`/`export`/`get` output:
+
+| Site | Scope |
+|---|---|
+| `src/mcp_server.rs:510-543` | `fnox mcp`'s `exec` tool: replaces secret values with `[REDACTED]` in the child's stdout/stderr before returning to the agent. Aho-Corasick, longest-match-wins, skips empty/short values, and **refuses to return output at all if the filter fails to build** (`:537`). Default **on** (`config.rs:489-491`, `redact_output.unwrap_or(true)`). |
+| `src/proxy.rs:875-884` | Proxy step 5: replaces *reflected* secret values in upstream response headers/bodies with placeholders. |
+| `src/commands/ci_redact.rs` | `fnox ci-redact` — emits **GitHub Actions `::add-mask::`** directives so the CI runner masks values in logs. Errors on a secret containing newlines, which "cannot be fully redacted in CI logs" (`:35`). |
+| `src/commands/scan.rs:76,294` | `fnox scan`'s findings carry a `redacted` rendering of each match. |
+
+**Control-armed grep** (my first attempt used a broken control that also returned
+0; redone):
+
+```
+$ grep -rni "redacted" src/ crates/ docs/   → 19 hits, exhaustively the four sites above
+$ grep -rn  "if_missing" src/ crates/       → 111   (control: discriminates)
+$ grep -rn  "no_daemon"  src/ crates/       →   4   (control: discriminates)
+```
+
+⇒ `fnox exec -- printenv` and `fnox export` **print values in full, by design** —
+`export` is a value-emitting command. The `redact_output` config key is a field of
+**`McpConfig`** (`config.rs:350-353`), not a global. **`fnox ci-redact` is the only
+lever for log safety outside MCP, and it delegates masking to the CI runner.**
+Note `ci-redact` is **not listed in `fnox --help`** (hidden), but is live and has
+`--help` (verified locally) and is listed among daemon-backed read commands
+(`docs/guide/daemon.md:50`).
+
+## Q6. Caching
+
+Two distinct caches, plus a third that is not fnox's.
+
+**1. The per-user daemon (`docs/guide/daemon.md`) — opt-in, memory-only.**
+"fnox does not use it unless you enable it in config or set `FNOX_DAEMON=on`"
+(`:5`). Enabled via `[daemon] enabled = true`, `idle_timeout` (`:11-15`).
+
+- Applies to read commands: `exec`, `get`, `hook-env`, `export`, `list --values`,
+  `check`, `tui`, `mcp`, `ci-redact` (`:40-50`). Mutating/admin commands
+  (`sync`, `reencrypt`, `edit`, `set`, `remove`, `provider`, `lease create`)
+  always resolve directly (`:52`).
+- **"The daemon cache is memory-only. Secret values are not written to disk by
+  the daemon."** (`:56`)
+- **Invalidation** (`:58-63`) — discarded when: `fnox daemon clear`;
+  `fnox daemon stop`; idle-timeout exit; or **"Config files, profile settings,
+  provider references, post-processing options, or relevant `FNOX_*` and provider
+  environment variables change"**.
+
+⚠️ **The rotation hazard is real and is the gap in that list.** Invalidation keys
+on *fnox-side inputs* — config, profile, provider refs, env. **A value rotated
+at the remote provider changes none of those**, so a running daemon keeps serving
+the rotated-away credential until `daemon clear`/`stop` or the idle timeout
+expires. `idle_timeout = "8h"` in upstream's own example (`:14`) is therefore the
+worst-case staleness window. Mitigations upstream provides: `daemon_cache = false`
+per-secret (`:71-76`) or per-provider (`:78-85`), and `--no-daemon` per
+invocation. `fnox check` deliberately **does not reuse cached values** — "It still
+contacts providers so it can validate the current state" (`:65`), which makes
+`check` the correct post-rotation probe.
+Per-invocation opt-out: `fnox --no-daemon get X` (`:29`); session:
+`FNOX_DAEMON=off` (`:35`).
+
+**2. `fnox sync` — an encrypted local cache that DOES survive restarts.**
+`daemon.md:97-101` contrasts them: use the daemon for fast in-session reads;
+use sync "when you want an encrypted local cache that survives restarts and can
+work offline". A synced value is a **materialised copy** and is stale until
+re-synced — after a rotation, `fnox sync` must be re-run. (This is the mechanism
+behind the already-known "every add/remove churns all 49 `sync` ciphertexts".)
+
+**3. `MISE_ENV_CACHE`** is mise's, not fnox's — it caches whatever the env plugin
+produced (`mise-integration.md:160-172`), invalidated by `mise cache clear` or
+`mise exec --fresh-env` (`:209-219`). Already recorded on this host as able to
+"serve a dead name in ONE directory long after the config is restored".
+
+**Security note:** daemon transport is a **Unix domain socket, never TCP**, in a
+user-owned runtime dir with strict permissions, with bidirectional peer-ownership
+verification (`daemon.md:89-95`). Unsupported platforms return a clear error.
+
+## Provenance / upstream status
+
+**A profile also selects a config FILENAME**, a second channel for the same
+silent failure: `find_local_config(dir, profiles)` (`config.rs:67`) and
+CHANGELOG `#64` ("add support for `fnox.$FNOX_PROFILE.toml` config files") +
+`#87` ("respect `--profile`/`-P` CLI flag when loading config files"). An unknown
+profile simply means `fnox.<name>.toml` does not exist and nothing extra loads —
+again with no diagnostic.
+
+**The fallback is intentional design, not a bug**: CHANGELOG `#21` "add top-level
+secret inheritance for profiles". The *inheritance* is deliberate; the silent
+acceptance of an **undeclared** profile name is the emergent gap.
+
+**Upstream has no issue tracking this** — `gh search issues --repo jdx/fnox
+"profile" --state open` → `[]`, and `"unknown profile"` (all states) → `[]`.
+⚠️ Weak evidence: those searches returned empty for *every* query shape I tried,
+so I cannot distinguish "no such issue" from "search not indexing this repo".
+Treat as **UNVERIFIED**; the source reading and the live probe are the load-
+bearing evidence, not the issue search.
+
+**Version alignment:** the cloned tree's `Cargo.toml` is `version = "1.32.0"`,
+byte-matching the installed binary, so source claims apply to this host's fnox.
+
+## Not covered / UNVERIFIED
+
+- No live HTTPS request was made through `fnox proxy run` (would resolve real
+  credentials into a live broker on this host). Q3 is design-from-source.
+- `--replace` exec semantics (PID/signal behaviour, lease interaction) read from
+  `--help` only, not exercised.
+- Multi-profile overlay *precedence* was confirmed for name-dropping only; I did
+  not test conflicting values across a profile stack (would require printing
+  values).
+- Daemon behaviour is documented-only: the daemon is opt-in and was **not**
+  enabled on this host, so no cache-staleness measurement was taken.
+
+## GitHub repos touched
+
+- [jdx/fnox](https://github.com/jdx/fnox) — primary source (`crates/fnox-core/src/config.rs`, `secret_resolver.rs`, `error.rs`, `src/shell/zsh.rs`, `src/proxy.rs`, `src/mcp_server.rs`, `src/commands/`), `docs/guide/*`, `CHANGELOG.md`, issue search
+- [jdx/mise-env-fnox](https://github.com/jdx/mise-env-fnox) — the experimental mise env plugin fnox's docs explicitly recommend against (referenced, not cloned)
+- [jdx/mise](https://github.com/jdx/mise) — the consuming side of Q2 (referenced via fnox's docs only)

--- a/docs/research/kb/reports/agents/fnox-sdk-config.md
+++ b/docs/research/kb/reports/agents/fnox-sdk-config.md
@@ -1,0 +1,464 @@
+# fnox SDK / config-model research
+
+**Question:** can our secrets CLI be a thin wrapper over fnox, or must it reimplement?
+**Date:** 2026-08-03 · **Local version:** fnox 1.32.0 · **Method:** primary sources only
+(`gh api` on `jdx/fnox`, repo `docs/`, `fnox --help` on the installed 1.32.0, crates.io).
+
+Status: **COMPLETE.** All six questions answered from primary sources.
+
+> **Provenance note.** The source read is the `jdx/fnox` tarball of `main` whose
+> `Cargo.toml` reads `version = "1.32.0"` — i.e. it *is* the installed version, so no
+> main-vs-release drift. Line numbers are that tree. Live probes ran against the
+> installed `fnox 1.32.0`. **No `fnox get` was ever run and no secret value was printed;**
+> live probes report line counts or fixture-only fake names.
+
+## Bottom line
+
+| | verdict |
+|---|---|
+| SDK | **Exists** (`fnox-core`, published) but **Rust-only — no Python bindings**, so unusable for us |
+| JSON | **No general `--json`.** 4 commands only; every introspection command is human-formatted |
+| Wrapper viability | **Thin wrapper = shell out + screen-scrape.** Possible, but the contract is weak |
+| Biggest hazard | **Unknown profile fails OPEN** — all 50 secrets, rc=0, zero stderr |
+| Scoping | **Achievable**, but only as `-P <name> --no-defaults` on every invocation |
+
+## Q1 — Is there an SDK (library crate)?
+
+**YES — a real, published, documented-as-such library crate: `fnox-core`.
+But it is Rust-only, and our CLI is Python, so it is unreachable for us.**
+
+Evidence:
+
+- `Cargo.toml` (root) is a **workspace**: `members = [".", "crates/fnox-core"]`,
+  `resolver = "3"`. The root `fnox` package declares `[[bin]] name = "fnox"` **and**
+  depends on `fnox-core = { path = "crates/fnox-core", version = "1.32.0" }` — the
+  `version =` key is what makes it publishable.
+  <https://github.com/jdx/fnox/blob/main/Cargo.toml>
+- `crates/fnox-core/Cargo.toml` → `description = "Provider library and core types for fnox"`.
+- `crates/fnox-core/src/lib.rs` doc comment, verbatim:
+  > "Core library for fnox: provider implementations, config types, secret resolution.
+  > This crate is the reusable engine underneath the `fnox` binary. It contains the
+  > `Provider` trait, every provider implementation, the config data types, the secret
+  > resolver, the lease backends, and the `Fnox` convenience API **for downstream
+  > consumers**."
+- Public modules: `auth_prompt, config, config_path, env, error, http, lease,
+  lease_backends, library, providers, secret_resolver, settings, source_registry,
+  spanned, suggest, temp_file_secrets`; re-exports `FnoxError, Result, Fnox`.
+- The root `fnox` crate ALSO has `src/lib.rs`, which re-exports fnox-core "so existing
+  `fnox::providers`, `fnox::config`, etc. paths continue to work **for downstream
+  consumers**", plus CLI-only modules (`commands, daemon, hook_env, mcp_server, proxy,
+  shell, tui`). So both crates are lib+consumable.
+
+**Published on crates.io — both crates, at 1.32.0.** The crates.io JSON API returned an
+access-policy error for every name including the control (`serde`), so that probe was
+broken, not the world; I switched to the sparse index:
+
+| crate | `index.crates.io` | versions | latest |
+|---|---|---|---|
+| `fnox` | HTTP 200 | 21 | 1.32.0 (unyanked) |
+| `fnox-core` | HTTP 200 | 12 | 1.32.0 (unyanked) |
+| `serde` (control, present) | HTTP 200 | 316 | — |
+| `zzqwvbnmnonexist` (control, absent) | **HTTP 404** | — | — |
+
+Both arms fire, so the 200s are real.
+
+### The `Fnox` client API (`crates/fnox-core/src/library.rs`, 430 lines)
+
+> "Convenience client over `Config` — load once, query many. Cheap to clone (Config is
+> held behind an `Arc`); hold across `.await` freely." (`library.rs:42-45`)
+
+| item | line | note |
+|---|---|---|
+| `Fnox::discover()` | `library.rs:75` | upward search, same as the binary |
+| `Fnox::open(path)` | `library.rs:100` | explicit config path |
+| `.with_profile(p)` | `library.rs:127` | builder |
+| `.with_profiles(iter)` | `library.rs:132` | **multiple** active profiles |
+| `.with_no_defaults(bool)` | `library.rs:140` | mirrors `--no-defaults` |
+| `.profile()` / `.config()` | `library.rs:146` / `153` | accessors |
+| `async .get(key) -> Result<Option<String>>` | `library.rs:167` | |
+| `.list() -> Result<Vec<String>>` | `library.rs:202` | |
+
+`library.rs:38` also re-exports the discovered filename "so callers can probe with the
+same name fnox itself uses".
+
+### ⚠️ The decision-relevant caveat
+
+**There are no Python bindings.** `gh api search/code repo:jdx/fnox pyo3` → **0**;
+control arm `clap` on the same query shape → **45**, so the probe discriminates. No
+`maturin`, no `cdylib`, no FFI crate in the workspace member list.
+
+So for a **Python** wrapper the SDK is not usable without writing our own PyO3 binding
+and shipping a compiled wheel per platform. **Practically: we shell out and parse
+output** — which makes Q2 the load-bearing question, not Q1.
+
+## Q2 — Machine-readable output
+
+**There is NO general `--json`. Structured output exists on exactly four commands, and
+none of them is an introspection command a wrapper would want.** Everything a wrapper
+needs to *read* (`list`, `check`, `profiles`, `config-files`, `doctor`, `provider list`)
+is human-formatted only — rendered via the `tabled` crate (`Cargo.toml` dep).
+
+Method: `fnox <cmd> --help` on the installed 1.32.0 for each command, cross-checked
+against `fnox.usage.kdl` in the 1.32.0 source tarball (the tarball's
+`Cargo.toml` reads `version = "1.32.0"`, i.e. it *is* the installed version, not `main`
+drift).
+
+### The complete structured-output surface
+
+| command | flag | values | note |
+|---|---|---|---|
+| `export` | `-f/--format env\|shell\|json\|yaml\|toml` | `usage.kdl:63` | **emits secret VALUES** |
+| `import` | `--format env\|json\|yaml\|toml` | `usage.kdl:100` | *input* parsing, not output |
+| `lease create` | `-f/--format shell\|json\|env` | `usage.kdl:118` | `src/commands/lease.rs:326-346` |
+| `scan` | `--format human\|json` | `usage.kdl:203` | `src/commands/scan.rs:167,402` |
+| `schema` *(hidden)* | — | `src/commands/schema.rs` | JSON Schema of the config |
+
+Control arm for the negative: grepping `fnox.usage.kdl` for `json` returns those **4**
+hits against a total of **71** `flag ` lines — so the file is being read and the token
+is found where it exists. `fnox list --help` etc. were read in full, not grepped.
+
+### `fnox schema` — the one genuinely useful machine contract (undocumented)
+
+`src/commands/schema.rs` is `#[command(hide = true)]`, so it does **not** appear in
+`fnox --help`, but it is wired (`src/commands/mod.rs:32,168-170,200`) and it runs:
+
+```
+$ fnox schema | head -3
+{ "$schema": "https://json-schema.org/draft/2020-12/schema", "title": "Config", ...
+$ fnox schema | wc -c
+47739
+```
+
+It is `schemars::schema_for!(Config)` — a 47 KB JSON Schema of the **config file
+format**. Useful for validating/generating a `fnox.toml`; it says nothing about
+*runtime* state. Being `hide = true` it carries no stability promise.
+
+### What screen-scraping actually looks like
+
+```
+$ fnox config-files
+~/.config/fnox/config.toml          # one path per line — parseable, but no contract
+
+$ fnox profiles
+Available profiles:
+  default (50 secrets)              # prose + parenthesised count
+```
+
+`fnox list` is a `tabled` table with truncation by default (`-f/--full` to disable,
+`-s/--sources` to add source paths, `-V/--values` to add values). Parsing it is a
+column-width-dependent screen-scrape.
+
+**Consequence for the wrapper decision:** a Python wrapper gets one clean contract
+(`fnox schema`, hidden), one value-bearing structured dump (`export --format json`,
+which defeats the point of not handling values), and otherwise **regex over
+human-formatted tables**. That is the fragility to price in — not the absence of an SDK.
+
+## Q3 — Config discovery and precedence
+
+**The prior measurement is CONFIRMED against 1.32.0 source, and it is stronger than
+"`-c` adds a config": the global config is layered under *everything*, and even
+`root = true` does not switch it off.** Source comment, verbatim
+(`crates/fnox-core/src/config.rs:640-644`, doc comment on `load_explicit`):
+
+> "Unlike `Self::load_with_recursion` this does not search parent directories, but the
+> file's own imports and the global config are still layered underneath it — **the
+> global config is the base for every project, and `root = true` doesn't disable it
+> either.**"
+
+### The two load strategies (`config.rs:621-639`, `load_smart`)
+
+`uses_config_discovery(path)` (`config.rs:44-48`) decides. It returns true **only for a
+bare default filename**; the doc comment (`config.rs:38-43`) is explicit:
+
+> "Only the bare default filenames do; anything else (**including `./fnox.toml` or an
+> absolute path to a `fnox.toml`**) is treated as an explicit path and loads just that
+> file, its imports, and the global config."
+
+So `-c fnox.toml` recurses, but `-c ./fnox.toml` does **not** — a real footgun for a
+wrapper that normalises paths.
+
+| strategy | trigger | behaviour |
+|---|---|---|
+| `load_with_recursion` (`:710`) | bare default filename | walk **up from cwd**, merging every dir's config files; global as base at fs root |
+| `load_explicit` (`:646`) | any other `-c` value | that file + its `import`s + **the global config** |
+
+### Precedence, lowest → highest
+
+1. **`FNOX_CONFIG_DIR/config.toml`** — the global/user config (`config.rs:813-814`,
+   `global_config_path()`). `FNOX_CONFIG_DIR` defaults to `$XDG_CONFIG_HOME/fnox`, else
+   `~/.config/fnox` on unix (`crates/fnox-core/src/env.rs:44-55`).
+2. **Parent-directory configs**, farthest ancestor first (`load_recursive`, `:735-793`).
+3. **`import = [...]`** entries of a given file — loaded *before* and overridden by the
+   file that imports them (`:773-777`).
+4. **The nearest/most-local config file.**
+
+Within a single directory, `all_config_filenames()` gives the order
+(`config.rs:20-36`), "first = lowest priority, last = highest":
+
+`fnox.toml` → `.fnox.toml` → `fnox.<profile>.toml` → `.fnox.<profile>.toml` →
+`fnox.local.toml` → `.fnox.local.toml`
+
+### The single exception
+
+`load_explicit` returns early **only** when the explicit path *is itself* the global
+config path (`config.rs:659-663`) — otherwise the global is always merged in.
+
+`root = true` stops the *upward walk* but still loads the global underneath
+(`config.rs:757-770`).
+
+**Verified live:** `fnox config-files` run from this repo prints exactly
+`~/.config/fnox/config.toml` — one file, the global, with no project config present.
+
+### Consequence for a per-project wrapper
+
+There is **no supported way to get a clean, project-only view.** Not `-c`, not
+`root = true`. The only lever is `FNOX_CONFIG_DIR` — pointing it at an empty/temp dir
+makes `load_global()` find nothing (`config.rs:820-829` returns `(Config::new(), false)`
+when the path does not exist). That is an env-var override, not a config feature, but it
+is the one mechanism that actually isolates.
+
+## Q4 — Profiles
+
+### Declaration and activation
+
+Declared as TOML sections — `[profiles.<name>.secrets]` and
+`[profiles.<name>.providers]` (`docs/guide/profiles.md`). Activation, in precedence
+order (`Config::get_profiles`, `config.rs:1326-1331`): **CLI `-P/--profile` > `FNOX_PROFILE` env > default**.
+`normalize_profiles` (`:1335-1347`) splits on commas, trims, drops names failing
+`env::is_valid_profile_name`, and falls back to `["default"]` when the result is empty.
+
+### Composition (#605) — what it means
+
+PR [#605](https://github.com/jdx/fnox/pull/605), *"feat(config): support composing
+multiple active profiles"*, **MERGED 2026-07-12** by @gaojunran. From the PR body:
+
+> "Allow activating multiple profiles simultaneously as an ordered overlay stack. Later
+> profiles override earlier ones on key conflicts, with top-level config as the base."
+>
+> ```
+> top-level config + profiles.aws + profiles.prod
+> ```
+
+Three activation spellings, all equivalent: `-P aws -P prod`, `-P aws,prod`,
+`FNOX_PROFILE=aws,prod`. The overlay is a plain ordered `extend` over an `IndexMap`
+(`config.rs:1440-1444`), so "compose" means **last-wins key-by-key merge**, not any kind
+of intersection or scoping.
+
+Consequences the PR body lists: `--write-profile` becomes **required** when multiple
+profiles are active (write target is otherwise the single active profile); the daemon's
+socket-path hash and cache key include the full stack; `Fnox` gained `with_profiles()`.
+
+### ⚠️ The unknown-profile fail-open — CONFIRMED, and it has a mitigation
+
+**Root cause, at source.** `Config::get_secrets_with_no_defaults`
+(`crates/fnox-core/src/config.rs:1428-1444`):
+
+```rust
+let has_non_default = profiles.iter().any(|p| p != "default");
+let mut secrets = if !has_non_default || !no_defaults {
+    self.secrets.clone()          // <-- ALL top-level secrets
+} else {
+    IndexMap::new()
+};
+for profile in profiles.iter().filter(|p| *p != "default") {
+    if let Some(profile_config) = self.profiles.get(profile) {   // <-- silent no-match
+        secrets.extend(profile_config.secrets.clone());
+    }
+}
+```
+
+`if let Some(...)` with no `else`: an unknown profile name simply **contributes
+nothing**, and since `no_defaults` defaults to `false`, the top-level secrets remain.
+There is no existence check anywhere on the read path. (The two `profiles.get(profile).is_none()`
+sites at `config.rs:1131` and `:1259` are **write** paths that *auto-create* the table —
+they are not validation.)
+
+**Live probe, control-armed** (`fnox list`, line counts only — no values printed):
+
+| arm | lines | rc | stderr |
+|---|---|---|---|
+| `-P default list` (known-good control) | 51 (hdr + 50) | 0 | 0 bytes |
+| `-P zqbwmxvv77 list` (unknown) | **51 — identical** | **0** | **0 bytes** |
+| `-P zqbwmxvv77 --no-defaults list` | **1 (hdr only, 0 secrets)** | 0 | 0 bytes |
+
+The known-good arm and the unknown arm are indistinguishable → fail-open reproduced. The
+third arm shows **`--no-defaults` flips it to fail-CLOSED.** (Control string invented
+fresh for this run.)
+
+`fnox -P zqbwmxvv77 profiles` still prints only `default (50 secrets)` — it lists
+*declared* profiles and never objects to the bogus active one.
+
+### Is it intentional / documented / tracked?
+
+- **Intentional by construction, yes** — `docs/guide/profiles.md` § "Profile Inheritance"
+  documents that "Profiles automatically inherit secrets from the top level" as a
+  *feature* to "reduce duplication". An unknown profile inheriting everything is the
+  degenerate case of that design.
+- **Documented as a hazard: NO.** Nothing in `docs/` warns that a typo'd profile name
+  silently yields the full default set.
+- **Tracked upstream: cannot be tracked.** ⚠️ **`jdx/fnox` has GitHub Issues DISABLED**
+  (`gh issue list -R jdx/fnox` → *"the 'jdx/fnox' repository has disabled issues"*). My
+  first issue-search returned 0 results for that reason, **not** because nothing matches
+   — a broken probe. They use **Discussions** (124 total). Searching those for `profile`
+  returns 4, none about unknown-profile handling:
+  #631 `ci-redact does not respect FNOX_PROFILE`, #601 `FR: support composing multiple
+  active profiles` (→ #605), #570 `Fall back to default value when provider isn't
+  configured for the active profile`, #577 `fnox daemon clear can be misleading with
+  profile-scoped daemon caches`.
+
+### `--no-defaults` / `FNOX_NO_DEFAULTS`
+
+Per `fnox --help`: *"Do not merge top-level secrets into the selected profile."* It is a
+real setting (`crates/fnox-core/src/settings.rs:47`), bound to env
+`FNOX_NO_DEFAULTS` (`crates/fnox-core/settings.toml:57`), documented at
+`docs/reference/environment.md:35-40` and `docs/reference/configuration.md:535-538`:
+
+> "With `--no-defaults`, only `[profiles.<name>.secrets]` are used for the selected profile."
+
+**It is a no-op unless a non-default profile is active** (`has_non_default &&
+no_defaults`, `config.rs:1433-1438`) — so `--no-defaults` alone, on the default profile,
+does nothing at all.
+
+Doc drift noted: `docs/guide/profiles.md` shows `fnox profiles` printing
+`default (active)`, but 1.32.0 prints `default (50 secrets)`.
+
+## Q5 — Per-project scoping
+
+**YES — "this project gets these 6 secrets" IS expressible, but only via
+`[profiles.<name>.secrets]` + `--no-defaults`, and `--no-defaults` must be passed on
+EVERY invocation because it cannot be declared in a config file.**
+
+### The default model is purely ADDITIVE — a project config cannot subtract
+
+`docs/guide/hierarchical-config.md` states the merge order explicitly:
+
+> 1. Loads `~/.config/fnox/config.toml` (global config, if exists)
+> 2. Loads `project/fnox.toml` (parent) … 5. `…/fnox.local.toml`
+>
+> "**Global config provides the base layer available to all projects.**"
+
+So a project-local `fnox.toml` alone can only **add** to (or key-override within) the
+global's 50. There is no `exclude`, no allow-list, no `root`-style cut for the global
+(Q3: `root = true` explicitly does not disable it).
+
+### The mechanism that DOES scope: profile + `--no-defaults`
+
+Measured in a purpose-built isolated fixture (`FNOX_CONFIG_DIR` pointed at a temp dir
+holding 3 fake `GLOBAL_*` secrets; a project `fnox.toml` with 1 top-level `PROJ_TOP` and
+`[profiles.proj.secrets]` holding `SCOPED_ONE`/`SCOPED_TWO`; plaintext `default =`
+values, no real credentials):
+
+**Isolation control arm:** `fnox config-files` printed exactly the two fixture files and
+**not** `~/.config/fnox/config.toml` — so `FNOX_CONFIG_DIR` really does relocate the
+global layer, and the fixture is not silently merging the host's 50.
+
+| arm | resulting secret set |
+|---|---|
+| A — default profile | `GLOBAL_A GLOBAL_B GLOBAL_C PROJ_TOP` |
+| B — `-P proj` | `GLOBAL_A GLOBAL_B GLOBAL_C PROJ_TOP SCOPED_ONE SCOPED_TWO` (inheritance) |
+| **C — `-P proj --no-defaults`** | **`SCOPED_ONE SCOPED_TWO` — exactly the scoped set** |
+| D — `-P typo99` (unknown) | `GLOBAL_A GLOBAL_B GLOBAL_C PROJ_TOP` — identical to A (**fail-open**) |
+| E — `-P typo99 --no-defaults` | *(empty)* — fail-closed |
+
+Five arms, five distinct outcomes (D matching A is itself the finding), so the fixture
+admits every result and is not rigged toward one answer. Arm C independently reproduces
+the Q4 fail-open in a clean environment, away from the host config.
+
+### ⚠️ The catch that decides the design
+
+**`no_defaults` cannot be declared in a `fnox.toml`.** Control arm: enumerating every
+`sources.` line in `crates/fnox-core/settings.toml` yields **11 entries across all 7
+settings — every one is `sources.cli` or `sources.env`, and there is not a single
+`sources.config`.** (Settings: `age_key_file`, `profile`, `no_defaults`,
+`shell_integration_output`, `if_missing`, `http_timeout`, `if_missing_default`.)
+
+So scoping is **invocation-time only**. A project cannot declare "I am scoped"; the
+caller must supply `-P <name> --no-defaults` (or `FNOX_PROFILE` + `FNOX_NO_DEFAULTS`)
+every single time. Miss either half and you silently get all 50 back — arm D is what
+that looks like, and it is rc=0 with zero stderr.
+
+For a **wrapper**, that is actually workable: injecting two flags on every `fnox`
+call is exactly the kind of thing a wrapper is for. But it means the scoping guarantee
+lives entirely in *our* code, not in fnox's config — nothing on disk enforces it, and
+anyone invoking `fnox` directly bypasses it completely.
+
+## Q6 — `fnox.<profile>.toml`
+
+**The prior session's conclusion is CONFIRMED on the reachability half, and REFUTED on
+the "mutually exclusive with `--no-defaults`" half.**
+
+### It exists, and it is generated purely from the active profile list
+
+`crates/fnox-core/src/config.rs:24-36`:
+
+```rust
+pub fn all_config_filenames(profiles: &[String]) -> Vec<String> {
+    let mut files = vec![DEFAULT_CONFIG_FILENAME.to_string(), ".fnox.toml".to_string()];
+    for p in profiles.iter().filter(|p| *p != "default") {
+        files.push(format!("fnox.{p}.toml"));
+        files.push(format!(".fnox.{p}.toml"));
+    }
+    files.push("fnox.local.toml".to_string());
+    files.push(".fnox.local.toml".to_string());
+    files
+}
+```
+
+Note the `.filter(|p| *p != "default")` — **`fnox.default.toml` is never loaded.** A
+per-profile file only exists for non-default profile names.
+
+### CONFIRMED: it is project-config-only, unreachable for a user-level setup
+
+`all_config_filenames()` is consumed only by the **directory-walking** paths —
+`load_recursive` (`config.rs:737`), `find_project_dir` (`config.rs:797`), and
+`uses_config_discovery` (`config.rs:45`). Each joins the filename onto a *directory being
+walked* (`dir.join(filename)`, `config.rs:745`).
+
+The global config never goes through that function. It is a single hardcoded name:
+
+```rust
+pub fn global_config_path() -> PathBuf { env::FNOX_CONFIG_DIR.join("config.toml") }  // config.rs:813-814
+```
+
+**Control arm for the absence:** grepping the entire source (`crates/fnox-core/src/` and
+`src/`) for the literal `"config.toml"` returns **exactly one hit** — `config.rs:814`.
+The same grep shape finds the six project filenames in `all_config_filenames`, so it
+discriminates. There is no `~/.config/fnox/config.<profile>.toml`, no
+`~/.config/fnox/fnox.<profile>.toml`, and no `.local` variant at user level.
+
+⚠️ **Caveat on "unreachable":** `FNOX_CONFIG_DIR` is a *directory*, and the upward walk
+starts at **cwd**, not at the config dir — so pointing `FNOX_CONFIG_DIR` at a directory
+does not cause `fnox.<profile>.toml` files inside it to be picked up. The only way to
+reach a per-profile file is to have it in cwd or an ancestor of cwd.
+
+### REFUTED: it is NOT mutually exclusive with `--no-defaults`
+
+They operate on **different layers** and compose fine:
+
+- `fnox.<profile>.toml` selects which **files** are read (`all_config_filenames`).
+- `--no-defaults` controls whether **top-level secrets are merged into the selected
+  profile** (per `fnox --help`) — a within-config merge decision, applied after loading.
+
+Nothing in `all_config_filenames` or `load_recursive` consults a no-defaults flag; see
+Q4 for where `no_defaults` is actually read. Marking the prior claim **REFUTED**, though
+the practical effect for us is unchanged because the reachability half already rules the
+mechanism out for a user-level setup.
+
+## Probes that were broken (recorded so they are not repeated)
+
+1. **crates.io JSON API** (`https://crates.io/api/v1/crates/<name>`) returned an
+   *"unable to process your request … API data access policy"* error for **every** name
+   including the control `serde`. Not a signal about fnox. **Use
+   `https://index.crates.io/<a>/<b>/<name>` instead** — it gave 200/200/200/404 across
+   fnox / fnox-core / serde / a nonsense name.
+2. **`gh issue list -R jdx/fnox` / `gh search issues`** return nothing because
+   **the repo has GitHub Issues DISABLED**, not because nothing matches. Use the
+   **Discussions** GraphQL query (124 discussions) for upstream reports.
+
+## GitHub repos touched
+
+- [jdx/fnox](https://github.com/jdx/fnox) — primary subject: `Cargo.toml`,
+  `crates/fnox-core/{Cargo.toml,src/lib.rs,src/library.rs,src/config.rs,src/config_path.rs,src/env.rs,src/settings.rs,settings.toml}`,
+  `src/{lib.rs,commands/schema.rs,commands/mod.rs,commands/lease.rs,commands/scan.rs}`,
+  `fnox.usage.kdl`, `CHANGELOG.md`, `docs/guide/{profiles.md,hierarchical-config.md}`,
+  `docs/reference/{configuration.md,environment.md}`, PR #605, Discussions #570/#577/#601/#631

--- a/docs/research/kb/reports/agents/fnox-shell-activation.md
+++ b/docs/research/kb/reports/agents/fnox-shell-activation.md
@@ -1,0 +1,558 @@
+# fnox shell-activation surface — scoping and cost
+
+**Agent:** fnox-shell-activation research
+**Date:** 2026-08-03
+**fnox version under test:** 1.32.0 (`/Users/rmanaloto/.local/share/mise/installs/fnox/latest/fnox`)
+**Status:** COMPLETE
+
+Goal: determine what replaces `~/.zshrc.d/50-mde-secrets.zsh` (`fnox activate zsh`)
+with something this repo owns — scoped if possible, cheap if possible.
+
+---
+
+## Q1 — Can `fnox activate` be scoped?
+
+**NO. `fnox activate` CANNOT be scoped by flag. The flags are accepted and
+silently discarded.** This is the single most important finding in this task,
+and it is the opposite of the hoped-for answer.
+
+### Root cause (source)
+
+`ActivateCommand` has **exactly two fields** — `shell` and `no_hook_env`:
+
+```rust
+// src/commands/activate.rs:5-17
+pub struct ActivateCommand {
+    /// Shell to generate activation code for (bash, zsh, fish, nu, pwsh)
+    #[arg(value_name = "SHELL")]
+    pub shell: Option<String>,
+
+    /// Don't automatically invoke hook-env (for testing)
+    #[arg(long)]
+    pub no_hook_env: bool,
+}
+```
+<https://github.com/jdx/fnox/blob/main/src/commands/activate.rs>
+
+`-P/--profile`, `--no-defaults`, `-c/--config`, `--if-missing`, `--no-daemon`
+are **global** clap flags (they appear on every subcommand's `--help`,
+including `activate`), but `ActivateCommand` never reads them. It builds
+`ActivateOptions { exe, no_hook_env }` — and `ActivateOptions` (`src/shell/mod.rs:29-35`)
+carries **only those two fields**. There is nowhere for a profile to go.
+
+The generated zsh hook is a hardcoded format string with no flag interpolation:
+
+```rust
+// src/shell/zsh.rs:41-48
+_fnox_hook() {{
+  trap -- '' SIGINT
+  eval "$({exe} hook-env -s zsh)"
+  trap - SIGINT
+}}
+```
+<https://github.com/jdx/fnox/blob/main/src/shell/zsh.rs>
+
+`{exe}` is the only substitution. So every per-prompt invocation is bare
+`fnox hook-env -s zsh` — default profile, defaults merged, config discovered
+by upward search from `$PWD`.
+
+### Empirical confirmation — both arms
+
+fnox 1.32.0, local binary:
+
+| Arm | Command | `hook-env` line emitted |
+|---|---|---|
+| A (baseline) | `fnox activate zsh` | `eval "$(… fnox hook-env -s zsh)"` |
+| B (scoped attempt) | `fnox activate zsh -P shell --no-defaults` | `eval "$(… fnox hook-env -s zsh)"` |
+| C (config attempt) | `fnox activate zsh -c /nonexistent/x.toml` | `eval "$(… fnox hook-env -s zsh)"` |
+
+`diff <(arm A) <(arm B)` → **IDENTICAL** (rc=0, zero lines of diff). Arm C is
+identical too, and note it does **not error** on a nonexistent config path —
+another fail-open.
+
+**CONTROL ARM (this is the important part):** the same `diff` harness against
+`fnox activate zsh --no-hook-env` produces a **16-line diff** (the whole
+`_fnox_hook` / `precmd_functions` / `chpwd_functions` block is removed). So the
+probe *can* detect a difference in activation output — the `IDENTICAL` for
+`-P … --no-defaults` is a real negative, not a blind harness.
+
+### The consequence for the replacement file
+
+`fnox activate zsh -P <anything>` is **not a scoping mechanism** — it is
+`fnox activate zsh` with extra words. Combined with the already-established
+fail-open on an unknown profile, a replacement file written as
+`eval "$(fnox activate zsh -P agent --no-defaults)"` would look scoped in
+review, pass any "does it run" check, and yield **all 50 secrets**. That is a
+silently-wrong config, which is worse than the current file.
+
+### What DOES scope a shell activation
+
+The only lever that reaches the per-prompt `hook-env` is the **environment**,
+because the hook inherits it:
+
+- **`FNOX_PROFILE`** — read as the profile default (it is the documented
+  fallback in the global `-P` help text: *"default: default, or FNOX_PROFILE
+  env var"*), and the docs confirm the hook picks up a change on the next
+  prompt: *"fnox detects the change on the next prompt automatically"*
+  (`docs/guide/shell-integration.md` § Using Profiles).
+  So `export FNOX_PROFILE=agent` **before** the `eval` does scope the hook.
+- **`--no-defaults` has NO environment equivalent** — see the flag table in
+  Q1b below. This is the gap: you can select a profile shell-wide, but you
+  **cannot suppress the top-level secret merge** shell-wide.
+
+Net: a shell-wide *scoped* activation is only **half** achievable. Selecting a
+profile: yes, via `FNOX_PROFILE`. Excluding the 50 top-level secrets: **no**,
+not through `activate`. To get `--no-defaults` you must be on an `exec`/`get`/
+`export` code path, which is the `fnox exec` model, not the shell-activation
+model.
+
+### Q1b — which global flags have an env fallback
+
+From `fnox <cmd> --help` (1.32.0), only two globals declare an `[env: …]`
+binding:
+
+- `--non-interactive` → `[env: FNOX_NON_INTERACTIVE=]`
+- (`--profile` documents `FNOX_PROFILE` in prose, not as a clap `[env:]` tag)
+
+`--no-defaults`, `--no-daemon`, `--if-missing` and `--config` show **no**
+`[env:]` tag. `FNOX_CONFIG_DIR` and `FNOX_SHELL_OUTPUT` exist but are separate
+knobs, not `--no-defaults`. Marked **UNVERIFIED-NEGATIVE** for
+`--no-defaults`: absence of an `[env:]` tag in `--help` is strong but not
+proof; a `std::env::var` read elsewhere in the source would not show up there.
+Control arm run: the same `--help` scan **does** surface
+`FNOX_NON_INTERACTIVE`, so the scan can find an env binding when one exists.
+
+## Q2 — What does `hook-env` do per prompt?
+
+**On an unchanged prompt it short-circuits BEFORE touching any provider.** The
+steady-state per-prompt cost is one process spawn plus a handful of `stat()`
+calls. It does **not** re-resolve secrets, so a hung provider CLI does **not**
+wedge every prompt — but it *does* wedge every `cd` and every new shell (see
+"Where the wedge actually is" below).
+
+### The early-exit is the first thing that runs
+
+`HookEnvCommand::run` (`src/commands/hook_env.rs`) does, in order:
+
+1. `Settings::try_get()` — output mode.
+2. `shell::get_shell(...)`.
+3. **`if hook_env::should_exit_early() { return Ok(()) }`** — returns with
+   **no output at all**.
+4. Only past that point: `hook_env::find_config()`, then
+   `load_secrets_from_config(cli)` → `daemon::resolve_batch(…, Purpose::HookEnv, …)`,
+   which is what actually contacts providers.
+
+<https://github.com/jdx/fnox/blob/main/src/commands/hook_env.rs>
+
+So provider resolution is strictly downstream of the early-exit gate.
+
+### What `should_exit_early()` actually costs
+
+```rust
+// src/hook_env.rs — should_exit_early()
+if has_directory_changed()   { return false }  // env::current_dir() vs PREV_SESSION.dir
+if has_config_been_modified(){ return false }  // stat sweep, see below
+if has_fnox_env_vars_changed(){ return false } // hash of all FNOX_* vars
+true
+```
+<https://github.com/jdx/fnox/blob/main/src/hook_env.rs>
+
+The three checks, by cost:
+
+| Check | Work done |
+|---|---|
+| `has_directory_changed` | one `getcwd`, compare to `PREV_SESSION.dir` |
+| `has_config_been_modified` | `collect_config_files(cwd)`: **walks cwd up to `/`, and at every level `stat()`s every name in `all_config_filenames(profile)`** (`fnox.toml`, `.fnox.toml`, `fnox.<profile>.toml`, `fnox.local.toml`, …). Then **also `stat()`s the global config** `Config::global_config_path()`. Hashes (path, mtime) pairs with `DefaultHasher`. |
+| `has_fnox_env_vars_changed` | iterate `std::env::vars()`, collect `FNOX_*` into a `BTreeMap`, hash |
+
+Plus, lazily on first access, `PREV_SESSION` decodes `__FNOX_SESSION`:
+**base64 → miniz inflate → msgpack deserialize** (`src/hook_env.rs`, `decode_session`).
+
+Two consequences worth naming:
+
+- The stat sweep is **O(directory depth × config filename count)** and it runs
+  on **every prompt**. In a deep tree that is tens of syscalls per prompt.
+  Cheap, but not free, and it grows with `cd` depth.
+- **`collect_config_files` stats the GLOBAL config on every prompt.** This is
+  the source-level confirmation of the previously-recorded behaviour that fnox
+  pulls `~/.config/fnox/config.toml` into every invocation: the global config's
+  mtime is part of the change-detection hash, so touching it invalidates every
+  shell's session on the next prompt.
+
+### `__FNOX_SESSION` — a second `__MISE_DIFF`-shaped blob, but NOT secret-bearing
+
+`hook_env_output` always appends `__FNOX_SESSION` (`src/shell/mod.rs`,
+`hook_env_output`). It is base64(deflate(msgpack(`HookEnvSession`))).
+
+**It does not contain secret values.** The struct stores
+`secret_hashes: IndexMap<String, String>` — BLAKE3 **keyed** hashes, with a
+per-session random `hash_key`, domain-separated by the secret name
+(`hash_secret_with_key`). The doc comment states the intent: *"Hashed with the
+session's hash_key to prevent offline dictionary attacks"*.
+
+It **does** contain, in cleartext-after-decode: **every secret NAME**, the cwd,
+the config path, and temp-file paths for `as_file` secrets. So it is a
+**name-disclosure** blob, not a value-disclosure blob — materially different
+from `__MISE_DIFF`, which carries values. A committed `env` dump would leak all
+50 credential *names* and the local paths, not the credentials. Worth knowing
+for this repo's `no_env_dump` scanner: `__FNOX_SESSION` deserves the same
+"don't commit it" treatment, but it is not a rotation event if it leaks.
+
+### Where the wedge actually is
+
+The early exit fails — and a full 50-secret provider resolution runs — in
+exactly three situations:
+
+1. **Directory changed.** The hook is registered in `chpwd_functions` *and*
+   `precmd_functions`, so **every `cd` triggers a full re-resolve.**
+2. **Any config file in the hierarchy, or the global config, changed mtime.**
+3. **Any `FNOX_*` env var changed** (including `FNOX_PROFILE`).
+
+Plus an unlisted fourth, which is the expensive one in practice:
+
+4. **Every brand-new shell.** A fresh login shell has no `__FNOX_SESSION`, so
+   `PREV_SESSION` is `Default` with `dir: None`; `has_directory_changed()`
+   compares `None != Some(cwd)` → **true** → full resolve. So **every new
+   terminal, and every shell that does not inherit the parent's
+   `__FNOX_SESSION`, pays a complete resolution of all 50 secrets.**
+
+This reconciles the "hung `doppler` hangs every shell prompt" observation with
+the early-exit: the hang is not on the *steady-state* prompt, it is on
+**shell startup and on every `cd`** — which, in interactive use, is
+indistinguishable from "every prompt". The fix framing therefore is not "make
+the prompt hook cheaper" (it already is); it is "stop the *startup* and *cd*
+paths from contacting a provider at all".
+
+### The per-secret confinement lever that survives
+
+`load_secrets_from_config` filters the resolved set before emitting it:
+
+```rust
+// src/commands/hook_env.rs — load_secrets_from_config
+// Skip secrets unless their env mode allows shell injection —
+// env=false and env="exec" secrets must never appear in shell
+// integration output.
+if let Some(secret_config) = profile_secrets.get(&key)
+    && !secret_config.env_mode().in_shell()
+{
+    continue;
+}
+```
+
+So **per-secret `env` mode is the only working scoping mechanism for shell
+activation.** It is enforced in the hook-env code path itself, not merely by
+convention. Under the current `env = true`-for-all-50 posture this filter
+passes everything; it is the lever that would narrow the shell set if that were
+ever wanted, and it works *without* any profile plumbing.
+
+## Q3 — Cheaper / non-hook activation mode
+
+### What `--no-hook-env` actually does
+
+It removes the **entire** hook block. Measured diff (`fnox activate zsh` vs
+`fnox activate zsh --no-hook-env`, fnox 1.32.0): 16 lines removed — the
+`_fnox_hook` function, the `precmd_functions` registration, and the
+`chpwd_functions` registration. What survives is only:
+
+```zsh
+export FNOX_SHELL=zsh
+fnox() { … }        # the wrapper that eval's `deactivate`/`shell`
+```
+
+So `--no-hook-env` is **not** a cheaper way to load secrets — it loads **zero**
+secrets. It gives you the `fnox` wrapper function and nothing else. The
+`(for testing)` in its help text is accurate.
+
+(Aside, low-stakes: the emitted wrapper special-cases `deactivate|shell`, but
+`fnox shell` is **not a subcommand in 1.32.0** — `fnox shell --help` →
+`error: unrecognized subcommand 'shell'`. Dead branch in the generated code.)
+
+### There IS a once-per-shell mode, and it is the answer to this whole task
+
+`fnox export --format shell` emits exactly the same `export …` lines the hook
+emits, and — unlike `activate` — it is a **normal subcommand that honours the
+global flags**. Confirmed in the isolated fixture:
+
+| Arm | `fnox export -f shell …` | Output |
+|---|---|---|
+| default | (no flags) | `FIXTURE_TOP_A`, `FIXTURE_TOP_B` |
+| profile | `-P scoped` | `FIXTURE_TOP_A`, `FIXTURE_TOP_B`, `FIXTURE_SCOPED_ONLY` (inheritance) |
+| **scoped** | `-P scoped --no-defaults` | **`FIXTURE_SCOPED_ONLY` only** |
+| bogus, fail-OPEN | `-P bogus` | `FIXTURE_TOP_A`, `FIXTURE_TOP_B`, rc=0 |
+| bogus, fail-CLOSED | `-P bogus --no-defaults` | **nothing**, rc=0 |
+
+Both arms discriminate: the scoped arm drops the two top-level secrets that the
+unscoped arm emits, and the bogus arm reproduces the known fail-open.
+
+Two correctness properties I verified rather than assumed, because the whole
+recommendation rests on them:
+
+1. **It respects per-secret `env` mode.** A fixture with
+   `FX_ENVFALSE = { …, env = false }` and `FX_ENVEXEC = { …, env = "exec" }`
+   emitted **neither** through `export -f shell`. Control arm: `FX_PLAIN` and
+   `FX_SPACES` in the same file **did** appear, so the probe can see secrets —
+   the two omissions are real filtering, not a blind probe. This matters
+   because it means `export -f shell` is **not** a confinement regression
+   versus `activate`.
+2. **It quotes safely.** `FX_SPACES = "has spaces and 'quote' and $DOLLAR"`
+   round-tripped through `eval "$(fnox export -f shell)"` **byte-identical**
+   (`posix_quote` / `shlex::try_quote`, `src/shell/mod.rs`). Output was
+   `export FX_SPACES="has spaces and 'quote' and "'$DOLLAR'` — correct
+   concatenated quoting.
+
+**So the once-per-shell, scoped, fail-closed activation is:**
+
+```zsh
+eval "$(fnox export --format shell --profile <name> --no-defaults)"
+```
+
+No hook. No `precmd_functions`. No `chpwd_functions`. One provider resolution
+per shell instead of one per shell **plus one per `cd`**.
+
+What you give up versus `activate`: automatic load/unload as you `cd` between
+projects, and pickup of a project-local `fnox.toml`. For a machine whose
+credential set is a single global config — which is this host's situation —
+that is a feature, not a loss.
+
+## Q4 — Does the daemon make activation cheap?
+
+**It makes the expensive path cheaper; it does nothing for the steady-state
+prompt, because that path already does no work.**
+
+- The daemon is **opt-in**: *"The daemon is opt-in. fnox does not use it unless
+  you enable it in config or set `FNOX_DAEMON=on`."*
+  (`docs/guide/daemon.md`)
+- `hook-env` **is** on the daemon-backed list, alongside `exec`, `get`,
+  `export`, `list --values`, `check`, `tui`, `mcp`, `ci-redact`
+  (`docs/guide/daemon.md` § What Uses It).
+- Source confirms the wiring: `load_secrets_from_config` calls
+  `crate::daemon::resolve_batch(cli, &config, profile_name, &profile_secrets,
+  crate::daemon::Purpose::HookEnv, false)` (`src/commands/hook_env.rs`).
+
+**But `resolve_batch` is only reached after `should_exit_early()` returns
+false.** On an unchanged prompt the daemon is never contacted either — there is
+no socket round-trip, because there is no resolution at all. So:
+
+| Path | Daemon OFF | Daemon ON |
+|---|---|---|
+| unchanged prompt | early exit, no resolution | early exit, no resolution (**identical**) |
+| `cd` / new shell / config change | full provider resolution (50 secrets, spawns `doppler` etc.) | Unix-socket round-trip to memory cache |
+
+So the daemon's value is precisely on the **shell-startup and `cd`** paths —
+which, per Q2, are the paths that actually hurt. Enabling it would convert a
+provider round-trip into a same-user Unix-socket read for every new shell after
+the first.
+
+Caveats that bear on whether it is the right lever here:
+
+- Cache is **memory-only**, discarded on `daemon clear`/`stop`, idle timeout,
+  or *"Config files, profile settings, provider references, post-processing
+  options, or relevant `FNOX_*` and provider environment variables change"*
+  (`docs/guide/daemon.md` § Cache Behavior). Invalidation keys on fnox-side
+  inputs only — it will not notice a rotation performed out-of-band.
+- Per-secret / per-provider opt-out exists: `daemon_cache = false`.
+- **It does not remove the first resolution.** The very first shell after boot
+  still pays the full provider cost, and that is still where a hung `doppler`
+  wedges. The daemon narrows the window; it does not close it.
+
+**Measured cost of the warm path** (isolated fixture, fnox 1.32.0, this Mac):
+
+| Measurement | avg over 30 runs |
+|---|---|
+| `fnox hook-env -s zsh`, warm (early exit, 0 bytes output) | **11.78 ms** |
+| same, from a directory 12 levels deeper | **11.65 ms** |
+| `fnox --version` (bare process-spawn floor) | **9.57 ms** |
+
+Reading: the early-exit *logic* costs roughly **2 ms**; the other ~9.6 ms is
+just starting a Rust binary. The `collect_config_files` stat sweep is
+**below the noise floor** — 12 extra directory levels changed nothing
+(11.78 vs 11.65 ms is within run-to-run variance, i.e. **not a difference**).
+
+⚠️ **Fixture limitation, stated rather than glossed:** this fixture uses
+`default = "…"` values with **no provider**, so it **cannot** measure the cold
+path's real cost. Cold measured 12.3 ms here only because there was nothing to
+fetch. The real cold path on this host resolves 50 secrets through Doppler /
+keychain / age and is orders of magnitude slower. I deliberately did **not**
+run a real cold `hook-env` against the live config: it would print 50 secret
+values, and it is the exact shape known to hang on a keychain-backed provider.
+The real cold cost is therefore **UNVERIFIED** here.
+
+## Q5 — Ordering with mise
+
+**No documented guidance, no known-conflict report — and that absence is
+control-armed and structural.** But there is a real structural interaction that
+falls out of the source, and this repo has already been bitten by it.
+
+### The absence, and the control arms
+
+- **fnox's docs say nothing about ordering.** `docs/guide/mise-integration.md`
+  mentions mise 39 times and never discusses rc-file ordering with
+  `mise activate`. Control arm: that same file **does** state a hard ordering-ish
+  requirement for the plugin (*"`tools = true` is required so the plugin can
+  access the mise-managed fnox binary. Without it, the plugin runs before mise
+  tools are added to PATH"*), so the document is fully capable of expressing an
+  ordering constraint. It expresses one for the plugin and none for `activate`.
+- **`jdx/fnox` has issues DISABLED** (`gh api repos/jdx/fnox` →
+  `"has_issues": false`). My first probe, `gh search issues --repo jdx/fnox`,
+  returned `[]` — and the control arm exposed it as **blind**: searching
+  `daemon`, a term fnox certainly discusses, also returned `[]`. Reported
+  absence from an issue search would have been a false negative.
+- **Discussions are enabled** (`"has_discussions": true`) and *do*
+  discriminate: `daemon` → **5** hits. Against that working probe,
+  `precmd` → **0**, `activate order` → **0**, `zshrc order mise` → **0**,
+  `FNOX_SHELL conflict` → **0**. So the absence of ordering discussion is a
+  **real** negative.
+- The nearest real report is discussion
+  [#300](https://github.com/jdx/fnox/discussions/300) — *"mise integration not
+  working with mise activated and fnox not installed"* — but that is about the
+  **`mise-env-fnox` plugin** racing tool installation (`sh: fnox: not found`),
+  not about `mise activate` vs `fnox activate` hook ordering.
+
+### The structural interaction (derived from source, not docs)
+
+Both tools prepend into `precmd_functions`. fnox:
+
+```zsh
+# src/shell/zsh.rs
+precmd_functions=( _fnox_hook ${precmd_functions[@]} )
+chpwd_functions=( _fnox_hook ${chpwd_functions[@]} )
+```
+
+Because it **prepends**, whichever tool is `eval`'d **last** ends up **first**
+in the array and therefore **runs first** each prompt. Ordering in the rc file
+is thus load-bearing, and inverted from the intuitive reading.
+
+Three consequences worth acting on:
+
+1. **fnox's resolution order consults the environment.** *"When fnox resolves a
+   secret, it checks in this order: 1. Encrypted value … 2. Provider reference
+   … **3. Environment variable (if already set in shell)** … 4. Default value.
+   First match wins!"* (`docs/guide/how-it-works.md`). So if mise's hook has
+   already put a same-named variable into the environment, fnox can resolve to
+   **mise's** value. Name collisions between `mise.toml [env]` and fnox secrets
+   are silently resolved by whoever ran first.
+2. **mise snapshots the environment fnox creates.** This is the already-recorded
+   incident behind `.claude/rules/secrets-out-of-the-shell-env.md`: fnox's
+   exports were captured into **`__MISE_DIFF`** (zlib+base64), a form no secret
+   scanner reads. That capture is an ordering artifact — it happens because
+   fnox's exports land inside the window mise is diffing. Any replacement file
+   inherits this hazard **unless it stops exporting into the login shell**.
+3. **Both are active on this host simultaneously** (`MISE_SHELL` and
+   `FNOX_SHELL` both set), so this is live configuration, not a hypothetical.
+
+**Recommendation:** if the replacement keeps a shell-wide load at all, do the
+fnox load **once, early, and without a hook** (Q3's `export -f shell` form).
+That sidesteps the `precmd` ordering question entirely — there is no fnox
+prompt hook to order against mise's.
+
+## Q6 — Recommended production setup per fnox's own docs
+
+fnox's docs offer **three** supported shapes and rank them only indirectly.
+Quoting:
+
+- **Shell integration** — `docs/guide/shell-integration.md`:
+  > "fnox can automatically load secrets when you `cd` into directories with a
+  > `fnox.toml` file." … "Add this to your shell profile: … `eval "$(fnox
+  > activate zsh)"`"
+
+- **`fnox exec` for anything task-launched** — `docs/guide/mise-integration.md`:
+  > "The recommended setup is to install the fnox CLI with mise, then use fnox
+  > directly through shell integration, `fnox exec`, or mise tasks."
+
+  and, explicitly for mise tasks:
+  > "For commands launched through mise, run them through `fnox exec`: … This
+  > keeps secret resolution inside fnox, so options such as `env = false`,
+  > `as_file`, leases, profiles, and provider-specific behavior all work the
+  > same as they do outside mise."
+
+- **The env plugin is explicitly NOT recommended** — same file, a `::: warning`
+  block:
+  > "**Experimental plugin.** We do not recommend using fnox through the
+  > [`jdx/mise-env-fnox`](https://github.com/jdx/mise-env-fnox) env plugin. It
+  > is an incomplete experiment and does not track every fnox feature."
+
+  and: "For new setups, prefer shell integration or `fnox exec`."
+
+So the docs' answer is **"shell integration *or* `fnox exec`"** — presented as
+co-equal, with the mise env plugin ruled out. There is **no** doc statement
+preferring global activation over per-project, and **no** doc recommending
+`activate` for a machine with a single global credential set. The `cd`-driven
+auto-load that `activate` sells is aimed at **per-project `fnox.toml` files**,
+which is not this host's shape.
+
+### The fourth shape the docs describe, aimed exactly at this problem
+
+`docs/guide/proxy.md` — the **credential proxy** — is worth flagging because it
+targets the precise hazard of "50 credentials inherited by every agent":
+
+> "The fnox credential proxy lets a command use API credentials without
+> receiving their real values. The child process receives placeholders, and
+> fnox substitutes the real values only in approved HTTPS requests. **This is
+> useful for AI agents** and other untrusted or highly automated programs that
+> need to call external APIs."
+
+with first-class examples `fnox proxy run -- codex` and
+`fnox proxy run -- claude`, `egress = "strict"` by default, and
+`"The CA private key and real secret values remain in fnox process memory."`
+
+This is **out of scope** for "what replaces the rc file" and is **not** a
+recommendation here — the current host posture (`env = true` for all 50) is a
+deliberate user decision. Recorded only because it is fnox's own answer to the
+agent-inheritance problem, and it was not on the table when that decision was
+made.
+
+---
+
+## Summary — what the replacement file should be
+
+| Option | Scoped? | Per-prompt cost | Provider hit | Verdict |
+|---|---|---|---|---|
+| `eval "$(fnox activate zsh)"` (status quo) | **No** | ~11.8 ms spawn | every `cd` + every new shell | current pain |
+| `eval "$(fnox activate zsh -P p --no-defaults)"` | **No — flags silently dropped** | same | same | **never write this**; looks scoped, is not |
+| `export FNOX_PROFILE=p; eval "$(fnox activate zsh)"` | profile only, **no** `--no-defaults` | same | same | half-scoped, fail-open on typo'd profile |
+| **`eval "$(fnox export -f shell -P p --no-defaults)"`** | **Yes, fail-closed** | **none** | **once per shell** | **best fit** |
+| `fnox exec -- <cmd>` in tasks | Yes | none | per invocation | docs-endorsed for task-launched work |
+
+The one thing that must not survive review: `fnox activate` with scoping flags
+on it. It parses, exits 0, and yields the full 50.
+
+---
+
+## Verification notes
+
+- All local probes ran against fnox **1.32.0** at
+  `/Users/rmanaloto/.local/share/mise/installs/fnox/latest/fnox`.
+- All secret-bearing probes ran in an **isolated fixture** under the session
+  scratchpad with `FNOX_CONFIG_DIR` pointed at an empty directory and
+  `FNOX_PROFILE`/`__FNOX_SESSION` unset via `env -u`. Fixture values are
+  `aaa`/`bbb`/`ccc`/`plain` — no real credential was read, printed, or resolved.
+- The user's real `~/.config/fnox/config.toml` was **not** modified or read.
+- `fnox get` and `fnox list -V` were **never** invoked.
+- **UNVERIFIED:** the real cold-path cost against the live 50-secret config
+  (deliberately not measured — it prints values and is the known keychain-hang
+  shape). Also **UNVERIFIED-NEGATIVE:** that no `FNOX_NO_DEFAULTS` env var
+  exists anywhere in the source; the `--help` scan that found
+  `FNOX_NON_INTERACTIVE` (control) showed no `[env:]` tag for `--no-defaults`,
+  which is strong but not a source-level proof.
+- Source read from `main`, not the `v1.32.0` tag. The `--help` output of the
+  installed 1.32.0 binary matches the `main` source structure on every point
+  relied upon here (two-field `ActivateCommand`, bare `hook-env -s zsh` in the
+  emitted hook), so the drift risk is low but non-zero.
+
+---
+
+## GitHub repos touched
+
+- [jdx/fnox](https://github.com/jdx/fnox) — primary source of every claim here:
+  `src/commands/activate.rs`, `src/commands/hook_env.rs`, `src/hook_env.rs`,
+  `src/shell/zsh.rs`, `src/shell/mod.rs`, `CHANGELOG.md`, and
+  `docs/guide/{shell-integration,mise-integration,daemon,profiles,how-it-works,proxy,real-world-example}.md`,
+  `docs/cli/activate.md`. Repo metadata probed via `gh api` (issues disabled,
+  discussions enabled); discussion [#300](https://github.com/jdx/fnox/discussions/300) read.
+- [jdx/mise-env-fnox](https://github.com/jdx/mise-env-fnox) — referenced only;
+  fnox's own docs carry an explicit "we do not recommend" warning against it.
+  Not cloned or read.
+- [jdx/mise](https://github.com/jdx/mise) — named as the co-resident shell-hook
+  installer in Q5; no mise source was read for this report (the `precmd`
+  prepend interaction is derived from fnox's `src/shell/zsh.rs` plus this
+  repo's own `.claude/rules/secrets-out-of-the-shell-env.md`).

--- a/docs/research/kb/reports/agents/fnox-write-surface.md
+++ b/docs/research/kb/reports/agents/fnox-write-surface.md
@@ -1,0 +1,327 @@
+# fnox write / CRUD surface — research report
+
+**Agent:** fnox-write-surface · **Date:** 2026-08-03 · **fnox version probed:** 1.32.0 (local, mise-managed)
+**Status:** COMPLETE
+
+Primary sources only: the `jdx/fnox` repo (`docs/`, `src/`, `CHANGELOG.md`) and the local 1.32.0 binary's `--help`.
+`fnox get` was never run.
+
+---
+
+## Q1 — Which providers accept writes?
+
+**Answer: read-only is the MINORITY, not the rule — but the split is not the one the
+docs' categories suggest.** 17 of 23 documented providers accept `fnox set`. Infisical is
+**one of 5 read-only providers** (1password, bitwarden *personal*, doppler, infisical,
+proton-pass), plus azure-ac which is read-only by explicit declaration. **All five
+read-only ones are the "password manager / CLI-shell-out" class** — fnox drives their
+vendor CLI for reads only.
+
+### The mechanism (source of truth)
+
+Write support is decided entirely by `Provider::capabilities()`
+(`crates/fnox-core/src/providers/mod.rs:229-233`), whose **default is
+`vec![ProviderCapability::RemoteRead]`** — i.e. read-only. Three capability values exist
+(`mod.rs:45-52`):
+
+| Capability | Meaning for a write | Where the value lands |
+|---|---|---|
+| `Encryption` | `provider.encrypt(value)` | **ciphertext in the fnox config file** |
+| `RemoteStorage` | `provider.put_secret(key, value)` | **value in the remote**; only a key/reference in the config |
+| `RemoteRead` (default) | ⚠️ **no error** — see Q2 defect | **plaintext in the config file** |
+
+Default `put_secret` (`mod.rs:210-227`) errors for a `RemoteRead` provider — but
+`set.rs` never calls it for one (see Q2).
+
+### The table
+
+Derived by reading each provider's `capabilities()` impl. A file with **no**
+`capabilities()` impl inherits the read-only default.
+
+| Provider | `capabilities()` | `fnox set` writes? | Where the secret goes | Source |
+|---|---|---|---|---|
+| age | `Encryption` | ✅ yes | ciphertext into fnox.toml | `providers/age.rs:141` |
+| aws-kms | `Encryption` | ✅ yes | ciphertext into fnox.toml | `providers/aws_kms.rs:211` |
+| azure-kms | `Encryption` | ✅ yes | ciphertext into fnox.toml | `providers/azure_kms.rs:144` |
+| gcp-kms | `Encryption` | ✅ yes | ciphertext into fnox.toml | `providers/gcp_kms.rs:121` |
+| fido2 | `Encryption` | ✅ yes | ciphertext into fnox.toml | `providers/fido2.rs:142` |
+| yubikey | `Encryption` | ✅ yes | ciphertext into fnox.toml | `providers/yubikey.rs:76` |
+| plain | `Encryption` | ✅ yes (no-op "encrypt") | plaintext into fnox.toml | `providers/plain.rs:28` |
+| aws-ps | `RemoteStorage` | ✅ yes | AWS SSM Parameter Store | `aws_ps.rs:326`, `put_secret` `:405` |
+| aws-sm | `RemoteStorage` | ✅ yes | AWS Secrets Manager | `aws_sm.rs:258`, `put_secret` `:460` |
+| azure-sm | `RemoteStorage` | ✅ yes | Azure Key Vault | `azure_sm.rs:156`, `put_secret` `:204` |
+| gcp-sm | `RemoteStorage` | ✅ yes | GCP Secret Manager | `gcp_sm.rs:232`, `put_secret` `:300` |
+| bitwarden-sm | `RemoteStorage` | ✅ yes | Bitwarden Secrets Manager | `bitwarden_sm.rs:176`, `put_secret` `:232` |
+| foks | `RemoteStorage` | ✅ yes | FOKS KV | `foks.rs:360`, `put_secret` `:371` |
+| vault | `RemoteStorage` | ✅ yes | HashiCorp Vault | `vault.rs:174`, `put_secret` `:231` |
+| keychain | `RemoteStorage` | ✅ yes | OS keychain | `keychain.rs:100`, `put_secret` `:188` |
+| keepass | `RemoteStorage` | ✅ yes | .kdbx database | `keepass.rs:354`, `put_secret` `:395` |
+| password-store | `RemoteStorage` | ✅ yes | GPG pass store | `password_store.rs:122`, `put_secret` `:135` |
+| **azure-ac** | `RemoteRead` (explicit) | ❌ **no** | — write via `az appconfig kv set` | `azure_ac.rs:179`; doc `docs/providers/azure-ac.md:82` |
+| **1password** | *(no impl → default RemoteRead)* | ❌ **no** | — write via `op` CLI | `onepassword.rs` (0 `ProviderCapability` mentions) |
+| **bitwarden** (personal) | *(no impl → default)* | ❌ **no** | — write via `bw` CLI | `bitwarden.rs` (0 mentions) |
+| **doppler** | *(no impl → default)* | ❌ **no** | — write via `doppler secrets set` | `doppler.rs` (0 mentions) |
+| **infisical** | *(no impl → default)* | ❌ **no** | — write via `infisical secrets set` | `infisical.rs` (0 mentions); doc `docs/providers/infisical.md:31,146` |
+| **proton-pass** | *(no impl → default)* | ❌ **no** | — read-only, no write path at all | `proton_pass.rs` (0 mentions); doc `docs/providers/proton-pass.md:109-125` |
+
+`passwordstate.rs` exists in source (`RemoteRead`, `passwordstate.rs:270`) but has **no
+`docs/providers/*.md` page**, so it is outside the 23 asked about. `yubikey_usb.rs`,
+`hw_encrypt.rs`, `aws_shared.rs`, `resolved.rs`, `resolver.rs`, `secret_ref.rs` are
+helper modules, not providers.
+
+**Control arm for the "no impl = read-only" claim:** `grep -l "fn capabilities" *.rs`
+returned 20 files (including `age.rs` → `Encryption`, so the pattern discriminates);
+`grep -L` returned the 11 without. For the 5 read-only providers named above I then ran a
+*second, wider* probe — `grep -c ProviderCapability <file>` — which returned **0** for
+each, so they cannot be declaring a capability by any other spelling.
+
+**Corroborating doc arm:** in the docs for every read-only provider, the only `fnox set`
+occurrences are `fnox set <PROVIDER>_TOKEN … --provider age` — i.e. storing that
+provider's *own auth token* encrypted, never writing a secret *through* it
+(`1password.md:15,85,248`; `doppler.md:195`; `infisical.md:22,107,315,390`;
+`bitwarden.md:18,91,308`). `proton-pass.md:119` lists "`fnox set` to create or update
+Proton Pass items" under **Not supported**.
+
+## Q2 — `fnox set` semantics
+
+**Both, depending on provider class — and it *always* writes the config file.**
+`src/commands/set.rs:118-196` resolves the provider, reads `capabilities()`, then:
+
+- `Encryption` → `provider.encrypt(value)` and the **ciphertext is stored in the config
+  TOML** (`set.rs:146-160`, `:233-235`). Nothing leaves the machine except a KMS call.
+- `RemoteStorage` → `provider.put_secret(key_name, value)` writes to the **remote**, and
+  the returned key/reference is stored in the config (`set.rs:161-179`, `:230-232`).
+- Everything else (i.e. `RemoteRead`) → `(None, None)` at `set.rs:180-183`.
+
+The config write itself is `config.save_secret_to_source(...)` at `set.rs:322-328`.
+
+### ⚠️ DEFECT: `fnox set` through a read-only provider silently writes PLAINTEXT
+
+`set.rs:236-243`:
+
+```rust
+} else if provider_name_to_use.is_some() {
+    // Provider specified or default provider available (but not an encryption/remote provider)
+    secret_config.set_value(Some(value.clone()));
+```
+
+So `fnox set FOO bar --provider infisical` (or `1password`/`doppler`/`bitwarden`/
+`proton-pass`/`azure-ac`) does **not** error, does **not** reach the provider, and writes
+the **cleartext value into `fnox.toml`**. The `put_secret` default that *would* have
+errored (`mod.rs:222-226`) is never called on this path. `--dry-run` shows the value
+truncated to 50 chars (`set.rs:301-309`), so a dry run does reveal it, but nothing warns.
+Marked **UNVERIFIED-BY-EXECUTION**: read from source only; not executed, because doing so
+would write a value into a live config.
+
+### Value input: argv, stdin, or hidden prompt
+
+`set.rs:70-92`. `value` is an **optional positional** (`set.rs:20`). Precedence:
+
+1. argv if given;
+2. **stdin when not a TTY** — `echo "x" | fnox set KEY` (`set.rs:76-83`, trimmed);
+3. otherwise an **interactive hidden prompt** — `demand::Input::new(...).password(true)`
+   (`set.rs:85-91`).
+
+The help text itself warns: *"Passing secrets as arguments exposes them in shell history
+and `ps` output. For sensitive values, prefer stdin or the interactive prompt."*
+(`set.rs:18-19`, and identically in local `fnox set --help` at 1.32.0). **A CLI wrapping
+fnox should pipe on stdin, never argv.**
+
+Other flags (from `set.rs:22-53`, matching local 1.32.0 `--help`): `-d/--description`,
+`-g/--global` (writes `~/.config/fnox/config.toml`), `-k/--key-name`, `-n/--dry-run`,
+`-p/--provider`, `--base64-encode`, `--default`, `--if-missing`. Global-level
+`--write-profile` selects the target profile and is **required when multiple profiles are
+active** (`fnox --help`, and `Config::resolve_write_profile` at `set.rs:58`).
+
+## Q3 — Delete
+
+**`fnox remove` exists (aliases `rm`, `delete`) and removes the DECLARATION ONLY. It
+never touches the remote.** Verified in local 1.32.0 `fnox remove --help` and in
+`src/commands/remove.rs`.
+
+- Signature: `fnox remove [-g|--global] [-n|--dry-run] <KEY>`, plus the global
+  `--write-profile` (`remove.rs:6-19`).
+- The whole implementation is: resolve the target config path, load **that file only**
+  (not the merged config, `remove.rs:54`), confirm the key exists in the write profile
+  (`remove.rs:58-77`), then `Config::remove_secret_from_source(...)` — a `toml_edit` AST
+  delete + rewrite (`remove.rs:96-97`, impl at `crates/fnox-core/src/config.rs:1171`).
+- **No provider is ever instantiated.** There is no `get_provider_resolved` call in
+  `remove.rs`, and the `Provider` trait has **no delete method at all**: `grep -rn
+  'fn delete_secret|fn remove_secret|fn delete\b' crates/fnox-core/src/providers/` →
+  **0 hits**. *Control arm:* the same grep shape for `fn put_secret` over the same
+  directory returns **11 files**, so the probe discriminates.
+
+**Consequence for a CLI using fnox as its single entrypoint:** `fnox rm` orphans the
+remote value. Deleting from AWS SM / keychain / Vault / Doppler still requires that
+provider's own CLI or API. This is a genuine hole in the CRUD surface — fnox is
+**CRU**, not CRUD, with respect to remotes.
+
+## Q4 — Write safety (#438): locking + atomicity
+
+**Still true at v1.32.0: config writes are neither locked nor atomic.** The prior
+session's finding stands; nothing has changed.
+
+Every config mutation ends in a bare truncating `std::fs::write` of the whole rendered
+document — `crates/fnox-core/src/config.rs:1011` (save), **`:1157`
+(`save_secret_to_source`, used by `fnox set`)**, **`:1209`
+(`remove_secret_from_source`, used by `fnox rm`)**, **`:1289`
+(`save_secrets_to_source`, used by `fnox sync`)**.
+
+- **No temp-file-then-rename.** `tempfile` is a dependency
+  (`crates/fnox-core/Cargo.toml:59`) but is not used on any config write path; there is
+  no `NamedTempFile`/`persist`/`rename` in `config.rs`.
+- **No file locking.** The workspace *does* pull `xx = { version = "2", features =
+  ["fslock"] }` (`Cargo.toml:106`), but the only two uses in the entire tree are
+  `crates/fnox-core/src/lease.rs:45` and `:99` — the **ephemeral-lease store**, not the
+  config. *Control arm:* the same `grep -rn` shape for `fs::write` over `src/ crates/`
+  returns **38 hits**, so the 2-hit result for lock terms is a real negative, not a dead
+  probe.
+- **The pattern is read-modify-write.** `save_secret_to_source` reads the file
+  (`config.rs:1099-1114`), edits the `toml_edit` AST, writes the whole thing back
+  (`:1157`). Two concurrent `fnox set` calls therefore **lose one update**; a crash or a
+  full disk mid-write leaves a **truncated config**, and since a file may hold age
+  ciphertexts that exist nowhere else, that is data loss, not just inconvenience.
+
+**Has anything changed recently? No.** *Control-armed negative:*
+- `CHANGELOG.md` grep for `lock|atomic|concurren|race|corrupt|clobber` returns **~30
+  hits, all of them Renovate "lock file maintenance" / `aube-lock.yaml` / `mise.lock` /
+  a proton-pass "unlock session" UX message** — none about config writes. Control: the
+  same file has **215** hits for `### `/`fnox set`, so the grep works.
+- `git log --oneline -15 -- crates/fnox-core/src/config.rs` shows the last 15 touches;
+  none is a locking/atomicity fix (nearest are `6702e0f fix(config): preserve secret
+  table formatting (#467)` and `debd3cc fix(config): load global config for explicit
+  --config paths (#651)`).
+- **The repo has GitHub Issues DISABLED** — `gh api repos/jdx/fnox --jq .has_issues` →
+  `false`, so every number is a PR and "search the issue tracker" is not available.
+  *This is exactly the control-arm case:* `gh search issues --repo jdx/fnox "sync"`
+  returned `[]`, which reads as "no such discussion" but actually means "no such
+  tracker". PR-title searches for `atomic` and `race` return **0** against a control of
+  **551 total PRs** and 17/39/27/12 body-level hits for atomic/concurrent/race/corrupt —
+  so the zero is real, not a broken query.
+
+**Implication:** a wrapper CLI that may run concurrently (a hook, a devcontainer
+bootstrap, two shells) must serialise its own `fnox set`/`rm`/`sync` calls. fnox will not
+do it. (This is the same class of hazard as dotfiles #438.)
+
+## Q5 — `fnox sync`
+
+**`sync` is a native fnox command, and it is manual-trigger only.**
+`fnox sync [FLAGS] [KEYS]…` — "Sync secrets from remote providers to a local encryption
+provider" (`docs/cli/sync.md`, `src/commands/sync.rs:12`).
+
+### What it does
+
+1. Picks a **target provider** that must have the `Encryption` capability — otherwise it
+   errors `SyncTargetProviderUnsupported` (`sync.rs:104-109`). That is why age is the
+   target in Ray's config.
+2. Selects every secret that (a) has a `provider`, (b) whose provider is **not already
+   the target**, and (c) passes the `KEYS` / `--source` / `--filter` filters
+   (`sync.rs:128-159`).
+3. Resolves each one **raw from its original provider**, deliberately bypassing the
+   cached sync value and any `json_path` post-processing (`sync.rs:222-231`).
+4. `target_provider.encrypt(plaintext)` each value and stores it as a per-secret
+   `sync = { provider = "age", value = "<ciphertext>" }` block (`sync.rs:276-282`,
+   `SyncConfig`).
+5. `Config::save_secrets_to_source(...)` writes the file (`sync.rs:301`).
+
+### Answers to the specific sub-questions
+
+- **Is it a fnox feature?** Yes, entirely. The 49 age `sync` ciphertexts in Ray's config
+  are fnox's own format.
+- **What triggers it?** **Only an explicit `fnox sync` invocation.** `SyncCommand` is
+  referenced in exactly two places, both plumbing: `src/commands/mod.rs:179` (enum
+  variant) and `:234` (dispatch). Nothing in `activate`, `hook_env`, `exec`, or the
+  daemon calls it. *Control arm:* the same grep found the `set`/`remove` dispatch lines
+  the same way, so the search shape is sound. It also **prompts for confirmation unless
+  `--force`** (`sync.rs:196-220`).
+- **Does adding/removing one secret rewrite all 49?** **`fnox set` / `fnox rm`: NO.**
+  Both `save_secret_to_source` (`config.rs:1141-1154`) and `save_secrets_to_source`
+  (`config.rs:1269-1286`) edit **only the named keys** in the `toml_edit` AST and leave
+  every other entry — including its `sync` ciphertext — byte-identical; comments and
+  formatting are preserved by design.
+  **A bare `fnox sync`: YES.** With no `KEYS`, no `--source` and no `--filter`, step 2
+  selects *every* eligible secret and step 4 re-encrypts *every* one; age encryption is
+  non-deterministic, so all 49 ciphertexts change even when no plaintext did.
+
+  **So the observed churn is the CALLING TOOL's fault, and it is avoidable**: `fnox sync
+  <KEY>` (positional) or `--filter '^KEY$'` scopes the re-encryption to one secret. A
+  wrapper CLI should always pass the key.
+
+## Q6 — List without values
+
+**`fnox list` (aliases `ls`, `secrets`) is names-only BY DEFAULT — but it CAN print
+values, via `-V/--values`.** The premise "confirm it cannot print values" is **false**;
+this is a correction, not a confirmation.
+
+From local 1.32.0 `fnox list --help`:
+
+```
+  -V, --values                         Show secret values (if available)
+  -f, --full                           Show full provider keys without truncation
+  -s, --sources                        Show source file paths where secrets are defined
+```
+
+Source: `src/commands/list.rs:23-25` declares the flag; `:120-121` only resolves values
+`if self.values`; `:143-144` / `:137-138` pick the value-printing renderers. Without the
+flag, `:159-169` prints the key plus a *provider reference* and a category string
+(`"stored value"` / `"default value"`) — never the plaintext. Note `-f/--full` widens the
+**provider key/reference**, not the value; for a `plain`-provider secret the "reference"
+IS the value, so `--full` is not unconditionally safe either.
+
+**For a wrapper CLI:** `fnox list` with no flags is the safe enumeration call, and
+`-V/--values` must be treated as dangerous exactly like `fnox get`. This repo's
+`hook_guard` currently has no rule for `fnox list --values` / `fnox list -V`
+(UNVERIFIED — not checked against `hook_guard.py` in this run; flagged for follow-up).
+
+## Bonus — the rest of the write surface (relevant to "single entrypoint")
+
+Enumerated from local 1.32.0 `fnox --help` and per-command `--help`:
+
+| Command | Writes what |
+|---|---|
+| `set` / `s` | secret declaration + (encrypt or remote put) — Q2 |
+| `remove` / `rm` / `delete` | declaration only — Q3 |
+| `sync` | `sync = {…}` ciphertext blocks — Q5 |
+| `import` / `im` | bulk-import secrets from a format; **requires `--provider`** |
+| `reencrypt` | re-encrypt `[KEYS]…` with the current provider config (scopeable) |
+| `edit` | opens the config in `$EDITOR` — arbitrary hand edits |
+| `init` / `i` | creates a new config file |
+| `provider` | ⚠️ **at 1.32.0 there is NO `provider add` / `provider remove`** — both are `unrecognized subcommand`, even though the global `--write-profile` help text lists "provider add/remove" as write commands. Either unreleased or the help text is stale. |
+| `lease` | ephemeral credential leases — the **only** path with real file locking (`lease.rs:45,99`) |
+| `tui` | interactive dashboard "for managing secrets" (write-capable; not audited here) |
+
+## Bottom line for "can a CLI use fnox as its single entrypoint?"
+
+- **Create/update: mostly yes** — 17 of 23 providers, including every KMS, every cloud
+  secrets manager, keychain, KeePass, pass and Vault.
+- **Delete: no** — fnox can only delete the declaration; remote deletion always needs the
+  provider's CLI.
+- **The five password-manager providers (1password, bitwarden, doppler, infisical,
+  proton-pass) are read-through-only**, and — the sharp edge — `fnox set --provider
+  <one of those>` **does not error, it writes plaintext into the config**
+  (`set.rs:236-243`). A wrapper must refuse that combination itself.
+- **Concurrency is the wrapper's problem**: no lock, no atomic rename, read-modify-write.
+- **Never put the value on argv**; pipe it on stdin (`set.rs:76-83`).
+
+## Method / provenance
+
+- fnox source read from a shallow clone of `jdx/fnox` at `292c788` (tip of `main`,
+  one commit past tag `v1.32.0`; `v1.32.1` was still an open release PR #673). All
+  `file:line` citations are against that tree.
+- Local binary probed: `fnox 1.32.0` (mise install). Only `--help` subcommands were run.
+  **`fnox get` was never invoked and no secret value was printed.**
+- `https://fnox.jdx.dev` was not fetched — `docs/` in the repo is the source the site is
+  generated from, and `docs/cli/*.md` is marked `@generated by usage-cli from usage spec`.
+
+### UNVERIFIED items
+
+| Claim | Why unverified | What was tried |
+|---|---|---|
+| `fnox set --provider <read-only>` writes plaintext | read from source only; executing it would write a real value into a config | `set.rs:180-183` + `:236-243` read directly; not run |
+| Whether this repo's `hook_guard` blocks `fnox list -V` | out of scope of this brief | not probed |
+| `fnox tui` write behaviour | not audited | `fnox --help` only |
+| Whether `provider add/remove` exists unreleased | `--write-profile` help names them; 1.32.0 rejects them | `fnox provider add --help` → `unrecognized subcommand` |
+
+## GitHub repos touched
+
+- [jdx/fnox](https://github.com/jdx/fnox) — primary source under study: `src/commands/{set,remove,sync,list}.rs`, `crates/fnox-core/src/{config.rs,lease.rs,providers/*}`, `docs/providers/*.md`, `docs/cli/sync.md`, `CHANGELOG.md`, `Cargo.toml`, PR list via `gh api`

--- a/docs/research/kb/reports/agents/jdx-crate-stack.md
+++ b/docs/research/kb/reports/agents/jdx-crate-stack.md
@@ -1,0 +1,326 @@
+# jdx shared Rust crate stack — mise / hk / fnox
+
+**Status:** COMPLETE
+**Question:** how cheap is it to build a new CLI on the same foundation jdx uses?
+**Method:** `git clone --depth 1` of `jdx/{mise,hk,fnox,usage,xx}` into the session
+scratchpad; manifests + `Cargo.lock` + `.github/workflows/` + `mise.toml` read from disk;
+crates.io API for publish status; `gh repo list jdx` for the starter-template search.
+Raw manifests are copied verbatim to `.agent/kb/raw/jdx-<repo>-cargo-toml.md`.
+
+## Headline
+
+There **is no jdx CLI starter template**, but there is a very consistent *house style*, and
+about **70% of a new CLI's scaffolding is copy-paste from any one of these three repos**.
+The jdx-owned crates you actually get for free are `xx`, `usage-lib`, `demand`, `clx`,
+`clap_usage` and `clap-sort` — all published on crates.io, all current, but only `xx` and
+`usage-lib` are documented for downstream use. Distribution is **not** cargo-dist; it is a
+hand-rolled but near-identical `release.yml` + `release-plz` + a `mise-tasks/release-plz`
+shell script that is ~95% byte-identical between hk and fnox.
+
+## Clone provenance
+
+| repo | HEAD | commit date |
+|---|---|---|
+| jdx/mise | `72379d0c459808f980a037065ac9c39a60032280` | 2026-08-04T06:40:11Z |
+| jdx/hk | `fc81820fb21f72497b28d4fd1315a64244076aad` | 2026-08-01T20:55:05-05:00 |
+| jdx/fnox | `292c7880d095d63de7c994a18752851064cdb78d` | 2026-08-02T02:42:28Z |
+| jdx/usage | `6cbc9317b9e7f7b96394e2a974a3b14d1bea4f8c` | 2026-08-01T22:10:39-05:00 |
+| jdx/xx | `0d481453629ffb39fa1fc0128fb385df6a699e55` | 2026-08-04T06:36:42Z |
+
+Declared versions: mise **2026.8.1** (`jdx-mise/Cargo.toml:13`), hk **1.54.0**
+(`jdx-hk/Cargo.toml:23`), fnox **1.32.0** (`jdx-fnox/Cargo.toml:6`), xx **2.6.1**
+(`jdx-xx/Cargo.toml:3`). Each matches its crates.io `max_version` exactly (below), so the
+clones are at released state, not ahead of it.
+
+> ⚠️ **Probe corrections made during this run — three, all caught by a control arm.**
+> 1. A first pass read lock versions with `awk … {print; exit}`, returning the **first**
+>    entry per name. Lockfiles carry multiple majors, so it reported `indexmap 1.9.3` while
+>    every manifest declares `indexmap = "2"`. The manifest/lock disagreement caught it.
+> 2. `gh repo list jdx --limit 200` returned **exactly 200** — my own bound, not a total.
+>    `gh api users/jdx --jq .public_repos` says **623**. The "no template" claim below is
+>    re-derived from the full 623.
+> 3. The first crates.io sweep printed **empty for all 9 crates** — a broken python
+>    one-liner, not an absent registry. No control arm had passed, so the zero was not an
+>    answer. Re-run below with a working parser.
+
+## 1. Crate table — the load-bearing categories
+
+Versions are resolved from each repo's own `Cargo.lock` (**all** versions present per name).
+"transitive" = in the lock but not declared in that repo's manifest.
+
+| Category | Crate | mise | hk | fnox | What it does | jdx's? |
+|---|---|---|---|---|---|---|
+| **CLI parsing** | `clap` | 4.6.5 | 4.6.4 | 4.6.4 | arg parser — **derive in all three** | no |
+| | └ features | `env`,`derive`,`string` | `derive` | `derive`,`env` | note: **no `cargo` feature anywhere** | |
+| | `usage-lib` | 4.1.0 (`clap`,`docs`) | 4.0.0 (via `clap_usage`) | 4.0.0 (`clap`) | CLI spec → completions + docs | **yes** |
+| | `clap_usage` | 4.0.0 | 4.0.0 | — | clap→usage-spec bridge | **yes** |
+| | `clap-sort` (dev) | 1 | 1 | 1 | test-only: subcommands must be sorted | **yes** |
+| **Errors** | `miette` | 7.6.0 (`fancy`) | 7.6.0 (transitive) | 7.6.0 (`fancy`) | diagnostic-rich errors | no |
+| | `eyre` | 0.6.12 | 0.6.12 | — | error context | no |
+| | `color-eyre` | 0.6.5 | — | — | pretty eyre reports | no |
+| | `thiserror` | 1.0.69, 2.0.19 | 2.0.19 | 1.0.69, 2.0.19 | derived error enums | no |
+| | `anyhow` | 1.0.104 | — | 1.0.104 | boxed errors | no |
+| **Async** | `tokio` | 1.53.1 (`full`) | 1.53.1 (`process`,`rt-multi-thread`,`signal`,`sync`) | 1.53.1 (`full`) | **all three are async** | no |
+| | `async-trait` | 0.1 | — | 0.1 | | no |
+| **Config** | `serde` (derive) | 1.0.229 | 1.0.229 | 1.0.229 | | no |
+| | `toml` | 0.5.11, 0.8.23, 1.1.4 | 1.1.3 | 0.5.11 (transitive) | TOML parse | no |
+| | `toml_edit` | 0.22.27, 0.25.13 | — | 0.25.13 (`serde`) | format-preserving TOML | no |
+| | `serde_json` / `serde_yaml` | ✓ / ✓ | ✓ / ✓ | ✓ / ✓ | | no |
+| | `indexmap` (`serde`) | 2.14.0 | 2.14.0 | 2.14.0 | order-preserving maps | no |
+| | `pklr` | — | 1 | — | **hk only** — Apple Pkl eval | **yes** |
+| | `schemars` | — | — | 1 | JSON-schema generation | no |
+| | **no `figment`, no `kdl`, no `config`** in any of the three | | | | | |
+| **HTTP** | `reqwest` | 0.13.4 | 0.13.4 (transitive) | 0.13.4 (+0.12.28) | **not `ureq`** | no |
+| **Logging** | `tracing` | 0.1.44 | 0.1.44 | 0.1.44 | | no |
+| | `tracing-subscriber` | 0.3.23 | 0.3.23 (`env-filter`,`json`,`fmt`) | 0.3.23 (`env-filter`) | | no |
+| | `log` | 0.4 | 0.4 | (transitive) | legacy facade, still declared in mise+hk | no |
+| **TUI / progress** | `console` | 0.16.4 | 0.16.4 | 0.16.4 | terminal styling | no |
+| | `clx` | 3.0.2 | 3.0.2 | — | jdx's progress/output layer | **yes** |
+| | `indicatif` | 0.18.6 (transitive) | 0.18.6 (via `ensembler`) | — | progress bars — **never a direct dep** | no |
+| | `demand` | 2.0.5 | 2.0.5 | 2.0.5 | **prompts/selects, all three** | **yes** |
+| | `tabled` (`ansi`) | 0.21.0 | — | 0.21.0 | tables | no |
+| | `ratatui` | — | — | 0.30.2 | full TUI — **fnox only** | no |
+| | `crossterm` | 0.29.0 (transitive) | — | 0.29.0 (`event-stream`) | terminal events | no |
+| **Templating** | `tera` | 1.20.1 + 2.1.0 | 2.1.0 | 2.1.0 | mise keeps v1 aliased as `tera1` | no |
+| **Utility** | `xx` | 2.6.1 (`glob`) | 2.6.1 (`hash`) | 2.6.1 (`fslock`) | **jdx std-lib extension, all three** | **yes** |
+| | `strum` (derive) | 0.27.2, 0.28.0 | 0.27.2, 0.28.0 | 0.28.0 | enum↔string | no |
+| | `globset` / `ignore` | 0.4.19 / 0.4.31 | same | same | **identical pair in all three** | no |
+| | `tempfile` | 3.27.0 | 3.27.0 | 3.27.0 | | no |
+| | `which` | 8.0.5 | — | 8.0.5 | binary lookup | no |
+| | `regex` / `chrono` | 1 / 0.4 | 1 / 0.4 | 1 / 0.4 | | no |
+| | `expr-lang` | 1.1.1 | 1.1.1 (`serde`) | — | expression language | **yes** |
+| | `ensembler` | — | 1.1.3 | — | command runner + progress | **yes** |
+| **Testing** | `bats` (shell) | — | **150 files** | **72 files** | ⚠️ **the primary CLI test harness** | n/a |
+| | `insta` | 1.48.0 (`filters`,`json`) — **80 `.snap`** | — | — | snapshot tests, **mise only** | no |
+| | custom `e2e/` | 24 files | — | — | mise's own e2e runner | n/a |
+| | `test-log` / `pretty_assertions` / `mockito` / `ctor` | ✓ | — | — | mise only | no |
+| | `assert_cmd`, `rstest`, `trycmd`, `predicates` | **0** | **0** | **0** | control arm: `tempfile` → 1/1/1 | — |
+
+### The intersection: direct deps common to ALL THREE
+
+| Crate | mise | hk | fnox | Note |
+|---|---|---|---|---|
+| `clap` (derive) | 4.6.5 | 4.6.4 | 4.6.4 | |
+| `usage-lib` | 4.1.0 | 4.0.0 (via `clap_usage`) | 4.0.0 | **jdx** |
+| `xx` | 2.6.1 | 2.6.1 | 2.6.1 | **jdx**, one feature each |
+| `demand` | 2.0.5 | 2.0.5 | 2.0.5 | **jdx** |
+| `clap-sort` (dev) | 1 | 1 | 1 | **jdx** — the only dev-dep shared by all three |
+| `tokio` | 1.53.1 | 1.53.1 | 1.53.1 | |
+| `serde` + `serde_json` + `serde_yaml` | 1.0.229 | 1.0.229 | 1.0.229 | |
+| `miette` | 7.6.0 | 7.6.0 | 7.6.0 | |
+| `thiserror` | 2.0.19 | 2.0.19 | 2.0.19 | |
+| `tracing` + `tracing-subscriber` | 0.1.44 / 0.3.23 | same | same | |
+| `console` | 0.16.4 | 0.16.4 | 0.16.4 | |
+| `reqwest` | 0.13.4 | 0.13.4 | 0.13.4 | rustls in fnox; mise defaults native-tls |
+| `indexmap` (`serde`) | 2.14.0 | 2.14.0 | 2.14.0 | |
+| `globset` + `ignore` | 0.4.19 / 0.4.31 | same | same | |
+| `tera` | 2.1.0 | 2.1.0 | 2.1.0 | |
+| `strum` (derive), `regex`, `chrono`, `tempfile` | ✓ | ✓ | ✓ | |
+| edition **2024** + `resolver = "3"` | ✓ | ✓ | ✓ | |
+
+**Errors are the one category that is NOT uniform.** mise = `eyre` + `color-eyre` +
+`miette`; hk = `eyre` + `thiserror`; fnox = `miette(fancy)` + `anyhow` + `thiserror`.
+`miette` appears in all three only because **`xx` itself depends on `miette 7`
+unconditionally** (`jdx-xx/Cargo.toml:25`) — every `xx` consumer inherits it. So there is no
+single house error story; if you copy one, copy fnox's (`miette` fancy for user-facing
+diagnostics + `thiserror` for library errors + `anyhow` at the edges).
+
+**Everything is async on tokio** — even hk, a git-hook runner, pulls
+`process`/`rt-multi-thread`/`signal`/`sync`. Nothing here is a blocking CLI.
+
+## 2. jdx's OWN crates — published, and how reusable
+
+All queried live against `https://crates.io/api/v1/crates/<name>`:
+
+| Crate | crates.io max | total dl | recent dl | documented for downstream? |
+|---|---|---|---|---|
+| `xx` | **2.6.1** | 338,149 | 102,180 | **yes** — `docs.rs/xx`, rustdoc with runnable examples |
+| `usage-lib` | **4.1.0** | 381,404 | 112,590 | **yes** — `usage.jdx.dev` |
+| `demand` | **2.0.5** | 417,659 | 147,639 | no `documentation` field set |
+| `expr-lang` | **1.1.1** | 178,030 | 48,479 | `docs.rs/expr-lang` |
+| `clx` | **3.0.2** | 134,507 | 80,408 | none — effectively internal |
+| `clap_usage` | **4.0.0** | 73,918 | 48,294 | points at `usage.jdx.dev`; thin |
+| `clap-sort` | **1.0.3** | 67,192 | 30,377 | `docs.rs/clap-sort`; trivial |
+| `ensembler` | **1.1.3** | 23,420 | 6,179 | `docs.rs/ensembler`; thin, hk-only |
+| `pklr` | **1.3.0** | 12,341 | 7,995 | none |
+| `usage` (the CLI binary) | 1.4.0 | 8,749 | 313 | — (note: **binary is 1.x while the lib is 4.x**) |
+
+Download counts are heavily inflated by mise/hk/fnox's own CI, so treat them as
+"published and maintained", not "third-party adoption".
+
+### `xx` — the full surface (this is the reusable one)
+
+`jdx-xx/src/`: `archive.rs` · `cache.rs` · `context.rs` · `env.rs` · `error.rs` ·
+`file.rs` · `fslock.rs` · `git.rs` · `hash.rs` · `home.rs` · `http.rs` · `platform.rs` ·
+`process.rs` · `rand/` · `regex.rs` · `suggest.rs` · `test.rs` — **9,769 LOC / 21 files**.
+
+Beyond `xx::fslock` (fnox's `lease.rs`), you get:
+
+- **file ops** — `file::read_to_string`, `file::write` (auto-creates parent dirs),
+  `file::mkdirp`, all with better error messages (`jdx-xx/src/lib.rs:44-57`)
+- **process** — `process::sh("…")`, `process::cmd("git", &["status"]).read()` builder
+  (`jdx-xx/src/lib.rs:60-71`), backed by `duct`
+- **git** — `git::Git`, `git::CloneOptions` high-level repo management
+- **hashing** — sha2 by default; `hash_blake3` / `hash_md5` / `hash_sha1` opt-in
+- **archives** — tar.gz / tar.bz2 / tar.xz / zip, **both directions** (10 granular features)
+- **http** — a `reqwest` wrapper (gzip + json + urlencoded)
+- **glob** (`globwalk`), **cache**, **env**, **platform detection**, **did-you-mean
+  suggestions** (`strsim`), **test helpers**
+
+Feature flags: `archive`, `cache`, `fslock`, `glob`, `hash`, `hash_blake3`, `hash_md5`,
+`hash_sha1`, `http`, `native-tls` / `rustls` / `rustls-native-roots`
+(`jdx-xx/Cargo.toml:48-70`). Always-on core: `rand`, `log`, `miette`, `regex`, `strsim`,
+`thiserror`, plus (non-wasm) `duct`, `filetime`, `homedir`. **It builds for wasm**
+(`getrandom` wasm_js target block, `jdx-xx/Cargo.toml:45-46`). MSRV **1.88**, edition 2024.
+
+`xx`'s own dev-deps show the house library-test style, which differs from the CLI style:
+`insta`, `pretty_assertions`, `test-log`, `wiremock`, `tempfile` (`jdx-xx/Cargo.toml:72-81`).
+
+## 3. Project shape
+
+| | mise | hk | fnox | usage | xx |
+|---|---|---|---|---|---|
+| shape | **workspace**, 5 members + root | **single crate** | **workspace**, 2 members | **workspace**, 3 members | **single crate** |
+| members | `vfox`, `aqua-registry`, `mise-interactive-config`, `mise-shim`, `mise-sigstore` | — | `.` + `crates/fnox-core` | `cli`, `clap_usage`, `lib` | — |
+| edition | 2024 | 2024 | 2024 | — | 2024 |
+| resolver | 3 | 3 | 3 | — | — |
+| MSRV | **1.91** | **1.88.0** | **1.91.1** | — | **1.88** |
+| `.rs` files | 496 | 101 | 116 | 82 | 21 |
+| total `.rs` LOC | 240,573 | 22,678 | 37,995 | 24,721 | 9,769 |
+| root `src/` LOC | 220,645 | 21,607 | 36,755 | 20,553 | 9,769 |
+| build script | `build.rs` (`built`, `phf_codegen`, `cfg_aliases`) | `build/mod.rs` (`codegen` crate) | in `fnox-core` (`proc-macro2`+`quote`) | — | none |
+| extra bins | `mise-shim` (workspace member) | `generate-docs` (`bin/generate_docs.rs`) | — | `usage` | lib only |
+| shell tests | — (`e2e/`, 24 files) | 150 `.bats` | 72 `.bats` | — | — |
+
+mise workspace member LOC: `vfox` 6,688 · `mise-interactive-config` 5,655 ·
+`aqua-registry` 4,449 · `mise-sigstore` 2,194 · `mise-shim` 73.
+
+**fnox's split is the shape to copy for a new CLI.** `fnox-core` holds providers, config and
+secret resolution; the root `fnox` binary holds commands, MCP server, TUI, hook-env and
+shell integration, and re-declares only what the *binary* needs — the manifest says so
+explicitly at `jdx-fnox/Cargo.toml:126-128`. All versions live in `[workspace.dependencies]`
+(`jdx-fnox/Cargo.toml:17-106`) and members write `{ workspace = true }`.
+
+**MSRV is a deliberate, documented decision, not drift.** fnox pins 1.91.1 with a comment
+telling you not to raise it for a dependency bump — *"pin the dependency to an
+MSRV-compatible version instead"* (`jdx-fnox/Cargo.toml:11-15`), because distro/nixpkgs
+packagers build from source with an older shared rustc.
+
+`tokei` is **not installed on this host** — LOC is `find … -name '*.rs' | xargs wc -l`
+excluding `target/` and `vendor/`, so it includes tests and comments.
+
+## 4. Release / distribution tooling
+
+**Not cargo-dist.** Control-armed: `grep -ril 'cargo-dist\|cargo dist'` finds **zero** hits
+in hk/fnox/usage/xx; mise's two hits are `registry/cargo-dist.toml` (mise's *registry entry*
+for cargo-dist as a tool it can install) and its vendored aqua registry — not its own use.
+No `dist-workspace.toml` / `dist.toml` anywhere. Control: `grep -ril release` over
+`.github/` returns 16/4/6/3/1 files, so the probe can see.
+
+**The jdx-standard answer, in four layers:**
+
+1. **Version + changelog + tag** — `release-plz` (mise, hk, fnox, usage) driven by a
+   `release-plz.yml` workflow that does nothing but `mise run release-plz`
+   (`jdx-hk/.github/workflows/release-plz.yml:38`). The actual logic is a **shell script at
+   `mise-tasks/release-plz`** (hk 65 lines, fnox 68 lines). `xx` is the odd one out — it
+   uses `release-please` instead. Changelog generation is `git cliff`.
+2. **Binary build** — `taiki-e/upload-rust-binary-action` in a target matrix, with
+   `build-tool: cargo` for macOS/Windows and `build-tool: cross` for Linux
+   (`jdx-fnox/.github/workflows/release.yml:26-63`). Run with `dry-run: true` so it *builds
+   and packages* but doesn't upload; the artifacts are collected and a separate
+   `create-release` job runs `gh release create`. macOS binaries are **codesigned** via
+   `apple-actions/import-codesign-certs` + `codesign: "Developer ID Application: Jeffrey
+   Dickey (4993Y37DX6)"`. Targets: aarch64/x86_64 × {apple-darwin, linux-gnu, linux-musl,
+   pc-windows-msvc} = 8 for fnox, 7 for hk.
+3. **crates.io** — plain `cargo publish` from a workflow job
+   (`jdx-hk/.github/workflows/release.yml:224`), or from the release-plz script for
+   workspaces (`cargo publish -p fnox-core` then `-p fnox`, because the binary path-depends
+   on core at an exact version).
+4. **Release notes** — `communique generate "$TAG" --github-release` (another jdx tool; uses
+   `ANTHROPIC_API_KEY`) plus a hardcoded sponsor blurb appended with `gh release edit`.
+
+**mise alone is bespoke and much larger** (434-line `release.yml` vs fnox's 173) because it
+fans out to every packaging channel: `rpm`, `deb`, plus separate workflows for
+`copr-publish`, `ppa-publish`, `snapcraft-publish`, `winget`, `npm-publish`, `docker`,
+`release-alpine`. **A new CLI does not inherit any of that** — hk and fnox ship
+tarballs + crates.io only, and are installed via mise/`ubi` from GitHub releases.
+
+**The workflow set is a template.** hk, fnox and usage all carry the same nine files with
+near-identical sizes: `aube-lock` (20/20/20 lines), `auto-merge-release` (74/74/74),
+`pr-closer` (17/21/21), `perf-pr` (205/208/205), `perf` (90/95/90), `docs` (72/62/62),
+`zizmor` (21/25/21), `release-plz`, `release`. The `mise-tasks/release-plz` scripts diff to
+**~12 lines** between hk and fnox, and every difference is workspace-vs-single-crate publish
+or a `|| true`. That is copy-paste, not a shared action or reusable workflow.
+
+Other house conventions visible in the workflows: every action is **SHA-pinned with a
+version comment**, `permissions: {}` at workflow level with per-job grants,
+`persist-credentials: false`, a `zizmor` (GHA security lint) workflow, `jdx/mise-action` +
+`mise trust --all` as the universal setup step, a **per-repo PAT** (`HK_GH_TOKEN`,
+`FNOX_GH_TOKEN`) rather than `GITHUB_TOKEN`, and an `auto-merge-release` cron that will not
+merge a release younger than 7 days. hk additionally does **PGO + BOLT** optimized builds
+with dedicated `[profile.serious]` / `[profile.serious-pgo]` profiles
+(`jdx-hk/Cargo.toml:88-99`).
+
+### The dev-loop task vocabulary (the real scaffolding)
+
+Every repo has a `mise.toml` with the same task names: `build`, `test`, `lint`, `lint-fix`,
+`ci`, `render` (regenerate docs/completions/schemas), `perf`, `perf:record`, `release-plz`.
+hk puts them in `mise-tasks/` as files (18 of them); fnox and usage put most inline in
+`mise.toml` and keep only `release-plz` as a file. fnox's `test` is
+`depends = ["test:cargo", "test:bats"]` and runs bats under `fnox exec --` with
+`--jobs 16` and tranche-splitting for CI (`jdx-fnox/mise.toml:30-56`).
+
+## 5. Is there a "jdx CLI starter"? — **No.**
+
+Control-armed search over **all 623** of jdx's public repos (`gh api users/jdx --jq
+.public_repos` = 623; `gh repo list jdx --limit 700` returned 623 rows — the earlier
+`--limit 200` was my own bound and was discarded):
+
+- `isTemplate == true`: **3 repos**, all mise-plugin templates —
+  `mise-tool-plugin-template`, `mise-backend-plugin-template`, `mise-env-sample`. **None is
+  a Rust CLI starter.**
+- Regex over name+description for
+  `template|starter|scaffold|boilerplate|cookiecutter|skeleton|generator|create-|toolkit`:
+  **7 hits**, all accounted for — the three mise-plugin templates, `mise-env-plugin-template`,
+  `angular-boilerplate` ("example angular app"), `heroku-plugin-readme-generator`,
+  `smithy-typescript` (a fork). **Control arm: `mise` in name → 14 repos**, so the search sees.
+- `create-my-cli` looked promising and is **empty** — created 2018-01-09, no README, no
+  primary language, 0 stars, last pushed 2024. A dead stub from jdx's oclif (Node) era.
+- `gabarit` (French for "template") is **not one either** — `gh repo view` description:
+  *"⚠️ SUPER WIP, ignore — toolbelt experiment for coding agents"*, created 2026-07-16.
+- `jdx/usage` docs (`jdx-usage/docs/`) contain **no "build a CLI like mise" guide** — the
+  tree is `cli/`, `spec/`, `contributing.md`, `index.md`. Grepping for
+  `scaffold|starter|template|getting started|new project` hits only vitepress theme files
+  and the spec reference. Control arm: `completions` → 14 files, so the corpus is greppable.
+
+**So the honest answer:** the jdx foundation is a *convention*, distributed by copy-paste.
+There is no `cargo generate jdx/cli-template`. To stand up a new CLI in this style you would
+fork the manifest + `.github/workflows/` + `mise.toml` + `mise-tasks/release-plz` from
+**fnox** (the smallest complete workspace example) and delete what you don't need.
+
+### Cost estimate for a new jdx-style CLI
+
+| You get for free | You must copy/write |
+|---|---|
+| `xx` (file/process/git/hash/archive/http/lock) — 9,769 LOC you don't write | `Cargo.toml` dep block (~40 lines, transcribe from fnox) |
+| `usage-lib` + `clap_usage` — completions + docs generation from your clap tree | 9 GHA workflows (~700 lines total, near-verbatim from fnox) |
+| `demand` — prompts/selects | `mise-tasks/release-plz` (~68 lines) |
+| `clx` — progress/output | `mise.toml` task set (~120 lines) |
+| `clap-sort` — the sorted-subcommand test | The bats harness + `test/*.bats` |
+| `release-plz` + `git cliff` + `taiki-e/upload-rust-binary-action` (all third-party) | Codesigning secrets / Apple Developer ID (if you want signed macOS builds) |
+
+Realistically: **a day of scaffolding**, and the dependency list is the cheap part. The
+expensive, non-obvious parts are the release pipeline (~700 lines of workflow you inherit by
+copying, not by importing) and the bats test harness.
+
+## GitHub repos touched
+
+- [jdx/mise](https://github.com/jdx/mise) — manifest, lockfile, workspace shape, 7-channel release pipeline
+- [jdx/hk](https://github.com/jdx/hk) — manifest, lockfile, single-crate shape, PGO+BOLT profiles, release-plz task
+- [jdx/fnox](https://github.com/jdx/fnox) — workspace manifest, fnox-core split, MSRV policy, bats harness, release.yml
+- [jdx/usage](https://github.com/jdx/usage) — jdx-owned CLI spec crate; docs tree searched for a starter guide
+- [jdx/xx](https://github.com/jdx/xx) — jdx-owned utility crate; full module + feature surface
+- [jdx/gabarit](https://github.com/jdx/gabarit) — probed as a possible template ("gabarit" = FR "template"); it is not
+- [jdx/create-my-cli](https://github.com/jdx/create-my-cli) — probed as a possible starter; empty 2018 stub
+- [taiki-e/upload-rust-binary-action](https://github.com/taiki-e/upload-rust-binary-action) — the binary-release action all three use
+- [release-plz/release-plz](https://github.com/release-plz/release-plz) — version/changelog/publish automation

--- a/docs/research/kb/reports/agents/jdx-fnox-core-bindings.md
+++ b/docs/research/kb/reports/agents/jdx-fnox-core-bindings.md
@@ -1,0 +1,379 @@
+# fnox-core: binding surface for a NON-Rust consumer
+
+**Agent:** jdx-fnox-core-bindings
+**Date:** 2026-08-04
+**Status:** COMPLETE
+**Corpus:** shallow clone of `jdx/fnox` @ `292c788` (2026-08-02, "ci: build perf binaries on bamboo (#674)"), workspace version **1.32.0**
+
+## Question list
+
+1. Any binding protocol out of `fnox-core` a non-Rust caller could use?
+2. `fnox mcp` — usable programmatic surface?
+3. `fnox-core` public API surface, precisely.
+4. Stability / semver / lockstep with the binary.
+
+---
+
+## Q1 — Binding protocol out of `fnox-core`: **NONE**
+
+### Crate type
+
+`crates/fnox-core/Cargo.toml` has **no `[lib]` section at all** (verified: file is 94 lines,
+`[package]` / `[dependencies]` / target-cfg deps / `[build-dependencies]` / `[dev-dependencies]` only).
+No `[lib]` ⇒ default `crate-type = ["rlib"]` ⇒ **Rust-only, statically linked at Rust compile time.**
+There is no `.so`/`.dylib`/`.a` artifact for a non-Rust caller to link or `dlopen`.
+
+### Grep sweep (repo root, `--include='*.rs' --include='*.toml'`, `Cargo.lock` excluded)
+
+| Term | Hits |
+|---|---|
+| `crate-type` | **0** |
+| `cdylib` | **0** |
+| `staticlib` | **0** |
+| `no_mangle` | **0** |
+| `wasm-bindgen` / `wasm_bindgen` | **0** / **0** |
+| `napi` | **0** |
+| `uniffi` | **0** |
+| `neon` | **0** |
+| `cbindgen` | **0** |
+| `interoptopus` | **0** |
+| `pyo3` | **0** |
+| `extern "C"` | 26 — **inbound only, see below** |
+| `ffi` | 62 |
+
+**Control arm** (same command shape, terms known present): `clap` → 56, `async_trait` → 68,
+`libloading` → 5, `rmcp` → 13. The probe discriminates; the zeros are real.
+
+### The 26 `extern "C"` are fnox CONSUMING C, not exposing it
+
+Every one is in `crates/fnox-core/src/providers/yubikey_usb.rs:91-208` — function-pointer *types*
+for `libusb` symbols resolved at runtime through `libloading::Library::new` (`yubikey_usb.rs:131`,
+`:147-208`, e.g. `.get::<unsafe extern "C" fn(...)>(b"libusb_init\0")`). The file's own doc comment
+(`yubikey_usb.rs:4`) says it "loads libusb at runtime via `libloading`". Direction is **inbound**:
+fnox is the C *caller*, never the C *callee*. `libloading` appears at exactly 5 sites, all this file
+plus the two Cargo.toml declarations — there is no plugin-loading system.
+
+**Conclusion Q1a: there is no FFI, no dynamic library, no WASM, no language binding of any kind
+out of `fnox-core`. A non-Rust program cannot link it. Full stop.**
+
+---
+
+## Q3 (partial) — the `Fnox` convenience API is READ-ONLY
+
+`crates/fnox-core/src/library.rs`. Public surface of the `Fnox` struct:
+
+| Item | Signature | Notes |
+|---|---|---|
+| `CONFIG_FILENAME` | `pub const &str = "fnox.toml"` | `library.rs:40` |
+| `Fnox::discover()` | `-> Result<Self>` | `library.rs:75` — upward walk + parent/local/global merge (`Config::load_smart`) |
+| `Fnox::open(path)` | `-> Result<Self>` | `library.rs:100` — **strictly one file**, no merge, no discovery |
+| `.with_profile(s)` / `.with_profiles(iter)` | builder | `library.rs:127`, `:132` |
+| `.with_no_defaults(bool)` | builder | `library.rs:140` |
+| `.profile()` | `-> &str` | `library.rs:146` |
+| `.config()` | `-> &Config` | `library.rs:153` — escape hatch to the lower-level surface |
+| `.get(key)` | `async -> Result<Option<String>>` | `library.rs:167` — resolves a VALUE |
+| `.list()` | `-> Result<Vec<String>>` | `library.rs:202` — **declared** names, sync, no I/O |
+
+**No `set`.** The module doc says so explicitly (`library.rs:10-16`): the API was designed in
+response to [jdx/fnox discussions/441], "First cut covers `get` and `list`. `set` is left to a
+follow-up because the orchestration in `commands::set::SetCommand::run` … is substantial enough to
+warrant its own design pass." So the library API is read-only *by design*. Writes live in the
+**binary's** `commands` module, which is not published as a library. (Note: the `Provider` **trait**
+is *not* read-only — it has `encrypt` and `put_secret`. See the Q3 correction below.)
+
+`Fnox` is `Clone` + `Debug`, `Config` behind `Arc` (`library.rs:46-52`), test at `:417` asserts clone
+shares the Arc.
+
+### `fnox-core/src/lib.rs` module visibility (`lib.rs:11-32`)
+
+`pub`: `auth_prompt, config, config_path, env, error, http, lease, lease_backends, library,
+providers, secret_resolver, settings, source_registry, spanned, suggest, temp_file_secrets`.
+`pub(crate)` (NOT downstream-reachable): **`credential_command`**, **`keyring_store`**.
+Re-exports: `pub use error::{FnoxError, Result}; pub use library::Fnox;`.
+
+---
+
+## Q1b — The daemon: a real wire protocol, but PRIVATE and versioned-against-you
+
+`src/daemon.rs` (1,650 lines) — note it lives in the **binary** crate `src/`, **not** in
+`crates/fnox-core/`. So it is not part of the published library at all.
+
+**Transport:** newline-delimited **JSON over a Unix domain socket**. `tokio::net::UnixListener`
+(`daemon.rs:16`), `serde_json::to_string` + `read_line` (`daemon.rs:673`, `:691`, `:720`, `:734`).
+Docs confirm: "Unix-first and uses a Unix domain socket. It does not listen on TCP"
+(`docs/guide/daemon.md` § Security Model).
+
+**Message types — all PRIVATE (no `pub`):**
+
+```rust
+// daemon.rs:93-137
+#[derive(Serialize, Deserialize)] #[serde(tag = "type", rename_all = "snake_case")]
+enum Request { ResolveBatch(..), ResolveOne(..), Status, Clear, Shutdown }
+
+// daemon.rs:138-151
+#[derive(Serialize, Deserialize)] #[serde(tag = "status", rename_all = "snake_case")]
+enum Response {
+    Resolved { values: IndexMap<String, Option<String>> },   // ← raw VALUES
+    Status { pid: u32, cached_entries: usize },
+    Ok,
+    Error { message: String },
+}
+```
+
+**The wire format is explicitly declared unstable, and the design actively LOCKS OUT
+third-party clients.** `daemon.rs:1044-1048`:
+
+```rust
+/// Wire-protocol version tag included in the socket path hash.
+/// Incrementing this ensures new clients don't connect to stale daemons
+/// running an incompatible wire format.
+const WIRE_VERSION: u8 = 2;
+```
+
+The socket *path* is `runtime_dir()/<blake3(WIRE_VERSION ‖ profiles ‖ no_defaults ‖ if_missing ‖
+age_key_file)[..16]>-fnoxd.sock` (`daemon.rs:1048-1068`), with `runtime_dir()` = `$XDG_RUNTIME_DIR/fnox`
+or `$TMPDIR/fnox-<uid>/fnox`, with a `/tmp/fnox-<uid>/<hash8>/fnox` fallback when the path would
+exceed the ~100-byte `sun_path` limit (`daemon.rs:1069-1089`). A third-party client would have to
+reimplement that whole hash to even *find* the socket, and the version byte guarantees a silent
+disconnect on any bump. There is **no negotiation and no compatibility window** — the only nod to
+compat is a single `#[serde(rename = "include_env_false")]` kept for a renamed field
+(`daemon.rs:118-120`).
+
+**Zero documentation of the protocol.** `docs/guide/daemon.md` (saved verbatim to
+`.agent/kb/raw/fnox-docs-guide-daemon.md`) documents `[daemon] enabled/idle_timeout`, the
+`fnox daemon start|status|clear|stop` verbs, cache behavior, `daemon_cache = false`, and the
+security model. It documents **no message shape, no socket path, no field names.** Nothing in
+`docs/` describes the JSON schema.
+
+Also: the daemon is **opt-in** (`docs/guide/daemon.md`: "fnox does not use it unless you enable it
+in config or set `FNOX_DAEMON=on`") and Unix-only, and it verifies the peer's uid both directions.
+
+**Verdict:** speaking the daemon protocol from Python is *technically possible* and *categorically
+unwise* — it is a private, unversioned-except-to-break-you, undocumented internal IPC that requires
+the user to have opted the daemon in. It is not a binding surface.
+
+---
+
+## Q2 — `fnox mcp`: a REAL, documented programmatic surface (the only one)
+
+Sources: `docs/guide/mcp.md` (verbatim → `.agent/kb/raw/fnox-docs-guide-mcp.md`),
+`src/commands/mcp.rs` (84 lines), `src/mcp_server.rs` (689 lines).
+
+**Transport: stdio only.** `src/commands/mcp.rs:73` — `server.serve(rmcp::transport::io::stdio())`.
+Built on `rmcp` v2 (the official Rust MCP SDK) with features `["server", "transport-io", "macros"]`
+(`Cargo.toml:77`). Control arm on capabilities: `enable_tools` → 1 hit, `enable_resources` → **0**,
+`enable_prompts` → **0**, `enable_logging` → **0** (`src/mcp_server.rs:568`
+`ServerCapabilities::builder().enable_tools().build()`). **No resources, no prompts — tools only.**
+No HTTP/SSE transport anywhere.
+
+**Exactly two tools** (`#[tool]` attribute count in `src/mcp_server.rs` = 2, at `:209` and `:292`):
+
+| Tool | Line | Returns |
+|---|---|---|
+| `get_secret` | `mcp_server.rs:209` | **the raw secret VALUE** as a text ContentBlock |
+| `exec` | `mcp_server.rs:292` | subprocess stdout/stderr (captured, ≤1 MiB) |
+
+`get_secret` returns `CallToolResult::success(vec![ContentBlock::text(value.clone())])`
+(`mcp_server.rs:246-248`, `:268`) — the plaintext value, unredacted.
+
+**What `redact_output` actually gates — narrower than it sounds.** It is read at **exactly one
+site**: `src/mcp_server.rs:463`, `if self.mcp_config.redact_output() { … }`, inside the **`exec`**
+tool's output handling. Default `true` (`crates/fnox-core/src/config.rs:489-490`). It literal-string-
+replaces resolved secret values in the subprocess's stdout/stderr with `[REDACTED]`. It does
+**not** touch `get_secret`, and the docs say so: "Redaction performs literal string matching and does
+not detect base64-encoded or otherwise transformed values" (`docs/guide/mcp.md:100`). The intended
+lockdown posture is `tools = ["exec"]` + redaction on, which removes the value-returning path
+entirely.
+
+**Other config knobs** (`[mcp]` in `fnox.toml`): `tools = ["get_secret", "exec"]` (default both;
+disabled tools are **not advertised in `tools/list`** — `mcp_server.rs:574` `list_tools` +
+`:593` `get_tool`), `secrets = [...]` allowlist (`commands/mcp.rs:66` `mcp_config.filter_secrets`),
+`exec_timeout_secs` (must be ≥ 1, `commands/mcp.rs:59-64`), `redact_output`.
+
+**Read-only?** With respect to fnox's own state, **yes** — there is no `set_secret`, `remove`,
+`sync`, or `provider` tool. Control arm: the `#[tool]` grep returns exactly the two above; a
+write tool would have to carry that attribute. But `exec` runs **arbitrary commands with secrets
+injected**, so the *process* is not sandboxed — it just cannot mutate fnox config through MCP.
+(You could of course have `exec` shell out to `fnox set`. That is the agent choosing to, not a
+surface fnox exposes.)
+
+**Behavioral notes that matter to a downstream driver:**
+- Non-interactive is forced (`commands/mcp.rs:18` `env::set_non_interactive(true)`) — provider
+  prompts would corrupt the JSON-RPC stream. So any provider needing a TTY prompt **fails** here.
+- First tool call batch-resolves every `env = true` / `env = "exec"` secret
+  (`mcp_server.rs:94` `ensure_resolved`), amortizing yubikey/SSO. `env = false` resolves on demand.
+- `as_file = true` secrets are **rejected** by `get_secret` (`mcp_server.rs:222-231`) — exec only.
+- Cache is process-memory, cleared on EOF/disconnect.
+- It can sit on top of the daemon (`Purpose::Mcp` at `daemon.rs:73`).
+
+**Viability as a Python-facing surface:** yes, mechanically. It is a standard stdio MCP server, so
+`mcp` (the Python SDK) `stdio_client` drives it in a few lines, and it is the one surface with a
+public spec and user-facing documentation. But note what it costs versus shelling out to the CLI:
+you still spawn the `fnox` binary as a subprocess (`command: "fnox", args: ["mcp"]`), you now carry
+an MCP client dependency and a JSON-RPC handshake, and you get **strictly fewer verbs** —
+`get_secret` and `exec` only, i.e. no `set`, `list`, `sync`, `check`, `provider`, `edit`, `import`.
+Shelling out to `fnox` gives you the whole CLI for the same process spawn.
+
+---
+
+## Q3 (rest) — the `Provider` trait, and whether a downstream can implement one
+
+`crates/fnox-core/src/providers/mod.rs` (487 lines).
+
+**The trait IS `pub` and IS implementable by a downstream crate** (`providers/mod.rs:169-170`):
+
+```rust
+#[async_trait]
+pub trait Provider: Send + Sync {
+    async fn get_secret(&self, value: &str) -> Result<String>;                       // :172 required
+    async fn get_secrets_batch(&self, ..) -> HashMap<String, Result<String>>;        // :185 defaulted
+    async fn encrypt(&self, _value: &str) -> Result<String>;                          // :195 defaulted → Err
+    async fn put_secret(&self, _key: &str, value: &str) -> Result<String>;            // :208 defaulted
+    fn capabilities(&self) -> Vec<ProviderCapability>;                                // :227 defaulted
+    async fn test_connection(&self) -> Result<()>;                                    // :233 defaulted
+}
+```
+
+Not sealed, not `#[non_exhaustive]` (control: `non_exhaustive` → **0** hits across `crates/` + `src/`).
+Only `get_secret` is required.
+
+⚠️ **CORRECTION to a premise in the brief.** The brief said "fnox is CRU, not CRUD — the `Provider`
+trait has no delete method." The *delete* half is right; the implication that the trait is read-only
+is not. `Provider` has **`encrypt`** (`:195`) and **`put_secret`** (`:208`) — real write methods
+("Store a secret and return the value to save in config"). What is missing is a **delete/remove**
+method: the CLI's `fnox remove` (alias `delete`) removes the *declaration from the TOML*, never the
+value from the backing store. So: trait = C/R/U, no D. Separately, the **`Fnox` convenience API**
+(Q3 above) really is read-only — no `set` at all.
+
+**But a downstream `Provider` impl cannot be REGISTERED.** There is no plugin/registry hook:
+
+| Hook | Hits (`crates/` + `src/`, `*.rs`) |
+|---|---|
+| `register_provider` | **0** |
+| `add_provider` | **0** |
+| `inventory` (typed distributed slice) | **0** |
+| `linkme` | **0** |
+| `non_exhaustive` | **0** |
+| *control* `Box<dyn Provider>` | 4 |
+
+Providers are **code-generated at build time** from **24 in-tree TOML files** in
+`crates/fnox-core/providers/*.toml` (`1password.toml`, `age.toml`, `aws-kms.toml`, … `yubikey.toml`)
+by `crates/fnox-core/build.rs` → `build/generate_providers.rs`, emitted into `$OUT_DIR` and
+`include!`-ed at `providers/mod.rs:134-162`. The generated `ProviderConfig` / `ResolvedProviderConfig`
+enums and `get_provider_from_resolved` (`providers/mod.rs:165-167`) are closed sets. A downstream
+`impl Provider` compiles and can be called by hand, but nothing in config parsing or secret
+resolution will ever route to it — adding a provider means a PR to fnox.
+
+*(This is Rust-internal detail; it changes nothing for a non-Rust caller, who cannot reach the trait
+at all.)*
+
+---
+
+## Q4 — Stability: lockstepped to the binary, no promise, undocumented, 3 months old
+
+**Lockstep: CONFIRMED.** `crates/fnox-core/Cargo.toml:3` is `version.workspace = true`, and the root
+`Cargo.toml:6` sets `version = "1.32.0"` for the whole workspace; the binary depends on it as
+`fnox-core = { path = "crates/fnox-core", version = "1.32.0" }` (`Cargo.toml:124`) — an **exact
+pinned version**, re-written every release. crates.io bears it out:
+
+| | fnox (binary) | fnox-core |
+|---|---|---|
+| First published | 0.1.0, 2025-10-20 | **1.23.1, 2026-05-02** |
+| Versions published | 21 | 12 |
+| Latest | 1.32.0 (2026-08-01) | 1.32.0 (2026-08-01) |
+| Downloads (all-time) | — | **968** |
+
+Every fnox-core release is a same-numbered fnox release. (Two gaps: `1.25.0` was never published to
+either; `1.28.0` shipped as fnox-core but **not** as the fnox binary crate — publish hiccups, nothing
+semantic.) **fnox-core bumps its minor on every single fnox release** — 12 releases in 3 months,
+roughly one per week. That is exactly the "different proposition" the brief warned about: the version
+number carries no information about API change, because it is the binary's release cadence.
+
+**No stability promise exists.** Grep over `README.md`, `docs/**.md`, `AGENTS.md`, `CONTRIBUTING.md`:
+`semver` → **0**, `semantic version` → **0**, `stability` → **0**, `stable API` → **0**,
+`breaking change` → **0**, `BREAKING` → **0**. Control arm, same files, same command shape:
+`provider` → **339**, `secret` → **511**, `daemon` → **55**. The probe sees; there is genuinely
+nothing to find. The 1,272-line `CHANGELOG.md` (git-cliff generated from conventional commits, per
+`cliff.toml`) contains **zero** "breaking" entries — breaking changes are not labelled at all.
+
+**The library is invisible in the project's own documentation.** `fnox-core` / `fnox_core` appears
+**0 times** across `README.md`, the whole `docs/` site, `AGENTS.md` and `CONTRIBUTING.md` (same
+control arm as above). The only mention anywhere is one CHANGELOG line under **1.23.1**
+(`CHANGELOG.md:373`): "extract providers and core types into fnox-core crate … [#458]". There is no
+"using fnox as a library" guide, no example, no stability statement.
+
+**It is new, and it has had one contributor-driven PR in its life.** The `Fnox` API landed in
+**v1.23.0, 2026-04-26** as `feat(library): top-level Fnox::discover() / get / list convenience API`
+by **@bglusman** (their first contribution) — `CHANGELOG.md:406`, PR
+[#442](https://github.com/jdx/fnox/pull/442), from discussion
+[#441](https://github.com/jdx/fnox/discussions/441). The crate split (#458) followed a week later.
+A `gh pr list -R jdx/fnox --state all --search "library API"` sweep (control arm: the same query
+shape with `"fnox-core"` returns 5 unrelated but real PRs, so the search works) finds **no
+subsequent PR adding `set`** or otherwise extending the library API. The `set` follow-up promised in
+`library.rs:13-16` has not landed as of 1.32.0.
+
+**docs.rs IS built and browsable:** `https://docs.rs/fnox-core/latest/fnox_core/` → **HTTP 200**,
+`<title>fnox_core - Rust</title>`, zero build-failure markers. Control arm: a bogus crate path →
+**404**, so the 200 is real.
+
+---
+
+## Bonus: the machine-readable surfaces that DO exist (both probed live on 1.32.0)
+
+These are not "bindings", but they are the closest thing to a contract a Python CLI could lean on,
+and neither was in the brief's question list:
+
+1. **`fnox usage`** — emits the complete `usage` (jdx's CLI spec DSL) KDL description of the entire
+   CLI: 275 lines, version-stamped `version "1.32.0"`, every command/flag/arg with help text.
+   Probed: `/Users/rmanaloto/.local/share/mise/installs/fnox/latest/fnox usage` → rc=0, 275 lines,
+   byte-comparable to the checked-in `fnox.usage.kdl`. It is **regenerated every release**
+   (`mise.toml:92` `fnox usage > fnox.usage.kdl`; `mise-tasks/release-plz:58` lists it as a release
+   artifact) and also published as **JSON**: `mise.toml:95` `usage g json -f fnox.usage.kdl >
+   docs/cli/commands.json` → a 60 KB JSON tree shipped in the repo and on the docs site. A Python
+   wrapper can generate/validate its own argument surface from this and detect CLI drift
+   mechanically.
+2. **`fnox schema`** — a hidden subcommand (`src/commands/schema.rs`; NOT in `fnox --help`) printing
+   a **JSON Schema draft 2020-12** for `fnox.toml` (schemars-derived). Probed: rc=0, emits
+   `{"$schema": "https://json-schema.org/draft/2020-12/schema", "title": "Config", …}`. Also shipped
+   as `docs/public/schema.json` (42 KB).
+3. **`fnox export --format json|yaml|toml|env|shell`** — structured output of resolved secrets.
+   ⚠️ This emits **VALUES**; `--all` widens it to `env = false` / `env = "exec"` secrets. Useful as
+   a batch-read path, dangerous as a debugging habit.
+4. `fnox list` has **no** `--json`; `-V/--values` prints values (do not run it here).
+
+---
+
+## Bottom line
+
+| Surface | Exists? | Usable from Python? | Documented / stable? |
+|---|---|---|---|
+| `fnox-core` as a linkable library | rlib only, **no** cdylib/staticlib | **No** — Rust-to-Rust only | docs.rs yes; project docs **0 mentions** |
+| C FFI / WASM / PyO3 / napi / uniffi | **No** (all 0 hits, control-armed) | No | — |
+| Daemon Unix-socket JSON protocol | Yes | Technically; **don't** | Private types, `WIRE_VERSION` lockout, **0** protocol docs, opt-in only |
+| `fnox mcp` (stdio MCP, `rmcp` v2) | **Yes** | **Yes** | Documented (`docs/guide/mcp.md`); 2 tools only |
+| CLI + `usage` KDL/JSON spec + `schema` JSON Schema | **Yes** | **Yes** | Documented, regenerated every release |
+
+**For a new secrets CLI written in a non-Rust language, there is exactly one sane integration path:
+shell out to the `fnox` binary**, and use `fnox usage` / `docs/cli/commands.json` and `fnox schema`
+as the machine-readable contracts to code against. The MCP server is a real, documented, standards-
+based alternative but is strictly narrower (`get_secret` + `exec`, no `set`/`list`/`sync`/`check`)
+and costs the same process spawn plus a JSON-RPC client dependency. `fnox-core` is irrelevant to
+anything that is not Rust — and even for a Rust consumer it is a 3-month-old, weekly-minor-bumping,
+un-promised, project-docs-invisible API with 968 lifetime downloads.
+
+**If the new CLI were written in Rust**, `fnox-core` becomes real but still buys less than it looks:
+`Fnox::discover/open/with_profile(s)/with_no_defaults/get/list` is read-only, and every write verb
+(`set`, `remove`, `sync`, `reencrypt`, `import`, `provider add`) lives in the binary's unpublished
+`commands` module. You would be linking a library to do the half you could already do, and shelling
+out for the other half.
+
+## GitHub repos touched
+
+- [jdx/fnox](https://github.com/jdx/fnox) — primary subject; shallow-cloned at `292c788` and grepped; docs, CHANGELOG, Cargo manifests, daemon/MCP/provider source, PR + discussion refs
+- [jdx/usage](https://github.com/jdx/usage) — the CLI spec/generator behind `fnox.usage.kdl`, `usage g markdown`, `usage g json` (referenced via `mise.toml:92-95`, `usage-lib = "4"` at `Cargo.toml:103`); not itself read
+- [modelcontextprotocol/rust-sdk](https://github.com/modelcontextprotocol/rust-sdk) — the `rmcp` v2 crate fnox's MCP server is built on (`Cargo.toml:77`, `src/commands/mcp.rs:8,73`); identified as the dependency, source not read
+
+
+## GitHub repos touched
+
+- [jdx/fnox](https://github.com/jdx/fnox) — primary subject; shallow clone grepped at `292c788`

--- a/docs/research/kb/reports/agents/jdx-usage-generator.md
+++ b/docs/research/kb/reports/agents/jdx-usage-generator.md
@@ -1,0 +1,479 @@
+# jdx/usage — what it generates, and what a new CLI on it costs
+
+**Agent:** jdx-usage-generator · **Date:** 2026-08-04 · **Status:** COMPLETE
+
+Binary probed: `/Users/rmanaloto/.local/share/mise/installs/usage/4.1.0/usage`
+(`usage-cli 4.1.0`, released 2026-07-28 per `usage/CHANGELOG.md:3`).
+Shallow clones in scratchpad: `jdx/usage`, `jdx/fnox`; pre-existing `jdx-mise`,
+`jdx-hk`. Raw sources persisted to `.agent/kb/raw/usage-*.md`, `fnox.usage.kdl`.
+
+## Bottom line
+
+`usage` is **"OpenAPI for CLIs"** (the README's own framing). It is a spec
+format (KDL) plus a standalone binary that turns that spec into completions for
+5 shells, markdown docs, man pages, JSON, typed TS/Python SDKs, a Fig spec, and
+an MCP server — **and can also be the argument parser at runtime for a program
+in any language**.
+
+For the three jdx Rust CLIs it is a *superset layer over clap*: clap still
+parses; usage generates everything downstream from a spec clap emits. For a
+**non-Rust CLI it is a full substitute** — proven by experiment below.
+
+Three answers that change the decision:
+1. **`usage` does not replace clap in a Rust CLI** — it consumes clap's tree.
+   You still write clap.
+2. **A Python CLI gets the whole downstream stack from a hand-written KDL file**
+   with zero Rust. Experiment run, all arms green.
+3. **There is no `usage init` / template / scaffold.** You write the first KDL
+   by hand, or emit it from clap/cobra.
+
+---
+
+## Q1 — What `usage` generates, and from what
+
+Input in every case is a **usage spec**: a `.usage.kdl` file (`-f`), a raw
+string (`--spec`), stdin (`-f -`), a `usage` shebang script, or the stdout of a
+CLI invoked with `--usage-cmd`.
+
+`usage --help` (verbatim, 4.1.0):
+
+```
+Commands:
+  bash           Execute a shell script using bash
+  complete-word  Generate shell completion candidates for a partial command line [alias: cw]
+  exec           Execute a script, parsing args and exposing them as environment variables [alias: x]
+  fish           Execute a shell script using fish
+  generate       Generate completions, documentation, and other artifacts from usage specs [alias: g]
+  lint           Lint a usage spec file for common issues
+  mcp            Serve a usage spec over the Model Context Protocol [alias: mcp-server]
+  powershell     Execute a shell script using PowerShell
+  sponsors       Show the companies sponsoring usage and the jdx.dev open source tools
+  zsh            Execute a shell script using zsh
+Options:
+      --usage-spec  Outputs a `usage.kdl` spec for this CLI itself
+```
+
+### The generator surface (`usage generate --help`)
+
+| Artifact | Command | Notes |
+|---|---|---|
+| Shell completions | `usage g completion <SHELL> <BIN>` | **bash, fish, nu, powershell, zsh** |
+| Shell init for all shebang scripts | `usage g completion-init <SHELL>` | bash, fish, zsh; source once from rc |
+| Fig / Amazon Q spec | `usage g fig` | |
+| JSON spec | `usage g json` | |
+| Man page | `usage g manpage [-s SECTION] [-o FILE]` | |
+| Markdown docs | `usage g markdown [-m --out-dir …] [--url-prefix …] [--html-encode] [--replace-pre-with-code-fences]` | `-m` = one file per subcommand → a docs site |
+| Typed SDK | `usage g sdk -l <typescript\|python> -o <DIR>` | subprocess wrapper, not a native binding |
+| MCP server | `usage mcp -f <spec>` | stdio JSON-RPC; **describes**, does not execute |
+| Spec lint | `usage lint <FILE> [-f json] [-W]` | |
+
+⚠️ **Docs are ahead of the shipped binary on SDK languages.** `docs/spec/index.md:11`
+claims "type-safe SDK client libraries for **TypeScript, Python, and Rust**", but
+4.1.0 refuses Rust:
+
+```
+$ usage g sdk -f vaultpy.usage.kdl -l rust -o /dev/null
+error: invalid value 'rust' for '--language <LANGUAGE>'
+  [possible values: typescript, python]
+```
+
+(The clone is `--depth 1` of `main`, so the docs are at HEAD and 4.1.0 is the
+last release — the Rust SDK is either unreleased or aspirational. Do not plan on
+it.)
+
+### Runtime argument PARSING is in scope too
+
+This is the part that is easy to miss and is the whole answer to Q3:
+
+- `usage exec <INTERPRETER> <SCRIPT> [ARGS]…` — parses args per the spec and
+  exposes them as `usage_<name>` **environment variables** to the script.
+- `usage bash|zsh|fish|powershell <SCRIPT> [ARGS]…` — same, for shell scripts.
+- `usage complete-word` — the runtime completion engine that generated
+  completion scripts call back into on every keystroke.
+
+### Completions are DYNAMIC, not a static word list
+
+`usage g completion zsh vaultpy -f vaultpy.usage.kdl` emits a script that:
+1. hard-checks for the `usage` binary — *"Error: usage CLI not found. This is
+   required for completions to work in vaultpy."* → **`usage` is a RUNTIME
+   dependency of the completions on the end user's machine**;
+2. writes the spec into `${XDG_CACHE_HOME:-~/.cache}/usage/usage__usage_spec_<bin>.spec`;
+3. delegates each keystroke to
+   `command usage complete-word --shell zsh -f "$spec_file" -- "${(Q)words[@]}"`.
+
+With `--usage-cmd "<bin> usage" --cache-key <version>` it instead re-derives the
+spec by calling your CLI, cached per version — that is what fnox does.
+
+### The MCP server (4.1.0, PR #746) — describe, not execute
+
+Real JSON-RPC handshake against my toy spec (`usage mcp -f vaultpy.usage.kdl`,
+rc=0):
+
+```
+INIT: {"protocolVersion":"2024-11-05","capabilities":{"tools":{}},
+       "serverInfo":{"name":"usage","version":"4.1.0"},
+       "instructions":"Describes a CLI from its usage spec. Every command, flag and
+        argument may carry an `effect`: `read` only inspects state, `write` changes it,
+        `destructive` removes …"}
+TOOL: list_commands     — "Every command in the CLI, with its effect. Start here."
+TOOL: describe_command  — "Full detail for one command: help, flags, arguments…"
+```
+
+Only 2 tools, both read-only. It teaches an agent the CLI's shape and — via
+`effect=` (added 3.6.0 #739 for commands, 4.0.0 #742 for flags/args) — which
+commands are `read` / `write` / `destructive`. **Directly relevant to a secrets
+CLI:** it is the mechanism by which an agent can be told `get` is read and
+`remove` is destructive, without the agent guessing.
+
+### Other spec features worth knowing for a secrets CLI
+
+`docs/spec/index.md` (persisted at `.agent/kb/raw/usage-spec-reference.md`):
+
+```kdl
+config_file ".mycli.toml" findup=#true
+flag "-u --user <user>" help="User to run as" env="MYCLI_USER" config="settings.user" default="admin"
+```
+
+> "The priority over which is used (CLI flag, env var, config file, default) is
+> the order which they are defined, so in this example it will be
+> `CLI flag > env var > config file > default`."
+
+So **env-var and config-file backing of flags is a first-class spec feature**,
+not something you implement.
+
+---
+
+## Q2 — Direction of generation: **clap → KDL, checked in, AND verified in CI**
+
+Answer is **(b) + (c)**: emitted from clap definitions, committed to the repo,
+and a CI job re-renders and asserts an empty diff. A small hand-authored
+*extras* file is appended for what clap cannot express.
+
+⚠️ **I got this wrong on the first pass and am correcting it.** My first probe
+was `grep -rn 'usage.kdl' <repo>/.github/workflows` → 0 hits, and I concluded
+"no CI drift check". The control arm I ran (`grep -rln 'cargo'` → 2 files)
+proved the probe could *see the directory* but not that I had aimed at the right
+token — the workflow invokes the task **by name** (`mise run render`), so the
+filename never appears. Re-probing on `render` found the check in all three
+repos. A control arm proves the probe can see; it does not prove you pointed it
+at the right thing.
+
+### The emitter — `jdx-fnox/src/commands/usage.rs:8-19`
+
+```rust
+impl UsageCommand {
+    pub async fn run(&self, _cli: &Cli) -> Result<()> {
+        use clap::CommandFactory;
+        let cmd = Cli::command();
+        let spec: usage::Spec = cmd.into();          // clap Command -> usage::Spec
+
+        let min_version = r#"min_usage_version "1.3""#;
+        let extra = include_str!("../assets/fnox-extras.usage.kdl").trim();
+
+        println!("{min_version}\n{}\n{extra}", spec.to_string().trim());
+        Ok(())
+    }
+}
+```
+
+`fnox usage` is a `#[command(hide = true)]` subcommand. The standalone-crate
+equivalent for a CLI that doesn't want the `usage` crate as a dep is
+`clap_usage::generate(&mut cmd, "example", &mut stdout)`
+(`usage/clap_usage/README.md`).
+
+### The regeneration task — `jdx-fnox/mise.toml:88-96`
+
+```toml
+[tasks."render:usage"]
+description = "Generate CLI documentation from usage"
+depends = ["build"]
+run = [
+  "fnox usage > fnox.usage.kdl",
+  "rm -rf docs/cli && mkdir -p docs/cli",
+  "usage g markdown -mf fnox.usage.kdl --out-dir docs/cli --url-prefix /cli",
+  "usage g json -f fnox.usage.kdl > docs/cli/commands.json",
+  "prettier --write docs/cli",
+]
+```
+
+### The CI drift gate — identical in all three repos
+
+`jdx-fnox/.github/workflows/ci.yml:298-305`, `jdx-hk/.github/workflows/ci.yml:219-226`,
+`jdx-mise/.github/workflows/test.yml:247-256`:
+
+```yaml
+      - name: mise run render
+        run: mise run render
+      - name: assert render produces no diff
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::'mise run render' produced changes. Run it locally and commit."
+            git status
+            git diff HEAD
+            exit 1
+```
+
+mise's `render` chain (`jdx-mise/tasks.toml:64-96`) also renders man pages
+(`usage generate manpage --file mise.usage.kdl > man/man1/mise.1`) and
+completions off the same spec.
+
+### The hand-authored half — small, and only what clap cannot say
+
+| Repo | Generated spec | Hand-authored extras |
+|---|---|---|
+| fnox | `fnox.usage.kdl` — **275 lines**, 46 `cmd`, 71 `flag` | `src/assets/fnox-extras.usage.kdl` — **13 lines** |
+| hk | `hk.usage.kdl` — **775 lines** | `src/hk-extras.usage.kdl` — **0 bytes** (empty) |
+| mise | `mise.usage.kdl` — **5,457 lines** | `src/assets/mise-extra.usage.kdl` — **99 lines** (mostly a Tera template mapping command paths to source files for doc links) |
+
+fnox's entire hand-written KDL:
+
+```kdl
+// Dynamic completions for fnox commands
+complete "key" run="fnox list --complete 2>/dev/null || true"
+complete "name" run="fnox provider list --complete 2>/dev/null || true"
+complete "profile" run="fnox profiles --complete 2>/dev/null || true"
+complete "config_file" type="file"
+```
+
+**That is the whole shape of the split: clap emits structure; you hand-write the
+dynamic completion hooks and the safety/effect metadata clap cannot express.**
+
+### mise shows the richer pattern — post-process the derived Spec in Rust
+
+`jdx-mise/src/cli/usage.rs:18-63` mutates the `usage::Spec` after conversion:
+
+```rust
+pub fn spec() -> usage::Spec {
+    let cli = Cli::command().version(Resettable::Reset);
+    let mut spec: usage::Spec = cli.into();
+    spec.default_subcommand = Some("run".to_string());          // `mise foo` completes like `mise run foo`
+    if let Some(run) = spec.cmd.subcommands.get_mut("run") {
+        run.args = vec![];
+        run.mounts.push(usage::SpecMount::new("mise tasks --usage".to_string()));  // dynamic sub-spec
+        run.restart_token = Some(":::".to_string());
+    }
+    crate::cli::command_effects::apply(&mut spec);              // read/write/destructive table
+    spec
+}
+```
+
+`SpecMount` is worth flagging for a secrets CLI: it **mounts a sub-spec produced
+at completion time by another command**, so completions can cover things not
+known at build time (mise uses it for task names; the analogue would be secret
+keys or profiles).
+
+`jdx-mise/src/cli/command_effects.rs:1-40` is a doc-comment worth reading
+verbatim if a secrets CLI is going to expose an MCP surface:
+
+> "**An unlisted command means "unknown", not "safe".** Consumers treat the
+> absence of a value as "ask", so leaving a command out is the conservative
+> choice and mislabeling one `read` is the dangerous one."
+
+and the classification is kept as **one table** deliberately: *"a safety
+classification is much easier to review as a single list than as annotations
+scattered over sixty files."*
+
+### Notable coupling: fnox's `completion` command shells out to `usage`
+
+`jdx-fnox/src/commands/completion.rs:16-27` — `fnox completion <shell>` runs:
+
+```
+usage g completion <shell> fnox --usage-cmd "fnox usage" --cache-key <CARGO_PKG_VERSION>
+```
+
+fnox vendors no completion generation at all and **requires the `usage` binary
+at runtime** for its own `completion` subcommand.
+
+---
+
+## Q3 — Usable from a NON-Rust CLI? **YES. Experiment run, all arms green.**
+
+I hand-authored `vaultpy.usage.kdl` — a 30-line spec for a fictional Python
+secrets CLI `usage` has never seen — and drove the real 4.1.0 binary against it.
+Spec source: scratchpad `toy/vaultpy.usage.kdl` (3 subcommands, aliases, global
++ per-command flags, 2 `complete` hooks).
+
+`usage lint` on it: `Found 0 error(s), 0 warning(s), 1 info(s)` (the info is
+`missing-cmd-help` on the root), rc=0.
+
+### 3a. Completions for all five shells, with no binary present
+
+`command -v vaultpy` → **not found** at generation time.
+
+```
+$ usage g completion <sh> vaultpy -f vaultpy.usage.kdl
+bash rc=0 1925B   zsh rc=0 2498B   fish rc=0 1577B   nu rc=0 1796B   powershell rc=0 1986B
+```
+Control arms on the zsh output: `grep -c 'vaultpy'` → **12**;
+`grep -c 'quuxfrobnicate'` → **0**. The probe discriminates.
+
+### 3b. The completion engine, exercised directly
+
+| Arm | Command | Result |
+|---|---|---|
+| subcommands | `usage cw --shell zsh -f … -- vaultpy ''` | `g / get / list / ls / set`, each with help text |
+| prefix filter | `… -- vaultpy 'l'` | only `list`, `ls` |
+| **positional-aware** | `… -- vaultpy get '--'` | `--profile` (get's own) **+** `--verbose` (global); **not** `--json` (list's) |
+| **dynamic hook, binary absent** | `… -- vaultpy get ''` | `sh: vaultpy: command not found` / `exited with code 127 · sh -c vaultpy list` — proves the hook really shells out |
+| **dynamic hook, real Python binary** | same, after putting a 6-line `python3` `vaultpy` on `$PATH` | `db_password / api_token / ssh_key` — the Python program's own stdout |
+| prefix-filtered dynamic | `… -- vaultpy get 'db'` | `db_password` only |
+| negative arm | `… -- vaultpy get 'zzq'` | empty, rc=0 → discriminates |
+
+The dynamic hook cost one line of KDL: `complete "KEY" run="vaultpy list"`.
+
+### 3c. Docs / man / JSON / SDK off the same hand-authored spec
+
+- `usage g markdown -mf vaultpy.usage.kdl --out-dir md` → `get.md`, `set.md`,
+  `list.md`, `index.md` — each with Usage line, Aliases, Arguments, Flags. rc=0.
+- `usage g manpage -f …` → valid roff (`.TH VAULTPY 1`, `.SH SYNOPSIS`, …).
+- `usage g json -f …` → structured spec with `required`, `double_dash`, `hide`
+  per arg.
+- `usage g sdk -f … -l python -o sdk-py` → **4 files** (`client.py`, `types.py`,
+  `runtime.py`, `__init__.py`), header `# @generated by usage-cli from
+  vaultpy.usage.kdl. Do not edit manually.`:
+
+```python
+class Vaultpy:
+    def __init__(self, bin_path: str = "vaultpy") -> None: ...
+    @property
+    def ls(self) -> List: """Alias for list."""
+class Get:
+    """Print a secret's value. Aliases: g"""
+    def exec(self, args: GetArgs, flags: Optional[GetFlags] = None) -> CliResult:
+```
+
+It is a **subprocess wrapper**, stated as such in `docs/cli/sdk.md`: *"it invokes
+your CLI binary via `subprocess.run` / `child_process.spawn`, not a native
+binding."*
+
+### 3d. Runtime parsing — the shebang model replaces argparse
+
+`usage/examples/test-exec-help.py`, run against the real binary:
+
+```python
+#!/usr/bin/env -S usage exec python3
+#USAGE bin "test-exec-help"
+#USAGE flag "-f --force" help="Force the operation"
+#USAGE arg "<file>" help="File to process"
+import os
+print(f"force: {os.environ.get('usage_force', '')}")
+```
+
+| Arm | Output |
+|---|---|
+| `usage exec python3 ./tp.py --force in.txt` | `force: true` / `verbose: ` / `file: in.txt`, rc=0 |
+| `… --help` | full rendered help (Usage, Arguments, Flags), rc=0 |
+| `… ` (missing required) | `Error: × Missing required arg: <file>`, **rc=1** |
+| `… --nope x` | `Error: × unexpected word: x` |
+
+Comment syntax by language: `#USAGE` (bash/python), `//USAGE` or `// [USAGE]`
+(JS/Go-style) — `docs/cli/scripts.md`, `examples/test-usage-double-slash.js`.
+Tab-completion for shebang scripts is **opt-in**: `source <(usage g
+completion-init bash)` once in the rc file, then every usage-shebang script on
+`$PATH` completes with no per-script step.
+
+### Verdict on Q3
+
+A Python CLI gets, from one hand-authored KDL file: 5-shell dynamic
+completions, per-subcommand markdown docs, a man page, a JSON spec, a typed
+Python/TypeScript SDK, an MCP describe-server, and — optionally — the entire
+argument parser, `--help` renderer and validator. **The only cost is that the
+`usage` binary must be installed on the end user's machine for completions to
+function** (a `mise use usage` or a package dep; it is a single Rust binary).
+
+### Non-Rust generators that exist upstream
+
+`integrations/cobra` (Go) — `cobra_usage.Generate(rootCmd) string` converts a
+Cobra tree to KDL, with the documented pattern of a `--usage-spec` flag checked
+before `Execute()`, then `mycli --usage-spec | usage generate completion bash`
+(`.agent/kb/raw/usage-cobra-integration.md`). There is **no Python/argparse or
+click generator** — a Python CLI hand-authors the KDL or writes its own emitter.
+
+---
+
+## Q4 — Starter / template: **there is none**
+
+Control-armed searches:
+
+- `usage --help` lists 10 subcommands: `bash, complete-word, exec, fish,
+  generate, lint, mcp, powershell, sponsors, zsh` — **no `init` / `new` /
+  `scaffold`**.
+- `usage generate --help` lists 7 generators: `completion, completion-init, fig,
+  json, manpage, markdown, sdk` — **no `scaffold`**.
+- `grep -rniE 'usage (init|new|scaffold)|scaffold|template repo|starter'` over the
+  whole `jdx/usage` clone → **2 files**, and both hits are the *same aspirational
+  bullet*: `README.md:11` and `docs/spec/index.md:13` — "Scaffold one spec into
+  different CLI frameworks—even different languages". It is a listed *reason to
+  adopt the spec*, not a shipped command. Control arm: `grep -rli 'completion'`
+  over the same tree → **90 files**, so the probe sees plenty.
+- No `templates/`, no `create-*` package, no `cargo generate` template in the repo.
+  `docs/` contains only `spec/` (the format reference) and `cli/` (generated
+  command reference) — the tutorial-shaped page is `docs/cli/scripts.md`, which
+  is the shebang walkthrough, not a project starter.
+
+**So the "start a new CLI" path is:** write the KDL by hand from
+`docs/spec/index.md` (its two worked examples — a flat CLI and a nested-subcommand
+CLI — are effectively the template), or generate it from an existing clap/cobra
+tree. `usage lint` is the only scaffolding-adjacent affordance.
+
+Docs site: **https://usage.jdx.dev** (VitePress, built from `docs/` — `docs.yml`
+deploys to GitHub Pages). Sources persisted under `.agent/kb/raw/usage-*.md`.
+
+---
+
+## Q5 — Authoring cost, from the worked examples
+
+| | fnox | hk | mise | my toy Python spec |
+|---|---|---|---|---|
+| Spec lines | 275 | 775 | 5,457 | 30 |
+| Subcommands (`cmd`) | 46 | — | — | 3 |
+| Flags | 71 | — | — | 4 |
+| **Lines per subcommand (incl. its flags)** | **~6** | — | — | **~8** |
+| Hand-authored KDL | 13 lines | 0 bytes | 99 lines | **all 30** |
+
+Read the shape from `fnox.usage.kdl` — a subcommand with an alias, a flag and a
+positional is 5 lines:
+
+```kdl
+cmd exec help="Execute a command with secrets as environment variables" {
+    alias x
+    flag --replace help="Run the command in fnox's process, keeping the same PID…"
+    arg "[COMMAND]…" help="Command to run" required=#false double_dash=automatic var=#true
+}
+```
+
+**What ~6 lines/subcommand buys:** completions in 5 shells that are dynamic and
+positional-aware, a per-command markdown docs site, a man page, a JSON spec, a
+typed SDK in 2 languages, a Fig spec, an MCP describe-server with read/write/
+destructive safety metadata, and (if you want it) the parser itself. For a Rust
+CLI on clap the marginal authoring cost is **near zero** — the 275 lines are
+generated; you write ~13.
+
+## Caveats to carry into a decision
+
+1. **`usage` must be installed at runtime** for completions to work on the end
+   user's machine — the generated scripts hard-fail with an explicit error if
+   it is missing. For a Rust CLI you can avoid this by vendoring the `usage`
+   crate, but fnox chose to shell out.
+2. **The Rust SDK target is documented but not in 4.1.0.** Only `typescript`
+   and `python`.
+3. **`usage mcp` describes, it does not execute** — 2 read-only tools. An agent
+   still runs the CLI itself.
+4. **The generated spec must be committed and gated** — all three jdx repos use
+   the same `mise run render` + `git status --porcelain` assert-no-diff CI step.
+   Without it the checked-in KDL silently rots away from clap.
+5. **Issues are disabled on `jdx/fnox`**, so the absence of upstream complaints
+   about any of this is absence of a venue, not absence of a problem. `jdx/usage`
+   does have issues open (PR numbers up to #753 in the 4.1.0 changelog).
+
+---
+
+## GitHub repos touched
+
+- [jdx/usage](https://github.com/jdx/usage) — the subject: shallow-cloned, read README/docs/examples/`clap_usage`/`integrations/cobra`, and exercised the local 4.1.0 binary against a hand-written toy spec.
+- [jdx/fnox](https://github.com/jdx/fnox) — shallow-cloned for `fnox.usage.kdl`, `src/commands/usage.rs`, `src/commands/completion.rs`, `src/assets/fnox-extras.usage.kdl`, `mise.toml`, `.github/workflows/ci.yml`.
+- [jdx/mise](https://github.com/jdx/mise) — read `src/cli/usage.rs`, `src/cli/command_effects.rs`, `mise.usage.kdl`, `tasks.toml`, `.github/workflows/test.yml` for the richest post-processing + CI-drift-gate example.
+- [jdx/hk](https://github.com/jdx/hk) — read `hk.usage.kdl`, `src/hk-extras.usage.kdl`, `src/cli/usage.rs`, `.github/workflows/ci.yml` as the third instance of the same pattern.
+- [spf13/cobra](https://github.com/spf13/cobra) — named as the Go CLI framework the `integrations/cobra` generator converts from (docs read, repo not cloned).
+- [scop/bash-completion](https://github.com/scop/bash-completion) — referenced by `usage g completion --include-bash-completion-lib` as a prerequisite for bash completions.
+- [kdl-org/kdl](https://kdl.dev) — the spec's document language (docs reference only).

--- a/docs/research/kb/reports/agents/mise-shell-activation.md
+++ b/docs/research/kb/reports/agents/mise-shell-activation.md
@@ -1,0 +1,453 @@
+# Can mise own shell activation for secrets?
+
+**Agent:** mise-shell-activation · **Date:** 2026-08-03 · **Status:** COMPLETE
+
+Question: can `mise` replace `~/.zshrc.d/50-mde-secrets.zsh`'s `fnox activate zsh`,
+which is what puts 50 credentials into every shell?
+
+Primary sources: local mise doc cache
+(`docs/research/mintlify-cache/jdx/mise/llms-full.txt`, 5434 lines, fetched
+2026-07-02), local `mise` 2026.8.1 binary + `--help`/`settings`, and
+`github.com/jdx/mise` / `github.com/jdx/mise-env-fnox`.
+
+---
+
+## Q1 — What does `mise activate` install in the shell?
+
+**Method:** ran `mise activate zsh` locally (mise 2026.8.1 macos-arm64, 2026-08-03)
+and read the emitted script verbatim. This is the authoritative answer — it is the
+exact text `.zshrc` evals.
+
+**Hooks installed — precmd + chpwd, the same two fnox uses:**
+
+```zsh
+add-zsh-hook precmd _mise_hook_precmd
+add-zsh-hook chpwd _mise_hook_chpwd
+```
+
+Both funnel into one function that re-evals mise's env delta:
+
+```zsh
+_mise_hook() {
+  eval "$(/Users/rmanaloto/.local/bin/mise hook-env -s zsh "$@")";
+}
+_mise_hook_chpwd() { export __MISE_ZSH_CHPWD_RAN=1; _mise_hook --reason chpwd; }
+```
+
+`preexec` is **not** used. Control arm: the emitted script contains
+`add-zsh-hook precmd` and `add-zsh-hook chpwd` but zero occurrences of
+`preexec` — and the same grep does find `precmd`, so the probe discriminates.
+
+**It installs four things beyond the hooks:**
+
+1. A **`mise` shell function** wrapping the binary, so `mise deactivate` /
+   `mise shell` can `eval` their output into the live shell.
+2. A **`command_not_found_handler`** that offers to install a missing tool
+   (chains to any pre-existing handler, saved as `_command_not_found_handler`).
+3. An **undo preamble**. Before installing anything, the script emits `unset`
+   for every variable mise currently has in its `__MISE_DIFF`. On this host that
+   preamble literally begins `unset AUTH_TOKEN` / `unset AWS_ACCESS_KEY_ID` /
+   `unset DOPPLER_TOKEN`. ⚠️ **This does not mean mise sources the secrets** —
+   Q2 shows it does not. It means mise's diff has *absorbed* the
+   fnox-exported credentials from the ambient shell, so `mise activate` (and
+   `mise deactivate`) will happily `unset` all 50. Worth knowing before touching
+   the activation order in `.zshrc`.
+4. A **precmd fast-path** (`__MISE_ZSH_PRECMD_RUN`, `__MISE_ZSH_ACTIVATE_PATH`,
+   `__MISE_ZSH_ACTIVATE_ENV`) that skips the first post-activation `hook-env`
+   when `PATH` and the `MISE_*` state are unchanged, and skips `precmd` entirely
+   when `chpwd` already ran for the same prompt.
+
+**Versus fnox.** Structurally identical: fnox registers `_fnox_hook` into
+`precmd_functions` + `chpwd_functions`; mise registers `_mise_hook_precmd` +
+`_mise_hook_chpwd` via `add-zsh-hook`. Both therefore run **before every
+prompt**. mise's is the more defensive of the two — it has the dedup fast-path
+above, which fnox's does not (fnox's hook has no equivalent short-circuit).
+So replacing fnox's hook with mise's does **not** add a per-prompt hook; the
+mise hook is already installed and already running.
+
+> Incidental find worth flagging to the caller: mise's `_mise_hook_env_state`
+> carries a comment that referencing `${parameters}` "autoloads the
+> zsh/parameter module via dlopen, which can deadlock under Rosetta in login
+> shells (https://github.com/jdx/mise/discussions/11187)". Relevant to this
+> repo's Rosetta/amd64 posture.
+
+## Q2 — Can mise provide env GLOBALLY? **YES — and it already does.**
+
+This is the crux, and the answer is stronger than expected: **the global
+`~/.config/mise/config.toml` `[env]` applies in every directory, including
+outside any project**, and on this host mise is *already* emitting all 50
+credentials everywhere.
+
+**Method:** `mise env -C <dir> --json | jq -r 'keys[]'` — keys only, never
+values (per `secrets-out-of-the-shell-env.md` rule 7). `-C/--cd` is a real
+`mise env` flag (`mise env --help`).
+
+| Directory | Keys returned | `DOPPLER_TOKEN`/`AWS_SECRET_ACCESS_KEY`/`AGE_PRIVATE_KEY` present? |
+|---|---|---|
+| `/tmp` (outside every repo) | **75** | **3 / 3 — yes** |
+| `$HOME` | **75** | yes |
+| `~/dev/.../dotfiles` (repo) | **79** | yes |
+
+**Control arm:** the probe is not stuck returning one answer — it returns 79 in
+the repo and 75 outside it, and the 4-key delta is exactly the repo-scoped vars
+(`GITLEAKS_CONFIG`, `HK_MISE`, `HK_LOG_FILE_LEVEL`, … sourced from
+`dotfiles/mise.toml` per `--json-extended`). So it genuinely distinguishes
+global from directory-scoped.
+
+### ⚠️ CORRECTION — the 50 secrets above were INHERITED, not mise-produced
+
+The table above surprised me (why would mise hold `DOPPLER_TOKEN`?), so I
+cross-checked by a second route before reporting it — and the surprise was my
+probe. `mise env` **echoes back variables already present in the ambient
+environment**, and this agent's shell inherits all 50 credentials from
+`fnox activate zsh`. `--json-extended` was already hinting at it: every secret
+had source `?` (no config file), while every real mise var named a file.
+
+**Re-run under a sanitized environment** (`env -i` with only `HOME`/`PATH`):
+
+```
+env -i HOME=$HOME PATH=/usr/bin:/bin:/usr/sbin:/sbin:/Users/rmanaloto/.local/bin \
+  /Users/rmanaloto/.local/bin/mise env -C /tmp --json | jq -r 'keys[]'
+```
+
+| Arm | Grep | Result |
+|---|---|---|
+| **CONTROL** — vars we *know* the global config sets (`HK_PKL_BACKEND`, `CPPFLAGS`, `GIT_TERMINAL_PROMPT`) | `grep -c` | **3 / 3 present** |
+| **TEST** — secrets (`DOPPLER_TOKEN`, `AWS_SECRET_ACCESS_KEY`, `AGE_PRIVATE_KEY`, `GITHUB_TOKEN`) | `grep -c` | **0 / 4 — absent** |
+
+The control arm proves the probe can see mise's global env; the test arm is
+therefore a real negative. **First attempt at this control was itself broken** —
+I used `command -v mise`, which resolves to the *shell function* `mise` installed
+by `mise activate`, not a path, so both arms returned 0. A control arm returning
+0 means the probe is broken, not the world; re-ran against
+`/Users/rmanaloto/.local/bin/mise` directly.
+
+### The corrected answer
+
+**YES, mise has a genuine global env source — but it is not currently carrying
+the secrets.**
+
+- `~/.config/mise/config.toml` `[env]` **does apply in every directory**,
+  including `/tmp` and `$HOME`, with no project config anywhere near. Confirmed:
+  **26 keys** survive the sanitized run at `/tmp`, all attributable to the global
+  config (`CC`, `CXX`, `CPPFLAGS`, `LDFLAGS`, `GOROOT`, `CARGO_HOME`,
+  `RUSTUP_HOME`, `PKG_CONFIG_PATH`, `CONDA_SUBDIR`, `GIT_TERMINAL_PROMPT`,
+  `HK_MISE`, `HK_PKL_BACKEND`, the eleven `MDE_DIR_*`/`MDE_*` vars,
+  `NOTEBOOKLM_HOME`, `PATH`).
+- Directory-scoping applies to a **project** `mise.toml`, not to the global one.
+  The cache calls the global config's env "global" and mise's config resolution
+  is hierarchical: global config first, then each config file from root down to
+  cwd.
+- The current `~/.config/mise/config.toml` `[env]` block holds only
+  `HK_PKL_BACKEND` and `HK_MISE`; the other global vars come from elsewhere in
+  that same file. **No secret mechanism is wired into it today.**
+
+So the premise "shell-wide availability requires a global env source" is
+satisfied — `~/.config/mise/config.toml` **is** that global source, it is proven
+to reach every directory, and it is the correct place to hang a secrets
+mechanism. Whether a mechanism exists that can *fill* it from fnox is Q3/Q5.
+
+> Also worth flagging for the mde retirement: the eleven `MDE_*` variables are
+> set by `~/.config/mise/config.toml`, not by mde's zsh files — so they survive
+> the repo's deletion, and are a separate cleanup item.
+
+## Q3 — Every `[env]` mechanism; which can pull from a COMMAND?
+
+**Method — enumerated, not asserted.** The doc cache is a 2026-07-02 snapshot and
+a shape-match over it (`grep -oE '_\.[a-zA-Z][a-zA-Z0-9_-]*'`) finds only three
+(`_.source` 8, `_.file` 7, `_.path` 6) — it misses `_.python`. So I pulled the
+**live JSON schema** from the repo instead:
+
+```
+curl https://raw.githubusercontent.com/jdx/mise/main/schema/mise.json   # http=200, 152170 bytes
+jq '.["$defs"].env' mise-schema.json
+```
+
+### `[env]._` modules — the complete list from the schema
+
+| Directive | What it takes | Can it run a COMMAND? |
+|---|---|---|
+| `_.file` | "environment file to load (**dotenv, json, yaml, or toml**)"; string, or array, or `{path, redact, tools, required}` | **No — file only.** (sops-encrypted files are auto-decrypted; age backend only) |
+| `_.path` / `_.paths` | `PATH` entries to add; string/array/object, supports `tools = true` | No |
+| `_.source` | "**bash script to load**"; string, or array, or `{path, redact, …}` | **YES — this is the only command escape hatch.** |
+| `_.python` | `{ venv = <path> \| {path, create, python, python_create_args, uv_create_args} }` | No |
+| *(anything else)* | `_` is `additionalProperties: true` in the schema — which is what lets an **env plugin** add its own key, e.g. `_.fnox-env` | Yes, via plugin (see Q5) |
+
+### Per-variable forms (also from the schema)
+
+`{value}`, `{default}`, `{required}` (bool or help-string), `{age = {value, format}}`
+(**experimental** — inline age-encrypted value), each combinable with
+`tools = true` and `redact = true`. Plus Tera templates (`{{config_root}}`,
+`{{env.VAR}}`, `{{tools.node.version}}`) and `env_shell_expand` (`$VAR`,
+`${VAR:-default}`) — **both interpolate, neither shells out.**
+
+Multiple directives of the same kind need `[[env]]` (array of tables), because
+TOML forbids duplicate keys.
+
+### So: `_.source` is the mechanism, and it works
+
+Verified end-to-end that `_.source` executes and its exports reach `mise env`:
+
+```toml
+[[env]]
+_.source = "ctl.sh"     # ctl.sh: export ZZQ_CTL_ARM=1
+```
+
+→ `ZZQ_CTL_ARM` present in `mise env --json` under a sanitized `env -i`.
+**Control arm 1/1 in all four runs.** The cache warns the sourced file must be a
+**bash** script — "the shebang is ignored, mise always sources the file using
+`source ./script.sh` in bash."
+
+`fnox export` fits it exactly: `fnox export --format shell` emits
+`export KEY=value` lines (`fnox export --help`, fnox 1.32.0), so
+`eval "$(fnox export --format shell)"` in a sourced script is the composition.
+Measured: **52 lines** from `fnox export --format shell` in a normal shell, run
+from an unrelated directory — fnox finds `~/.config/fnox/config.toml` regardless
+of cwd (`fnox config-files` → that one path), so it is already global.
+
+### 🚨 HAZARD, measured: `_.source` + a mise-shimmed binary = infinite recursion
+
+Calling **`fnox`** (unqualified) from an `_.source` script while the mise shims
+dir is on `PATH` **fork-bombs**. The shim re-enters mise → mise resolves `[env]`
+→ runs `_.source` → calls the `fnox` shim → … Measured on this host:
+
+- `ps aux | grep -c '[f]nox'` → **3011 processes**, 1-min load **17.9 → 28.4**
+- the `mise env` call never returned (killed at 120s)
+
+**This is the same failure the global config already documents** —
+`~/.config/mise/config.toml` carries a comment that enabling `mise-env-fnox` on
+2026-04-09 spawned "runaway `fnox config-files` subprocesses (10+ concurrent at
+100% CPU each, shell hangs during login-shell sourcing)", tracked as
+`macos-development-environment#75`. My reproduction says the root cause is
+**shim re-entry**, not the plugin per se.
+
+**Control arm for that diagnosis:** the identical config with the *absolute*
+binary path
+(`/Users/rmanaloto/.local/share/mise/installs/fnox/latest/fnox export …`)
+returned **rc=0 immediately, 0 runaway processes**, control arm still 1/1. So the
+recursion is caused by the shim indirection and is avoided by an absolute path
+(or by the plugin's documented `tools = true`).
+
+### ⚠️ UNVERIFIED — end-to-end secret *delivery* through `_.source`
+
+I could **not** prove the secrets themselves arrive, and the reason is my
+harness, not mise. Across three fixtures the TEST arm stayed 0/5 while the
+CONTROL arm stayed 1/1, with fnox's own stderr giving the cause:
+
+```
+WARN fnox_core::secret_resolver: Error resolving secret 'GEMINI_API_KEY':
+     Age identity file not found: /Users/rmanaloto/.config/fnox/age.txt
+```
+
+`AGE_PRIVATE_KEY` is **ABSENT** from this agent's environment (probed with
+`printenv`, presence only) and `~/.config/fnox/age.txt` **does not exist**, so
+every age-encrypted secret fails to resolve in any subprocess. `DOPPLER_TOKEN`,
+`EXA_API_KEY`, `GITHUB_TOKEN` *are* set, i.e. fnox decrypted fine at login —
+the bootstrap key just is not itself exported.
+
+**Fixture iterations, each an armed correction of the last** (rule 8 — ask
+whether the setup admits the other answer):
+
+| # | Fixture | Why it could only fail |
+|---|---|---|
+| 1 | `env -i`, no shims | `fnox: command not found` |
+| 2 | shims on PATH | fork bomb, 3011 procs |
+| 3 | absolute fnox path | no `AGE_PRIVATE_KEY` → age decryption fails |
+| 4 | + real `doppler` dir on PATH, `DOPPLER_TOKEN` passed | same — fnox still fell back to the missing age.txt |
+
+What this **does** establish: `_.source` runs, fnox is invoked, and fnox in a
+normal shell yields 52 export lines. What remains unproven is only the join,
+and it is blocked by an agent-shell artifact. Re-run in Ray's real interactive
+shell to close it.
+
+## Q4 — Redaction and per-prompt cost
+
+### Redaction — exists, but does **not** reduce exposure here
+
+mise supports `redact = true` per variable, on `_.file` and on `_.source`, plus
+a glob list (`redactions = ["SECRET_*", "*_TOKEN", "PASSWORD"]`), and
+`mise env --redacted` / `--redacted --values` to inspect. Age-decrypted values
+are "always marked as redacted".
+
+**The load-bearing caveat, verbatim from the cache:** *"Redactions work by
+intercepting **task output** line-by-line, so they require a non-`raw` output
+mode. Tasks with `raw = true` bypass this interception."*
+
+So redaction hides values in **mise's own task logs**. It does nothing about the
+variable being present in the environment of every child process — which is the
+entire exposure `secrets-out-of-the-shell-env.md` documents. **Adopting mise
+would not shrink the blast radius**; the 50 credentials remain inherited by every
+child either way, and `__MISE_DIFF` would still carry them in the
+scanner-invisible zlib+base64 form.
+
+One additional silent-failure hazard, verbatim: for direct age encryption, *"If
+no identities are found or decryption fails, **mise returns the encrypted value
+as-is**."* — a consumer would receive ciphertext rather than an error.
+
+### Cost — mise's hook is already running; caching is on by default
+
+- The `precmd` hook is **already installed** on this host (Q1), so moving
+  secrets to mise adds **no new per-prompt hook**. It would let
+  `50-mde-secrets.zsh`'s `_fnox_hook` be *removed*, i.e. one fewer per-prompt
+  hook, not one more.
+- mise's `_mise_hook_precmd` has a dedup fast-path (skips when `chpwd` already
+  ran this prompt, and skips the first one when `PATH` + `MISE_*` are unchanged).
+- **`MISE_ENV_CACHE` is real and already enabled.** From `mise settings --all`
+  on this host:
+
+  | Setting | Value |
+  |---|---|
+  | `env_cache` | `true` |
+  | `env_cache_ttl` | `"1h"` |
+
+  Note `mise settings` (without `--all`) does **not** print them — only
+  `--all` does; a probe using the short form would wrongly report them absent.
+  These are absent from the 2026-07-02 doc cache entirely (grep for
+  `MISE_ENV_CACHE|env_cache` → 0 hits, while `_.source` → 8, so the probe
+  discriminates); the schema lists both under settings.
+
+  This means an `_.source` shelling out to fnox is **not** paid every prompt —
+  it is cached for an hour. It also means **decrypted secrets are cached to
+  disk**. `mise-env-fnox`'s README describes this as "cached encrypted on disk"
+  and "scoped to your shell session"; ⚠️ that README also says caching is opt-in
+  via `MISE_ENV_CACHE=1`, which **contradicts** the measured default of
+  `env_cache = true` — treat the README as stale and the live setting as
+  authoritative.
+
+## Q5 — `jdx/mise-env-fnox`
+
+**What it is.** A vfox-style Lua env plugin, read in full at
+`~/.local/share/mise/plugins/fnox-env/hooks/mise_env.lua` (already cloned on this
+host). `PLUGIN:MiseEnv(ctx)` does exactly this:
+
+1. `fnox config-files` → list of config files (empty ⇒ return no env);
+2. `fnox export --format json` (`+ --profile <p>` if `profile` is set);
+3. `json.decode` → `data.secrets` → emit as env vars;
+4. returns `{cacheable = true, watch_files = config_files, redact = true}`.
+
+So it is a **thin wrapper around the same two fnox CLI calls** I tested by hand
+in Q3 — it does not embed fnox, and it does not remove the fnox dependency.
+
+**Wiring required** (README): the plugin must be *both* registered and invoked —
+```toml
+[plugins]
+fnox-env = "https://github.com/jdx/mise-env-fnox"
+[env]
+_.fnox-env = { tools = true }        # options: tools, profile, fnox_bin
+```
+On this host it is registered in `~/.config/mise/config.toml` **but `_.fnox-env`
+is absent from `[env]`**, so it is genuinely inert — matching the "intentionally
+disabled" comment there. `tools = true` is *required* when fnox is mise-managed
+(it is here) — that is the plugin's answer to the shim-recursion hazard I
+measured in Q3.
+
+**What upstream says — verbatim from the plugin's own README:**
+
+> [!CAUTION]
+> I am not sure this plugin is a good idea. fnox was built as a separate CLI for
+> a reason. I would probably advise avoiding this.
+
+And mise's own docs, cache line **3147**: *"There is **no direct integration**
+between fnox and mise — you configure fnox independently, and it sets
+environment variables that mise picks up like any other variables in your
+shell."* (line 3145 notes fnox is "a separate project by the same author".)
+
+**Maintenance status** (`gh api`, 2026-08-03):
+
+| Fact | Value |
+|---|---|
+| Last commit (default branch) | **`4c9ca02`, 2026-03-09** — "Update README.md" |
+| Last *code* commit | `e8304bf`, **2026-02-21** — redact=true by default |
+| Releases | **0** |
+| Open issues | **7** |
+| Stars | 16 |
+| Archived | no |
+
+So: ~5 months since the last commit, ~5.5 months since the last code change,
+never released, 7 open issues, and the author advising against it. The
+local clone is at upstream HEAD (`4c9ca02` both sides) — not stale, just
+dormant.
+
+**Why upstream discourages it** is stated as a design position, not a bug list
+("fnox was built as a separate CLI for a reason"). The concrete costs visible
+from the source: it forks fnox twice per uncached env resolution, it can only
+surface fnox failures as `print()` warnings while returning an **empty env**
+(a silent-degradation path — secrets vanish rather than erroring), and it
+inherits the shim-recursion hazard unless `tools = true` is set. This repo has
+already been burned by it once (`macos-development-environment#75`, 2026-04-09).
+
+## Q6 — Verdict
+
+**mise can take over the shell-activation *role*, but it cannot replace fnox,
+and adopting it buys less than it looks like it does.**
+
+Component by component:
+
+| Capability `50-mde-secrets.zsh` provides | Can mise do it? | Evidence |
+|---|---|---|
+| A hook that refreshes env before every prompt | **Yes — already installed.** `mise activate zsh` registers `precmd` + `chpwd`, same two hooks fnox uses | Q1 |
+| Env in **every** shell regardless of directory | **Yes.** `~/.config/mise/config.toml` `[env]` applies globally — 26 keys survive at `/tmp` under a sanitized env, control arm 3/3 | Q2 |
+| Pull values from the fnox CLI | **Yes, via `_.source`** (the only command-capable directive) — or the discouraged `_.fnox-env` plugin | Q3, Q5 |
+| **Replace fnox itself** (Doppler sync, keychain, age, profiles, 50 declarations) | **No.** Both native paths (sops `_.file`, inline `age`) are **experimental**, file/inline-only, and would mean re-homing all 50 secrets out of fnox+Doppler | Q3, cache §Secrets |
+
+### The honest answer to the three options posed
+
+**It is option 1 — mise *can* provide shell-wide 50-secret availability — but
+only by continuing to call fnox.** It is a re-housing of the activation line,
+not a retirement of the dependency. Concretely, `50-mde-secrets.zsh` can be
+replaced by adding to `~/.config/mise/config.toml`:
+
+```toml
+[env]
+_.source = "~/.config/mise/fnox-env.sh"
+# fnox-env.sh:  eval "$(/abs/path/to/fnox export --format shell)"
+```
+
+…with **the absolute fnox path, never the bare name** (Q3's fork bomb).
+
+**What it genuinely gains:** the mde repo's zsh file goes away; one per-prompt
+hook is removed rather than added (mise's is already there); resolution becomes
+cached (`env_cache_ttl = 1h`) instead of running fnox's hook every prompt.
+
+**What it does not gain, and should be said plainly:**
+
+- **fnox remains a hard dependency** — the mde retirement does not remove it.
+- **No security improvement.** mise's redaction only covers mise's own task
+  output; all 50 credentials still land in every child process, and
+  `__MISE_DIFF` still carries them in the scanner-invisible form.
+- **New failure modes**: shim recursion (measured: 3011 processes), secrets
+  cached to disk for an hour, and a `_.source` script whose failure is a silent
+  empty env rather than an error.
+- **Neither native secret path is production-ready** — both are flagged
+  experimental by mise, and direct age returns **ciphertext as-is** on
+  decryption failure.
+
+**Recommendation.** If the only requirement is "delete
+`~/.zshrc.d/50-mde-secrets.zsh`", the lowest-risk move is not mise at all — it is
+to move the existing `fnox activate zsh` line into a chezmoi-managed
+`~/.zshrc.d/` file in *this* repo. That is a one-line relocation of a mechanism
+that is known to work, versus mise's route which adds an `_.source` shell-out,
+a disk cache, and a fork-bomb footgun to achieve the same end state.
+The `mise-env-fnox` plugin should stay disabled: unreleased, 5 months dormant,
+7 open issues, already broke this host once, and its own author advises against it.
+
+**Do not** treat "mise natively decrypts sops / has built-in age" as a path to
+retiring fnox — those replace the *storage*, not the *sync*, and both are
+experimental.
+
+## GitHub repos touched
+
+- [jdx/mise](https://github.com/jdx/mise) — live `schema/mise.json` (authoritative
+  `[env]._` enumeration), cached docs `llms-full.txt`, and the local 2026.8.1
+  binary's `activate`/`env`/`settings` output.
+- [jdx/mise-env-fnox](https://github.com/jdx/mise-env-fnox) — plugin source
+  (`hooks/mise_env.lua`, `metadata.lua`, README CAUTION), commit history and
+  repo metadata via `gh api`.
+- [jdx/fnox](https://github.com/jdx/fnox) — `fnox export`/`config-files` CLI
+  surface probed locally at v1.32.0; referenced by mise's secrets docs.
+- [ray-manaloto/macos-development-environment](https://github.com/ray-manaloto/macos-development-environment)
+  — issue #75, the prior runaway-`fnox config-files` incident cited in
+  `~/.config/mise/config.toml`, independently reproduced here.
+- [getsops/sops](https://github.com/getsops/sops) · [FiloSottile/age](https://github.com/FiloSottile/age)
+  — named as mise's native secret backends (both experimental in mise).
+

--- a/docs/research/kb/reports/agents/secret-consumers.md
+++ b/docs/research/kb/reports/agents/secret-consumers.md
@@ -1,0 +1,267 @@
+# Secret Consumption Sweep — which of the 50 declared secrets are actually consumed
+
+**Agent:** secret-consumers · **Date:** 2026-08-04 · **Status:** COMPLETE
+
+Research question: which of this Mac's 50 declared secrets are actually consumed,
+by what, and where — and which are orphans? Feeds a decision about what a new
+"universal CRUD for API keys across dev projects" CLI must support.
+
+## Safety posture for this sweep
+
+No secret VALUE was printed, logged, or written at any point. Presence was probed
+with `printenv VAR >/dev/null` and `[ -n "$VAR" ]`; the alias question was settled
+with `[ "$A" = "$B" ]`, which emits one bit and never the value. No `fnox get`, no
+`fnox list -V`. No value-emitting substitution (`${VAR:-x}` / `${VAR:=x}`) was used.
+`fnox` was invoked only via its absolute path.
+
+## Corpus
+
+All 50 names are declared in ONE file — `/Users/rmanaloto/.config/fnox/config.toml`
+(via `fnox list --sources`). 49 resolve through provider
+`doppler_dotfiles_dev_personal`; **`DOPPLER_TOKEN` alone resolves via `keychain`**
+— it is the bootstrap credential for the other 49.
+
+Swept: `dotfiles`, `knowledge-base`, `macos-development-environment`, the other
+25 `~/dev/github/ray-manaloto/*` repos (enumerated, not assumed — 28 total),
+`~/.claude/` (162 `.mcp.json` files), `~/.claude.json`, and `~/.config/`.
+
+## Finding 0 — raw hit counts are worthless here; four classes inflate them
+
+| Class | Example | Consumer? |
+|---|---|---|
+| Baseline declaration | `dotfiles/doctor.toml` (all 50) | NO |
+| Guard / protection list | `python/src/dotfiles_setup/hook_guard.py` — `secret_value_substitution` names credentials in order to **deny** printing them | NO |
+| Test fixture | `tests/test_child_env.py`, `tests/test_hook_guard.py` | NO |
+| Vendor doc cache | `docs/research/mintlify-cache/jdx/fnox/llms-full.txt` — 24 hits for `AWS_ACCESS_KEY_ID` | NO — third-party example text |
+
+`AWS_ACCESS_KEY_ID` scores 46 non-markdown hits across the three repos and **not
+one is a consumer**.
+
+## Finding 1 — four names, ONE value (verified, not assumed)
+
+The brief asked me to verify the alias belief rather than assume it. **It is wrong
+as stated, and it undercounts.**
+
+mise's docs (`docs/research/mintlify-cache/jdx/mise/llms-full.txt:4004-4011`)
+document a **precedence chain**, not aliases — three *distinct* variables mise
+consults in order:
+
+| Priority | Source |
+|---|---|
+| 1 | `MISE_GITHUB_TOKEN` |
+| 2 | `GITHUB_API_TOKEN` |
+| 3 | `GITHUB_TOKEN` |
+
+They are separate variables that happen to carry the same value here. That they
+are distinct is proven by `.devcontainer/Dockerfile:311`, which must explicitly
+derive one from the other: `export MISE_GITHUB_TOKEN="$GITHUB_TOKEN"`.
+
+Equality bits measured on this host (one bit each, no values):
+
+```
+GITHUB_TOKEN == GITHUB_API_TOKEN
+GITHUB_TOKEN == MISE_GITHUB_TOKEN
+GITHUB_TOKEN == GITHUB_MCP_PAT        <-- NOT previously suspected
+AWS_REGION   == AWS_DEFAULT_REGION
+NVIDIA_API_KEY != NVIDIA_20260705     <-- two DIFFERENT keys
+OTEL_EXPORTER_OTLP_ENDPOINT != GEMINI_TELEMETRY_OTLP_ENDPOINT
+```
+
+So **one GitHub PAT is stored under four names**, and `AWS_REGION` /
+`AWS_DEFAULT_REGION` are a fifth duplicate pair. A rotation of that PAT must
+update four Doppler entries or the host silently runs split-brain.
+
+**Implication for the new CLI: it needs a first-class alias/fan-out concept** —
+one logical credential, N exported names — or rotation stays a four-place manual edit.
+
+## Finding 2 — a predecessor secret store still exists
+
+`~/.config/mise/secrets.sops.json` is a **SOPS-encrypted store holding 34 of the
+50 names**, including every one of the orphans below. It is the historical
+provenance of the observability block (Grafana/Loki/Mimir/Tempo/OpenLIT) and
+predates the Doppler+fnox arrangement.
+
+`~/.config/fnox/` additionally carries **8 timestamped backup copies** of the
+config, with names like `config.toml.BROKEN-by-claude-20260801-1420` and
+`config.toml.WIPED-evidence-20260730-055104`. Any migration must treat these as
+part of the surface — a "universal CRUD" tool that only knows the live file will
+leave 34 names' worth of stale declarations behind it.
+
+## Finding 3 — MCP servers get credentials by INHERITANCE, not interpolation
+
+Control-armed negative: across `~/.claude/settings.json`, `~/.claude/mcp_servers.json`,
+`~/.claude.json`, and all 162 `.mcp.json` files under `~/.claude`, exactly **three**
+files interpolate a secret name, and they are the same plugin at three paths:
+
+```
+~/.claude/plugins/marketplaces/context7-marketplace/plugins/claude/context7/.mcp.json:7
+        "Authorization": "${CONTEXT7_API_KEY:-}"
+```
+
+Everything else relies on `env = true` putting the credential in the environment the
+server inherits. That is the mechanism the whole posture rests on, and it means
+**grep-for-`${VAR}` will systematically under-report consumption** — the new CLI
+cannot infer usage from config files alone.
+
+## Finding 4 — two declared secrets are ABSENT from the environment
+
+`OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_PROTOCOL` are declared in
+fnox but **not set in this process** (48/50 present). Under `env = true` the
+project rule states that outcome is unreachable, so this is a real failure, not a
+design choice — worth a follow-up (likely a stale `MISE_ENV_CACHE` entry or a
+per-secret override). I did not diagnose it; it is out of this sweep's scope.
+
+## Findings table
+
+Category legend: **A** = agent/AI tooling · **O** = observability · **C** = cloud/infra
+· **S** = social/scraping · **W** = web app.
+
+| Secret | Consumed by (file:line) | Cat | Verdict |
+|---|---|---|---|
+| AGE_PRIVATE_KEY | `mde/src/mde/secrets/manage.py:45,486-507` (bootstrap parity check vs Doppler) | C | CONSUMED |
+| AUTH_TOKEN | `~/.config/last30days/.env:5`; last30days skill `README.md:148` (X/Twitter cookie, Bird CLI) | S | CONSUMED |
+| AWS_ACCESS_KEY_ID | no in-repo consumer; read by AWS SDK/CLI by convention | C | AMBIENT |
+| AWS_DEFAULT_REGION | AWS CLI convention; **value-identical to `AWS_REGION`** | C | ALIAS + config |
+| AWS_REGION | `mde/.agents/skills/aws-agentic-ai/services/gateway/deploy-template.sh`; AWS SDK convention | C | AMBIENT (config, not secret) |
+| AWS_SECRET_ACCESS_KEY | no in-repo consumer; AWS SDK/CLI convention | C | AMBIENT |
+| BRAVE_API_KEY | `~/.config/last30days/.env`; `mde/scripts/mcp/mde-mcp-brave-search:1`; `dotfiles/scripts/devcontainer-smoke.sh` | S | CONSUMED |
+| BSKY_APP_PASSWORD | `~/.config/last30days/.env`; skill `README.md:155` | S | CONSUMED |
+| BSKY_HANDLE | `~/.config/last30days/.env:5`; skill `README.md:155` | S | CONSUMED (config, not secret) |
+| CONTEXT7_API_KEY | `~/.claude/plugins/.../context7/.mcp.json:7`; `~/.config/opencode/opencode.json:13`; `dotfiles/python/src/dotfiles_setup/doctor.py` | A | CONSUMED |
+| CT0 | `~/.config/last30days/.env`; skill `README.md:148,165` (X cookie, pairs with AUTH_TOKEN) | S | CONSUMED |
+| DB_PASSWORD | no consumer in Ray's code — only vendored `claude-flow-src` examples and vendor docs | W | ORPHAN |
+| DOPPLER_TOKEN | keychain-backed bootstrap for the other 49; `mde/src/mde/secrets/manage.py` (14 refs), `mde/.mise.toml` | C | CONSUMED (critical) |
+| EXA_API_KEY | last30days `README.md:157,364`; exa plugin; `dotfiles/scripts/devcontainer-smoke.sh` | A | CONSUMED |
+| GEMINI_API_KEY | `knowledge-base/mise.toml:2` + `kb_setup/graphify_env.py`; `~/.config/fabric/.env.all:9`; `mde/scripts/install-agent-stack.sh` | A | CONSUMED |
+| GEMINI_TELEMETRY_ENABLED | `mde/src/mde/telemetry_verify.py` (4); `mde/scripts/status-dashboard.sh` | O | CONSUMED (boolean, not secret) |
+| GEMINI_TELEMETRY_LOG_PROMPTS | declaration only | O | ORPHAN (boolean, not secret) |
+| GEMINI_TELEMETRY_OTLP_ENDPOINT | `mde/src/mde/telemetry_verify.py` (2); `status-dashboard.sh` | O | CONSUMED (endpoint, not secret) |
+| GEMINI_TELEMETRY_OTLP_PROTOCOL | `mde/src/mde/telemetry_verify.py`; `status-dashboard.sh` | O | CONSUMED (config, not secret) |
+| GEMINI_TELEMETRY_TARGET | `mde/scripts/status-dashboard.sh` | O | CONSUMED (config, not secret) |
+| GITHUB_API_TOKEN | `renovate_dryrun.py:98`; mise precedence #2 | C | ALIAS of GITHUB_TOKEN |
+| GITHUB_MCP_PAT | `mde/scripts/mcp/mde-mcp-github:2`, `gemini-wrapper.sh`; **value-identical to GITHUB_TOKEN** | A | ALIAS of GITHUB_TOKEN |
+| GITHUB_TOKEN | 8 GHA workflows/actions; `.devcontainer/Dockerfile:309-311,562-564`; `docker-bake.hcl`; `renovate_dryrun.py:97`; `hk.pkl` | C | CONSUMED (heaviest) |
+| GOOGLE_CLIENT_ID | `guilde-lite-tdd-sprint/backend/app/core/oauth.py`, `config.py:112`, `kubernetes/secret.yaml` | W | CONSUMED (not a secret — public ID) |
+| GOOGLE_CLIENT_SECRET | `guilde-lite-tdd-sprint/backend/app/core/oauth.py`, `config.py:113` | W | CONSUMED |
+| GRAFANA_PASSWORD | `mde/docker/observability/compose.yaml:28` (→ `GF_SECURITY_ADMIN_PASSWORD`); `mde/src/mde/domain/observability_stack.py` | O | CONSUMED |
+| LANGSMITH_API_KEY | `mde/scripts/mcp/mde-mcp-langsmith:1`; `verify-langchain-tools.sh`; `health-check.sh` | A | CONSUMED |
+| LANGSMITH_WORKSPACE_ID | `knowledge-base/python/src/kb_setup/evals.py:1`; `knowledge-base/mise.toml`; `mde/scripts/mcp/mde-mcp-langsmith:2` | A | CONSUMED (ID, not secret) |
+| LINEAR_API_KEY | `~/.claude/plugins/marketplaces/claude-tag-plugins/linear/skills/linear-api/scripts/linear_issues.sh` | A | CONSUMED (if that plugin is enabled) |
+| LOKI_S3_ACCESS_KEY | declaration only | O | ORPHAN |
+| LOKI_S3_BUCKET | declaration only | O | ORPHAN (config, not secret) |
+| LOKI_S3_SECRET_KEY | declaration only | O | ORPHAN |
+| MIMIR_S3_ACCESS_KEY | declaration only | O | ORPHAN |
+| MIMIR_S3_BUCKET | declaration only | O | ORPHAN (config, not secret) |
+| MIMIR_S3_SECRET_KEY | declaration only | O | ORPHAN |
+| MISE_GITHUB_TOKEN | `.github/actions/lock-refresh/action.yml` (3); `.devcontainer/Dockerfile:311,564`; mise precedence #1 | C | ALIAS of GITHUB_TOKEN |
+| NEXTAUTH_SECRET | no consumer in Ray's code (only vendored `claude-flow-src` skill docs) | W | ORPHAN |
+| NEXTAUTH_URL | declaration only — **zero** refs outside declarations | W | ORPHAN (URL, not secret) |
+| NVIDIA_20260705 | `hook_guard.py` (protection list only) — **value differs from NVIDIA_API_KEY** | A | ORPHAN (dated/stale) |
+| NVIDIA_API_KEY | `dotfiles/python/src/dotfiles_setup/graph_bakeoff.py:1` | A | CONSUMED |
+| OPENLIT_ENDPOINT | `mde/scripts/verify-openlit.sh` (2); `mde/configs/otel/collector-gateway.yaml`, `collector-env.sample` | O | CONSUMED (endpoint, not secret) |
+| OPENLIT_UI_PASSWORD | declaration only | O | ORPHAN |
+| OPENLIT_UI_USER | declaration only | O | ORPHAN (username, not secret) |
+| OTEL_EXPORTER_OTLP_ENDPOINT | `mde/src/mde/observability.py`, `telemetry_verify.py` (11), `mde/.claude/settings.json`, `mde/.codex/config.toml`; OTel SDK convention | O | AMBIENT + CONSUMED (endpoint, not secret) ⚠ absent from env |
+| OTEL_EXPORTER_OTLP_PROTOCOL | `mde/src/mde/telemetry_verify.py`; `mde/.claude/settings.json`; OTel SDK convention | O | AMBIENT (config, not secret) ⚠ absent from env |
+| SCRAPECREATORS_API_KEY | `~/.config/last30days/.env`; skill `README.md:134-153` (TikTok/IG/Threads/LinkedIn/Reddit/YouTube) | S | CONSUMED |
+| SKILLSMP_API_KEY | `mde/src/mde/research/clients/skillsmp_client.py` (6); `mde/src/mde/research/skill_discover.py` | A | CONSUMED (mde is deprecated) |
+| TEMPO_S3_ACCESS_KEY | declaration only | O | ORPHAN |
+| TEMPO_S3_BUCKET | declaration only | O | ORPHAN (config, not secret) |
+| TEMPO_S3_SECRET_KEY | declaration only | O | ORPHAN |
+
+### Tally
+
+- **CONSUMED**: 25
+- **AMBIENT** (third-party reads by convention, no in-repo ref): 4 — `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `OTEL_EXPORTER_OTLP_PROTOCOL`
+- **ALIAS**: 4 — `GITHUB_API_TOKEN`, `GITHUB_MCP_PAT`, `MISE_GITHUB_TOKEN` (all = `GITHUB_TOKEN`), `AWS_DEFAULT_REGION` (= `AWS_REGION`)
+- **ORPHAN**: 17
+
+### The orphan block is one dead project
+
+14 of the 17 orphans are a single coherent group: an **S3-backed
+Grafana/Loki/Mimir/Tempo/OpenLIT observability stack** (9 names) plus a
+**NextAuth web app** (2) plus stragglers (`DB_PASSWORD`,
+`GEMINI_TELEMETRY_LOG_PROMPTS`, `NVIDIA_20260705`). The observability compose that
+survives (`mde/docker/observability/compose.yaml`) uses **local storage and reads
+only `GRAFANA_PASSWORD`** — the S3 tier was declared and never wired.
+
+## Names that look like CONFIGURATION, not secrets
+
+Project rule `.claude/rules/secrets-out-of-the-shell-env.md` rule 3 — "do not mark
+a non-secret as a secret" — because fnox redaction is value-based, so a short or
+empty "secret" corrupts every log the tool writes. **19 of the 50 qualify:**
+
+Endpoints/URLs: `OTEL_EXPORTER_OTLP_ENDPOINT`, `GEMINI_TELEMETRY_OTLP_ENDPOINT`,
+`OPENLIT_ENDPOINT`, `NEXTAUTH_URL`
+Protocols/targets: `OTEL_EXPORTER_OTLP_PROTOCOL`, `GEMINI_TELEMETRY_OTLP_PROTOCOL`,
+`GEMINI_TELEMETRY_TARGET`
+Booleans: `GEMINI_TELEMETRY_ENABLED`, `GEMINI_TELEMETRY_LOG_PROMPTS`
+Regions: `AWS_REGION`, `AWS_DEFAULT_REGION`
+Buckets: `LOKI_S3_BUCKET`, `MIMIR_S3_BUCKET`, `TEMPO_S3_BUCKET`
+Usernames/handles/IDs: `OPENLIT_UI_USER`, `BSKY_HANDLE`, `LANGSMITH_WORKSPACE_ID`,
+`GOOGLE_CLIENT_ID` (public by OAuth design)
+
+`GEMINI_TELEMETRY_ENABLED` is the sharpest case: a boolean whose value is almost
+certainly `true` or `1`. A 1-4 character "secret" means fnox will redact every
+occurrence of that string in any log it touches.
+
+## Stale / dated
+
+- **`NVIDIA_20260705`** — a date-stamped name (2026-07-05), value **differs** from
+  `NVIDIA_API_KEY`, and its only reference is `hook_guard.py`'s protection list.
+  Almost certainly a superseded key kept "just in case". Prime deletion candidate.
+- **`AUTH_TOKEN`** — dangerously generic name for what is specifically an
+  **X/Twitter session cookie**. Any tool that reads a variable called `AUTH_TOKEN`
+  by convention will silently get an X cookie.
+- **`SKILLSMP_API_KEY`** — sole consumer is `macos-development-environment`, which
+  is deprecated.
+- The 8 `~/.config/fnox/config.toml.*` backups, two of them named `BROKEN-by-claude`
+  and `WIPED-evidence`.
+
+## Implications for the "universal CRUD for API keys" CLI
+
+1. **Aliases are a first-class requirement, not a nicety.** One PAT lives under
+   four names; rotation today means four coordinated edits.
+2. **Usage cannot be inferred from config files.** Only 1 of 50 is interpolated
+   into an MCP config; the rest are consumed by environment inheritance. Any
+   "find unused secrets" feature that greps for `${VAR}` will report ~49 false orphans.
+3. **Secret vs config must be a declared field.** 19 of 50 are not secrets, and
+   marking them so actively corrupts logs via value-based redaction.
+4. **Migration must handle predecessor stores.** A SOPS store with 34 of the names
+   and 8 config backups are still on disk.
+5. **`DOPPLER_TOKEN` is the bootstrap root** — the only keychain-backed entry, and
+   the one every other read depends on. It needs a distinct lifecycle.
+
+## Control arms
+
+Every negative below was armed before being reported.
+
+| Probe | Positive arm | Negative arm | Verdict |
+|---|---|---|---|
+| Secret names in Claude MCP/settings configs → 0 | `mcpServers`/`enableAllProjectMcpServers`, same `rg -F -w -f` shape → **31 hits in `~/.claude.json`** | — | probe discriminates; the 0 is real |
+| ORPHAN claim across all corpora | `GITHUB_TOKEN` → **272 files** | freshly-invented `QWFJVZ_NOPE_7731` (never written to disk before this run) → **0 files** | probe discriminates in both directions |
+| `LOKI_S3_ACCESS_KEY` "orphan" | — | 13 files, all enumerated and inspected: fnox config + 8 backups, SOPS store, `doctor.toml`, a test-values doc, and this report | all declarations, zero consumers |
+
+The known-absent term was **invented fresh for this run** rather than reused from a
+prior receipt — a published control string is in the corpus and stops discriminating.
+It is deliberately not repeated as a reusable token.
+
+### Two bounds I hit and corrected mid-sweep
+
+1. **`| head -200` on a `tee` pipeline killed the loop via SIGPIPE**, truncating
+   the per-name breakdown at name 28 of 50. Re-run unbounded.
+2. **`sort -u -t: -k3` collapsed each file to a single name** (the `-o` output has
+   only 2 colon fields, so `-k3` sorted on nothing). This under-reported
+   `~/.config/last30days/.env` as holding one variable when it holds six — and
+   those six are the reclassification that moved five names out of the orphan list.
+   My own parser was the bound.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — primary sweep corpus; `doctor.toml`, `hook_guard.py`, `renovate_dryrun.py`, workflows, Dockerfile
+- [ray-manaloto/knowledge-base](https://github.com/ray-manaloto/knowledge-base) — `kb_setup/graphify_env.py`, `evals.py`, `mise.toml`
+- [ray-manaloto/macos-development-environment](https://github.com/ray-manaloto/macos-development-environment) — deprecated historical owner; `mde/secrets/manage.py`, `telemetry_verify.py`, observability compose, MCP wrappers
+- [ray-manaloto/guilde-lite-tdd-sprint](https://github.com/ray-manaloto/guilde-lite-tdd-sprint) — sole consumer of the Google OAuth pair
+- [jdx/mise](https://github.com/jdx/mise) — cached docs establishing the GitHub token precedence chain (refuting the alias framing)
+- [jdx/fnox](https://github.com/jdx/fnox) — cached docs; the declaring tool
+- [twpayne/chezmoi](https://github.com/twpayne/chezmoi) — cached docs (source of many false-positive hits)

--- a/docs/research/kb/reports/agents/secrets-backend-bitwarden-sm.md
+++ b/docs/research/kb/reports/agents/secrets-backend-bitwarden-sm.md
@@ -1,0 +1,584 @@
+# Bitwarden Secrets Manager — primary-source evaluation as a secrets backend
+
+**Date:** 2026-08-03
+**Source discipline:** PRIMARY ONLY — `bitwarden.com/help/**`, `bitwarden.com/pricing/**`,
+`github.com/bitwarden/{server,clients,sdk-sm}`, `bws` docs and `--help`.
+Third-party comparison blogs / news write-ups are BANNED for this sweep; any fact
+that exists only there is marked `UNVERIFIED (secondary-only)`.
+
+**Status:** COMPLETE.
+
+## Verdict at a glance
+
+| Q | Answer |
+|---|---|
+| 1 Free tier | 2 users / 3 projects / 3 machine accounts / unlimited secrets. SM has its own free subscription. 3 primary pages agree on numbers; they **contradict each other on self-hosting**. |
+| 2 Licensing | SM **server** = AGPL 3.0 (FOSS). **`bws` CLI + `bitwarden-sm` SDK = proprietary** Bitwarden SDK EULA. Self-host = Enterprise licence file. |
+| 3 Machine accounts | **Scoped per PROJECT** (not per secret), read or read/write. A strict subset is achievable at project granularity. |
+| 4 `bws run` | **EXISTS** — env injection, plus `--no-inherit-env` and `--project-id`. Not retrieval-only. |
+| 5 Offline | **No offline mode, no secret cache.** State file caches auth tokens only. Unreachable service → nonzero exit, no secrets. |
+| 6 Agent surface | **`bitwarden/agent-access` (Apache-2.0, `aac` CLI)** + `bitwarden/mcp-server` (GPL-3.0). Both target the **password manager**, not SM. No Claude Code plugin. |
+| 7 **Fail-open?** | **REFUSES** on bad project id, bad/expired token. ⚠️ One rc=0 defect: token with no org → exit 0, command never runs, no secrets emitted. |
+
+**Headline for the decision at hand:** on the one property the replacement CLI
+was specified to add — converting fnox's silent scope-widening fail-open into a
+refusal — `bws` already refuses, structurally (Q7). The costs are that the
+client is **not FOSS**, there is **no offline operation**, and the agent-scoping
+story you'd actually want (`agent-access`) is on the **other** Bitwarden product
+and in **early preview**.
+
+## Q1 Free tier, exactly
+
+Source: <https://bitwarden.com/products/secrets-manager/> (pricing block on the
+product page).
+
+| Tier | Users | Projects | Machine accounts | Secrets |
+|---|---|---|---|---|
+| **Free** | "Up to 2 users" | "Up to 3 projects" | "Up to 3 machine accounts" | unlimited |
+| Teams ($6/user/mo) | unlimited | unlimited | "Up to 20 machine accounts, $1 per additional machine account" | unlimited |
+| Enterprise ($12/user/mo) | unlimited | unlimited | "Up to 50 machine accounts, $1 per additional machine account" | unlimited |
+
+Annual rates, USD, excl. tax.
+
+⚠️ `https://bitwarden.com/help/about-secrets-manager/` returns **HTTP 404** — the
+help-doc counterpart had to be located elsewhere.
+
+### Cross-check against the help docs — numbers AGREE
+
+<https://bitwarden.com/help/secrets-manager-plans/>:
+
+| | Free | Teams | Enterprise |
+|---|---|---|---|
+| Users | "Up to 2 users" | "Unlimited users" | "Unlimited users" |
+| Projects | "Up to 3 projects" | "Unlimited projects" | "Unlimited projects" |
+| Machine accounts | "Up to 3 machine accounts" | "Up to 20 … extra accounts billed per account" | "Up to 50 … extra accounts billed per account" |
+| Secrets | "Unlimited secret storage" | unlimited | unlimited |
+
+<https://bitwarden.com/help/secrets-manager-faqs/> states it in one sentence:
+
+> "Bitwarden Secrets Manager offers a free subscription with unlimited secret
+> storage and **up to 2 users, 3 projects, and 3 machine accounts**."
+
+**Three independent primary pages agree on the numbers** (product pricing block,
+plans help page, FAQ). No disagreement on limits.
+
+### Is Secrets Manager included in the free plan?
+
+**Yes — it is its own free subscription, not a Password Manager add-on you must
+pay for.** `secrets-manager-quick-start` confirms the free path exists at signup:
+*"If you are on the Free plan, select **Submit**. If you are on an upgraded plan,
+enter the desired number of **Subscription seats**…"* SM is subscribed to
+separately from Password Manager but has its own free tier.
+
+### ⚠️ The help docs DO disagree — on self-hosting
+
+- `secrets-manager-plans/`: **"Coming Soon: Self-host option"**, listed against
+  all three tiers — i.e. not available anywhere.
+- `secrets-manager-faqs/`: **"Enterprise organizations can self-host Bitwarden
+  Secrets Manager alongside their existing self-hosted installations."**
+  Requires *"minimum server version 2023.10.0 and a new license file from your
+  cloud organization."*
+
+These cannot both be current. The FAQ is the more specific and more plausible
+(it cites a concrete minimum server version, 2023.10.0, which is ~3 years old);
+the plans page's "Coming Soon" reads as stale marketing copy. **Treat
+self-hosting as Enterprise-gated and requiring a cloud-issued licence file**, and
+treat the plans page as out of date — but this is a documented contradiction in
+Bitwarden's own help corpus, not a settled fact.
+
+### Free-tier fit for the use case at hand
+
+3 machine accounts × 3 projects is the entire scoping budget on free. Since
+machine-account scope is per-project (Q3), the free plan permits **at most 3
+disjoint blast radii**. Adequate for a single developer host with, say,
+`agent` / `devcontainer` / `ci` splits; nothing beyond that without paying $6/user/mo.
+
+## Q2 Licensing
+
+Bitwarden's licensing really is mixed. Read from the LICENSE files themselves,
+not from summaries.
+
+### Server (`bitwarden/server`) — Secrets Manager code is **AGPL 3.0**
+
+`LICENSE.txt` (verbatim):
+
+> Source code in this repository is covered by one of two licenses: (i) the GNU
+> Affero General Public License (AGPL) v3.0 (ii) the Bitwarden License v1.0. The
+> default license throughout the repository is AGPL v3.0 unless the header
+> specifies another license. **Bitwarden Licensed code is found only in the
+> /bitwarden_license directory.**
+
+`bitwarden_license/README.md`: *"All source code under this directory is licensed
+under the Bitwarden License Agreement."*
+
+`bitwarden_license/src` contains exactly: `Commercial.Core`,
+`Commercial.Infrastructure.EntityFramework`, `Scim`, `Services`, `Sso`.
+**No `SecretsManager` directory.** The Secrets Manager server code lives at
+`src/Core/SecretsManager` and `src/Api/SecretsManager` — *outside*
+`bitwarden_license/`, therefore **AGPL 3.0**. (Verified by listing both trees via
+`gh api repos/bitwarden/server/contents/...`.)
+
+`LICENSE_FAQ.md` adds that the Bitwarden License is *"source available"*:
+*"provides users access to product source code for non-production purposes such
+as development and testing, but requires a paid subscription for production use"*,
+and states plainly *"The Bitwarden License does not qualify as an open source
+license under the OSI definition."* It also notes the Api module includes
+`Commercial.Core` by default, disable-able with
+`` /p:DefineConstants="OSS" ``.
+
+### `bws` CLI + SDK (`bitwarden/sdk-sm`) — **NOT open source**
+
+- GitHub license metadata for `bitwarden/sdk-sm`: `spdx_id: NOASSERTION`.
+- `sdk-sm/LICENSE` is the **"BITWARDEN SOFTWARE DEVELOPMENT KIT LICENSE
+  AGREEMENT, Version 1, 17 March 2023"** — a bespoke proprietary EULA. It
+  restricts use to a *"Compatible Application"*, defined as software that
+  *"connects to and interoperates with a current version of the Bitwarden server
+  products distributed by the Company"* and complies with Bitwarden's acceptable
+  use policy. **This is the licensing controversy referenced in the brief**: the
+  SDK is source-available under a bespoke agreement, not GPL/AGPL, and the
+  Compatible-Application clause is what makes it unusable for a
+  non-Bitwarden-server client.
+- `crates/bws/Cargo.toml` sets `license-file.workspace = true`; the workspace
+  `Cargo.toml` sets `license-file = "LICENSE"` — i.e. **the `bws` binary itself
+  ships under that same SDK EULA**, not GPL. `bws` version in-tree: **2.1.0**.
+
+### `bitwarden/sdk-internal` — dual GPL-3.0 **OR** SDK License v2.0
+
+Materially relevant, and easy to miss: `sdk-sm`'s workspace now pulls
+`bitwarden-core`, `bitwarden-crypto`, `bitwarden-sm`, `bitwarden-cli`,
+`bitwarden-auth` as **git dependencies on `bitwarden/sdk-internal`** (pinned rev
+`15ab4caf17fc7b9f1c80a1141d4341dd80432562`). That repo's `LICENSE` says:
+
+> Source code in this repository is covered by one of two licenses: (i) the GNU
+> General Public License (GPL) v3.0 (ii) the BITWARDEN SOFTWARE DEVELOPMENT KIT
+> LICENSE v2.0. The default license throughout the repository is **your choice of
+> GPL v3.0 OR BITWARDEN SOFTWARE DEVELOPMENT KIT LICENSE** unless the header
+> specifies another license. Anything contained within a directory named
+> bitwarden_license is covered solely by the BITWARDEN SOFTWARE DEVELOPMENT KIT
+> LICENSE.
+
+So the **general SDK crates were relicensed to a GPL-3.0 dual option** in
+`sdk-internal` (v2 of the SDK licence), while the `sdk-sm` repo wrapper —
+including the `bws` crate — still carries the **v1 EULA with no GPL option**.
+Anyone reasoning about "the SDK licensing controversy" from 2023-era material is
+reading a state that has partially moved.
+
+⚠️ **BUT — the Secrets Manager crate is carved back out.** `sdk-internal`'s
+LICENSE says *"Anything contained within a directory named bitwarden_license is
+covered solely by the BITWARDEN SOFTWARE DEVELOPMENT KIT LICENSE."* And
+`bitwarden-sm` — the crate that actually implements every SM operation
+(`list_by_project`, `get_by_ids`, `sync`) — lives at
+**`bitwarden_license/bitwarden-sm/`**, alongside `bitwarden-commercial-vault`
+and `bitwarden-pam`. `crates/` holds the GPL-dual-licensed general crates
+(`bitwarden-core`, `bitwarden-crypto`, `bitwarden-cli`, `bitwarden-auth`, …).
+
+**Net: the entire Secrets Manager client stack is proprietary.** The GPL dual
+option covers the generic plumbing; every SM-specific line is SDK-License-only.
+Verified by `ls bitwarden_license/` on a shallow clone of `bitwarden/sdk-internal`
+(control: `crates/` listing returns 30+ non-SM crates, so the probe distinguishes
+the two trees).
+
+### Clients (`bitwarden/clients`)
+
+`spdx_id: NOASSERTION`; per `LICENSE_FAQ.md`, *"The core password management code
+for individual password vaults, including Desktop, Web, Browser, Mobile, and CLI
+versions, is available under the GPL 3.0 license."* Not the Secrets Manager
+surface — the SM CLI is `bws`, in `sdk-sm`.
+
+### Summary — what is and is not FOSS
+
+| Component | License | FOSS? |
+|---|---|---|
+| Secrets Manager **server** code (`src/{Core,Api}/SecretsManager`) | AGPL 3.0 | **YES** |
+| `bitwarden_license/**` (SSO, SCIM, Commercial.Core) | Bitwarden License v1.0 | NO — source-available, production use needs a paid subscription |
+| **`bws` CLI** (`sdk-sm/crates/bws`) | Bitwarden SDK License Agreement v1 | **NO** — bespoke EULA, Compatible-Application restriction |
+| `sdk-sm` Rust/py/wasm SDK wrappers | Bitwarden SDK License v1 | NO |
+| `sdk-internal` crates (incl. `bitwarden-sm`) | GPL-3.0 **OR** SDK License v2.0 | **YES, at your choice** |
+| Password-manager clients | GPL 3.0 | YES |
+
+**Self-hosting Secrets Manager gated to enterprise? YES — by *licence file*, not
+by source licence.** The distinction matters and is easy to garble:
+
+- The SM **server source** is AGPL 3.0 and sits outside `bitwarden_license/`, so
+  it is *not* source-gated the way SSO and SCIM are. You may legally build and
+  run it.
+- But `secrets-manager-faqs` states *"Enterprise organizations can self-host
+  Bitwarden Secrets Manager alongside their existing self-hosted installations,"*
+  requiring *"a new license file from your cloud organization"* — i.e. the
+  **feature is unlocked at runtime by an Enterprise-tier licence**, and
+  `secrets-manager-plans` still says "Coming Soon: Self-host option" (see Q1 for
+  the contradiction).
+- And the **client is proprietary regardless**: `bws` and `bitwarden-sm` are
+  SDK-License-only, so even a fully self-hosted AGPL server is talked to by a
+  non-FOSS CLI whose EULA restricts use to a "Compatible Application"
+  interoperating with *"Bitwarden server products distributed by the Company."*
+
+**Net for a FOSS-preference evaluation: Secrets Manager is not a FOSS-viable
+stack.** The server half is AGPL; the half you actually run on your laptop is
+not, and there is no open-source `bws` alternative in Bitwarden's own repos. The
+one Apache-2.0 component in this sweep (`agent-access`, Q6) is on the password
+manager, not SM.
+
+## Q3 Machine accounts — scoping
+
+Source: <https://bitwarden.com/help/machine-accounts/>
+
+- Definition (verbatim): *"Machine accounts represent non-human machine users,
+  like applications or deployment pipelines, that require programmatic access to
+  a discrete set of secrets."*
+- **Scope unit = PROJECT, not secret.** Configuration asks you to *"type or
+  select the name of the project(s) that this machine account should be able to
+  access."*
+- Two permission levels per assigned project:
+  - *"Can read"* — retrieve secrets from assigned projects.
+  - *"Can read, write"* — retrieve/edit secrets in assigned projects, create new
+    secrets in assigned projects, or create new projects.
+- Access token grants *"programmatic access to, and the ability to decrypt,
+  edit, and create secrets"* for that machine account.
+- The help docs do **not** document per-secret scoping — only whole projects.
+
+**Answer to "can it be scoped to a strict subset?": YES, at project
+granularity.** A machine account holding one project's grant structurally cannot
+decrypt secrets in other projects. Sub-project (per-secret) scoping is
+`UNVERIFIED` / apparently unsupported — tried the machine-accounts help page,
+which enumerates only project selection.
+
+⚠️ Free-tier interaction: 3 projects max means at most 3 disjoint blast radii
+before you must pay.
+
+## Q4 `bws` injection semantics
+
+Source: <https://bitwarden.com/help/secrets-manager-cli/>
+
+**`bws run` EXISTS.** Verbatim: *"The `run` command runs commands with secrets
+injected as environment variables, enabling you to easily adapt existing
+development projects and scripts to use secure secrets management."*
+
+Documented forms:
+
+```
+bws run -- 'npm run start'
+bws run --project-id <PROJECT_ID> -- <command>
+bws run --shell fish -- <command>
+bws run --no-inherit-env -- <command>
+bws run --uuids-as-keynames -- <command>
+```
+
+So `bws` is **not** retrieval-only: it has the `infisical run` / `sops exec-env`
+shape, plus `--no-inherit-env` (drop the parent environment — a real
+confinement knob that fnox's `env = true` posture does not offer) and
+`--project-id` to bound which secrets are injected. No shell-interpolation
+wrapper is required, so the transcript-leak shape (`echo "$SECRET"`) is
+avoidable by construction.
+
+Retrieval commands also exist: `bws secret {create,delete,edit,get,list}`,
+`bws project {create,delete,edit,get,list}`, `bws config {server-base,state-dir,--profile,--config-file}`.
+
+## Q5 Offline behaviour
+
+**There is no offline mode and no secret cache.** The only on-disk persistence is
+the **state file**, and it caches *authentication tokens*, not secret values.
+
+Source: <https://bitwarden.com/help/secrets-manager-cli/> (state-files section),
+verbatim:
+
+> "State files are fully encrypted files that store authentication tokens and
+> additional relevant data."
+> "State files can reduce rate limiting while authenticating, using stored tokens
+> for authentication."
+> "The state directory default location is `~/.config/bws/state`."
+> "If your workflow uses many separate sessions (where each use of an access token
+> to authenticate constitutes a 'session') to make requests from the same IP
+> address in a short span of time, you may encounter rate limits."
+
+Opt-out: set `state_opt_out` to `true`/`1` in `~/.config/bws/config`; set the
+directory with `bws config state-dir /absolute/path` (absolute path required).
+
+Source-side confirmation (`sdk-sm` @ HEAD): `crates/bws/src/state.rs` only
+computes a path (`~/.config/bws/state/<access_token_id>`) and `create_dir_all`s
+it; `crates/bws/src/config.rs` has exactly two state keys — `state_dir` and
+`state_opt_out`. A grep of `crates/bws/src/{cli,config}.rs` for
+`state|cache|offline` returns **only** those two keys — no cache TTL, no offline
+flag, no stale-read path.
+
+**When the service is unreachable:** the `reqwest` transport error becomes
+`Err` at `bitwarden-api-base`, propagates through `?`, and `bws` exits nonzero
+with **no secrets**. Consistent with Q7 — it refuses rather than degrading. Note
+`main.rs:87-102` treats a *state-file* failure as recoverable (prints
+`"Warning: … Attempting to continue without using state"` and continues with
+`state_file = None`), which affects auth caching only, never secret retrieval.
+
+**Operational consequence:** every `bws run` is a live network round-trip. A
+laptop offline, or Bitwarden's service down, means the wrapped command does not
+run. That is the safe direction, but it is a hard availability dependency that
+fnox's local-file/keychain reads do not have.
+
+## Q6 Agent / plugin surface
+
+**Answer: YES — and this is the most under-appreciated finding of the sweep.**
+Bitwarden ships *two* separate agent-facing products, neither of which is
+Secrets Manager.
+
+### Control arm (run first, per `probes-need-a-control-arm.md`)
+
+Method: `gh search repos --owner=bitwarden --limit 100 --json name,description`,
+then substring-filter the combined name+description.
+
+| Arm | Term | Result |
+|---|---|---|
+| Target | `mcp` / `agent` / `claude` / `model context` | **3 matches** — `mcp-server`, `agent-access`, `key-connector` |
+| **Control** | `sdk` (known present — `sdk-sm` was already read this session) | **14 matches** — `sdk-sm`, `sdk-internal`, `sdk-go`, `sdk-swift`, `agent-access`, 9 × `passwordless-*` |
+
+64 repos enumerated total. The control returns a large non-zero set by the same
+method, so the probe discriminates — the target result is a real positive, not a
+blind search. (No absence is being claimed here anyway; both arms found things.)
+
+### 1. `bitwarden/agent-access` — **Apache-2.0**, `aac` CLI
+
+<https://github.com/bitwarden/agent-access> · created 2025-12-19 · 121 stars ·
+license `Apache-2.0` (the **only genuinely OSI-open** component in this whole
+sweep).
+
+README verbatim:
+
+> "Agent Access allows users to provide credentials from their password manager to
+> remote systems, **without exposing their entire vault**. Agent Access creates an
+> end-to-end encrypted tunnel between a remote system and a credential provider."
+>
+> "Agent Access is an open protocol, CLI tool, and SDK that can be implemented
+> directly into agents or custom software. While Agent Access has been built and
+> developed by the team at Bitwarden, **it is open for any credential provider**…"
+
+And, directly on point for the transcript-leak concern:
+
+> ⚠️ "This project is in an **early preview stage**. APIs and protocols are subject
+> to change. We do not recommend inputting sensitive credentials directly into LLMs
+> or AI agents (any unknown software, really).
+>
+> For LLM's specifically, where possible **use environment injection (e.g. `aac
+> run`) to pass secrets to processes without exposing them in recorded context**."
+
+Shape: `aac listen` on the human's machine (holds the vault, interactive
+`/unlock`, mints a **pairing token**) ↔ `aac connect` / `aac run` on the remote
+/ agent side. Per-request, per-domain credential release —
+`aac connect --domain github.com --provider bitwarden --output json`. Crates:
+`ap-cli`, `ap-client`, `ap-relay`, `ap-relay-protocol`, `ap-noise` (Noise-protocol
+tunnel), `ap-uniffi`. Protocol spec in-repo at `protocol-v0.md`.
+
+Bindings/examples shipped: Python (UniFFI), JS/WASM, Swift (UniFFI), Rust
+listener + remote, shell, **GitHub Action**, and **`examples/skills/`** — an
+agent *skill* directory. The README documents installing it as an **OpenClaw
+skill**:
+
+```shell
+curl -fsSL "https://raw.githubusercontent.com/bitwarden/agent-access/main/examples/skills/agent-access/SKILL.md" \
+  -o ~/.openclaw/skills/agent-access/SKILL.md --create-dirs
+```
+
+⚠️ **No Claude Code plugin is documented** — the shipped skill targets OpenClaw's
+`~/.openclaw/skills/` path. The `SKILL.md` format is portable, but a Claude Code
+integration is not something Bitwarden ships or documents. `UNVERIFIED` whether
+the skill works unmodified under `.claude/skills/`; not tested.
+
+⚠️ **Agent Access reads the PASSWORD MANAGER vault (`bw` CLI), not Secrets
+Manager.** `--provider bitwarden` is the `bw` CLI provider; `--provider example`
+is a built-in demo. No `bws` / Secrets Manager provider is documented in the
+README. So it is **not** an agent front-end for the SM backend this report is
+evaluating — it is a parallel product on the other vault.
+
+### 2. `bitwarden/mcp-server` — **GPL-3.0**
+
+<https://github.com/bitwarden/mcp-server> · created 2025-05-23 · 217 stars ·
+`@bitwarden/mcp-server` on npm. Two interfaces: **vault management via the `bw`
+CLI**, and **organization administration via the Bitwarden Public API**
+(collections, members, groups, policies, audit logs, subscriptions).
+
+Its own README carries a blunt warning worth quoting in full before anyone
+considers it:
+
+> "When you grant an AI assistant access to this server, you are providing the
+> ability to: Read vault items including passwords, secure notes, and sensitive
+> data … **Expose credentials and vault contents through AI responses**"
+>
+> "Never: Deploy this server to cloud hosting … Grant access to untrusted AI
+> clients or services"
+
+Configuration is documented for **Claude Desktop** ("Option 1 … Recommended") —
+Claude *Desktop*, not Claude Code.
+
+⚠️ **The MCP server's feature list contains no Secrets Manager tools.** Every
+listed capability is password-manager vault or org-admin. So there is no MCP
+path to SM secrets.
+
+⚠️ Note also that this server is the **opposite** of the scoping property the user
+wants: it hands an assistant the whole vault, by design.
+
+### Agent-scoped identity primitives beyond machine accounts
+
+- **Machine accounts** (Q3) — project-scoped, for SM.
+- **Agent Access pairing tokens** — per-session, per-domain, human-in-the-loop
+  release, on the password-manager vault. Genuinely a *different and stronger*
+  primitive (the agent never holds a long-lived credential), but on the wrong
+  product for an SM-backed design, and **early preview** by Bitwarden's own label.
+- `bitwarden/key-connector` — despite "agent" in its description ("An agent that
+  stores and provides cryptographic keys to Bitwarden clients"), this is
+  self-hosted key custody for SSO, not an AI-agent primitive. Not relevant.
+
+## Q7 DECISIVE — fail-open vs refusal
+
+Method: shallow-cloned `bitwarden/sdk-sm` (bws 2.1.0) and `bitwarden/sdk-internal`
+and read the actual call chain. `bws` is not installed on this host
+(`which bws` → not found), so this is **source-verified, not runtime-probed**.
+
+### Verdict per input
+
+| Bad input | Behaviour | Confidence |
+|---|---|---|
+| **Nonexistent / unauthorized project id** (`--project-id`) | **REFUSES** — nonzero exit, no secrets emitted | source-verified |
+| **Invalid / unparseable access token** | **REFUSES** — nonzero exit | source-verified |
+| **Expired / rejected access token** | **REFUSES** — nonzero exit | source-verified |
+| **Valid token not associated with an organization** | ⚠️ **rc=0, command never runs** — a distinct rc-lying defect, but **no secrets emitted** | source-verified |
+
+### The chain (project-id path)
+
+`crates/bws/src/command/run.rs:62-74`:
+
+```rust
+let res = if let Some(project_id) = project_id {
+    client.secrets()
+        .list_by_project(&SecretIdentifiersByProjectRequest { project_id }).await?
+} else {
+    client.secrets()
+        .list(&SecretIdentifiersRequest { organization_id: organization_id.into() }).await?
+};
+```
+
+**There is no fallback branch.** If `--project-id` is supplied, the org-wide
+`list` is never reached. This is the structural difference from fnox: a bad scope
+argument cannot silently widen to "everything", because the widened call is in the
+*other* arm of the `if`.
+
+Error propagation, bottom-up:
+
+1. `crates/bitwarden-api-base/src/request.rs:57-69` — the shared response
+   processor returns `Err(ResponseContent { status, message })` for **any**
+   `status.is_client_error() || status.is_server_error()`. 4xx/5xx are errors,
+   not empty successes.
+2. `bitwarden_license/bitwarden-sm/src/secrets/list.rs` —
+   `list_secrets_by_project` calls `get_secrets_by_project(input.project_id)`
+   with `?`; no `unwrap_or_default`, no empty-vec fallback.
+3. `run.rs` — `.await?` propagates to `main`.
+4. `crates/bws/src/main.rs:23` — `async fn main() -> Result<()>`; an `Err` from
+   `process_commands()` is printed by `color_eyre` and Rust exits **nonzero**.
+
+So a 403/404 on an unknown or unpermitted project produces a nonzero exit with
+**zero secrets in the child environment**. **REFUSES.**
+
+### Access token handling
+
+`main.rs:63-67`:
+
+```rust
+let access_token = match cli.access_token {
+    Some(key) => key,
+    None => bail!("Missing access token"),
+};
+let access_token_obj: AccessToken = access_token.parse()?;
+```
+
+Absent token → `bail!` (nonzero). Malformed token → `parse()?` (nonzero).
+`main.rs:107-113` — `login_access_token(...).await?` — a rejected/expired token
+errors out of the login call before any secret is fetched. **REFUSES.**
+
+### ⚠️ The one rc=0 defect found — `main.rs:115-121`
+
+```rust
+let organization_id = match client.get_access_token_organization() {
+    Some(id) => id.into(),
+    None => {
+        error!("Access token isn't associated to an organization.");
+        return Ok(());
+    }
+};
+```
+
+A token that authenticates but carries no organization claim causes `bws` to log
+to stderr and **return `Ok(())` → exit code 0**, *before* the command dispatch.
+For `bws run -- ./deploy.sh`, that means **the wrapped command never executes and
+`bws` reports success**. A CI step would go green having done nothing.
+
+Classify precisely: this is **not** a secrets fail-open (nothing is decrypted or
+emitted, so it cannot leak), but it **is** an rc-lies-about-outcome path, and it
+is exactly the shape a refusal-enforcing wrapper must still guard. Any adoption
+should treat "token has no org" as a case to detect explicitly rather than trust
+`bws`'s exit code for.
+
+### Two things NOT verified
+
+- **Does the server return 404/403 or an empty 200** for a project id the machine
+  account cannot see? The client refuses on 4xx, but an empty-200 would instead
+  produce "runs the child with zero secrets, propagating the child's exit code"
+  — still no leak, still no widening, but not a hard refusal. `UNVERIFIED`: not
+  runtime-probed (no `bws`, no Bitwarden org on this host) and the controller
+  authorization path in `bitwarden/server` was not read to completion.
+- **No runtime probe was run at all.** Every verdict above is read from source at
+  the pinned revisions (`sdk-sm` @ HEAD, `sdk-internal` @ rev
+  `15ab4caf17fc7b9f1c80a1141d4341dd80432562` as pinned by `sdk-sm`'s workspace).
+
+### Contrast with fnox 1.32.0
+
+fnox `exec -P <nonexistent>` returns all 49 secrets at rc=0 with no stderr — the
+scope argument is silently discarded and the call widens to everything. `bws run
+--project-id <nonexistent>` cannot do that: the widening call lives in a branch
+the code does not take, and a 4xx becomes a nonzero exit. **On the specific
+property the replacement CLI was specified to add, `bws` already has it.**
+
+## Open gaps / UNVERIFIED
+
+Listed so nobody mistakes an unasked question for a negative answer.
+
+1. **No runtime probe of `bws` was performed.** `which bws` → not found on this
+   host, and there is no Bitwarden org/token here. Every Q7 verdict is
+   **source-verified at a pinned revision**, not observed. Before adopting, run
+   the real arms: `bws run --project-id 00000000-0000-0000-0000-000000000000 --
+   env` and an expired-token arm, and read `echo "rc=$?"` from a file (never a
+   piped tail).
+2. **Server-side response for an unauthorized project id** — 403/404 vs empty
+   200 — not read to completion in `bitwarden/server`'s SM controllers. The
+   client refuses on 4xx; an empty 200 would instead run the child with zero
+   secrets. Neither leaks, but only the first is a hard refusal.
+3. **Self-hosting availability is genuinely contradictory** between
+   `secrets-manager-plans` ("Coming Soon") and `secrets-manager-faqs`
+   ("Enterprise organizations can self-host"). Not resolvable from the help
+   corpus alone.
+4. **`bws --help` was not captured firsthand** (binary not installed); the flag
+   and subcommand list is from the CLI help page plus `crates/bws/src/cli.rs`.
+   The two agree on `--project-id`, `--no-inherit-env`, `--shell`,
+   `--uuids-as-keynames`, `state_dir`, `state_opt_out`.
+5. **Whether `agent-access`'s `SKILL.md` loads under Claude Code** (vs its
+   documented `~/.openclaw/skills/` target) is untested.
+6. **`bitwarden/agent-access` has no documented Secrets Manager provider** —
+   only `--provider bitwarden` (the `bw` CLI) and `--provider example`. Whether
+   a `bws` provider is planned was not researched.
+
+**Banned-source discipline:** no third-party comparison blog, news write-up, or
+aggregator was consulted for any claim above. Every fact carries a
+`bitwarden.com/*` URL, a `github.com/bitwarden/*` URL, or a file:line from a
+shallow clone of a Bitwarden repo. No claim in this report is marked
+`UNVERIFIED (secondary-only)` because none was sourced that way — gaps were left
+as gaps instead.
+
+**Revisions pinned:** `bitwarden/sdk-sm` @ HEAD of `main` (bws 2.1.0);
+`bitwarden/sdk-internal` @ `15ab4caf17fc7b9f1c80a1141d4341dd80432562` (the rev
+`sdk-sm`'s workspace `Cargo.toml` pins); `bitwarden/server` read via
+`gh api .../contents` at `main`. Sweep date 2026-08-03.
+
+## GitHub repos touched
+
+- [bitwarden/server](https://github.com/bitwarden/server) — `LICENSE.txt`, `LICENSE_FAQ.md`, `bitwarden_license/README.md`, and directory listings of `src/` and `bitwarden_license/src/` to prove Secrets Manager code is AGPL and outside the commercial tree.
+- [bitwarden/sdk-sm](https://github.com/bitwarden/sdk-sm) — `LICENSE` (SDK EULA v1), workspace + `crates/bws/Cargo.toml` for the `bws` licence, and `crates/bws/src/{main,state,config,cli}.rs` and `src/command/run.rs` for the Q4/Q5/Q7 semantics.
+- [bitwarden/sdk-internal](https://github.com/bitwarden/sdk-internal) — `LICENSE` (GPL-3.0 OR SDK v2), `bitwarden_license/bitwarden-sm/**` (the SM crate is carved back out as proprietary), and `crates/bitwarden-api-base/src/request.rs` for the 4xx/5xx → `Err` rule that decides Q7.
+- [bitwarden/clients](https://github.com/bitwarden/clients) — licence metadata only; confirmed the SM CLI is not here (it is `bws` in `sdk-sm`).
+- [bitwarden/agent-access](https://github.com/bitwarden/agent-access) — README, repo metadata (Apache-2.0), `crates/` and `examples/` listings; the Q6 agent-scoped credential protocol and `aac run` env injection.
+- [bitwarden/mcp-server](https://github.com/bitwarden/mcp-server) — README and repo metadata (GPL-3.0); Bitwarden's MCP surface and its explicit whole-vault-exposure warning.
+- [bitwarden/key-connector](https://github.com/bitwarden/key-connector) — description only, via the org repo enumeration; checked and ruled out as an AI-agent primitive.

--- a/docs/research/kb/reports/agents/secrets-backend-infisical.md
+++ b/docs/research/kb/reports/agents/secrets-backend-infisical.md
@@ -1,0 +1,430 @@
+# Infisical as a secrets backend — primary-source research
+
+**Agent:** secrets-backend-infisical
+**Date:** 2026-08-03
+**Source rules:** `infisical.com/docs/**`, `infisical.com/pricing`, `Infisical/infisical` GitHub repo,
+official API reference, official CLI `--help`. **`infisical.com/blog/**` is BANNED** (vendor
+marketing); third-party comparison posts are BANNED. A fact only available from a banned source is
+recorded as `UNVERIFIED (marketing-only)`.
+
+Status: **COMPLETE** (written incrementally). One limitation is load-bearing and stated in Q7: the
+CLI was **not** installed and no account exists on this host, so Q7 is **source-verified on two
+independent routes, not live-probed**.
+
+## Q1 — Free tier limits
+
+Source: <https://infisical.com/pricing> (fetched 2026-08-03).
+
+Free plan, verbatim numbers from the pricing table:
+
+| Dimension | Free |
+|---|---|
+| Identities | **5** ("5 identities, unlimited projects") |
+| Projects | **unlimited** |
+| Environments | **3** |
+| Secret Syncs | **10** |
+| Custom Environments | **–** (not available) |
+
+Pro tier is described as "Everything in Free, plus: Unlimited identities, Access Controls,
+Secret Rotation, SAML SSO, 30-day Audit log retention, Secret Versioning, Point-in-time Recovery".
+Dynamic Secrets is Advanced-tier only.
+
+⚠️ **The pricing page does not state a numeric cap on secrets or on users/members** in what was
+returned. `UNVERIFIED`: per-secret count limit and per-user/member seat limit on Free — not found on
+the pricing page; tried <https://infisical.com/pricing>.
+
+### What "identity" means
+
+Source: <https://infisical.com/docs/documentation/platform/identities/machine-identities>
+
+Verbatim: *"An Infisical machine identity is an entity that represents a workload or application
+that require access to various resources in Infisical."* The docs compare it to "an IAM user in AWS
+or service account in Google Cloud Platform (GCP)".
+
+Consequence for the solo-dev question: an identity is a **created object with its own auth method
+and role**, not a per-human count. The docs do NOT state that a CI token or a machine consumes
+exactly one identity, but the model is one identity object per workload/application, each of which
+you create individually. A solo developer using the CLI interactively logs in as a *user*, not as a
+machine identity — machine identities are for workloads.
+
+`UNVERIFIED`: whether the pricing page's "5 identities" counts **users + machine identities** or
+machine identities only. The pricing page uses the bare word "identities"; the docs page defines
+only "machine identity". Tried both URLs above; the two do not cross-reference. **This is a real
+ambiguity and it matters** — if it counts both, a solo dev with 2 laptops + 2 CI runners is already
+at 5.
+
+## Q2 — License split
+
+**Two repos, same dual-license structure.**
+
+Server/platform: <https://github.com/Infisical/infisical> — root `LICENSE`
+(<https://raw.githubusercontent.com/Infisical/infisical/main/LICENSE>), verbatim:
+
+> Copyright (c) 2022 Infisical Inc. Portions of this software are licensed as follows...
+> All content that resides under any "ee/" directory of this repository, if such directories exists,
+> are licensed under the license defined in "ee/LICENSE".
+> ... Content outside of the above mentioned directories or restrictions above is available under the
+> "MIT Expat" license as defined below.
+
+CLI: <https://github.com/Infisical/cli> — GitHub API reports `license.spdx_id = NOASSERTION`
+(i.e. GitHub cannot classify it), and its `LICENSE` carries the **same** carve-out text, dated 2025:
+
+> Copyright (c) 2025 Infisical Inc. ... All content that resides under any "ee/" directory of this
+> repository, if such directories exists, are licensed under the license defined in "ee/LICENSE".
+> ... Content outside ... is available under the "MIT Expat" license.
+
+**The `ee/` tree is real and substantial.** GitHub code search on `repo:Infisical/infisical
+filename:LICENSE` returns `backend/src/ee/LICENSE.md`, and the tree contains
+`backend/src/ee/services/license/`, `backend/src/ee/services/license-v2/`,
+`backend/src/ee/routes/v1/license-router.ts`, plus a Go mirror at
+`backend-go/internal/ee/services/license/`. So a licence-gating subsystem is compiled into the
+same binary and its own directory is under separate (non-MIT) terms.
+
+**RESOLVED — the `ee/` licence is a proprietary Enterprise License, not an OSI licence.**
+<https://raw.githubusercontent.com/Infisical/infisical/main/backend/src/ee/LICENSE.md> (HTTP **200**;
+control arm: a bogus sibling path returned **404**, so the fetch discriminates). Verbatim opening:
+
+> The Infisical Enterprise license (the "Enterprise License")
+> Copyright (c) 2022 Infisical Inc
+> ... This software ... may only be used in production, if you (and any entity that you represent)
+> have agreed to, and are in compliance with, the Infisical Subscription Terms of Service ... and
+> otherwise have a valid Infisical Enterprise License for the correct number of user seats.
+> ... Notwithstanding the foregoing, you may copy and modify the Software for development and testing
+> purposes, without requiring a subscription. ... it is forbidden to copy, merge, publish, distribute,
+> sublicense, and/or sell the Software.
+
+So the answer to "is any part of the repo non-open-source" is **yes, explicitly**: `ee/` is
+**production-use-forbidden without a paid seat-counted subscription**, dev/test use excepted. It is
+not BUSL — it is Infisical's own Enterprise License, closer to the Sentry/GitLab "ee/" model.
+
+**Paywalled features** (source: <https://infisical.com/pricing>, Pro tier described as "Everything
+in Free, plus: …"):
+
+| Feature | Free? |
+|---|---|
+| Secret versioning | ❌ Pro |
+| Point-in-time recovery | ❌ Pro |
+| RBAC / "Access Controls" | ❌ Pro |
+| Secret rotation | ❌ Pro |
+| Audit logs | ❌ Pro (30-day retention) |
+| SAML SSO | ❌ Pro |
+| Dynamic secrets | ❌ Advanced |
+
+This is the decisive shape for a solo user: **secret versioning and point-in-time recovery — the
+two things that make a secrets store recoverable — are both paid.**
+
+## Q3 — `infisical run` injection semantics
+
+Sources: <https://infisical.com/docs/cli/commands/run> and CLI source
+`packages/cmd/run.go` (<https://github.com/Infisical/cli>).
+
+Command forms (from the cobra `Example`/`Use` fields in `packages/cmd/run.go:29-35`, verbatim):
+
+```
+infisical run --env=dev -- npm run dev
+infisical run --command "first-command && second-command; more-commands..."
+```
+
+`Use: "run [any infisical run command flags] -- [your application start command]"`,
+`Short: "Used to inject environments variables into your application process"`.
+
+**Yes, it execs a child with secrets in that child's environment.** `formatSecretsForShell`
+(`packages/cmd/run.go`) copies `os.Environ()` into a map, overlays the Infisical secrets on top, and
+hands the resulting `[]string` to `executeSingleCommandWithEnvs` / `executeMultipleCommandWithEnvs`.
+The parent's own environment is never mutated, so **teardown is structural** — the variables exist
+only in the child process and die with it. This is exactly the `fnox exec --` shape.
+
+Notable behaviour found in source, not in the docs summary: `filterReservedEnvVars` **silently drops**
+secrets named `HOME PATH PS1 PS2 PWD EDITOR XAUTHORITY USER TERM TERMINFO SHELL MAIL` and anything
+prefixed `XDG_` / `LC_`, printing a warning.
+
+Documented flags: `--command`, `--env` (default `dev`), `--projectId` (required with machine-identity
+auth), `--path` (repeatable), `--token`, `--watch` (restarts the child on secret change),
+`--project-config-dir`, `--expand` (default true), `--include-imports` (default true),
+`--secret-overriding` (default true), `--tags`.
+
+**Interactive shell / the `fnox activate` equivalent: NOT documented.** The docs page does not
+document injecting into an interactive shell. The closest supported thing is
+`infisical run -- $SHELL` (a child shell — same teardown semantics), which is an inference from the
+exec model, **not a documented feature**: `UNVERIFIED (not documented)`. There is no
+`infisical activate` / shell-hook / `eval "$(infisical …)"` form on the `run` docs page.
+
+## Q4 — Offline / unreachable behaviour
+
+**There IS an offline cache, and it is real code, not a doc claim.**
+Source: `packages/util/secrets.go` in <https://github.com/Infisical/cli>, function
+`GetAllEnvironmentVariables`:
+
+```go
+// only attempt to serve cached secrets if no internet connection and if at least one secret cached
+if !isConnected {
+    backupEncryptionKey, _ := GetBackupEncryptionKey()
+    if backupEncryptionKey != nil {
+        backedUpSecrets, err := ReadBackupSecrets(params.WorkspaceId, params.Environment, params.SecretsPath, backupEncryptionKey)
+        if len(backedUpSecrets) > 0 {
+            PrintWarning("Unable to fetch the latest secret(s) due to connection error, serving secrets from last successful fetch. For more info, run with --debug")
+            secretsToReturn = backedUpSecrets
+            errorToReturn = err
+        }
+    }
+}
+```
+
+Mechanics, read off the same file:
+
+- Every **successful** fetch writes a backup: `WriteBackupSecrets(workspaceId, environment,
+  secretsPath, key, secrets)` → `<config-dir>/secrets-backup/project_secrets_<workspace>_<env>_<path>.json`.
+- The backup is **encrypted**, with the key stored in the **OS keyring**
+  (`GetBackupEncryptionKey` → `GetValueInKeyring(INFISICAL_BACKUP_SECRET_ENCRYPTION_KEY)`, generating
+  a random 16-byte key on first use). If the platform has no keyring it returns an error telling you
+  to use a service token.
+- The gate is `isConnected := ValidateInfisicalAPIConnection()`. So the cache serves **only** when the
+  API is unreachable — it is not a general fallback for API errors.
+- Cache is **keyed by (workspace, environment, secretsPath)** and only used when
+  `len(backedUpSecrets) > 0`.
+
+So: **offline → serves the last successful fetch, with a stderr warning, rc unchanged.** This is a
+cache-on-unreachable, not a fail-open on a bad request (see Q7).
+
+⚠️ **The cache path applies only to the logged-in-user branch.** The `else` branch of
+`GetAllEnvironmentVariables` — used when `InfisicalToken` (service token) or
+`UniversalAuthAccessToken` (machine identity) is set — has **no cache fallback at all**. CI/machine
+auth therefore hard-fails when the API is unreachable.
+
+`UNVERIFIED`: whether the offline cache is documented on `infisical.com/docs/**`. A grep of
+`https://infisical.com/docs/llms.txt` for `offline` and `cache` returned **0** — but that index is
+API-reference-only (control arm: `docs` → 957 lines of 963, all `api-reference/endpoints/*`), so the
+0 proves the index is narrow, not that the docs are silent. Treat the offline behaviour as
+**source-verified, doc-status unknown**.
+
+## Q5 — Self-host requirements
+
+Source: <https://infisical.com/docs/self-hosting/deployment-options/docker-compose>
+(<https://infisical.com/docs/self-hosting/overview> lists the deployment options — Docker,
+Kubernetes, Docker Compose, AWS, GCP, Linux package — but carries **no** resource numbers).
+
+Three services, all required:
+
+1. Backend — "The main Infisical application (exposed on host port 80, internal port 8080)"
+2. **PostgreSQL** — "PostgreSQL database for storing encrypted secrets"
+3. **Redis** — "Redis for caching and job queues"
+
+Stated minimum resources: **2 CPU cores, 4 GB RAM, 20 GB disk.**
+
+Required configuration: `ENCRYPTION_KEY`, `AUTH_SECRET`, `DB_CONNECTION_URI`
+(`postgresql://<user>:<password>@<host>:5432/<dbname>`), `REDIS_URL`
+(`redis://:<password>@<host>:6379`), `SITE_URL`, and `SMTP_*` for email.
+
+`UNVERIFIED`: the exact minimum **Postgres version**. Not stated in what the page returned.
+
+**Read this against the alternative.** fnox is a single static binary with no server. Infisical
+self-hosted is a Postgres + Redis + Node service with a 4 GB RAM floor, which on this Mac means
+another always-on container stack. The SaaS free tier avoids that but reintroduces a hard network
+dependency (see Q4).
+
+## Q6 — Agent / plugin surface
+
+**Found, and it is the strongest part of the whole offering.** Three separate primitives:
+
+### 6a. Official MCP servers — TWO of them
+
+- <https://github.com/Infisical/infisical-mcp-server> — "Infisical's official MCP server."
+  JavaScript, **Apache-2.0**, last pushed 2026-04-14 (GitHub API `repos/Infisical/infisical-mcp-server`).
+- A hosted **docs** MCP at `https://infisical.com/docs/mcp`, which
+  <https://github.com/Infisical/ai-skills> README documents installing as:
+  `claude mcp add --transport http infisical-docs https://infisical.com/docs/mcp`
+
+### 6b. A Claude Code plugin marketplace
+
+<https://github.com/Infisical/ai-skills> — "AI skills and MCP connection for Infisical". Its tree
+contains **`.claude-plugin/marketplace.json`**, an `AGENTS.md`, a `.github/workflows/validate-plugins.yml`,
+and a full `evals/infisical-agent/` tree with `with_skill` vs `without_skill` A/B runs. README:
+*"They follow the [Agent Skills](https://agentskills.io) open standard and work across 45+ AI tools"*,
+installable via `npx skills add Infisical/ai-skills` or the Claude Code plugin marketplace.
+
+### 6c. An agent-scoped credential-brokering primitive in the CLI itself
+
+This is the notable one. `packages/cmd/agent_proxy.go` / `agent_proxy_run.go` in
+<https://github.com/Infisical/cli> define:
+
+| Command | `Short` (verbatim) |
+|---|---|
+| `infisical secrets agent-proxy` | "Secrets brokering: run an agent proxy and connect agents to it" |
+| `… agent-proxy start` | "Start the agent proxy (MITM proxy that brokers credentials on the wire)" |
+| `… agent-proxy connect [flags] -- [agent start command]` | "Set up the environment and launch an agent behind the agent proxy" |
+| `… agent-proxy run [flags] -- [agent start command]` | "Launch an agent on this machine, sandboxed, with credentials brokered on the wire" |
+
+The `Example` for `run` is, verbatim: **`infisical secrets agent-proxy run --env=dev --path=/myapp -- claude`**
+— i.e. Claude Code is the named example agent. Design details read off the source:
+
+- The child gets **no credentials at all**. Comment: *"The single identity for the run: fetches config
+  and secret values in the parent. The child gets none of it."* Secrets are injected on the wire by a
+  MITM proxy instead of into the environment.
+- `secretShapedEnvSubstrings = {"TOKEN","SECRET","PASSWORD","PASSWD","CREDENTIAL","API_KEY","APIKEY","PRIVATE_KEY","ACCESS_KEY"}`
+  — env vars whose *name* contains any of these are **scrubbed from the child**; `--pass-env <NAME>`
+  re-admits one explicitly. Its test file asserts this on `ANTHROPIC_API_KEY` and `AWS_SECRET_ACCESS_KEY`.
+- OS-level sandboxing (`resolveSandboxEnabled`, `--allow-read` / `--allow-write` / `--allow-host`,
+  `--unmatched-host allow|block`), a per-run `0700` tempdir, and a darwin-specific CA in
+  `~/.infisical/agent-proxy`.
+- It knows the agent harnesses by name: the test fixture creates `~/.claude`, `~/.claude.json` and
+  checks for `~/.codex` in `defaultAgentStateWritePaths`.
+
+**This is exactly the posture `.claude/rules/secrets-out-of-the-shell-env.md` says this repo gave up**
+(50 credentials in every agent child). Infisical ships a scrub-plus-broker primitive for it, with
+Claude Code as the worked example.
+
+### Control arm for the absence claims
+
+A grep of the CLI repo for `mcp` / "model context protocol" (excluding `kmip`) returned **0** — but the
+control arm (`gateway`, known present) returned **57 files**, so the probe discriminates and the CLI
+binary genuinely does not embed an MCP server. The MCP surface lives in the two separate repos above,
+which is why the org-level `gh api orgs/Infisical/repos` sweep was needed to find it. **A repo-scoped
+grep would have produced a false "no MCP".**
+
+## Q7 — Fail-open vs refusal (DECISIVE)
+
+### Verdict: **REFUSES** — nonzero exit, no secrets emitted, no child process started.
+
+⚠️ **Method disclosure up front.** I could **not** run a live probe: `infisical` is not installed on
+this host (`which infisical` → not found) and I have no Infisical account or token, so there is no
+credential with which to issue a real bad-project request. The verdict below is **source-verified on
+two independent routes** (the Go CLI's error path and the TypeScript backend's throw sites), which
+cross-check each other, but it is **not empirical** the way the fnox `-P <nonexistent>` → 49 secrets
+at rc=0 result is. Treat it as `SOURCE-VERIFIED, NOT LIVE-PROBED`.
+
+### Route 1 — the CLI never swallows an API error
+
+`packages/api/api.go:603` `CallGetSecretsV4` (<https://github.com/Infisical/cli>):
+
+```go
+if response.IsError() {
+    return GetSecretsV4Response{}, NewAPIErrorWithResponse(operationCallGetRawSecretsV3, response, nil)
+}
+```
+
+Any non-2xx becomes an error. That error propagates unchanged:
+
+`GetPlainTextSecretsV4` → `util.GetAllEnvironmentVariables` (`errorToReturn = err`) →
+`fetchSecrets` (`return nil, fmt.Errorf("failed to fetch secrets for path %q: %w", path, err)`) →
+`fetchAndFormatSecretsForShell` (`return models.InjectableEnvironmentResult{}, err`) →
+`runCmd.Run`:
+
+```go
+injectableEnvironment, err := fetchAndFormatSecretsForShell(...)
+if err != nil {
+    util.HandleError(err, "Could not fetch secrets", "If you are using a service token to fetch secrets, please ensure it is valid")
+}
+```
+
+`util.HandleError` (`packages/util/log.go:67`) is `PrintErrorAndExit(1, err, ...)`, whose last
+statement is `os.Exit(exitCode)` — **rc=1, and the `-- <command>` child is never exec'd**, because
+`executeSingleCommandWithEnvs` is called only after that block. There is **no** `if err != nil {
+log and continue }` anywhere on this path.
+
+Two more refusal points before any network call, both `util.HandleError` (rc=1):
+
+- no project resolvable → *"Please either run infisical init to connect to a project or pass in
+  project id with --projectId flag"* (`packages/util/secrets.go`)
+- machine-identity auth without a project → *"Project ID is required when using machine identity"*
+
+And in the agent-proxy lane (`packages/cmd/agent_proxy_run.go`), a missing environment is a hard
+refusal: *"the environment is required; pass --env, set INFISICAL_ENVIRONMENT, or set
+defaultEnvironment in .infisical.json"*.
+
+### Route 2 — the backend actually returns an error for each bogus input
+
+`backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts`, function `getSecrets`
+(<https://github.com/Infisical/infisical>):
+
+- **Nonexistent project** → `permissionService.getProjectPermission(...)` is called *before* any
+  secret lookup; `backend/src/ee/services/permission/permission-service.ts:465` throws
+  `NotFoundError({ message: \`Project with ${projectId} not found\` })`.
+- **Nonexistent environment slug or path** → both branches throw, unconditionally:
+
+```ts
+if (recursive) {
+  const deepPaths = await recursivelyGetSecretPaths({ ... environment, currentPath: path });
+  if (!deepPaths?.length) {
+    throw new NotFoundError({
+      message: `Folder with path '${path}' in environment '${environment}' was not found. Please ensure the environment slug and secret path is correct.`,
+      name: "SecretPathNotFound"
+    });
+  }
+} else {
+  const folder = await folderDAL.findBySecretPath(projectId, environment, path);
+  if (!folder) {
+    throw new NotFoundError({ message: `Folder with path '${path}' ... not found ...`, name: "SecretPathNotFound" });
+  }
+}
+```
+
+I specifically checked whether the throw is gated behind a flag (which would open a fail-open lane) —
+it is not; it is unconditional in both the `recursive` and non-recursive branches. The same
+`Folder with path ... not found` throw appears at ~10 other call sites in the file for the
+write/update/delete paths.
+
+- **Nonexistent identity** → the token is rejected at auth, before `getSecrets` is reached.
+
+### Two residual soft-fail-open axes worth naming honestly
+
+1. **The offline cache serves STALE secrets at rc=0** with only a stderr `Warning:` line
+   (`PrintWarning("Unable to fetch the latest secret(s) due to connection error, serving secrets from
+   last successful fetch...")`, Q4). That is not the fnox failure mode (wrong scope → wrong secrets),
+   but it *is* "rc=0 with secrets you did not just authorise". It is bounded: the backup is keyed by
+   `(workspaceId, environment, secretsPath)`, so a **bogus** project/env has no backup file,
+   `len(backedUpSecrets) == 0`, the fallback is skipped, and the original error still propagates to
+   `os.Exit(1)`. So offline + bogus scope still **REFUSES**.
+2. **A real-but-empty folder** injects zero secrets and runs the child at rc=0. There is no
+   `--require-secrets` / minimum-count flag in `run.go`'s flag set. So "valid scope, nothing in it" is
+   silent — but a *typo'd* scope is a 404, which is the case that matters.
+
+### Against the incumbent
+
+| | fnox 1.32.0 | Infisical CLI |
+|---|---|---|
+| Bogus profile/project | **FAILS OPEN** — 49 secrets, rc=0, zero stderr | **REFUSES** — rc=1, no child exec'd (source-verified) |
+| Bogus environment | n/a | **REFUSES** — backend 404 `SecretPathNotFound` |
+| Offline | n/a | serves encrypted local cache + warning, rc=0 (user-auth lane only) |
+
+**Recommended follow-up before deciding:** install the CLI (`brew install infisical/get-cli/infisical`
+per <https://github.com/Infisical/homebrew-get-cli>), create a free-tier project, and run the live
+arm — `infisical run --projectId <bogus> --env dev -- echo REACHED` — asserting that `REACHED` is
+**not** printed and `rc != 0`. Also run the *positive* control (a real project, expecting `REACHED`),
+or the probe can only fail. That converts this from `SOURCE-VERIFIED` to measured.
+
+## Method notes / control arms run
+
+- **Absence of MCP in the CLI repo**: grep for `mcp` (ex-`kmip`) → 0 files; control `gateway` → 57
+  files. Probe discriminates ⇒ the 0 is real for that repo. The org-wide sweep
+  (`gh api orgs/Infisical/repos`) then found the MCP surface in two *other* repos — a repo-scoped
+  grep alone would have been a false negative.
+- **`docs/llms.txt` grep for `offline`/`cache`/`self-hosting` → 0**: control `docs` → 957 of 963
+  lines. The index is **API-reference-only**, so the 0 means "the index is narrow", not "the docs are
+  silent". I did **not** report doc-silence on the strength of it.
+- **`raw.githubusercontent.com/.../backend/src/ee/LICENSE` → HTTP 404**: a 404 is "never asked", not
+  "no ee licence". GitHub code search gave the real path, `backend/src/ee/LICENSE.md`.
+- **No live CLI probe was possible** (not installed, no account) — stated in Q7 rather than papered
+  over.
+
+## GitHub repos touched
+
+- [Infisical/infisical](https://github.com/Infisical/infisical) — root `LICENSE` (MIT Expat + `ee/`
+  carve-out), `backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts` (`getSecrets`
+  NotFoundError throws), `backend/src/ee/services/permission/permission-service.ts` (project-not-found),
+  `backend/e2e-test/routes/v4/secrets.spec.ts`, full tree listing for the `ee/` inventory.
+- [Infisical/cli](https://github.com/Infisical/cli) — the Go CLI: `packages/cmd/run.go`,
+  `packages/cmd/agent_proxy*.go`, `packages/util/secrets.go` (offline cache), `packages/util/log.go`
+  (`HandleError` → `os.Exit(1)`), `packages/api/api.go` (`CallGetSecretsV4`), `LICENSE`,
+  `agent-config.yaml`.
+- [Infisical/infisical-mcp-server](https://github.com/Infisical/infisical-mcp-server) — official MCP
+  server; metadata only (Apache-2.0, JS, pushed 2026-04-14).
+- [Infisical/ai-skills](https://github.com/Infisical/ai-skills) — Claude Code plugin marketplace
+  (`.claude-plugin/marketplace.json`), agent skills, docs-MCP install instructions, evals tree.
+- [Infisical/homebrew-get-cli](https://github.com/Infisical/homebrew-get-cli) — named only as the
+  install route for the recommended live follow-up probe; not inspected.
+
+Non-GitHub primary sources: <https://infisical.com/pricing>,
+<https://infisical.com/docs/documentation/platform/identities/machine-identities>,
+<https://infisical.com/docs/cli/commands/run>, <https://infisical.com/docs/self-hosting/overview>,
+<https://infisical.com/docs/self-hosting/deployment-options/docker-compose>,
+<https://infisical.com/docs/llms.txt>. **`infisical.com/blog/**` was not fetched.**

--- a/docs/research/kb/reports/agents/secrets-backend-sops-age.md
+++ b/docs/research/kb/reports/agents/secrets-backend-sops-age.md
@@ -1,0 +1,479 @@
+# SOPS + age as a secrets backend — primary-source research
+
+**Agent:** secrets-backend-sops-age
+**Date:** 2026-08-03
+**Source rules:** primary only — `github.com/getsops/sops`, `github.com/FiloSottile/age`,
+official SOPS docs site, `age` spec/man pages, local `--help` output.
+Third-party tutorials/comparisons are BANNED; any fact available only there is
+marked `UNVERIFIED (secondary-only)`.
+
+## Local versions probed
+
+| Tool | Version | Path |
+|---|---|---|
+| `sops` | 3.13.3 | `~/.local/share/mise/installs/aqua-getsops-sops/latest/sops` |
+| `age` | v1.3.1 | `~/.local/share/mise/installs/aqua-filo-sottile-age/latest/age/age` |
+| `age-keygen` | (same install) | `.../age/age-keygen` |
+
+Offline KB corpus (`knowledge-base/sources/`) has **no** sops or age tree —
+control arm: the same `ls | grep` for `agent-harness-docs` returns 2, so the
+probe discriminates. All repo facts below are fetched from GitHub.
+
+---
+
+Repos cloned (shallow) for file:line citation:
+
+- `getsops/sops` @ `382c478` (2026-08-03)
+- `FiloSottile/age` @ `706dfc1` (2026-03-20)
+
+---
+
+## Q3 — `sops exec-env` semantics (READ FROM SOURCE)
+
+**Yes, it execs a child process with the decrypted values in its environment.**
+It does NOT "tear them down on exit" in any active sense — there is nothing to
+tear down, because the values were never placed in the *caller's* environment.
+
+Call chain: `cmd/sops/main.go:186` (`exec-env` command) →
+`decryptTree(opts)` at `main.go:249` → the decrypted tree's top-level branch is
+flattened into `KEY=VALUE` strings at `main.go:254-274` → passed as
+`ExecOpts.Env` to `exec.ExecWithEnv` at `main.go:276-284`.
+
+Inside `ExecWithEnv`
+(`cmd/sops/subcommand/exec/exec.go:130-182`):
+
+- `exec.go:143-146` — if `--pristine` is NOT set, `env = os.Environ()` (the
+  parent env is forwarded); with `--pristine`, `env` starts empty so **only**
+  the decrypted values are present.
+- `exec.go:147-156` — the plaintext is split on newlines; blank lines and lines
+  starting with `#` are skipped; each remaining line is appended as an env
+  entry. (For `exec-env` the plaintext is `[]byte{}` — `main.go:278` — and the
+  real values arrive via `opts.Env`, appended at `exec.go:159`.)
+- `exec.go:170-181` — default path: `cmd := BuildCommand(opts.Command)`;
+  `cmd.Env = env`; stdio wired to the parent; `cmd.Run()`. `BuildCommand` is
+  `exec.Command("/bin/sh", "-c", command)` (`exec_unix.go:19-21`).
+- `exec.go:161-168` — with `--same-process`, it calls `ExecSyscall`, i.e.
+  `syscall.Exec("/bin/sh", ["-c", command], env)` (`exec_unix.go:15-17`). The
+  comment at `exec.go:166` states *"the call does NOT return, unless an error
+  happens"* — the sops process is **replaced**, so there is no parent left to
+  clean up.
+
+**Teardown is process lifetime, not cleanup code.** The env lives in the child
+(or the replaced process). When it exits, the environment dies with it. Nothing
+in `ExecWithEnv` scrubs or zeroes anything. Any blog claiming an explicit
+"tear-down" step is describing process semantics, not sops code.
+
+**Caveat worth knowing:** the values pass through `/bin/sh -c`, so the command
+string is shell-interpreted, and the child's env is visible to anything that can
+read `/proc/<pid>/environ` (Linux) or is a descendant of it.
+
+### `exec-file` — yes, documented, and materially different
+
+`cmd/sops/main.go:292-381`. Usage string: *"execute a command with the decrypted
+contents as a temporary file"* (`main.go:293`).
+
+| | `exec-env` | `exec-file` |
+|---|---|---|
+| Delivery | env vars on the child | a temp **file**, path substituted for `{}` in the command (`exec.go:115`) |
+| Backing store | process env | a **FIFO by default** (`main.go:372` passes `Fifo: !--no-fifo`); `--no-fifo` uses a regular file |
+| Perms | n/a | `0600` — regular file chmod at `exec.go:53`, FIFO `syscall.Mkfifo(tmpfn, 0600)` at `exec_unix.go:37` |
+| Cleanup | none needed | **explicit**: temp dir created at `exec.go:71` with `defer os.RemoveAll(dir)` at `exec.go:75` |
+| Shape | flat `KEY=VALUE` only; complex values REJECTED (`main.go:256-258`) | whole decrypted document in any supported output format |
+
+So `exec-file` is the one with real teardown (`defer os.RemoveAll`), and the
+FIFO default means the plaintext never has to touch disk at all. Windows has no
+FIFOs — sops warns and downgrades (`exec.go:66-69`).
+
+`exec-env` also **refuses** several shapes rather than silently mangling them:
+complex/nested values (`main.go:256-258`), non-string keys (`main.go:262-265`),
+and keys containing `=` (`main.go:266-268`) each return a nonzero exit.
+
+---
+
+## Q7 — fail-open vs refusal: **IT REFUSES.** (LIVE PROBE, both arms)
+
+### Why it structurally cannot fail open
+
+`cmd/sops/main.go:249-252`:
+
+```go
+tree, err := decryptTree(opts)
+if err != nil {
+    return toExitError(err)
+}
+```
+
+The decrypt happens **before** `exec.ExecWithEnv` is reached (`main.go:276`).
+Any decrypt failure returns early — the child process is never constructed.
+There is no partial-population path: `env` is built from an already-successful
+`decryptTree` in one loop (`main.go:254-274`), and every anomaly inside that
+loop is `return`, not `continue`.
+
+### Live probe
+
+Fixture: throwaway age identities A (held) and B (**private key deleted** after
+encrypting, so it is genuinely unheld), a fake dotenv (`FIXTURE_VAR`,
+`OTHER_VAR` — no real secrets), in a scratch dir. Never touched
+`~/.config/fnox/config.toml`. Child probe prints **presence flags only**
+(`printenv VAR >/dev/null; echo rc=$?`), never a value.
+Script: `scratchpad/sopsfix/probe.sh`, child: `scratchpad/sopsfix/child.sh`.
+
+Confounder control: no `~/.config/sops/age/keys.txt` on this host; `SOPS_AGE_KEY`
+unset; ambient `SOPS_AGE_KEY_FILE` **overridden per-arm** — ARM4's error text
+names the override path, proving the override took effect.
+
+| Arm | Case | EXIT | Child ran? | stderr (first line) |
+|---|---|---|---|---|
+| **1** | **known-good, recipient held** | **0** | **YES** (`CHILD_RAN=yes`, both vars `rc=0`) | _(empty)_ |
+| 2 | nonexistent file | **2** | no | `Error reading file: open does-not-exist.env: no such file or directory` |
+| 3 | recipient NOT held | **128** | no | `Failed to get the data key required to decrypt the SOPS file.` → `Group 0: FAILED` |
+| 4 | identity file missing | **128** | no | same, plus `failed to open SOPS_AGE_KEY_FILE file: ... no such file or directory` |
+| 5 | file is not sops-encrypted | **1** | no | `sops metadata not found` |
+| 6 | `--pristine`, recipient held | **0** | YES | _(empty)_ |
+
+**The probe discriminates** — ARM 1 and ARM 6 succeed with the child running and
+both variables present; ARMs 2-5 every one exits nonzero and `CHILD_RAN=yes`
+never appears on stdout. So "no values" is a *refusal*, not a silent pass.
+
+**Verdict: `sops exec-env` REFUSES.** Nonzero exit, no child process, no partial
+environment. Distinct exit codes per class (2 = file read, 1 = not a sops file,
+128 = no master key). ARM 3's message is explicit and would be hard to miss in a
+log: `at least one key has to be successful, but none were`.
+
+This is the opposite of the classic fail-open hazard, and it is the strongest
+single point in SOPS's favour for this evaluation.
+
+**Known caveat (primary source):** getsops/sops issue
+[#840](https://github.com/getsops/sops/issues/840) — *"exec-env/exec-file signal
+handling might be broken"* (OPEN). Refusal is sound; signal propagation to the
+child is not fully settled.
+
+---
+
+## Q1 — Disaster recovery: age supports the mechanisms, but **documents no DR story**
+
+### What age DOES support (all cited, all decisive for DR)
+
+**Multiple recipients — YES, first-class.** `age-src/README.md:208-215`:
+
+> ### Multiple recipients
+> Files can be encrypted to multiple recipients by repeating `-r/--recipient`.
+> **Every recipient will be able to decrypt the file.**
+
+Usage line `README.md:174`: `age [--encrypt] (-r RECIPIENT | -R PATH)...` — the
+`...` is repetition. Flag help `README.md:184-185`: `-r, --recipient RECIPIENT
+… Can be repeated.` / `-R, --recipients-file PATH … Can be repeated.`
+
+Recipient **files** (`README.md:217-228`) let you keep the recipient set as a
+checked-in, commented list — one per line, `#` comments allowed. This is exactly
+the "primary key + YubiKey + offline paper key + second machine" shape, and it
+is a **file you can version-control**.
+
+**Passphrase mode — YES.** `README.md:254-264`:
+
+> Files can be encrypted with a passphrase by using `-p/--passphrase`. By
+> default age will automatically generate a secure passphrase. Passphrase
+> protected files are automatically detected at decrypt time.
+
+**Passphrase-protected identity files — YES, and this is the DR primitive.**
+`README.md:266-278`: `age-keygen | age -p > key.age`; an identity file passed to
+`-i` that is itself a passphrase-encrypted age file *"will be automatically
+decrypted"* (`README.md:268`). The README's own stated use case is precisely
+off-machine storage — `README.md:280`:
+
+> Passphrase-protected identity files are not necessary for most use cases,
+> where access to the encrypted identity file implies access to the whole
+> system. **However, they can be useful if the identity file is stored
+> remotely.**
+
+That sentence is the closest thing in the entire age corpus to DR guidance, and
+it is one line long.
+
+**YubiKey — supported, via a THIRD-PARTY plugin.** `README.md:30`:
+> 🔑 Hardware PIV tokens such as YubiKeys are supported through the
+> [age-plugin-yubikey](https://github.com/str4d/age-plugin-yubikey) plugin.
+
+Note it is `str4d/age-plugin-yubikey`, not a FiloSottile repo — so it is out of
+the primary-source boundary for its own behaviour. Also `README.md:301` warns
+*"SSH keys held on YubiKeys can't be used to decrypt files"* — the SSH-key
+convenience path and the YubiKey path are **not** the same thing.
+
+**Also usable as recovery recipients:** SSH public keys (`README.md:282-289`,
+`ssh-rsa` / `ssh-ed25519`; `ssh-agent` NOT supported) and post-quantum hybrid
+keys (`README.md:232-252`, age ≥ v1.3.0; recipients ~2000 chars).
+
+### What age does NOT do — control-armed absence
+
+**There is no documented backup / disaster-recovery guidance in age.**
+
+- ABSENCE ARM: `grep -rniE "back ?up|backups|recover|disaster|lost (key|device)|key loss"` over
+  `age-src/README.md` + `age-src/doc/` (all 12 man-page files) → **0 hits, rc=1**.
+- CONTROL ARM, same corpus, same method: `grep -rncE "passphrase"` → README **10**,
+  `age.1` **17**, `age.1.ronn` **21**, `age-plugin-batchpass.1` **14**. The probe
+  discriminates; the zero is real.
+- `age-keygen(1)` (`doc/age-keygen.1.ronn`, read in full) says nothing about
+  backing up the identity. Its only protective note is on `-o/--output`: *"If
+  OUTPUT already exists, it is not overwritten."*
+
+**So the answer to "what do the age docs themselves recommend" is: nothing.**
+age ships the *primitives* for a robust DR posture (multiple recipients,
+passphrase-wrapped identities) and leaves the *policy* entirely to the operator.
+Any "recommended age backup procedure" you have read is
+`UNVERIFIED (secondary-only)` — it is not in the primary corpus.
+
+### The one hard constraint that shapes any DR design
+
+Recipients are fixed **at encrypt time**. `README.md:210` — every recipient *"will
+be able to decrypt the file"*, but there is no notion of adding a recipient to an
+existing age file without re-encrypting it. Consequence: **the recovery key must
+exist BEFORE the first secret is encrypted, or every file must be rewritten to
+add it.** For SOPS this is softened — see Q4, where `updatekeys` rewraps the data
+key without touching the values.
+
+---
+
+## Q2 — Does "encrypted secrets in a private git repo" satisfy cloud durability? **Partially — and the gap is total, not marginal.**
+
+### What is actually stored in the repo
+
+Structure of a real sops+age dotenv file (throwaway fixture, ciphertext
+truncated):
+
+```
+FIXTURE_VAR=ENC[AES256_GCM,data:waLXDvGQ…]
+OTHER_VAR=ENC[AES256_GCM,data:EKafvf0S…]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5…
+sops_age__list_0__map_recipient=age1xs9hmgql5e5zg9ur2gesvp4t0e67vnmqw60t4e93jkla4wc9m3jsl6xsk6
+sops_lastmodified=2026-08-04T01:30:40Z
+sops_mac=ENC[AES256_GCM,data:5G4CxQBL…]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.3
+```
+
+**Stored:** the encrypted values; the age-wrapped **data key** (`_map_enc`); the
+**recipient public key in cleartext**; a MAC; version and mtime metadata. Note
+the **variable NAMES are cleartext** — a git clone leaks your key *inventory*
+even though it leaks no values.
+
+**NOT stored:** the age **private key** (`AGE-SECRET-KEY-1…`). By construction —
+that is the whole point.
+
+### Therefore, precisely:
+
+A `git clone` on a new Mac recovers **100% of the ciphertext and 0% of the
+ability to read it.** It is a perfect backup of a locked box and no backup at
+all of the key. Restated as durability: the repo gives you *availability* of the
+encrypted payload from anywhere, and gives you **nothing** toward *recoverability*.
+
+**The requirement "secrets must survive the Mac being lost or destroyed" is
+therefore NOT satisfied by the git repo alone.** If the age identity exists only
+on that Mac, losing the Mac loses every secret permanently, with the useless
+ciphertext preserved in perfect fidelity forever. Git durability is orthogonal to
+the failure mode being guarded against.
+
+**What closes the gap** (and it is the operator's job — Q1 shows age documents
+none of it): the identity must independently survive, via at least one of —
+
+1. a **second recipient** whose key lives elsewhere (`README.md:208-215`) —
+   YubiKey (`README.md:30`), a second machine, or an offline key;
+2. a **passphrase-wrapped identity file** stored remotely — the README's own
+   stated use case (`README.md:266-280`); this one CAN go in the repo, because
+   what is committed is then an age-encrypted blob whose only secret is a
+   passphrase in your head or a password manager;
+3. an out-of-band copy (printed, hardware, another vault).
+
+Option 2 is the only one that makes "private git repo" genuinely sufficient on
+its own — and it must be set up **before** encryption begins (Q1's fixed-recipient
+constraint), or every file has to be rewritten. **`age -p` on the identity is the
+single decision that turns this option from "loses everything" into "survives".**
+
+---
+
+## Q4 — Rotation and re-encryption cost: TWO different operations, very different costs
+
+SOPS uses envelope encryption: a per-file **data key** encrypts the values; the
+**master keys** (here, age recipients) each wrap a copy of that data key. Rotating
+the age key and rotating the data key are separate things.
+
+### `sops updatekeys <file…>` — the cheap one (this is what you want)
+
+`cmd/sops/main.go:725-772` → `cmd/sops/subcommand/updatekeys/updatekeys.go`.
+
+What it does (`updatekeys.go:101-110`):
+
+```go
+key, err := tree.Metadata.GetDataKeyWithKeyServices(...)   // decrypt data key with a key you still hold
+tree.Metadata.KeyGroups = conf.KeyGroups                    // adopt the .sops.yaml recipient set
+errs := tree.Metadata.UpdateMasterKeysWithKeyServices(key, ...)  // REWRAP the SAME data key
+```
+
+**It re-wraps the data key; it does NOT re-encrypt the values.** The `ENC[…]`
+payloads are untouched — only the `sops_age_*` wrapping entries and the metadata
+change. Cost is O(recipients), not O(secrets).
+
+Operational shape:
+
+- **Per FILE, not per value** — `UpdateKeys` rejects a directory outright
+  (`updatekeys.go:36-38`, `"can't operate on a directory"`), but the CLI accepts
+  **multiple file arguments** and loops (`main.go:753`, `for _, path := range c.Args()`).
+  So ~50 values in **one** dotenv file = one invocation. 50 separate files = 50
+  files on the command line (`sops updatekeys $(git ls-files 'secrets/*.env')`).
+- **Driven by `.sops.yaml`**, not by flags — it reads the creation rule and syncs
+  the file to it (`updatekeys.go:54-60`). **Hard-fails** if no creation rule
+  matches: `"The config file %s does not contain any creation rule"`. So rotation
+  is: edit the recipient list in `.sops.yaml` once → run `updatekeys` over the files.
+- **Interactive by default** — it prints a diff (`updatekeys.go:83-85`) and
+  prompts `Is this okay? (y/n):` (`updatekeys.go:87-100`). Pass `-y/--yes` for
+  non-interactive (`main.go:729-732`).
+- **Idempotent** — no-ops with `"File %s already up to date"` when nothing
+  changed (`updatekeys.go:79-82`).
+- **Requires you still hold a current key** (`updatekeys.go:101`). You cannot
+  `updatekeys` your way out of having lost every identity — which is Q1/Q2 again.
+
+### `sops --rotate` / `sops rotate` — the expensive one
+
+`cmd/sops/rotate.go:26`. It decrypts the whole tree (`rotate.go:43-52`), then:
+
+```go
+// Create a new data key
+dataKey, errs := tree.GenerateDataKeyWithKeyServices(opts.KeyServices)   // rotate.go:70
+// Reencrypt the file with the new key
+err = common.EncryptTree(...)                                            // rotate.go:77
+```
+
+**Full re-encrypt of every value** with a brand-new data key. Also supports
+`--add-{age,kms,pgp,…}` / `--rm-{…}` to edit the master-key set inline
+(`rotate.go:54-67`; `main.go:150-151` documents the flags against `--rotate` *or*
+`updatekeys`).
+
+### Summary
+
+| | `updatekeys` | `--rotate` |
+|---|---|---|
+| Data key | reused | **new** |
+| Values re-encrypted | **no** | yes, all |
+| Granularity | per file (multi-arg) | per file |
+| Driven by | `.sops.yaml` | CLI flags |
+| Use for | **age key rotation / adding a recovery recipient** | data-key compromise |
+
+**Answer to "what does rotating the age key across ~50 values require":** edit
+`.sops.yaml`, then `sops updatekeys -y <files>`. Not a full re-encrypt, and if
+the 50 values live in one file it is a single invocation. This is materially
+cheaper than the fnox situation described in the brief, where each add/remove
+churns all 49 `sync` ciphertexts.
+
+---
+
+## Q5 — Interactive-shell injection: **no such thing exists.** (control-armed)
+
+**There is no SOPS-native equivalent of `fnox activate`.** `exec-env` is strictly
+per-command: it builds a child process (or `syscall.Exec`-replaces itself) and
+the environment exists only for that command's lifetime — see Q3,
+`exec.go:170-181` / `exec.go:161-168`. There is no chpwd hook, no precmd hook, no
+`eval "$(sops …)"` shell-init form, no daemon, no directory-scoped activation.
+
+Control-armed:
+
+- ABSENCE ARM: `grep -rniE "chpwd|precmd|shell hook|shellhook|direnv"` over
+  `sops-src` (`*.go`, `*.md`, `*.rst`) → **0 files, rc=1**.
+- CONTROL ARM, same corpus, same method: `grep -rn "exec-env"` → **2 files**
+  (`CHANGELOG.md`, `cmd/sops/main.go`). The probe discriminates.
+
+The CLI surface confirms it — `sops --help` exposes `exec-env` and `exec-file`
+as the only injection verbs (`main.go:186`, `main.go:292`); there is no
+`activate`, `shellenv`, or `hook` command.
+
+**Implication for this evaluation:** replacing `fnox activate` with SOPS means
+giving up ambient secrets in interactive shells. Every consumer becomes
+`sops exec-env secrets.env '<cmd>'`. Whether that is a cost or a *feature*
+depends entirely on the posture chosen in
+`.claude/rules/secrets-out-of-the-shell-env.md` — under the 2026-08-02 reversal
+(`env = true`, all 50 in every shell by decision), SOPS **cannot reproduce the
+current behaviour**. Under the prior exec-only posture it would have been a
+near-drop-in. This is the sharpest functional mismatch between SOPS and the
+requirement as it stands today.
+
+The nearest hand-rolled approximation would be wrapping a login shell:
+`sops exec-env secrets.env "$SHELL"`. That is one shell for the whole session
+with a fixed snapshot — not per-directory reactivation, and not something either
+project documents. Marked `UNVERIFIED` as a *recommendation*; the mechanism
+(`exec-env` runs any command, including a shell, via `/bin/sh -c` —
+`exec_unix.go:19-21`) is verified.
+
+---
+
+## Q6 — Agent / plugin surface: **nothing, in either project.** (control-armed)
+
+Neither `getsops/sops` nor `FiloSottile/age` ships or documents a Claude Code
+plugin, an MCP server, or any agent-scoped access primitive.
+
+**Source-tree arm:**
+
+- ABSENCE ARM: `grep -rniE "model context protocol|\bMCP\b|claude|anthropic|\.mcp\.json|agent-scoped"`
+  over BOTH `sops-src` and `age-src` (`*.go`, `*.md`, `*.rst`, `*.json`, `*.yaml`)
+  → **0 files, rc=1**.
+- CONTROL ARM, same method: `grep -rniE "plugin"` over `age-src` → **8+ files**
+  (`age.go`, `README.md`, `parse.go`, `cmd/age-plugin-batchpass/plugin-batchpass.go`,
+  `cmd/age/age.go`, `plugin/example_test.go`, …). The probe discriminates.
+
+**Issue-tracker arm** (a second route, per the cross-check habit):
+
+- `gh search issues --repo getsops/sops "MCP OR claude OR anthropic"` → `[]`
+- `gh search issues --repo FiloSottile/age "MCP OR claude OR anthropic"` → `[]`
+- CONTROL ARM: `gh search issues --repo getsops/sops "exec-env"` → **5 issues**
+  (#1469, #1127, #840, #872, #1096). The search API works; the zero is real.
+
+**What age DOES have that is adjacent but is not this:** a documented **plugin
+protocol** for *key backends* (`age-src/plugin/`, `README.md:30`,
+`README.md:248-252`, and the in-tree `age-plugin-batchpass`). That is an
+extensibility point for hardware tokens and alternative KDFs — it is not an
+agent, an MCP server, or a permission boundary for a subprocess.
+
+**Assessment for this repo's context:** both tools are plain CLIs. Any
+agent-scoped access is something we would build (and per
+`.claude/rules/research-doc-sources.md` § "MCP: two lanes", that puts us in lane
+2 — CLI/API first, never a registered MCP server). The *upside* is that SOPS's
+per-command model (Q5) plus its hard refusal semantics (Q7) compose well with a
+`PreToolUse`-style guard: a subprocess either gets exactly the file it was
+pointed at, or it gets a nonzero exit and nothing.
+
+---
+
+## Bottom line against the stated requirement
+
+**"Secrets must survive the Mac being lost or destroyed":**
+
+- SOPS+age is **free and open source** — verified by reading both LICENSE files,
+  not from memory: sops is **MPL-2.0** (`sops-src/LICENSE:1`, *"Mozilla Public
+  License Version 2.0"*); age is **BSD-3-Clause** (`age-src/LICENSE:9-17`, three
+  clauses incl. the no-endorsement clause). Requirement met.
+- The git repo alone **does not** meet the survival requirement (Q2). The
+  ciphertext survives; the key does not.
+- age **has** every primitive needed to fix that — multiple recipients,
+  `age -p`-wrapped identity files — but **documents no DR procedure at all**
+  (Q1, control-armed). The policy is 100% ours to design and write down.
+- Because this repo **already** has `[providers.age]` + 49 age ciphertexts, the
+  decisive question is not "adopt age?" but **"does a second, off-Mac recipient
+  exist for those 49?"** If it does not, the current setup has the identical gap,
+  and the fix (a passphrase-wrapped identity copy, or a second recipient) is
+  worth doing regardless of whether SOPS is ever adopted.
+- SOPS's strongest differentiator here is **Q7: it refuses.** Nonzero exit, no
+  child, no partial env, distinct exit codes.
+- SOPS's sharpest mismatch is **Q5: no interactive-shell activation**, which
+  directly contradicts the current `env = true` posture.
+
+---
+
+## GitHub repos touched
+
+- [getsops/sops](https://github.com/getsops/sops) — read `cmd/sops/main.go`,
+  `cmd/sops/rotate.go`, `cmd/sops/subcommand/exec/*.go`,
+  `cmd/sops/subcommand/updatekeys/updatekeys.go`, `LICENSE`, `CHANGELOG.md` at
+  `382c478` for Q3/Q4/Q5/Q7; searched its issue tracker for Q6.
+- [FiloSottile/age](https://github.com/FiloSottile/age) — read `README.md`,
+  `doc/age-keygen.1.ronn`, `doc/` man pages, `plugin/`, `LICENSE` at `706dfc1`
+  for Q1/Q2/Q6; searched its issue tracker for Q6.
+- [str4d/age-plugin-yubikey](https://github.com/str4d/age-plugin-yubikey) —
+  referenced only as the YubiKey path named by age's README:30; **not read**, and
+  outside the primary-source boundary, so no claim here rests on it.
+

--- a/docs/specs/secrets-cli.md
+++ b/docs/specs/secrets-cli.md
@@ -1,0 +1,216 @@
+# Spec — the secrets CLI
+
+Supersedes **§ 3 of `docs/specs/secrets-takeover.md`**, which carries a STATUS 3 banner marking it
+VOID: its exit gate rested on converting fnox's fail-open into a refusal, and that arm can never
+fire once agents hold all 50 credentials by design.
+
+Child of [#431](https://github.com/ray-manaloto/dotfiles/issues/431) (wayfinder map).
+Decisions and their measurements: `docs/research/kb/decisions/secrets-cli-grilling-2026-08-04b.md`.
+Prototype evidence: branch `prototype/secrets-cli-claims`, `prototype/RESULTS.md`.
+
+---
+
+## Problem Statement
+
+I keep API keys and credentials for dev projects on this Mac in Doppler, surfaced into every
+terminal and every AI agent. Managing them is manual, inconsistent, and in three cases has no
+procedure at all.
+
+**Adding a credential is a nine-step runbook across four systems.** I create it at the vendor, set
+it in Doppler, verify it by name, declare it in fnox, sync an encrypted local copy, add it to the
+doctor's reviewed baseline, and run a consumer health check. The one tool that automates any of
+this covers steps three to seven and silently skips the baseline — so the baseline drifts, and the
+drift is only caught later by a session-start check that tells me to fix it by hand.
+
+**Removing a credential has no documented procedure, and rotating one has none either.** There is
+no heading for either in the secrets runbook, while "add" and "diagnose" both have one. The
+credential store cannot delete: remote deletion always requires the vendor CLI directly. Rotation
+is worse than undocumented — one GitHub token lives under **four** distinct names that a tool
+consults in a documented precedence chain, so rotating it means four coordinated edits, and a
+running resolver daemon keeps serving the rotated-away value until it idles out.
+
+**The store has quietly rotted, and nothing tells me.** Of fifty declared entries: **nineteen are
+not secrets at all** (regions, buckets, endpoints, protocols, usernames, handles, client IDs,
+booleans) — which actively corrupts logs, because redaction is value-based and a short or empty
+"secret" makes the redactor useless. **Seventeen are orphans**, fourteen of them a single dead
+observability project whose surviving compose file reads exactly one of them. Four names carry one
+value. One is a dated leftover sitting beside its own replacement.
+
+I cannot find any of this out without a manual sweep, because **only one of the fifty is
+interpolated into a config file** — the other forty-nine reach their consumers by environment
+inheritance, so grepping for them finds nothing.
+
+## Solution
+
+A `secrets` verb-set in the existing `dotfiles-setup` CLI that owns the whole credential lifecycle
+over **Doppler plus the macOS keychain**, and can tell me the truth about the store.
+
+Every verb does the full job across every layer, in the right order, idempotently — so "add a
+credential" is one command rather than nine steps, and "remove" and "rotate" exist for the first
+time. Every verb can be asked what it *would* do before it does it, and the preview is produced by
+the same code as the real run.
+
+Alongside the write verbs, a **reconcile** verb answers the questions I currently cannot ask: which
+declared names no consumer wants, which entries are configuration masquerading as secrets, which
+names share one value, and where the layers disagree with each other or with the reviewed baseline.
+
+The credential store itself becomes simpler. The resolver layer and its encrypted local cache are
+retired; Doppler's own offline fallback replaces the cache, Doppler's per-directory scoping replaces
+per-project declaration, and the keychain holds exactly one item — the bootstrap token. Measured, a
+clean shell gets forty-nine of fifty names in **0.117 seconds** from a single line, which is what
+every terminal and every agent already depends on.
+
+## User Stories
+
+1. As the maintainer of this Mac, I want to add a new API key with one command, so that I do not have to remember a nine-step runbook across four systems.
+2. As the maintainer, I want the add verb to update the reviewed baseline in the same run, so that the session-start doctor does not report drift I just created.
+3. As the maintainer, I want to type the credential value into a hidden prompt, so that it never enters my shell history or a process argument list.
+4. As the maintainer, I want the add verb to refuse a name that already exists unless I ask for an update, so that I cannot silently overwrite a live credential.
+5. As the maintainer, I want to remove a credential with one command, so that I stop leaving orphans behind because removal was never written down.
+6. As the maintainer, I want removal to clear the credential from every layer that references it, so that a deleted secret does not linger in a baseline or a local cache.
+7. As the maintainer, I want to rotate a credential with one command, so that a rotation is not four coordinated hand edits.
+8. As the maintainer, I want rotation to update every name that shares the rotated value, so that a token living under several names cannot end up half-rotated.
+9. As the maintainer, I want rotation to tell me when a cached resolver would still serve the old value, so that I do not believe a rotation took effect before it has.
+10. As the maintainer, I want to see exactly what a verb would do before it does it, so that I can run a destructive command on fifty live credentials without guessing.
+11. As the maintainer, I want the preview to be produced by the same code path as the real run, so that the preview cannot drift away from the behaviour it claims to describe.
+12. As the maintainer, I want every verb to be safe to re-run, so that a failure halfway through is recovered by running the same command again.
+13. As the maintainer, I want to list which declared credentials no consumer appears to use, so that I can retire the dead ones.
+14. As the maintainer, I want orphan detection to account for credentials consumed by environment inheritance, so that it does not report forty-nine false orphans.
+15. As the maintainer, I want orphan detection to account for credentials read by convention by third-party tooling, so that a cloud SDK's variables are not called dead.
+16. As the maintainer, I want to see which declared entries are configuration rather than credentials, so that I can stop marking non-secrets as secrets and corrupting my logs.
+17. As the maintainer, I want to record a classification decision durably, so that the same entry is not re-flagged every time I run the check.
+18. As the maintainer, I want to see which names carry the same value, so that I know a rotation touches more than one name before I start.
+19. As the maintainer, I want to see where the credential store and the reviewed baseline disagree, so that drift is a report rather than a surprise.
+20. As the maintainer, I want reconcile to be read-only, so that I can run it any time without risk to a live store.
+21. As the maintainer, I want reconcile to exit non-zero when it finds drift, so that I can wire it into a gate later without changing it.
+22. As the maintainer, I want reconcile to explain each finding in terms of what to do about it, so that a report is actionable rather than merely alarming.
+23. As the maintainer, I want every command to print names, counts and states but never a credential value, so that a transcript of my session is never a credential leak.
+24. As an AI agent working in this repo, I want the CLI to declare which of its commands read, write, or destroy, so that I do not have to guess whether a verb is safe to invoke.
+25. As an AI agent, I want an unclassified command to be treated as unknown rather than safe, so that a newly added verb defaults to caution.
+26. As the maintainer, I want a bootstrap command that provisions the keychain item correctly the first time, so that I never re-learn the access-control rules by hitting a dialog that blocks forever.
+27. As the maintainer, I want the bootstrap item to grant access to a stable operating-system path, so that the grant does not break every time a tool is upgraded.
+28. As the maintainer, I want bootstrap to be a one-time operation with no password prompt, so that it can run unattended.
+29. As the maintainer, I want a command that scopes a project directory to a Doppler project and config, so that per-project credentials do not require a bespoke mechanism.
+30. As the maintainer, I want directory scoping to use fully resolved paths, so that a symlinked temporary directory does not silently fail to match.
+31. As the maintainer, I want a single shell line to populate every new terminal, so that all my credentials remain available exactly as they are today.
+32. As an AI agent spawned from my shell, I want to inherit the same credentials as the shell, so that my tooling works without a separate credential path.
+33. As the maintainer, I want the shell population to work with no network, so that an offline laptop still opens working terminals.
+34. As the maintainer, I want to know when the offline copy is stale relative to the remote, so that I am not silently working against old values.
+35. As the maintainer, I want the CLI to own the shell fragment that populates my terminals, so that retiring the deprecated environment repo does not take my credentials with it.
+36. As the maintainer, I want shell completion for credential names, so that I do not mistype a name into a destructive verb.
+37. As the maintainer, I want generated documentation and a man page for the CLI, so that its interface is discoverable without reading its source.
+38. As the maintainer, I want the CLI's flags to be backed by environment variables and config where sensible, so that repeated invocations do not need repeated flags.
+39. As the maintainer, I want the CLI to fail loudly when a required external tool is missing, so that a partial environment does not produce a partial write.
+40. As the maintainer, I want a verb that reports what the store looks like right now, so that I can answer "what do I have" without a manual sweep.
+41. As the maintainer, I want the CLI's checks to run without network access or a live keychain in tests, so that its own test suite cannot touch my real credentials.
+42. As a future maintainer, I want the CLI to work if it is moved to its own repository, so that graduating it later is a move rather than a rewrite.
+
+## Implementation Decisions
+
+### Scope of ownership
+
+- The CLI ships as a **verb-set inside the existing `dotfiles-setup` CLI**, not a new binary. It graduates to its own repository later if it earns it; being a subcommand group now keeps that a move rather than a rewrite.
+- It is written in **Python**, in the existing package. The alternative (Rust on the credential resolver's library crate) was evaluated and rejected: that library is read-only — it has no write method at all — so it cannot serve the write verbs that are this tool's entire purpose, and the resolver it belongs to is being retired anyway.
+
+### Backing stack
+
+- The stack is **Doppler plus the macOS keychain**. The fnox resolver layer, its age-encrypted local cache, and its per-project config hierarchy are **retired**.
+- **Doppler owns credential storage and CRUD.** It is the only writer: the resolver could never write to Doppler, so shelling to the vendor CLI was always the real write path.
+- **Doppler's own encrypted fallback file replaces the local cache.** This removes the re-encryption of every cached credential on every single write, which the retired mechanism performed unconditionally.
+- **Doppler's directory scoping replaces per-project declaration.** Scopes must be registered with fully resolved paths; an unresolved path silently never matches, which reads as a tool limitation and is not one.
+- **The keychain holds exactly one item — the bootstrap token.** Everything else resolves through it. Putting the full set in the keychain was evaluated and rejected: it multiplies the access-control surface fiftyfold and buys no secrecy, because every credential is already resident in every process by design.
+
+### The bootstrap credential
+
+- The keychain item is provisioned **at creation time** with its access grant already in place. An item's creator is implicitly trusted, and an explicit grant to a stable operating-system path reads with no prompt.
+- **Access grants are never amended in place.** Amending requires the login keychain password interactively, and the flag that avoids the prompt is deprecated and would place the password in an argument list. Changing a grant is therefore **delete-and-recreate**.
+- The grant targets a **stable operating-system path**, not a version-pinned tool path. This is the durability argument: the retired resolver's binary path moved five times in four months, and every move silently broke the grant.
+
+### Verb structure — plan then execute
+
+Every verb splits into a **pure planner** and a **thin executor**. This is the decision the prototype encoded most precisely, so the shape is given rather than described:
+
+```
+read_state()  -> State      # names, metadata, presence. NEVER a credential value.
+plan(state, baseline, request) -> Plan   # pure; no I/O, no subprocess
+execute(plan) -> Outcome    # the ONLY code that shells out
+```
+
+- `State` carries **names, metadata and presence flags only, and never a credential value.** This mirrors the existing doctor state object, which documents the same constraint.
+- `--dry-run` renders a `Plan` instead of executing it. Because it is the *same* `Plan`, a preview cannot drift from the behaviour it describes.
+- Plans are **idempotent**: re-running a verb after a partial failure re-plans against current state and completes.
+
+### Verbs
+
+- **`add`** — create at Doppler, then update the reviewed baseline, in one run. Value entry is via a hidden prompt; it never enters an argument list or shell history. Refuses an existing name unless updating.
+- **`rm`** — remove from every layer that references the name, including the baseline.
+- **`rotate`** — replace a value and update **every name that shares it**, so a multi-named token cannot be half-rotated. Reports when a cached resolver would still serve the previous value.
+- **`reconcile`** — read-only. Reports orphans, misclassified entries, shared values, and layer-versus-baseline drift. Exits non-zero on findings so it can be gated later without modification.
+- **`bootstrap`** — provision the keychain item and its grant, once, unattended.
+- **`scope`** — bind a project directory to a Doppler project and config, using a resolved path.
+- **`status`** — what the store looks like right now.
+
+### Orphan and classification detection
+
+- **Usage cannot be inferred by scanning for interpolations.** Only one of fifty credentials is interpolated into any config; the rest arrive by environment inheritance, so an interpolation scan reports near-total false orphans. Detection must combine an explicit declaration of intent with a known set of convention-read variables, and must report confidence rather than asserting deadness.
+- **Classification is a recorded decision, not an inference.** Whether an entry is a credential or configuration is declared and reviewed, so the same entry is not re-flagged forever.
+
+### Agent-facing metadata
+
+- Every command declares its **effect** — read, write, or destructive — in the CLI's interface specification, and that classification is served to agents. An **unlisted command means unknown, not safe.** This is not new machinery: the CLI-spec tool already used by this toolchain supports the tagging and serves it, and the prevailing convention keeps the classification as one reviewable table.
+- Shell completions, generated documentation, and a man page come from that same specification. Dynamic completion of credential names is supported by the spec format and should be used, so a destructive verb is less likely to receive a mistyped name.
+
+### Shell population
+
+- A single shell fragment, **owned by this repo**, populates every terminal from Doppler's offline fallback. This replaces the fragment owned by the deprecated environment repository, whose removal would otherwise take credential loading with it.
+- The behaviour every terminal and agent depends on is preserved: all credentials present in every shell, inherited by every child process.
+
+### Non-negotiable output rule
+
+- **No command ever prints a credential value.** Presence is reported as a flag, never by substituting the variable — a value-emitting substitution is what leaked four live credentials previously. Commands that must handle values pass them to a consumer or a hidden prompt; they never render them.
+
+## Testing Decisions
+
+**What makes a good test here:** it asserts externally observable behaviour — the plan produced, the finding reported, the exit code — and never an internal call sequence. It runs with **no network, no keychain, and no live credentials**, because the subject under test manipulates fifty real secrets and a test suite that touches them is a hazard, not a safety net.
+
+**Prior art, and the seam to copy:** the doctor module is the same shape and is the most thoroughly tested module in the package — it parses configuration into a state object that never holds a value, compares it to a reviewed baseline with pure functions, and confines subprocess use to live probes. Its suite drives that seam with **83 tests** and needs no live tooling. Its test names read as behaviour ("flags a wiped env mode", "is silent on the sanctioned state"), which is the register to match.
+
+**The seam is the planner.** Tests construct a `State` and a baseline directly, call `plan(...)`, and assert on the resulting `Plan`. This covers every verb's branches — including the destructive ones — without any credential existing.
+
+**What gets tested:**
+
+- Each verb's planner: the happy path, the refusal paths, and idempotency (planning against a state that already reflects the plan yields no actions).
+- Reconcile's detectors: orphan, misclassification, shared-value, and baseline-drift, each with a **negative arm** proving the detector stays silent on a clean store.
+- The state readers: parsing well-formed input, and reporting unreadable input as a finding rather than passing silently — the doctor suite already has this exact case and it is the pattern to follow.
+- The redaction rule: an assertion that no command's rendered output contains a value, driven by a state carrying a recognisable marker.
+- The executor gets a **small number of integration tests** against a throwaway Doppler config directory and a throwaway keychain service, deleted afterwards. These are the only tests that shell out, and they must be skippable so the main suite stays hermetic.
+
+**Every negative finding needs a control arm.** A detector that has only ever reported "clean" is not evidence. This is a standing rule in this repo and it earned its place during the research for this spec: five probes across the session could only produce one answer until re-armed, and two were one step from being published as findings.
+
+## Out of Scope
+
+- **Migrating the credential store to a different provider.** Doppler stays; the constraint was free cloud hosting, which it satisfies.
+- **Confinement or blast-radius reduction.** All credentials are present in every shell and every agent by explicit decision. This tool does not restrict access and must not be justified as if it did.
+- **Managing the credentials of any machine other than this one**, and any multi-user or team-sharing concern.
+- **Replacing dotfile management.** The toolchain's own dotfile support was verified as usable during this work and is a separate concern.
+- **Reporting the upstream defect found while researching this spec** — the retired resolver writes a plaintext value into its config when asked to write through a provider that cannot accept writes. Real, verified against a control, and tracked separately; it does not block this work because the CLI owns writes rather than delegating them.
+- **Retiring the deprecated environment repository itself.** This spec removes its last load-bearing responsibility; the removal is its own task.
+- **Cleaning up the seventeen orphans, nineteen misclassifications and four-named token.** Reconcile *reports* them. Acting on the report is follow-on work, deliberately separated so a read-only tool lands before anything deletes anything.
+
+## Further Notes
+
+**Why this is not the original "takeover" spec.** That document's phase three has been marked void: its exit gate depended on turning a permissive fallback into a refusal, which cannot happen now that every agent legitimately holds every credential. The replacement justification is **origination** — owning CRUD, and providing the delete and rotate procedures that have never existed — plus **reconciliation** across layers that no single existing tool can see at once.
+
+**The requirement, in the owner's words:** *"dev projects on the mac having a universal way to crud api keys secrets."* That, not "takeover", is what this is measured against.
+
+**Why the verb priority is inverted from the obvious.** Create is the one operation that already has a documented procedure and partial automation. Rotate, classify and retire have none — and the store's measured state (seventeen orphans, nineteen non-secrets, one value under four names) is the direct result. The valuable verbs are the ones that do not exist.
+
+**Every decision in this spec rests on a measurement taken during its research**, not on documentation. Several documented claims were contradicted by probing, in both directions. The measurements, their control arms, and the five probes that had to be re-armed before they discriminated are recorded in the decision document and the prototype results.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the repo this spec is for
+- [jdx/fnox](https://github.com/jdx/fnox) — the resolver being retired; write surface, config model, provider traits
+- [jdx/mise](https://github.com/jdx/mise) — token precedence chain; dotfile management; CLI-spec integration
+- [jdx/usage](https://github.com/jdx/usage) — CLI spec format, effect tagging, completions and docs generation
+- [DopplerHQ/cli](https://github.com/DopplerHQ/cli) — the credential store's CLI: CRUD, scoping, offline fallback

--- a/docs/specs/secrets-takeover.md
+++ b/docs/specs/secrets-takeover.md
@@ -58,6 +58,43 @@ its own PR and its own gates.
 >
 > The decisions in §§ 1–4 and § 6 are unaffected; the rationale sentences above are not.
 
+> ## ⚠️ STATUS 3 — Phase 3's stated purpose is VOID (added 2026-08-04)
+>
+> Do not build § 3 as written. Its exit gate (`:518-535`) rests on converting
+> `fnox exec -P <nonexistent>`'s fail-open into a refusal, called "the CLI's job"
+> and "the arm that proves the CLI added something". **That arm cannot fire.**
+> Ray ruled (2026-08-03) that agents hold **all 50** credentials and confinement is
+> dead as a goal, so nothing passes `-P` and the fail-open is never reached.
+> #432 and #441 are **retired**, not re-judged.
+>
+> Measured this session, superseding the inherited figures:
+>
+> - **The fail-open is real and current** — fnox 1.32.0, both arms: control (no
+>   profile) and `-P <bogus>` each put **50** secrets in the child at `rc=0` with
+>   zero stderr. It is 50 now, not 49. Its blast radius is what Ray already accepted.
+> - **The constraint is FREE CLOUD HOSTING, not licence purity** (Ray, 2026-08-04).
+>   Doppler is therefore **not** disqualified, and the migration this spec's later
+>   phases contemplate is not required.
+> - **fnox stays** — 23 providers, v1.32.0 (2026-08-01). But it **cannot write to
+>   Doppler or Infisical**: neither implements `capabilities()`, both have 0
+>   `put_secret`. And it is **CRU, not CRUD** — the `Provider` trait has no delete
+>   method at all, so remote deletion always needs the vendor CLI.
+> - **mise 2026.8.1 already provides** sops decryption, age encryption,
+>   redaction, per-directory scoping, **and dotfile management** (`[dotfiles]`,
+>   `symlink-each`, `status --json --missing`). Anything the CLI writes over those
+>   is reinvention.
+>
+> **The CLI's replacement justification** is origination (CRUD ownership, retiring
+> `macos-development-environment`, which Ray deprecated 2026-08-04) plus
+> **reconciliation** across five drift seams — Doppler↔fnox, fnox↔`doctor.toml`,
+> host↔devcontainer, keychain↔Doppler, project-scope↔code — of which **three have
+> no owner today**. That is work no existing tool does, because none can see across
+> all four layers.
+>
+> `/to-spec` should rewrite § 3 against this. Evidence:
+> `docs/research/kb/reports/agents/{secrets-backend-*,fnox-*,mise-shell-activation}.md`
+> and the five decision pages in `docs/research/kb/artifacts/`.
+
 **Resolution decreases with distance** (approved 2026-08-02). Phases 1–2 carry PR-sized steps;
 phases 3–4 carry the transition, its exit gate and its open items, and are deepened when their
 preconditions come near. That is deliberate: #448 records `mise dotfiles` → `mise bootstrap


### PR DESCRIPTION
- **docs(research): secrets-CLI direction — 8 agent reports + 5 decision artifacts**
- **docs(spec): mark secrets-takeover Phase 3 void — its exit gate can never fire**
- **docs(research): grilling outcome — 6 decisions + 4 agent reports**
- **docs(research): D5 resolved — drop fnox, the stack is Doppler + keychain**
- **docs(spec): the secrets CLI — Doppler + keychain, rotate/retire/reconcile**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788460909&installation_model_id=429246&pr_number=543&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F543&signature=e2f4a5365626e82f7489ac87e1979937a6bd24a2c20053e87f4fbcc05b5bafe2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive research artifacts covering secrets backends, CLI architecture, shell activation, provider behavior, and implementation options.
  * Documented findings from secret consumption, tooling, and integration investigations.
  * Added a secrets CLI specification covering lifecycle management, reconciliation, scoping, bootstrap, status, and safe execution.
  * Updated planning documentation to reflect the revised direction for secrets management and retire outdated confinement goals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->