### PR TITLE
docs(receipts): receipt for #575 — terminal-reason taxonomy + escalation gates

### DIFF
--- a/docs/receipts/575.md
+++ b/docs/receipts/575.md
@@ -1,0 +1,157 @@
+# Receipt — #575: Grill the escalation gates and the terminal-reason taxonomy
+
+**Verdict:** Terminal reason is **two-tier**. A node writes `~/.claude/jobs/<id>/state.json` —
+it has no choice, because `doSpawnUnlessSettledOnDisk` reads `rh(state)` and a terminal state
+there is *how a node tells the #578 watchdog not to restart it* — and the **scheduler projects**
+that file into an append-only tracker comment during its tick, one direction only, keeping
+#573's *"only the scheduler transitions state"* intact. The taxonomy is **symphony's SPEC five
+with one substitution**: `Succeeded` · `Failed` · **`NeedsHuman`** · `Stalled` ·
+`CanceledByReconciliation` — we drop `TimedOut` (we have no timeout mechanism until #590) and
+add **NeedsHuman**, a reason symphony structurally cannot have, since its reference posture makes
+`user-input-required` a hard failure while a `--bg` main session natively sets `state=blocked`
+with a `needs` + `suggestedReply` payload (verbatim example on this host). Four of the five read
+straight off the harness's own `state` field, which #565 live-armed 7/7. Adopting NeedsHuman
+forced an amendment to **shipped** code: `dag_tick.py` deliberately excludes `blocked` from
+`TERMINAL_STATES`, so an escalated node whose process died classifies **DEAD → respawn**, and
+#565 measured that `claude respawn` returns a node **IDLE with no prompt** — a zombie that will
+never re-ask. `blocked ∧ needs≠∅` therefore becomes a new **NEEDS_HUMAN** class that logs,
+projects, labels and **never respawns**; plain `blocked` is unchanged. The Codex lane breaks the
+two-tier — `codex exec` writes no job dir and is **invisible to the census** — so supervision is
+**taken from the already-adopted `fable-orchestrator` plugin** (`scripts/run-lane.sh`:
+detached launch + watchdog, process-group kill, `EXITED`/`STILL-RUNNING`, and an `EXIT: <code>`
+marker whose *absence* means group-killed) rather than reinvented; #580 adds the typed
+`--output-schema`/`-o` verdict on top. A blocker is valid **only if it names what was
+exhausted** — `needs` must state the decision required *and* the fallbacks already tried, and the
+scheduler rejects an evidence-free escalation at projection time. Retry policy is **per reason**,
+not one cap: Succeeded advances; Failed retries to #573's cap 3 with its backoff; Cancelled
+consumes **no attempt** (the scheduler reconciled it out); NeedsHuman is **never** auto-retried;
+Stalled has no automatic action until #590. And the **run axis stays split from the verdict
+axis** — a `review` run is `Succeeded` whatever it concluded, while its verdict routes:
+`approve` advances, `revise` reopens **implement**, `reject` reopens **research** (which
+transitively re-blocks both), each incrementing rework against #573's `max_rework` 2 before
+`dag:needs-human`.
+
+**Resolved:** 2026-08-06
+
+## The taxonomy, and what it maps to
+
+| Reason | Read from | Retry policy |
+|---|---|---|
+| `Succeeded` | `state=done` · Codex `EXIT: 0` | advance; no retry |
+| `Failed` | `state=failed` · Codex `EXIT: <non-zero>` | retry to cap 3, backoff `min(10·2^(n-1),300)s` |
+| `NeedsHuman` | `state=blocked` **∧ `needs`≠∅** | **never** auto-retry |
+| `Stalled` | inferred (no native state) | **no action until #590** |
+| `CanceledByReconciliation` | `state=stopped` · Codex **no `EXIT:` line** | not a failure; re-selected later, consumes **no attempt** |
+
+Counters stay **tracker-owned** per #573 — the harness's own `attempt` self-resets after five
+healthy minutes, so it cannot be trusted as a cap. `573-gh-issues-db.md` §VERDICT independently
+fixes the same split: *"LABELS for anything the selector reads; APPEND-ONLY COMMENTS for retry
+counts, terminal reasons and stall timestamps. Never the body."*
+
+## Sources — what I actually opened
+
+- `docs/receipts/573.md` — the retry backoff, cap 3, tracker-owned counters, `max_rework` 2, and
+  the rework-by-reopen mechanism (live-probed 1→0→1) this grill routes onto.
+- `docs/receipts/574.md` — the stage table, the `gate`-as-escalation-only-kind ruling, and the
+  `xhigh` implement decision this receipt records a divergence from.
+- `docs/receipts/578.md` + `python/src/dotfiles_setup/dag_tick.py` — the shipped watchdog;
+  `:120` `TERMINAL_STATES = {done, failed, stopped}` with the verbatim comment *"`killed`/`blocked`
+  are **deliberately NOT terminal** — the harness auto-respawns both"*, and `:70` naming the two
+  live census nodes as *"blocked/dead since July 13 and July 22"*.
+- `docs/research/kb/reports/agents/wf-dag-recovery.md` §8 — `state.json` confirmed by
+  shape-enumeration of three real job dirs, the verbatim `fdfdaf90` escalation record, and the
+  `doSpawnUnlessSettledOnDisk` fact that makes tier 1 non-optional.
+- `docs/research/kb/reports/agents/symphony-and-ports.md` — SPEC's run-attempt lifecycle and its
+  five terminal reasons (`SPEC.md:680-692`); the narrow asymmetric escape hatch
+  (`elixir/WORKFLOW.md:187-197`); stokowski's per-state fields with `rework_to`/`max_rework`
+  **gate-only** (`config.py:115-116`, validation at `:643-645`).
+- `docs/research/kb/reports/agents/573-symphony-cc-ports.md` §1.6 — the cross-check that cymphony
+  attributes its blocker rule to SPEC §8.2, **which does not contain it**.
+- `docs/research/kb/reports/agents/wf-dag-symphony-gaps.md` E4, I7, §5 — the escalation-asymmetry
+  gap, the process-group-kill gap, and the ticket table.
+- `docs/research/kb/reports/agents/wf-dag-codex-lane.md` — OMC's reaper mechanics (liveness gate
+  `runtime-v2.ts:3047-3048`, CAS-under-file-lock, rename-for-idempotency), the instruction
+  *"wire the reaper's typed result enum straight into the escalation path"* (`:489`), and
+  **NEEDS-PROBE #12**, unrun.
+- `docs/research/kb/reports/agents/573-gh-issues-db.md` §VERDICT — labels vs comments vs body.
+- `docs/research/kb/reports/agents/wf-dag-context-gate.md` `:507,:512` — *"the escalation gate
+  needs a testable condition"*, and escalation triggers feeding the dynamic gate.
+- `~/.claude/plugins/marketplaces/fable-orchestrator/scripts/run-lane.sh` — read in full (186
+  lines); the supervisor adopted in R4.
+- The **codex-cli 0.146.0 binary** — byte-searched for the effort enum, because
+  `codex exec --help` does not carry it (`model_reasoning_effort` is a `-c` config key).
+
+## Prior art — the search I ran
+
+**Query:** `grep -rliE 'terminal reason|escalation gate|valid blocker|needs-human|rework_to'` over
+`docs/research/kb/reports/`, `docs/specs/`, `docs/adr/`, `docs/receipts/`
+
+### Control arm — run before believing the result
+
+**Known-present term:** `max_rework` → **5** files
+**Known-absent term (invented fresh this run):** `mwtkzheub93` → **0** files
+The probe discriminates in both directions. ⚠️ Publishing it burns it; the next receipt mints
+its own — and #574's `xhrupvondaq82` is now also spent.
+
+All eight hits were opened; every one is in **Sources** above. None dismissed.
+
+## Adversarial review
+
+**Lens:** the grill itself, run against **already-shipped code and an installed plugin** rather
+than against documents alone. Two decisions were overturned by what the lookup found:
+
+- **R2 → R3.** Adopting `NeedsHuman` sent me to `dag_tick.py`, which turned out to exclude
+  `blocked` from `TERMINAL_STATES` *deliberately*. The consequence is a live defect: an escalated
+  node whose process dies is classified DEAD and respawned into an idle zombie, silently
+  discarding the human's question. **The two stale July nodes in the census are that exact case**,
+  and only the 24h `--max-age` bound is preventing it today. R3 amends shipped behaviour.
+- **R4 was rewritten by the maintainer's question, not by my analysis.** I had drafted a
+  hand-rolled reaper; Ray asked *"shouldn't we be using the codex plugin"*. `run-lane.sh` already
+  owns detached launch, a polling watchdog that survives the calling agent, and **process-group
+  kill** (`set -m`; `kill -- -PID`, because *"the CLIs spawn child workers, and killing only the
+  parent leaves orphans"*) — which **closes `wf-dag-symphony-gaps.md` I7**, a gap flagged MISSING
+  and independently needed by two prior ports. Building beside it would have been the exact
+  reinvention `use-tool-builtins.md` forbids.
+
+**Provenance corrected, not inherited:** the port rule *"GitHub is not a valid blocker by
+default"* is a port's **practice**, not a spec ruling — `573-symphony-cc-ports.md` §1.6
+control-armed that cymphony cites SPEC §8.2 for a blocker clause §8.2 does not contain. R5
+therefore generalises the idea (a blocker must name what was exhausted) rather than copying the
+clause.
+
+## Notes
+
+- ⚠️ **A knowing divergence from #574, recorded rather than smoothed:** `run-lane.sh` hardcodes
+  `-c model_reasoning_effort=high` and exposes only `[model]`, so #574's `xhigh` for implement is
+  **unreachable through the plugin today**. Settled from the binary (three-corpus rule: binary >
+  `--help` > docs), the codex effort enum is `none · minimal · low · medium · high · xhigh · max ·
+  ultra` — control-armed (`model_reasoning_effort` → 25 hits; fresh `qzwmpvx71` → 0). So `xhigh`
+  is real, the plugin sits one level below our decision, and **two levels above it — `max` and
+  `ultra` — have never been considered in this project**; `ultra` has no Claude equivalent.
+- ⚠️ **Unrun and load-bearing (NEEDS-PROBE #12):** does `codex exec --output-schema` still write
+  its `-o` file on a failed or limit-aborted turn? A partial write is plausible (`exit(1)` at
+  `lib.rs:1061-1063`). Until it runs, *"the file exists"* may not mean *"the run succeeded"*, so
+  #580's reaper needs an explicit unknown-outcome branch rather than a boolean. Map #556 carries
+  the same item.
+- ⚠️ **Single-route and unverified:** #578's comment asserts *"the harness auto-respawns
+  killed/blocked"*. Nobody in this grill checked it, and R3 partly rests on it being **false** for
+  a NeedsHuman node. Fold it into #590's probe — same session, same instrument.
+- **#590 gates the `Stalled` row**, which ships with no behaviour. Accepted deliberately: the
+  row's existence is what stops `Stalled` silently inheriting the `Failed` retry policy, which is
+  a different thing from the decoration #574's R8 rejected.
+- **`codex exec review` has no `--cd`** — it reviews the invoking script's working directory, a
+  hazard once parallel lanes run in worktrees.
+- **The ticket's third ask was stale, and is recorded as checked rather than skipped:** *"is
+  rework a cycle or a new task?"* was settled by #573 (reopen the upstream issue) and the fog line
+  was cleared from map #556 at #574's close-out. Confirmed here, not reopened: **a new task via
+  reopen, never a cycle** — which obtains stokowski's `rework_to`-targets-any-earlier-state
+  semantics while `blockedBy` stays acyclic. Note stokowski scopes `rework_to`/`max_rework` to
+  **gate** states only; ours hangs off the review verdict, because #574 made `gate` escalation-only.
+- **Deferred deliberately:** the `dag:*` label spellings (`573-gh-issues-db.md` uses
+  `sched:needs-human`, #573's receipt `dag:needs-human` — the receipt is later and governs), the
+  projection's comment format, and the evidence contract each stage's brief renders.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the repo this grill is for;
+  map #556 and ticket #575 read via `gh`.


### PR DESCRIPTION
Resolves the wayfinder grilling ticket #575 on map #556. Seven decisions:

- R1 terminal reason is two-tier: the node writes `state.json` (forced —
  `doSpawnUnlessSettledOnDisk` reads it, so a terminal state there is how a
  node tells the #578 watchdog not to restart it), and the scheduler projects
  it to an append-only tracker comment, one direction only.
- R2 the taxonomy is symphony's SPEC five with one substitution — Succeeded /
  Failed / NeedsHuman / Stalled / CanceledByReconciliation. `TimedOut` drops
  (no timeout mechanism until #590); NeedsHuman is added, a reason symphony
  structurally cannot have.
- R3 amends shipped #578: `blocked ∧ needs≠∅` becomes a NEEDS_HUMAN class that
  never respawns. `dag_tick.py:120` excludes `blocked` from TERMINAL_STATES, and
  #565 measured that respawn returns a node IDLE with no prompt — so an
  escalated node whose process died is respawned into a zombie that will never
  re-ask. The two stale July census nodes are that exact case; only the 24h
  `--max-age` bound prevents it today.
- R4 Codex supervision is taken from the fable-orchestrator plugin's
  `run-lane.sh` (detached launch + watchdog, process-group kill, `EXIT: <code>`
  whose absence means group-killed) rather than reinvented — this closes gap
  I7. #580 adds the typed `--output-schema`/`-o` verdict on top.
- R5 a blocker is valid only if it names what was exhausted; the scheduler
  rejects an evidence-free escalation at projection time.
- R6 retry policy is per reason, not one cap: NeedsHuman never auto-retries,
  Cancelled consumes no attempt, Stalled is inert until #590.
- R7 the run axis stays split from the verdict axis — a review run is Succeeded
  whatever it concluded, while approve advances, revise reopens implement and
  reject reopens research, bounded by #573's max_rework 2.

Records a knowing divergence: `run-lane.sh` hardcodes
`model_reasoning_effort=high` while #574 chose `xhigh`. The codex effort enum
was settled from the binary (`--help` does not carry it):
none/minimal/low/medium/high/xhigh/max/ultra — so `xhigh` is real, and `max`
and `ultra` have never been considered in this project.

Map #556 updated: decision line added, the escalation-gate standing preference
bounded by R5's asymmetry rule, and the `TaskStop`-reaps-a-grandchild fog line
cleared — R4 means we never rely on `TaskStop` for the Codex lane.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Kx2UVERPARrYqr4qTKFawy

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788587996&installation_model_id=429246&pr_number=600&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F600&signature=5e343eafec0a13a43e3d7f093adc16d9df306ccbcd1fbb23e8e1172befaf8c90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->