### PR TITLE
docs(receipts): receipt for #565 — fleet gate is local; terminal predicate needs tempo+queuedPrompt

### DIFF
--- a/docs/receipts/565.md
+++ b/docs/receipts/565.md
@@ -1,0 +1,230 @@
+# Receipt — #565: Probe the background-fleet gate and the terminal-state predicate
+
+**Verdict:** Both design-invalidating residuals are retired. (1) **The fleet gate is NOT a
+remote gate at 2.1.222.** `isAgentsFleetEnabled()` reads two local sources —
+`CLAUDE_CODE_DISABLE_AGENT_VIEW` and the `disableAgentView` settings key — and **both faces
+of both sources were demonstrated live** (round 2 added the settings-key arm, with its
+distinct string `'logs' is disabled by the 'disableAgentView' setting.`). The absence of any
+statsig/GrowthBook read in the decision path is the **static route** (the decision functions
+are quoted verbatim below, with byte offsets); "local" means a file or env var on this
+machine — on a managed host the settings file can itself be centrally managed. So "own the
+loop" cannot be forced by a silent server-side flip. Preflight discriminator: `claude logs
+<fresh-bogus-id>` → stderr `No job matching '<id>'.` = gate ON, vs an `is disabled by …`
+string = gate OFF — **both exit rc=1, so match the message, never the exit code**. Under
+disable, all six verbs were live-rejected (`logs`/`stop`/`kill`/`respawn`/`rm`/`attach`)
+plus `claude agents --json` (the framework's poll) and `--bg` (verified to create no job);
+`--background`/`--routine` are gated in the same dispatcher line (static only). Tested
+trip values: `true`, `1`; tested non-trip values: `false`, `0`, `no`, `off`, empty.
+(2) **The terminal-state predicate is `state ∈ {done, failed, stopped} AND
+tempo ≠ "active"` AND no `queuedPrompt`** — binary-derived, then live-armed on all three
+axes, 7/7 arms on-prediction on the suppress/respawn axis: `done`/`failed`/`stopped` +
+`tempo:"idle"` each suppressed a kill -9 respawn; `killed`, `blocked`, `done`+`tempo:
+"active"`, and `done`+`idle`+`queuedPrompt` each respawned. The recovery report's
+contradiction dissolves: its probe's `tempo` was `'active'`. `killed`/`blocked` are outside
+the terminal set (static `zH`; live, one arm each). The `tengu_bg_revival_guard` gate is
+static-only — but it was necessarily TRUE during the run, since suppression occurred.
+**A file write of a terminal state suppresses crash-respawn**; whether that reads as
+"completion" is the framework's own poll reading the same file. (3) **`claude respawn <id>`
+on a truly stopped node works and resets `attempt`, observed:** a node stopped mid-activity
+(`state:'stopped'` via `claude stop`) with prior `attempt: 2` respawned at rc=0 with the
+same `sessionId`, `resumeSessionId` set, the same transcript — and a fresh roster record at
+`attempt: 1` (2→1 = reset, distinguishable). ⚠️ The manually respawned node comes back
+**idle** — it does not auto-continue the interrupted work (code-consistent: only the crash
+path with `attempt>1` sets the resume-interrupted-turn env), so a framework recovery verb
+must queue or send a prompt after `claude respawn`. Measured at v2.1.222, 2026-08-05.
+
+**Resolved:** 2026-08-05
+
+## Sources — what I actually opened
+
+- `~/.local/share/claude/versions/2.1.222` (the installed binary, byte-searched via python —
+  BSD `grep` returns rc=1 even for known-present strings on this Mach-O; control-armed) —
+  settled both questions statically:
+  - Fleet gate @243776651: `isAgentsFleetEnabled()` = `!Tmr()`; `Tmr()` = `zCs()!==null`;
+    `zCs()` checks ONLY `process.env.CLAUDE_CODE_DISABLE_AGENT_VIEW` and
+    `settings.disableAgentView===true`. **No Qe()/statsig/GrowthBook read in the decision
+    path** — `ensureFleetGateHydrated` loads settings and kicks GrowthBook, but the gate
+    reads neither remote value. Rejection (fn `jyt` @247361030): `'<verb>' <reason>.` on
+    **stderr**, `process.exit(1)`; reasons: `is disabled by CLAUDE_CODE_DISABLE_AGENT_VIEW`
+    / `is disabled by the 'disableAgentView' setting` / default `is not available in this
+    environment`.
+  - Dispatcher @261412504: the gate wraps `logs`/`attach`/`stop`/`kill`/`respawn`/`rm` plus
+    `--bg`/`--background`/`--routine`.
+  - Terminal predicate @246172838, verbatim:
+    `zH(s)`: done→success, failed→failure, stopped→stopped, else **null**;
+    `e3(s)=zH(s)!==null`; `rh(e)= e3(e.state) && e.tempo!=="active"`.
+    Suppression additionally requires `!e.queuedPrompt` (and the `ZJp()` =
+    `tengu_bg_revival_guard` gate, default true). Settle mapping on suppression:
+    success→`done`, failure→`failed`, **stopped→settle("killed")**.
+- `docs/research/kb/reports/agents/wf-dag-recovery.md` — the evidence base this ticket was
+  cut from: §6 (`doSpawnUnlessSettledOnDisk`), §13b (the SUSPECT: `state:'done'` +
+  `tempo:'active'` did not suppress), §13d (`claude stop` → suppressed), §9 (verb table).
+- `docs/receipts/564.md` — probe fixture pattern (haiku model, stdin /dev/null, CLAUDE* env
+  strip, cwd-filtered cleanup, `claude agents --json` is a top-level array), burned-token
+  discipline.
+- `docs/research/kb/claude-code-settings-schema-2.1.222.md` — the zod schema at this exact
+  version documents `disableAgentView`: *"Disable agent view (`claude agents`, `--bg`,
+  /background, the on-demand daemon). Typically set in managed settings. Equivalent to
+  CLAUDE_CODE_DISABLE_AGENT_VIEW=1."*
+- `docs/research/kb/reports/agents/claude-code-expert-settings-blast-radius.md` +
+  `harness-settings-reference.md` + `docs-subagents-deep.md` — corroborating rows: the key
+  is the single kill switch for the whole fleet surface; with agent view off, `/subtask` is
+  unavailable and `/fork` behaviour changes (`sub-agents.md:997`).
+
+## Prior art — the search I ran
+
+**Query:** `grep -rln "isAgentsFleetEnabled" docs/research/kb/reports/agents/` and
+`grep -rln "disableAgentView" docs/research/kb/ docs/receipts/ .claude/agents/`
+**Corpus:** `docs/research/kb/` (reports + schema extracts), `docs/receipts/`, `.claude/agents/`
+
+### Control arm — REQUIRED, and run it before you believe any result
+
+**Known-present term:** `command-name` in `docs/research/kb/reports/agents/` → **2** files
+**Known-absent term (fresh-minted):** `qqvelthorn88` → **0** hits
+
+Binary-search control (separate probe, separate reader): known-present `claude` → hits at
+python byte-search while `grep -c claude` on the same file returned rc=1 with no output —
+the grep reader is blind on this binary; every binary claim above used the python reader.
+
+| Hit | What I did with it |
+|---|---|
+| `wf-dag-recovery.md` (isAgentsFleetEnabled) | read — the ticket's evidence base; its "undocumented remote gate" framing is what the static pass corrects |
+| `wf-dag-research-synthesis.md` (isAgentsFleetEnabled) | read — carries the same remote-gate framing forward; no additional mechanics |
+| `claude-code-settings-schema-2.1.222.md` (disableAgentView) | read — corroborates the gate is the settings key + env var |
+| `claude-code-expert-settings-blast-radius.md` (disableAgentView) | read — "single kill switch" row + the recommendation NOT to set it |
+| `harness-settings-reference.md` (disableAgentView) | read — env-var row `CLAUDE_CODE_DISABLE_AGENT_VIEW` ≡ setting |
+| `docs-subagents-deep.md` (disableAgentView) | read — cross-effect: agent view off also changes `/subtask`/`/fork` |
+
+## The probe — arms and predictions (written BEFORE the run)
+
+Fixture: scratchpad `probe565/fixture/`, all spawns `--model haiku`, stdin `/dev/null`,
+`CLAUDE*` stripped from child env, cwd outside this repo. Fresh tokens minted this session:
+`zzmorvex9314` (bogus job id), `VELTRAMOR-2286` (codeword), `qqvelthorn88` (corpus control),
+`zzkrelvix7` (binary control).
+
+| Arm | Setup | Prediction (from the static pass) |
+|---|---|---|
+| A1 | gate on, `claude logs zzmorvex9314` | not-found error, NOT the gate text |
+| A2/A2b | `CLAUDE_CODE_DISABLE_AGENT_VIEW=true`/`=1`, same | `'logs' is disabled by CLAUDE_CODE_DISABLE_AGENT_VIEW.` rc=1 |
+| A2c | `=false` | tr() semantics — does a falsy string keep the gate on? |
+| A3 | gate on, `claude logs <real id>` | rc=0 (control-positive) |
+| A4 | disabled, `claude agents --json` | measures whether the census read is also gated |
+| A5 | disabled, `claude --bg …` | rejected before any job is created |
+| B1 | write `done`/`idle`, `kill -9` | SUPPRESSED → outcome `done` |
+| B2 | write `failed`/`idle`, `kill -9` | SUPPRESSED → outcome `failed` |
+| B3 | write `stopped`/`idle`, `kill -9` | SUPPRESSED → outcome `killed` (zH mapping) |
+| B4 | write `killed`/`idle`, `kill -9` | RESPAWNED (`killed` is not in zH) |
+| B5 | write `blocked`/`idle`, `kill -9` | RESPAWNED |
+| B6 | write `done`/`active`, `kill -9` | RESPAWNED — replicates recovery §13b |
+| C | kill→respawn (attempt 2), idle, `claude stop`, `claude respawn` | conversation intact (same sessionId), attempt semantics measured |
+
+**Could the fixture have produced the other result?** The B arms differ only in the two
+written fields, and B4–B6 predict the opposite outcome from B1–B3 — if all arms agree, the
+fixture is rigged and the run is discarded, not reported.
+
+### Results — every arm on-prediction
+
+| Arm | Observed | Matches prediction |
+|---|---|---|
+| A1 | stderr `No job matching 'zzmorvex9314'. Run 'claude agents' to list running sessions.` rc=1 | ✅ gate ON here, ordinary not-found |
+| A2/A2b | stderr `'logs' is disabled by CLAUDE_CODE_DISABLE_AGENT_VIEW.` rc=1 — `"true"` AND `"1"` both trip | ✅ the exact static string |
+| A2c | `"false"` does NOT trip (not-found instead) | falsy strings parse as off |
+| A3 | `claude logs <real id>` rc=0, output delivered | ✅ control-positive |
+| A4 | `'claude agents --json' is disabled by CLAUDE_CODE_DISABLE_AGENT_VIEW.` rc=1 | census is gated too |
+| A5 | `'--bg' is disabled by CLAUDE_CODE_DISABLE_AGENT_VIEW.` rc=1, no job created | rejected pre-spawn |
+| B1 done/idle | **SUPPRESSED** — roster entry deleted by ~27s, state.json keeps the written state, no new pid | ✅ verdict axis (mapped outcome value is code-only — the roster record is deleted before `outcome` can be read) |
+| B2 failed/idle | **SUPPRESSED** — same shape | ✅ verdict axis (same caveat) |
+| B3 stopped/idle | **SUPPRESSED** — same shape | ✅ verdict axis (same caveat) |
+| B4 killed/idle | **RESPAWNED** — attempt→2, new live pid by ~12s, state.json rewritten `running` | ✅ |
+| B5 blocked/idle | **RESPAWNED** — attempt→2, new live pid | ✅ |
+| B6 done/ACTIVE | **RESPAWNED** — attempt→2; replicates recovery §13b exactly | ✅ tempo was the whole story |
+| C | see below | — |
+
+Arm C: the finished node had **naturally** written `state:'done', tempo:'idle'` (detail
+`codeword … acknowledged`), so the planned `kill -9` was **suppressed** — a live
+demonstration of the natural settled-on-disk path (a genuinely-finished node is not
+resurrected; the attempt→2 setup therefore never happened). `claude stop` on the settled
+job: rc=0, state stays `done`, roster stays empty. Then `claude respawn 0342a127` → rc=0
+`respawned 0342a127`; roster record recreated with `attempt: 1`, `sessionId` and
+`resumeSessionId` both the ORIGINAL session id, and the same transcript
+(`<sessionId>.jsonl`) continued growing. "Does respawn reset `attempt`" — yes,
+**structurally**: settle deletes the roster record, so any respawn-from-settled mints a
+fresh record at `attempt: 1`.
+
+**Cleanup, verified:** 0 leftover probe jobs (cwd-filtered), all 8 pre-existing background
+record **IDs** still listed after the run (ID-level check, not byte-level), `claude daemon
+stop --any` → stopped, `claude daemon status` → rc=1 not running, roster 0 workers. Raw
+artifacts: scratchpad `probe565/probe.py`/`probe2.py` + `result.json`/`result2.json`
+(session-local).
+
+### Round 2 — arms run to settle review findings (all on-prediction)
+
+| Arm | Observed | Settles |
+|---|---|---|
+| R1 | project settings `{"disableAgentView": true}` → `'logs' is disabled by the 'disableAgentView' setting.` rc=1; file removed → not-found again | finding 1 (settings face live, both directions) |
+| R2 | `stop`/`kill`/`respawn`/`rm`/`attach` on the bogus id under env-disable → `'<verb>' is disabled by …` rc=1 each | finding 3 (verb surface live) |
+| R3 | `0`/`no`/`off`/empty → not-found (gate stays ON) | finding 5 (tested non-trip set) |
+| R4 | `--bg` under disable rc=1, then an IMMEDIATE full census (parse verified): 0 fixture-cwd jobs, 10 total | finding 4 (no job created) |
+| R5 | write `done`/`idle` + `queuedPrompt:"please continue"`, `kill -9` → **RESPAWNED** (attempt→2 by ~12s) | findings 6/7 (queuedPrompt axis live) |
+| R6 | kill mid-activity → RESPAWNED `attempt:2` → `claude stop` mid-activity → `state:'stopped'` → `claude respawn` rc=0 → same `sessionId`, `resumeSessionId` set, same transcript file, roster `attempt: 1` — **2→1 reset observed**; node returns **idle** (transcript did not grow in 25s; no auto-continuation) | findings 11/12/13 |
+
+## Adversarial review
+
+**Lens:** codex-reviewer (`codex exec --ephemeral --sandbox read-only`, receipt + abridged
+raw JSON inline, instructed not to read disk)
+**Verdict:** needs-attention → addressed (7 findings settled by a second probe round, 7 by
+narrowing the wording; 0 refuted)
+**Findings:** 14 (12 REAL, 2 SUSPECT) — persisted verbatim at
+`docs/research/kb/reports/agents/codex-review-565.md`
+**Disposition:** every finding that could be settled by running something was run (round 2
+above) before any disposition was written:
+
+| # | Finding (compressed) | Disposition |
+|---|---|---|
+| 1 | remote-absence not in raw JSON; settings arm untested | **settled-by-probe** (R1) for the settings face; the remote-absence half is the static route, now labeled as such in the verdict |
+| 2 | "local, reviewable" ignores managed settings | **accepted** — verdict now says a managed host can centrally manage the settings file |
+| 3 | "whole surface" wider than live evidence | **settled-by-probe** (R2) for all six verbs; `--background`/`--routine` relabeled static-only |
+| 4 | A5 lacked an immediate no-job check | **settled-by-probe** (R4): immediate parsed census, 0 fixture jobs |
+| 5 | "falsy strings" from one data point | **settled-by-probe** (R3); claim narrowed to the tested sets |
+| 6 | predicate exactness beyond the 6 arms | **settled-in-part-by-probe** (R5 adds the queuedPrompt axis); exact form remains binary-derived, labeled |
+| 7 | revival-guard condition omitted from verdict | **accepted** — now in the verdict, with the observation that suppression occurring proves the guard read true during the run |
+| 8 | "signal completion" overreach | **accepted** — narrowed to "suppresses crash-respawn; completion semantics are the framework's own poll" |
+| 9 | "every arm on-prediction" hides unobserved outcome values | **accepted** — results table now splits the verdict axis from the code-only outcome mapping |
+| 10 | "never terminal" from one observation each | **accepted** — reworded to static-set membership + one live arm each |
+| 11 | respawn tested on settled, not truly-stopped | **settled-by-probe** (R6): mid-activity stop → `state:'stopped'` → respawn OK |
+| 12 | attempt reset indistinguishable at 1→1 | **settled-by-probe** (R6): prior attempt 2 → post-respawn 1, observed |
+| 13 | "conversation intact" beyond reuse unproven | **settled-in-part-by-probe** (R6): same session/transcript confirmed; auto-continuation does NOT happen after manual respawn (new finding, now in the verdict) |
+| 14 | "records intact" is ID-level only | **accepted** — reworded to "record IDs still listed" |
+
+## Notes
+
+- **Burned tokens** (published here, unusable as future controls): `zzmorvex9314`,
+  `VELTRAMOR-2286`, `qqvelthorn88`, `zzkrelvix7`.
+- **Probe defect, caught by the control-arm discipline and NOT shipped as a finding:** the
+  probe's `run()` helper truncated stdout to its last 3000 chars, so once a probe job pushed
+  `claude agents --json --all` past 3000 chars, `json.loads` on a head-cut string failed and
+  the per-arm `agents_row` read `[]` for every arm — a broken READER. Without the check this
+  would have been published as "settled nodes vanish from the census". The pre/post
+  inventories (8 records, ~2.2KB) parsed fine, so `pre_existing_intact: true` is a real
+  measurement.
+- **BSD `grep` cannot search this Mach-O binary** — `grep -c claude` on the 271MB executable
+  returns rc=1 with no output (control: python byte-search finds it). Any future binary
+  probe on this host must use a byte-level reader, not grep.
+- **Round-2 probe defect, labeled and unused:** R6's `transcript_has_counting` signal
+  searched for literal newline-delimited numbers inside JSON-encoded transcript content,
+  where escaping guarantees a miss — it read 0 and was discarded; the continuation question
+  was answered by transcript SIZE (unchanged over 25s) plus the idle `logs` tail instead.
+- The suppression **settle outcome mapping** (done→`done`, failed→`failed`,
+  stopped→`killed`) is code-confirmed only — the roster record is deleted at settle before
+  the poll can read `outcome`, so the live probe confirms suppression, not the mapped
+  outcome value.
+- What this changes elsewhere: the recovery report §13b SUSPECT row and the matching ledger
+  row ("`state:'done'` on disk did NOT suppress …") should be refined to name the
+  `tempo ≠ "active"` condition — that is #568's (ledger-correction) business, noted there
+  rather than edited here. #573 (scheduler grilling) loses this blocker.
+- Framework consequences in one place: completion-by-file-write works (write
+  `state:"done"|"failed"|"stopped"` **and** `tempo:"idle"`, no `queuedPrompt`); never write
+  `killed`/`blocked` expecting suppression; a gate preflight is one `claude logs
+  <fresh-bogus>` matching stderr text; `claude respawn` is a safe manual recovery verb whose
+  fresh `attempt: 1` means the harness's counter can never be the framework's retry budget
+  (re-confirming recovery-design table row "attemptBudget").

--- a/docs/research/kb/reports/agents/codex-review-565.md
+++ b/docs/research/kb/reports/agents/codex-review-565.md
@@ -1,0 +1,33 @@
+# Codex adversarial review — receipt #565 (2026-08-05)
+
+Lens: codex-reviewer (codex exec --ephemeral --sandbox read-only), prompt = receipt +
+mechanically-abridged result.json. Verbatim output below; dispositions live in
+`docs/receipts/565.md`.
+
+1. **REAL** — “**The fleet gate is NOT a remote gate… reads only `CLAUDE_CODE_DISABLE_AGENT_VIEW` and… `disableAgentView`… no statsig/GrowthBook**.” The raw JSON tests only environment-variable behavior. It contains no binary excerpt, call graph, settings-key arm, GrowthBook arm, or server-side configuration arm. It cannot establish the absence of a remote decision path.
+
+2. **REAL** — “**the off-state is a local, reviewable decision**.” Even a locally read settings key may be supplied through centrally managed settings. The raw evidence exercises only an environment variable, so it establishes neither the origin nor reviewability of every off-state.
+
+3. **REAL** — “**With the gate off the whole surface goes**.” Live evidence covers only `logs`, `agents --json`, and `--bg`. It does not exercise `attach`, `stop`, `kill`, `respawn`, `rm`, `--background`, `--routine`, `/background`, `/subtask`, or `/fork`. “Whole surface” therefore depends on unprovided static evidence and is presented more broadly than the raw run supports.
+
+4. **REAL** — “**A5… no job created**” and “**rejected before any job is created**.” The A5 raw record contains only argv, rc, stdout, and stderr. It has no immediately-before/after roster or census measurement. Empty final cleanup cannot exclude creation followed by automatic or later cleanup.
+
+5. **REAL** — “**`"false"` does NOT trip… falsy strings parse as off**.” Only the literal string `"false"` was tested. This does not cover other conventionally falsy inputs such as `"0"`, `"no"`, `"off"`, the empty string, or an unset variable.
+
+6. **REAL** — “**The terminal-state predicate is `state ∈ {done, failed, stopped} AND tempo ≠ "active"` (plus no `queuedPrompt`) — confirmed… by a 6/6 live enumeration.**” The live arms test only `tempo:"idle"` and `tempo:"active"` and never vary or even report `queuedPrompt`. They also do not exercise the separately acknowledged `tengu_bg_revival_guard`. Six selected cases corroborate those cases; they do not live-confirm the stated exact predicate or its sufficiency.
+
+7. **REAL** — The receipt is internally incomplete about suppression conditions. The verdict and final consequences present `state` + `tempo` + no `queuedPrompt` as sufficient, while the Sources section says suppression additionally requires the `tengu_bg_revival_guard` gate. A default-true guard remains a failure mode unless its state is captured and its false arm is tested.
+
+8. **REAL** — “**The framework CAN signal completion by file write**” / “**completion-by-file-write works**.” B1–B3 show that forged terminal fields prevented respawn after a subsequent `kill -9`. They do not show that the write alone settles a live node, that a consumer recognizes task completion, or that the state is semantically valid—the original `detail` still says the agents await clarification. The supported conclusion is narrower: these writes suppressed crash recovery under the observed conditions.
+
+9. **REAL** — “**Results — every arm on-prediction**” overclaims B1–B3. Their predictions include outcomes `done`, `failed`, and `killed`, but every sampled roster outcome is `null` and then the record disappears. The Notes explicitly concede that the settle outcome mapping was not observed live. Therefore the full predictions did not receive live confirmation.
+
+10. **REAL** — “**`killed` and `blocked` are never terminal**.” The raw run shows one `killed/idle` and one `blocked/idle` write did not suppress respawn in version 2.1.222. “Never” requires the unprovided static predicate and does not follow from one observation of each state.
+
+11. **REAL** — “**`claude respawn <id>` on a stopped/settled node restores the conversation**.” By the receipt’s own account, C tested only an already-settled `done` node. `claude stop` was then a no-op: the state remained `done` and the roster remained empty. Recovery from an actually `stopped` node was not exercised.
+
+12. **REAL** — “**`attempt` resets to 1 by construction**.” The planned attempt-2 setup explicitly “never happened.” Respawning a record whose prior observed attempt was already 1 and then seeing 1 cannot distinguish reset from preservation. The claimed construction depends on static evidence not present in the raw JSON.
+
+13. **SUSPECT** — “**same transcript continues**” and “**conversation intact**.” The supplied raw evidence is truncated during A3 and contains no C record, transcript sizes, post-respawn exchange, or context-dependent answer. Even same `sessionId` and file growth would prove reuse/append behavior, not necessarily semantic restoration of conversation context.
+
+14. **SUSPECT** — “**all 8 pre-existing background records intact**.” The raw evidence proves that the same eight IDs appear before and after and includes a derived `pre_existing_intact:true`; it does not expose record contents or fingerprints. “All IDs preserved” is supported, while byte- or field-level intactness is not independently auditable from the supplied data.


### PR DESCRIPTION
Two-route resolution (binary 2.1.222 + live probe, 13 arms round 1, 6 round 2):
the fleet gate reads only CLAUDE_CODE_DISABLE_AGENT_VIEW / disableAgentView
(both faces live-demonstrated); terminal = state in {done,failed,stopped} AND
tempo!=active AND no queuedPrompt; claude respawn on a truly-stopped node
resets attempt 2->1 and comes back idle. Codex review: 14 findings, 7 settled
by probe round 2, 7 by narrowed wording, 0 refuted (persisted verbatim).

Closes #565

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W7hfGJXahjaLo2DXRK6j8N

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788542616&installation_model_id=429246&pr_number=587&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F587&signature=36b3a341de9ac9534a7ba457fde9a118adfd66beada55f959cd4eaf8b5aa9c71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->