### PR TITLE
docs(rules): a skill is the top of a three-layer stack, never the whole thing

### DIFF
--- a/.claude/rules/agent-artifact-conventions.md
+++ b/.claude/rules/agent-artifact-conventions.md
@@ -72,6 +72,30 @@ A citation to something only you can open is not a citation.
    `name` should match the directory name so slash-invocation and auto-loading
    stay consistent. Same for `.claude/rules/` and `.claude/agents/`.
 
+6. **A skill is the TOP of a three-layer stack, never the whole thing**
+   (Ray, 2026-08-08). Build downward: **skill → mise task → python library**
+   (modular modules/functions). The skill carries only what needs *judgement* —
+   when to reach for this, and the non-obvious failure modes; every mechanic
+   lives in the library, and the task is the seam. **No bash**
+   ([[zero-bash-logic]]).
+
+   **Make each layer reusable by PARAMETER, not by copy.** The skill passes
+   arguments through to the task, the task to the library function. A library
+   function that hard-codes this repo's case cannot serve the next caller — make
+   that case the parameter's *default* instead.
+
+   **Author skills with `/skill-creator:skill-creator`, and shape the prose with
+   `/writing-for-agents`.** Hand-written skills drift from the frontmatter and
+   description shape the loader and the matcher depend on — and a `description`
+   over 1,536 chars is silently truncated, taking the keywords Claude matches on
+   with it ([[md-size-budgets]]).
+
+   **The point is token economy.** Every step an agent performs by hand it will
+   perform by hand again, paying full reasoning cost each time. Worked case: the
+   image-lock recipe was re-derived from CI config across ~15 turns and produced
+   a silent 51% lock truncation on the way (#650); three sibling candidates from
+   the same session are #651–#653, and #654 is the skill that finds them.
+
 ## Why this rule cannot be `paths:`-scoped
 
 It is **creation-triggered**: it governs *where to create* an artifact, so you


### PR DESCRIPTION
Ray's mandate, 2026-08-08, recorded as rule 6 of agent-artifact-conventions so
it binds every future session rather than living in one conversation:

- build downward, **skill -> mise task -> python library**; the skill carries
  only judgement (when to reach for this, and the non-obvious failure modes),
  every mechanic lives in the library, no bash;
- make each layer reusable **by parameter, not by copy** — a library function
  that hard-codes this repo's case cannot serve the next caller, so that case
  becomes the parameter's default;
- author skills with `/skill-creator:skill-creator` and shape the prose with
  `/writing-for-agents`, because a hand-written skill drifts from the frontmatter
  and description shape the loader and matcher depend on — and a `description`
  over 1,536 chars is silently truncated, taking its matching keywords with it.

Filed here rather than as a new rule file: `agent-artifact-conventions.md` rule
5 already owns "where skills live", so "how they are built" is its natural
neighbour and costs no new eager file. 79 -> 103 lines, 4,299 -> 5,745 bytes,
well inside the rule_unscoped budget (200 / 24,000) — no offsetting trim needed.

The motivating cost is concrete rather than theoretical: this session
re-derived the image-lock recipe from CI config across ~15 turns and produced a
silent 51% lock truncation on the way. That is #650; #651-#653 are three sibling
candidates from the same session, and #654 is the skill that finds them — which
is why the rule points at them instead of arguing in the abstract.

Gates: `mise run lint` rc=0 (0 task failures) · `mise run lint-docs` no issues ·
pytest 1732 passed · `verify run` 121 passed, 0 failed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016SGa1MC4TUELrVHv5ER5BT

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788767736&installation_model_id=429246&pr_number=655&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F655&signature=97f11698de052cc4e955798a231ca65f9a6c89726cbe5e63c59e4649cebe467a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for designing reusable, three-layer skills that separate decision-making from implementation details.
  - Documented authoring requirements for skills, including description length limits and expected failure-mode guidance.
  - Added recommendations for efficient token usage.
  - Included an image-lock workflow as a practical example, with references for further context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->