### PR TITLE
docs(602): the phase-2 fixture is manufacturable, not lost with the nodes

### DIFF
--- a/docs/specs/dag-needs-human-projection.md
+++ b/docs/specs/dag-needs-human-projection.md
@@ -30,7 +30,9 @@ evidence.
 | M5 | **Exactly two live escalations exist**, both `blocked ∧ needs ∧ ¬queuedPrompt`, both `tempo=blocked`. | enumerated `~/.claude/jobs/*/state.json` | 8 job dirs read, 6 non-matching — the filter discriminates |
 | M6 | **Neither live payload names what was exhausted** ⇒ both fail #575 R5. | read verbatim (§2.2) | — |
 | M7 | **2.1.224 added no new delivery route to a blocked node** (§3). | byte-diff of the 2.1.223 and 2.1.224 bundles: every delivery term identical | `crossSessionInbound` 0→18, `peer-send-message` 0→10 on the same command — the probe can produce a delta, and produces none here |
-| M8 | **Neither the `dag:needs-human` label nor a standing escalation issue exists yet.** Both are phase-1 work. | `gh label list` → no `dag:*` label (only `needs-triage`, `needs-info`); `gh issue list --state open` → no escalation issue | 23 labels and 137 open issues returned by the same commands, so neither probe is blind |
+| M8 | **Neither the `dag:needs-human` label nor a standing escalation issue existed** before phase 1. | `gh label list` → no `dag:*` label (only `needs-triage`, `needs-info`); `gh issue list --state open` → no escalation issue | 23 labels and 137 open issues returned by the same commands, so neither probe is blind |
+| M9 | **A real NEEDS_HUMAN node is manufacturable in seconds** — `claude --bg --bare` lands in `blocked` + `needs: "login required — run /login"` (§4 phase 2). | spawned one 2026-08-07; it satisfied `is_needs_human()` on first read | the same `claude agents --json` census showed the two interactive rows as `busy`, not `blocked` — the probe distinguishes the states |
+| M10 | **`claude rm` requires a live daemon, and its error text misattributes the cause.** It says *"the background service may be restarting"* when the supervisor has been dead for days. | `roster.json`'s `supervisorPid` 42939 → `ProcessLookupError`; `~/.claude/daemon/dispatch/` empty; three `claude rm` attempts refused. Spawning any `--bg` session revives it (new PID 50245) and `rm` then succeeds rc=0 | the liveness probe reported the shell's own PID as ALIVE, so it discriminates; and after the fix, `rm` removed exactly the two named nodes while an untargeted node stayed present |
 
 ⚠️ **TWO wrong claims were made during this pass and corrected by evidence.
 Recorded, because both would otherwise read as facts — and the second is the more
@@ -574,9 +576,34 @@ detect a fidelity loss that renders nicely.
 `--dry-run` prints exactly what it would post and posts nothing. Reuses
 `dag_tick`'s predicates per §2.1 invariant 1.
 
-**Gate:** `--dry-run` output for the two live nodes is byte-identical to the
-phase-1 hand-written comments, modulo the timestamp. That is the control arm — a
-projector verified only against fixtures it authored has proven nothing.
+**Gate:** `--dry-run` output is byte-identical to the phase-1 hand-written
+comments, modulo the timestamp — a projector verified only against fixtures it
+authored has proven nothing.
+
+⚠️ **Both phase-1 nodes were `claude rm`'d on 2026-08-07** (their work resolved:
+`ad8baf35` moot, `fdfdaf90`'s proposal filed as #625). Their full `state.json`
+records are preserved verbatim in the #623 comments. **This does NOT weaken the
+gate, and the reason is a measurement, not a hope:**
+
+> **A real escalation is MANUFACTURABLE on demand, in seconds.**
+> `claude --bg --bare "<any prompt>"` spawns a background node that lands
+> immediately in `state="blocked"` with `needs: "login required — run /login"`
+> and no `queuedPrompt` — because `--bare` skips keychain reads, so the session
+> has no credentials. Measured 2026-08-07 while reviving the daemon; the node
+> satisfied `is_needs_human()` on the first read.
+
+That is **better** than the removed files, not a degraded substitute: the
+`state.json` is written by **the harness's own writer**, so it carries whatever
+fields that writer emits at the current CLI version — which a hand-authored
+fixture cannot promise and would silently drift from. Phase 2 should therefore
+build its fixture by spawning one, reading it, and stopping it, rather than by
+transcribing a payload.
+
+**A third R5 data point fell out of it.** `"login required — run /login"` also
+fails R5 — it names no exhausted alternative. That is now **3 of 3** independent
+harness-native payloads `UNVALIDATED`, from three different CLI versions
+(2.1.207, 2.1.217, 2.1.224), which is stronger support for §2.4's structural
+predicate than the two cases the decision was originally made on.
 
 ### Phase 3 — the write path
 
@@ -643,6 +670,15 @@ from phases 1–4 is complete without it.
 6. **`_needs_human_reason()` is reproduced verbatim into a GitHub comment**, so
    the golden-equality test now indirectly pins operator-facing tracker content.
    That is intended, and worth knowing before someone "improves" the string.
+7. ⚠️ **An escalated node whose daemon has died cannot be cleaned up by any
+   automated path — and that is not this spec's to fix.** `claude rm` needs the
+   daemon socket (M10), and `dag_tick` deliberately never acts on a NEEDS_HUMAN
+   node, which is the whole of #601. So the class of node most likely to go
+   stale is exactly the class nothing can remove. Both phase-1 nodes hit this;
+   the manual cure is to spawn any `--bg` session, which revives the supervisor.
+   **This belongs with #590 (stall recovery), not #602** — a projector that
+   started removing nodes would stop being one-directional. Recorded here because
+   #602's own phase 1 is where it surfaced.
 
 ---
 


### PR DESCRIPTION
Both phase-1 nodes were `claude rm`'d once their work resolved (ad8baf35 moot,
fdfdaf90's proposal filed as #625), and the #623 resolution comment warned that
phase 2's gate would fall back to a synthetic fixture — "a weaker control arm
than the real files were".

That warning is wrong, and reviving the daemon is what disproved it. Spawning a
throwaway `claude --bg --bare` session to bring the supervisor back up produced
a node that landed IMMEDIATELY in `state="blocked"` with
`needs: "login required — run /login"` and no queuedPrompt — `--bare` skips
keychain reads, so the session has no credentials. It satisfied
`is_needs_human()` on the first read.

So a real escalation is manufacturable in seconds, and it is BETTER than the
removed files rather than a degraded substitute: the state.json is written by
the harness's own writer at the current CLI version, which a hand-authored
fixture cannot promise and would silently drift from. Phase 2 builds its fixture
by spawning one, not by transcribing a payload.

A third R5 data point fell out of it. "login required — run /login" also names
no exhausted alternative, so it is 3 of 3 harness-native payloads UNVALIDATED,
across three CLI versions (2.1.207, 2.1.217, 2.1.224) — stronger support for
§2.4's structural predicate than the two cases it was decided on.

Also recorded, as M10 and known hole 7: `claude rm` requires a live daemon and
its error text misattributes the cause — it says "the background service may be
restarting" when the supervisor has been dead for days. Consequence worth
naming: an escalated node whose daemon died cannot be cleaned up by ANY
automated path, since `claude rm` needs the socket and dag_tick deliberately
never touches a NEEDS_HUMAN node. That belongs with #590, not #602 — a projector
that removed nodes would stop being one-directional.

Gates: lint rc=0 (0 task failures) · lint-docs rc=0 · pytest 1656 passed,
10 deselected · verify run 118 passed, 0 failed, 4 skipped.

Refs #602, #623, #625, #590

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016npXNzS9Jvn7sREeYbaqKH

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788681974&installation_model_id=429246&pr_number=626&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F626&signature=b9620c724e0dfd72cd4f6f87602bf2e9fd8683931b345ad53fa1c6c81e43ca80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->