### PR TITLE
docs(rules): a probe's sneakiest bound is WHEN you ran it; and canary > symptom

### DIFF
--- a/.claude/rules/probes-need-a-control-arm.md
+++ b/.claude/rules/probes-need-a-control-arm.md
@@ -78,6 +78,19 @@ Full case tables — five false negatives, five cross-check disagreements:
    session once grepped `lmstudio`/`lm_studio`, got 0, and reported the feature
    unsupported; it is spelled `LM Studio`, with a space.
 
+   **The sneakiest bound is WHEN YOU RAN IT.** Every bound above is in the
+   query; this one is in the world. If the causal condition has already been
+   repaired — often by your own earlier commands — the probe cannot reproduce
+   it, and "cannot reproduce" is not "no cause". Measured 2026-08-08: four
+   independent routes were probed for what spawned 1,174 wedged processes and
+   **all four returned delta=0**, so the result was published as
+   *"unattributed"*. The real answer was that the deleted installs behind it had
+   since been restored, partly by that same session's `mise install`. Before
+   reporting a null, ask **"could this still be true right now?"** and say
+   *"the condition has passed, so this probe cannot speak to it"* — which
+   locates the ignorance in the probe — rather than *"unattributed"*, which
+   locates it in the world.
+
    **Arm the component you actually depend on.** That same probe *did* run a
    control arm — it proved `sharehistory` was set, i.e. that the FILE was
    complete. True, and irrelevant: the broken part was the READER. A control arm
@@ -127,6 +140,25 @@ Full case tables — five false negatives, five cross-check disagreements:
    real configuration over one that isolates the variable. A second case (a
    parent-directory config the tool silently merged) and both re-runs:
    `docs/rules-evidence/probes-need-a-control-arm.md`.
+
+9. **When you must BUILD a check, assert the capability — never sniff for a
+   symptom of its absence.** A symptom check binds something you do not own: a
+   log string, a version number, a warning's wording. When that changes upstream
+   your check silently becomes a no-op that can only pass, and nothing tells you.
+   Instead feed the tool an input it **must fail on** and require the failure —
+   the gate then carries its own control arm on every run, and it tests the
+   thing you depend on rather than a proxy for it.
+
+   Worked case (#644): `renovate-config-validator` warns *"RE2 not usable"* and
+   **still exits 0**, so every regex went unchecked while the gate stayed green.
+   The fix validates a canary config whose only flaw is a lookahead and demands
+   a non-zero exit. It beat a **version** check on its first run by accident:
+   `mise which` reported the fixed version while `PATH` still resolved the stale
+   one, so a version assertion would have consulted the pin and said "fine"
+   while the executing process was blind. **A canary tests the binary that RUNS;
+   a version tests the one you believe you installed.** Note the inversion makes
+   the canary itself load-bearing — pin that it is still genuinely invalid, or a
+   later "tidy-up" neuters the gate toward silence.
 
 ## Applies to
 

--- a/docs/rules-evidence/probes-need-a-control-arm.md
+++ b/docs/rules-evidence/probes-need-a-control-arm.md
@@ -153,10 +153,102 @@ the other value?"* — and no amount of arming the probe reaches it. Two habits:
   disjoint names, no confounds — and that is exactly what made it wrong: the real
   system duplicates names across the two layers, which is the whole mechanism.
 
+## Rule 3, the temporal bound — four probes that could not have worked (2026-08-08)
+
+A session found **1,174** wedged `mise/shims/git` processes, each with a stuck
+`fnox export --format json` child (1,190 total), load average 10.4, oldest 1d10h.
+It attributed them to the `mise-env-fnox` plugin, then — correctly — tried to
+prove it.
+
+Four independent routes, each measured as a before/after process-count delta:
+
+| probe | delta |
+|---|---|
+| a mise-shimmed `git` (the shape that parents the stuck procs) | 0 |
+| `mise env` with `MISE_ENV_CACHE` busted | 0 |
+| a fresh `zsh` sourcing `50-mde-secrets.zsh` | 0 |
+| bare `fnox activate zsh` + `cd` | 0 |
+
+The session concluded **"unattributed"** and published that. Two errors in it:
+
+1. **Four arms that all agree are one probe, not four.** Unanimity across routes
+   reads as thoroughness and is the opposite: nothing discriminated, so the
+   result cannot name a culprit *in either direction* — it could not have
+   convicted the plugin nor exonerated it.
+2. **The bound was TIME, and it was invisible because it was not in the query.**
+   The cause was `kb-reclaim` deleting mise versions this repo pins (its own
+   `reclaim.py:530` docstring records removing three python versions on
+   **2026-08-07**, inside the burst window, because `mise ls` resolves configs
+   relative to the CURRENT DIRECTORY). By probe time those installs had been
+   restored — **partly by the same session's own `mise install`** an hour
+   earlier. The precondition was gone, so no route could reproduce it.
+
+The user supplied the answer from a repo the session had not thought to open.
+
+**The habit:** before reporting a null, ask *"could this still be true right
+now?"* — and especially *"did I repair it myself?"*. A session that installs,
+rebuilds or cleans has mutated the very world it is about to interrogate. Report
+**"the condition has passed, so this probe cannot speak to it"** (ignorance in
+the probe) rather than **"unattributed"** (ignorance in the world); only the
+first tells a reader the question is still open.
+
+Note the rule already listed "a time window" as a bound — but that meant a bound
+*inside the search*. This is the world moving under a query with no time bound at
+all, which is why it was not recognised.
+
+## Rule 9, canary over symptom — the #644 gate (2026-08-08)
+
+`renovate-config-validator` compiles `renovate.json`'s regexes with RE2. `re2` is
+an **optional** npm dependency, and npm optional deps fail silently; when absent
+the validator warns *"RE2 not usable, falling back to RegExp"* and **still exits
+0** (`renovate/dist/util/regex.js` sets `RegEx = RegExp` on the catch path).
+Measured: `(?!latest)` in a `matchStrings` entry produced *"Config validated
+successfully"*, rc=0 — the local gate was strictly weaker than CI.
+
+Three candidate guards, and why two lose:
+
+- **Grep stderr for the warning.** Binds a message string nobody here owns. A
+  reword upstream makes the check a no-op — and because this check is *inverted*
+  (absence of a warning means healthy), it fails toward **silence**.
+- **Assert the version.** Refuted by accident on the first run: `mise which`
+  reported the fixed 44.14.10 while `command -v` still resolved the stale
+  44.13.2 that a shell's baked-in `PATH` was holding. A version assertion
+  consults the pin and says "fine" while the executing process is blind.
+  **A canary tests the binary that RUNS; a version tests the one you believe you
+  installed.**
+- **Feed it a canary and require failure.** A config whose only flaw is a
+  negative lookahead must exit non-zero. Control-armed against the two installs
+  on disk — the old version *is* a control arm:
+
+  | renovate | canary exit | verdict |
+  |---|---|---|
+  | 44.13.2 (no re2) | rc=0 | degraded |
+  | 44.14.10 (re2) | rc=1 | healthy |
+
+**The inversion moves the fragility into the canary itself**, so the canary must
+be pinned two ways: it must still contain an RE2-unsupported construct (or a
+"tidy-up" neuters the gate), and it must still be valid for JS `RegExp` (a
+merely malformed pattern fails on *both* engines, so the gate would report
+"healthy" on a degraded one). Mutation-verified with differing blast radii:
+dropping the lookahead fails 4 tests; ignoring the engine verdict fails exactly
+the 2 degradation/ordering tests.
+
+Ordering is a safety property, not style: the engine check runs **before** the
+real validation, or a degraded run prints a green line first and the failure
+mode gets reported as a pass with a footnote.
+
 ## GitHub repos touched
 
 - [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the probes,
   `hk.pkl`'s `no_grep_q_under_pipefail`, and the #289 base build.
+- [ray-manaloto/knowledge-base](https://github.com/ray-manaloto/knowledge-base) —
+  `kb_setup.reclaim`'s `scan_mise_versions`, whose CWD-relative pin probe is the
+  temporal case's root cause (issue #243).
+- [renovatebot/renovate](https://github.com/renovatebot/renovate) — `util/regex.js`
+  and `config-validator.js`, read from the installed 44.13.2/44.14.10 bundles;
+  URL taken from the package's own `repository` field, not from memory.
+- [jdx/mise-env-fnox](https://github.com/jdx/mise-env-fnox) — the env plugin whose
+  hook shells out to `fnox export`; URL as written in the live mise config.
 - [jdx/fnox](https://github.com/jdx/fnox) — the tool both rule-8 fixtures probed
   (`fnox proxy run`, profile config files), at the installed v1.32.0.
 


### PR DESCRIPTION
Two lessons from 2026-08-08, both paid for in that session.

**Rule 3 gains a temporal bound.** Chasing 1,174 wedged `mise/shims/git`
processes (plus 1,190 stuck `fnox export` children, load 10.4), four independent
routes were probed and ALL FOUR returned delta=0, so the result was published as
"unattributed". Two errors in that:

- Four arms that all agree are ONE probe, not four. Unanimity reads as
  thoroughness and is the opposite — nothing discriminated, so the result could
  neither convict nor exonerate.
- The bound was TIME, invisible because it was not in the query. The cause was
  `kb-reclaim` deleting mise versions this repo pins (knowledge-base
  `reclaim.py:530` records removing three python versions on 2026-08-07, inside
  the burst window, because `mise ls` resolves configs relative to the CURRENT
  DIRECTORY). By probe time those installs had been restored — partly by the
  same session's own `mise install` an hour earlier.

The rule already listed "a time window" as a bound, but that meant a bound
INSIDE the search. This is the world moving under a query with no time bound at
all, which is why it went unrecognised. Filed upstream as knowledge-base#243.

The habit added: before reporting a null, ask "could this still be true right
now?" and "did I repair it myself?" — a session that installs, rebuilds or
cleans has mutated the world it is about to interrogate. Say "the condition has
passed, so this probe cannot speak to it" (ignorance in the probe), not
"unattributed" (ignorance in the world); only the first says the question is
still open.

**New rule 9: assert the capability, never sniff for a symptom of its absence.**
From #644, where `renovate-config-validator` warns "RE2 not usable" and STILL
EXITS 0. A stderr grep binds a message string we do not own, and since the check
is inverted it fails toward SILENCE. A version assertion was refuted by accident
on its first run: `mise which` reported the fixed version while PATH still
resolved the stale one — a canary tests the binary that RUNS, a version tests
the one you believe you installed. Appended as rule 9 rather than inserted, so
the existing "rule 3" / "rule 8" citations elsewhere keep pointing at the same
text.

Case histories, tables and both control arms go to
docs/rules-evidence/probes-need-a-control-arm.md per agent-artifact-conventions
(directive + one example stays eager). The rule file lands at 180/200 lines and
10,823/24,000 bytes, inside the rule_unscoped budget.

Every repo URL in the enumeration was resolved FROM DISK, not memory — the
renovate one from the installed package's own `repository` field, the
mise-env-fnox one as written in the live mise config. Asserting a URL from
memory is the defect this rule warns about.

Gates: `mise run lint` rc=0 (0 task failures) · pytest 1720 passed ·
`verify run` 120 passed, 0 failed · `mise run lint-docs` no issues.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016SGa1MC4TUELrVHv5ER5BT

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788762405&installation_model_id=429246&pr_number=649&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F649&signature=81254d7612f805f9b6fa39addd24a23eb353d7321047e51b17757cf064652e29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for distinguishing a repaired condition from an unattributed result when probes can no longer reproduce an issue.
  * Documented control-arm testing with deliberately invalid inputs to verify required capabilities.
  * Added case studies covering temporal conditions, missing regular-expression support, canary constraints, mutation checks, and validation order.
  * Expanded the list of supporting reference sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->