### PR TITLE
chore(settings): pin the DAG topology in .claude/settings.json (#567)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -96,3 +96,14 @@ host-only in `mise.toml` (`codex`, `antigravity-cli`); auth is per-user. The Cla
 and **verifies evidence** before "done" — only execution is delegated; terminal fallback is Claude
 Opus. The authoritative routing/fallback doctrine (and its KB-graph grounding) is the
 `orchestrator-routing` skill in the **knowledge-base** repo.
+
+## DAG topology pins (#567)
+
+`.claude/settings.json` pins the DAG substrate (map #556): the `env` block plus
+`fallbackModel` + `switchModelsOnFlag`. `CLAUDE_*` pins go in settings `env`, NEVER a
+shell export (background launch strips them; respawn re-reads only settings). Evidence:
+`docs/receipts/567.md`.
+
+**NOT set — do not "fix" back:** `DISABLE_AUTO_COMPACT` (kills the PreCompact gate),
+`CLAUDE_CODE_SUBAGENT_MODEL` (overrides per-node model choice),
+`CLAUDE_CODE_NO_MODEL_FALLBACK` (kills the availability chain AND Fable credit substitution).

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,12 @@
 {
   "env": {
+    "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "33",
     "CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD": "1",
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS": "20",
+    "CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION": "200",
+    "CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH": "3",
+    "CLAUDE_CODE_TASK_LIST_ID": "dotfiles-dag",
     "OTEL_LOG_RAW_API_BODIES": "0"
   },
   "permissions": {
@@ -140,5 +145,7 @@
   },
   "prefersReducedMotion": true,
   "teammateMode": "auto",
-  "disableClaudeAiConnectors": true
+  "disableClaudeAiConnectors": true,
+  "fallbackModel": ["opus", "sonnet"],
+  "switchModelsOnFlag": true
 }

--- a/docs/receipts/567.md
+++ b/docs/receipts/567.md
@@ -1,0 +1,105 @@
+# Receipt — #567: Pin the DAG topology in `.claude/settings.json`
+
+**Verdict:** Pinned, in one reviewed diff: the `env` block gains
+`CLAUDE_CODE_TASK_LIST_ID="dotfiles-dag"` (the session's stated value — lowercase-alnum-dash,
+the one charset the config dir and inbox/task dir derivations agree on; repo-prefixed because
+the namespace is the whole machine; purpose-named for the DAG framework, map #556),
+`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="33"` (~30% of a 200K window; lower-only; applies to
+subagents), and the three spawn caps under their real names at today's defaults —
+`CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH="3"`, `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS="20"`,
+`CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION="200"` — pinned not to change behaviour but to freeze
+it: depth and concurrency are otherwise server-adjustable (`tengu_hazel_trellis` supplies
+depth when unset; `tengu_amber_kestrel` can remove the concurrency cap). Top-level settings
+gain `fallbackModel: ["opus", "sonnet"]` (REPLACES across scopes, max 3, excludes
+429/rate-limit/billing) and `switchModelsOnFlag: true` (a flagged headless turn degrades
+instead of ending in a refusal). The NOT-set list (`DISABLE_AUTO_COMPACT`,
+`CLAUDE_CODE_SUBAGENT_MODEL`, `CLAUDE_CODE_NO_MODEL_FALLBACK`) is documented with rationale
+in `.claude/CLAUDE.md` § "DAG topology pins (#567)" — colocated where every future session
+loads it, since JSON carries no comments. Known cost, accepted: a pinned task-list id
+disables the native fork-carry (`if(CLAUDE_CODE_TASK_LIST_ID) return` — no carry), which is
+moot here because every session and fork resolves to the SAME pinned list; and all
+interactive sessions in this repo now share one task list rather than per-session lists —
+that sharing is the feature, not a side effect.
+
+**Resolved:** 2026-08-05
+
+## Sources — what I actually opened
+
+- `docs/research/kb/reports/agents/wf-dag-recovery.md` §11/§13 — `CLAUDE_CODE_TASK_LIST_ID`
+  is NOT in `RQr` (the respawn env set); unpinned it defaults to the session id, so an
+  id-minting respawn hands the node an EMPTY task list; the fork-carry suppression when pinned
+- `docs/research/kb/reports/agents/claude-code-expert-settings-blast-radius.md` A5/B7 — the
+  namespacing recipe (`dotfiles-<purpose>`, lowercase-alnum-dash, repo prefix), the env-var
+  table with defaults and server-controllability flags, the exec-mode `CLAUDE_*` env strip
+- `docs/research/kb/reports/agents/wf-dag-context-gate.md` §1/§3 — the trigger formula
+  `min(window − round(window×buffer), min(floor(window×pct/100), window−13000))`; `=33` on
+  200K ≈ 30%; lower-only; applies to subagents; the exact settings-env JSON adopted verbatim
+- `docs/research/kb/reports/agents/wf-dag-model-routing.md` §2/§4/§6 — `fallbackModel`
+  REPLACES across scopes (binary merge fn @239909258), excludes 429/billing; `switchModelsOnFlag: false`
+  turns a bio/cyber flag into a turn-ending refusal in `-p`/SDK; the recommended settings
+  snippet adopted verbatim; never `CLAUDE_CODE_SUBAGENT_MODEL` / `_NO_MODEL_FALLBACK`
+- `docs/research/kb/reports/agents/wf-dag-plugin-extraction.md` §2 — the real spawn-pin names
+  (shape-enumeration of all 439 `CLAUDE_CODE_*` tokens; refuted the plausible-looking
+  alternatives at 0 binary matches); the env block can never move into a plugin (2-key pick
+  discards `env` silently)
+- `docs/research/kb/reports/agents/wf-dag-research-synthesis.md` D5/D8/D11/D25 — the
+  consolidated decisions this diff encodes
+- `.claude/agents/claude-code-expert.md` (ledger) — the CONFIRMED task-DAG row (live probe,
+  control arm: different id returns EMPTY)
+- `parity.toml` + `doctor.toml` — checked for coverage of the touched keys: parity pins only
+  the two orchestration-lane `enabledPlugins` entries (untouched); doctor has no
+  settings-env baseline → no companion baseline edit needed
+
+## Prior art — the search I ran
+
+**Query:** `grep -rl <term> docs/research/kb/reports/agents/` for each of
+`CLAUDE_CODE_TASK_LIST_ID`, `fallbackModel`, `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH`
+**Corpus:** `docs/research/kb/reports/agents/` (the 8-report wayfinder pass + expert sweeps)
+
+### Control arm — REQUIRED, and run it before you believe any result
+
+**Known-present term:** `CLAUDE_CODE_TASK_LIST_ID` → **9** files (`fallbackModel` → **3**,
+spawn-depth pin → **8**)
+**Known-absent term (fresh-minted):** `qelvarnith-2907` → **0** files
+
+| Hit | What I did with it |
+|---|---|
+| `wf-dag-recovery.md`, `settings-blast-radius.md`, `wf-dag-context-gate.md`, `wf-dag-model-routing.md`, `wf-dag-plugin-extraction.md`, `wf-dag-research-synthesis.md` | read — each supplied a value, a name, or a constraint listed under Sources |
+| `wf-dag-symphony-gaps.md` (P0: settings env, never shell export) | read — independent confirmation of D8, no new values |
+| `wf-dag-protocol-verbs.md`, `claude-code-expert-teams.md`, `harness-settings-reference.md`, `docs-teams-hooks.md`, `claude-code-expert-orchestration.md` | read the matching rows only — control-arm usages and restatements of the same findings; no conflicts |
+
+**Could this fixture have produced the other result?** The "fixture" is the evidence corpus
+itself; it demonstrably admits refutation — plugin-extraction §2 records the researcher's own
+first-guess names being REFUTED (0 binary matches), and model-routing records the docs
+contradicting the binary on the Fable-consent path. A corpus that has reversed its own claims
+can say no; these values survived that.
+
+## Adversarial review
+
+**Lens:** codex-reviewer (`codex exec --ephemeral --sandbox read-only`, diff-only, no disk)
+**Verdict:** clean
+**Findings:** 0 — verdict file in the session scratchpad; nothing to persist beyond this section
+**Disposition:** n/a — no findings to accept or refute
+
+Asked to attack: wrong key names, wrong scope (env vs top-level), value/type errors, key
+interactions, JSON validity. Real diff → **NO FINDINGS**. **Control arm** (required before
+believing a clean verdict): the same prompt over a mutated diff — `fallbackModel` planted as
+the string `"opus"` *inside* the `env` block — was flagged precisely (wrong scope, wrong
+type, Sonnet dropped from the chain), so the reviewer demonstrably discriminates on the axes
+it cleared. Honest coverage note: a name-level defect (a plausible-but-nonexistent env var)
+is likely OUTSIDE this lens's reach — name correctness rests on the binary shape-enumeration
+in the plugin-extraction report, not on this review. Mechanical arms ran before the lens:
+`python3 -m json.tool` parses the result; gates `lint` / `pytest` (1239 passed) / `verify` /
+`parity` / `lint-docs` all recorded `rc=0` on this tree.
+
+## Notes
+
+- The one open value the handoff reserved for this session: **`dotfiles-dag`**. Keep any
+  future `CLAUDE_INTERNAL_ASSISTANT_TEAM_NAME` identical to it (blast-radius A5: the task
+  list id defaults to the team name, and pinning both prevents a rename orphaning the list).
+- These pins take effect at the next session start in this repo; the env block is re-read
+  from disk by every child/respawn — that disk-read is the entire point (D8).
+- If a later session is tempted to set any of the three NOT-set vars, the rationale is in
+  `.claude/CLAUDE.md` § "DAG topology pins (#567)" — read that first.
+- The known-absent control term in the Prior-art section is now published in this file and
+  therefore burned — the next receipt must mint a fresh one.


### PR DESCRIPTION
Env pins (all values evidence-derived, see docs/receipts/567.md):
CLAUDE_CODE_TASK_LIST_ID=dotfiles-dag (the durable cross-session task
list; NOT in the respawn env set, so it must live here, never in a
shell export), CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=33 (~30% of a 200K
window, the context gate's sensor), and the three spawn caps frozen at
their defaults (3/20/200) because depth and concurrency are otherwise
server-adjustable via statsig gates. Top-level: fallbackModel
["opus","sonnet"] (REPLACES across scopes, max 3) and
switchModelsOnFlag true.

Deliberately NOT set (rationale in .claude/CLAUDE.md so a later session
does not "fix" it back): DISABLE_AUTO_COMPACT, CLAUDE_CODE_SUBAGENT_MODEL,
CLAUDE_CODE_NO_MODEL_FALLBACK.

Closes #567.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W7hfGJXahjaLo2DXRK6j8N

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/586"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788539245&installation_model_id=429246&pr_number=586&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F586&signature=91245ec93ab767220a5fbe098347c2d010988be0b4f4807e62002581bdaf4901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing pinned environment and model configuration settings.
  * Added an evidence receipt recording configuration details, validation sources, review results, and operational notes.
* **Chores**
  * Updated development environment settings for task management, concurrency, subagent limits, automatic compaction, fallback models, and feature-flag model switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->