### PR TITLE
docs(skill): retire the stale rtk hold-back example

### DIFF
--- a/.claude/skills/tool-currency-check/SKILL.md
+++ b/.claude/skills/tool-currency-check/SKILL.md
@@ -49,8 +49,11 @@ here) with a **broad `mise outdated --bump` sweep** of every other pin — so th
 signal spans all tools, not just the deep set. `--bump` is mandatory (the engine
 passes it): every pin is exact, so bare `mise outdated` can never report
 movement (control-armed 2026-07-20: it said "up to date" while graphify sat at
-0.9.20 vs PyPI 0.9.22). Tools intentionally held back (comments in `mise.toml`,
-e.g. `rtk` for a lockfile bug) are decisions, not drift.
+0.9.20 vs PyPI 0.9.22). Tools intentionally held back — with a comment in
+`mise.toml` saying why — are decisions, not drift. **Re-read the reason before
+honouring it:** `rtk` was the standing example, held for a github-backend
+lockfile bug; mise #10703 fixed that in 2026.7.0 and the hold was retired
+2026-08-04, so the comment had outlived the constraint by a month.
 
 ## Procedure
 


### PR DESCRIPTION
The tool-currency skill cited `rtk` as the standing example of a tool
intentionally held back for a lockfile bug. That hold was retired in the
previous commit — mise #10703 fixed the github-backend issue in 2026.7.0, and
rtk now tracks the registry's aqua backend at 0.44.2.

Generalises the sentence so it does not depend on one example staying true,
and keeps rtk as the worked case with the lesson attached: the comment had
outlived its constraint by a month, so re-read a hold-back's stated reason
before honouring it.

Gates: lint 0 · lint-docs 0.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TqznQnzuk4ewjTrimsvZdZ

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788465338&installation_model_id=429246&pr_number=545&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F545&signature=3abec4c75903f774052c3391a5fb0849c7be725fe5753892fa29c4f1964aec78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->