### PR TITLE
docs: the spec said the pin still predates the when_to_use fix — #642 moved it

### DIFF
--- a/docs/research/kb/reports/skill-eval-memory-index-curation-20260807.md
+++ b/docs/research/kb/reports/skill-eval-memory-index-curation-20260807.md
@@ -1,0 +1,94 @@
+# `/skill-creator` eval of `memory-index-curation` — a NULL RESULT, and two tool bugs
+
+**Date:** 2026-08-07 · **Outcome:** the eval could not distinguish the improved
+skill from the original. Recorded so nobody spends the tokens again without
+changing the design.
+
+Raw artifacts (4 sandboxed memory-dir fixtures per iteration, per-run
+`grading.json`, agent reports) lived in a session-scoped scratchpad and were
+deliberately **not** promoted — the conclusion below is the durable part, and
+the fixtures were four copies of a 246-file memory directory.
+
+## Design
+
+- **Subject:** `.claude/skills/memory-index-curation/SKILL.md`, before vs after
+  the 2026-08-07 edit (PR #643).
+- **Baseline:** the OLD skill version, snapshotted — not "no skill". For an
+  *improvement*, a no-skill baseline flatters the result, because both arms
+  would otherwise carry the verify→migrate→shorten discipline that already
+  existed and the delta would measure the original skill, not the edit.
+- **Isolation:** `memory_index.py` honours `CLAUDE_CONFIG_DIR`, so each run got
+  its own copy of the real memory dir. Armed before use: sandbox reported
+  **105** entries vs the real **104**.
+- **Fixture:** 22,030 B (88.1% of the 25 KB cap) with **two planted index-only
+  facts** — issue ref `#9971` and sha `deadbe7`, present in a hook and absent
+  from its topic file. That makes the skill's whole purpose gradable: a run that
+  trims without migrating them destroys them, provably.
+- **12 runs:** 2 tasks (trim-to-target, delete-a-memory) × 2 arms × 3 iterations.
+
+## Result
+
+| | iter-1 | iter-2 | iter-3 (process assertions) |
+|---|---|---|---|
+| new skill | 9/9 | 9/9 | ~7/8 |
+| old skill | 9/9 | 9/9 | ~7/8 |
+
+**No assertion — outcome or process — reliably separated the two versions.**
+Both arms hit every byte target and preserved both planted facts every time.
+Final trim sizes across runs: 17,478 / 17,377 / 17,090 / 16,917 / 16,836 B
+against a 17,500 B target.
+
+The honest reading: the original skill's core (verify → migrate → shorten, and
+"a clean `rc=0` is a floor, not a clearance") was already sufficient to make a
+capable agent do the right thing. The 2026-08-07 additions are defensible
+because each claim is independently **true**, not because they measurably change
+behaviour.
+
+One thing the old-skill arm did that neither version documents: a corpus-wide
+grep that found a **prose-only** fact the checker is structurally blind to, and
+migrated it. Better than the new text asks for.
+
+## What the exercise actually produced
+
+Four defects, none of them in the skill:
+
+1. **A rigged fixture (mine).** The first build sat at 17,609 B = 70.4% while the
+   prompt claimed 88%, so "trim to under 70%" was nearly satisfied on arrival and
+   that assertion could only pass. Caught mid-flight and rebuilt.
+2. **An assertion that rewarded scope creep (mine).** "Checker ends rc=0" on the
+   *delete* task imported the fixture's unrelated planted facts, so the arm that
+   did work outside its brief scored the point. Dropped.
+3. **Three premature gradings (mine).** Report-file stability is NOT agent
+   completion — an agent goes quiet while thinking. Twice the numbers reported
+   were artifacts of scoring a still-running run; one sandbox was still mutating
+   90 seconds after a "quiescent" check passed. Only a 4-minute window held.
+4. **Two upstream `/skill-creator` bugs** (see below).
+
+## Upstream bugs
+
+- **Trigger eval is non-functional here.** `run_eval.py` reports ~0 recall for
+  every description, including a query that names the skill outright — the
+  control arm that proves it is the probe, not the description. Known upstream:
+  `anthropics/claude-plugins-official` **#4425**, **#2678**, **#2003** (plus
+  #632, #4692, #3172, #1749), all OPEN, with fix PRs #3339, #3714, #1988 all
+  **closed unmerged**. Root cause per #4425: it registers the description as a
+  *slash command* then watches for a *`Skill`* tool call.
+- **`improve_description.py:147` silently adopts prose as the description.** A
+  missed `<new_description>` regex falls back to `text.strip()`, so a
+  conversational reply becomes the candidate — the literal string
+  `"Description delivered above."` was evaluated as a description. Filed as
+  `anthropics/claude-plugins-official` **#5069** (not previously reported; dedup
+  control-armed across six query shapes).
+
+## If someone retries this
+
+Do not reuse these assertions. Both tasks are ones a capable agent completes
+correctly from either version, so they cannot discriminate. A design with a
+chance would need a task where the *wrong* procedure produces a *different
+artifact* — e.g. an index whose only copy of a fact is a prose sentence the
+checker cannot extract, where a naive trim measurably loses it.
+
+## GitHub repos touched
+
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the skill under test and its checker.
+- [anthropics/claude-plugins-official](https://github.com/anthropics/claude-plugins-official) — `/skill-creator`; issues searched for dedup and #5069 filed.

--- a/docs/specs/progressive-disclosure-eager-context.md
+++ b/docs/specs/progressive-disclosure-eager-context.md
@@ -84,8 +84,12 @@ does not exist.
 description of 1,789 chars was being silently truncated at the hard 1,536 cap —
 and the 253 characters cut were its **negative** example, so truncation removed
 the half of the trigger that says when *not* to use it; and the installed,
-SHA-pinned `kb_setup` predates the `when_to_use` fix, so the repo's own
-`md_size_budget` gate is currently measuring `description` alone.
+SHA-pinned `kb_setup` predated the `when_to_use` fix, so the repo's own
+`md_size_budget` gate was measuring `description` alone. **(Fixed 2026-08-07 by
+#642 — the pin moved to `46a3e7d` and the gate now measures the two fields
+combined, verified on the INSTALLED package by behaviour. #640 stays open for
+the second defect folded into it: `md_budget.py:430` still prints tokens as
+`bytes ÷ 4`.)**
 
 `rule_unscoped` is **108,382 B = 86.4%** of repo-eager. The inherited
 "~88% is unscoped rules" figure (dated 2026-07-28) was re-derived, not repeated,


### PR DESCRIPTION
Two doc-sync items from clear-prep.

`docs/specs/progressive-disclosure-eager-context.md` asserted in the present
tense that the SHA-pinned kb_setup predates the `when_to_use` fix "so the repo's
own md_size_budget gate is currently measuring `description` alone." PR #642
moved the pin to 46a3e7d and the gate now measures the two fields combined,
verified on the INSTALLED package by behaviour. Marked as fixed in place rather
than deleted — the passage is a dated finding and rewriting it would erase why
the gate was ever wrong. The note also records that #640 stays open for the
second defect folded into it (`md_budget.py:430` still prints `bytes / 4`).

Adds the `/skill-creator` eval writeup as a NULL RESULT: 12 sandboxed runs
across 3 iterations could not separate the improved memory-index-curation skill
from the original, on outcome OR process assertions. Recorded so the tokens are
not spent again without changing the design, and it says what a design with a
chance would need. Raw fixtures deliberately dropped (Ray's ruling) — four
copies of a 246-file memory dir whose value is nil once the conclusion is
written down.

It also documents the four defects the exercise DID produce, none in the skill:
a fixture of mine rigged so its assertion could only pass, an assertion that
scored work outside the brief, three gradings of still-running agents, and two
upstream /skill-creator bugs (the trigger eval is known-broken —
anthropics/claude-plugins-official#4425/#2678/#2003, open, three fix PRs closed
unmerged; the improve_description prose fallback is newly filed as #5069).

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014avv44T9TS3zSe3SQSwzzo

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788756385&installation_model_id=429246&pr_number=645&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F645&signature=9d9b60a1eeef158ad87b81a36e6e407128f80f36ad5433fa115165ddb7b00247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->