### PR TITLE
docs(578): #593 is closed — and the deferral's stated reason was one layer off

### DIFF
--- a/docs/receipts/578.md
+++ b/docs/receipts/578.md
@@ -73,10 +73,11 @@ Three layers, implementer = codex lane (GPT-5.6 Sol), per the declared codex mod
    8b99273 (missing-binary degradation so always-rc-0 actually holds; three distinct
    census-failure warnings so a blind watchdog cannot look healthy-idle; mise-shims-first
    launchd PATH; stop-side fresh re-check; mutation-sensitive dispatcher tests for the
-   STOP/LOG branches; lock opens `"a"` not `"w"`). **1 deferred with evidence** → #593:
-   the roster's `procStart` is captured but not compared (PID-reuse false-ALIVE); the live
-   roster's `workers{}` was empty so the encoding could not be sampled, and a blind
-   comparison risks false-DEAD → double-respawn — probe first, same discipline as #590.
+   STOP/LOG branches; lock opens `"a"` not `"w"`). **1 deferred with evidence** → #593
+   (**since CLOSED — see Notes**): the roster's `procStart` is captured but not compared
+   (PID-reuse false-ALIVE); the live roster's `workers{}` was empty so the encoding could not
+   be sampled, and a blind comparison risks false-DEAD → double-respawn — probe first, same
+   discipline as #590.
    **2 accepted as documented**: the launchd block is host-personal by design (the adjacent
    comment says so; launchd env values cannot be `~`-expanded), and log growth tracks
    events, not the 60s cadence (healthy-idle ticks print nothing).
@@ -114,10 +115,16 @@ Three layers, implementer = codex lane (GPT-5.6 Sol), per the declared codex mod
 - **Activation is a deliberate human step:** `mise bootstrap macos launchd-agents apply`,
   then `mise bootstrap macos launchd-agents status` to confirm `loaded`. Logs land in
   `~/Library/Logs/dotfiles-dag-tick.log` / `.err.log`.
-- **Deferred, tracked:** #593 (probe `procStart` encoding, then add PID-reuse defense to
-  `background_pid_alive`; until then a recycled pid reads alive and suppresses respawn —
-  a missed recovery, never a wrong action). #590 (stall signal probe) still gates any
-  WEDGED auto-action.
+- **Deferred, tracked → ✅ #593 CLOSED 2026-08-07** (PR #634, receipt `docs/receipts/593.md`).
+  `background_pid_alive` now requires liveness AND a matching `procStart`; a recycled pid no
+  longer reads alive. ⚠️ **The deferral was right and its stated reason was one layer off**,
+  which is worth recording rather than quietly superseding: the *format* was already on disk
+  (`docs/research/kb/reports/agents/wf-dag-recovery.md` §3 carries a real sample), so "the
+  encoding could not be sampled" was not the binding constraint. What was absent corpus-wide —
+  `lstart` and `TZ=UTC`, **0 hits** against a control of 6 for `procStart` — is the *reader
+  recipe*, and building from the format alone yields a reader that is off by the host's UTC
+  offset and mismatches **every** node, i.e. exactly the false-DEAD → double-respawn this
+  deferral existed to prevent. #590 (stall signal probe) still gates any WEDGED auto-action.
 - **What a later slice adds on top of this tick:** select/dispatch phases (the #573
   reconcile→preflight→select→dispatch tick reads GitHub readiness via
   `issue_dependencies_summary`), and a post-respawn prompt — a manually respawned node


### PR DESCRIPTION
`docs/receipts/578.md` still carried #593 as deferred, saying the live roster's
`workers{}` was empty "so the encoding could not be sampled". #593 shipped
today (PR #634), so the status was stale — but the reason was wrong in a way
worth recording rather than quietly superseding.

The FORMAT was already on disk: `wf-dag-recovery.md` §3's field table carries a
real `procStart` sample and the note "defeats PID reuse". What was genuinely
absent corpus-wide is the READER RECIPE — `lstart` and `TZ=UTC` return 0 hits
against a control of 6 for `procStart` — and building from the format alone
yields a reader that is off by the host's UTC offset and mismatches EVERY node,
which is precisely the false-DEAD -> double-respawn the deferral existed to
prevent.

So the decision was right and its recorded justification was not. That matters
because a right decision recorded with the wrong reason gets overturned by the
next person who checks the reason — they find the sample in the prior art,
conclude the deferral was unfounded, and implement blind.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016npXNzS9Jvn7sREeYbaqKH

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788732702&installation_model_id=429246&pr_number=636&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F636&signature=98e14c08c336b64dc870f95959c8f60bc42e6ce051283d0fa279919b602b20ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->