### PR TITLE
feat/memory index curation skill v2

### DIFF
--- a/.claude/skills/memory-index-curation/SKILL.md
+++ b/.claude/skills/memory-index-curation/SKILL.md
@@ -18,7 +18,19 @@ dangerous part**.
 ```bash
 mise run memory-index                    # audit: budget + what a trim would cost
 mise run memory-index -- --refs <name>   # before DELETING a memory
+wc -c ~/.claude/projects/<encoded-cwd>/memory/MEMORY.md   # the byte count you can trust
 ```
+
+⚠️ **Read the byte count from `wc -c`, never from the `mise run` line.** mise
+redacts digit runs in task output — a live regression
+(`feedback_mise_run_masks_digits`), so the report's own `22,086` may reach you as
+`[redacted]2,086`. The report is the right tool for *what a trim would cost*; it
+is the wrong one for *how big the file is*.
+
+⚠️ **The index moves while you work on it.** Auto-memory writes concurrently, so
+a figure you measured five minutes ago may already be stale. Re-measure
+immediately before and after any edit, and treat an unchanged byte count as your
+confirmation that nothing landed underneath you.
 
 ## Why this exists (measured, not theorized)
 
@@ -47,6 +59,15 @@ defect, opposite fix.
      migrating it down would have pushed an outdated sha into a file that had
      already moved on).
    - **Fact is dead** → drop it deliberately, having looked at it.
+   - **Fact is safe in the file, but the HOOK is where you meet it** → the
+     checker sees no loss here and it is right: nothing is destroyed. What is
+     destroyed is *eager visibility*. For a trap that keeps recurring, that is a
+     real loss, because a memory you never open is one you re-learn the hard way.
+     Promote it to a `feedback_*` memory of its own and index it in the Feedback
+     section — ~150 B of hook, instead of the 400–2,800 B the session entry was
+     spending to keep it in view. This is a judgement call and a good one to put
+     to the user; it was the only decision in the 2026-08-07 pass that needed a
+     ruling.
 3. **Re-run** until `rc=0`.
 4. **Now shorten.** Rewrite the hook as a one-line pointer. Re-run to confirm
    still `rc=0`.
@@ -105,6 +126,39 @@ the remaining 56% is judgment. Numbers, and the redesign they argue for:
 **[#476](https://github.com/ray-manaloto/dotfiles/issues/476) — read it before
 curating again**, especially if you are about to spend agents on this (the first
 run put **52%** of its tokens into its *least* accurate phase).
+
+### So you will hand-verify — and your own grep needs a control arm
+
+Because `rc=0` is a floor, the real work is checking a hook's claims against its
+topic file yourself. The obvious way is to pull the distinctive tokens out of the
+hook and grep the file for each. That probe **fails in the direction that costs
+you**: it reports *loss* for anything the file merely says differently.
+
+Measured on 2026-08-07, checking 16 session hooks: the first pass reported **5
+missing facts. All five were false.** Every one was a case or format variant —
+`LEDGER` vs `ledger`, `Byte-search` vs `byte-search`, `BRIEF` vs `in the brief`,
+`9.5k` vs `9,500`. A paraphrase is indistinguishable from a deletion to an exact
+substring match, and prose is full of paraphrase.
+
+So: **match case-insensitively, and read both sides before believing any miss.**
+Then arm the probe — run it against a token you know is absent (invent a fresh
+nonsense string every time; one you have written down before is now *in* the
+corpus) and confirm it reports missing. On the same pass, 77 distinctive tokens
+checked, 0 missing, control arm firing correctly — that is a result worth
+reporting, and the bare "0 missing" without the arm is not.
+
+### Where the bytes actually are
+
+Session entries. On 2026-08-07 the 17 `project_session_*` hooks were **8,576 B
+of 22,086 (~40%)**, one of them 2,836 B on its own — 12.8% of the whole index
+for a single line. Compressing them to pointers took the index **22,086 →
+17,292 B (88% → 69% of cap)** with nothing lost, because every fact in them was
+already in the linked file.
+
+Start there. Feedback entries are mostly at their floor already, and the
+session-entry precedent is established: sessions before a cutoff get un-indexed
+entirely (nothing deleted — `memory-index` still lists them under "Unindexed",
+and they open by name).
 
 The classes are narrow on purpose. An earlier prototype cast wider and
 over-reported (`25.8GB` vs `25.8 GB`), and a checker that cries wolf gets

--- a/.claude/skills/memory-index-curation/SKILL.md
+++ b/.claude/skills/memory-index-curation/SKILL.md
@@ -69,8 +69,17 @@ defect, opposite fix.
      to the user; it was the only decision in the 2026-08-07 pass that needed a
      ruling.
 3. **Re-run** until `rc=0`.
-4. **Now shorten.** Rewrite the hook as a one-line pointer. Re-run to confirm
-   still `rc=0`.
+4. **Now shorten — and actually reach the number you were given.** Rewrite each
+   fat hook as a one-line pointer. Re-run to confirm still `rc=0`, and re-measure
+   with `wc -c` against the target before you stop.
+
+   ⚠️ **Verifying is not the deliverable; it is what makes the deliverable safe.**
+   Across four sandboxed eval runs on 2026-08-07 every run cleared its target,
+   but the margins were thin — **17,478 / 17,377 / 17,090 / 16,749 B against a
+   17,500 B target**, one of them by 22 bytes. A margin that small is not a
+   result you should assume; it is one you confirm. When the verification is
+   done, keep compressing hooks until `wc -c` clears the target, then say which
+   number you hit.
 
 ## Deleting a memory
 
@@ -88,6 +97,13 @@ mise run memory-index -- --refs feedback_colima_recommendation
   DD-vs-Colima call). It was absorbed into `feedback_docker_desktop_runtime`
   before deletion, and the citation in `feedback_base_image_ci_only` repointed.
 - **No inbound refs is not a clearance.** The colima file had two.
+- ⚠️ **`--refs` cannot see the index entry itself.** It reports the memory
+  *files* that cite a name; `MEMORY.md` is not one of them, so the index line
+  linking the memory you are about to delete is invisible to it. Verified with
+  both arms 2026-08-07: `--refs feedback_codex_worktree` reported **1** citing
+  file while `MEMORY.md` also linked it and went unreported. So after `--refs`,
+  `grep -rn <name> "$(dirname MEMORY.md)"` across the whole memory directory
+  — index included — and resolve what the grep adds.
 
 ## Reading the budget
 


### PR DESCRIPTION
- **docs(skills): the curation skill told you to hand-verify, not that hand-verification lies**
- **docs(skills): three curation traps the skill walked into rather than warned about**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788753589&installation_model_id=429246&pr_number=643&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F643&signature=79af577b80ffe3f94ab6fb7eed8d3371a5b88e13e7ef1e96393a861709121652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->