### PR TITLE
docs(receipt-567): one of the three spawn pins went inert in CLI 2.1.224

### DIFF
--- a/docs/receipts/567.md
+++ b/docs/receipts/567.md
@@ -7,7 +7,8 @@ the namespace is the whole machine; purpose-named for the DAG framework, map #55
 `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE="33"` (~30% of a 200K window; lower-only; applies to
 subagents), and the three spawn caps under their real names at today's defaults —
 `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH="3"`, `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS="20"`,
-`CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION="200"` — pinned not to change behaviour but to freeze
+`CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION="200"` (⚠️ **inert since CLI 2.1.224** — see
+"Superseded in part" below) — pinned not to change behaviour but to freeze
 it: depth and concurrency are otherwise server-adjustable (`tengu_hazel_trellis` supplies
 depth when unset; `tengu_amber_kestrel` can remove the concurrency cap). Top-level settings
 gain `fallbackModel: ["opus", "sonnet"]` (REPLACES across scopes, max 3, excludes
@@ -22,6 +23,48 @@ interactive sessions in this repo now share one task list rather than per-sessio
 that sharing is the feature, not a side effect.
 
 **Resolved:** 2026-08-05
+
+## Superseded in part — 2026-08-07, CLI 2.1.224
+
+**One of the three spawn pins is now inert. The other two are unchanged.**
+
+CLI **2.1.224** removed the per-session subagent cap outright ("Removed the
+200-subagent-per-session spawn cap; long-running sessions no longer refuse new agents
+(concurrency and depth limits still apply)"). So the Verdict's claim that all three caps are
+"pinned not to change behaviour but to freeze it" **is no longer true of
+`CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION`** — there is nothing left to freeze.
+
+Measured by diffing the two bundles on disk (`~/.local/share/claude/versions/2.1.223` vs
+`2.1.224`), because a changelog line says what changed, not what a given setting now does:
+
+| probe | 2.1.223 | 2.1.224 | |
+|---|---|---|---|
+| reader `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION??` (with its `ZH_=200` default) | 1 | **0** | REMOVED |
+| enforcement string `Subagent spawn limit reached` | 4 | **0** | REMOVED |
+| telemetry event `subagent_count_cap` | 2 | **0** | REMOVED |
+| reader `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS??` — **control arm** | 1 | 1 | intact |
+| `tengu_amber_kestrel` concurrency gate — **control arm** | 2 | 2 | intact |
+| `CLAUDE_CODE_ZZ_NOPE??` — **control arm** | 0 | 0 | intact |
+
+The two control arms are what make the zeros mean something: the same `??`-reader search
+still finds the concurrency cap in 2.1.224, so the pattern can match — the per-session reader
+is genuinely gone, not merely unmatched.
+
+**The name survives in 3 string tables** (the recognized-settings lists), and nowhere else.
+That is the load-bearing distinction: the setting is **accepted and silently ignored**, not
+rejected. Keeping it costs nothing and produces no warning; it simply no longer does
+anything.
+
+**Decision (Ray, 2026-08-07): correct this receipt, keep the pin.** Removing a provably
+inert entry would re-open a reviewed diff for a no-op, and the pin still reads correctly if
+an older CLI is ever installed. What could not be left alone was the sentence — a receipt is
+a primary source future sessions trust, and a true-when-written claim that has quietly
+stopped being true is the exact failure `.claude/rules/verify-before-advancing.md` closes on.
+
+**Not re-verified here:** `CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH`. The `??`-reader probe
+returned 0 in **both** versions, so it is a null arm and says nothing either way — the depth
+value is evidently read by another route (the Verdict cites `tengu_hazel_trellis` supplying
+it when unset). Do not read the table above as covering depth.
 
 ## Sources — what I actually opened
 


### PR DESCRIPTION
CLI 2.1.224 removed the per-session subagent cap outright. #567's Verdict
says all three spawn caps are "pinned not to change behaviour but to
freeze it" — no longer true of `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION`,
because there is nothing left to freeze.

Measured by diffing the two bundles on disk rather than trusting the
changelog line, since a changelog says what changed and not what a given
setting now does. In 2.1.224 the `??`-reader (with its `ZH_=200` default),
the `Subagent spawn limit reached` enforcement string and the
`subagent_count_cap` telemetry event are all gone — 1/4/2 occurrences in
2.1.223, 0/0/0 in 2.1.224.

Two control arms make those zeros mean something: the same `??`-reader
search still finds `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` (1 -> 1) and the
`tengu_amber_kestrel` gate is intact (2 -> 2), so the pattern can still
match. The per-session reader is genuinely gone, not merely unmatched.

The name survives in 3 recognized-settings string tables and nowhere else,
which is the load-bearing distinction: the setting is accepted and
silently ignored, not rejected. Keeping it costs nothing and warns about
nothing.

Ray's decision, 2026-08-07: correct the receipt, keep the pin. Removing a
provably inert entry would re-open a reviewed diff for a no-op, and the
pin still reads correctly under an older CLI. What could not be left alone
was the sentence — a receipt is a primary source future sessions trust,
and a true-when-written claim that has quietly stopped being true is
exactly what `verify-before-advancing.md` closes on.

`CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH` is explicitly NOT re-verified: its
`??`-reader probe returned 0 in BOTH versions, so that arm is null and
says nothing either way. Labelled as such rather than folded into the
table.

Settings are untouched; this is docs-only. Gates: lint rc=0, lint-docs
clean, pytest 1,656 passed, verify 118 passed 0 failed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Kx2UVERPARrYqr4qTKFawy

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788675977&installation_model_id=429246&pr_number=621&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F621&signature=1a5a57990991a8933aab179e76acc07891077e98efb4f7ce9c632fcbc4564357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->