### PR TITLE
docs: bytes/token was folklore — the eager corpus is 58.6k tokens, not 36.8k

### DIFF
--- a/docs/research/kb/reports/context-baseline-20260807.md
+++ b/docs/research/kb/reports/context-baseline-20260807.md
@@ -1,0 +1,181 @@
+# Context baseline — `/context all`, 2026-08-07
+
+The harness's **own** accounting of what occupies the window, captured from
+`/context all` on `claude-opus-5[1m]`. Stored because every prior figure in this
+repo was a **byte count with an assumed bytes-per-token divisor**, and this is
+the first measurement that reports tokens directly.
+
+⚠️ **It corrects this repo's published numbers upward by ~57%.** See §3.
+
+## 1. Category totals
+
+Session state at capture: 405.8k / 1m tokens (41%).
+
+| Category | Tokens | % of window |
+|---|---|---|
+| System prompt | 6.2k | 0.6% |
+| System tools | 12.3k | 1.2% |
+| Custom agents | 4.2k | 0.4% |
+| **Memory files** | **58.6k** | **5.9%** |
+| Skills | 9.6k | 1.0% |
+| Messages | 314.9k | 31.5% |
+| Compact buffer | 3.0k | 0.3% |
+| Free space | 591.2k | 59.1% |
+
+These eight sum to exactly 1000.0k, which is the control that the list is
+complete and non-overlapping.
+
+⚠️ A re-rendered copy of the same output circulated with two extra rows — "MCP
+tools (deferred) 18.1k" and "System tools (deferred) 19.2k". **Do not treat those
+as additional standing cost**: adding them breaks the sum (1037k > 1m), so they
+are either a subdivision of `System tools` or an artifact of the re-render. The
+ASCII output above is authoritative.
+
+**Standing overhead before any conversation** — everything except `Messages`,
+`Compact buffer` and `Free space`: **90.9k tokens**. Of that, **58.6k (64%) is
+this repo's instruction corpus** and **13.8k (15%) is the skill + agent listing**.
+
+## 2. Per-file, the eager instruction corpus
+
+| File | Tokens |
+|---|---|
+| `.claude/rules/secrets-out-of-the-shell-env.md` | 4,900 |
+| `.claude/rules/mise-tasks-only.md` | 4,600 |
+| `AGENTS.md` | 4,600 |
+| `.claude/rules/research-doc-sources.md` | 3,300 |
+| `.claude/rules/probes-need-a-control-arm.md` | 3,100 |
+| `.claude/rules/verify-before-advancing.md` | 2,800 |
+| `.claude/CLAUDE.md` | 2,500 |
+| `.claude/rules/long-running-command-hangs.md` | 2,400 |
+| `.claude/rules/do-not.md` | 2,300 |
+| `.claude/rules/clarify-before-acting.md` | 2,200 |
+| `.claude/rules/tool-currency-and-native-first.md` | 2,200 |
+| `.claude/rules/agent-artifact-conventions.md` | 1,700 |
+| `.claude/rules/use-tool-builtins.md` | 1,700 |
+| `.claude/rules/local-devcontainer-first.md` | 1,600 |
+| `.claude/rules/agent-report-persistence.md` | 1,500 |
+| `.claude/rules/persistence-gate-retry.md` | 1,300 |
+| `.claude/rules/gh-cli-watch.md` | 1,100 |
+| `.claude/rules/zero-skip-policy.md` | 1,100 |
+| `.claude/rules/ai-cli-invocation.md` | 1,100 |
+| `.claude/rules/zero-bash-logic.md` | 1,000 |
+| `.claude/rules/research-repo-enumeration.md` | 982 |
+| `.claude/rules/clean-git-state.md` | 630 |
+| `CLAUDE.md` | 14 |
+| **21 rules subtotal** | **42,171** |
+| **repo eager subtotal** | **49,285** |
+| `MEMORY.md` (auto-memory index) | **9,500** |
+| **memory-files total** | **58,785** ≈ the reported 58.6k |
+
+**Control arm:** summing the harness's own per-file figures reproduces its
+category total. The per-file list is therefore being read correctly, and is safe
+to prioritise from.
+
+## 3. ⚠️ The correction: bytes/token was wrong by 57%
+
+Every token figure this repo published before today was
+`bytes ÷ 4`. Measured against the harness:
+
+| | Bytes | Tokens claimed (÷4) | Tokens actual | Error |
+|---|---|---|---|---|
+| Repo eager | 125,376 | 31,344 | **49,285** | **+57%** |
+| `MEMORY.md` | 21,134 | 5,284 | **9,500** | **+80%** |
+| Skill + agent listing | 32,595 | 8,148 | **13,800** | **+69%** |
+
+The true divisor for this corpus is **~2.5 bytes/token**, not 4.0 — and for
+`MEMORY.md` it is **~2.2**, because a dense index of backticked paths, issue
+refs and symbol names tokenises far worse than prose.
+
+**What this does and does not invalidate.** The BYTE measurements stand: they
+were taken with the size engine's own classifier and cross-checked to the CLI
+total. What was wrong is only the **conversion**, and it was wrong in the
+direction that understates the problem. Restated:
+
+- eager instruction corpus: **58.6k tokens**, not ~36.8k
+- plus the listing: **72.4k tokens** of standing instruction context
+- the whole standing overhead: **90.9k tokens**
+
+The lesson is `probes-need-a-control-arm.md` rule 6, applied to a **constant**
+rather than a measurement: `bytes ÷ 4` arrived as folklore, was never armed
+against this corpus, and was then reported as a finding. A conversion factor is
+an inherited number too.
+
+## 4. What the harness itself suggests
+
+> Memory files using 58.6k tokens (6%) → save ~17.6k
+> Largest: `MEMORY.md` (9.5k), `secrets-out-of-the-shell-env.md` (4.9k),
+> `mise-tasks-only.md` (4.6k). Use `/memory` to review and prune stale entries.
+
+Its top three match this repo's own byte-ordered head exactly, which is a second
+route to the same priority list.
+
+## 5. Bearing on `docs/specs/progressive-disclosure-eager-context.md`
+
+- §1's headline is understated; the corrected figures above supersede it.
+- The trigger-shape classification is **unaffected** — it is a partition of the
+  same files, and shares are byte-proportional.
+- The corpus ratchet should stay pinned in **bytes** (deterministic, gate-visible)
+  while reporting tokens alongside, since the tokeniser is not ours to pin.
+- `MEMORY.md` at 9.5k tokens is the single largest instruction file — larger than
+  any rule and than `AGENTS.md`. The spec defers it to phase 4; this measurement
+  argues it is the biggest single lever available.
+
+## 6. Second capture, after disabling 6 unused plugins — and a REFUTED hypothesis
+
+`/doctor` disabled 6 zero-use plugins (code-modernization, feature-dev,
+session-report, a duplicate exa, claude-md-management, claude-code-setup), then
+`/context all` was re-run. Both captures are on the same session, same model.
+
+| Category | Before | After | Δ |
+|---|---|---|---|
+| System prompt | 6.2k | 6.2k | 0 |
+| System tools | 12.3k | **14.3k** | **+2.0k** |
+| Custom agents | 4.2k | 3.0k | −1.2k |
+| Memory files | 58.6k | 58.6k | 0 |
+| Skills | 9.6k | 7.6k | −2.0k |
+| **Standing overhead** | **90.9k** | **89.7k** | **−1.2k** |
+
+Skills + agents fell **−3.2k**, as predicted. But `System tools` rose **+2.0k**,
+so the net saving is **−1.2k**, not the ~3.3k projected. That rise is
+**unexplained** and is recorded rather than rationalised — the plausible story
+(disabling plugins changed what is deferred vs resident) is untested.
+
+### ⚠️ The hypothesis was REFUTED, and the real cause is mundane
+
+The prediction was: the skill listing is saturated at ~1% of the window, so
+freeing plugin descriptions would let 11 absent project skills back in. It
+**failed on both arms**:
+
+- the listing dropped to **7.6k, comfortably under budget** — and
+- **not one of the 15 absent skills reappeared.** The same 9 project skills are
+  listed before and after.
+
+The actual cause, found by inventorying frontmatter and the settings cascade:
+
+| Mechanism | Count |
+|---|---|
+| `skillOverrides: "off"` in `.claude/settings.local.json` | **12** |
+| `disable-model-invocation: true` in the skill's own frontmatter | **4** (one also in the 12) |
+| **Total explained** | **15 of 15** |
+
+**Zero unexplained, zero over-explained.** Every absent skill is absent *by
+deliberate configuration*. Nothing was broken, nothing was crowded out, and the
+plugin cleanup — while a real if smaller saving — repaired no functional defect,
+because there was no functional defect.
+
+The generalisable error: a plausible mechanism (budget saturation) was fitted to
+a real observation (skills missing) without first checking the **boring**
+explanation (someone turned them off). The settings cascade was read for
+`defaultMode` and `enabledPlugins` in the same session and `skillOverrides` was
+simply not looked at. *Check the config before theorising about the engine.*
+
+### One stale entry worth cleaning
+
+`skillOverrides` names **`omc-hud-wrapper-diagnostic`**, a skill that no longer
+exists on disk — a leftover from the disabled `oh-my-claudecode` plugin. Harmless
+but misleading: an override for a nonexistent skill reads as a live decision.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the corpus
+  measured; the spec and gate this baseline corrects

--- a/docs/specs/progressive-disclosure-eager-context.md
+++ b/docs/specs/progressive-disclosure-eager-context.md
@@ -10,6 +10,30 @@ design; #476's measurements are preserved verbatim.
 
 ---
 
+## 0. ⚠️ Token figures below are SUPERSEDED — read this first
+
+Every token number in this spec was `bytes ÷ 4`. Measured against the harness's
+own `/context all` on 2026-08-07, that divisor is wrong for this corpus by
+**57%** — the real figure is **~2.5 bytes/token** (and ~2.2 for `MEMORY.md`,
+whose dense backticked paths and issue refs tokenise far worse than prose).
+
+| | Stated here | Actual |
+|---|---|---|
+| Repo eager | 31,344 tok | **49,285 tok** |
+| `MEMORY.md` | 5,426 tok | **9,500 tok** |
+| Skill + agent listing | 8,148 tok | **13,800 tok** |
+| **Standing instruction context** | ~44,900 tok | **~72,400 tok** |
+
+**The BYTE measurements stand** — they were taken with the size engine's own
+classifier and cross-checked to the CLI total; only the conversion was wrong,
+and it understated the problem. The trigger-shape classification is unaffected,
+being a partition of the same files. Full capture, per-file token table and the
+control arm: `docs/research/kb/reports/context-baseline-20260807.md`.
+
+⭐ `MEMORY.md` at **9,500 tokens is the single largest instruction file** —
+larger than any rule and than `AGENTS.md`. This spec defers it to phase 4; the
+measurement argues it is the biggest single lever available.
+
 ## 1. The measurement this rests on
 
 Taken fresh 2026-08-07, using `kb_setup.md_budget`'s **own** classifier over


### PR DESCRIPTION
Every token figure this repo has published was `bytes / 4`. Measured against
the harness's own `/context all`, that divisor is wrong for this corpus by 57%:
the real ratio is ~2.5 bytes/token, and ~2.2 for MEMORY.md, whose dense
backticked paths and issue refs tokenise far worse than prose.

  repo eager      31,344 -> 49,285 tokens
  MEMORY.md        5,284 ->  9,500
  skill listing    8,148 -> 13,800
  standing total  ~44,900 -> ~72,400

The BYTE measurements stand — taken with the size engine's own classifier and
cross-checked to the CLI total. Only the conversion was wrong, and it was wrong
in the direction that understated the problem. A conversion factor is an
inherited number too: `bytes / 4` was never armed against this corpus and was
then reported as a finding.

Control arm: summing the harness's per-file figures gives 58,785 against its
reported 58.6k category total, so the table is being read correctly.
MEMORY.md at 9,500 tokens is the single largest instruction file — larger than
any rule and than AGENTS.md.

Also records a REFUTED hypothesis, in full. 15 project skills are absent from
the skill listing; the prediction was that the listing was saturated at ~1% of
the window and that freeing plugin descriptions would let them back in. Both
arms failed: the listing fell to 7.6k, comfortably under budget, and not one
skill reappeared. The real cause is `skillOverrides: "off"` in local settings
(12) plus `disable-model-invocation` (4, one overlapping) — 15 of 15 explained,
zero unexplained. A plausible mechanism was fitted to a real observation without
first checking the boring explanation, in a file already opened twice that
session for other keys.

The measured saving from disabling 6 unused plugins is -1.2k, not the -3.3k
projected: skills and agents fell -3.2k as predicted but System tools rose
+2.0k. That rise is recorded as unexplained rather than rationalised.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016npXNzS9Jvn7sREeYbaqKH

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788743369&installation_model_id=429246&pr_number=641&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F641&signature=83784d842eb3a9faa1e0856792bab613b1e75fd5d2653a85ba78ecc93afb7495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a research report documenting measured token usage across the repository’s instruction context.
  * Corrected prior token estimates and updated guidance for progressive context disclosure.
  * Documented the impact of unused plugins, skill configuration, and a stale override.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->