### PR TITLE
docs(602): a control arm drawn from the wrong subsystem is worse than none

### DIFF
--- a/docs/specs/dag-needs-human-projection.md
+++ b/docs/specs/dag-needs-human-projection.md
@@ -403,8 +403,20 @@ receive-side gate — `crossSessionInbound` is `["accept","hold","refuse"]`,
 controlling whether an inbound peer message auto-delivers or is held for review —
 and an expanded send-side refusal surface: `reply-only` 1→**11**, `only in reply`
 0→**2**, `recordModelViewOfBridgePeers` 0→**3**, while `bridgeOutboundOnly` held
-at 9/9 and `isBridgeDispatchable` at 2/2. Both axes narrow what a message can do.
-2.1.224 made cross-session messaging **more reviewed, not further-reaching.**
+at 9/9. Both axes narrow what a message can do. 2.1.224 made cross-session
+messaging **more reviewed, not further-reaching.**
+
+⚠️ **`isBridgeDispatchable` (2/2) was cited here as a messaging control arm and
+that was WRONG — it is a SLASH-COMMAND predicate** (`@255903477`, sitting beside
+`isAdvertisedSlashCommand`/`getCommands`). It governs commands, not peer
+delivery. Its flatness across the two versions is therefore not evidence that
+messaging was left alone; it is evidence about an unrelated subsystem. Removed
+rather than silently deleted, because the failure is worth naming: **a control
+arm drawn from the wrong subsystem is worse than no control arm** — a real
+constant, a real measurement, and an inference the numbers cannot support. Same
+shape as the provenance and token-multiplicity defects this spec records
+elsewhere: the datum was true, the *attribution* was not. Caught by the probe
+agent, which flagged it explicitly.
 
 ### 3.2 The two sub-cases
 


### PR DESCRIPTION
The #602 spec's §3.1 listed `isBridgeDispatchable` (2/2, flat across 2.1.223 and
2.1.224) among the send-side messaging counts, as evidence that the messaging
surface was left alone while the refusal surface expanded.

It is a SLASH-COMMAND predicate, not a peer one. Verified independently against
the 2.1.224 binary before accepting the correction: at @255903477 it sits in an
export list with `isSkillToolCommand`, `isSkillOff`, `isCommandEnabled`,
`isBridgeSafeCommand`, `isAdvertisedSlashCommand`, `hasCommand` and
`getSlashCommandToolSkills`. It governs commands, not delivery.

So its flatness is not evidence that messaging was untouched — it is evidence
about an unrelated subsystem. Removed from the list, with a note rather than a
silent deletion, because the failure shape is worth naming: **a control arm drawn
from the wrong subsystem is worse than no control arm.** It reads as
discrimination in a domain the probe never entered — a real constant, a real
measurement, and an inference the numbers cannot support.

Same shape as two defects this spec already records: the provenance laundering
(a real byte-probe, attributed to a doc that did not contain it) and the token
multiplicity (a real token, matching sites it did not mean). The datum was true
each time; the ATTRIBUTION was not.

The surrounding conclusion is unaffected and independently supported:
`reply-only` 1->11, `only in reply` 0->2, `recordModelViewOfBridgePeers` 0->3,
`bridgeOutboundOnly` 9/9, against a control arm that shows the probe can produce
a delta (`crossSessionInbound` 0->18). 2.1.224 added restriction, not reach.

Caught by the `xsession-probe` agent, which flagged it explicitly in its
round-2 handback; the report at
docs/research/kb/reports/agents/602-crosssession-sendmessage-probe.md is
unchanged (agent reports stay verbatim per agent-report-persistence.md).

Gates: lint rc=0 (0 task failures) · lint-docs rc=0 · pytest 1688 passed,
10 deselected · verify 119 passed, 0 failed, 4 skipped.

Refs #602

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016npXNzS9Jvn7sREeYbaqKH

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788716741&installation_model_id=429246&pr_number=632&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F632&signature=49a7a76cd164cfb0a0054b9875270cdb4021a92a8af2068e6a3ec31373999e36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the cross-session messaging analysis.
  * Removed an unrelated slash-command control comparison.
  * Clarified the receive- and send-side delivery restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->