### PR TITLE
docs(wayfinder): receipt for #564 + three ledger rows from the --bg probe

### DIFF
--- a/.claude/agents/claude-code-expert.md
+++ b/.claude/agents/claude-code-expert.md
@@ -210,6 +210,9 @@ overturns it, and say in your report that you did.
 | `memory:` writes a topic file, but nothing reads it without the store's own `MEMORY.md` | CONFIRMED | live probe, `prototype/RESULTS.md` claim 4 | 2.1.221 | 2026-08-04 |
 | Workflow resume replays only to the first unfinished agent; everything dispatched after re-runs | CONFIRMED | live probe + binary replay code | 2.1.222 | 2026-08-04 |
 | `permissionMode` / `mcpServers` / `hooks` are ignored for plugin-scoped subagents | CONFIRMED | `$CC/sub-agents.md:282`, `:285`, `:286` | 2.1.221 | 2026-08-04 |
+| **`claude --bg "<positional>"` travels the same user-prompt expansion path as `-p`** — a `disable-model-invocation` verb expands (`<command-name>` frame + token); prefix-only holds; `--bg` + `--print` is a hard rc=1 error by design | CONFIRMED | 5-arm live probe; controls: `-p` arm expanded, unknown-verb arm did not; `docs/receipts/564.md` | 2.1.222 | 2026-08-05 |
+| **An unknown slash verb under `--bg` creates a LIVE background job at rc=0** (transcript shows `Unknown command`) — verb preflight must precede dispatch | CONFIRMED | probe arm C; control: known verb expanded in the same fixture | 2.1.222 | 2026-08-05 |
+| `claude agents --json` returns a top-level ARRAY, not `{agents:[…]}` — code keyed on the wrapper shape silently no-ops | CONFIRMED | live parse; a cleanup loop keyed on `.agents` skipped every job | 2.1.222 | 2026-08-05 |
 
 ## Local hazards that break probes on this host
 

--- a/docs/receipts/564.md
+++ b/docs/receipts/564.md
@@ -1,0 +1,93 @@
+# Receipt — #564: Probe: does `claude --bg` expand a slash verb, and what supervises a `-p` verb node?
+
+**Verdict:** `claude --bg "/verb args"` **expands the slash verb exactly as `-p` does** — the
+positional prompt travels the same user-prompt expansion path, so the `--bg`-vs-`-p` collision
+dissolves: verb nodes and worker nodes share one launch shape (`--bg`, with the native watchdog),
+and `-p` is reserved for synchronous driver reads. Conditions attached: expansion is prefix-only
+under `--bg` too (a mid-message verb silently runs a *different* visible skill); `--bg` + `--print`
+is a hard rc=1 error by design; and an **unknown verb under `--bg` creates a live background job at
+rc=0**, so verb-existence preflight must run *before* dispatch. SKILL.md adaptation is not needed.
+Measured at v2.1.222, 2026-08-05.
+
+**Resolved:** 2026-08-05
+
+## Sources — what I actually opened
+
+- `docs/research/kb/reports/agents/wf-dag-protocol-verbs.md` — the `-p` expansion mechanics, the
+  fixture recipe, the four preconditions, and the burned-token list this probe minted fresh ones for
+- `docs/research/kb/reports/agents/wf-dag-recovery.md` §6–§8 — `--bg` job mechanics, respawn
+  suppressions, `jobs/<short>/state.json` shape, and the cleanup verbs (`stop`/`rm`/`daemon stop --any`)
+- `docs/research/kb/reports/agents/wf-dag-research-synthesis.md` — the contradiction ("THE --bg / -p
+  COLLISION") this ticket was cut from
+- Live probe artifacts (this receipt's evidence): `bg_probe.py` / `bg_probe2.py` with `result.json` /
+  `result2.json` — five arms, transcripts scanned for `<command-name>` frames and marker tokens
+
+## Prior art — the search I ran
+
+**Query:** `grep -rln -- "--bg" docs/research/kb/reports/agents/`
+**Corpus:** `docs/research/kb/reports/agents/` (the 8-report wayfinder research pass + earlier sweeps)
+
+### Control arm — REQUIRED, and run it before you believe any result
+
+**Known-present term:** `command-name` in `wf-dag-protocol-verbs.md` → **7** hits
+**Known-absent term (fresh-minted):** `vroxandel-8843` → **0** hits across the corpus
+
+| Hit | What I did with it |
+|---|---|
+| `wf-dag-recovery.md` (7 `--bg` mentions) | read — supplied the job/cleanup mechanics and the "exec workers are never auto-respawned" boundary this probe tested against |
+| `wf-dag-model-routing.md` (12) | read — the `--bg` ⊥ `--print` mutual-exclusion claim ($CC/errors.md:1191-1195), reproduced live as arm X |
+| `wf-dag-research-synthesis.md` (17) | read — the collision statement; this probe is its resolution |
+| 5 other reports with incidental `--bg` matches | dismissed — mentions in passing, no expansion-path claims |
+
+## The probe — five arms, arms first
+
+Fixture: scratchpad `bg-verb-probe/fixture/` with two skills minted fresh
+(`bgprobe-verb`, `disable-model-invocation: true`, token `ZORVANEK-3317-DELTA`;
+`bgcontrol-verb`, unflagged, token `QUILMHART-9042-ECHO`). Every spawn: `--model haiku`
+(the saved user default is Fable — probes must not burn it), stdin `/dev/null`,
+`CLAUDE_CODE_*` stripped from the child env.
+
+| Arm | Command | Result |
+|---|---|---|
+| X | `claude --bg -p "/bgprobe-verb"` | rc=1: *"--bg and --print conflict: --print never starts the interactive session that `claude agents` attaches to, so the job would be unattachable"* |
+| B (control-positive) | `claude -p "/bgprobe-verb"` | expands — 1 `<command-name>` frame, flagged token in stdout and transcript, 0 `Skill` calls |
+| **A (the question)** | `claude --bg "/bgprobe-verb"` | **expands** — job `731ca6a4`; transcript `731ca6a4-….jsonl` carries `<command-name>/bgprobe-verb</command-name>` + `ZORVANEK-3317-DELTA`, 0 `Skill` calls |
+| C (unknown verb) | `claude --bg "/zundrapel-6628-nonexistent"` | rc=0, **job `f11cc457` created and running**; transcript shows `Unknown command`, 0 frames |
+| D (prefix-only) | `claude --bg "Do nothing else first. /bgprobe-verb"` | 0 frames; model called `Skill{bgcontrol-verb}` and emitted the **control** token — the silent-wrong-verb hazard, reproduced under `--bg` |
+
+**Could the fixture have produced the other result?** Yes on every axis that matters: arm C shows
+the fixture can yield non-expansion (`Unknown command`), arm D shows it can yield wrong-skill
+fallback, and B/A show it can yield expansion — the setup admits all three outcomes, so A's
+positive is informative.
+
+**Cleanup, verified:** all three probe jobs `claude stop` + `claude rm` (rc=0 each,
+`removed <id>` echoed); `probe_jobs_left: []` filtered by fixture cwd; second
+`claude daemon stop --any` → `no daemon running` (the control that the first stop took). Two
+pre-existing background job records (`ad8baf35`, `fdfdaf90` — weeks-old, state `blocked`, records
+not processes per the recovery report) were present before the probe and left untouched.
+
+## Adversarial review
+
+**Lens:** none
+**Verdict:** not-run
+**Findings:** 0 — n/a
+**Disposition:** n/a
+
+**Not run:** every claim here is a live measured probe with its control arms recorded in the same
+table — re-running `bg_probe.py`/`bg_probe2.py` *is* the review, and each arm's opposite outcome was
+demonstrated by a sibling arm. Noting the standing concern: this makes four recent receipts at
+`lens: none`; the next judgment-shaped (grilling) ticket should carry a real lens.
+
+## Notes
+
+- **Burned tokens** (published here, unusable as future controls): `ZORVANEK-3317-DELTA`,
+  `QUILMHART-9042-ECHO`, `zundrapel-6628-nonexistent`, `vroxandel-8843`.
+- Probe-1 defect, fixed in probe-2: `claude agents --json` returns a **top-level array**, not
+  `{agents: […]}` — the first run's per-job cleanup silently no-op'd (caught because the cleanup
+  list was empty while jobs demonstrably existed; the daemon stop covered the processes and probe-2
+  removed the records).
+- The first `claude daemon stop --any` reported "terminated 3 background sessions" where my probe
+  had created 2 — the third was most plausibly a supervisor-hosted process for one of the two stale
+  records; both records survived unchanged, and both interactive sessions were untouched.
+- What this changes on the map: #572's preconditions become five (add verb-existence preflight
+  before `--bg` dispatch); #573 loses this blocker (#565 remains).


### PR DESCRIPTION
The --bg/-p collision from the research synthesis dissolves: a 5-arm
control-armed probe shows the --bg positional travels the same
user-prompt expansion path as -p (flagged verbs expand; prefix-only
holds; --bg+--print hard-errors by design). New hazard: an unknown verb
under --bg creates a live background job at rc=0, so verb preflight must
precede dispatch (#572 gains a fifth precondition). #573's blockers drop
to #565. Resolution: #564; map: #556.

Co-Authored-By: Claude Fable 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W7hfGJXahjaLo2DXRK6j8N

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788514854&installation_model_id=429246&pr_number=585&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F585&signature=29579e3c4b473d12c9019f096a76d5292a85d18db10f965ed7b921dbaffc9732"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->