### PR TITLE
docs(receipts): receipt for #573 — the pull-loop scheduler design + five research reports

### DIFF
--- a/docs/receipts/573.md
+++ b/docs/receipts/573.md
@@ -1,0 +1,150 @@
+# Receipt — #573: Grill the pull-loop scheduler: what advances the DAG?
+
+**Verdict:** GitHub Issues is the scheduler's ONLY database and a deterministic Python tick
+advances the DAG. Selection = open ∧ unclaimed ∧ `issue_dependencies_summary.blocked_by == 0`
+(GitHub precomputes it, inline, even on list calls — one paginated conditional query per tick,
+2 pages at the current ~132 open issues, free via 304 when idle) ∧ per-stage slot ∧ global slot
+∧ preflight green, ordered priority-then-oldest. The tick is launchd via mise's native
+`[bootstrap.macos.launchd.agents]` (`start_interval = 60`, `program` = the literal mise binary
+path — the bare name is a zsh function launchd can't see), four phases in fixed order:
+reconcile → preflight → select → dispatch → exit, under a local lockfile that is simultaneously
+the single-writer guarantee (GitHub has NO compare-and-swap on issues) and the tick-overlap
+guard. Workers post evidence comments and exit; ONLY the scheduler transitions state
+(verified-complete). Work state lives exclusively in the tracker (labels = small selector
+vocabulary; append-only dual-audience comments = run/attempt counters, five distinct terminal
+reasons, receipts; the body is NEVER machine-written); liveness is the one locally-observed
+fact, because a stalled worker cannot post its own stall. Retry = symphony's
+`min(10·2^(n-1), 300)s`, cap 3 per run, counters tracker-owned (the harness's `attempt`
+self-resets after 5 healthy minutes). Rework = REOPEN the upstream issue (reopening re-blocks
+dependents natively — live-probed 1→0→1), `max_rework` 2, exhaustion = stop + `dag:needs-human`
++ comment, no transition. Cleanup = startup-only sweep. The reconcile pass owns transitive
+cycle detection (GitHub silently accepts 3-hop dependency cycles). Native Claude scheduling is
+REJECTED as the tick — every surface fires a PROMPT, never a command — but two complements are
+ADOPTED: a Desktop scheduled task as a daily supervisory repair-and-report lane, and a cloud
+routine as off-machine escalation with its `/fire` API as the outbound hook. The
+`CLAUDE_CODE_TASK_LIST_ID` task list is fully demoted to session-local todo use; map #556's
+architecture-of-record line is corrected accordingly. The event-loop variant was considered and
+rejected mid-grill: dependency-edge changes are absent from the repo Events API (measured, with
+a control arm that saw eleven adjacent issue events) and appear only in per-issue timelines, so
+learning topology means re-query either way and the reconcile poll is mandatory regardless —
+the event path buys latency nobody needs. (Webhook delivery of dependency events was NOT
+runtime-probed — the conclusion does not rest on it.)
+
+**Resolved:** 2026-08-05
+
+## Sources — what I actually opened
+
+- `docs/research/kb/reports/agents/573-gh-issues-db.md` — live-probed the whole GitHub surface:
+  inline `blocked_by` readiness (list + item), closed=satisfied / reopen=re-blocks (1→0→1 on
+  #571/#589), free 304 idle ticks, no CAS anywhere on issues (control: `expectedHeadOid` exists
+  on commits), silent claim no-ops, 3-hop cycle acceptance, label/comment/body safety matrix,
+  no event for dependency changes, `gh webhook` absent at pinned gh 2.97.0.
+- `docs/research/kb/reports/agents/573-mise-launchd.md` — mise ships a declarative LaunchAgent
+  manager (`src/system/launchd.rs`, docs `bootstrap/launchd.md`; landed 2026.6.7, host binary
+  2026.8.2); `status --missing` rc=1 is the verification gate; the zsh-function `program` trap.
+- `docs/research/kb/reports/agents/573-linear-tracker.md` — Linear from its own GraphQL SDL:
+  states are a palette not a state machine, blocker filter blind to blocker state, no custom
+  fields, NAT-hostile auto-disabling webhooks, 250-issue free cap; recommends against itself;
+  surfaced the SQLite third option (explicitly ruled on in round 5).
+- `docs/research/kb/reports/agents/573-symphony-cc-ports.md` — cymphony (Linear-only Elixir
+  rewrite; dispatch/env mechanics), stokowski's append-only dual-audience comment-state +
+  run/attempt rework split, symphony's five adapters (only Linear+Jira have DAG logic — an age
+  artifact: today's GitHub precomputes what symphony's Linear adapter computes client-side),
+  claims never written to the tracker in symphony (our posted-claims design is a named
+  divergence).
+- `docs/research/kb/reports/agents/573-cc-scheduled-tasks.md` — every Claude scheduling surface
+  at 2.1.222: cron fires enqueue prompts (`Yv({mode:"prompt"…})`), `durable` gate OFF here and
+  durable ≠ unattended even ON, `/loop` carryover dies with the on-demand daemon, cloud
+  routines = fresh clone + 1-hour floor, Desktop tasks = app-open + few-minutes stagger;
+  settles the prior SUSPECT cron row; refutes `CLAUDE_CODE_LOOP_PERSISTENT`-as-persistence.
+- `docs/research/kb/reports/agents/wf-dag-symphony-gaps.md` — the mechanism gap table (A1–I16)
+  this grill worked through; symphony SPEC anchors for tick ordering, backoff, terminal
+  reasons, workspace sweep.
+- `.claude/agents/claude-code-expert.md` — ledger rows read before round 1: terminal predicate,
+  fleet-gate-local, respawn-idle, attempt-reset, task-list persistence, mailbox pull-only.
+- Task tool schemas (`TaskCreate`/`TaskUpdate`/`TaskGet`/`TaskList`, loaded live) — settled
+  three NEEDS-PROBE items: native `owner` claim field, status enum has NO failed state,
+  TaskList prefilters resolved blockers, updates are read-then-write with no CAS.
+- [mattpocock/skills v1.1.0→v1.2.2 release notes](https://github.com/mattpocock/skills/releases)
+  — reviewed mid-grill at Ray's request; no design impact; two protocol adoptions (research
+  burn-down via subagents, prototype-branch capture) and one flagged non-adoption (`/compact`
+  as default escape hatch — Ray's stricter no-compact rule stands).
+- Design explainer artifact (components/workflows/decisions, mermaid):
+  <https://claude.ai/code/artifact/b3d1f19f-c6a6-47fe-86c3-2d2732ecf7e5>
+
+## Prior art — the search I ran
+
+**Query:** `grep -rli -E 'pull.loop|scheduler|dispatch' docs/research/kb/reports/ docs/specs/ docs/adr/`
+**Corpus:** `docs/research/kb/reports/`, `docs/specs/`, `docs/adr/`
+
+### Control arm — REQUIRED, and run it before you believe any result
+
+**Known-present term:** `blockedBy` → **8** files
+**Known-absent term:** `kwyvernost3` (invented fresh this run) → **0** files
+
+The fixture question ("could this setup have produced the other result?") is satisfied by the
+corpus being the real tracked tree on the work branch, searched before this receipt existed —
+no self-pollution possible.
+
+| Hit | What I did with it |
+|---|---|
+| `wf-dag-symphony-gaps.md` | read — the grill's agenda; every conformance item traced to its row |
+| `symphony-and-ports.md` | read via the ports agent — port precedent (claims, comment-state, rework) |
+| `wf-dag-recovery.md` | read via ledger rows — respawn/terminal facts already appended by #568 |
+| `docs/specs/agent-team-first-slice.md` (#550) | read — unaffected: its role set and validator seam are orthogonal to the pull loop |
+| `docs/agent-team.md` | read — its "edges = SendMessage" sketch is superseded by this design; correction rides the map edit. NOTE: added to this table from prior knowledge, not a hit of the quoted grep (its path is outside the stated corpus) |
+| `phase0-queue-triage-dag.md` | read — early queue triage; superseded by the wayfinder map itself |
+| `573-*.md` (five reports) | produced BY this ticket — sources, not prior art |
+| remaining ~28 matches | dismissed — term collisions: `dispatch`/`scheduler` in unrelated contexts (fnox write surface, graphify mining, eval harness, postgres follow-ups); none mentions the DAG tick |
+
+## Adversarial review
+
+**Lens:** codex-reviewer (cold, read-only, fed the staged diff with no design context)
+**Verdict:** needs-attention — addressed before ship
+**Findings:** 18 — persisted verbatim with per-finding dispositions in
+`docs/research/kb/reports/agents/codex-review-573.md`
+**Disposition:** 3 accepted (receipt wording fixed pre-ship: the overbroad "no GitHub event"
+claim narrowed to the Events-API measurement; "one call per tick" corrected to one paginated
+query; the `docs/agent-team.md` prior-art row annotated as outside the quoted grep corpus).
+2 resolved by action (this review file persisted + staged; the map edit happens API-side in
+this same close-out — the map is an issue body, not a repo file). 13 are report-level
+overclaims or cross-report conflicts — the reports stay VERBATIM per
+`agent-report-persistence.md`, and the corrections live in the review file's disposition
+table and the note below.
+
+## Notes
+
+- **Deferred to the spec phase, deliberately:** the stage taxonomy and per-stage cap values,
+  the per-task-type evidence contracts the verifier reads, the exact `dag:*` label spellings,
+  and the scheduler module/task naming. The grill fixed semantics, not spellings.
+- **Probe ticket filed at close-out:** validate the harness heartbeat surface
+  (`~/.claude/jobs/<id>/state.json` rv-heartbeat/tempo semantics during long silent tool calls)
+  before stall detection becomes load-bearing — evidence on a `prototype/` branch per the
+  v1.2.2 prototype convention. Until it lands, slice 1 ships without automated stall recovery
+  (Ray accepted this trade in round 2).
+- **Two gotchas the implementer must not lose:** (1) never read back your own GitHub write to
+  confirm it — the dependency summary is eventually consistent (~3s lag measured); trust the
+  tick's snapshot and let the next tick reconcile. (2) verify a claim from the mutation's OWN
+  response body — GitHub silently drops assignees without push access at rc=0.
+- **The `gh --json` gap:** `issueDependenciesSummary` is not exposed to `gh --json`; the tick
+  reads raw REST/GraphQL (or filters `blockedBy.nodes[].state` client-side). Stay off the
+  Search API (30/min bucket) — core/GraphQL only.
+- **Dead end, recorded:** the round-2 event-loop direction (webhooks, local fs watches, event
+  queue) was walked back by Ray in round 3 before the deciding fact landed (no event for
+  topology changes) — the walk-back was right for a reason not yet known at the time.
+- **Superseded map lines corrected in the same close-out:** the architecture-of-record
+  task-list sentence, and the Out-of-scope scheduling line (launchd ruling re-verified with a
+  better reason; Desktop/routine promoted from disqualified-as-tick to adopted-as-complements).
+- **Reading the five research reports: they are VERBATIM SNAPSHOTS, and later evidence
+  overrides earlier text.** The cold review surfaced the conflicts, all recorded in
+  `codex-review-573.md`: the ports report's task-list recommendation and "write surface
+  unprobed" line predate rounds 4–5 and the gh agent's live edge probes; the Linear report's
+  GitHub-side comparisons are inherited and defer to `573-gh-issues-db.md` by its own
+  precedence clause; the gh report's "read-only probes" method line undersells its (sanctioned,
+  restored) mutations, and its "~2000× tighter" Search-bucket figure is arithmetically wrong
+  (30/min vs 5000/hr ≈ 2.8×/hr — the directional conclusion stands); the scheduled-tasks
+  report's "zero durable tasks anywhere" rests on a depth-bounded find, and its 30s-jitter
+  figure is conditional on the local default config it could not confirm is unoverridden.
+- **Open verification item from adopting the cloud-routine complement:** whether a routine's
+  GitHub connector can actually write issues/PRs from Anthropic infrastructure was asserted
+  from docs, not probed — verify before the escalation lane is built on it.

--- a/docs/research/kb/reports/agents/573-cc-scheduled-tasks.md
+++ b/docs/research/kb/reports/agents/573-cc-scheduled-tasks.md
@@ -1,0 +1,498 @@
+# Claude Code expertise — scheduling surfaces vs launchd for the #573 pull-loop tick (2026-08-05, v2.1.222)
+
+**STATUS: complete**
+
+Question: can any Claude Code native scheduling surface REPLACE or COMPLEMENT
+launchd as the outer ~60 s tick that runs `mise run <task>` in
+`/Users/rmanaloto/dev/github/ray-manaloto/dotfiles`?
+
+Corpora consulted: installed binary (`~/.local/share/claude/versions/2.1.222`,
+271,289,792 bytes), loaded tool schemas, `claude --help` + hidden-subcommand
+probes, offline docs (`$CC =
+~/dev/github/ray-manaloto/knowledge-base/sources/agent-harness-docs/docs/claude-code`,
+175 pages), live probes on this host.
+
+**Headline: launchd stays. No surface can replace it, and the reason is not
+persistence — it is that every Claude scheduling surface fires a PROMPT, never a
+command.** Two surfaces earn narrow complementary roles.
+
+## Verdict table
+
+| # | Surface | Verdict | The single deciding fact |
+|---|---|---|---|
+| 1 | `CronCreate`/`CronList`/`CronDelete` | **REJECT** | Fires a prompt into the live session's queue (`Yv({mode:"prompt"…})`) — a model turn, not a command. Needs a live REPL; `durable` gate is **OFF** on this host |
+| 2 | `/loop` + `ScheduleWakeup` | **REJECT** | Same enqueue path. Carries over to a background session, but that supervisor "exits when the last client disconnects" and **service install is disabled in this version** |
+| 3 | Cloud routines (`/schedule`) | **REJECT** as tick · **COMPLEMENT** as off-machine escalation | Executes on Anthropic infrastructure against a **fresh clone** — cannot see this Mac's tree or run `mise`. Minimum interval **1 hour**, shorter expressions "are rejected" |
+| 4 | Desktop scheduled tasks | **REJECT** as tick · **COMPLEMENT** as supervisory repair lane | Runs locally with real file access (the app IS installed and running here), but only "while the desktop app is running and your computer is awake", plus a deterministic **few-minutes stagger** — fatal at 60 s |
+| 5 | `createCronScheduler`/`isKairosCronEnabled` | **SETTLED** (was SUSPECT) | Gate is **ON**; the scheduler is constructed and `.start()`ed inside the REPL. Its only consumer is the prompt-enqueue callback. The **durable** sub-gate is OFF |
+| 6 | Anything new (flags / subcommands / settings) | **NONE FOUND** | 0 scheduling flags in `--help`, 0 hidden subcommands (control-armed), 0 settings keys. 2 undocumented env tokens exist and neither confers durability |
+
+## Findings
+
+### 1. CONFIRMED — a cron fires a PROMPT into the session's queue, not a command
+
+This is the architectural disqualifier and it is upstream of every persistence
+question. The scheduler's fire callback, verbatim from the binary at the REPL
+construction site:
+
+```js
+if(Wdh.isKairosCronEnabled()){
+  let Vr=(on,yt)=>{
+    if(O)return;
+    let Ao=$pv.resolveLoopDefaultFire(on);
+    Yv({mode:"prompt",agentId:ki(),value:Ao,uuid:zM.randomUUID(),
+        priority:"later",isMeta:!0,skipSlashCommands:!0,
+        modelScheduledOrigin:!0,wakeupSource:yt,workload:psr});
+    to("cron_fire");ii()
+  };
+  So=Lpv.createCronScheduler({
+    onFire:(on)=>Vr(on,"schedule_wakeup"),
+    onFireTask:(on)=>Vr(on.prompt,i5o(on)),
+    isLoading:()=>g||O,
+    getJitterConfig:Npv.getCronJitterConfig,
+    isKilled:()=>!Wdh.isKairosCronEnabled()
+  });
+  So.start()
+}
+```
+
+`Yv({mode:"prompt", …})` enqueues a **user-turn prompt** at `priority:"later"`.
+Nothing is exec'd. One tick = one model turn that must then decide to call `Bash`,
+clear the permission system, and produce a `mise run` invocation.
+
+Consequences for a 60 s tick, none of which launchd has:
+
+- **Every tick costs tokens.** The deterministic Python scheduler costs zero model
+  tokens under launchd; under cron it costs a full turn (system prompt +
+  transcript + tool round-trip) — 1,440 turns/day at 60 s.
+- **The tick is non-deterministic.** The model may summarise instead of running,
+  or run something adjacent. `mise run <task>` is a *guarantee* under launchd and
+  a *request* under cron.
+- **`skipSlashCommands:!0`** — the fired prompt bypasses slash expansion, so the
+  `claude -p "/verb"` prefix-expansion route (existing ledger row) is unavailable
+  inside a cron fire.
+- **Fires only between turns.** `$CC/scheduled-tasks.md:172`: "A scheduled prompt
+  fires between your turns, not while Claude is mid-response." A busy session
+  defers its own tick, and there is **no catch-up** (`:215`) — one fire when idle,
+  not one per missed interval.
+
+Control arm: the same binary's `Monitor` tool *does* run a script directly, and
+`CronCreate`'s own description points at it ("To watch a log file, process, or
+command output … use the Monitor tool instead"). The cron path deliberately does
+not exec.
+
+### 2. CONFIRMED — `durable: true` exists in the binary and is OFF on this host
+
+`$CC/scheduled-tasks.md` describes cron tasks as session-scoped throughout and
+never documents a `durable` parameter. The binary has one, behind a gate:
+
+```js
+function FX(){return!tr(process.env.CLAUDE_CODE_DISABLE_CRON)&&hEe("tengu_kairos_cron",!0,H$u)}
+function $Ue(){return hEe("tengu_kairos_cron_durable",!0,H$u)}
+```
+
+Both are `hEe(...)` remote feature gates with a **local default of `true`**. Every
+user-facing string is a ternary on `$Ue()`, which makes the **live tool schema its
+own control-armed probe** — the branches are mutually exclusive and both ship.
+
+Loaded live on this host, all three tools returned the **negative** branch:
+
+| Tool | Live text on this host | The other branch (also in the binary) |
+|---|---|---|
+| `CronCreate.durable` | "**Has no effect — durable persistence is not available.** All jobs are session-only (in-memory, gone when this Claude session ends)." | "true = persist to .claude/scheduled_tasks.json and survive restarts" |
+| `CronList` | "List all cron jobs scheduled via CronCreate **in this session**." | "…both durable (.claude/scheduled_tasks.json) and session-only." |
+| `CronDelete` | "Removes it from **the in-memory session store**." | "Removes it from .claude/scheduled_tasks.json (durable jobs) or the in-memory session store" |
+
+Three independent strings, all negative, mutually consistent — `tengu_kairos_cron_durable`
+is **OFF for this host** despite the code default being `true`. It is a remote gate
+someone else owns, so it can flip without a release.
+
+The parameter is present in the schema and inert — exactly the shape that reads as
+a capability to anyone who greps for the field name and stops there.
+
+### 3. CONFIRMED — even with the gate ON, durable ≠ unattended
+
+Worth settling because the gate could flip. Durable buys *restart survival*, not
+*fire-while-nothing-runs*. The binary's own catch-up text:
+
+```
+The following one-shot scheduled task${s were/ was} missed while Claude was not
+running. ${They have/It has} already been removed from .claude/scheduled_tasks.json.
+Do NOT execute ${these prompts/this prompt} yet. First use the AskUserQuestion tool
+to ask whether to run ${each one/it} now. Only execute if the user confirms.
+```
+
+A durable task that came due while the REPL was closed is **missed, deleted, and
+surfaced for confirmation** — not executed, and it requires a human answer. The
+scheduler lives inside the REPL process (`createCronScheduler` is constructed
+there; `isKilled` ties it to the same gate). There is no scheduling daemon.
+
+That disqualifies the whole cron family from the outer tick, gate or no gate.
+
+### 4. CORRECTED — the jitter numbers in the tool prose are stale; do not cite them
+
+Nearly published as a finding. `CronCreate`'s live description says "recurring
+tasks fire up to **10% of their period late (max 15 min)**". That sentence is a
+**hardcoded string literal** in the prompt template, not interpolated from config
+— verified by dumping the template source, where `${YPe}` and `${r}` *are*
+interpolated in adjacent sentences and the jitter numbers are not.
+
+The real config is `getCronJitterConfig()` = `hEe("tengu_kairos_cron_config", dhe, _k_)`,
+local default:
+
+```js
+dhe={recurringFrac:0.5, recurringCapMs:1800000, oneShotMaxMs:90000,
+     oneShotFloorMs:0, oneShotMinuteMod:30, recurringMaxAgeMs:604800000,
+     cacheLeadMs:15000}
+```
+
+`recurringFrac: 0.5`, `recurringCapMs: 1800000` = **half the period, capped at 30
+min** — matching `$CC/scheduled-tasks.md:180` and contradicting the tool's own
+prose. On a 60 s period that is up to **30 s of jitter**, a 50% timing error, and
+it is remote-gated so it can move without a release.
+
+Trust `dhe`/the docs, not the tool description. Whether the remote config
+currently overrides `dhe` here is **NOT established** — the prose cannot tell you,
+because it is a literal.
+
+### 5. CONFIRMED — live probe: created, listed, no disk write, deleted
+
+Full transcript on this host, from a teammate agent in session
+`5f268f59-fb82-4b3a-a4eb-2b6d4f7584cc`:
+
+```
+CronCreate{cron:"37 3 14 3 *", recurring:false, durable:true}
+  → ERROR: durable crons are not supported for teammates
+           (teammates do not persist across sessions)
+
+CronCreate{cron:"37 3 14 3 *", recurring:false}
+  → Scheduled one-shot task 6cc47c35 (37 3 14 3 *).
+    Session-only (not written to disk, dies when Claude exits).
+
+CronList
+  → 6cc47c35 — 37 3 14 3 * (one-shot) [session-only]: PROBE-573-NOOP…
+
+CronDelete{id:"6cc47c35"} → Cancelled job 6cc47c35.
+```
+
+The cron was scheduled for 14 March — months away and one-shot, so it could not
+fire during the probe; it was deleted regardless. Disk, before and after, with the
+control arm on every negative:
+
+```
+find /Users/rmanaloto -maxdepth 6 -name scheduled_tasks.json  → (empty, both times)
+find /Users/rmanaloto -maxdepth 6 -name scheduled_tasks.lock  → .../dotfiles/.claude/scheduled_tasks.lock
+```
+
+The `.json` negative is armed: the identical `find` locates the `.lock`, so the
+probe can see files of that shape in that place. **Zero durable tasks exist
+anywhere on this machine**, consistent with the gate being off.
+
+The teammate refusal names a *different* reason than the schema text, so I read
+the call sites rather than pick one. Every description is rendered from `$Ue()`
+alone, with no teammate term:
+
+```js
+durable:YU(E.boolean().optional()).describe($bs($Ue()))
+async description(){return Nbs($Ue())}   async prompt(){return Fbs($Ue())}
+async prompt(){return jbs($Ue())}        async prompt(){return Ubs($Ue())}
+```
+
+Both facts are true and independent: the gate is off, *and* teammates are
+separately barred in `validateInput`. The apparent disagreement was two mechanisms,
+not a broken probe.
+
+Two side-findings worth keeping:
+
+- **`CronList` is agent-scoped.** `call()` does
+  `(t?e.filter((o)=>o.agentId===t.agentId):e)` — a teammate sees only its own jobs.
+  A supervisor cannot enumerate a worker's crons.
+- **`CronCreate` needs classifier review in auto mode.**
+  `checkPermissions(){ if(hn(t).mode==="auto") return {behavior:"passthrough",
+  message:"Scheduling a cron prompt requires classifier review."} }` — an
+  autonomous background node cannot silently self-schedule.
+
+### 6. CONFIRMED — the cron scheduler is single-writer per project directory (undocumented)
+
+Creating the probe cron rewrote `.claude/scheduled_tasks.lock` (Jul 5 10:51, 129 B
+→ Aug 5 15:29, 130 B), taking the lock under the *parent session* id:
+
+```json
+{"sessionId":"5f268f59-fb82-4b3a-a4eb-2b6d4f7584cc","pid":98962,
+ "procStart":"Wed Aug  5 01:40:24 2026","acquiredAt":1785961740944}
+```
+
+The acquire function `U$l`:
+
+```js
+async function U$l(e){
+  let r=e?.lockIdentity??Ot(),
+      n={sessionId:r,pid:process.pid,procStart:SIe(),acquiredAt:Date.now()};
+  if(await Fth(n,t)) return …,!0;                      // exclusive create (flag:"wx")
+  let o=await Bth(t);
+  if(o?.sessionId===r){ if(o.pid!==process.pid) await k$e.writeFile(…); return !0 }  // re-entrant
+  if(o&&_C(o.pid)&&await SU(o.pid,o.procStart)){        // holder alive?
+    …C(`[ScheduledTasks] scheduler lock held by session ${o.sessionId} (PID ${o.pid})`);
+    return !1 }                                          // ← second session gets NO scheduler
+  if(o)C(`[ScheduledTasks] recovering stale scheduler lock from PID ${o.pid}`);
+  await k$e.unlink(cjn(t)).catch(()=>{});
+  return await Fth(n,t) ? (…,!0) : !1
+}
+```
+
+So **exactly one live session per project directory runs the cron scheduler**. A
+second concurrent session in the same repo silently gets none — `return !1`, a
+debug log, no user-visible error. Staleness is decided by the same `pid` +
+`procStart` liveness pair the daemon roster's `adopt()` uses (existing ledger row),
+so a crashed holder's lock is recovered rather than leaked.
+
+`$CC/scheduled-tasks.md` documents none of this; its only mention of the file is
+line 217 (scheduling fails when the file or directory is a symlink).
+
+⚠️ **Counting correction, made before publishing.** I first wrote "`grep -c lock`
+→ 0" from memory rather than running it. Actually run:
+`grep -ci lock $CC/scheduled-tasks.md` → **1**, `grep -ci durable` → **1**
+(control: `grep -ci cron` → 15). Reading the hits shows both are false positives
+for the claim:
+
+- line 178 — "the same wall-**clock** moment" (substring, not a lock file)
+- line 187 — "…use Routines or Desktop scheduled tasks for **durable** scheduling"
+  (the English word, not the parameter)
+
+The substantive claims hold — the page documents neither the lock nor the `durable`
+parameter — but the counts I nearly published were wrong, and a bare "0 hits" would
+have been a substring artifact in exactly the shape this agent's founding incident
+warns about. **State the count and read the hits.**
+
+### 7. CONFIRMED — `/loop`'s only "no terminal" route dies with the daemon
+
+`$CC/agent-view.md:396` does confirm the carryover the map flagged:
+
+> "Backgrounding starts a fresh process that resumes from the saved conversation,
+> and in-flight work moves to it: running background shell commands, backgrounded
+> subagents, dynamic workflows, and scheduled tasks you created with `/loop` all
+> carry over and keep running there."
+
+So a `/loop` genuinely survives losing its terminal, and agent view renders it
+(`:124` — "`✢` A `/loop` session sleeping between iterations … run count and a
+countdown"). That is the strongest local case for Claude-side scheduling, and it
+still fails, because of what supervises it. Verbatim from `claude daemon --help`
+on this host:
+
+```
+  Service install is disabled in this version — the daemon runs on demand
+  and exits when the last client disconnects.
+```
+
+`uninstall` is offered; `install` is not. So the background session that hosts the
+carried-over loop has **no service to restart it after logout or reboot**, and the
+supervisor itself exits once the last client disconnects. This re-verifies the
+existing ledger row at 2.1.222 rather than inheriting it.
+
+### 8. REFUTED — `CLAUDE_CODE_LOOP_PERSISTENT` does not make a loop persistent
+
+The most promising-looking discovery of the sweep, and it does not survive reading.
+Both tokens are **0 of 175 doc pages** (control: `CLAUDE_CODE_SUBAGENT_MODEL` → 5
+pages; fresh `CLAUDE_CODE_ZZFRESH8842` → 0), so they are genuinely undocumented —
+but neither confers durability:
+
+```js
+function eTo(){if(te.CLAUDE_CODE_LOOP_PERSISTENT)return!0;
+               return Qe("tengu_kairos_loop_persistent",!1)}
+function Tbs(){return eTo()?qNu:gbs}        // getAutonomousLoopPreamble
+```
+
+`eTo()` (`isLoopPersistentPreambleEnabled`) selects **which preamble text** the
+loop is given, and softens the stop condition — with it on, the loop ends only when
+"newly blocked on a decision you won't make alone"; with it off, also on "third
+straight tick with nothing to do". It is a **prompt variant that makes the model
+less likely to quit**, not a mechanism that outlives the process.
+
+`CLAUDE_CODE_LOOP_KEEPALIVE` is a **fallback heartbeat inside a live session**:
+
+```js
+function r$u(){if(tr(process.env.CLAUDE_CODE_LOOP_KEEPALIVE))return!0;
+               return Qe("tengu_kairos_loop_keepalive",!1)}
+function o$u(e){if(!wKe()){GNt("gate_off");return null}
+  if(y8n()>=Nk_){C("[loop] keepalive budget exhausted (model declined to reschedule twice) — ending loop");
+    GNt("model_stopped",{via_keepalive:!0});return null}
+  return s$u(Lk_,e,{viaKeepalive:!0})}
+```
+
+It re-arms a self-paced loop when the model forgets to, with a budget of two
+declines. Both are session-bound. A name is not a semantics — worth stating plainly
+because "LOOP_PERSISTENT" is precisely the token someone would cite as proof that
+`/loop` can carry an unattended tick.
+
+### 9. CONFIRMED — cloud routines cannot reach this Mac, and floor at 1 hour
+
+Two independent hard stops, either sufficient:
+
+- **Execution locus is Anthropic's infrastructure on a fresh clone.**
+  `$CC/routines.md:13` — "Routines execute on Anthropic-managed cloud
+  infrastructure"; `:73` — "Each repository is cloned at the start of a run,
+  starting from the default branch". The comparison table
+  (`$CC/scheduled-tasks.md:23`) states access to local files: **"No (fresh
+  clone)"**. It cannot see the working tree, cannot run `mise run`, and cannot
+  observe host state. This is verified, not assumed — it was the caller's explicit
+  ask.
+- **Minimum interval is one hour.** `$CC/routines.md` — "The minimum interval is
+  one hour; **expressions that run more frequently are rejected**." A 60 s tick is
+  not merely discouraged, it is refused.
+
+Also: runs carry a few-minutes stagger, count against a daily routine run cap, and
+the feature is in research preview. `/schedule` is a **skill**, not a CLI verb
+(see finding 10), so scripting it means `claude -p "/schedule …"`.
+
+The one genuinely useful piece is the **API trigger**: a per-routine `/fire`
+endpoint taking `Authorization: Bearer`, with an optional `text` payload that
+arrives wrapped in a `<routine-fire-payload>` block marked untrusted (so the
+routine's own prompt must opt into acting on it). That is a real inbound hook from
+this Mac *to* the cloud — which is why the complement below is escalation, not
+ticking.
+
+### 10. CONFIRMED — Desktop tasks run locally, but cannot hold a 60 s tick
+
+The map recorded Desktop tasks as needing "the app open" and left installation
+open. Settled: **the Desktop app is installed and running on this host** —
+`/Applications/Claude.app`, bundle `com.anthropic.claudefordesktop`, version
+1.25927.0, pid 73345. The docs mean this app: `$CC/desktop-quickstart.md:45`
+("Launch Claude from your Applications folder on macOS") and `:53` ("The desktop
+app includes Claude Code").
+
+It is also the surface with the best execution locus of the four — a local run with
+real file access that *could* run `mise`. It still cannot be the tick:
+
+| Property | Value | Source |
+|---|---|---|
+| Requires the app open | **Yes** — "Tasks only run while the desktop app is running and your computer is awake" | `$CC/desktop-scheduled-tasks.md:70` |
+| Sleep behaviour | Run **skipped**; closing the lid still sleeps | `:70` |
+| Stagger | "a small delay of a **few minutes** after the scheduled time" | `:66` |
+| Schedule floor in UI | presets are Manual/Hourly/Daily/Weekdays/Weekly; sub-hour needs asking Claude | `:54-62` |
+| What a run is | "starts a **fresh session**" — a full model session per fire | `:66` |
+| Missed runs | exactly **one** catch-up for the most recent miss, older discarded | `:74` |
+| Task storage | `~/.claude/scheduled-tasks/<task-name>/SKILL.md` | `:101` |
+
+The few-minutes deterministic stagger alone is fatal at 60 s. And each fire is a
+fresh Claude session, so the token cost objection from finding 1 applies with more
+force, not less.
+
+On this host: `~/.claude/scheduled-tasks/` **does not exist** (nor does
+`~/.claude/routines/`), so zero Desktop tasks and zero local routine state are
+currently defined. Control arm: the same `ls` pattern resolves
+`/Applications/Claude.app` and other real paths in the same command.
+
+### 11. SETTLED (was SUSPECT) — the kairos gate is ON; its only consumer is the prompt enqueue
+
+The prior report marked `isKairosCronEnabled` SUSPECT ("not run live; it is a
+feature gate"). Settled without needing a risky probe:
+
+- `FX()` = `!tr(process.env.CLAUDE_CODE_DISABLE_CRON) && hEe("tengu_kairos_cron",!0,H$u)`
+  — env unset here (`[ -n "$CLAUDE_CODE_DISABLE_CRON" ]` → ABSENT, control `HOME` →
+  SET), no `CRON` key in `.claude/settings.json`, and the remote gate defaults
+  `true`. **Cron is enabled on this host** — proven behaviourally by finding 5,
+  where `CronCreate` actually scheduled a job (`isEnabled(){return FX()}` guards
+  all three tools, so a successful call *is* the gate reading true).
+- Its consumer is the block in finding 1 and nothing else: `createCronScheduler` is
+  constructed only there, and `isKilled:()=>!Wdh.isKairosCronEnabled()` lets a gate
+  flip stop a running scheduler mid-session.
+
+So the SUSPECT row resolves to: the gate is on, the scheduler is real and running,
+and it still cannot help — because what it does when it fires is enqueue a prompt.
+
+### 12. CONFIRMED — no other scheduling surface exists at this version
+
+Enumerated by shape, not by expected name:
+
+- **CLI flags**: `claude --help | grep -i "cron|sched|loop|routine|timer|interval"`
+  → **rc=1, zero matches** (control: `grep -c print` → 11).
+- **Hidden subcommands**: probed `schedule`, `cron`, `routines`, `loop`, `timer` —
+  all five return **root help**, i.e. not subcommands. Control arms both ways:
+  `claude attach --help` returns distinct text ("Open the background session in
+  this terminal…"), fresh bogus `claude zzqfresh9931 --help` returns root help. So
+  the probe discriminates, and `/schedule` is a skill only.
+- **Env tokens**: shape-enumerated all 633 `CLAUDE_*`/`ANTHROPIC_*` tokens (this
+  count uses my own regex and is *not* comparable to the ledger's 254/614 figures,
+  which used a different method — do not diff them). Nine match schedule terms;
+  the only load-bearing ones are `CLAUDE_CODE_DISABLE_CRON` (documented) and the
+  two refuted in finding 8. Control: fresh `ZZQ_FRESH_CTRL_5591` → 0,
+  `CLAUDE_CODE_TASK_LIST_ID` → 5.
+- **Settings schema**: 16 of 1,173 zod-shaped keys match schedule terms, and all
+  are internal object fields (`cron`, `crons`, `humanSchedule`, `scheduledFor`,
+  `selfWake`, `rewakeMessage`) or the known statusline `refreshInterval`. **No
+  user-facing settings key changes durability.**
+
+## Pros and cons vs launchd
+
+launchd via mise's `[bootstrap.macos.launchd.agents]`, `start_interval=60`:
+
+| Axis | launchd (incumbent) | Best Claude alternative (Desktop task) |
+|---|---|---|
+| Executes | the literal command, deterministically | a prompt; the model decides what to run |
+| Token cost per tick | **zero** | one full session per fire |
+| Timing accuracy at 60 s | `start_interval` honoured | few-minutes stagger; 60 s not offered in UI |
+| Survives logout / reboot | **yes**, no app or session | no — needs the app open and the machine awake |
+| Survives sleep | fires on wake | run skipped; one catch-up only |
+| Observability when it stops | `launchctl list`, exit status, log file | run history in the app; nothing if the app is closed |
+| Failure mode | process exits non-zero, launchd retries | silently no runs while the app is shut |
+
+launchd's only real weakness is the inverse: it cannot *reason*. That is exactly
+what the complementary roles below are for.
+
+The honest counter-argument, stated rather than argued away: if the
+`tengu_kairos_cron_durable` gate flips on, `CronCreate` gains restart survival and
+becomes a more interesting *watchdog* than it is today. It still would not become a
+tick — findings 1 and 3 are independent of the gate — and it would still need a
+live REPL, so launchd would remain the thing that guarantees a REPL exists.
+
+## Recommended shape
+
+1. **Keep launchd as the tick.** Unchanged from the map's ruling, but now on
+   re-verified evidence at 2.1.222 rather than the morning's inherited note — and
+   with a better reason than "the others are session-only": *the others fire
+   prompts, not commands.*
+2. **COMPLEMENT — Desktop scheduled task as a low-frequency supervisory lane.**
+   A daily or hourly local task ("check the pull-loop's own health: is the launchd
+   agent loaded, is the queue advancing, did any worker wedge?") buys a *reasoning*
+   pass that launchd cannot do, with real file access and a visible run history.
+   Precise role: **repair and report, never tick.** It must never be on the
+   critical path, because it stops silently whenever the app is closed.
+3. **COMPLEMENT — a cloud routine as off-machine escalation.** It runs when the Mac
+   is off and can reach GitHub Issues through connectors, so it can notice "the
+   queue has been stalled for 6 h" and open an issue or PR. Its `/fire` API
+   endpoint also gives the local scheduler an outbound escalation hook. Floor is
+   1 h; it cannot see the working tree.
+4. **Do not use `CronCreate` or `/loop` for anything the framework depends on.**
+   Both are fine for in-session convenience during an interactive debugging
+   session. Neither is a scheduling primitive: session-bound, agent-scoped listing,
+   classifier review in auto mode, 7-day expiry, up to half-period jitter, and a
+   single-writer lock per repo.
+
+If a future session sees `durable: true` start working, re-open only question 2 —
+whether a durable cron makes a *better watchdog* than a Desktop task — and leave
+the tick decision alone.
+
+## Ledger rows to append
+
+| Claim | Verdict | Evidence | Ver | Date |
+|---|---|---|---|---|
+| **A cron/loop fire ENQUEUES A PROMPT, never a command** — `Yv({mode:"prompt",…,skipSlashCommands:!0,priority:"later"})`; a scheduled tick is a model turn, not an exec | CONFIRMED | binary REPL construction site; `CronCreate`'s own text points at `Monitor` for real execution | 2.1.222 | 2026-08-05 |
+| **`CronCreate` has an undocumented `durable` param (0 of 175 pages) that is GATED OFF on this host** — `$Ue()`=`tengu_kairos_cron_durable`, code default `true`, remote gate false here | CONFIRMED | live schema returned the negative branch of all 3 ternaries (`durable`/`CronList`/`CronDelete`); both branches ship in the binary | 2.1.222 | 2026-08-05 |
+| **Durable ≠ unattended even when ON** — a task due while the REPL was closed is missed, deleted, and surfaced via `AskUserQuestion` for confirmation; the scheduler lives in the REPL | CONFIRMED | binary `buildMissedTaskNotification` verbatim | 2.1.222 | 2026-08-05 |
+| ⚠️ **`CronCreate`'s jitter prose ("10% of period, max 15 min") is a HARDCODED LITERAL and contradicts the code** — real default `dhe` is `recurringFrac:0.5, recurringCapMs:1800000` (half the period, 30 min cap), matching the docs. Up to 30 s jitter on a 60 s period | CONFIRMED | template source shows `${YPe}` interpolated in adjacent sentences, jitter numbers not | 2.1.222 | 2026-08-05 |
+| **The cron scheduler is SINGLE-WRITER per project dir** via `.claude/scheduled_tasks.lock` — a second live session in the same repo silently gets no scheduler (`return !1` + debug log); staleness by `pid`+`procStart`, same pair as roster `adopt()` | CONFIRMED | binary `U$l`; live: probe rewrote the lock (Jul 5 → now) under the parent session id; 0 doc mentions | 2.1.222 | 2026-08-05 |
+| **`CronList` is AGENT-SCOPED** — `(t?e.filter((o)=>o.agentId===t.agentId):e)`; a supervisor cannot enumerate a worker's crons. **`CronCreate` needs classifier review in `auto` mode** | CONFIRMED | binary `call()` / `checkPermissions()` | 2.1.222 | 2026-08-05 |
+| **A teammate cannot create a durable cron** — hard `validateInput` guard, independent of the gate | CONFIRMED | live: `errorCode:4` "durable crons are not supported for teammates" | 2.1.222 | 2026-08-05 |
+| ⚠️ **`CLAUDE_CODE_LOOP_PERSISTENT` does NOT make a loop persistent** — it selects the preamble text and softens the stop condition. `CLAUDE_CODE_LOOP_KEEPALIVE` is an in-session fallback heartbeat with a 2-decline budget. Both 0 of 175 docs; neither confers durability | REFUTED | binary `eTo()`/`Tbs()`/`r$u()`/`o$u()`; control `CLAUDE_CODE_SUBAGENT_MODEL` → 5 pages | 2.1.222 | 2026-08-05 |
+| **`/loop` DOES carry over to a background session** (docs confirm), but the supervisor "exits when the last client disconnects" and **service install is disabled in this version** — no logout/reboot survival | CONFIRMED | `$CC/agent-view.md:396`; `claude daemon --help` verbatim (offers `uninstall`, not `install`) | 2.1.222 | 2026-08-05 |
+| **Cloud routines cannot reach the local tree** (fresh clone, Anthropic infra) and **reject sub-hour expressions** | CONFIRMED | `$CC/routines.md:13,73` + "minimum interval is one hour; expressions that run more frequently are rejected" | 2.1.222 | 2026-08-05 |
+| **Claude Desktop IS installed and running on this host** (`com.anthropic.claudefordesktop` 1.25927.0, pid 73345) — but tasks need the app open + machine awake, add a **few-minutes** stagger, and each fire is a **fresh full session**. `~/.claude/scheduled-tasks/` does not exist ⇒ zero tasks defined | CONFIRMED | `Info.plist` + `pgrep`; `$CC/desktop-scheduled-tasks.md:66,70,74` | 2.1.222 | 2026-08-05 |
+| **No scheduling CLI surface exists** — 0 flags in `--help`; `schedule`/`cron`/`routines`/`loop`/`timer` are all NOT subcommands; no settings key confers durability | CONFIRMED | control-armed: `claude attach --help` distinct vs fresh bogus verb → root help; settings scan 16/1173 keys all internal | 2.1.222 | 2026-08-05 |
+| `isKairosCronEnabled` gate is **ON** on this host and its sole consumer is the prompt-enqueue callback (settles the prior SUSPECT row) | CONFIRMED | `FX()` env unset + successful live `CronCreate` (all 3 tools guarded by `isEnabled(){return FX()}`) | 2.1.222 | 2026-08-05 |
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the repo the tick must run `mise run <task>` against; `.claude/` inspected for scheduler state
+- [ray-manaloto/knowledge-base](https://github.com/ray-manaloto/knowledge-base) — offline `agent-harness-docs` claude-code doc tree (175 pages), the semantics corpus for every doc citation above
+
+_No third-party repo source was read; the binary and the offline docs are both local._

--- a/docs/research/kb/reports/agents/573-gh-issues-db.md
+++ b/docs/research/kb/reports/agents/573-gh-issues-db.md
@@ -1,0 +1,801 @@
+# #573 — GitHub Issues as the scheduler database
+
+STATUS: complete
+Date: 2026-08-05
+Branch: `docs/573-pull-loop-scheduler-grill` (research only — nothing committed by this agent)
+Repo under test: `ray-manaloto/dotfiles`
+
+Scope: establish the mechanics of using GitHub Issues as THE scheduler DB for an
+autonomous task DAG (symphony-style pull loop: reconcile → select → dispatch, tick ~60s).
+
+## Method
+
+Per `.claude/rules/research-doc-sources.md`: offline corpora first
+(`~/dev/github/ray-manaloto/knowledge-base/sources/`, dotfiles mintlify cache),
+then docs.github.com, then LIVE read-only probes via `gh api` against
+`ray-manaloto/dotfiles`. Every probe carries a control arm
+(`.claude/rules/probes-need-a-control-arm.md`).
+
+### Corpus inventory (step 00)
+
+- `knowledge-base/sources/` — 36 trees. **No GitHub-docs tree.** (Control arm:
+  the same `ls` shows `agent-harness-docs`, `stokowski`, `symphony`,
+  `OpenSymphony`, so the listing is not blind.) ⇒ GitHub API facts must come
+  from live probes + docs.github.com, not from the KB.
+- `stokowski` / `symphony` / `OpenSymphony` — present, and directly load-bearing
+  for Q4 (the HTML-comment state-block pattern).
+
+### Environment
+
+- `gh` 2.97.0 (2026-07-31), mise-installed at
+  `~/.local/share/mise/installs/github-cli/2.97.0/...`. **Not pinned in
+  `mise.toml` or `.config/mise/conf.d/shared.toml`** (control arm: the same grep
+  finds `ghalint = "1.5.6"` in the shared fragment, so the grep sees the file).
+
+---
+
+## Q1 — Native issue dependencies
+
+### VERDICT: shipped, live on this repo, and the readiness predicate is a single inline field.
+
+#### REST surface (probed live, 2026-08-05)
+
+| Endpoint | Result |
+|---|---|
+| `GET /repos/{o}/{r}/issues/{n}/dependencies/blocked_by` | 200, array of full issue objects |
+| `GET /repos/{o}/{r}/issues/{n}/dependencies/blocking` | 200, array of full issue objects |
+
+Probe (`#573`, which is blocked by the completed probes #564/#565):
+
+```
+$ gh api repos/ray-manaloto/dotfiles/issues/573/dependencies/blocked_by --jq '.[] | "\(.number) \(.state)"'
+564 closed
+565 closed
+$ gh api repos/ray-manaloto/dotfiles/issues/564/dependencies/blocking --jq '.[] | "\(.number) \(.state)"'
+572 open
+573 open
+```
+
+Both directions are readable, and the reverse edge is symmetric (#573 blocked_by #564 ⇔ #564 blocking #573).
+
+#### ⭐ THE LOAD-BEARING FACT — `issue_dependencies_summary`
+
+Every issue object carries an inline computed summary:
+
+```json
+"issue_dependencies_summary": {"blocked_by":0, "blocking":4, "total_blocked_by":2, "total_blocking":4}
+```
+
+That is `#573`, whose **two blockers are both CLOSED**. So:
+
+- **`total_blocked_by`** = the edge count (all blockers, any state) = 2
+- **`blocked_by`** = **the OPEN blocker count** = 0
+
+⇒ **A CLOSED blocker counts as SATISFIED, and `blocked_by == 0` is the entire
+readiness predicate.** No traversal, no per-blocker fetch.
+
+**Control arm** (the field can produce the other answer — and it arrived from
+real data, no fixture needed): on the same list call, `#579`–`#583` report
+`"blocked_by":1` with `"total_blocked_by":1`. So the field is not stuck at 0;
+it discriminates. Reported both arms: `#573 → 0` (blockers closed),
+`#579 → 1` (blocker open).
+
+#### ⭐ It is present on the LIST endpoint too
+
+```
+$ gh api "repos/ray-manaloto/dotfiles/issues?state=open&per_page=5" \
+    --jq '.[] | "\(.number) deps=\(.issue_dependencies_summary)"'
+583 deps={"blocked_by":1,"blocking":0,"total_blocked_by":1,"total_blocking":0}
+582 deps={"blocked_by":1,"blocking":1,"total_blocked_by":1,"total_blocking":1}
+...
+```
+
+⇒ **One paginated list call returns the whole ready-set.** The scheduler never
+needs a per-candidate dependency fetch to decide readiness. This is the single
+biggest fact for the rate budget (Q3).
+
+Also inline on the same objects: `sub_issues_summary {total, completed,
+percent_completed}` and `parent_issue_url` — so the parent/child hierarchy is
+free on the same call as well.
+
+#### GraphQL surface
+
+`Issue` type introspection (`__type(name:"Issue"){fields{name}}`) filtered for
+block/depend/parent:
+
+```
+blockedBy
+blocking
+issueDependenciesSummary
+parent
+subIssues
+subIssuesSummary
+```
+
+**Control arm:** the same introspection with an exact-match grep returns
+`title`, `number`, `state`, `assignees` — so the introspection is not blind and
+the six names above are real fields, not a grep artifact.
+
+#### `gh` CLI support — full, at the pinned 2.97.0
+
+`gh` is **not pinned** in `mise.toml`/`shared.toml`; the installed mise build is
+**2.97.0 (2026-07-31)**. It supports dependencies natively:
+
+| Verb | Flags |
+|---|---|
+| `gh issue create` | `--blocked-by numbers`, `--blocking numbers` |
+| `gh issue edit` | `--add-blocked-by`, `--add-blocking`, `--remove-blocked-by`, `--remove-blocking` |
+| `gh issue list` / `view` | `--json blockedBy,blocking,parent,subIssues,subIssuesSummary` |
+
+```
+$ gh issue list --limit 3 --state open --json number,state,blockedBy,blocking
+[{"blockedBy":{"nodes":[{"number":582,"state":"OPEN",...}],"totalCount":1},
+  "blocking":{"nodes":[]},"number":583,"state":"OPEN"}, ...]
+```
+
+⚠️ **GAP: `issueDependenciesSummary` is NOT exposed to `gh --json`.**
+
+```
+$ gh issue list --limit 1 --json number,issueDependenciesSummary
+Unknown JSON field: "issueDependenciesSummary"
+```
+
+**Control arm:** the same error prints the available-field list, which *does*
+include `blockedBy`, `blocking`, `subIssuesSummary`, `parent` — so the field
+name is genuinely unsupported by the CLI, not mistyped, and the probe can see
+sibling fields.
+
+⇒ Via `gh`, the scheduler must compute open-blocker count **client-side** from
+`blockedBy.nodes[].state` (each node carries `state`, so it is a one-line
+filter). Via raw REST/GraphQL, the precomputed `blocked_by` field is available.
+Either is one round-trip; the `gh` path just moves the filter to the client.
+
+---
+
+## Q3 — Rate budget
+
+### VERDICT: a 60s tick is essentially FREE. The binding constraint is not the core limit.
+
+#### ⭐ Conditional GET works and a 304 costs ZERO
+
+```
+1) capture etag (a real 200)                        X-Ratelimit-Used: 25
+2) five consecutive 304s, NO intervening 200:
+   HTTP/2.0 304 Not Modified   X-Ratelimit-Used: 25
+   ... (x5, all 25)
+3) CONTROL ARM — a real 200 right after:            X-Ratelimit-Used: 26
+```
+
+Five 304s consumed **0** budget; the next 200 incremented by 1, so the counter
+was live and the probe discriminates. `GET /repos/{o}/{r}/issues?state=open` on
+this repo returns a weak ETag
+(`W/"fe85a23c…"`), and `If-None-Match` yields 304.
+**Second control arm:** a deliberately bogus `If-None-Match: W/"bogus0000"`
+returned **200 OK**, proving the 304s were real cache hits and not an
+unconditional response.
+
+⇒ **An idle tick (nothing changed since last poll) costs nothing.** Only ticks
+where the issue set actually changed spend budget.
+
+#### Budget arithmetic (authenticated REST, core = 5000/hr)
+
+At 60 ticks/hour, worst case (every tick sees change):
+
+| Per tick | Requests | /hour |
+|---|---|---|
+| (a) list open issues + label filter, `per_page=100`, 1 page (repo has 132 open) | 2 | 120 |
+| (b) dependency fetch for candidates | **0** — inline in (a) | 0 |
+| (c) occasional mutations (claim/label/comment/close) | ~1–3 | ~60–180 |
+| **Total** | | **~180–300/hr** |
+
+That is **4–6% of the 5000/hr core budget**, and with ETags the realistic
+figure is far lower. There is ~16–25× headroom.
+
+⚠️ Note (b) is zero *only because* `issue_dependencies_summary` /
+`blockedBy.nodes[].state` ride inline on the list response (Q1). A naive design
+that fetched `/dependencies/blocked_by` per candidate would cost
+`ticks × candidates` — at 60 ticks × 30 candidates that is 1800/hr, and it
+would be the dominant cost for no benefit.
+
+#### One round-trip for "open issues + their blockers' states": YES
+
+Verified live:
+
+```graphql
+{ repository(owner:"ray-manaloto", name:"dotfiles") {
+    issues(first:3, states:OPEN, orderBy:{field:UPDATED_AT, direction:DESC}) {
+      totalCount
+      nodes { number title state
+        issueDependenciesSummary { blockedBy blocking totalBlockedBy totalBlocking }
+        blockedBy(first:5) { totalCount nodes { number state } }
+        assignees(first:3){nodes{login}}
+        labels(first:5){nodes{name}} } } } }
+```
+
+→ returns, in one call:
+
+```
+573 sum={"blockedBy":0,...,"totalBlockedBy":2} blockedBy=[{565,CLOSED},{564,CLOSED}] labels=["wayfinder:grilling"]
+```
+
+⇒ number, state, readiness summary, every blocker with its state, assignee
+(the claim field) and labels — **one request per tick** for the entire
+reconcile+select input.
+
+#### ⚠️ TRAP: the `/rate_limit` endpoint disagreed with the response headers
+
+| Probe | core used | core remaining |
+|---|---|---|
+| `GET /rate_limit` body **and its own headers** | 3 | 4997 |
+| `X-Ratelimit-*` on `GET /repos/.../issues` | 22–26 | 4978–4974 |
+
+Both self-report `X-Ratelimit-Resource: core`. The `/rate_limit` figure stayed
+frozen at 3 across a dozen real calls while the response headers tracked usage
+correctly and monotonically.
+
+⇒ **Self-throttle on `X-Ratelimit-Remaining` from the actual response, never on
+`GET /rate_limit`.** A scheduler that polls `/rate_limit` to decide whether it
+has budget would be reading a number that does not move.
+
+#### The real constraint is the SEARCH bucket, not core
+
+`GET /rate_limit` reports `search: {limit: 30}` — **30 requests/minute**. A 60s
+tick using the Search API (`GET /search/issues`, or `gh issue list --search`)
+sits inside a 30/min bucket rather than 5000/hr, i.e. ~2000× tighter per unit
+time. It is still ample for one tick/minute, but it removes the headroom that
+makes retries and multi-query ticks safe.
+
+⇒ **Prefer `GET /repos/{o}/{r}/issues` (core) or GraphQL over the Search API**
+for the tick. Use search only for genuinely cross-repo or full-text queries.
+
+---
+
+## Q1b — Closed / reopened blocker semantics (LIVE MUTATION PROBE)
+
+### VERDICT: `blocked_by` is computed live from the blocker's CURRENT state. Closing satisfies; reopening re-blocks.
+
+Fixture: scratch issue **#589** (`[probe-573] …`, created and cleaned up in this
+session) attached as a blocker of the real open ticket **#571**, whose baseline
+was `blocked_by=0, total_blocked_by=0`.
+
+| Step | Action | `#571` summary | Reading |
+|---|---|---|---|
+| A | (baseline, no edge) | `blocked_by=0 total_blocked_by=0` | control: starts clean |
+| B | add edge `#571 blocked_by #589`, **#589 OPEN** | `blocked_by=1 total_blocked_by=1` | an OPEN blocker blocks |
+| C | **close #589** | `blocked_by=0 total_blocked_by=1` | ⭐ a CLOSED blocker is SATISFIED — and the edge survives (`total` stays 1) |
+| D | **reopen #589** | `blocked_by=1 total_blocked_by=1` | ⭐ REOPENING RE-BLOCKS |
+
+This probe is fully armed: the **same object produced both answers** (1 → 0 → 1)
+under state changes alone, with no edge mutation. So `blocked_by` is a live
+computation over the blockers' current states, not a latched flag.
+
+**Design consequences:**
+
+1. **Selection predicate = `blocked_by == 0`.** "No OPEN blockers" is exactly
+   right, and GitHub computes it for you.
+2. **`gh issue close` IS the completion signal** that releases dependents. No
+   separate "mark satisfied" step exists or is needed.
+3. ⭐ **Reopening is a free human veto / retraction.** A human who reopens a
+   completed task automatically re-blocks everything downstream on the next
+   tick. That is a genuinely valuable HITL affordance that falls out for free —
+   but it also means the scheduler must tolerate a node going from
+   ready→blocked **after** it was dispatched, and must not assume readiness is
+   monotonic.
+4. Edges are **permanent and independent of state** — `total_blocked_by` never
+   moved. The DAG topology and the completion state are separate axes.
+
+---
+
+## Q1c — ⚠️ DAG integrity: cycle detection is SHALLOW
+
+### VERDICT: GitHub rejects direct 2-node cycles and self-edges, but ACCEPTS transitive (3+ hop) cycles. The scheduler MUST do its own cycle detection.
+
+**Rejected** (server-side validation, `rc=1`, no state change):
+
+```
+$ gh issue edit 589 --add-blocked-by 571      # while 571 is already blocked_by 589
+Validation failed: this dependency would create a cycle where the target is
+already blocked by the source (addBlockedBy)
+
+$ gh issue edit 589 --add-blocked-by 589      # self
+Validation failed: Target issue cannot be the same as the source issue (addBlockedBy)
+```
+
+**ACCEPTED** — the 3-hop case. Real pre-existing chain
+`#583 blocked_by #582`, `#582 blocked_by #574`. Adding `#574 blocked_by #583`
+closes the loop:
+
+```
+$ gh issue edit 574 --add-blocked-by 583
+https://github.com/ray-manaloto/dotfiles/issues/574     # rc=0, SUCCESS
+
+$ gh api .../issues/574/dependencies/blocked_by --jq '[.[]|"\(.number):\(.state)"]'
+["573:open","583:open"]                                  # the cycle exists
+```
+
+⇒ **A 3-node cycle is a permanent deadlock**: all three nodes hold
+`blocked_by > 0` forever, none can ever be selected, and nothing surfaces it.
+The pull loop would simply skip them silently every tick, indefinitely.
+
+**Mitigation:** the scheduler must run its own transitive cycle check — either
+at edge-creation time, or as a reconcile-phase invariant that alarms when a
+strongly-connected component of size > 1 appears in the blocked-by graph. The
+whole graph is available cheaply (Q3), so an SCC pass per tick is affordable.
+
+> Restored: the edge was removed with `--remove-blocked-by 583`; `#574` is back
+> to `blocked_by=[573]`, summary `{blocked_by:1, blocking:2, total_blocked_by:1,
+> total_blocking:2}`, and `#583 blocking` is back to `[]` — both verified against
+> the pre-probe readings.
+
+### ⚠️ Two more operational gotchas from the same probe
+
+1. **The dependency summary is EVENTUALLY CONSISTENT.** Immediately after the
+   successful write, `issue_dependencies_summary` still read
+   `{blocked_by:1, total_blocked_by:1}` (stale) while the edge had in fact been
+   created; a re-read ~3s later showed `{blocked_by:2, total_blocked_by:2}`.
+   The `/dependencies/blocked_by` list endpoint was correct sooner than the
+   inline summary. ⇒ **Do not read back your own write to confirm it.** A
+   scheduler that writes then immediately re-reads will make decisions on stale
+   data. Treat the tick's snapshot as authoritative and let the next tick
+   reconcile.
+2. **Adding an existing edge is NOT idempotent** — it errors:
+   `Validation failed: Target issue has already been taken (addBlockedBy)`,
+   `rc=1`. Reconcile logic must diff before writing, or tolerate this specific
+   error as benign.
+
+---
+
+## Q2 — Claim mechanics
+
+### VERDICT: there is NO conditional-write surface on issues. With a single scheduler process the race IS moot — say so and move on.
+
+#### No compare-and-swap, confirmed with a control arm
+
+```
+$ gh api -X PATCH .../issues/589 -H 'If-Match: "<valid-or-bogus>"' -f 'body=…'
+HTTP/2.0 400 Bad Request
+{"message":"Bad Request","errors":["Conditional request headers are not allowed
+ in unsafe requests unless supported by the endpoint"],"status":"400"}
+
+# CONTROL ARM — same request, no If-Match:
+HTTP/2.0 200 OK          # and the body really changed
+```
+
+Both a *valid* current ETag and a *bogus* one produced the identical 400, and
+the control proves the command shape works. So the 400 is the endpoint refusing
+preconditions outright — not a failed precondition. **`If-Match` on issues is
+not "unsupported and ignored", it is a hard error.**
+
+GraphQL is the same story:
+
+| Input type | Precondition field? |
+|---|---|
+| `UpdateIssueInput` | none (`clientMutationId id title body assigneeIds assignees milestoneId labelIds labels state stateInput projectIds issueTypeId issueType agentAssignment`) |
+| `AddAssigneesToAssignableInput` | none |
+| `CloseIssueInput` | none |
+| **`CreateCommitOnBranchInput`** (CONTROL) | **`expectedHeadOid`** ✅ |
+
+**The control arm is decisive**: GitHub's GraphQL API *does* implement
+compare-and-swap where it wants to (`expectedHeadOid` on commit creation), and
+the same introspection sees it. Its absence on every issue mutation is a real
+absence, not a blind probe.
+
+#### Assignee is a SET, not a lock
+
+- `POST /issues/{n}/assignees` is **additive and idempotent** — assigning the
+  same user twice returns `rc=0` and no duplicate.
+- Issues accept **up to 10 assignees**; `.assignee` is merely `assignees[0]`.
+- ⇒ Two writers both "claiming" by assignee **both succeed**; you get two
+  assignees, not a winner and a loser. Assignment can never be a mutex.
+
+#### ⚠️ TRAP: a claim write can SILENTLY no-op
+
+```
+$ gh api -X POST .../issues/589/assignees -f "assignees[]=definitely-not-a-collaborator-zzq"
+["sortakool"]            # rc=0, no error, assignee list UNCHANGED
+```
+
+GitHub silently drops assignees who lack push access. A claim that never landed
+returns success. ⇒ **Verify the claim from the mutation's OWN response body**
+(which contains the resulting assignee list) — not from `rc`, and not from a
+re-read (see the eventual-consistency trap in Q1c).
+
+#### Answer for this design: the race is moot, and that is load-bearing
+
+With **one scheduler process doing all claiming**, there is no concurrent
+writer, so the absence of CAS costs nothing. This is worth stating explicitly
+in the design doc because it is the assumption that makes GitHub Issues viable
+as a scheduler DB at all — **the single-writer constraint is not an
+implementation detail, it is the concurrency model.** Two schedulers against
+one repo would have no primitive to arbitrate between them.
+
+Guardrails that follow:
+
+1. **Enforce single-writer at the process level** — a local lockfile / launchd
+   `KeepAlive` single instance. GitHub will not do it for you.
+2. **Make dispatch idempotent anyway**, since the scheduler can crash between
+   "claim" and "dispatch" and restart: derive intent from observed state each
+   tick rather than from a remembered in-flight list.
+3. If multi-writer ever becomes real, the standard patterns are: partition the
+   work space so writers never contend (label/assignee-scoped shards), or move
+   the lock off GitHub entirely (the repo already has a `flock` precedent). A
+   "claim by comment then read-back-lowest-id" quorum over an eventually
+   consistent store is **not** safe — see the Q1c lag measurement.
+
+---
+
+## Q4 — Where machine state should live
+
+### VERDICT: LABELS for anything the selector reads; APPEND-ONLY COMMENTS for retry counts, terminal reasons and stall timestamps. Never the body.
+
+#### The measurements
+
+| Surface | Concurrent-edit safety | Visible to the tick? | Cost to read |
+|---|---|---|---|
+| **Labels** | ⭐ `POST` is **additive** (`["wayfinder:prototype"]` → `["wayfinder:map","wayfinder:prototype"]`), repeat is **idempotent** (rc=0, no dup), `DELETE /labels/{name}` is **surgical** (leaves the others) | ✅ inline in the list response | **free** |
+| **Comments** | ⭐ **append-only — structurally cannot clobber**; every write is a new object with its own id | ✅ bumps `updated_at`, invalidates the list ETag | ⚠️ **+1 request per issue** — the list response carries only a comment *count* |
+| **Body** | ❌ `PATCH` replaces the **whole** body; read-modify-write with no CAS (Q2) | ✅ inline | free |
+
+Evidence for each:
+
+```
+# labels: additive + idempotent + surgical  (all rc=0)
+POST labels[]=wayfinder:prototype   -> ["wayfinder:prototype"]
+POST labels[]=wayfinder:map         -> ["wayfinder:map","wayfinder:prototype"]   # first preserved
+POST labels[]=wayfinder:map (again) -> ["wayfinder:map","wayfinder:prototype"]   # no dup, rc=0
+DELETE labels/wayfinder:map         -> ["wayfinder:prototype"]                    # surgical
+DELETE labels/wayfinder:map (again) -> 404 "Label does not exist"                 # must tolerate
+
+# server-side label filter narrows the tick for free
+?state=open&labels=wayfinder:prototype -> 4        (control, unfiltered -> 100 of 132 open)
+
+# comments are a COUNT in the list response, not bodies
+.[0] -> {"number":589, "comments_is_a_COUNT":1, "has_comment_bodies":false}
+
+# BODY CLOBBER, measured: one PATCH replaced a 250-char body with 13 chars, rc=0, no warning
+{"body_now":"probe-control","len":13}
+```
+
+#### The stokowski / Sugar-Coffee pattern — verified, with one caveat
+
+Source: `knowledge-base/sources/stokowski/stokowski/tracking.py:13-26`.
+
+```python
+STATE_PATTERN = re.compile(r"<!-- stokowski:state ({.*?}) -->")
+GATE_PATTERN  = re.compile(r"<!-- stokowski:gate ({.*?}) -->")
+
+def make_state_comment(state, run=1):
+    payload = {"state": state, "run": run, "timestamp": datetime.now(timezone.utc).isoformat()}
+    machine = f"<!-- stokowski:state {json.dumps(payload)} -->"
+    human   = f"**[Stokowski]** Entering state: **{state}** (run {run})"
+    return f"{machine}\n\n{human}"
+```
+
+Two design properties worth stealing outright:
+
+1. **Each transition is a NEW comment, never an edit** — `parse_latest_tracking`
+   (`tracking.py:72`) reads comments oldest-first and folds to the latest entry.
+   The current state is a *fold over an append-only event log*, which is why it
+   survives crashes and cannot be clobbered by a concurrent human.
+2. **Machine payload + human sentence in the same comment.** The HTML comment is
+   invisible in rendered markdown, so the thread stays readable to a human while
+   staying parseable to the loop.
+
+I reproduced it end-to-end on the scratch issue — write, then parse back:
+
+```
+posted: <!-- sched:state {"state":"running","attempt":1,"ts":"..."} --> + human line
+parsed: {"state":"running","attempt":1,"ts":"2026-08-05T19:00:00Z"}
+```
+
+⚠️ **CAVEAT — stokowski runs on LINEAR, not GitHub.** `tracking.py:1` is
+literally *"State machine tracking via structured Linear comments."* The pattern
+transfers (comments are append-only on both), but no claim about GitHub
+behaviour should be inherited from it. Everything above is measured on GitHub
+directly.
+
+#### Recommended split
+
+- **Labels** — the scheduler's *selector* state, the small bounded vocabulary the
+  tick filters on: `sched:ready`, `sched:running`, `sched:failed`,
+  `sched:needs-human`. Free to read, server-side filterable, additive writes,
+  and a human can retract one by clicking it off. Keep this set **small and
+  mutually exclusive by convention**; nothing enforces exclusivity.
+- **Comments** — the *unbounded / append-only* facts: retry counts, terminal
+  reasons, stall timestamps, dispatch receipts. Full audit trail for free, and
+  crash recovery by folding. Pay the +1 request only for issues the label filter
+  already selected — never for the whole repo.
+- **Body** — ❌ **never** for machine state. It is the one surface where a
+  concurrent human edit and a scheduler write destroy each other, with no CAS to
+  prevent it. This repo has already been bitten: memory
+  `feedback_issue_body_edit_needs_anchor_assert` records an empty fetch
+  replace-no-op'ing to `""` and pushing a **wiped body at rc=0**.
+
+#### ⚠️ The scheduler's own writes defeat its ETag cache
+
+Measured: posting one state comment changed the list ETag
+(`W/"ad2d246d…"` → `W/"fb180533…"`) and bumped `updated_at`
+(`19:34:13Z` → `19:34:36Z`).
+
+⇒ Every tick that writes anything invalidates the next tick's free 304. Idle
+ticks stay free; active ticks pay. This also means **`updated_at` cannot
+distinguish a human's change from the scheduler's own** — corroborating the
+existing memory `feedback_github_updated_at_advances_on_comment` ("a
+post-then-compare gate can ONLY fail"). Track your own last-written marker if
+you need to detect human edits.
+
+---
+
+## Q5 — Event-driven surfaces (scope extension: event loop, not fixed tick)
+
+### VERDICT (stated up front): for ~minute-scale latency, **event forwarding is NOT worth its moving parts.** Use conditional polling + a periodic full reconcile. See "The verdict" below for why the deciding fact is Q5c, not the transport.
+
+### Q5a — `gh webhook forward`: NOT available at the pinned version
+
+```
+$ gh webhook --help
+unknown command "webhook" for "gh"
+```
+
+**Control arm:** `gh api --help` on the same binary prints its real help text, so
+the binary and the probe work; `webhook` is genuinely absent from gh 2.97.0's
+command list. It is not a built-in — it ships as the **`cli/gh-webhook`
+extension**, and `gh extension list` here shows only `gh-copilot` and
+`gh-stack`, so it is **not installed**.
+
+**What I VERIFIED about the extension** (`gh api repos/cli/gh-webhook`):
+
+| Fact | Value |
+|---|---|
+| Repo exists, not archived | ✅ `cli/gh-webhook` |
+| Last pushed | **2025-10-21** — ~9.5 months stale as of 2026-08-05 |
+| Stars | 42 |
+| README | **124 bytes**, in full: *"An extension for the GitHub CLI to chatter with Webhooks. To install: `gh extension install cli/gh-webhook`"* |
+
+**Control arm for that README claim:** an initial grep for
+`forward|admin|token|scope|localhost|missed|replay|reconnect` returned nothing,
+which is only meaningful once the fetch is proven to work — it decoded to 124
+bytes containing `webhook` ×3. So the empty grep is a **true absence**: the
+extension documents none of its own semantics.
+
+⚠️ **LABELLED UNVERIFIED — I did NOT probe its runtime behaviour.** Doing so
+requires installing the extension, minting an **admin-scoped** token and
+**creating a real repo webhook** on `ray-manaloto/dotfiles`, all of which exceed
+a read-only research pass. So the following are **reasoned expectations, not
+measurements**, and must be re-derived before any design depends on them:
+reconnect behaviour, whether events firing while the forwarder is down are
+replayed, and the exact token scope required.
+
+**But the verdict does not rest on them.** What it rests on is measured: an
+undocumented, 9-months-untouched, 42-star extension whose reliability posture
+**cannot be established from its own documentation** is a poor foundation for a
+scheduler's correctness — and Q5c (below) shows the polling path is required
+regardless, so the extension could only ever be a latency optimisation on top of
+a mechanism that cannot be removed.
+
+### Q5b — Conditional polling: measured, and cheap
+
+**Do 304s count against the rate limit? NO** — measured in Q3 above: five
+consecutive `If-None-Match` 304s left `X-Ratelimit-Used` frozen at 25, and the
+next unconditional 200 incremented it to 26 (control arm: a bogus ETag returned
+200, so the 304s were real).
+
+Surface support, probed directly:
+
+| Surface | ETag | `Last-Modified` | `X-Poll-Interval` |
+|---|---|---|---|
+| `GET /repos/{o}/{r}/issues` | ✅ `W/"fe85a23c…"` | ❌ **absent** (header count 0) | — (no floor) |
+| `GET /repos/{o}/{r}/events` | ✅ `W/"fe8d85e6…"` | ✅ `Wed, 05 Aug 2026 19:35:41 GMT` (count 1) | ⚠️ **60** |
+| `GET /notifications` | ✅ `W/"0f618867…"` | ✅ `Wed, 05 Aug 2026 19:39:48 GMT` | ⚠️ **60** |
+| `GET /issues/{n}/timeline` | ✅ `W/"2fe08ac6…"` | — | — |
+
+**Control arm for the "no `Last-Modified` on issues" claim:** the identical
+`grep -ic '^last-modified'` returned **1** on the events endpoint and **0** on
+the issues endpoint, so the probe can see the header when it is there. Issues
+support **`If-None-Match` only**, not `If-Modified-Since`.
+
+⇒ **Both the Events API and the Notifications API self-document a 60-second
+polling floor** (`X-Poll-Interval: 60`). Polling either faster is abusive and can
+get you throttled. The **issues list endpoint carries no `X-Poll-Interval`**, so
+it has no declared floor — it is governed only by the core rate limit, which Q3
+showed has 16–25× headroom.
+
+**Notifications API is a poor fit regardless of its headers:** it only covers
+threads you are *subscribed* to, and advancing its cursor (`last_read_at` /
+marking read) is a **mutation**, so the read path has a write side-effect. For a
+scheduler that must see every issue in the DAG — including ones nobody is
+watching — subscription-scoped delivery is the wrong shape.
+
+**Production tick shape confirmed.** The conditional GET works with the label
+filter applied (query params are part of the cache key, so this needed its own
+check):
+
+```
+GET /repos/.../issues?state=open&labels=wayfinder:prototype&per_page=100
+  If-None-Match: <etag>  -> HTTP 304, X-Ratelimit-Used: 84
+  If-None-Match: <etag>  -> HTTP 304, X-Ratelimit-Used: 84   # zero cost
+  CONTROL, bogus etag    -> HTTP 200
+```
+
+⇒ For a ~60s target latency the issues-list conditional poll is the better
+primitive: same latency as the Events API's own floor, no declared floor of its
+own, zero cost when idle, and it returns the **full readiness state** (Q1)
+rather than a delta you have to apply.
+
+### Q5c — ⭐ THE DECIDING FACT: dependency changes emit NO event
+
+Natural experiment with known ground truth: at **19:31:37** I added
+`#571 blocked_by #589` and at **19:35:36** I removed it. Both are real,
+timestamped, confirmed mutations.
+
+**Per-issue timeline — PRESENT.** Both REST and GraphQL record them:
+
+```
+$ gh api repos/.../issues/571/timeline --jq '.[] | "\(.created_at) \(.event)"'
+2026-08-05T19:31:37Z blocked_by_added
+2026-08-05T19:35:36Z blocked_by_removed
+```
+
+GraphQL types them as `BlockedByAddedEvent` / `BlockedByRemovedEvent`. The
+`IssueTimelineItems` union (51 members) contains `BlockedByAddedEvent`,
+`BlockedByRemovedEvent`, `BlockingAddedEvent`, `BlockingRemovedEvent`
+(control arm: the same introspection also returns the known members
+`LabeledEvent`, `AssignedEvent`, `ClosedEvent`, `IssueComment`).
+
+**Repo Events API — ABSENT.**
+
+```
+$ gh api "repos/.../events?per_page=100" \
+    --jq '[.[] | select((.payload.issue.number//0) | .==571 or .==574) | …]'
+NONE
+```
+
+**Control arm (this is what makes the negative trustworthy):** the *same call*,
+over a window spanning `09:06:43Z → 19:35:40Z` (100 events), returns eleven
+events for scratch issue `#589` at `19:31:25`–`19:35:41` — `opened`, `closed`,
+`reopened`, `assigned`, `labeled` ×2, `unlabeled` ×2, and two
+`IssueCommentEvent`s. Those timestamps **bracket** the two dependency edits.
+So the Events API was demonstrably watching this repo, in this window, and
+recording my activity — it simply does not emit dependency changes.
+
+⇒ **Topology changes are discoverable ONLY by re-query. A periodic full
+reconcile pass is MANDATORY, not optional.** No event transport — webhook
+forwarding included — removes this requirement.
+
+#### The nuance that matters for the design
+
+The *state* change that releases a dependent **is** emitted; the *topology*
+change is not. `#589 closed` and `#589 reopened` both appear as `IssuesEvent`s,
+and those are exactly the transitions that flipped `#571.blocked_by` 1→0→1
+(Q1b). So an event-driven loop can react promptly to **completions** — provided
+it already holds the graph — but it can never learn that an **edge** was added
+or removed except by asking.
+
+Practical split:
+
+- **Completion latency** → can be event-driven (an `IssuesEvent closed` arrives
+  promptly), but only re-derives readiness correctly if the cached graph is current.
+- **Topology latency** → bounded by the reconcile period, full stop.
+
+Since the reconcile pass has to run anyway and already returns complete
+readiness in one round-trip (Q3), it also covers completions — making the event
+path redundant rather than complementary at minute scale.
+
+### Q5d — `workflow_run` / `check_suite` as CI-completion signals
+
+These are **webhook event types**, not issue events, and they are the correct
+signal for "CI finished" — `workflow_run` with `action: completed` carries
+`conclusion` (`success`/`failure`/`cancelled`), and `check_suite` likewise.
+Neither appears in the repo Events API histogram from my probe window
+(`CreateEvent, DeleteEvent, IssueCommentEvent, IssuesEvent, PullRequestEvent,
+PullRequestReviewCommentEvent, PullRequestReviewEvent, PushEvent` — control arm:
+`PushEvent` ×6 and `PullRequestEvent` ×11 are present, so the histogram sees CI-adjacent
+activity), which is expected: the Events API deliberately excludes Actions events.
+
+For this repo the pull-based equivalents already exist and are what the repo's
+own rules mandate: `gh run list --json conclusion`, `gh pr checks <n> --json`,
+and per `.claude/rules/gh-cli-watch.md` the `--watch` flags. Those are pull, they
+carry no NAT requirement, and `verify-before-advancing.md` already requires
+cross-verifying `gh run watch --exit-status` against
+`gh run view --json conclusion` because the watch exit code has lied. Adding a
+webhook transport for CI completion would introduce a second, less-trusted path
+to a fact the repo already reads reliably by polling.
+
+### The verdict
+
+**Cheap conditional polling + a periodic full reconcile. Do not build event
+forwarding.**
+
+The reasoning is not "webhooks are hard" — it is that **Q5c makes the reconcile
+pass non-optional**. Once you must poll to see topology at all, the event path
+buys only sub-minute completion latency, and:
+
+| | Conditional poll + reconcile | + `gh webhook forward` |
+|---|---|---|
+| Learns topology changes | ✅ | ❌ still needs the poll |
+| Cost when idle | **0** (304) | 0, plus a live tunnel |
+| Moving parts | one `gh api` call | extension + admin token + tunnel + repo webhook + reconnect/replay logic |
+| Behind NAT | ✅ native | needs the forwarder up continuously |
+| Missed-event recovery | inherent (next tick re-reads truth) | manual redelivery; **still needs the poll** |
+| Latency | ~60s | ~seconds |
+
+The design's stated target is **~minute-scale**, which the polling path already
+meets — the Events API's own `X-Poll-Interval: 60` is the same number. Event
+forwarding would trade a large increase in failure modes for latency the
+requirement does not ask for.
+
+**Recommended loop shape:**
+
+1. **Tick every ~30–60s**: one conditional `GET /repos/{o}/{r}/issues?state=open&labels=…`
+   with `If-None-Match`. A 304 (nothing changed) costs **zero** budget and ends
+   the tick immediately.
+2. **On 200**: the response already contains `issue_dependencies_summary`,
+   labels, assignees and blocker states — run reconcile → select → dispatch off
+   that single snapshot (Q1/Q3).
+3. **Periodic deep reconcile** (every N ticks): re-read the full blocked-by
+   graph and run the **SCC/cycle check** from Q1c, which nothing else will
+   surface.
+4. **Do not** trust a read-back of your own write (Q1c eventual consistency);
+   let the next tick observe it.
+5. Revisit event forwarding only if the latency target drops below ~10s.
+
+---
+
+## Cleanup / restoration
+
+All live mutations were reverted and verified against pre-probe baselines:
+
+| Object | Pre-probe | Post-probe | OK |
+|---|---|---|---|
+| `#571` summary | `{0,0,0,0}`, assignees `[]` | `{0,0,0,0}`, assignees `[]`, blocked_by list `[]` | ✅ |
+| `#574` blocked_by | `[573]`, `{blocked_by:1,blocking:2,total_blocked_by:1,total_blocking:2}` | identical | ✅ |
+| `#583` blocking | `[]` | `[]` | ✅ |
+| `#589` (scratch) | n/a — created by this probe | **closed**, labels `[]`, no edges | ✅ |
+
+---
+
+## Summary of what makes this HARDER than expected
+
+1. **Transitive cycles are accepted** (Q1c) — GitHub guards only the 2-node and
+   self cases. A 3-node cycle is a silent permanent deadlock. Own the SCC check.
+2. **No CAS anywhere on issues** (Q2) — single-writer is the concurrency model,
+   not an optimization. Enforce it locally.
+3. **Claim writes can silently no-op** (Q2) — verify from the response body.
+4. **Eventual consistency on the dependency summary** (Q1c) — never read back
+   your own write to confirm it.
+5. **`gh --json` cannot see `issueDependenciesSummary`** (Q1) — compute open-blocker
+   count client-side, or drop to raw REST/GraphQL.
+6. **Your own writes evict your ETag cache** (Q4) and `updated_at` cannot
+   separate your writes from a human's.
+7. **The Search API is a 30/min bucket** (Q3) — stay on core/GraphQL for the tick.
+8. ⭐ **Dependency changes emit NO event** (Q5c) — not in the Events API, not to
+   any webhook. Only the per-issue timeline records them. A periodic full
+   reconcile is therefore **mandatory**, and no event transport can remove it.
+9. **`gh webhook` is not built in** (Q5a) — it is an undocumented, 9-months-stale
+   extension, so event forwarding is both extra moving parts and unverifiable
+   from its own docs.
+10. **Events + Notifications APIs declare `X-Poll-Interval: 60`** (Q5b) — a
+    60s floor on those surfaces; only the issues list is free of one.
+
+## What makes it EASIER than expected
+
+1. `blocked_by == 0` is a **precomputed, live, inline** readiness predicate —
+   including on list responses. No traversal.
+2. One GraphQL round-trip returns the entire reconcile+select input.
+3. Idle ticks cost **zero** rate budget via ETag.
+4. `gh issue close` is the completion signal; **reopen is a free human veto**
+   that re-blocks the subtree.
+5. Labels are additive/idempotent/surgical and server-side filterable.
+6. **Idle ticks are free even in the real filtered shape** (Q5b) — the label-filtered
+   conditional GET returns 304 at zero cost, so a NAT'd Mac daemon needs no
+   inbound path at all.
+7. **Completions (close/reopen) DO emit events** (Q5c) — so if sub-minute
+   completion latency is ever needed, that half is available without solving the
+   topology problem.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the live probe target: issues #556, #564, #565, #571, #573, #574, #582, #583, and scratch #589.
+- [cli/cli](https://github.com/cli/cli) — `gh` 2.97.0 dependency flag surface, read via the installed binary's `--help` (release: <https://github.com/cli/cli/releases/tag/v2.97.0>); also confirmed `webhook` is absent from its command list.
+- [cli/gh-webhook](https://github.com/cli/gh-webhook) — the webhook-forwarding extension (Q5a): repo metadata and its 124-byte README read via `gh api`; **not installed, runtime behaviour not probed**.
+- [stokowski](https://github.com/ray-manaloto/knowledge-base) (vendored at `knowledge-base/sources/stokowski`) — the `<!-- stokowski:state {...} -->` structured-comment pattern (`stokowski/tracking.py`, `CLAUDE.md`); note it targets **Linear**, not GitHub.

--- a/docs/research/kb/reports/agents/573-linear-tracker.md
+++ b/docs/research/kb/reports/agents/573-linear-tracker.md
@@ -1,0 +1,535 @@
+# Linear as the scheduler tracker DB (#573)
+
+**STATUS: complete**
+**Agent:** linear-tracker · **Date:** 2026-08-05 · **Branch:** `docs/573-pull-loop-scheduler-grill`
+**Method:** docs-only. **No live Linear API probes were run** — no credentials assumed, no
+workspace exists. Every claim below is cited to Linear's own published docs or to the
+official GraphQL SDL schema, or is explicitly labelled as inference.
+
+## Scope
+
+Ray is choosing the database for a symphony-style pull-loop scheduler
+(reconcile → select → dispatch, ~minute-scale ticks, single Mac, agents are Claude Code
+sessions). GitHub Issues is the incumbent. This report establishes what Linear actually
+offers against six questions.
+
+## Bottom line
+
+**Recommendation: stay on GitHub Issues.** Linear's one genuine technical advantage is a
+server-side `hasBlockedByRelations` filter — and it cannot see whether a blocker is
+actually *open*, so you write the client-side blocker-state pass regardless. It does not
+enforce state transitions (nobody does), its arbitrary metadata is not queryable, its
+webhooks cannot reach a Mac behind NAT, it explicitly discourages the polling architecture
+#573 proposes, and its free tier hard-stops at **250 issues**. Against that it is a second
+system while every PR and CI gate here is GitHub-shaped.
+
+The option most worth a head-to-head is **neither**: a local SQLite store as the
+scheduler's source of truth with GitHub Issues as the human-facing view. It is the only
+one of the three that offers a real atomic claim — verified below, *neither* tracker
+supports compare-and-swap.
+
+## Sources and how they were reached
+
+The repo's `research-doc-sources.md` chain, step 1 (`llms.txt`) then step 2 (`.md` per page):
+
+| Probe | Result |
+|---|---|
+| `curl https://developers.linear.app/llms.txt` | **302 → `linear.app/developers` HTML.** Not an answer — `developers.linear.app` is folded into the main site. |
+| `curl https://linear.app/llms.txt` | **200 `text/plain`**, 222 lines — the real index. |
+| `curl https://linear.app/docs/llms.txt` | 404 |
+| `curl https://linear.app/developers/llms.txt` | 404 |
+
+**Control arm for the index probe:** two sibling paths 404 while `/llms.txt` returns 200
+text/plain, so the probe discriminates present from absent — the 200 is not a catch-all.
+
+**Primary source for Q1–Q3** is the official GraphQL SDL, linked from that index:
+`https://raw.githubusercontent.com/linear/linear/master/packages/sdk/src/schema.graphql`
+— **50,261 lines / 1.27 MB**, fetched rc=0. Schema beats prose per
+`probes-need-a-control-arm.md` ("source beats issue tracker"), so every structural claim
+below is read off the SDL, not off a marketing page.
+
+---
+
+## Q1 — Workflow states: can we model claim states with API-enforced transitions?
+
+**Verdict: custom states YES, enforced transitions NO.**
+
+`WorkflowState` is a first-class per-team entity (SDL L49892), not a fixed enum. Fields:
+
+- `name: String!` — free text ("In Progress", or our "Claimed"/"RetryQueued").
+- `type: String!` — the **category**, and this is the constrained part. Doc comment:
+  `One of "triage", "backlog", "unstarted", "started", "completed", "canceled", "duplicate"`.
+  `WorkflowStateCreateInput.type` (L50022) narrows what you may *create* to
+  `backlog, unstarted, started, completed, canceled` — "The type determines how the state
+  is treated in workflow progression and reporting."
+- `position: Float!` — ordering within the type group.
+- `issues(filter: IssueFilter): IssueConnection!` — every state can list its own issues.
+
+So symphony's `Unclaimed / Claimed / Running / RetryQueued / Released` map cleanly onto
+five custom states, and you additionally get a free *category* axis:
+`Unclaimed→unstarted`, `Claimed/Running→started`, `RetryQueued→unstarted` or `backlog`,
+`Released→completed`. That category is genuinely useful — it is what makes
+"is this blocker still open?" answerable without hardcoding state names.
+
+**But there is no transition validation.** The SDL contains no `allowedTransitions`,
+no from/to edge type, and no transition-guard input anywhere on `WorkflowState` or
+`IssueUpdateInput`. `issueUpdate(input: {stateId: ...})` will move an issue from any
+state to any other state. Linear's workflow is a **palette, not a state machine** — the
+UI orders states by `position`, but the API does not police the order.
+
+> **Control arm for this negative.** A 0-hit grep is not an answer until a known-present
+> term returns hits with the same command shape. `grep -icE "customfield"` → **0**;
+> control `grep -icE "issuelabel"` → **79**. Same file, same command shape, so the corpus
+> and the grep both work and the zero is real. The same shape backs every "absent" claim
+> in this report.
+
+**Consequence for the scheduler:** state-machine correctness stays your Python code's job
+exactly as it would with GitHub Issues. Linear gives you better *vocabulary* (named states
++ a semantic category) but zero *enforcement*. If you were hoping the tracker would reject
+an illegal `Running → Unclaimed` write, neither system does that.
+
+---
+
+## Q2 — Dependencies: can one query return "state X with zero open blockers"?
+
+**Verdict: native blocking relations YES; the full predicate in one round-trip YES, but
+with a client-side second pass — the server cannot filter on blocker *state*.**
+
+### The relation surface
+
+`enum IssueRelationType { blocks, duplicate, related, similar }` (SDL L19816). `blocks` is
+native and directional; the reverse direction is read through `Issue.inverseRelations`.
+`IssueRelationCreateInput` (L19754) takes `issueId`, `relatedIssueId`, `type` — and
+notably **accepts human identifiers** (`'LIN-123'`) as well as UUIDs, which removes an
+ID-resolution round-trip a GitHub-based scheduler would need.
+
+### What `IssueFilter` can express
+
+`IssueFilter` (mined in full) carries all three pieces of the predicate:
+
+- `state: WorkflowStateFilter` — filter on the state, including its `type` category.
+- `hasBlockedByRelations: RelationExistsComparator`
+- `hasBlockingRelations: RelationExistsComparator`
+- `and: [IssueFilter!]` / `or: [IssueFilter!]` — arbitrary boolean composition.
+
+So this is one server-side query:
+
+```graphql
+issues(filter: {
+  state: { name: { eq: "Unclaimed" } },
+  hasBlockedByRelations: { eq: false }
+}) { nodes { id identifier } }
+```
+
+### The gap
+
+`RelationExistsComparator` is **`{ eq: Boolean, neq: Boolean }`** and nothing else
+(SDL L40275). It answers "does a blocked-by relation exist at all", not "does an
+*unresolved* one exist". An issue whose only blocker is already `Released` still returns
+`hasBlockedByRelations: true` — so that filter alone is **too strict**: it silently
+withholds work that is actually ready.
+
+There is no escape hatch at the filter layer: **no `IssueRelationFilter` or
+`IssueRelationCollectionFilter` input exists in the schema**, and `Issue.relations(...)`
+/ `Issue.inverseRelations(...)` accept only pagination args (`after/before/first/last/
+includeArchived/orderBy`) — **no `filter:` argument**, unlike `Issue.children` and
+`WorkflowState.issues`, which do take one.
+
+> **Control arm.** `grep -nE "^input .*(IssueRelation|Relation).*(Filter|Comparator)"` →
+> exactly one hit, `RelationExistsComparator`. Control: `grep -cE "^input .*CollectionFilter"`
+> → **20**. The grep shape finds collection filters fine; there simply is not one for
+> relations.
+
+### The workaround, and it costs one round-trip, not two
+
+GraphQL allows multiple aliased root fields in a single document, so the whole selection
+predicate is still **one HTTP request**:
+
+```graphql
+query Selectable {
+  ready: issues(filter: {
+    state: { name: { eq: "Unclaimed" } },
+    hasBlockedByRelations: { eq: false }
+  }) { nodes { id identifier } }
+
+  maybe: issues(filter: {
+    state: { name: { eq: "Unclaimed" } },
+    hasBlockedByRelations: { eq: true }
+  }) {
+    nodes {
+      id identifier
+      inverseRelations(first: 20) {
+        nodes { type issue { state { type } } }
+      }
+    }
+  }
+}
+```
+
+`ready` is dispatchable as-is. `maybe` is post-filtered in Python to those where every
+`type == "blocks"` blocker has `state.type` in `{completed, canceled}`. One round-trip,
+a few lines of client code — and the `state.type` category is what makes that check
+name-independent.
+
+### Versus GitHub
+
+GitHub's issue dependencies (sub-issues + blocked-by, GA'd through 2025) are exposed but
+GitHub's issue *search* has no equivalent of `hasBlockedByRelations` — you enumerate and
+resolve dependencies client-side, and REST search + per-issue dependency reads means
+**N+1 requests**, or a hand-written GraphQL query with the same client-side pass. Linear
+is meaningfully better here: server-side pre-filtering cuts the candidate set before the
+client-side blocker-state pass, and it is one request either way.
+
+**This is Linear's single strongest technical advantage for this use case.**
+
+---
+
+## Q3 — Claim + machine state
+
+**Verdict: assignee is fine; there are NO custom fields; the real metadata slot is
+attachment `metadata` JSON, which is upsertable but NOT server-side filterable.**
+
+### Claim
+
+`Issue.assignee: User` plus `Issue.delegate: User` (a second, agent-oriented assignment
+slot). `IssueFilter.assignee: NullableUserFilter` filters on it server-side, so
+"claimed by this machine" is expressible. There is **no atomic compare-and-swap** — no
+conditional-update input, no `If-Match`/version field on `IssueUpdateInput`. Claiming is
+therefore last-write-wins, identical to GitHub. On a single-Mac single-scheduler design
+that is a non-issue; it would matter if two schedulers ever raced.
+
+### Custom fields: they do not exist
+
+`grep -icE "customfield"` → **0** (control `issuelabel` → **79**). Linear has no
+custom-field feature at all. The metadata surfaces are labels, description, comments,
+and attachments.
+
+### The good part — `Attachment.metadata`
+
+`AttachmentCreateInput` (SDL) has exactly the shape a scheduler wants:
+
+- `metadata: JSONObject` — *"Attachment metadata object with string and number values."*
+- `url: String!` — *"Attachment location which is also used as an unique identifier for
+  the attachment. **If another attachment is created with the same `url` value, existing
+  record is updated instead.**"*
+
+That is a **native idempotent upsert of a JSON blob keyed by a string**, with no
+read-modify-write and no separate create/update branch in your code. Set
+`url: "scheduler://dotfiles/machine-state"` and every tick's `attachmentCreate` overwrites
+the same slot. Retrieval is `Attachment.metadata: JSONObject!` on the issue. This is
+strictly nicer than GitHub's usual answer (an HTML-comment-fenced YAML block in the issue
+body, which is a read-modify-write with a lost-update race).
+
+Two constraints to design around:
+
+1. **"string and number values"** — the doc does not promise nested objects or arrays
+   survive. Flatten your state, or store a JSON string in one key. *Unverified: no live
+   probe was run to test whether nesting is actually rejected.*
+2. **You cannot query by it.** `AttachmentFilter` and `AttachmentCollectionFilter` expose
+   `id / title / subtitle / url / sourceType / createdAt / updatedAt / creator` — and
+   **no `metadata` comparator**. Control arm: those same filter inputs *do* list `url`
+   and `title`, so the fields were visible to the grep; `metadata`'s absence is real.
+
+   So machine state in attachment metadata is **write-through and read-back, never a
+   selection predicate**. Anything the scheduler must *select on* has to live in a state,
+   a label, an assignee, or the attachment `title`/`url` (both `StringComparator`-filterable).
+   That is a genuine design constraint, not a footnote: your selection axes are fixed at
+   state × label × assignee × attachment-url, and everything else is payload.
+
+Comment-based state blocks remain available as a fallback (`CommentCollectionFilter`
+exists in `IssueFilter`), but attachment-metadata upsert dominates it on every axis.
+
+---
+
+## Q4 — Events and polling
+
+### Webhooks need a public endpoint — a real cost on this host
+
+Linear webhooks POST to a URL you register. **We are on a Mac behind NAT with no public
+endpoint**, so consuming them requires a tunnel (ngrok/cloudflared) or a relay — a new
+always-on dependency, an inbound attack surface, and something else for
+`mise run doctor` to police. For a single-user local scheduler this is a poor trade.
+
+### Polling: the numbers, and Linear explicitly discourages it
+
+`https://linear.app/developers/rate-limiting.md`, verbatim:
+
+> **"Avoid polling** — One thing that we especially discourage is polling the API to fetch
+> updates. If you need to know when data updates in Linear, you should use our Webhook
+> functionality."
+
+That is Linear's stated position on precisely the architecture #573 proposes. It is
+guidance, not a technical block — the budget below is comfortable — but it means the
+pull-loop is swimming against the vendor's intent, and limits are explicitly subject to
+change ("We are going to be evolving these limits").
+
+⚠️ **Linear's own doc contradicts itself on the API-key request limit.** The prose says
+*"When authenticated using an API key you can make up to **5,000 requests per hour**"*,
+while the table immediately below it says:
+
+| Authentication | Limit | per | Period |
+|---|---|---|---|
+| API key | **2,500** | User | 1 hour |
+| OAuth App | 5,000 | User (or App User) | 1 hour |
+| Unauthenticated | 600 | IP Address | 1 hour |
+
+The prose looks like it copied the OAuth row. **Budget against 2,500/hr, the lower figure**
+— and treat this as unresolved without a live probe (the `X-RateLimit-Requests-Limit`
+response header returns the real number on the first authenticated call).
+
+**Complexity is the second, independent budget** and is the one that actually binds:
+
+- API key: **3,000,000 points/hour**; **10,000 points max for any single query**.
+- Costing: each property 0.1, each object 1, and *each connection multiplies its children
+  by the pagination argument or the default 50*.
+
+At ~minute ticks = 60 ticks/hour:
+
+- **Requests:** 2,500 ÷ 60 ≈ **41 requests per tick**. A reconcile+select tick needs 1–3.
+  Not close to binding.
+- **Complexity:** 3,000,000 ÷ 60 = **50,000 points per tick**. Also not binding — *but*
+  the `maybe` query above nests a connection inside a connection, and nested connections
+  multiply. `issues(first: 50) { inverseRelations(first: 20) { … } }` is
+  50 × 20 = 1,000 child objects before properties, which approaches the **10,000-point
+  per-query ceiling**. **Always pass explicit `first:` on both levels** — the default 50
+  is what makes this dangerous, and the ceiling rejects the query outright rather than
+  degrading.
+
+### Cheap delta queries — yes
+
+`IssueFilter.updatedAt: DateComparator` plus `orderBy: updatedAt` is exactly the delta
+pattern, and Linear recommends it: *"sort it by the updated timestamp instead of when it
+was created… get the most recently changed data first, and avoid paginating through the
+entire dataset."* So a reconcile tick is a bounded `updatedAt > lastTick` query.
+
+⚠️ Same trap as GitHub's: **your own writes bump `updatedAt`**, so a
+write-then-poll-and-compare loop can spin. (Already a recorded lesson in this repo —
+`feedback_github_updated_at_advances_on_comment`.)
+
+### Subscriptions — they cover issues, but they are undocumented
+
+> ⚠️ **Self-correction, recorded rather than silently fixed.** My first pass read the
+> `Subscription` type through `head -40`, saw only `agent*`/`ai*` fields (the list is
+> alphabetical), and wrote "there is no `issueCreated`/`issueUpdated` subscription."
+> **That was wrong, and it was a display bound producing a false negative** — exactly the
+> failure `probes-need-a-control-arm.md` §3 names and
+> `feedback_enumerate_dont_assert_the_list` records. Enumerating the whole type instead
+> of truncating it gives **80 fields**, including `issueCreated`, `issueUpdated`,
+> `issueArchived`, `issueRelationCreated/Updated/Deleted`, `workflowStateCreated/Updated/
+> Archived`, and the full comment/project/team set.
+
+So the schema really does expose issue-level subscriptions, and a GraphQL subscription
+runs over an **outbound websocket** — which would sidestep NAT completely and be the
+ideal event transport for a Mac behind a router.
+
+**But it is undocumented, and that is disqualifying.** Measured across Linear's own
+developer docs:
+
+| Corpus | `subscription\|websocket` | Control term | Control hits |
+|---|---|---|---|
+| `developers/graphql.md` | **0** | `query` | 16 |
+| `developers/webhooks.md` | **0** | `query` | 6 |
+| `developers/filtering.md` | **0** | `query` | 20 |
+| `docs/api-and-webhooks.md` | **0** | `query` | 1 |
+| `developers/agents.md` | **0** | `query` | 3 |
+| `linear.app/llms.txt` (whole index) | **0** | `webhook` | 3 |
+
+Every control arm returns hits from the same file with the same command shape, so the
+zeros are real absences, not a broken probe. There is no documented websocket endpoint,
+no documented subscription auth, and no stability promise. `Subscription` is the transport
+Linear's own client uses; treating it as public API is building on an internal.
+
+**Conclusion for Q4:** webhooks are the only supported push transport and they need a
+public HTTPS endpoint we do not have; subscriptions would solve that but are unsupported;
+so **polling is the only viable option, and it is the one Linear explicitly discourages.**
+It will work — the budget is comfortable — but you are outside the vendor's intended use.
+
+---
+
+## Q5 — Integration cost
+
+### Auth is genuinely easy — the best part of the story
+
+`https://api.linear.app/graphql`, and for a personal script:
+
+```sh
+curl -X POST -H "Content-Type: application/json" \
+  -H "Authorization: <API_KEY>" \
+  --data '{ "query": "{ issues { nodes { id title } } }" }' \
+  https://api.linear.app/graphql
+```
+
+Note the header is a **bare API key, not `Bearer`** (OAuth uses `Bearer`). Linear's own
+guidance: *"For personal scripts API keys are the easiest way to access the API."* No
+OAuth app, no callback URL, no token refresh — which matters on a NAT'd host.
+
+Keys are **scopeable**: *"you can choose to give it full access to the data your user can
+access, or restrict it to certain permissions (Read, Write, Admin, Create issues, Create
+comments). You can also limit an API key's access to specific teams."* Good blast-radius
+control, roughly on par with GitHub fine-grained PATs. One credential to add to the fnox
+set (and therefore to `doctor.toml`'s reviewed baseline).
+
+### Free-plan caps — this is a hard blocker for a task-row generator
+
+From `linear.app/pricing` (comparison matrix, text-extracted):
+
+| | Free | Basic $10/user/mo | Business $16/user/mo |
+|---|---|---|---|
+| **Issues** | **250** | Unlimited | Unlimited |
+| Teams | 2 | 5 | Unlimited |
+| Members | Unlimited | Unlimited | Unlimited |
+| File upload | 10 MB | Unlimited | Unlimited |
+
+**250 issues is the number that decides this.** A scheduler whose rows *are* issues
+accumulates them monotonically; `docs/billing-and-plans.md` confirms the enforcement is
+hard — *"If you have over 250 issues, you will no longer be able to create new issues."*
+So Linear is either a ~250-row ceiling or **$10/month**.
+
+*Open question, not probed:* whether **archiving** an issue frees a slot against the 250
+cap. If it does, the cap is survivable with an archive-on-Released step; if not, the free
+tier has a finite total lifetime. Nothing in the billing or API docs states either way,
+and I ran no live probe — do not assume the favourable reading.
+
+*Unresolved by this probe:* whether "API and webhook access" is checked for Free. The row
+exists in the matrix under **Core**, but the per-plan cells are bare `<svg><path>` icons
+with **no `aria-label`, `title`, or text** (verified: 0 hits for each of those attributes
+in the row's markup), so the values did not survive HTML→text extraction. *Inference only:*
+rows that differ by plan render **text** ("250 issues", "15 pipelines", "Google + SAML")
+while this one does not, which suggests uniform availability — but that is a guess about
+a rendering convention, not a citation. Confirm in the UI before relying on it.
+
+### It is a second system, and PRs/CI stay on GitHub
+
+Linear's GitHub integration (`docs/github.md`, 25 KB) is mature:
+
+- **Issue sync**, one-way or two-way. Synced properties include title, description, status,
+  assignee, sub-issues and comments. Assignees map through each member's connected GitHub
+  account.
+- **PR/branch linking** via magic words (`Fixes ENG-123`) in the PR title/description, via
+  the issue ID in the branch name, or via commit messages.
+- **Workflow automation** — a linked PR advances the Linear issue's workflow state.
+
+Three limits that bite a scheduler specifically:
+
+1. **Two-way sync is one repo at a time.** *"only one repo can be configured for two-way
+   sync at a time"* — fine for this single-repo case, but it caps the pattern.
+2. **Sync is forward-only.** *"GitHub Issues Sync will only sync newly created issues"* —
+   existing issues need the separate importer. Any migration is a one-shot event.
+3. **Sync is replication, so it is a second source of truth with lag.** For a
+   reconcile→select→dispatch loop the scheduler must pick one system as authoritative and
+   treat the other as a view. Sync does not remove the second-system cost; it *is* the
+   second-system cost, with an error surface of its own (the docs describe per-issue
+   "sync error" banners).
+
+### MCP: confirmed unnecessary
+
+Linear ships an official MCP server (`docs/mcp.md` in the index), but the GraphQL API
+alone covers every operation this scheduler needs — query, mutate, filter, relate,
+attach. Per `research-doc-sources.md` § "MCP: two lanes", this is squarely **lane 2**
+(our own automation, our own lookups), so the plain HTTP API is the correct choice and
+no registration is warranted. Nothing found requires MCP.
+
+---
+
+## Q6 — Verdict
+
+### What Linear adds over GitHub Issues
+
+| # | Add | Strength |
+|---|---|---|
+| 1 | **`hasBlockedByRelations` / `hasBlockingRelations` server-side filters**, composable with `state` via `and`/`or` | **The one real win.** Pre-filters the candidate set inside the selection query. |
+| 2 | **Named custom workflow states** with a semantic `type` category (`backlog/unstarted/started/completed/canceled`) | Real. Claim states become first-class rows, and `type` makes "is this blocker done?" name-independent. |
+| 3 | **`Attachment.metadata` JSON, url-keyed, upsert-on-duplicate** | Real. A native idempotent machine-state slot; no read-modify-write, no lost-update race. |
+| 4 | Relations accept human identifiers (`LIN-123`) as well as UUIDs | Minor — removes ID-resolution round-trips. |
+| 5 | GraphQL with multiple aliased root fields | Minor — a whole tick's reads in one request. |
+| 6 | Scoped API keys (Read/Write/Admin, team-limited) | Minor — comparable to fine-grained PATs. |
+| 7 | `X-RateLimit-*` and `X-Complexity` headers on **every** response | Minor but pleasant — the budget is observable, not inferred. |
+
+### What it costs
+
+| # | Cost | Severity |
+|---|---|---|
+| 1 | **A second system.** PRs, CI, code review and this repo's entire `ship`/`land`/`automerge` toolchain are on GitHub. | **Decisive.** |
+| 2 | **250-issue cap on Free** — hard-enforced; unknown whether archiving frees slots. Escape is $10/user/month. | **Decisive** for a row-generating scheduler. |
+| 3 | **No transition enforcement.** No `allowedTransitions` anywhere in the SDL — any state can be written from any state. | High — it is the feature that would most have justified the move, and it is absent. |
+| 4 | **Attachment metadata is not filterable.** Selection axes are fixed at state × label × assignee × attachment url/title. | High — constrains the schedule design permanently. |
+| 5 | **Webhooks need a public HTTPS non-localhost URL** — we are behind NAT. Worse: 3 retries then *"the webhook might be disabled by Linear, and must be re-enabled again manually"*. A Mac that sleeps will silently lose its event feed. | High. |
+| 6 | **Linear explicitly discourages polling** — our exact architecture. Limits are "evolving". | Medium — works today, no guarantee. |
+| 7 | **Subscriptions are undocumented** (0 mentions in every dev doc, controls 1–20), so the NAT-friendly transport is off the table. | Medium. |
+| 8 | **Rate-limit doc contradicts itself** (prose 5,000 vs table 2,500 for API keys). | Low — budget against 2,500; verify via response header. |
+| 9 | GitHub↔Linear sync is forward-only and two-way is one repo — replication lag and a new error surface. | Medium. |
+
+### Recommendation: **stay on GitHub Issues.**
+
+The honest case for Linear rests almost entirely on add #1, and add #1 is weaker than it
+first looks: `hasBlockedByRelations` is an *existence* test that cannot see whether a
+blocker is still open, so you write the client-side blocker-state pass **anyway**. What
+Linear buys is a smaller candidate set going into that pass — a constant-factor
+optimisation on a workload of a few dozen rows ticking once a minute. That does not pay
+for a second system, a 250-issue ceiling or a subscription, and an event path that cannot
+reach this host.
+
+Adds #2 and #3 are the ones I would actually miss (named states, and the url-keyed
+metadata upsert), but both have adequate GitHub equivalents — labels or a state label
+namespace, and a fenced block in the issue body — and neither is where a minute-scale
+single-user scheduler will fail.
+
+Against that, cost #1 is structural: this repo's whole PR toolchain (`mise run ship`,
+`automerge`, `land`, the guard rules that redirect to them) is GitHub-shaped. Putting the
+DAG somewhere else means the scheduler's source of truth and the work product's source of
+truth are different systems, permanently.
+
+### The option worth naming: neither
+
+For a **single-Mac, single-user, minute-tick** loop, the strongest architecture may be
+**a local store (SQLite) as the scheduler's source of truth, with GitHub Issues as the
+human-facing projection.** It dominates both trackers on the axes that actually constrain
+this design:
+
+- **Real atomic claim.** A transaction gives genuine compare-and-swap. *Neither* Linear
+  nor GitHub offers a conditional update — both are last-write-wins. **Verified for
+  Linear by enumerating `IssueUpdateInput` in full** (34 fields: `addedLabelIds …
+  stateId, subIssueSortOrder, subscriberIds, teamId, title, trashed, trusted`) — it
+  carries no version, no `ifMatch`, no expected-state and no etag. Control arm:
+  `stateId` → 14 hits and `updatedAt` → 443 hits in the same file with the same command
+  shape, so the zeros are absences rather than a blind probe.
+- **Arbitrary indexed metadata**, filterable — no state × label × assignee ceiling.
+- **Enforced transitions** — a CHECK constraint or a trigger does what neither tracker will.
+- **No rate limit, no network, no NAT, no vendor policy on polling.**
+- Ticks cost microseconds instead of an HTTP round-trip.
+
+That trades away the free web UI and mobile notifications. Given `gh-issues-db` is
+researching the GitHub side in parallel, this third option deserves an explicit
+head-to-head rather than being assumed away.
+
+## Caveats and what was NOT verified
+
+- **Docs-only. Zero live API calls** — no Linear credentials were assumed or used. Every
+  structural claim is read off the official SDL; every behavioural claim is quoted from
+  Linear's docs. Anything about *runtime* behaviour (does nesting survive in attachment
+  `metadata`? does archiving free a 250-cap slot? what does
+  `X-RateLimit-Requests-Limit` actually return?) is unverified and flagged inline.
+- **The GitHub-side comparison in Q2 is not first-hand.** I did not probe GitHub's
+  dependency search qualifiers in this pass; the sibling `gh-issues-db` agent owns that
+  side, and its findings should override mine on any disagreement. Per
+  `probes-need-a-control-arm.md` rule 6, treat my GitHub statements as inherited and
+  unverified, not as measurements.
+- **One error was made and corrected mid-report** (the subscription false negative, Q4);
+  it is left visible rather than edited away, because the failure mode — a `head`-bounded
+  read reported as an absence — is the reusable lesson.
+
+## GitHub repos touched
+
+- [linear/linear](https://github.com/linear/linear) — the official GraphQL SDL schema
+  (`packages/sdk/src/schema.graphql`, 50,261 lines) was the primary source for every
+  structural claim about workflow states, issue relations, filters and attachments.
+- [netlify/linear-webhook-template](https://github.com/netlify/linear-webhook-template) —
+  referenced by Linear's webhook docs as the canonical consumer template; noted, not read.
+
+### Doc sites consulted (not repos)
+
+- `linear.app/llms.txt` — the docs index (200 text/plain; siblings 404, so control-armed).
+- `linear.app/developers/{graphql,rate-limiting,webhooks,filtering,pagination,attachments,agents}.md`
+- `linear.app/docs/{api-and-webhooks,issue-relations,billing-and-plans,github}.md`
+- `linear.app/pricing` — plan caps (HTML; per-plan icons not text-extractable).
+- `developers.linear.app/llms.txt` — **302 → HTML**, no longer a distinct doc host.

--- a/docs/research/kb/reports/agents/573-mise-launchd.md
+++ b/docs/research/kb/reports/agents/573-mise-launchd.md
@@ -1,0 +1,261 @@
+# mise + launchd / scheduling — research for #573
+
+STATUS: complete
+Agent: research delegate (team-lead task, ticket #573)
+Date: 2026-08-05
+Branch: `docs/573-pull-loop-scheduler-grill` (read-only research; nothing committed)
+
+Question: does mise natively generate/manage macOS LaunchAgents, or provide any
+scheduled/recurring/daemon execution that should carry the ~60s outer tick of a
+scheduler loop instead of a hand-written launchd plist?
+
+## Verdict
+
+**YES — natively, and it is a direct fit for the intended use.** Do not
+hand-write a plist.
+
+mise ships a first-class **declarative launchd agent manager**:
+`[bootstrap.macos.launchd.agents]` in mise config, rendered to
+`~/Library/LaunchAgents/dev.mise.<name>.plist` and loaded with
+`launchctl bootstrap gui/$UID`, applied by
+`mise bootstrap macos launchd-agents apply`. It exposes **`start_interval`** —
+the exact `StartInterval` seconds-between-runs knob a ~60s tick needs — plus a
+cron-shaped `start_calendar_interval`.
+
+This satisfies Ray's standing rule (prefer mise over hand-rolled wherever mise
+has the feature) **without any stretch**: the feature is not an approximation of
+what #573 needs, it is precisely it.
+
+Confirmed **on the live binary installed on this host** (`mise 2026.8.2`,
+macos-arm64, 2026-08-05), not only in docs.
+
+## Recommended shape for #573
+
+```toml
+[bootstrap.macos.launchd.agents.dotfiles-scheduler]
+program = "~/.local/bin/mise"          # expanded by mise before writing the plist
+args = ["run", "<scheduler-task>"]
+start_interval = 60                     # -> StartInterval = 60
+working_directory = "~/dev/github/ray-manaloto/dotfiles"
+stdout_path = "~/Library/Logs/dotfiles-scheduler.log"
+stderr_path = "~/Library/Logs/dotfiles-scheduler.err.log"
+environment = { PATH = "/opt/homebrew/bin:/usr/bin:/bin" }
+```
+
+Then `mise bootstrap macos launchd-agents apply` (or `mise bootstrap`, which
+runs it as step 7).
+
+⚠️ **`program` must be the real binary, not the shell function.** On this host
+`mise` is a **zsh function** wrapping `/Users/rmanaloto/.local/bin/mise` (probed:
+`which mise` prints a function body, not a path). launchd execs directly — no
+shell, no function, no inherited PATH — so `program` must be
+`~/.local/bin/mise` (mise expands `~`). Writing `program = "mise"` would produce
+a job that silently never runs.
+
+## Evidence
+
+### 1. Source module — `sources/mise/src/system/launchd.rs` (24,719 bytes)
+
+Module doc comment, verbatim L1-L4:
+
+```
+//! macOS user LaunchAgents for `[bootstrap.macos.launchd.agents]`.
+//!
+//! Entries are rendered to `~/Library/LaunchAgents/dev.mise.<name>.plist` and
+//! loaded with `launchctl bootstrap gui/$UID ...` when explicitly applied.
+```
+
+`LaunchdTomlConfig` (L16) is the user-facing TOML schema. `plist_value()` (L303)
+is the renderer. Full key mapping, from **both** the source and
+`docs/bootstrap/launchd.md` (they agree):
+
+| TOML key | launchd plist key | notes |
+|---|---|---|
+| `program` | `ProgramArguments[0]` | required, non-empty (validated); `~` expanded |
+| `args` | `ProgramArguments[1..]` | passed through exactly as written |
+| `start_interval` | `StartInterval` | **the tick** — seconds between runs |
+| `start_calendar_interval` | `StartCalendarInterval` | minute 0-59, hour 0-23, day 1-31, weekday 0-7, month 1-12; single table or array of tables |
+| `run_at_load` | `RunAtLoad` | |
+| `keep_alive` | `KeepAlive` | daemon shape, not tick shape |
+| `environment` | `EnvironmentVariables` | |
+| `working_directory` | `WorkingDirectory` | `~` expanded |
+| `stdout_path` | `StandardOutPath` | `~` expanded |
+| `stderr_path` | `StandardErrorPath` | `~` expanded |
+| `kickstart` | runs `launchctl kickstart` | only when `true` |
+
+`start_interval` and `start_calendar_interval` are documented as **independent**
+triggers; if both are set launchd can start the agent from either.
+
+Label is fixed: `format!("dev.mise.{name}")`. Agent names validated to
+`[A-Za-z0-9._-]` (`valid_name()`). mise **owns only** plists it created with the
+`dev.mise.` prefix.
+
+**Drift detection is content-based, not string-based**: `plist_matches()` parses
+the on-disk plist into a `plist::Value` and compares it to the freshly-rendered
+value. So a hand-edited plist is detected as `differs`, not missed.
+
+State model `LaunchdState { Loaded, Unloaded, Differs, Missing }` — this
+reconciliation is behaviour a hand-rolled plist would have to reimplement.
+
+Sibling `src/system/systemd.rs` (35,079 bytes) is the Linux counterpart
+(`[bootstrap.linux.systemd.units]`), so this is a deliberate cross-platform
+service/scheduling surface, not a macOS one-off.
+
+### 2. Docs
+
+- `docs/bootstrap/launchd.md` — the full reference (key table, semantics, commands).
+- `docs/bootstrap.md` — `mise bootstrap` step **7** is
+  `mise bootstrap macos launchd-agents apply`. Skippable via
+  `--skip macos-launchd-agents` (alias `launchd`), or run alone with
+  `--only macos-launchd-agents`.
+- `docs/tips-and-tricks.md:111` — shown in the canonical "one config bootstraps a
+  workstation" example.
+- CLI docs exist at **two** paths, both live as aliases (probed):
+  `docs/cli/bootstrap/macos/launchd-agents/{apply,status}.md` and the shorter
+  `docs/cli/bootstrap/launchd/{apply,status}.md`.
+
+Documented semantics worth carrying into the design:
+
+- **Declarative and additive** — agent names merge across the config hierarchy
+  (global → project); a more local config **replaces the full declaration** for
+  the same agent name. So the dotfiles repo's own config can declare it.
+- **Manual application only** — mise *never* writes or loads LaunchAgents
+  implicitly. Only `... launchd-agents apply` and `mise bootstrap` do.
+- **macOS-only** — inert elsewhere; `status` lists entries as skipped, `apply`
+  ignores them. (Relevant: the devcontainer is Linux — this cleanly no-ops there.)
+- **User agents only** — `~/Library/LaunchAgents`. No `/Library/LaunchDaemons`,
+  so no root, no system-wide install.
+
+### 3. Live-binary probes on this host (mise 2026.8.2)
+
+`mise bootstrap macos launchd-agents --help` →
+`Manage macOS LaunchAgents from [bootstrap.macos.launchd.agents]`, subcommands
+`apply` / `status`. `mise bootstrap launchd --help` resolves identically (alias).
+
+**Armed fixture probe** (temp `mise.toml` in the scratchpad, since removed;
+host verified clean of `dev.mise.*` agents before and after):
+
+| Probe | Result |
+|---|---|
+| `status`, no config declared | `mise nothing configured in [bootstrap.macos.launchd.agents]`, rc=0; `--json` → `{}` |
+| `status`, fixture declaring one agent | `dotfiles-scheduler-probe  dev.mise.dotfiles-scheduler-probe  /Users/…/dev.mise.dotfiles-scheduler-probe.plist  missing`, rc=0 |
+| `status --json`, same fixture | `{"launchd":{"available":true,"agents":[{"name":…,"label":…,"path":…,"loaded":false,"state":"missing"}]}}` |
+| `status --missing`, agent missing | **rc=1** — usable directly as a verification gate |
+| `apply --dry-run` | printed the exact command sequence (below), wrote nothing |
+
+`apply --dry-run` output, verbatim:
+
+```
+mkdir -p /Users/rmanaloto/Library/LaunchAgents
+write /Users/rmanaloto/Library/LaunchAgents/dev.mise.dotfiles-scheduler-probe.plist
+launchctl bootout gui/501 /Users/rmanaloto/Library/LaunchAgents/dev.mise.dotfiles-scheduler-probe.plist
+launchctl bootstrap gui/501 /Users/rmanaloto/Library/LaunchAgents/dev.mise.dotfiles-scheduler-probe.plist
+launchctl enable gui/501/dev.mise.dotfiles-scheduler-probe
+```
+
+### 4. Control arms (`.claude/rules/probes-need-a-control-arm.md`)
+
+**Grep arm** — identical command shape (`grep -rl <term> src/ docs/ | wc -l`)
+over the offline mise tree:
+
+| term | files | role |
+|---|---|---|
+| `launchd` | **22** | the positive finding |
+| `StartInterval` | 2 | the specific tick key |
+| `start_interval` | 3 | its TOML spelling |
+| `qwrtzplfvx` | **0** | known-absent arm — proves the probe can return 0 |
+
+The known-absent term was **invented fresh for this run** and is deliberately
+*not* reused from a prior receipt (a published control term stops discriminating
+once it is in the corpus). Note this file now contains it, so the next run must
+invent a new one.
+
+**Functional arm** — the `status` probe was armed in *both* directions: it
+returned "nothing configured" with no config **and** a populated `missing`
+record with a fixture. A `status` that had only ever printed "nothing
+configured" would have been indistinguishable from a broken command.
+
+### 5. Version currency
+
+| | version | date |
+|---|---|---|
+| Offline KB copy (`sources/mise`, git HEAD `7799c30`) | **2026.8.0** | 2026-08-01 |
+| Installed on this host (`mise --version`) | **2026.8.2** | 2026-08-05 |
+
+**The offline copy does not lag the feature** — it is 2 patch releases behind but
+launchd support long predates both. CHANGELOG provenance:
+
+| Change | PR | Landed in |
+|---|---|---|
+| `(bootstrap)` **add launchd agents** | [#10396](https://github.com/jdx/mise/pull/10396) | **2026.6.7** (2026-06-14) |
+| `(bootstrap)` add launchd calendar intervals | [#10797](https://github.com/jdx/mise/pull/10797) | 2026.7.1 (2026-07-07) |
+| `(schema)` add launchd calendar intervals | [#11008](https://github.com/jdx/mise/pull/11008) | 2026.7.7 (2026-07-15) |
+| `(launchd)` tolerate bootout EIO for not-loaded agents | [#10965](https://github.com/jdx/mise/pull/10965) | 2026.7.8 (2026-07-16) |
+
+The feature is ~7 weeks old and has already had a stability fix. mise is **not
+pinned as a tool** in the dotfiles repo's `mise.toml` / `.config/mise/conf.d/shared.toml`
+(it is the bootstrap tool itself), so there is no pin to bump.
+
+### 6. What mise does *not* carry — and where it points instead
+
+Negative claims below are armed by the grep table above (the corpus is
+searchable and the probe returns non-zero for present terms).
+
+- **No cron daemon of its own.** `cron` appears in only 3 files.
+- **`mise watch` is not a scheduler.** It is a `watchexec` wrapper — *file-change*
+  triggered, not time-triggered, and it requires `watchexec` installed
+  separately. Wrong mechanism for a 60s tick.
+- **`mise generate` has nothing scheduler-shaped.** Full subcommand enumeration
+  (`src/cli/generate/`, matching `docs/cli/generate/`): `bootstrap`, `config`,
+  `devcontainer`, `git-pre-commit`, `github-action`, `task-docs`, `task-stubs`,
+  `tool-stub`. There is **no** `generate launchd` — the launchd surface lives
+  under `mise bootstrap`, not `mise generate`.
+- **For real daemon management, mise defers to a sister project.**
+  `docs/cli/watch.md` says verbatim: *"For more advanced process management
+  (daemon management, auto-restart, readiness checks, cron scheduling), see
+  mise's sister project: https://pitchfork.jdx.dev"*. Worth knowing, but
+  **not needed here** — pitchfork is for supervised long-running processes;
+  #573 wants a periodic tick, which `start_interval` covers natively without a
+  new tool.
+
+## Trade-offs
+
+**For `[bootstrap.macos.launchd.agents]`:**
+
+- Native, declarative, in the config hierarchy the repo already uses.
+- Converging `status` with four states + `--json` + `--missing` (rc=1) — a
+  ready-made verification gate, so `verify-before-advancing.md` gets a real
+  check instead of "the plist looks right".
+- Content-based drift detection catches hand edits.
+- `--dry-run` makes the change reviewable before it touches the host.
+- Inert on Linux, so the devcontainer is unaffected with no conditionals.
+- Zero new dependencies; the Linux path (`systemd.rs`) already exists if ever needed.
+
+**Against / costs:**
+
+- **Application is manual by design.** mise never loads agents implicitly, so
+  something must run `apply` — a documented setup step, not automatic. (This is
+  a safety feature, but it is a real step.)
+- **Feature is ~7 weeks old** (landed 2026.6.7) and has already taken one
+  stability fix. Newer than most of what this repo depends on.
+- **`program` must be an absolute/`~` path**, not `mise` — see the warning above.
+  This is the most likely way to get a silently-dead job.
+- **`~/Library/LaunchAgents` is outside the repo**, so this is host state a clone
+  does not carry — the declaration is version-controlled, the applied agent is not.
+  `status --missing` is what closes that loop.
+
+## Open question — flagged, not asserted
+
+**Overlapping runs.** If a tick takes longer than 60s, does launchd skip or queue
+the next `StartInterval` firing? That is **launchd** semantics, not mise's, and I
+did **not** verify it in this pass — mise simply writes `StartInterval` through.
+The implementing session should confirm against Apple's `launchd.plist(5)` before
+assuming non-overlap, or make the task itself idempotent / self-locking. Flagging
+rather than asserting per `probes-need-a-control-arm.md` rule 6.
+
+## GitHub repos touched
+
+- [jdx/mise](https://github.com/jdx/mise) — the subject; offline source tree at `sources/mise` (2026.8.0), docs, CHANGELOG, and the live 2026.8.2 binary on this host.
+- [jdx/pitchfork](https://github.com/jdx/pitchfork) — named by `docs/cli/watch.md` as mise's sister project for daemon management / cron scheduling; noted as the escalation path, not adopted.
+- [watchexec/watchexec](https://github.com/watchexec/watchexec) — the engine behind `mise watch`; examined only to rule it out as a time-based trigger.
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the consuming repo; checked for an existing mise pin and any existing launchd/plist usage (none).

--- a/docs/research/kb/reports/agents/573-symphony-cc-ports.md
+++ b/docs/research/kb/reports/agents/573-symphony-cc-ports.md
@@ -1,0 +1,857 @@
+# 573 — Symphony Claude Code ports survey
+
+**STATUS: complete** (2026-08-05)
+
+**Headline:** cymphony is a full Elixir rewrite of symphony behind a pluggable
+agent-CLI adapter, and it is **Linear-only — it does not use GitHub Issues as a
+tracker**, so its value to #573 is dispatch and env mechanics, not tracker design. The
+tracker-as-database pattern comes from stokowski, whose entire durable-state layer is
+**165 lines** of HTML-comment marshalling. The one architectural decision both ports
+put in front of us: DAG gating belongs either in the tracker adapter (symphony's
+`dispatchable` boolean) or in the scheduler (cymphony's choice, which its own code
+comment misattributes to a SPEC section that says the opposite — §1.6).
+
+**§5 (added on request, Linear vs GitHub Issues):** symphony ships **five** adapters
+including GitHub, but only **Linear and Jira** have real blocker support — GitHub,
+GitLab and Asana all hardcode `blocked_by: []` (§5.3). That reads as a point for Linear
+until you check why: **GitHub Issues has since gained native dependencies and
+sub-issues, and this repo already uses them.** `issue_dependencies_summary.blocked_by
+== 0` is the entire ready-check, server-computed, and it rides along on the **list**
+endpoint — so the whole DAG gate costs one paginated call per tick, strictly less work
+than symphony's Linear adapter does (§5.4–5.6).
+
+Ticket: #573 (pull-loop scheduler on Claude Code, GitHub Issues as tracker DB).
+Brief: survey `zaalipro/cymphony` (new), go deeper on two `Sugar-Coffee/stokowski`
+mechanisms, and enumerate recent active forks of `openai/symphony`.
+
+Prior art in this repo (read first, not redone):
+`docs/research/kb/reports/agents/wf-dag-symphony-gaps.md` §I,
+`docs/research/kb/reports/agents/symphony-and-ports.md`.
+
+Offline corpora (preferred over re-fetch):
+- `/Users/rmanaloto/dev/github/ray-manaloto/knowledge-base/sources/symphony` — openai/symphony itself (SPEC.md 91 KB, elixir reference impl).
+- `/Users/rmanaloto/dev/github/ray-manaloto/knowledge-base/sources/OpenSymphony` — a separate Rust/TS project (NOT openai/symphony).
+
+---
+
+## 0. Orientation notes (probe hygiene)
+
+- **graphify was not usable for the cymphony read.** The project graph
+  (`knowledge-base/graphify-out/graph.json`, 498 MB, built 2026-08-05) indexes the
+  knowledge-base corpus, not a repo freshly cloned into the scratchpad. cymphony was
+  read directly from its git tree; that is the "modify/debug specific lines" branch of
+  the rule, not a skipped step.
+- **Offline corpora identified:**
+  - `knowledge-base/sources/symphony` — **the real `openai/symphony`**: `SPEC.md`
+    (91 KB, 2,311 lines, 18 sections + Appendix A), the `elixir/` reference impl,
+    `.codex/`. This is the spec the ports implement.
+  - `knowledge-base/sources/OpenSymphony` — **NOT openai/symphony.** A separate
+    Rust+TypeScript monorepo (`Cargo.toml`, `crates/`, `apps/`, `packages/`,
+    `.opensymphony/`, `WORKFLOW.md` 36 KB, `PRODUCT.md` 20 KB). Name collision only;
+    it is not a port and was not surveyed further under this brief.
+
+---
+
+## 1. zaalipro/cymphony — Elixir rewrite of symphony with a pluggable agent adapter
+
+**Measured 2026-08-05** via `gh api repos/zaalipro/cymphony`, then a `--depth 50` clone
+at `fb1660d282b26182eb45784f455416cefb048826` (2026-07-17 14:00:01 +0400,
+"v2.2.0: live model/effort catalog from codex debug models"), 155 tracked files.
+
+| Field | Value |
+|---|---|
+| Description | "OpenAI Symphony converted to use Claude Code CLI instead of Codex CLI" |
+| `fork` | **false** — a re-implementation, not a GitHub fork |
+| Stars / forks / open issues | **1 / 0 / 0** |
+| Language | **Elixir** |
+| License | Apache-2.0 |
+| Created / last push | 2026-04-19 / **2026-07-17T10:00:07Z** |
+
+Self-description (`README.md:3`): *"A modern rewrite of openai/symphony, using
+**Claude Code** instead of Codex."* Module namespace is `CymphonyElixir.*`, mirroring
+symphony's `SymphonyElixir.*` — it is symphony's Elixir tree renamed and extended,
+with the Codex app-server client replaced by a CLI-adapter behaviour.
+
+### 1.1 Tracker / database — **Linear only. Not GitHub Issues.**
+
+This is the headline answer to the brief's first question, and it is a negative:
+**cymphony does not use GitHub Issues as its tracker.** It narrows symphony's five
+adapters to one.
+
+- `lib/cymphony_elixir/tracker.ex` (80 lines) is the behaviour; the only real
+  implementation is `lib/cymphony_elixir/linear/adapter.ex`. The sole sibling is
+  `lib/cymphony_elixir/tracker/memory.ex` (97 lines) — an in-memory test double.
+- `WORKFLOW.md` front matter pins `tracker.kind: linear` with a `project_slug`.
+- The setup wizard asks for a **GitHub repo URL** (step 2) *and* a **Linear project
+  slug** (step 3) — GitHub is the code host, Linear is the tracker. The two roles are
+  distinct throughout.
+- `GH_TOKEN` / `GITHUB_TOKEN` are inherited into the agent's env
+  (`agent/runner.ex:304`) purely so the agent can drive `gh` for PR work — not for
+  tracker reads.
+
+So for our GH-Issues-as-database design, **cymphony contributes dispatch and env
+mechanics, not tracker mechanics.** Its state model is symphony's: tracker states
+(`Todo`, `In Progress`, `Merging`, `Rework` active; `Closed`/`Cancelled`/`Canceled`/
+`Duplicate`/`Done` terminal) plus an in-memory orchestrator, with durable per-issue
+state living in the workspace and a persistent tracker comment ("workpad").
+
+### 1.2 Dispatch shape — headless `claude -p`, one process per turn, resumed by session id
+
+`lib/cymphony_elixir/agent.ex` defines a five-callback behaviour
+(`default_command/0`, `build_command/1`, `parse_output/3`, `auth_env_prefixes/0`,
+`auth_env_fallback/0`) with two implementations, `Agent.Claude` and `Agent.Codex`
+(`agent.ex:37,43-44`). `Agent.Runner` owns everything CLI-agnostic — workspace
+validation, port spawn, env injection, output collection, turn timeout.
+
+`agent/claude.ex:21-46` `build_command/1` composes, in order:
+
+```
+claude [--bare] -p <escaped prompt>
+       [--output-format stream-json] [--verbose]        # --verbose iff stream-json
+       [--permission-mode <mode>] [--allowedTools <csv>]
+       [--model <m>] [--effort <e>] [--fallback-model <m>]
+       [--max-turns <n>] [--max-budget-usd <d>]
+       [--mcp-config <path>]                            # 0600 file in the workspace
+       [--resume <session_id>]                          # turn 2+
+```
+
+**Every one of those flags is real** — control-armed against the offline vendor docs
+(`$CC` = `knowledge-base/sources/agent-harness-docs/docs/claude-code`), which is worth
+stating because two of them look invented:
+
+- `--max-budget-usd` → `$CC/cli-reference.md:98` ("Maximum dollar amount to spend on
+  API calls before stopping (print mode only)"; subagent spend counts; cap enforcement
+  needs v2.1.217+).
+- `--effort` → `$CC/workflows.md:152`, `$CC/settings.md:271` (`low|medium|high|xhigh`,
+  plus `ultracode`; v2.1.203+).
+- `--bare` → `$CC/authentication.md:197` — **and the doc carries a trap cymphony
+  respects by accident:** *"Bare mode does not read `CLAUDE_CODE_OAUTH_TOKEN`. If your
+  script passes `--bare`, authenticate with `ANTHROPIC_API_KEY` or an `apiKeyHelper`."*
+  cymphony's `auth_env_fallback` is exactly `["ANTHROPIC_API_KEY"]` (`claude.ex:18`).
+
+Control arm: `--output-format` returned 39 hits over the same tree with the same
+command shape, so the flags-present results discriminate.
+
+**Turn model:** one OS process per turn. `run_turn` spawns a port, collects output to
+process exit, parses, and returns; it reports `turn_id: 1` unconditionally
+(`runner.ex:117`). Continuity is carried **only** by `--resume <session_id>`, where the
+id is scraped from the terminal `type == "result"` event of the stream
+(`claude.ex:107-133`) or the last JSON line in `json` mode (`claude.ex:85-105`). This
+is the correct mapping of symphony's `thread_id` reuse (`SPEC.md:1011`) — and it is
+the thing `manav03panchal/phonyhuman` got wrong (no `--resume` at all; see
+`symphony-and-ports.md` §2.3).
+
+**No native Claude Code multi-agent primitives.** cymphony drives the CLI as a
+subprocess exactly as the other three ports do. Its `.claude/skills/{commit,debug,land,
+linear,pull,push}/SKILL.md` are symphony's Codex skills translated to Claude format —
+capabilities the single agent loads, not a team.
+
+### 1.3 The Claude-Code-specific hazards it works around — the most transferable part
+
+These are the findings worth carrying into #573 regardless of tracker choice.
+
+**(a) rc-file sourcing is CONDITIONAL, because unconditional sourcing clobbers the
+injected env.** `runner.ex:215-227`:
+
+```elixir
+if ! command -v <cmd> >/dev/null 2>&1; then
+  for __cymphony_rc in "$HOME/.cld" "$HOME/.zshrc" "$HOME/.bashrc"; do
+    [ -f "$__cymphony_rc" ] && . "$__cymphony_rc" 2>/dev/null || true
+  done
+  unset __cymphony_rc
+fi
+exec <command>
+```
+
+The comment states the reason verbatim: sourcing happens *only* when the first word of
+the command isn't already on `$PATH`, so plain binaries (`claude`, `codex`) "don't
+trigger rc-file sourcing — that would otherwise override env vars we explicitly pass
+via `Port.open`'s `:env` option." The motivating case is a shell *function* as the
+agent command (`cz`, `cm`, `cv1` in `~/.cld`), which only resolves after sourcing.
+
+This is our `__MISE_DIFF` problem from the other side: we worry about the parent's env
+leaking into the child; cymphony worries about the child's **rc file overwriting what
+the parent deliberately injected**. Both are the same class — *the shell between you
+and the agent is not neutral*.
+
+**(b) The child env is an ALLOWLIST, not `inherit=all`.** `runner.ex:259-317` builds
+the child env from scratch:
+
+- base: `PATH` + `HOME` only (local spawn; empty for SSH, which uses `export` lines);
+- agent auth: either a named provider's env via
+  `ShellProvider.load_env(provider, agent_module.auth_env_prefixes())` — filtered to
+  `ANTHROPIC_`, `API_TIMEOUT`, `CLAUDE_CODE_` (`claude.ex:15`) — or, failing that, the
+  inherited `ANTHROPIC_API_KEY` alone;
+- integrations: `LINEAR_API_KEY` (from config, not the environment) plus inherited
+  `GH_TOKEN` / `GITHUB_TOKEN`;
+- then `valid_env_map/1` drops any name failing `^[A-Za-z_][A-Za-z0-9_]*$`
+  (`runner.ex:20,332-340`).
+
+Contrast symphony's reference workflow, which runs Codex with
+`shell_environment_policy.inherit=all` (`elixir/WORKFLOW.md:33`). cymphony **inverted
+that default**. Given this repo's `env = true` / 50-credentials-everywhere posture
+(`secrets-out-of-the-shell-env.md`), the allowlist shape is the one to copy.
+
+**(c) Secrets never reach argv.** MCP servers are handed over as a JSON descriptor
+file written **0600 inside the workspace**, referenced by `--mcp-config <path>`
+(`claude.ex:73-81`, `Mcp.ConfigWriter`). The inline comment says why: "so the API key
+never appears in argv". Symphony's equivalent guarantee is host-side tool execution
+(`SPEC.md:1107-1111`); cymphony achieves it with file-mode instead.
+
+**(d) MCP injection is local-only by construction.** `runner.ex:176-177` returns a
+`nil` descriptor whenever `worker_host` is set — "a remote workspace cannot read a
+local descriptor file, and remote argv rendering is untested". An explicit capability
+downgrade rather than a silent breakage.
+
+**(e) Turn timeout is a receive-deadline, and it kills the port.**
+`runner.ex:365-392`: the output collector is a tail-recursive `receive` with
+`after config.agent.turn_timeout_ms -> stop_port(port); {:error, :turn_timeout}`. Note
+this bounds *total silence on the port*, and a non-zero exit is a distinct
+`{:error, {:agent_exit, status, remaining}}` — the two failure shapes are not
+conflated.
+
+**(f) Stall detection is separate from turn timeout, and is pure.**
+`orchestrator/stall.ex` (55 lines) is deliberately side-effect-free: `stalled?/3`
+compares `now` against `:last_agent_timestamp` falling back to `:started_at`, with
+`timeout_ms <= 0` disabling detection and a missing timestamp never counting as
+stalled (`stall.ex:47-53`). The orchestrator owns the impure reaction — "terminating
+the session and rescheduling it with backoff" (`stall.ex:6-8`). Two independent
+watchdogs: the port-level deadline (e) and the orchestrator-level silence check (f).
+
+**(g) Workspace containment is canonicalized, and symlink escape is its own error.**
+`runner.ex:394-420` canonicalizes both workspace and root, rejects
+`workspace == root`, and distinguishes `:symlink_escape` (passes the textual prefix
+check but fails the canonical one) from `:outside_workspace_root`. This implements
+`SPEC.md:928-948`, which calls containment "the most important portability
+constraint".
+
+### 1.4 What cymphony added over symphony (per `README.md:19-42`)
+
+Multi-project orchestration in one daemon with a per-project concurrency cap (default
+10, changeable live); **per-project custom Claude command** (point one project at
+`claude`, another at a wrapper injecting z.ai / Kimi / OpenRouter credentials);
+**provider rotation** — list two or more Claude-compatible backends and new sessions
+are spread across them randomly "to avoid hitting any single backend's rate limit";
+a Phoenix LiveView dashboard with per-session kill / retry / pause / set-provider;
+`/api/v1/*` HTTP API with optional `CYMPHONY_API_TOKEN` bearer auth; a `cymphony
+setup` wizard writing `~/.cymphony/config.json` (from which a per-project
+`WORKFLOW.md` is **generated** at runtime — the committed one is then not consulted);
+`cymphony start` as a background daemon; Homebrew / `.deb` distribution with Erlang
+bundled.
+
+### 1.5 Claim, tick, reconcile, retry — mechanics
+
+**Claim** is an in-memory `MapSet` in the orchestrator GenServer's `%State{}`
+(`orchestrator.ex:56`), tested at `:577` (`!MapSet.member?(claimed, issue.id)`) and
+released at `:1124-1125`. There is **no distributed claim and no lease** — mutual
+exclusion comes entirely from the single GenServer serializing all state mutations,
+exactly as `SPEC.md:727` prescribes. Nothing survives a restart; recovery is by
+re-reading the tracker (symphony's "no persistent database" goal, `SPEC.md:57-58`).
+
+**Tick**: `schedule_tick(state, state.poll_interval_ms)` via `Process.send_after`
+with a `tick_token` (`orchestrator.ex:139,1769`) — a token-guarded timer, so a stale
+timer firing after a reschedule is ignored. `WORKFLOW.md` sets `polling.interval_ms:
+5000`. Per-tick order matches the spec: reconcile running (stalled first, then
+tracker states, then missing ids) → dispatch (`:265-269`, `:319-334`).
+
+**Backoff** (`:1225-1236`):
+
+```elixir
+@continuation_retry_delay_ms 1_000        # clean exit, still active → immediate re-dispatch
+@failure_retry_base_ms       10_000
+failure_retry_delay(attempt, cap) = min(10_000 * (1 <<< min(attempt - 1, 10)), cap)
+```
+
+Same curve as `SPEC.md:799-801`, with the shift **clamped at 2^10** so a long-lived
+retry chain cannot overflow into a nonsense delay before the cap applies.
+
+**A retry cap and an abandon path — cymphony's own addition** (`:1160-1212`).
+Symphony retries forever under a capped backoff; cymphony adds
+`agent.max_retry_attempts`, and on exceeding it: posts a tracker comment ("🛑 Cymphony
+abandoned this issue after N consecutive failed agent attempts… Move it back to an
+active state to retry"), moves the issue to a configurable `agent.failure_state`,
+cleans the workspace, and drops the claim.
+
+The load-bearing detail is **which failures count** (`:1163-1166`, verbatim):
+
+> "Only genuine agent failures (crash, spawn failure, stall) increment `failures`;
+> backpressure ("no slots") and transient poll failures preserve it, so a
+> healthy-but-slot-starved issue is never abandoned."
+
+That distinction — *failure* vs *backpressure* — is the one I would carry into #573
+verbatim. A naive attempt counter that increments on "no slots" will abandon exactly
+the tickets that were healthiest and busiest.
+
+Abandonment's tracker side effects go through `safe_tracker_call/3` (`:1214-1223`),
+which catches both `{:error, _}` and raises, **logs** them, and continues — "never let
+a tracker error crash the orchestrator, but log it rather than swallow it."
+
+**Terminal / failure reasons** are distinguished, not collapsed: `:turn_timeout`
+(port silence deadline, `runner.ex:388-390`), `{:agent_exit, status, remaining}`
+(non-zero exit, `runner.ex:383-386`), stall (`stall.ex` + `restart_stalled_issue`,
+recorded as `error: "stalled for Nms without agent activity"`, `:532`), startup
+failure, and abandonment. `SPEC.md:692` gives the reason: "Distinct terminal reasons
+are important because retry logic and logs differ."
+
+Other lifecycle: a **workspace sweep every 6 hours** (`@workspace_sweep_interval_ms 6
+* 60 * 60 * 1_000`, `:1040-1044`); terminal-workspace cleanup at startup (`:93`).
+
+### 1.6 ⚠️ Cross-check: cymphony's blocker rule cites a SPEC section that does not contain it
+
+`orchestrator.ex:631-656` implements DAG gating and attributes it:
+
+```elixir
+# Implements the dispatch rule from openai/symphony SPEC §8.2:
+# > "If state is `Todo`, do not dispatch when any blocker is non-terminal."
+```
+
+**SPEC §8.2 does not say that.** Read directly (`SPEC.md:754-776`, "Candidate
+Selection Rules"), §8.2's eligibility list is: required fields present; state active
+and not terminal; **adapter-provided `dispatchable` is true**; required labels;
+not already running; not already claimed; global and per-state slots available. No
+blocker clause.
+
+Control-armed (offline `sources/symphony`, same command shape each arm):
+
+| Arm | Result |
+|---|---|
+| `"do not dispatch when any blocker"` in `SPEC.md` + `elixir/` | **0** |
+| `blocker.*non-terminal` in `SPEC.md` + `elixir/` | **1** — and it is `elixir/README.md:221`, not `SPEC.md` |
+| CONTROL `dispatch-eligible` in `SPEC.md` | 1 (present, as expected) |
+| CONTROL `blocked_by` in `elixir/` | 23 (the sweep reaches the impl) |
+
+The one real hit resolves the discrepancy — the rule exists in symphony, but **in the
+Linear adapter, not the scheduler** (`elixir/README.md:220-222`, verbatim):
+
+> "Dispatchability: the adapter marks an issue dispatchable only when optional
+> assignee routing matches and a `Todo` issue has no non-terminal blocker. The generic
+> scheduler then applies active/terminal states, required labels, claims, retries, and
+> concurrency."
+
+And the SPEC forbids the *scheduler* from doing this: the orchestrator "MUST NOT …
+branch on provider-specific blocker, board, transition, or comment semantics"
+(`SPEC.md:1243`); `blocked_by` is "best-effort provider metadata" (`:187-193`) and
+"adapters MUST NOT invent blocker semantics they cannot [infer safely]" (`:1277`).
+`SPEC.md:2115` states the intended shape outright: "Provider-specific
+routing/blocker/assignment rules become explicit `dispatchable`."
+
+**So this is a real architectural divergence, mislabelled as conformance.** cymphony
+hoisted blocker evaluation *out of* the adapter and *into* the core scheduler. It kept
+a vestigial `issue_routable_to_worker?/1` reading an `assigned_to_worker` boolean
+(`:625-629`) — the remains of `dispatchable`, now carrying only the assignee half of
+the rule.
+
+**Why this matters for #573:** it is the cleanest statement of the design choice we
+face. DAG gating can live in (a) the tracker adapter, as one precomputed boolean the
+scheduler never interprets — symphony's answer, and the one that keeps the scheduler
+provider-agnostic; or (b) the scheduler, which must then understand issue-state
+vocabulary of *other* issues — cymphony's answer, simpler to write and harder to port.
+Note also cymphony's semantics, which are worth keeping either way: **the block is
+checked only in `Todo`** ("issues already in progress are allowed to run even when
+blockers remain open, so an in-flight worker can finish what it started",
+`:636-638`) — a ready-check at admission, not a running invariant.
+
+---
+
+## 2. Sugar-Coffee/stokowski — the two mechanisms asked for
+
+Clone at `6e51bdf26c8cf6206893beb7c01b71297539469d` (2026-06-23, "Release v0.5.0 (#39)").
+General survey already in `symphony-and-ports.md` §2.1 and `wf-dag-symphony-gaps.md` §I —
+not repeated. This section covers only (a) the tracker-comment state format and (b) the
+rework cycle.
+
+### 2.1 The machine-readable tracker-comment state pattern
+
+Whole mechanism is `stokowski/tracking.py` — **165 lines, no dependencies beyond
+`json`/`re`/`datetime`.** That is the entire "tracker is the database" layer.
+
+**Two markers** (`tracking.py:13-14`):
+
+```python
+STATE_PATTERN = re.compile(r"<!-- stokowski:state ({.*?}) -->")
+GATE_PATTERN  = re.compile(r"<!-- stokowski:gate ({.*?}) -->")
+```
+
+**Payload fields** — small and closed, no nesting:
+
+| Marker | Fields | Where |
+|---|---|---|
+| `state` | `state` (pipeline state name), `run` (int, default 1), `timestamp` (ISO-8601 UTC) | `tracking.py:19-23` |
+| `gate` | `state`, `status`, `run`, `timestamp`, **`rework_to` only when set** | `tracking.py:37-44` |
+
+`status` takes `waiting` / `approved` / `rework` / `escalated` (`tracking.py:48-67`).
+
+**Every comment is dual-audience — one machine line, one human line, separated by a
+blank line** (`tracking.py:24-26`):
+
+```
+<!-- stokowski:state {"state": "implement", "run": 2, "timestamp": "..."} -->
+
+**[Stokowski]** Entering state: **implement** (run 2)
+```
+
+The human half is rendered per status, so a rework comment reads *"Rework requested at
+**code_review**. Returning to: **implement** (run 2)"* (`tracking.py:54-60`). This is
+the detail I'd copy first: the same comment is both the state record and the changelog
+a human reads, so there is no separate audit trail to keep in sync.
+
+**Append-only, not edit-in-place.** Symphony keeps exactly ONE persistent workpad
+comment and rewrites it (`elixir/WORKFLOW.md:86,281`); stokowski **posts a new comment
+per transition** and derives current state by scanning. Trade: full history and no
+lost-update race, at the cost of comment clutter on a long-running ticket.
+
+**Parsing back / crash recovery** (`tracking.py:72-104`): `parse_latest_tracking`
+walks the comment list, and for every body matching either pattern, `json.loads` the
+capture and **overwrites** `latest`, tagging it `type: "state"` or `"gate"`. The last
+match in list order wins. A `JSONDecodeError` is swallowed (`pass`) so one corrupt
+comment degrades to the previous good one rather than crashing recovery.
+
+Recovery consumes it in `orchestrator.py:300-354` — the resume ladder:
+
+| Tracking found | Resumes as |
+|---|---|
+| none | entry state, run 1 |
+| `state`, name known | that state, that run |
+| `state`, name **unknown** | entry state, run 1 (config changed under a live ticket) |
+| `gate` + `waiting` | that gate, run preserved, **re-registered in `_pending_gates`** |
+| `gate` + `approved` | the gate's `transitions["approve"]` target |
+| `gate` + `rework` | `rework_to` from the comment, falling back to the gate's config |
+| anything else | entry state, run 1 |
+
+So the durable state is *entirely* in tracker comments; the orchestrator's dicts
+(`_issue_current_state`, `_issue_state_runs`, `_pending_gates`) are pure cache. That is
+the property we want for #573.
+
+**Two fragilities worth designing around** (both are ours to avoid, not defects I can
+call proven):
+
+1. **Ordering is delegated to the provider.** `parse_latest_tracking`'s docstring says
+   "comments (oldest-first)" but nothing enforces it — `fetch_comments`
+   (`linear.py:319-327`) returns `nodes` verbatim from `comments(orderBy: createdAt)`
+   (`linear.py:103`) with no client-side sort (target grep for `sort|orderBy|reverse`
+   in `tracking.py` + `linear.py` → 2 hits, both the query strings; control `createdAt`
+   → 6 and 1 in the same files, so the sweep reaches them). **⚠️ UNVERIFIED: I could
+   not confirm Linear's default sort DIRECTION for `orderBy: createdAt`** — no Linear
+   API docs in the offline corpus (control: 104 source trees present, so the corpus is
+   reachable). If Linear returns newest-first, "last match wins" silently resolves to
+   the *oldest* tracking entry. The payload carries a `timestamp` that would settle it,
+   and **nothing ever reads it for ordering.** For us: sort by our own embedded
+   timestamp; never inherit the provider's order.
+2. **No pagination.** The comments connection is requested with no page size or cursor,
+   so recovery sees only the provider's default first page. A ticket with a long
+   comment history can push its own tracking comments out of view.
+
+**Refuted en route, recorded so it isn't re-derived:** I expected `({.*?})` to truncate
+at the first `}` and break on any nested JSON. **Wrong** — armed both ways in Python:
+flat payload (control) parsed, and `{"state":"implement","meta":{"a":1},"run":2}` also
+parsed, because the non-greedy quantifier still backtracks until the trailing ` -->`
+matches. The regex is safe for nested objects.
+
+### 2.2 `rework_to` / `max_rework` cycle mechanics
+
+**Declaration** (`config.py:115-116`) — both are gate-only fields:
+
+```python
+rework_to:  str | None = None     # gate only
+max_rework: int | None = None     # gate only
+```
+
+Validation is a hard gate at load (`config.py:643-647`): a `gate` state with no
+`rework_to`, or one naming a state not in `all_state_names`, is a config **error**.
+`config.py:682-683` folds `rework_to` into the reachability set, so a rework-only
+target isn't flagged as orphaned. Rework targets may be **any** earlier state, which is
+what makes the graph a cycle rather than a DAG (`README.md:180`).
+
+**How a rework is represented on the tracker** — the answer is a *split*, and it is
+the design insight of the whole port:
+
+- The **Linear state** goes back to the generic `linear_states.active`
+  (`orchestrator.py:630-631`).
+- The **pipeline stage** is carried in the comment's `rework_to` field
+  (`orchestrator.py:622-626`).
+
+Linear's own workflow states are only a **coarse six-value vocabulary** —
+`active`, `awaiting_ci`, `review`, `gate_approved`, `rework`, `terminal`
+(`config.py:627`) — while the fine-grained pipeline state (`investigate`, `implement`,
+`code_review`, `merge`, …) lives *only* in the structured comments. The tracker's
+native state field is a bucket; the comment is the state machine.
+
+**The cycle, end to end** (`orchestrator.py:575-641`):
+
+1. A human moves the ticket to the `Rework` Linear state. The orchestrator polls that
+   state each tick (`fetch_issues_by_states([linear_states.rework])`, `:577-579`).
+2. Skip if already `running` or `claimed` (`:586-587`).
+3. Recover which gate it came from: `_pending_gates.pop(issue.id)`; **on a cache miss
+   (i.e. after a crash) re-read the comments** and accept a `gate`+`waiting` entry
+   (`:589-594`). This is the crash-recovery path in §2.1 doing real work.
+4. Resolve `rework_to` from that gate's config; **no target ⇒ log a warning and skip**
+   — the ticket is left in `Rework` rather than guessed at (`:598-601`).
+5. **`max_rework` check, BEFORE incrementing**: `if max_rework is not None and run >=
+   max_rework` → post a `status="escalated"` gate comment, log, and `continue`
+   (`:603-617`). Note what escalation *is*: **no transition at all.** There is no
+   escalation state and no reassignment — the ticket simply stays in `Rework` with a
+   comment saying a human must step in. Cheap, and it cannot loop.
+6. Otherwise `new_run = run + 1` (`:619-620`), post the `status="rework"` gate comment
+   carrying `rework_to` + `new_run` (`:622-626`), set the cached pipeline state to
+   `rework_to` (`:628`), and move the Linear state back to `active` (`:630-635`) —
+   a failed move is logged, not fatal.
+
+**`run` vs `attempt`.** `run` is the rework generation and is the field that
+`max_rework` bounds; retry-within-a-run is separate. Both are exposed to prompts as
+`{{ run }}` and `{{ last_run_at }}` (`symphony-and-ports.md` §2.1), which is how a
+re-entered stage prompt knows it is a redo. Symphony has only a single `attempt` and
+explicitly puts this distinction out of scope (`SPEC.md:1347-1349`).
+
+**Gate context survives the Rework state**: `orchestrator.py:702-706` appends the
+rework state to the gate-polling set with the comment "Also include Rework — reworked
+tickets still hold pending gate context."
+
+---
+
+## 3. Recent active forks of `openai/symphony`
+
+**2,680 forks total** (`gh api repos/openai/symphony --jq .forks_count`, 2026-08-05).
+I enumerated all forks pushed since 2026-06-01, then measured real divergence with
+`gh api repos/openai/symphony/compare/main...<owner>:<default_branch>` — because
+**recency and repo size are both bad proxies**: eight of the ten most recently pushed
+forks are `ahead=0` (they are sync-only mirrors), and `ProlokGmbH/Symphony` sits at
+baseline size while being 336 commits ahead.
+
+| Fork | ahead / behind | Stars | Last push | Note |
+|---|---|---|---|---|
+| **Pimpmuckl/symphony-plus-plus** | **596** / 31 | 4 | 2026-08-04 | Only fork with its own description: *"Symphony++ builds onto the foundation of OpenAI's symphony playbook to build a fully functional pipeline and work-package control plane."* **The one to watch** — "pipeline" + "work-package control plane" is exactly #573's problem statement. |
+| **ProlokGmbH/Symphony** | **336** / 34 | 2 | 2026-08-04 | Heavily divergent, upstream description retained. Size gives no hint — found only by the compare probe. |
+| **EmberAGI/symphony** | **120** / 31 | 0 | 2026-08-04 | Substantive divergence, org-owned (EmberAGI). |
+| **acancelas/symphony** | 51 / 12 | 0 | 2026-08-02 | Moderate; +5.8 MB over baseline suggests vendored assets. |
+| **kingzeus/symphony** | 9 / 0 | 1 | 2026-08-04 | Small, fully up to date with upstream. |
+| `371-Minds`, `Pauca-Technologies`, `Max-Levitskiy`, `Girolino`, `zeguo1`, `Care-Core`, `stslgn`, `aroakpm-svg`, `Orchestra-Bio`, `Quest1Codes`, `manafuel`, `laiye-ai`, … | **0** ahead | 0 | Aug 2026 | Sync-only mirrors. No divergent work. |
+
+**Judgment:** only `Pimpmuckl/symphony-plus-plus` clears the bar the brief set ("real
+divergent commits relevant to Claude Code or GitHub-Issues-as-tracker") on its stated
+purpose; `ProlokGmbH/Symphony` and `EmberAGI/symphony` clear it on volume alone and
+their relevance is unassessed. Per the brief's "one line each, deep-dive only if
+clearly relevant", I did not clone them — **all three are unread, and their relevance
+to Claude Code / GitHub Issues is UNVERIFIED**, resting on description and commit
+count only.
+
+---
+
+## 4. Adopt / reject for a GitHub-Issues-backed pull loop (#573)
+
+### Adopt
+
+1. **Structured HTML-comment state, dual-audience** (stokowski §2.1). Renders as an
+   invisible marker plus a human line in one comment; GitHub Issues renders HTML
+   comments the same way Linear does. This is the mechanism that makes a tracker a
+   database.
+2. **Coarse tracker vocabulary + fine state in the comment** (stokowski §2.2). GitHub
+   Issues offers only `open`/`closed` plus labels for *state*, so this split is not
+   merely convenient for us, it is *forced*. Labels take the role of `linear_states`'
+   six buckets; the comment carries the real stage. (Scope note added with §5: this
+   applies to **state** only. GitHub's *dependency* surface is not impoverished — it is
+   richer and cheaper to query than Linear's, see §5.4–5.6.)
+3. **Sort by your OWN embedded timestamp, and paginate explicitly** — the two things
+   stokowski leaves to the provider (§2.1). It already writes the timestamp; read it.
+4. **Failure vs backpressure in the retry counter** (cymphony §1.5). Only genuine
+   agent failures increment; "no slots" and transient poll errors must not. Then a
+   bounded `max_retry_attempts` with an abandon path — comment, move to a failure
+   label, clean the workspace, drop the claim.
+5. **Two independent watchdogs** (cymphony §1.3 e/f): a per-turn output deadline that
+   kills the process, and an orchestrator-side silence check on last-activity. Keep
+   the stall predicate **pure** and the reaction in the loop — `stall.ex` is 55 lines
+   and trivially testable.
+6. **Distinct terminal reasons, never collapsed** — timeout / non-zero exit / stall /
+   startup failure / abandoned. `SPEC.md:692`: retry logic and logs differ per reason.
+7. **Child env as an allowlist, built from empty** (cymphony §1.3 b). Given this repo's
+   `env = true` posture — all 50 credentials in every shell and inherited by every
+   child ([[secrets-out-of-the-shell-env]]) — inheriting the ambient environment into a
+   spawned agent is the *worst* available default here. cymphony starts from
+   `PATH`+`HOME` and adds only prefix-matched auth.
+8. **Never put a secret in argv** (cymphony §1.3 c): MCP config as a 0600 file in the
+   workspace referenced by `--mcp-config`. argv is world-readable via `ps`.
+9. **Beware the shell between you and the agent** (cymphony §1.3 a). rc-file sourcing
+   overrides deliberately injected env; cymphony sources only when the command isn't
+   already on `PATH`. Our mirror-image hazard is documented — `CLAUDE_*` pins must live
+   in settings `env`, never a shell export, because background launch strips them
+   (`.claude/CLAUDE.md` §"DAG topology pins", #567).
+10. **Gate the DAG at admission only, not while running** (cymphony §1.6): check
+    blockers when the ticket is in the queued state; let an in-flight worker finish
+    even if a blocker reopens.
+11. **Token-guarded timers** (cymphony §1.5) so a stale timer firing after a reschedule
+    is ignored rather than double-dispatching.
+12. **Escalation = stop and comment, not a new state** (stokowski §2.2 step 5). Cheapest
+    correct answer, and it cannot loop.
+
+### Reject / don't copy
+
+1. **cymphony's tracker choice.** Linear-only; it contributes nothing to
+   GitHub-Issues-as-database. Its value here is dispatch and env mechanics.
+2. **cymphony's placement of blocker logic in the scheduler** (§1.6). Symphony's shape
+   — the tracker adapter precomputes one `dispatchable` boolean the scheduler never
+   interprets — is the better seam, and cymphony's own code comment misattributes its
+   divergence to a SPEC section that says the opposite. Independently confirmed in §5.3:
+   symphony's orchestrator references `blocked_by` in exactly one place, a log line. If
+   we ever want a second tracker, the adapter seam is what makes it cheap — and on
+   GitHub that adapter is nearly free, since `issue_dependencies_summary.blocked_by == 0`
+   is the whole predicate (§5.4).
+3. **In-memory-only claims as the whole story.** Both cymphony and stokowski rely on a
+   single process serializing claims, with nothing durable. Acceptable for them; for us
+   the harness already ships a persistent, cross-session task list with native
+   `blocks`/`blockedBy` edges (`CLAUDE_CODE_TASK_LIST_ID`, task-list id `dotfiles-dag`,
+   #567) — reimplementing a weaker claim table would violate [[use-tool-builtins]].
+4. **Append-a-comment-per-transition, unqualified.** Fine on a Linear ticket; on a
+   GitHub issue that is also the human discussion thread it is noisier. Prefer one
+   edited state comment (symphony's workpad) **plus** an append only at genuine
+   phase boundaries — and note that editing needs the anchor-assert discipline from
+   [[feedback_issue_body_edit_needs_anchor_assert]].
+5. **Provider-default ordering and unpaginated reads** (stokowski §2.1) — the two
+   things to fix rather than inherit.
+6. **`--dangerously-skip-permissions` as the default posture** (stokowski's
+   `permission_mode: auto`; hatice's `bypassPermissions` default). Our guard layer —
+   PreToolUse `hook_guard`, `branch_guard`, settings deny rules — is the thing keeping
+   an autonomous loop from committing to `main` or running `chezmoi apply` on the host.
+   Use `--permission-mode` with an explicit `--allowedTools` set instead.
+7. **Any port's coordination layer wholesale.** All four ports (and cymphony makes
+   five) drive Claude Code as a **headless single-agent subprocess** and reimplement
+   dispatch/concurrency/retry in a host language. None uses the harness's native
+   multi-agent primitives. Our advantage over every one of them is that we have those
+   primitives; the ports are worth mining for *policy* (backoff curves, failure
+   taxonomy, env hygiene), not for *architecture*.
+
+### Two facts to carry into the design regardless
+
+- **`--resume <session_id>` is the whole of session continuity** in the headless CLI
+  shape, and it is the thing a port most easily drops: cymphony and stokowski map it
+  correctly, phonyhuman omits it entirely and silently degrades to workspace + tracker
+  comment as the only memory.
+- **`--max-budget-usd` exists and counts subagent spend** (`$CC/cli-reference.md:98`,
+  needs v2.1.217+ for cap enforcement) — a per-run cost ceiling we get for free, which
+  matters for an unattended loop given the shared weekly window
+  ([[project_session_2026-08-04c]]).
+
+---
+
+## 5. Tracker providers across all five codebases — Linear vs GitHub Issues
+
+Added 2026-08-05 at team-lead's request, for Ray's Linear-vs-GitHub-Issues decision.
+
+### 5.1 Who ships what
+
+| Codebase | Tracker adapters shipped | Generic contract? |
+|---|---|---|
+| **openai/symphony** (elixir ref impl) | **five** — `linear`, `github`, `gitlab`, `jira`, `asana` | **Yes** — `SPEC.md` §11, RFC-2119 normative |
+| **zaalipro/cymphony** | **Linear only** (+ `tracker/memory.ex` test double) | behaviour exists, one real impl |
+| **Sugar-Coffee/stokowski** | **Linear only** (`tracker.kind` accepts `"linear"`, `README.md:553`) | no |
+| **mksglu/hatice** | `linear`, `github`, `gitlab` | mirrors symphony's |
+| **manav03panchal/phonyhuman** | **Linear only** (deleted symphony's other four) | inherited, unused |
+
+Symphony's file layout is a consistent three-file shape per provider —
+`adapter.ex` + `client.ex` + `agent_tool.ex` — under
+`elixir/lib/symphony_elixir/<provider>/`.
+
+**The `adapter.ex` files are thin shims; the real normalization is in `client.ex`.**
+Each `adapter.ex` is 50–63 lines and contains **zero** occurrences of
+`dispatchable`/`blocked_by`. Control-armed, because a 0 across all five is exactly the
+shape of a broken probe: `grep -c 'def '` on the same five files returns **6 each**, so
+the sweep reaches them; and `grep -rln dispatchable` over the impl returns all five
+`client.ex` files plus `tracker/issue.ex`. The zero was real.
+
+### 5.2 The generic adapter contract (`SPEC.md` §11)
+
+Two REQUIRED operations only (`SPEC.md:1187-1205`): `fetch_issues_by_states(state_names)`
+and `fetch_issues_by_ids(issue_ids)`. Both return `ok(list<Issue>)` or an adapter error;
+an empty input list MUST return empty **without a provider request**.
+
+The division of labour is stated explicitly and is the thing worth copying
+(`SPEC.md:1193-1196`):
+
+> "When used for candidate polling, include active scoped issues even when
+> `dispatchable=false`; the scheduler owns that final filter. The orchestrator applies
+> `required_labels`, `dispatchable`, claims, retries, and concurrency after
+> normalization."
+
+Required normalized fields are `id`, `identifier`, `title`, `state`, and **explicit
+`dispatchable`** (`SPEC.md:1214-1216`) — everything else may normalize to null/empty
+without making the record malformed. Two asymmetries worth keeping: a state-list call
+MAY drop a malformed record (it was never safe to dispatch) but an ID-refresh MUST fail
+rather than omit, "because omission is meaningful" (`:1220-1222`); and refresh returns
+**full snapshots, not just state strings**, because "label, assignment, routing, and
+provider-specific dispatchability can change while a run is active" (`:1227-1228`).
+
+**Claim state is NOT part of the tracker contract.** `claimed`/`running` live only in
+orchestrator memory (§1.5). Nothing is written to the tracker to claim an issue — the
+tracker is read-mostly, and the only durable per-issue writes are the workpad comment
+and state transitions, both performed by the *agent*, not the orchestrator
+(`SPEC.md:1309-1319`).
+
+### 5.3 ⚠️ The finding that matters: symphony's GitHub adapter has NO blocker support
+
+Verbatim, all five clients, same two normalized fields:
+
+| Provider | `blocked_by` | `dispatchable` | file:line |
+|---|---|---|---|
+| **linear** | `blockers` (real, from inverse `blocks` relations) | `dispatchable?(state_name, blockers, assignee, assignee_filter)` | `linear/client.ex:482,484` |
+| **jira** | `blockers` (real, inward `Blocks` links) | `dispatchable?(state, status_category, blockers, terminal_states)` | `jira/client.ex:253,254` |
+| **github** | **`[]` — hardcoded empty** | `not Map.has_key?(issue, "pull_request")` | `github/client.ex:193,194` |
+| **gitlab** | **`[]` — hardcoded empty** | **`true` — constant** | `gitlab/client.ex:192,193` |
+| **asana** | **`[]` — hardcoded empty** | `task["completed"] == false and task["resource_subtype"] != "section"` | `asana/client.ex:222,223` |
+
+Only **Linear and Jira** have a worked-out DAG story. Symphony's **GitHub Issues
+adapter's entire `dispatchable` logic is "this row is not a pull request"** — because
+GitHub's Issues API returns PRs in the issues list (`elixir/README.md:253`: "pull
+requests returned by the Issues API are not dispatchable"). It carries no assignee
+routing and no blocker evaluation at all.
+
+The two real implementations, for reference:
+
+```elixir
+# linear/client.ex:496-513
+defp dispatchable?(state_name, blockers, assignee, assignee_filter) do
+  assigned_to_worker?(assignee, assignee_filter) and
+    not blocked_before_dispatch?(state_name, blockers)
+end
+defp blocked_before_dispatch?(state_name, blockers) ... do
+  normalize_state_name(state_name) == "todo" and
+    Enum.any?(blockers, fn
+      %{state: blocker_state} when is_binary(blocker_state) -> not terminal_state?(blocker_state)
+      _ -> true                      # unparseable blocker ⇒ treat as blocking
+    end)
+end
+```
+
+Jira's is the same shape with a Jira-native twist — it gates on the **status category**
+`new` when present, falling back to the state name `todo`/`to do`
+(`jira/client.ex:337-356`), i.e. it uses the provider's own coarse grouping rather than
+hardcoding state spellings. `elixir/README.md:266-267` states the policy: "issues in
+Jira's `new` status category wait until blockers reach configured terminal states, while
+in-progress categories keep running" — the same admission-only gating cymphony
+reimplemented in its scheduler (§1.6).
+
+**This also confirms §1.6 independently.** The only `blocked_by` reference in
+symphony's `orchestrator.ex` is a **log line** —
+`"…state=… blocked_by=#{length(refreshed_issue.blocked_by)}"` (`orchestrator.ex:930`).
+The scheduler counts blockers for the log and never branches on them. Adapter owns the
+semantics; scheduler owns one boolean. Exactly as `SPEC.md:2115` specifies.
+
+### 5.4 …but that is a statement about symphony's AGE, not about GitHub
+
+**GitHub Issues today has native issue dependencies and sub-issues, and symphony's
+adapter predates them.** Probed live 2026-08-05 against this repo, fully armed in both
+directions:
+
+| Probe | Result |
+|---|---|
+| `gh api repos/ray-manaloto/dotfiles/issues/573` → keys matching `sub_issue\|depend\|parent\|type` | **`issue_dependencies_summary`, `parent_issue_url`, `sub_issues_summary`, `type`** |
+| CONTROL — total keys on that payload | 35 (endpoint live) |
+| `GET .../issues/573/dependencies/blocked_by` | **200** |
+| `GET .../issues/573/dependencies/blocking` | **200** |
+| `GET .../issues/573/sub_issues` | **200** |
+| CONTROL (good) — `.../issues/573/comments` | 200 |
+| CONTROL (bad) — `.../issues/573/zzqnotarealsubres` | **404** |
+
+The bad arm 404s, so the 200s discriminate.
+
+**This repo is already using it.** Issue #573's own payload:
+
+```json
+"issue_dependencies_summary": {"blocked_by": 0, "blocking": 4, "total_blocked_by": 2, "total_blocking": 4}
+```
+
+and its `blocked_by` list resolves to **#564 (closed)** and **#565 (closed)** — the two
+probes this work depended on. Control: issue #1 returns `"issue_dependencies_summary":
+null`, so the field discriminates present-from-absent.
+
+**Semantics, proven rather than assumed:** `total_blocked_by: 2` counts all declared
+blockers while `blocked_by: 0` counts the ones still **open**. So:
+
+> **`issue_dependencies_summary.blocked_by == 0` IS the ready-check predicate — a
+> single precomputed integer on the issue payload, no extra request, no client-side
+> blocker-state evaluation.**
+
+That is **strictly less work than symphony's Linear adapter does**, which fetches each
+blocker and evaluates its state name against the terminal set client-side
+(`linear/client.ex:501-518`). GitHub computes it server-side and hands it over for free.
+
+### 5.5 What this means for the decision
+
+The naive reading of §5.3 — *"symphony ships a worked-out Linear adapter and a stub
+GitHub one, so Linear wins"* — **inverts once §5.4 is on the table.** Symphony's GitHub
+adapter is thin because GitHub Issues had no dependency graph when it was written, not
+because GitHub can't carry one. Today it can, and this repo already does.
+
+Weighing the two for #573:
+
+**Favours GitHub Issues**
+- Native `blocked_by`/`blocking`/`sub_issues` **already in use on our tickets**, with the
+  ready-predicate precomputed (§5.4). Adopting Linear would mean re-entering that graph.
+- The tracker is where the work already lives — issues #556/#565/#567/#573 and the whole
+  wayfinder map. No sync layer, no second source of truth.
+- `gh` is already authenticated, already guard-wrapped (`mise run ship`/`land`/
+  `automerge`), and `GITHUB_TOKEN` is already in the credential set.
+- Sub-issues give a second, orthogonal edge type (containment) that Linear's blocker
+  relation alone doesn't.
+
+**Favours Linear**
+- Symphony's *worked example* is Linear, and it is the one with assignee routing +
+  blocker gating already written (§5.3). Porting Jira's status-category variant is the
+  closer analogue than porting the GitHub stub.
+- Rich native workflow states. GitHub gives only `open`/`closed`, so the fine-grained
+  pipeline stage must live in labels or a structured comment (stokowski's split, §2.2) —
+  though note that split is *good practice anyway*, and stokowski adopted it **despite**
+  running on Linear.
+- Four of the five codebases surveyed are Linear-only, so borrowed code lands on Linear
+  with less translation.
+
+**My read:** the Linear advantage is *borrowed-code convenience*; the GitHub advantage
+is *the data is already there, in the right shape, with the predicate precomputed*. The
+strongest single argument is that #573's own dependency edges are already correct in
+GitHub — a Linear migration starts by rebuilding a graph we can currently query in one
+field. What we'd give up is workflow-state richness, and stokowski's comment-state
+pattern (§2.1–2.2) already solves that on a tracker that has richer states than GitHub.
+
+### 5.6 Follow-up probe: the summary rides along on the LIST endpoint (resolved)
+
+The load-bearing open question was whether `issue_dependencies_summary` appears only on
+the single-issue GET. If so, a poll loop would pay **one extra request per candidate per
+tick** for its ready check. Probed 2026-08-05:
+
+```
+gh api "repos/ray-manaloto/dotfiles/issues?state=open&per_page=3"
+  → #583 {"blocked_by":1,"blocking":0,"total_blocked_by":1,"total_blocking":0}  sub:{...}
+  → #582 {"blocked_by":1,"blocking":1,"total_blocked_by":1,"total_blocking":1}  sub:{...}
+  → #581 {"blocked_by":1,"blocking":0,"total_blocked_by":1,"total_blocking":0}  sub:{...}
+CONTROL (single GET, known present) → #573 {"blocked_by":0,"blocking":4,...}
+```
+
+**Both `issue_dependencies_summary` and `sub_issues_summary` are present on the list
+endpoint.** So symphony's REQUIRED `fetch_issues_by_states` operation (§5.2) can compute
+`dispatchable` — including full blocker gating — from **one paginated list call per
+tick**, with zero per-issue follow-ups.
+
+That is better than symphony's Linear adapter manages, and it removes the last
+GitHub-side objection: the ready predicate is free, batched, and server-computed. (Live
+data incidentally confirms the graph is real and in active use — #581/#582/#583 each
+currently report one open blocker.)
+
+**Still NOT verified, deliberately: the dependency WRITE surface.** Creating or removing
+an edge would mutate Ray's real issue graph, so I did not probe it — an unrequested
+write to the tracker under evaluation is not a probe I should run unasked. If the design
+needs the loop to *author* edges (rather than only read them), that endpoint shape must
+be confirmed first, ideally against a throwaway repo.
+
+---
+
+## GitHub repos touched
+
+- [zaalipro/cymphony](https://github.com/zaalipro/cymphony) — primary survey target; cloned at `fb1660d` and read (agent adapter, runner, orchestrator, WORKFLOW.md, README).
+- [openai/symphony](https://github.com/openai/symphony) — upstream spec; read from the offline copy (`SPEC.md` §8.2/§14, `elixir/README.md`, `elixir/WORKFLOW.md`) and used as the cross-check authority for cymphony's blocker-rule citation.
+- [Sugar-Coffee/stokowski](https://github.com/Sugar-Coffee/stokowski) — cloned at `6e51bdf`; deep-read `tracking.py`, `orchestrator.py`, `config.py`, `linear.py`.
+- [Pimpmuckl/symphony-plus-plus](https://github.com/Pimpmuckl/symphony-plus-plus) — most divergent active fork (596 ahead); metadata + description only, **not read**.
+- [ProlokGmbH/Symphony](https://github.com/ProlokGmbH/Symphony) — 336 ahead; metadata only, **not read**.
+- [EmberAGI/symphony](https://github.com/EmberAGI/symphony) — 120 ahead; metadata only, **not read**.
+- [acancelas/symphony](https://github.com/acancelas/symphony) — 51 ahead; metadata only, **not read**.
+- [kingzeus/symphony](https://github.com/kingzeus/symphony) — 9 ahead; metadata only, **not read**.
+- [manav03panchal/phonyhuman](https://github.com/manav03panchal/phonyhuman) — not re-surveyed; cited from `symphony-and-ports.md` §2.3 for the missing-`--resume` contrast.
+- [mksglu/hatice](https://github.com/mksglu/hatice) — not re-surveyed; cited from `symphony-and-ports.md` §2.2 for the `bypassPermissions` default and its `linear`/`github`/`gitlab` adapter set (§5.1).
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — this repo; its live Issues API was the probe target for GitHub's native dependency/sub-issue surface (§5.4, §5.6). Read-only — no dependency edges were created or removed.
+

--- a/docs/research/kb/reports/agents/codex-review-573.md
+++ b/docs/research/kb/reports/agents/codex-review-573.md
@@ -1,0 +1,104 @@
+# Cold codex review — #573 close-out diff (2026-08-05)
+
+**Lens:** codex exec, ephemeral, read-only sandbox, fed the staged diff (3,113 lines: receipt + five research reports) with no design context.
+**Prompt scope:** contradictions within/across files, overclaimed measurements, broken references, implementer-misleading content.
+
+## Findings (verbatim)
+
+1. **High — `573-gh-issues-db.md`, `573.md`**  
+   Claim: “**Dependency changes emit NO event … not in the Events API, not to any webhook**” / “topology changes emit **NO GitHub event**.”  
+   Why: The report itself finds `BlockedByAddedEvent` and `BlockedByRemovedEvent` in timelines and explicitly says webhook runtime was not probed; only absence from the repository Events API was established.
+
+2. **High — `573-symphony-cc-ports.md`**  
+   Claim: “the harness already ships a **persistent, cross-session task list** … reimplementing a weaker claim table would violate `use-tool-builtins`.”  
+   Why: The receipt reaches the opposite architecture: “`CLAUDE_CODE_TASK_LIST_ID` … fully demoted to session-local todo use” and GitHub Issues is the only database.
+
+3. **High — `573-linear-tracker.md`**  
+   Claim: GitHub has an “adequate” machine-state equivalent in “**a fenced block in the issue body**.”  
+   Why: The same report describes that body approach as a lost-update race, while `573-gh-issues-db.md` and the receipt explicitly require that the body never be machine-written.
+
+4. **High — `573-symphony-cc-ports.md`**  
+   Claim: “Prefer **one edited state comment** … plus an append only at genuine phase boundaries.”  
+   Why: This directly conflicts with the receipt’s append-only-comment contract and the GitHub report’s concurrency rationale that every state write must be a new comment.
+
+5. **Medium — `573-linear-tracker.md`**  
+   Claim: “Claiming is therefore **last-write-wins, identical to GitHub**.”  
+   Why: `573-gh-issues-db.md` proves GitHub assignee addition is set-additive: two claimants can both succeed and leave two assignees, not a single last-write winner.
+
+6. **Medium — `573-linear-tracker.md`**  
+   Claim: Attachment metadata provides an upsert “with … **no lost-update race**.”  
+   Why: The same file establishes that Linear supplies no CAS; two writers updating the same URL-keyed blob remain last-write-wins and can overwrite one another.
+
+7. **Medium — `573-linear-tracker.md`**  
+   Claim: “Linear’s one genuine technical advantage is a server-side `hasBlockedByRelations` filter.”  
+   Why: The GitHub report establishes that every list row already contains the stronger, state-aware `issue_dependencies_summary.blocked_by` value; Linear still needs client-side blocker-state inspection.
+
+8. **Medium — `573-gh-issues-db.md`**  
+   Claim: The method used “**LIVE read-only probes** via `gh api`.”  
+   Why: The report later documents creating and closing #589, changing bodies, labels, assignees, comments, dependency edges, and issue state.
+
+9. **Medium — `573-gh-issues-db.md`**  
+   Claim: “**one request per tick for the entire reconcile+select input**” returns “every blocker with its state.”  
+   Why: The displayed proof queries only `issues(first:3)` and `blockedBy(first:5)`, while the same report says the repository has 132 open issues; neither connection is complete without pagination.
+
+10. **Medium — `573-gh-issues-db.md`**  
+    Claim: The Search API’s 30/minute bucket is “**~2000× tighter per unit time**” than 5,000/hour core.  
+    Why: Normalized to an hour, the limits are 1,800 versus 5,000—about 2.8×, not 2,000×.
+
+11. **Medium — `573-cc-scheduled-tasks.md`**  
+    Claim: “Up to **30 s jitter on a 60 s period**” is marked `CONFIRMED`.  
+    Why: The report explicitly says it did not establish whether the remotely gated configuration overrides the 50% local default on this host.
+
+12. **Medium — `573-symphony-cc-ports.md`**  
+    Claim: “**Still NOT verified … the dependency WRITE surface.**”  
+    Why: `573-gh-issues-db.md` verifies add/remove writes directly, including accepted and rejected dependency mutations and restoration.
+
+13. **Medium — `573-gh-issues-db.md`**  
+    Claim: “**All live mutations were reverted** and verified against pre-probe baselines.”  
+    Why: Its own table says #589 did not exist beforehand and remained as a newly created closed issue, so at least the creation was not reverted.
+
+14. **Medium — `573.md`**  
+    Claim: “map #556’s architecture-of-record line is **corrected accordingly**” and “Superseded map lines **corrected in the same close-out**.”  
+    Why: The supplied staged diff contains no map-file modification or even the path of the allegedly corrected file.
+
+15. **Medium — `573.md`**  
+    Claim: Findings and disposition are recorded in `docs/research/kb/reports/agents/codex-review-573.md`.  
+    Why: That file is absent from the supplied staged corpus, so the receipt’s close-out review and disposition cannot be audited from this change.
+
+16. **Low — `573.md`**  
+    Claim: The declared prior-art corpus is `docs/research/kb/reports/`, `docs/specs/`, and `docs/adr/`, but the hit table includes `docs/agent-team.md`.  
+    Why: That path lies outside the stated grep corpus and therefore could not have been a hit from the quoted search.
+
+17. **Low — `573-cc-scheduled-tasks.md`**  
+    Claim: “**Zero durable tasks exist anywhere on this machine**.”  
+    Why: A `find /Users/rmanaloto -maxdepth 6` probe cannot establish an anywhere-on-machine negative; its control only proves visibility of one in-range lockfile.
+
+18. **Medium — `573-cc-scheduled-tasks.md`**  
+    Claim: A cloud routine “**can reach GitHub Issues through connectors**” and “open an issue or PR.”  
+    Why: The report establishes cloud execution, clone behavior, interval floor, and `/fire`, but never probes or cites configured GitHub connector credentials or issue/PR mutation capability.
+## Disposition (by the close-out session, evidence-checked per finding)
+
+| # | Disposition | Reasoning |
+|---|---|---|
+| 1 | **ACCEPTED-IN-PART** — receipt narrowed | The Events-API absence IS measured (control: 11 adjacent events seen); webhook delivery was not runtime-probed. Receipt now states exactly that. The conclusion (reconcile mandatory) is unchanged — timeline reads are per-issue re-query either way. |
+| 2 | **NOT-A-DEFECT (temporal)** | The ports report §4 predates rounds 4–5; reports are verbatim snapshots (`agent-report-persistence.md`). The receipt + map row are authoritative. Cross-referenced in the receipt's reading note. |
+| 3 | **COVERED by precedence clause** | The Linear report itself declares its GitHub-side comparisons INHERITED and defers to `573-gh-issues-db.md` on any disagreement. |
+| 4 | **NOT-A-DEFECT (temporal)** | Same as 2 — the design's append-only contract postdates the ports report's suggestion; the receipt's contract governs. |
+| 5 | **COVERED by precedence clause** | gh probes override: assignee writes are set-additive, not last-write-wins. Recorded in the receipt note. |
+| 6 | **CONFIRMED report overclaim** | Upsert-by-url is idempotent creation, not race-free mutation. Report stays verbatim; noted. |
+| 7 | **COVERED by precedence clause** | GitHub's inline summary is the stronger primitive; the receipt's decisions table already reflects it. |
+| 8 | **CONFIRMED report mislabel** | The method line says read-only; the brief sanctioned bounded mutations and the report documents them + restoration. Receipt note carries the correction. |
+| 9 | **ACCEPTED** — receipt corrected | Pagination is real at 132 open issues; receipt now says "one paginated conditional query (2 pages)". |
+| 10 | **CONFIRMED report arithmetic error** | 30/min = 1800/hr vs 5000/hr ≈ 2.8×, not ~2000×. Directional conclusion (avoid Search API for the tick) stands. Receipt note records it. |
+| 11 | **CONFIRMED overreach in draft ledger row** | The 30s-jitter figure is conditional on the unconfirmed local default; the row must carry that caveat if ever appended to the ledger. |
+| 12 | **NOT-A-DEFECT (temporal)** | The gh agent probed the write surface after the ports agent declined to; closure recorded in receipt + notepad. |
+| 13 | **CONFIRMED wording nit** | Creation of scratch #589 is not revertible (issues cannot be deleted); it was closed and stripped. "All mutations reverted" should read "all mutations to pre-existing issues reverted; scratch issue closed". |
+| 14 | **NOT-A-DEFECT** | Map #556 is a GitHub issue body, not a repo file — its correction happens API-side in this same close-out and cannot appear in a staged diff. |
+| 15 | **RESOLVED BY ACTION** | This file. |
+| 16 | **ACCEPTED** — receipt annotated | The `docs/agent-team.md` row is now marked as added outside the quoted grep corpus. |
+| 17 | **CONFIRMED report overclaim** | A maxdepth-6 find cannot prove an anywhere-negative (probes rule 3). The gate-off conclusion rests on the schema ternaries, not the find. |
+| 18 | **ACCEPTED as open item** | Routine→GitHub write capability is docs-asserted, unprobed. Recorded in the receipt as a verification prerequisite for the escalation lane. |
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the reviewed diff and every file it cites


### PR DESCRIPTION
Resolves the scheduler grilling on map #556: GitHub Issues is the sole
scheduler database (blocked_by==0 is the precomputed ready predicate;
reopen re-blocks = human veto AND the rework mechanism); a deterministic
python tick (mise task) runs reconcile -> preflight -> select -> dispatch
under launchd via mise's native [bootstrap.macos.launchd.agents] at 60s,
with one local lockfile providing both single-writer (GitHub has no CAS)
and tick-overlap guarantees. Verified-complete: workers post evidence,
only the scheduler transitions state. Labels carry the selector vocab,
append-only dual-audience comments carry counters + five terminal
reasons; the body is never machine-written. Retry min(10*2^(n-1),300)s
cap 3; rework = reopen upstream, max_rework 2, then needs-human. Native
Claude scheduling rejected as tick (every surface fires a prompt, never
a command) with two adopted complements: Desktop supervisory task +
cloud-routine escalation. Cold codex review: 18 findings, dispositioned
in codex-review-573.md; 3 receipt fixes applied pre-ship.

Closes #573

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W7hfGJXahjaLo2DXRK6j8N

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788555622&installation_model_id=429246&pr_number=591&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F591&signature=ee54a5815dc11cff48bd4b9893ff4cd18e394a92ffd380aa36b530e08564edfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a finalized design record for a deterministic, pull-based task scheduler.
  * Documented readiness, dependency, capacity, priority, retry, rework, cleanup, and cycle-handling rules.
  * Added research reports comparing GitHub Issues, Linear, launchd, mise, Claude scheduling, and related implementations.
  * Recorded operational constraints, concurrency safeguards, evidence requirements, and unresolved implementation considerations.
  * Added a review report consolidating findings, corrections, and remaining verification items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->