### PR TITLE
docs(agents): interrupted resume measured — it constrains the script's shape

### DIFF
--- a/docs/agent-team.md
+++ b/docs/agent-team.md
@@ -126,7 +126,23 @@ Every workflow agent pays a full project-context load regardless of job size. Th
 contradict the resume constraint below, it sharpens it: *small* must mean **few tightly-scoped
 stages**, not a wide fan-out over trivia.
 
-Not tested: **resume**. The run is resumable by `runId`, but no interrupted run was exercised.
+✅ **Resume, both halves, now measured** (`prototype/RESULTS.md` claims 1f and 6).
+
+- **Clean resume** — append one stage to a completed run and re-invoke with `resumeFromRunId`:
+  `tool_uses` **6 → 1**, subagent tokens **465,028 → 81,256**, exactly one new transcript file.
+  Cached results come back as real values, not placeholders.
+- **Interrupted resume** — replay stops at the first agent that did not finish, and **everything
+  dispatched after it re-runs even when its result is already in the journal.** Measured on run
+  `wf_99fff833-07e`: an agent that had completed *and* journaled a result re-ran anyway, while the
+  agent ahead of the unfinished one was served from cache — that cache hit is the control arm,
+  without it "everything re-ran" would be indistinguishable from "nothing was cached".
+
+The harness's replay code confirms the mechanism and rules out the group-scoped reading the probe
+alone could not exclude: a **sticky first-miss flag** (`T ? void 0 : results.get(key)`) means that
+after one miss every later call skips the cache lookup entirely. The boundary is **positional**,
+fixed by `agent()` dispatch order — `parallel()` only decides that order. The journal key is a
+rolling chain hash over the preceding call sequence, and `label`/`phase` are excluded from it, so
+renaming a stage is cache-safe while reordering one is not.
 
 **Constraints that shape the design, not footnotes:**
 
@@ -135,7 +151,7 @@ Not tested: **resume**. The run is resumable by `runId`, but no interrupted run 
 | **No mid-run user input** (only permission prompts pause a run) | human sign-off means **one workflow per gated stage**, never one workflow for the whole pipeline — which is exactly the `gate` node from §1 |
 | **The script has no filesystem or shell access**; agents act, the script coordinates | the orchestrator is *pure coordination* and every side effect goes through a role agent — a feature for write/review isolation, not a limitation |
 | 16 concurrent agents; 1,000 per run | a 9-role team fits; a wide per-file fan-out does not |
-| **Resume replays from the first agent that did not finish** — everything started after it re-runs even if it completed | **many small agents preserve more progress than one long agent.** A direct constraint on role granularity |
+| ✅ **MEASURED — resume replays only up to the first agent that did not finish**; everything dispatched after it re-runs even if it completed | **a wide `parallel()` is the worst shape to be interrupted in** — one slow member early in the array discards every finished result after it, at ~78–85 k tokens each. Keep groups narrow, put the long pole **last** within a group, and place stage boundaries *before* slow work. A direct constraint on role granularity |
 | Resume works **only within the same session** | cross-session durability is still ours to build — the arXiv paper's failure mode #1, unfixed |
 
 **What each mechanism is now for:** roles are `.claude/agents/*.md` definitions; a **workflow
@@ -665,6 +681,10 @@ background and the `background:` frontmatter field is **inert**.
    agents.** The vendor docs state *"Ignored for plugin subagents"* on exactly those three rows
    (`$CC/sub-agents.md:282`, `:285`, `:286`; control — a phrase known to be in the same table
    returns 1). **So the team cannot ship as a plugin if any role needs them.**
+9. ✅ **CLOSED — interrupted resume behaves as documented, and it constrains the script's shape**
+   (§2, `prototype/RESULTS.md` claim 6). Write the orchestration script so an interrupt is cheap:
+   narrow `parallel()` groups, the slowest member ordered **last** inside each group, and a stage
+   boundary before any long-running role rather than after it.
 
 ⚠️ **If `claude-self-reflect` is ever considered**, it indexes **every transcript** — and this
 machine's transcripts have carried live credential values twice. It ships a sanitiser whose


### PR DESCRIPTION
The last untested claim in the agent-team design. Resuming an interrupted
workflow run replays only up to the first agent that did not finish;
everything dispatched after it re-runs even when its result is already in
the journal.

Measured on run wf_99fff833-07e with a byte-identical script across both
invocations: an agent that had completed and journaled a result re-ran
anyway, while the agent ahead of the unfinished one was served from cache.
That cache hit is the control arm — without it "everything re-ran" would be
indistinguishable from "nothing was cached".

The harness's replay code confirms the mechanism and rules out the
group-scoped reading the probe alone could not exclude: a sticky first-miss
flag means every call after one miss skips the cache lookup entirely, so the
boundary is positional and fixed by agent() dispatch order.

Design consequence, now recorded in §2 and as pre-flight item 9: a wide
parallel() is the worst shape to be interrupted in, so keep groups narrow,
order the long pole last within a group, and put stage boundaries before slow
work rather than after it.

Evidence: prototype/RESULTS.md claim 6, on prototype/agent-team-mechanisms.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W7hfGJXahjaLo2DXRK6j8N

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788488815&installation_model_id=429246&pr_number=548&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F548&signature=58af03faee2a3f4757db76103b955ee279b990742f2ef5e209a2b01c7cf5c362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how clean and interrupted runs resume.
  * Documented reuse of completed stages and replay of unfinished work.
  * Added details about cache boundaries and journal behavior.
  * Updated guidance for arranging parallel work to improve recovery after interruptions.
  * Added a pre-release checklist item for interruption-resistant orchestration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->