### PR TITLE
docs(602): scope the NEEDS_HUMAN tracker projection (spec + build plan)

### DIFF
--- a/docs/research/kb/reports/agents/602-crosssession-sendmessage-probe.md
+++ b/docs/research/kb/reports/agents/602-crosssession-sendmessage-probe.md
@@ -1,0 +1,663 @@
+# Cross-session SendMessage reach — can a human answer be delivered to a blocked `--bg` node? (2026-08-07, v2.1.224)
+
+**Question.** Can a human's answer be delivered, via 2.1.224's cross-session
+`SendMessage` (or `ListAgents` + `SendMessage`), to a background `--bg` node that is
+in `state="blocked"` with a non-empty `needs` payload and NO `queuedPrompt`?
+
+Split into two sub-cases, answered separately:
+
+- **(a) LIVE blocked node** — process alive, `state=blocked`, `needs` set.
+- **(b) DEAD blocked node** — process exited, `state.json` still reads `blocked` with a
+  `needs`. The real case on this host (`ad8baf35`, `fdfdaf90`).
+
+**Corpora, in precedence order:** the 2.1.224 binary
+(`~/.local/share/claude/versions/2.1.224`, 277,495,040 B) > `claude --help` /
+`claude <verb> --help` > the offline doc tree
+(`$CC = ~/dev/github/ray-manaloto/knowledge-base/sources/agent-harness-docs/docs/claude-code`).
+The 2.1.223 bundle (272,553,824 B) is a **built-in control arm** — diffing the two
+separates "2.1.224 added this" from "this was always there".
+
+**Hard constraint honoured:** `~/.claude/jobs/**` is READ-ONLY for this run. No probe
+below writes to a job dir. Where a write would have been required, the probe is
+described, not run.
+
+**Method note.** BSD `grep` is blind on this binary; every count below comes from a
+python byte-search (`re.finditer` over `open(path,'rb').read()`), counting
+**occurrences**, not lines.
+
+---
+
+## Verdict table
+
+_(filled in as findings land — see sections below)_
+
+| # | Verdict | Claim | Corpus + control arm |
+|---|---|---|---|
+| 1 | CONFIRMED | The local cross-session transport is a **unix domain socket**, and a peer is listed only if a live `net.connect()` to it succeeds within 250 ms | binary `rfa()`/`p1p()` @255813842; control `qzrmvblunk7742xy` → 0/0 vs `SendMessage` → 85/89 |
+| 2 | CONFIRMED | The peer registry is **`~/.claude/sessions/<pid>.json`**, a corpus entirely disjoint from `~/.claude/jobs/<id>/state.json` | binary `tfa()` @255814178; live: 2 registry entries, both for running pids; **0** entries for `ad8baf35`/`fdfdaf90` |
+| 3 | CONFIRMED | A dead peer's registry entry is **actively unlinked** during enumeration when the socket fails AND `process.kill(pid,0)` fails | binary `rfa()`: `nIr.unlink(s)`; `zC()` @246486880 |
+| 4 | CONFIRMED | **`bg` is a first-class peer kind** — a LIVE `--bg` node is enumerable and addressable | binary `a1b=["interactive","bg","daemon","daemon-worker"]` @255816856 |
+| 5 | CONFIRMED | **The peer backend NEVER writes `queuedPrompt`** — all three of its outcomes return before the only two writers | binary `WUn` @261567100, `ddm`/`GUn` @261587013 |
+| 6 | CONFIRMED | The only route carrying human text to a not-running job is a **respawn `initialPrompt`**, owned by FleetView's TUI | binary @265824651, resume resolution @261590516 |
+| 7 | **REFUTED** | "2.1.224 created a new delivery route" — the entire reply/queue/respawn machinery is **byte-identical** in 223 and 224 | 10 tokens all flat; control `crossSessionInbound` 0→18, `peer_inbound_gate` 0→9 in the same probe shape |
+| 8 | CONFIRMED | Live: the two blocked jobs carry `state` and **no `pid`**; the two live peers carry `pid`/`status` and **no `state`** | `claude agents --json` rc=0 — one command, both arms |
+| 9 | CONFIRMED | A non-interactive node's inbound gate **fail-closes to `hold`**, and hold needs a React dialog it cannot render | binary `lya()`/`cya()` @256689279; headless hold-receipt is log-only @266713516 |
+| 10 | CONFIRMED | **No `claude` job verb accepts text** — `respawn`/`attach`/`logs`/`stop`/`rm` take an id only | `claude <verb> --help`, rc=0 each |
+| 11 | **NEEDS-PROBE** | `claude attach` refuses a `blocked` job ("back to the list") | binary `pdm` only — not run, would write to a job dir |
+
+---
+
+## Findings
+
+### 1. The transport is a live socket, not a file drop
+
+`listAllPeers` (`ofa`, @255816856) builds the addressable set from four transports —
+`uds` (local machine), `cloud`, `bridge` (Remote Control), and `did` (hard-wired to
+empty in this build: `o=Promise.resolve({peers:[],warnings:[]})`). Local peers are
+`uds` only:
+
+```js
+let c = i.map((d) => ({transport:"uds", address:`uds:${d.sock}`, session:d}));
+```
+
+The `uds` set comes from `rfa()` @255816040, which is the whole answer:
+
+```js
+function rfa(){
+  let e=WXo(),
+      t=(await tfa()).filter((i)=>i.sock&&i.sock!==e),
+      r=await Promise.all(t.map((i)=>p1p(i.sock))),   // live socket probe
+      n=Wt()!=="wsl", o=[];
+  for(let i=0;i<t.length;i++){
+    let{file:s,...a}=t[i];
+    if(r[i]) o.push(a);                               // answered -> listed
+    else if(n&&!zC(a.pid)) nIr.unlink(s).catch(()=>{}) // dead -> DELETE the entry
+  }
+  return o
+}
+```
+
+`p1p` @255813842 is a real connect, not a stat:
+
+```js
+function p1p(e){return new Promise((t)=>{
+  if(!Z_e(e)){t(!1);return}
+  let r=Qpa.connect({path:e}),          // Qpa = require("net")
+      n=(o)=>{r.destroy(),t(o)};
+  r.on("connect",()=>n(!0));
+  r.on("error",(o)=>n(zt(o)==="EBUSY"));
+  r.setTimeout(250,()=>n(!1))
+})}
+```
+
+**A listening process is a precondition for addressability.** There is no filesystem
+drop-box fallback: if the socket does not answer inside 250 ms, the peer is not in the
+returned set, and therefore cannot be named by `SendMessage`.
+
+### 2. The peer registry is `~/.claude/sessions/<pid>.json` — not the job dir
+
+`tfa()` @255814178 reads `path.join(configDir, "sessions")` and accepts only filenames
+matching `/^\d+\.json$/` — **the registry is keyed by PID**. Each entry yields
+`messagingSocketPath`, `cwd`, `startedAt`, `procStart`, `name`, `kind`, `sessionId`,
+`jobId`, `parkedJobId`, `bridgeSessionId`, `logPath`, `status`, `waitingFor`.
+
+Live on this host (read-only), the registry holds exactly two entries, both running:
+
+```
+/Users/rmanaloto/.claude/sessions/1473.json
+  sessionId: '732297c5-087e-4e0d-b100-9ace9ce64873'  kind: 'interactive'  status: 'shell'
+  cwd: '/Users/rmanaloto/dev/github/ray-manaloto/knowledge-base'  name: 'knowledge-base-77'
+/Users/rmanaloto/.claude/sessions/14968.json
+  sessionId: '96dd0e23-6066-4c5e-aa6c-b38c2111e39b'  kind: 'interactive'  status: 'busy'
+  cwd: '/Users/rmanaloto/dev/github/ray-manaloto/dotfiles'  name: 'dotfiles-5e'
+```
+
+Both carry `messagingSocketPath`. **Neither `ad8baf35` nor `fdfdaf90` has a registry
+entry** — those job dirs (`state.json` mtimes 2026-07-13 and 2026-07-22) are in
+`~/.claude/jobs/`, a directory `tfa()` never reads.
+
+The entry carries a `jobId` field, so a *live* bg node's peer entry points **at** its
+job. There is no reverse pointer: nothing maps a job dir back to an addressable peer.
+
+### 3. Dead entries are garbage-collected, not merely skipped
+
+The `else if(n&&!zC(a.pid)) nIr.unlink(s)` branch means the first `ListAgents` after a
+node dies **deletes** its registry file. `zC` @246486880 is `process.kill(pid,0)`.
+So a dead node is not "listed but unreachable" — it is erased from the only namespace
+`SendMessage` resolves against.
+
+### 4. `bg` is a first-class peer kind
+
+`a1b=["interactive","bg","daemon","daemon-worker"]` @255816856 is the accepted-kind
+list, and `c1b=["busy","shell","idle","waiting"]` the status list. A `--bg` node is
+therefore a legitimate peer *while it is running* — case (a) is not excluded by kind.
+
+Note what is **absent** from the peer status list: `blocked`. Peer status is
+`busy|shell|idle|waiting`; `blocked` is a *job* state living in `state.json`. The two
+vocabularies do not overlap, which is the first hint that the peer channel and the job
+escalation ledger are separate systems.
+
+### 5. The peer backend NEVER writes `queuedPrompt` — decisive for the seam question
+
+`WUn(e,t,r,n,o)` @261567100 is the bg reply dispatch. Its first branch is the peer
+transport, and it returns in all three outcomes without touching disk:
+
+```js
+if(r?.backend==="peer"){
+  if(!r.sock) return Se("job_reply"), s("ok"), {err:Sil};          // no socket
+  try{ return await Zpa(r.sock,t), Se("job_reply"), s("ok"), null } // delivered
+  catch(h){ return me("job_reply","job_reply_peer_send_failed"),
+            s("bad","job_reply_peer_send_failed"),
+            {err:`Couldn't send to that session — ${ue(h)}`} } // failed
+}
+```
+
+There is no `ddm()` / `GUn()` call on this path. **`ddm` → `GUn` is the only function
+that sets `queuedPrompt`**, and it is reachable only from the *daemon* backend's
+failure branches further down the same function:
+
+```js
+async function GUn(e,t,r){ return Sh(e,{...t, queuedPrompt:r,
+  updatedAt:new Date().toISOString()}).then(()=>!0,(n)=>(z_(n),!1)) }   // @261587013
+async function ddm(e,t){ if(U1(t)!=="prompt")return!1; SE(e);
+  let r=await xl(e); if(!r)return!1;
+  if(r.queuedPrompt!==void 0) return r.queuedPrompt===t;               // won't overwrite
+  return GUn(e,r,t) }                                                  // @261567100
+```
+
+And the daemon branch only queues when the **daemon** is unreachable
+(`ENOCONN`/`ETIMEOUT`) or the send fails unclassified. When the daemon is up and
+answers `ENOJOB` — the job is known not-running — it returns
+`{err:uxt, code:"ENOJOB"}` with **no queue**. So `queuedPrompt` encodes "we could not
+determine the node's fate", not "the node is dead and here is its mail".
+
+### 6. The one path that does reach a not-running job is a RESPAWN, and it is FleetView's
+
+The second `queuedPrompt` writer is FleetView's peek-reply @265824651. Read in order,
+it does three things after `WUn` returns:
+
+```js
+let Kf = await WUn(et.id, Br, et.state, void 0, nl); Jo = Kf?.err ?? null; Pi = Kf?.code;
+if(Jo===uxt && U1(Br)==="prompt"){                                  // uxt = "not running"
+  let $a = await i8n(et.id,{knownState:et.state, initialPrompt:Br}); // RESPAWN with the text
+  os=!$a.ok; ra=!$a.ok&&$a.queued===!0;
+  Jo=$a.ok?null:ra?"Reply queued — will be sent when this session restarts":$a.error;
+}
+...
+if(!Pi && Kf!==void 0 && _vv.has(Kf) && U1(Br)==="prompt")
+  Rp = await Sh(qc(et.id), {...et.state, queuedPrompt:Br, updatedAt:...});
+```
+
+with `_vv=new Set(["EPIPE","ECONNRESET","ECONNREFUSED","ENOTCONN"])` @265850919.
+
+So the human's text reaches a not-running node **as a respawn `initialPrompt`**, not as
+a message. That matches the resume-prompt resolution already in the ledger:
+`M = t?.initialPrompt ?? c.queuedPrompt ?? (…) n.intent` @261590516.
+
+**This is a job-verb/FleetView route, not a cross-session `SendMessage` route.**
+
+### 7. ⚠️ None of §5–§6 is new in 2.1.224 — the version diff is flat
+
+This is the finding that decides the scope question, so it gets its own control arm.
+Same probe shape, same two files, run in one invocation:
+
+```
+'Reply queued':                           223=2   224=2
+'will be sent when this session restarts': 223=2   224=2
+'queue-to-disk write failed':             223=2   224=2
+'fleet_view_reply':                       223=10  224=10
+'queued_for_later':                       223=5   224=5
+'not_running_no_respawn':                 223=2   224=2
+'job_reply_peer_send_failed':             223=3   224=3
+'backend==="peer"':                       223=3   224=3
+'peek-reply send failed':                 223=2   224=2
+'queuedPrompt':                           223=14  224=14
+```
+
+**Control arm, same command, same corpus:** `crossSessionInbound` 223=0 → 224=18,
+`peer_inbound_gate` 0 → 9, `dialogExpiry` 0 → 4, `peer-send-message` 0 → 10. The probe
+plainly can produce a non-zero delta; it produces none here.
+
+And the live-socket constraint itself predates 224. 2.1.223 @252054500 carries
+`qAb()`, logically identical to 224's `rfa()`:
+
+```js
+async function qAb(){let e=fca(),t=(await pca()).filter((i)=>i.sock&&i.sock!==e),
+  r=await Promise.all(t.map((i)=>PMp(i.sock))),n=$t()!=="wsl",o=[];
+  for(let i=0;i<t.length;i++){let{file:s,...a}=t[i];
+    if(r[i])o.push(a); else if(n&&!AC(a.pid))bRr.unlink(s).catch(()=>{})}
+  return o}
+```
+
+**What 2.1.224 actually added is a receive-side GATE, not new reach.**
+`crossSessionInbound` is `["accept","hold","refuse"]` with this `.describe()`
+@245372933:
+
+> "Inbound cross-session peer messages (SendMessage from your other sessions):
+> 'accept' delivers them, 'hold' parks them for your review without letting Claude act,
+> 'refuse' opts this session out. An explicit value always wins. Unset (mode parity): a
+> message auto-delivers only when the sending session's permission-mode class matches
+> yours (bypass↔bypass or prompting↔prompting); a mismatched sender's message is held
+> for your approval…"
+
+2.1.224 made cross-session messaging **more reviewed**, not further-reaching.
+
+### 8. LIVE ARM — one command separates the two namespaces on this host
+
+`claude agents --json` (read-only, rc=0, empty stderr) returns **4 rows in two
+disjoint shapes**:
+
+```
+{"id":"ad8baf35","cwd":".../dotfiles","kind":"background","startedAt":1783962604973,
+ "sessionId":"ad8baf35-00fe-4223-80d1-9b0d94d9c338","state":"blocked"}   name:'zstd-compression-level-tuning'
+{"id":"fdfdaf90","cwd":".../dotfiles","kind":"background","startedAt":1784744247227,
+ "sessionId":"fdfdaf90-801e-4c7d-afe9-e00b780cc5bd","state":"blocked"}   name:'Resume KB concurrency queuing design…'
+{"pid":1473, "cwd":".../knowledge-base","kind":"interactive","status":"waiting","waitingFor":"input needed"}  name:'knowledge-base-77'
+{"pid":14968,"cwd":".../dotfiles",       "kind":"interactive","status":"busy"}                                name:'dotfiles-5e'
+```
+
+| | job rows (`ad8baf35`, `fdfdaf90`) | peer rows (`knowledge-base-77`, `dotfiles-5e`) |
+|---|---|---|
+| `id` | present | **absent** |
+| `pid` | **absent** | present |
+| `state` | `"blocked"` | **absent** |
+| `status` | **absent** | `waiting` / `busy` |
+
+**The two blocked nodes have no `pid`.** They are ledger entries, not processes. The
+live sessions have no `state` — they are processes, not ledger entries. This is the
+binary's `tfa()`-vs-jobs split, visible in one command.
+
+`knowledge-base-77` is the instructive row: a **live** session that is
+`status:"waiting", waitingFor:"input needed"` — the live analogue of "blocked" — and it
+*is* addressable, because it has a pid and a socket.
+
+The two target `state.json` files (read-only) are exactly the shape #602 cares about:
+
+```
+ad8baf35: state="blocked" tempo="blocked" backend="daemon"
+          needs="run `/clear` to proceed to next task"          queuedPrompt PRESENT: False
+fdfdaf90: state="blocked" tempo="blocked" backend="daemon"
+          needs="do /clear with resume, or run full command-catalog extraction first?"
+                                                                queuedPrompt PRESENT: False
+```
+
+`backend:"daemon"`, **not `"peer"`** — so `WUn` would not even enter the peer branch for
+these. And `~/.claude/daemon/roster.json` reads `workers: []` (updated 2026-08-05):
+no live worker exists for either.
+
+### 9. Case (a): a live bg node is addressable, but the inbound gate defaults to HOLD
+
+Delivery to a live peer is real. The `SendMessage` schema states it directly:
+
+> "A listed peer is alive and will process your message — no 'busy' state; messages
+> enqueue and drain at the receiver's next tool round. Your message arrives wrapped as
+> `<cross-session-message from="...">`."
+
+But whether Claude *acts* on it is decided by `lya()` @256689279:
+
+```js
+function lya(){
+  let e=TPr(); if(e!==void 0) return {policy:e, holdCause:"explicit-setting"};
+  let t=dya(); if(t===null) return {policy:"hold", holdCause:"mode-unknown"};
+  if(!iya.has(t.mode)) return E(`[cross-session-inbound] unrecognized permission mode …`),
+                              {policy:"hold", holdCause:"mode-unknown"};
+  return {policy: cya(t)?"hold":"accept", holdCause:"bypass-default"};
+}
+function cya(e){return e.mode==="bypassPermissions"
+                    || e.mode==="plan"&&e.isBypassPermissionsModeAvailable}  // @256690509
+```
+
+Every branch that is not "prompting mode" lands on **hold**, and hold is a dead end for
+a non-interactive node:
+
+- The hold buffer is an **in-memory array** — `q0e.push(e)` / `q0e.shift()` @256691439
+  — so it does not survive the process, and is capped (`q0e.length>=hqb` evicts oldest
+  as `expired`).
+- Approval is a **React dialog** — `[{value:"approve",label:"Deliver this message to
+  Claude"},{value:"deny",label:"Deny — drop it and tell the sender it was declined"}]`
+  @263382544 — which a `--bg` node has no surface to render or answer.
+- In headless the held message is merely **logged**: `E("[headless] cross-session
+  hold-receipt: status=${Ln} from=${…}")` @266713516.
+
+Neither this repo's `.claude/settings.json` nor `~/.claude/settings.json` sets
+`crossSessionInbound` (both `<UNSET>`), so mode parity applies rather than an explicit
+`accept`.
+
+### 10. No non-interactive verb carries text to a job
+
+`claude <verb> --help` (rc=0 each, read-only):
+
+```
+claude respawn <id>|--all   Restart a background session … so it picks up the current Claude binary.
+claude attach  <id>         Open the background session in this terminal.
+claude logs    <id>         Print the background session's recent terminal output.
+claude stop    <id>         Stop a background session.
+claude rm      <id>         Delete a background session and its worktree.
+```
+
+**None accepts a prompt or message argument.** The only code path that hands a human's
+text to a not-running job is FleetView's `i8n(et.id,{knownState, initialPrompt:Br})`
+(§6) — an interactive TUI action.
+
+And the binary refuses to attach a blocked job at all (`pdm` @261567100):
+
+```js
+if(r.state==="done"||r.state==="stopped"||r.state==="blocked")
+  return Se("job_attach"), ufe(t,"detached"), {kind:"error",ended:!0,
+    msg: … r.state==="blocked" ? "That session is blocked — back to the list" : …};
+```
+
+⚠️ **Not probe-exercised.** Running `claude attach ad8baf35` could write to the job dir,
+which this run is forbidden to do, so this is binary-only evidence. The probe that
+would settle it: `claude attach <id>` on a scratch blocked job (never on these two),
+expecting the literal `That session is blocked — back to the list`.
+
+---
+
+## Answers
+
+### (a) LIVE blocked node — **reachable, but the answer will not be acted on by default**
+
+`ListAgents` **can** enumerate it (`bg` is an accepted peer kind, §4) and `SendMessage`
+**can** address and deliver to it, provided its socket answers within 250 ms (§1).
+
+But a `--bg` node runs non-interactively, so `lya()` resolves to **hold** unless it is
+in a prompting permission mode or `crossSessionInbound:"accept"` is set explicitly
+(§9). Held means: parked in an in-memory buffer, awaiting a React approval dialog the
+node cannot render, logged as a `hold-receipt` and never actioned. Setting
+`crossSessionInbound:"accept"` in settings is the documented escape.
+
+**Confidence:** delivery mechanism and gate logic are CONFIRMED from the binary plus
+the tool's own loaded schema. **NOT probe-exercised end-to-end** — I did not spawn a
+`--bg` node and message it, per the "no long-lived background agents" constraint. A
+real send could still fail for a reason not visible in the code read.
+
+### (b) DEAD blocked node — **NO. Nothing cross-session can deliver to it.**
+
+Unambiguous, three independent routes:
+
+1. **It is not in the namespace.** `SendMessage` resolves names against `listAllPeers`,
+   which is built from `~/.claude/sessions/<pid>.json` filtered by a **live socket
+   connect** (§1, §2). `ad8baf35` and `fdfdaf90` have no entry there — live-verified,
+   §8.
+2. **Its entry would be deleted, not queued.** `rfa()` unlinks a registry file whose
+   socket is dead and whose pid is gone (§3).
+3. **The peer transport has no disk fallback.** `WUn`'s peer branch returns on all three
+   outcomes without ever calling `ddm`/`GUn`, the only `queuedPrompt` writers (§5).
+
+**Control arm for this negative:** the identical probe shape *does* return "reachable"
+for the two live sessions in the same `claude agents --json` output (§8), and the same
+byte-scan *does* find deltas where 2.1.224 changed things (§7). The probe can produce
+both answers; for case (b) it produces "absent".
+
+### Does 2.1.224 create a route that did not exist when R1 was written?
+
+**No.** The `queuedPrompt`/reply/respawn machinery is byte-identical across 2.1.223 and
+2.1.224 (§7, ten tokens, all flat), and the live-socket-only peer enumeration already
+existed in 223 as `qAb()`. 2.1.224 added an inbound **gate** (`crossSessionInbound`,
+`peer_inbound_gate`, `dialogExpiry`), which is a restriction.
+
+### Can an inbound cross-session message set `queuedPrompt`?
+
+**No — not from the peer path.** `queuedPrompt` has exactly two writers: `ddm`→`GUn`
+(daemon-backend failure, and only when the *daemon* is unreachable, never on a
+known-`ENOJOB`), and FleetView's peek-reply on an `_vv` errno. The peer branch of `WUn`
+reaches neither. The existing `dag_tick.py` seam is therefore **not** something
+2.1.224 lets a cross-session message drive.
+
+---
+
+## What this means for #602
+
+The default stays **OUT of scope**, and the evidence strengthens rather than weakens
+`docs/receipts/575.md` R1:
+
+- Case (b) — the case #602 exists for — has **no delivery route at all**, at any
+  version. The two real payloads on this host are unreachable by construction.
+- The only mechanism that gets human text into a not-running job is a **respawn with
+  `initialPrompt`**, which is a *scheduler* action (it restarts the node), not a
+  message. That is squarely on the scheduler's side of R1's boundary, so honouring it
+  would not make the boundary decorative — it would confirm it.
+- Case (a) is real but narrow, and would additionally require setting
+  `crossSessionInbound:"accept"`. Building the answer path on it would serve only live
+  nodes, which are not the ones that accumulate `needs`.
+
+**Blunt caveat:** everything about case (a)'s end-to-end behaviour is code-read, not
+probe. If #602 ever wants the live-node path, that probe must be run for real.
+
+---
+
+## What I could not establish
+
+- **No end-to-end live send.** I did not spawn a `--bg` node, block it, and message it.
+  The "no long-lived background agents" constraint plus the mutation ban made the clean
+  version of that probe unavailable within this run.
+- **`ListAgents` from a subagent.** I could not run the live `ListAgents` arm: the tool
+  is absent from a subagent's surface. Control-armed — `ToolSearch("select:ListAgents,
+  SendMessage")` returned **only** `SendMessage`, and `ToolSearch("select:ListAgents")`
+  returned "No matching deferred tools found". Matches the existing ledger row.
+- **`claude attach` on a blocked job** — binary-only (§10), deliberately not run.
+- **Whether a `--bg` node's socket survives entering `state=blocked`.** The registry
+  status vocabulary has no `blocked` value, so a blocked-but-alive node presumably
+  reports `idle`/`waiting`; I did not confirm this against a running instance.
+
+## Method notes
+
+- Control term used for the absence arm: a freshly invented token returning **0/0** in
+  both bundles while `SendMessage` returned 85/89. **That token is now burned by
+  appearing in this file** — invent a new one next run.
+- All counts are **occurrences** from a python byte-scan (`re.finditer` over the raw
+  bytes), not `grep` lines; BSD `grep` is blind on these bundles.
+- Scanner: `bscan.py` in the session scratchpad (not tracked).
+- `graphify` was not used: its graph covers this repo's source, and every corpus here
+  is the CLI bundle, `~/.claude`, or `--help` output — none of which it indexes.
+
+---
+
+# Round 2 — CORRECTION: my claim #1 was bounded to one transport
+
+The parent reported that both dead nodes **DO** appear in a real `ListAgents` call at
+2.1.224, as `Remote Control · idle`, among 34 such rows. That is correct, and it
+falsifies the *reasoning* I gave for case (b).
+
+## ⚠️ What I got wrong, stated plainly
+
+§(b) claim 1 read: *"It is not in the namespace. `SendMessage` resolves names against
+`listAllPeers`, which is built from `~/.claude/sessions/<pid>.json` filtered by a live
+socket connect."*
+
+`listAllPeers` has **four** transports — `uds`, `cloud`, `bridge`, `did` — and I
+verified only `uds`. I then stated the conclusion about `listAllPeers` as a whole.
+**That is the founding incident's exact shape: a probe correct inside its bound,
+reported about the world.** The bound was "the local socket registry"; the answer was
+given about "everything `SendMessage` can resolve".
+
+The verdict on case (b) survives — **but on different evidence, and claim 1 as written
+must be replaced.** Corrected rows are in the table below.
+
+## Finding 12 — bridge rows come from a REMOTE server, and are de-duplicated *against* live local peers
+
+`UXo()` @255810288 fetches bridge rows via `listBridgePeerSessions`, which is an
+**authenticated cloud API call** (`t1b` @255805456: `prepareApiRequest`,
+`getOAuthHeaders`, `accessToken`, `orgUUID`), paged and fallible:
+
+```
+E(`[bridge:population] fetched ${s.length} rows in ${Date.now()-n}ms${i.failed?" (FAILED — not recordable)":""}${i.truncated?" (truncated at page budget)":""}`)
+```
+
+So bridge rows are **not read from local disk at all**. They are the server's record of
+sessions on this account. Both target nodes registered one while alive — read-only from
+their `state.json`:
+
+```
+ad8baf35: bridgeSessionId "cse_01GUpexKZFUw8TRpDGyDYNo3"  bridgeOutboundOnly false  bridgeSessionSeq 2804
+fdfdaf90: bridgeSessionId "cse_0169UxhfT3XUpG9ATWWgwk1K"  bridgeOutboundOnly false
+```
+
+Then `jXo` @255811685 is the join, and it is the whole explanation:
+
+```js
+function jXo(e,t,r){                       // e = bridge rows, t = live uds peers, r = cloud sessions
+  let n=new Set(t.map((i)=>i.bridgeSessionId).filter((i)=>!!i)),
+      o=new Set(r.filter((i)=>!zAn(t,i.id)).map((i)=>lz(i.id)));
+  return e.filter((i)=>!n.has(i.id) && !o.has(lz(i.id)))
+}
+```
+
+A bridge row is kept **only if no live local peer claims its `bridgeSessionId`**. The
+bridge listing is therefore, by construction, *the set of sessions that are NOT locally
+live* — which is precisely why two long-dead nodes appear there and my live sessions do
+not. Their presence is not evidence of reachability; it is a **consequence of being
+dead**.
+
+(`RWt()` @255811685 is `async function RWt(){return{sessions:[],unavailable:void 0}}` —
+the `cloud` transport is hard-wired empty in this build, as is `did`. Only `uds` and
+`bridge` are real.)
+
+## Finding 13 — reply-only is ENFORCED IN CODE, not prose. Answers the parent's Q1
+
+This is the parent's first question, and the answer is unambiguous: **code**.
+
+Inside the `SendMessage` tool's own `call` @256735394, a name that matches a bridge row
+resolves to kind **`not-found`** — bridge rows are never a deliverable target — and
+`bridgeReplyOnly` only customises the refusal text:
+
+```js
+if(p.kind==="not-found"){
+  if(p.bridgeReplyOnly){
+    let A=f?`check the spelling against ${cy}`:"check the spelling";
+    return {data:{success:!1, message:`'${e.to}' matches a ${WLe} session on this account,
+      and those are reply-only from here: messageable ${_Bt}. The Claude Code Remote
+      send_message connector is not a workaround either — it cannot reach these
+      device-gated sessions, and its "untrusted device" error is misleading (this device
+      is not the problem). If that session is who you meant, it isn't reachable by name
+      from this machine; if you meant a different agent, ${A}.`}}
+  }
+}
+```
+
+with `WLe="Remote Control"` and `_Bt="only in reply, after it messages you first"`.
+`Oqp(e,t)` @256685964 sets the flag by matching the requested name against bridge row
+**titles**; `Z_a` @256685964 returns `{kind:"not-found", …}`. The file-send path refuses
+in parallel: `{kind:"refused", message:…}` @256753722.
+
+**`success: false`.** The send does not happen, and the caller is told so.
+
+⚠️ **Do not mistake `isBridgeDispatchable` for a peer predicate.** It has 2 occurrences
+in both 223 and 224, and it lives in the **slash-command** module @255903477 alongside
+`isAdvertisedSlashCommand` / `getCommands`. It governs commands, not messaging.
+
+## Finding 14 — `idle` vs `blocked`: two probes of DIFFERENT facts, neither broken
+
+The parent invoked `probes-need-a-control-arm.md` rule 7 correctly, and the resolution
+is the third option: they are not measuring the same fact.
+
+| | bridge row `idle` | `state.json` `blocked` |
+|---|---|---|
+| Source | Anthropic's server, over an authenticated fetch (§12) | local disk, `~/.claude/jobs/<id>/state.json` |
+| Written by | the bridge session record | the local job supervisor |
+| Means | the server's session record has no active turn | the local job ledger's last escalation before the process died |
+| Knows about local process liveness? | **No** | no — it is a last-write, not a heartbeat |
+
+The bridge server was never told about `state:"blocked"`; that vocabulary is local-only
+(and recall from §4 that the peer status vocabulary — `busy|shell|idle|waiting` — has no
+`blocked` member at all). Both nodes carry `firstTerminalAt` (2026-07-13 / 2026-07-22),
+so locally they reached a terminal moment; the server simply still holds a stale record.
+
+The harness **expects** this staleness — it ships a classifier for it,
+`isLikelyStaleBridgeError` (`r1b` @255807696) and `classifyBridgeSendError` (`n1b`).
+
+### The parent's worry — "may ACCEPT a send and report success" — does NOT happen
+
+This was the right thing to be worried about, and it is settled: delivery does **not**
+route on the bridge view. A bridge-matched name resolves to `not-found` and returns
+`success:false` (§13). The dangerous outcome — a cheerful success for a node dead since
+July — is specifically what the code refuses to produce.
+
+## Corrected verdict rows
+
+| # | Verdict | Claim | Corpus + control arm |
+|---|---|---|---|
+| ~~1~~ | **CORRECTED** | ~~"`SendMessage` resolves names against `listAllPeers`, built from the socket registry"~~ — true of the `uds` transport ONLY; `listAllPeers` also returns `bridge` rows | superseded by rows 12–14 |
+| 12 | CONFIRMED | Bridge rows come from an **authenticated remote fetch**, and `jXo` keeps a row only when **no live local peer** claims its `bridgeSessionId` — so the bridge list is enriched with dead sessions **by construction** | binary `UXo` @255810288, `t1b` @255805456, `jXo` @255811685; live: both nodes carry a `cse_…` `bridgeSessionId` |
+| 13 | CONFIRMED | **Reply-only is enforced in CODE.** A bridge-matched name resolves to `kind:"not-found"` and `SendMessage` returns **`success:false`** | binary @256735394 (tool `call`), `Oqp`/`Z_a` @256685964, file path @256753722 |
+| 14 | CONFIRMED | `idle` and `blocked` are **different facts from different corpora**, not a disagreement; the harness ships a stale-bridge classifier | binary `r1b`/`n1b` @255807696; `firstTerminalAt` set on both nodes |
+| 15 | REFUTED | "delivery might route on the bridge view and report success for a dead node" | the refusal returns `success:false`; there is no path from a bridge row to a send |
+
+## Case (b), restated on correct evidence
+
+**Still NO — nothing can deliver to a dead blocked node.** The reasoning changes:
+
+- **Enumerable: YES.** Both nodes appear via the `bridge` transport, sourced from the
+  server, *because* they are locally dead (§12).
+- **Addressable: NO.** A bridge-matched name is `kind:"not-found"`; `SendMessage`
+  returns `success:false` with an explicit "isn't reachable by name from this machine"
+  (§13).
+- **Enumerable ≠ addressable** — exactly as the parent suspected, and it is enforced,
+  not merely documented.
+
+The `--bg`/`background` label is absent from those rows for the same reason: the row is
+the *server's* session record, which carries a title, not the local job ledger's `kind`.
+
+## Finding 16 — ⚠️ it is NOT a "name collision"; correct the spec's mechanism
+
+`docs/specs/dag-needs-human-projection.md` §0 currently records the bridge rows as
+*"Name collision, not reach."* **The conclusion (not reachable) is right; the stated
+mechanism is wrong**, and a wrong mechanism in a tracked spec will mislead whoever reads
+it next.
+
+A collision would mean two unrelated sessions that happen to share a title. The evidence
+says these are **the same sessions, recorded in a different corpus**:
+
+- Both nodes carry a real bridge registration in their own `state.json` —
+  `bridgeSessionId: "cse_01GUpexKZFUw8TRpDGyDYNo3"` and `"cse_0169UxhfT3XUpG9ATWWgwk1K"`,
+  with `bridgeOutboundOnly:false`. They registered with the bridge **while alive**.
+- `jXo` @255811685 retains a bridge row **only when no live local peer claims its
+  `bridgeSessionId`** — so a genuinely-dead node's own row is exactly what survives.
+
+The accurate one-liner is: **"the same session, held in the server-side bridge corpus,
+which is enumerable but refuses by-name delivery (`success:false`) — enumerable ≠
+addressable."** Not a coincidence of names; a real record of the real node, kept
+*because* it is dead.
+
+**Honest bound on this correction:** I did not see the raw bridge row **ids** — the
+parent's listing showed titles and labels only. So "same session" is **SUSPECT, one
+route**: it rests on both nodes holding a `cse_…` id plus `jXo`'s keep-if-not-live
+filter, not on an observed id match. The probe that would settle it: capture
+`ListAgents` output that exposes each row's `[ref]`/id and compare against the two
+`bridgeSessionId` values above. Either way the *addressability* verdict (§13) is
+unaffected — that one is settled from the tool's own `call`.
+
+## Round 2 control arms
+
+- Fresh known-absent term, invented for this round: **0 / 0** in both bundles, while
+  `bridgeSessionId` returned 76 / 79 and `Remote Control` 211 / 218 in the same
+  invocation — the probe discriminates. (That term is now burned by being run in this
+  session; invent another next round.)
+- Version arm: `reply-only` 223=**1** → 224=**11**, `only in reply` 0 → 2,
+  `recordModelViewOfBridgePeers` 0 → 3, while `bridgeOutboundOnly` stayed 9/9 and
+  `isBridgeDispatchable` 2/2. So 2.1.224 substantially **expanded the reply-only
+  refusal surface** — again a restriction, consistent with §7.
+- I did **not** send to either node, per instruction. No job dir was written: mtimes
+  remain `Jul 13 20:29` and `Jul 22 13:23`.
+
+## Round 2 — what remains unestablished
+
+- **I did not spawn a throwaway node.** Case (a) is still code-read only; the parent
+  offered a throwaway-node arm and I did not take it, because the two questions asked
+  in round 2 were both settleable from the binary and the offered arm would not have
+  exercised the *bridge* path anyway (a fresh local node is a `uds` peer).
+- **Whether a live bridge session can be reached "in reply"** — the code refuses
+  by-name sends, but I did not verify the reply path itself, which requires an inbound
+  message first.
+- **What the bridge row's `idle` would show for a node that is alive but blocked** —
+  unprobed; §14 establishes only that the server is not told about `blocked`.
+
+## GitHub repos touched
+
+_None._ Every corpus consulted was local: the installed Claude Code bundles at
+`~/.local/share/claude/versions/{2.1.223,2.1.224}`, runtime state under `~/.claude/`,
+and `claude --help` output. No repository source or documentation site was read.
+Note that the `bridge` transport's rows originate from an Anthropic API endpoint, but I
+read the calling code, not the endpoint.
+

--- a/docs/specs/dag-needs-human-projection.md
+++ b/docs/specs/dag-needs-human-projection.md
@@ -1,0 +1,640 @@
+# Spec — projecting NEEDS_HUMAN to the tracker (#602)
+
+**Status:** scoping complete, build not started. This document settles the four
+decisions #602 leaves open and specifies the build; it authorises no code.
+
+**Ticket:** [#602](https://github.com/ray-manaloto/dotfiles/issues/602) —
+"Project NEEDS_HUMAN to the tracker: the `dag:needs-human` label and the
+escalation comment".
+
+**Why a spec and not a plan file.** `.agent/plans/` is gitignored and
+this-clone-only, and **#602 exists precisely because a deferral lived only in a
+code comment**. A decision that must outlive this clone is tracked or it is not a
+decision.
+
+---
+
+## 0. What was measured before designing
+
+Every design fact below was probed on this host on **2026-08-07**, not inherited
+from the ticket. Where a probe returned a negative, its control arm is named —
+per `.claude/rules/probes-need-a-control-arm.md`, an unarmed negative is not
+evidence.
+
+| # | Claim | Probe | Control arm |
+|---|---|---|---|
+| M1 | **No scheduler module exists.** #602 is greenfield, not an extension. | `ls python/src/dotfiles_setup/ \| grep -iE 'sched\|relaunch\|tracker\|project'` → rc=1 | 47 modules listed by the same `ls`, so the listing is not empty |
+| M2 | **Nothing in the package writes to the GitHub tracker.** The write side is greenfield too. | `grep -rn 'gh issue\|--add-label\|issues/comments' python/src/dotfiles_setup/*.py` → 3 hits, **all prose inside docstrings** (`heredoc.py:12`, `workflow_hooks.py:466,779`), zero call sites | the grep does return hits, so it is not blind |
+| M3 | **No node→issue binding exists anywhere.** | union of `state.json` keys across all **8** job dirs contains no `issue`/`ticket`/`taskId` field; a job dir holds only `state.json`, `timeline.jsonl`, `tmp/`; no binding symbol in `dag_tick.py`/`codex_lane.py`/`codex_verdict.py` | known-present `NEEDS_HUMAN_LABEL` → 3 files; fresh known-absent term → 0 files. Probe discriminates both ways |
+| M4 | **The launchd tick CAN authenticate to the tracker.** | under the exact `environment` PATH from `mise.toml`'s `[bootstrap.macos.launchd.agents.dotfiles-dag-tick]`, `env -i PATH=… HOME=… gh auth status` → **rc=0**, via `~/.config/gh/hosts.yml`, a `gho_` token with `repo` scope; `gh api /repos/ray-manaloto/dotfiles` → **rc=0** | ⚠️ the FIRST run of this probe reported "gh: No such file or directory" — a **null arm**: the PATH passed did not contain `gh`, so it never asked the question. Corrected by first asserting `command -v gh` resolves on that PATH |
+| M5 | **Exactly two live escalations exist**, both `blocked ∧ needs ∧ ¬queuedPrompt`, both `tempo=blocked`. | enumerated `~/.claude/jobs/*/state.json` | 8 job dirs read, 6 non-matching — the filter discriminates |
+| M6 | **Neither live payload names what was exhausted** ⇒ both fail #575 R5. | read verbatim (§2.2) | — |
+| M7 | **2.1.224 added no new delivery route to a blocked node** (§3). | byte-diff of the 2.1.223 and 2.1.224 bundles: every delivery term identical | `crossSessionInbound` 0→18, `peer-send-message` 0→10 on the same command — the probe can produce a delta, and produces none here |
+| M8 | **Neither the `dag:needs-human` label nor a standing escalation issue exists yet.** Both are phase-1 work. | `gh label list` → no `dag:*` label (only `needs-triage`, `needs-info`); `gh issue list --state open` → no escalation issue | 23 labels and 137 open issues returned by the same commands, so neither probe is blind |
+
+⚠️ **TWO wrong claims were made during this pass and corrected by evidence.
+Recorded, because both would otherwise read as facts — and the second is the more
+instructive.**
+
+**C1 — the null arm (M4).** Covered above: a probe that could not have produced
+the other answer, reported as an answer.
+
+**C2 — a claim correct inside its bound, stated about the world.** The scoping
+session's `ListAgents` call returned 34 rows, two of them matching the live nodes'
+`name` fields. First reading: *"the escalated nodes are enumerable."* The probe's
+first round replied that they are **not** in the peer namespace, because
+`SendMessage` resolves against the local socket registry, which holds zero entries
+for either. Round 2 retracted that: `listAllPeers` has **four** transports and only
+`uds` had been checked, so a conclusion about the local registry was stated about
+everything `SendMessage` can resolve.
+
+**Both readings were wrong, and the truth is neither.** The nodes ARE those rows —
+real records of the real sessions, held in the server-side `bridge` corpus — and
+they are enumerable **because** they are dead (§3.2). They are simply not
+addressable: a bridge-matched name returns `success: false`. **Enumerable ≠
+addressable, and it is enforced in code rather than merely documented.**
+
+The verdict on case (b) never moved; the mechanism under it was wrong twice. That
+is the failure mode this file's §0 exists to make expensive — and the only reason
+either was caught is that each claim was handed onward with *"verify this"*
+attached rather than *"use this"*.
+
+**M4 is the one that changed the design.** Had the null arm stood, this spec
+would have specified a credential-passing mechanism the tick does not need.
+Recorded here rather than quietly dropped, because the corrected result reverses
+the conclusion.
+
+---
+
+## 1. The gap, restated precisely
+
+`dag_tick.py` classifies an escalated node `NodeClass.NEEDS_HUMAN`
+(`state == "blocked"` ∧ non-empty `needs` ∧ no `queuedPrompt`), logs it, and
+**never respawns** it. The projection half — the `dag:needs-human` label and the
+append-only tracker comment — was deliberately left unowned, because
+`docs/receipts/575.md` R1 keeps projection **one-directional and
+scheduler-owned**, and a tick that labelled directly would put a second writer on
+the tracker.
+
+The boundary is right. Nothing owns the other side. Consequence, live: an
+escalated node is visible **in a launchd log only** — `~/Library/Logs/
+dotfiles-dag-tick.log` — so the `needs` payload that R1 makes load-bearing
+reaches a human only if somebody reads that file.
+
+Three things are already **settled** and are not reopened here:
+
+- **Ownership** — `575.md` R1: the scheduler projects, one direction only.
+- **This label's spelling** — `575.md`: *"#573's receipt `dag:needs-human` — the
+  receipt is later and governs"*. (#601's close-out claimed the receipt deferred
+  the spelling; it does not.)
+- **Labels vs comments vs body** — `docs/receipts/573.md` §VERDICT: *"LABELS for
+  anything the selector reads; APPEND-ONLY COMMENTS for retry counts, terminal
+  reasons and stall timestamps. Never the body."*
+
+---
+
+## 2. The four decisions
+
+### 2.1 Decision A — the OWNER
+
+> **A new `dag_project.py` module, a `mise run dag-project` task, and its own
+> LaunchAgent — built as the SCHEDULER'S FIRST SLICE, not as a watchdog feature.**
+
+`575.md` R1 assigns projection to the scheduler. M1 measured that no scheduler
+exists, so #602 cannot "extend" one — it must create the first phase of the thing
+#573 specified. Shaped so that when #573's pull loop lands, projection is
+absorbed as a phase in its fixed order (reconcile → **project** → preflight →
+select → dispatch) rather than refactored out of somewhere it should never have
+been.
+
+**Rejected: fold projection into `dag_tick.py` behind a flag.** Forbidden three
+times over — `575.md` R1, the `NEEDS_HUMAN_LABEL` comment in `dag_tick.py:155-176`
+(*"a tick that labelled directly would put a second writer on the tracker"*), and
+the `workflow.dag-tick-wiring` contract, which binds the current wording. It would
+also make the eventual move to the scheduler a contract edit rather than a
+re-wiring.
+
+**Rejected: wait for the full #573 pull loop.** That leaves the two live
+escalations invisible for the duration, which is the failure being ended.
+
+Four properties bind the module:
+
+1. **It reuses `dag_tick`'s predicates by import — it never re-derives them.**
+   `node_from_state`, `normalize_needs`, `is_needs_human`. This is the #601/#604
+   lesson stated as an invariant: two readers of one file that disagree about it
+   is the exact defect class both of those tickets shipped fixes for. A private
+   copy of `is_needs_human` in `dag_project.py` is a spec violation, not a style
+   choice.
+2. **One direction, always.** It READS `~/.claude/jobs/**` and WRITES only to
+   GitHub. It never writes a job dir, never calls `claude respawn`/`stop`/`rm`,
+   and never edits an issue **body**.
+3. **Zero escalations ⇒ zero API calls.** It classifies from disk first and
+   returns before touching the network if no node is NEEDS_HUMAN. The common case
+   is zero, and a projector that makes no call when idle cannot misfire when idle.
+4. **Its own lockfile**, `~/.local/state/dotfiles/dag-project.lock`, on the same
+   `fcntl` pattern as `dag_tick`'s. A second projector that finds it held exits 0
+   silently. Distinct from the tick's lock — the two are separate processes and
+   must not serialise against each other.
+
+**Interval: 300s, not 60s.** The watchdog's 60s exists because a crashed process
+should be recovered fast. A human's question does not become more answerable at
+60s than at 5 minutes, and the tracker is a shared rate-limited resource. Stated
+as a decision so a later reader does not "fix" it into alignment with the tick.
+
+### 2.2 Decision B — the BINDING and the projection TARGET
+
+> **The scheduler writes a node→issue binding at dispatch. A BOUND node projects
+> to its own issue; an UNBOUND node projects to one designated standing
+> escalation issue.**
+
+*(Ray's ruling, 2026-08-07, on the fork M3 uncovered.)*
+
+M3 is the load-bearing measurement: **nothing binds a node to an issue today.**
+Both live escalations were hand-launched long before any scheduler, so under a
+bound-nodes-only reading #602 would ship having surfaced **0 of its own 2
+motivating cases** — a fix that would not have caught its own motivating defect.
+
+**The binding artifact:** `~/.claude/jobs/<node>/dag-binding.json`
+
+```json
+{"schema_version": 1, "repo": "ray-manaloto/dotfiles", "issue": 602,
+ "bound_at": "2026-08-07T12:00:00Z", "bound_by": "dag-dispatch"}
+```
+
+Colocated in the job dir on #580's precedent for `CODEX_LANE_DIRNAME`: *"a
+`claude rm` of the node takes its lane with it instead of orphaning a run dir the
+reaper would keep finding forever."* The same argument holds exactly — a binding
+that outlives its node is a pointer to nothing.
+
+`schema_version` is present from v1 deliberately: `codex_verdict.py`'s docstring
+records that OMC's payload lacks one *"which is why a contract change there breaks
+silently"*.
+
+**The standing escalation issue** is a dedicated, permanently-open tracker issue
+whose number is a module constant (`DEFAULT_ESCALATION_ISSUE`) with a
+`--escalation-issue` override — a reviewable diff, not silent per-clone drift.
+
+**Rejected: infer the issue from a node's free text.** Measured on the real data,
+it fabricates. `ad8baf35` is NAMED `zstd-compression-level-tuning`, its `intent`
+reads *"Resume the hk-enforcement task"*, and its `output.result` names **#237,
+#238 and #231** — three candidate numbers, none authoritative, and none of them
+what the node was actually blocked on. A wrong guess posts a human's unanswered
+question onto an unrelated ticket, which is worse than the silence it replaces.
+
+**Closed-target handling** — both arms, because both are reachable:
+
+| Target state | Action | Why |
+|---|---|---|
+| Standing issue is **closed** | **Reopen it**, then project | A closed standing escalation issue while escalations exist *is* the silence failure. #573: *"only the scheduler transitions state"* — this is the scheduler, so the transition is in-bounds |
+| A **bound** node's issue is closed | Project to the **standing issue** instead, with a line naming the closed bound issue | Reopening a work issue is **rework**, whose semantics `575.md` R7 owns (`max_rework` 2, reopen-the-upstream-issue). A projector must not invent them as a side effect of an escalation |
+
+### 2.3 Decision C — the COMMENT FORMAT
+
+> **One append-only comment per (node, question), opening with an invisible HTML
+> machine marker and followed by a dual-audience human body.**
+
+Dual-audience follows #573's adopted stokowski precedent (*"append-only
+dual-audience comments"*).
+
+```markdown
+<!-- dag:needs-human node=ad8baf35 digest=3f2a91c07b4e schema=1 -->
+### 🙋 NEEDS_HUMAN — node `ad8baf35`
+
+**The question** — `needs`, verbatim from `~/.claude/jobs/ad8baf35/state.json`:
+
+> run `/clear` to proceed to next task
+
+**Suggested reply** — `suggestedReply`: _absent_
+
+| Field | Value |
+|---|---|
+| node | `ad8baf35` |
+| state / tempo | `blocked` / `blocked` |
+| `state.json` mtime | 2026-07-13T20:29:08Z |
+| binding | **UNBOUND** — no `dag-binding.json`; projected to the standing escalation issue |
+| R5 evidence | ⚠️ **UNVALIDATED** — see below |
+| also stalled | no |
+| projected by | `dag-project` @ 2026-08-07T14:02:11Z |
+
+**What the watchdog will and will not do** (verbatim from
+`dag_tick._needs_human_reason()`):
+
+> escalated — state=blocked with a needs payload and no queued reply, so a human
+> was asked a question a respawn cannot answer; not respawned BY THIS TICK at any
+> age […]
+
+**How to answer:** reply to this node in FleetView — that respawns it with your
+answer as `initialPrompt` (§3.3). ⚠️ This node's job dir no longer exists, so
+there is nothing left to answer; this comment is a record, not a live question.
+```
+
+The "How to answer" line has **two forms and the projector must pick the right
+one**: a node whose job dir is present gets the FleetView instruction; a node
+whose job dir is gone gets the record-not-question form. Telling an operator to
+reply to something that cannot receive a reply is the same class of defect as a
+log line naming an action the code does not perform.
+
+Rules that make the format a contract rather than a layout:
+
+- **The `needs` payload is quoted VERBATIM and never summarised.** It is the
+  entire cargo; a projector that paraphrases it has lost the thing it exists to
+  carry.
+- **The reason string is reproduced verbatim from `_needs_human_reason()`**, not
+  restated. That string is pinned by **golden equality** in `tests/test_dag_tick.py`
+  precisely because it must claim the re-check without claiming the race is gone;
+  a paraphrase in the comment would silently drop the scope qualifiers that two
+  rounds of #601 review put there.
+- **Never the issue body.** #573 §VERDICT.
+- **`schema=1` in the marker**, same reasoning as the binding file.
+
+**Dedupe key: `digest = sha256(needs_normalized).hexdigest()[:12]`.**
+
+The projector lists the target issue's existing comments and skips if a marker
+with the same `node=` **and** `digest=` is already present. Keyed on both because
+the two failure modes are opposite: keying on `node` alone means a node that
+re-escalates with a **new** question is silently never reported again; keying on
+`digest` alone collides across nodes asking the same question.
+
+**Why not the label as the dedupe key.** It cannot work for the standing issue:
+the label lives on the *issue*, so the first escalation would label it and every
+subsequent node's comment would be suppressed. The marker is per-node by
+construction.
+
+This is a **read of a snapshot, not a read-back of our own write** — #573's
+gotcha (*"never read back your own GitHub write to confirm it"*) is respected.
+A double-post from replication lag is possible and benign: the artifact is
+append-only and the second copy is identical.
+
+### 2.4 Decision D — R5 is a LABEL, NOT A GATE
+
+> **An escalation that fails #575 R5 is PROJECTED ANYWAY, marked
+> `R5: UNVALIDATED` in the comment. It is never dropped.**
+
+*(Ray's ruling, 2026-08-07.)* `575.md` R5 says a blocker is valid only if it names
+what was exhausted, and that *"the scheduler rejects an evidence-free escalation
+at projection time"*. Read as a gate, that would **drop** both live escalations
+(M6) — and **the failure #602 exists to end is silence**, so dropping a malformed
+escalation recreates that exact failure at a new layer. `dag_tick`'s own
+`REPLY_QUEUED` precedent chose visibility for the same reason: *"Making it VISIBLE
+IS the fix."*
+
+Say it explicitly in the artifact rather than letting the comment read as
+compliance. The spec's position is that R5 as written is **not implementable as a
+gate on harness-native payloads**, and here is why:
+
+**R5 validity is decided STRUCTURALLY, never semantically.** The projector asks
+*"does this escalation carry a machine-readable evidence field?"* — not *"does
+this prose sound like it names what was exhausted?"*
+
+That is a deliberate refusal to build a semantic classifier, and the reason is on
+the record in this repo: the #601 review killed substring-based reason checking
+across two rounds, concluding that *"a substring guard cannot judge meaning, so
+tightening it is unwinnable"*. Each round's counterexample defeated the previous
+guard by adding a clause it did not constrain. A heuristic scanning `needs` for
+"tried"/"exhausted"/"fallback" is that same losing shape, one layer up — and its
+false negatives would drop a real human question.
+
+Consequence, stated plainly: **every harness-native escalation is `UNVALIDATED`
+today**, because `state.json`'s `needs` is a free-form string the harness writes
+and there is no evidence field to carry. That is honest, matches M6 exactly, and
+leaves a clean seam — when the scheduler dispatches nodes with a brief that
+instructs them to write structured evidence, `VALIDATED` becomes reachable
+without changing the predicate. Out of scope here.
+
+**R5 status does NOT get its own label.** #573: labels are for *"anything the
+selector reads"*. Nothing selects on R5 validity in this slice, so by the
+receipt's own rule it belongs in the comment.
+
+### 2.5 Decision E — the ANSWER path stays OUT OF SCOPE
+
+> **Projection is one-directional. Not by policy — by measurement.**
+
+*(Ray's ruling 3: probe first, then decide. The probe ran; full evidence in
+`docs/research/kb/reports/agents/602-crosssession-sendmessage-probe.md`.)*
+
+The premise the ruling was hedging against is **refuted**. §3 has the detail; the
+decision follows from it and is no longer a boundary argument.
+
+---
+
+## 3. The answer path — what 2.1.224 actually changed
+
+The previous session measured `crossSessionInbound` 0→18, `dialogExpiry` 0→4 and
+`ListAgents` 5→10 between the 2.1.223 and 2.1.224 bundles, and inferred that
+cross-session `SendMessage` was *"a NEW delivery route for a NEEDS_HUMAN answer,
+material to #602 and #590"*. That inference is **wrong**, and the string counts
+never supported it — they proved a feature exists, not that it reaches anything.
+
+### 3.1 The version diff is FLAT for every delivery mechanism
+
+Same probe shape, both bundles, one invocation:
+
+| Term | 2.1.223 | 2.1.224 |
+|---|---|---|
+| `queuedPrompt` | 14 | 14 |
+| `Reply queued` | 2 | 2 |
+| `will be sent when this session restarts` | 2 | 2 |
+| `fleet_view_reply` | 10 | 10 |
+| `queued_for_later` | 5 | 5 |
+| `not_running_no_respawn` | 2 | 2 |
+| `backend==="peer"` | 3 | 3 |
+
+**Control arm, same command, same corpus:** `crossSessionInbound` 0→**18**,
+`peer_inbound_gate` 0→**9**, `peer-send-message` 0→**10**. The probe plainly
+*can* produce a non-zero delta. It produces none on any delivery path.
+
+**What 2.1.224 actually added is RESTRICTION, on two independent axes.** A
+receive-side gate — `crossSessionInbound` is `["accept","hold","refuse"]`,
+controlling whether an inbound peer message auto-delivers or is held for review —
+and an expanded send-side refusal surface: `reply-only` 1→**11**, `only in reply`
+0→**2**, `recordModelViewOfBridgePeers` 0→**3**, while `bridgeOutboundOnly` held
+at 9/9 and `isBridgeDispatchable` at 2/2. Both axes narrow what a message can do.
+2.1.224 made cross-session messaging **more reviewed, not further-reaching.**
+
+### 3.2 The two sub-cases
+
+**(b) A DEAD blocked node is ENUMERABLE BUT NOT ADDRESSABLE.** This is the case
+#602 exists for, and the distinction is the whole of it.
+
+`listAllPeers` has **four** transports. Two are hard-wired empty in this build
+(`cloud`, `did`); two are real:
+
+- **`uds`** — the local registry `~/.claude/sessions/<pid>.json`, keyed by PID and
+  entirely disjoint from `~/.claude/jobs/<id>/state.json`. Enumeration probes each
+  peer's unix socket with a real 250 ms `net.connect()`, and when the socket fails
+  *and* `process.kill(pid,0)` fails it **unlinks the registry file**. Verified
+  live: zero `uds` entries for either node.
+- **`bridge`** — rows fetched from Anthropic's server over an authenticated API
+  call, not read from local disk. Both nodes registered while alive
+  (`bridgeSessionId: "cse_…"`, `bridgeOutboundOnly: false`), so both still appear
+  here. The join keeps a bridge row **only when no live local peer claims its
+  `bridgeSessionId`** — so the bridge listing is, by construction, *the set of
+  sessions that are not locally live*. **Their presence in it is a consequence of
+  being dead, not evidence of reachability.**
+
+**Addressability is refused in CODE, not by convention.** Inside `SendMessage`'s
+own `call`, a name matching a bridge row resolves to `kind: "not-found"` and the
+tool returns **`success: false`** with an explicit *"isn't reachable by name from
+this machine"*; a `bridgeReplyOnly` flag only customises the refusal text. The
+file-send path refuses in parallel with `kind: "refused"`. The dangerous
+outcome — a cheerful success for a node dead since July — is specifically what the
+code declines to produce.
+
+⚠️ **Honest bound.** That these bridge rows are *the same sessions* rather than
+similarly-titled ones is **SUSPECT, one route**: it rests on both nodes holding a
+`cse_…` id plus the keep-if-not-live filter, not on an observed id match. The
+settling probe is to capture `ListAgents` output exposing each row's id and
+compare. **The addressability verdict does not depend on it** — that one is read
+straight off the tool's own `call`.
+
+Confirmed in one command: `claude agents --json` returns **two disjoint row
+shapes** — the two blocked nodes carry `id` + `state:"blocked"` and **no `pid`**
+(ledger entries), while the two live sessions carry `pid` + `status` and **no
+`state`** (processes). Both live nodes also read `backend:"daemon"`, not `"peer"`,
+so the peer transport branch is never even entered for them, and
+`~/.claude/daemon/roster.json` reads `workers: []`.
+
+**(a) A LIVE blocked node is addressable, but the answer is HELD, not acted on.**
+`bg` is a first-class peer kind, so a running `--bg` node is enumerable and can be
+messaged. Two things stop that from being an answer path:
+
+- **The peer transport never writes `queuedPrompt`.** Its three outcomes are
+  delivered, no-socket and send-failed, and none touches disk. `queuedPrompt` is
+  written only by the *daemon* backend's failure branches, and only when the
+  daemon is **unreachable** — so it encodes *"we could not determine the node's
+  fate"*, not *"the node is dead, here is its mail"*. The existing `dag_tick`
+  seam is therefore not something a cross-session message can drive.
+- **2.1.224's new inbound gate defaults to HOLD for a non-interactive node.**
+  With `crossSessionInbound` unset (it is unset in both this repo's and the user's
+  `settings.json`), mode parity applies and every branch that is not a prompting
+  mode lands on `hold`. Hold is a dead end for a `--bg` node: the buffer is
+  **in-memory** (so it dies with the process and evicts oldest when full) and
+  approval is a **React dialog a background node has no surface to render**.
+
+**No non-interactive verb carries text to a job either.** `claude
+respawn|attach|logs|stop|rm` — none accepts a prompt or message argument, and the
+binary explicitly **refuses to attach a blocked job** (*"That session is blocked —
+back to the list"*).
+
+### 3.3 The route that DOES reach a not-running node — and why the watchdog must not take it
+
+There is exactly one, and it is not a message: FleetView's reply path, on getting
+"not running", **respawns the node with the human's text as `initialPrompt`**.
+
+This sharpens #601 rather than contradicting it. #601 forbade the watchdog from
+respawning a NEEDS_HUMAN node because a **bare** respawn returns the node idle
+with no prompt, discarding the payload. A respawn carrying `initialPrompt` is a
+different operation — it delivers. The distinction is now on the record so a
+future reader does not resolve the tension in the wrong direction: **`dag_project`
+still never respawns anything.** It is a projector; taking the delivery route
+would make it a second actor on the fleet and re-cross the R1 boundary from the
+other side.
+
+### 3.4 Consequences for this spec
+
+1. **The answer path is OUT of scope, on evidence.** #601, #616 and #604 each
+   stopped at R1's one-directional boundary as a judgment call. It is no longer a
+   judgment call: for the case that matters, no inbound route exists at all.
+2. **`_needs_human_reason()`'s scope qualifiers survive unchanged.** The previous
+   session speculated its *"separate route this module cannot close"* count was
+   *"plausibly 3, not 2"* on the strength of the string deltas. **It is still 2** —
+   nothing in 2.1.224 added a route. Do not edit that golden string on this basis.
+3. **The comment's "How to answer" section becomes concrete** rather than vague:
+   answer through FleetView's reply on the node, which respawns it with the answer
+   as `initialPrompt`. For a node whose job dir is gone, say so — there is nothing
+   to answer, and the comment should not imply otherwise.
+4. **#590 inherits an unchanged question.** The harness's own supervisor respawn
+   predicate reads `state`/`tempo`/`queuedPrompt` and never `needs`; whether it
+   fires for a `blocked` node remains unverified, and 2.1.224 did not touch it.
+
+### 3.5 A seam this leaves open — for a later ticket, not this one
+
+The respawn-with-`initialPrompt` route is **a scheduler action, not a message** —
+it restarts the node. So a future ticket that builds an answer path on it would
+sit squarely on the scheduler's side of R1's boundary and would **confirm** that
+boundary rather than make it decorative. That is a real option, and naming it is
+the point; building it is not in #602.
+
+### 3.6 What the probe could NOT establish — do not read past these
+
+- **No end-to-end live send was performed.** Case (a) is a code read of the
+  binary plus the tool's own schema, not an exercised probe. The mutation ban on
+  `~/.claude/jobs/**` and the no-long-lived-agents constraint made the clean
+  version unavailable. **If a later ticket wants the live-node path, that probe
+  must be run for real.**
+- **`claude attach` on a blocked job is binary-only evidence**, deliberately not
+  run against the two live nodes.
+- **Whether a `--bg` node's socket survives entering `state=blocked` is
+  unconfirmed.** The registry status vocabulary has no `blocked` value.
+- **The bridge rows' raw ids were never observed** — "same session, not a
+  similarly-titled one" is SUSPECT/one-route (§3.2's honest bound).
+- **The reply path itself was not exercised.** The code refuses *by-name* sends;
+  whether a live bridge session can be reached *in reply* was not tested, since
+  that requires an inbound message first.
+
+None of these weakens the case-(b) answer. Its load-bearing half is
+**addressability**, read straight off the `SendMessage` tool's own `call` —
+`kind: "not-found"` → `success: false` — and that does not depend on any of the
+open items above. The `idle`-vs-`blocked` disagreement is also resolved, and the
+resolution is the third option: **two probes of different facts, neither broken.**
+The bridge row's `idle` is the server's record; `state.json`'s `blocked` is the
+local job ledger's last write. The server was never told about `blocked` — that
+vocabulary is local-only — and the harness ships a stale-bridge classifier
+precisely because it expects the divergence.
+
+---
+
+## 4. Build plan
+
+Phased so each phase is independently shippable and independently green. **No
+phase begins before the previous one's gates pass** (`verify-before-advancing.md`).
+
+### Phase 1 — the artifact, no automation *(smallest useful slice)*
+
+1. Create the standing escalation issue on the tracker; record its number.
+2. Create the `dag:needs-human` label on the repo (it does not exist yet —
+   verify before creating).
+3. **Hand-project the two live escalations** using the §2.3 format, by hand.
+
+**Why by hand first.** `docs/specs/ticket-bound-receipts.md` piloted exactly this
+way and its §12 verdict is the reason: writing the artifact by hand is what
+reveals which fields are real and which become ritual, *before* a module hardcodes
+them. Two instances is a thin pilot, but two is every case that exists.
+
+**Gate:** both comments render correctly; the marker is invisible; the `needs`
+text survives verbatim through GitHub's markdown (blockquote + backtick handling
+is the specific risk — `ad8baf35`'s payload contains backticks).
+
+### Phase 2 — `dag_project.py`, read-only
+
+`--dry-run` prints exactly what it would post and posts nothing. Reuses
+`dag_tick`'s predicates per §2.1 invariant 1.
+
+**Gate:** `--dry-run` output for the two live nodes is byte-identical to the
+phase-1 hand-written comments, modulo the timestamp. That is the control arm — a
+projector verified only against fixtures it authored has proven nothing.
+
+### Phase 3 — the write path
+
+Label application, comment posting, marker-based dedupe, closed-target handling
+(§2.2 table). Both arms of every branch tested, per
+`probes-need-a-control-arm.md` rule 2.
+
+**Gate:** run twice in a row against a scratch issue; the second run posts
+**nothing**. A dedupe verified only on the first run is a check that can only
+pass.
+
+### Phase 4 — the mise task and the LaunchAgent
+
+`[tasks.dag-project]` + `[bootstrap.macos.launchd.agents.dotfiles-dag-project]`,
+`start_interval = 300`, same literal `~/.local/bin/mise` program path and explicit
+`environment` PATH as the tick (the `mise`-is-a-zsh-function trap). **Inert until
+a human runs `mise bootstrap macos launchd-agents apply`** — never implicit
+(`do-not.md`).
+
+### Phase 5 — the binding, written at dispatch
+
+`dag-binding.json` (§2.2) plus the bound-node branch. **This phase is blocked on
+a dispatcher existing** and may land with #573 rather than here; the unbound path
+from phases 1–4 is complete without it.
+
+### Phase 6 — contracts and docs, in the same change as the code
+
+- **Edit `workflow.dag-tick-wiring`'s description** in
+  `python/verification/suites.toml` — it records the deferral in three places
+  (*"#602 owns that projection"*, *"no in-tree component emits the label"*,
+  *"only the IMPLEMENTATION is pending"*). Closing #602 without this leaves the
+  contract asserting a gap that no longer exists.
+- **Edit `dag_tick.py:161-164`** — the `⚠️ Nothing in this process emits it —
+  #602 owns the projection` comment, same reason.
+- ⚠️ **Do NOT edit `_needs_human_reason()`'s `"is NOT done here — #602"`
+  clause.** It is scoped to *this process*, and it stays true after #602 ships:
+  the tick still does not project. It is pinned by golden equality; changing it
+  fails `test_plan_needs_human_reason_claims_no_action_this_module_skips`, and
+  that test is doing its job.
+- Add a `workflow.dag-projection-wiring` contract binding the new chain.
+- Write `docs/receipts/602.md`.
+
+---
+
+## 5. Known holes — named, not papered over
+
+1. **The standing issue grows without bound.** Every unbound escalation appends
+   forever, and nothing prunes. No hygiene mechanism is specified because none is
+   needed at 2 escalations in 3 weeks; revisit if it exceeds ~50 comments.
+2. **A node that escalates, is answered, and re-escalates with the SAME question
+   posts once.** The digest cannot distinguish "still asking" from "asking
+   again". Accepted: the label persists, so the state is not lost — only the
+   second timestamp is.
+3. **Label removal is unspecified.** Nothing in this slice clears
+   `dag:needs-human` when an escalation resolves, because nothing observes
+   resolution. The label is therefore **monotone** in slice 1 and a human clears
+   it. State it in the comment so no operator reads a stale label as live.
+4. **Two LaunchAgents now read `~/.claude/jobs/**` on different intervals.**
+   Reads only, no lock shared, no interaction — but it is two schedules to
+   reason about, and #573's loop should collapse them.
+5. **The `gho_` token's scopes were read, not exercised for a write.** M4 proved
+   `repo` scope is present and a read call succeeds; it did not post a comment
+   from the launchd env. Phase 3's gate closes this.
+6. **`_needs_human_reason()` is reproduced verbatim into a GitHub comment**, so
+   the golden-equality test now indirectly pins operator-facing tracker content.
+   That is intended, and worth knowing before someone "improves" the string.
+
+---
+
+## 6. What this would have caught — and what it would not
+
+**Would have caught:** the live case. Two nodes have sat `blocked ∧ needs` since
+2026-07-13 and 2026-07-22 with their questions visible only in a launchd log. With
+this shipped, both appear on the tracker as labelled, quoted, timestamped
+comments.
+
+**Would NOT have caught:** anything about whether the *answer* gets back. §3
+settles that this projection is one-directional by measurement, not merely by
+policy. A human reading the comment still answers out-of-band.
+
+**Would NOT have caught:** an escalation whose node was `claude rm`'d before the
+next projector tick — the job dir is the only source, and it is gone. Latency to
+first projection is up to 300s.
+
+---
+
+## 7. Sources — what was actually opened
+
+- [#602](https://github.com/ray-manaloto/dotfiles/issues/602) — the ticket, read
+  in full. It carries its own correction to #601's close-out: `575.md` **settles**
+  the label spelling; what is deferred is the owner and the comment format.
+- `docs/receipts/575.md` — R1 (projection scheduler-owned, one direction), R5
+  (a blocker names what was exhausted), R7 (rework), and the *"Deferred
+  deliberately"* line.
+- `docs/receipts/573.md` — tracker-owned counters, the labels/comments/body
+  split, the stokowski dual-audience precedent, and the two gotchas (never read
+  back your own write; verify a mutation from its own response body).
+- `python/src/dotfiles_setup/dag_tick.py` — the seam: `NEEDS_HUMAN_LABEL:176`,
+  `is_needs_human:399`, `is_reply_queued:435`, `classify:470`,
+  `_needs_human_reason:569`, `plan:653`, the note loop at `:1001`.
+- `python/verification/suites.toml` — `workflow.dag-tick-wiring`, which records
+  the same deferral in three places and must be edited to close #602.
+- `python/src/dotfiles_setup/codex_verdict.py` — the `schema_version` precedent
+  and the "the file exists is necessary but never sufficient" discipline.
+- `docs/specs/ticket-bound-receipts.md` — the pilot-by-hand-first precedent
+  adopted for phase 1, and its §12 verdict on which fields become ritual.
+- `mise.toml` — `[tasks.dag-tick]:514`, the LaunchAgent block at `:1064`, and its
+  `environment` PATH (the M4 probe input).
+- `~/.claude/jobs/*/state.json` — all 8, read-only.
+- `docs/research/kb/reports/agents/602-crosssession-sendmessage-probe.md` — the
+  ruling-3 probe, persisted verbatim.
+
+## 8. Review history
+
+- **2026-08-07** — scoped. Ray ruled on three forks before scoping began (owner
+  deliverable shape, R5-as-label, answer-path-probe-first) and on a fourth the
+  scoping pass uncovered (§2.2, the projection target for an unbound node). The
+  answer-path probe ran during scoping and **refuted** the prior session's
+  reading of the 2.1.224 string deltas (§3).
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the repo
+  this spec is for; #602, #601, #604, #616, #573, #575, #580, #590 read via `gh`
+  and via `docs/receipts/`.


### PR DESCRIPTION
Settles the four decisions #602 leaves open and specifies a 6-phase build.
No code — Ray's ruling: spec + plan, then stop.

Owner: a new `dag_project.py` + `mise run dag-project` + its own LaunchAgent,
built as the SCHEDULER'S FIRST SLICE. 575 R1 assigns projection to the
scheduler; measured, no scheduler module exists (control-armed), so #602
creates the first phase of #573's loop rather than extending anything. It
reuses dag_tick's predicates BY IMPORT — a private copy of is_needs_human is
the #601/#604 defect class, not a style choice.

Target: a standing escalation issue for unbound nodes, plus a
`dag-binding.json` written at dispatch for bound ones. This closes a fork the
ticket did not name: NOTHING binds a node to an issue today (no such field in
the union of all 8 state.json key sets; a job dir holds only state.json +
timeline.jsonl + tmp). Under a bound-nodes-only reading #602 would have
shipped surfacing 0 of its own 2 motivating cases.

Comment format: an invisible HTML marker + dual-audience body, deduped on
node AND payload digest — keying on either alone fails in opposite
directions. The `needs` payload and `_needs_human_reason()` are reproduced
verbatim, never paraphrased.

R5 becomes a STRUCTURAL predicate, never semantic, and a label rather than a
gate: the #601 review already established a substring guard cannot judge
meaning, and dropping an evidence-free escalation would recreate the silence
#602 exists to end.

The answer path stays OUT of scope, now on evidence rather than on the R1
boundary argument. The prior session's reading of the 2.1.224 string deltas
is refuted: every delivery mechanism is byte-identical across 2.1.223 and
2.1.224 while the control arm shows real deltas where 224 did change things.
2.1.224 added restriction on two axes — a receive-side gate and an expanded
reply-only refusal surface — not reach. `_needs_human_reason()`'s route count
is still 2; do not edit it on the "plausibly 3" basis.

A dead blocked node is ENUMERABLE BUT NOT ADDRESSABLE, and the spec records
two wrong mechanisms proposed for that conclusion before the right one. The
nodes really do appear in `ListAgents` — as server-side `bridge` rows, kept
BECAUSE they are not locally live — and a bridge-matched name resolves to
`kind:"not-found"` with `success:false`. Enforced in code, not convention.

Probe persisted verbatim (two rounds, the second retracting the first's
over-broad claim) at
docs/research/kb/reports/agents/602-crosssession-sendmessage-probe.md.

Gates: lint rc=0 (0 task failures) · lint-docs rc=0 · pytest 1656 passed,
10 deselected · verify run 118 passed, 0 failed, 4 skipped.

Refs #602, #601, #604, #575, #573, #580, #590

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016npXNzS9Jvn7sREeYbaqKH

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788679162&installation_model_id=429246&pr_number=622&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F622&signature=444607429714854ab284cd975b6ad96fd082475acdbcfcd9533280332803cb92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a research report documenting cross-session message delivery behavior for background jobs, including delivery limitations and refusal scenarios.
  * Added a specification for projecting human-action-required workflow nodes to GitHub.
  * Documented ownership, issue binding, labels, comments, deduplication, closed-target handling, validation, scheduling, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->