### PR TITLE
docs(agents): claims 2 and 4 measured — enforcement works, memory does not

### DIFF
--- a/docs/agent-team.md
+++ b/docs/agent-team.md
@@ -231,6 +231,21 @@ proposes edits to the role files. ⚠️ It is gated — `CLAUDE_CODE_DISABLE_AU
 disables auto memory **and with it the `memory` frontmatter field entirely**
 (`$CC/sub-agents.md:518`).
 
+⚠️ **MEASURED, and it is not automatic** (`prototype/RESULTS.md` claim 4). A subagent with
+`memory: project` **wrote** to the documented path — and the next spawn returned
+`NOTHING IN MEMORY` with **`tool_uses: 0`**. It never read the file. Control arm for the cause:
+the pre-existing, working `~/.claude/agent-memory/researcher/` store carries a **`MEMORY.md`**
+alongside its topic files; the probe store had none. Auto-memory injects `MEMORY.md` and reads
+topic files on demand, so **an unindexed topic file is inert**.
+
+**A role that records a lesson without maintaining its own `MEMORY.md` index has written to a
+store nothing reads.** Any self-improvement design must own that index explicitly.
+
+⚠️ **On the teammate path it is worse than useless.** The same agent, spawned *named*, wrote
+into the **shared session auto-memory** and added an index line to the project's `MEMORY.md` —
+the file loaded into every session, already near its read limit. Nine roles doing that collide
+in one store; nine subagents each get an isolated one that nothing reads unless indexed.
+
 **`provide suggestions` is an output contract, not a role.** Every role's report ends with
 what it would change. A dedicated suggester has no privileged view.
 
@@ -552,6 +567,25 @@ the agent it is on the wrong branch and must not write.
 | **`SubagentStop`** | prevents the subagent stopping (`:712`, `:2042`) — payload includes `agent_transcript_path`, `last_assistant_message`, `background_tasks` |
 | **`TaskCreated`** | **rolls the creation back** (`:713`) |
 | **`TaskCompleted`** | prevents completion (`:714`) — fires on `TaskUpdate` *and* when a teammate ends a turn with in-progress tasks |
+
+### ✅ MEASURED — a `SubagentStop` hook really does force more work
+
+Probed on the **subagent** path (`prototype/RESULTS.md` claim 2):
+
+| | |
+|---|---|
+| call 1 | fired, `stop_hook_active: false` → returned `{"decision":"block", …}` |
+| effect | the agent wrote a witness file **nothing in its prompt had asked for** — the only instruction came from the hook's `reason` |
+| call 2 | fired, `stop_hook_active: true` → allowed; agent finished |
+| agent `tool_uses` | **2** — its own task, plus the forced work |
+
+Both arms in one run. The payload carries **`agent_transcript_path`**, so an enforcing hook can
+*inspect what the agent actually did* rather than merely nag — the difference between a gate and
+a reminder.
+
+⚠️ **Scope:** proven for a frontmatter hook on the **unnamed/subagent** path. On the named
+teammate path the same hook never fired at all (§2). Put enforcement in session-level
+`settings.json`, which applies inside subagents however they were spawned.
 
 **`TeammateIdle` and `SubagentStop` are the mechanism the repeatedly-failing
 "a delegated agent must deliver before going idle" rule has always needed.** That rule has now


### PR DESCRIPTION
Folds the last two prototype verdicts into the design. Both were open as
"needs a session restart"; the agent-type registry picked the definitions up on
its own, so they were settled directly (prototype branch, commit 74ffda6).

CLAIM 2 — CONFIRMED. A frontmatter Stop hook on the SUBAGENT path fires, blocks,
and forces extra work: the agent wrote a witness file nothing in its prompt had
asked for, on the strength of the hook's `reason` alone; call 2 then allowed it
to finish. tool_uses = 2. The payload carries agent_transcript_path, so an
enforcing hook can INSPECT the work rather than nag — the difference between a
gate and a reminder. Scope: the same hook never fired on the named teammate
path, which is why section 10 puts enforcement in settings.json.

CLAIM 4 — PARTLY REFUTED, and it changes the self-learning design. memory:
project WRITES to the documented path, but the next spawn returned NOTHING IN
MEMORY with tool_uses: 0 — it never read the file. Control arm: the working
~/.claude/agent-memory/researcher/ store carries a MEMORY.md alongside its topic
files; the probe store had none. Auto-memory injects MEMORY.md and reads topic
files on demand, so an unindexed topic file is inert.

So `memory:` is not automatic durable learning: a role that records a lesson
without maintaining its own MEMORY.md index writes to a store nothing reads.

⚠️ On the teammate path it is actively harmful — the same agent spawned NAMED
wrote into the shared session auto-memory and indexed itself into the project's
MEMORY.md, the file loaded into every session and already near its read limit.
That pollution was cleaned up during the probe run.

Gates: lint rc=0 · lint-docs rc=0.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TqznQnzuk4ewjTrimsvZdZ

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788485291&installation_model_id=429246&pr_number=547&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F547&signature=8969368d53290355c22a50ede257ba665ba9aec93a8aa141df1303dacb0b803c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->