### PR TITLE
feat(lock): local image-lock task, and make the collect step see platforms (#650, #648)

### DIFF
--- a/.claude/skills/lock-image/SKILL.md
+++ b/.claude/skills/lock-image/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: lock-image
+description: Regenerate the devcontainer IMAGE lockfiles (`.devcontainer/mise-system.lock` + `mise-runtime.lock`) via `mise run lock-image`. Use whenever a change to `.devcontainer/mise-system.toml`, `.devcontainer/mise-runtime.toml` or `.config/mise/conf.d/shared.toml` needs its locks refreshed, when `mise run lint`'s `mise_lock_integrity` step or CI reports the image locks stale or short, or when you are about to transcribe the recipe out of `.github/actions/lock-refresh/action.yml` by hand. Reach for it BEFORE hand-rolling `mise lock` against a staged config — regenerating these two files on macOS truncates them silently, and the tool count does not move, so the damage reads as success.
+user-invocable: true
+---
+
+# lock-image: regenerating the devcontainer image locks
+
+`mise run lock-image` is the whole mechanic. It stages the image's merged
+config, installs the image's **pinned** mise, converges under GitHub rate
+limits, and collects only after verifying platform coverage against `HEAD`.
+The recipe lives in `python/src/dotfiles_setup/image_lock.py`; the task is a
+thin caller (`.claude/rules/zero-bash-logic.md`).
+
+```bash
+mise run lock-image                            # derive platforms, auto-route
+mise run lock-image -- --platform linux-x64    # narrow it deliberately
+mise run lock-image -- --no-container          # refuse rather than route
+mise run lock-image -- --stage /path/to/stage  # resume a rate-limited run
+```
+
+This file carries only the judgement: which artifact you are touching, and the
+three ways a regen goes wrong while looking fine.
+
+## Which artifact — `lock` and `lock-image` are different files
+
+| You changed | Task | Artifact |
+|---|---|---|
+| a HOST tool in `mise.toml` / `shared.toml` | `mise run lock -- "<backend/name>"` | `mise.lock` |
+| `.devcontainer/mise-system.toml` or `mise-runtime.toml` | `mise run lock-image` | the two image locks |
+| `shared.toml` (merged into BOTH) | both, in either order | both |
+
+`shared.toml` is the one that catches people: it is merged into the image
+config *and* read on the host, so a bump there leaves the image locks stale
+even after a clean `mise run lock`.
+
+Bare `mise lock` is never the answer for either — it re-locks the whole file
+for the current platform. `.claude/rules/do-not.md` and
+`feedback_mise_lock_whole_file_is_destructive` carry that.
+
+## Three ways a regen looks fine and is not
+
+Each of these cost a cycle to learn, and each produces a lockfile that parses,
+commits, and passes a naive check.
+
+**macOS cannot write linux conda checksums** (jdx/mise#7700). A regen on
+darwin drops the linux entries — measured 2026-08-08, `mise-system.lock`'s
+`linux-x64` occurrences went 131 → 64 and `mise-runtime.lock`'s 35 → 12 —
+while the **tool count stayed at 49 and 22**. That is why the old collect step
+returned `rc=0` on it (#648). The task routes into the amd64 devcontainer by
+default rather than refusing, so the normal answer on this Mac is to run it and
+let it route; `--no-container` turns the routing into a loud refusal when you
+want to know rather than to fix.
+
+**A `linux-x64`-only pass loses the macOS entries of any BUMPED tool.** The
+committed lock carries six platforms, 29 of them `macos-x64` tool entries, and
+they survive only because the committed lock is seeded in as a starting point.
+Bump a tool and its entries are replaced, so `lock-check` then fails with
+`tool uv: lost platform(s) ['macos-x64']`. The task derives the platform set
+from the committed lock for exactly this reason — pass `--platform` only when
+you have decided to narrow it, never to reproduce what CI's workflow file does.
+
+**A short lock is the expected mid-run state, not a failure.** `mise lock`
+resolves through GitHub and anonymous quota runs out partway, which is what the
+convergence loop is for. Only the last pass has to succeed. If every pass
+fails, a tool is genuinely unresolvable — `mise lock` has hard-errored on that
+since 2026.6.13, so read the error rather than raising `--passes`.
+
+## Reading the result
+
+Success prints the mise version and the platform count, and means the coverage
+check passed against `HEAD` — not merely that the file was written. Two exits
+worth distinguishing:
+
+- **`LOST platform coverage`** — the regen truncated. The file on disk is
+  untouched; nothing landed. Almost always the wrong host, so re-run without
+  `--no-container`.
+- **`missing tools`** — the stage lock does not cover the merged config. A
+  config edit that never reached the stage, or an interrupted run.
+
+Then confirm with the gate the rest of the repo uses:
+
+```bash
+uv run --project python dotfiles-setup lock-check
+```
+
+## Adding a platform on purpose
+
+Widening coverage is a real change, not drift: the first regen that adds a
+platform makes it part of the committed lock, and every later run derives it
+automatically. Nothing needs editing to make that stick — which also means an
+*accidental* widening becomes permanent silently, so say in the commit body
+that you meant it.

--- a/mise.toml
+++ b/mise.toml
@@ -1018,6 +1018,25 @@ description = "Re-lock the NAMED tool(s), scoped, then assert coverage held"
 # verifies the artifact afterwards instead of trusting the exit code.
 run = 'uv run --project python dotfiles-setup lock-tools'
 
+[tasks.lock-image]
+description = "Regenerate the IMAGE locks (mise-system.lock + mise-runtime.lock) with CI's recipe, coverage-verified; routes into the amd64 devcontainer from macOS"
+# Thin caller; see image_lock.py. Sibling of `lock` above, and the division is
+# by ARTIFACT: `lock` re-locks named tools in the HOST lockfile, this rebuilds
+# the two IMAGE locks wholesale. Until #650 the only thing that knew this
+# recipe was .github/actions/lock-refresh/action.yml, so a session bumping the
+# shared fragment hand-transcribed it from a workflow — ~15 turns on
+# 2026-08-08, ending in a near-committed 51% coverage loss that the collect
+# step returned rc=0 on (#648, now fixed by verifying against HEAD).
+#
+# macOS CANNOT do this: mise there cannot write the linux conda checksums
+# (jdx/mise#7700) and the tool count does not move, so the truncation is
+# silent. The default routes into the devcontainer rather than refusing.
+#
+#   mise run lock-image                          # derive platforms, auto-route
+#   mise run lock-image -- --platform linux-x64  # narrow it deliberately
+#   mise run lock-image -- --no-container        # fail instead of routing
+run = 'uv run --project python dotfiles-setup image-lock'
+
 [tasks.p2996-hash]
 description = "Print the content-hash of P2996 cache inputs (matches the CI :p2996-<hash> tag)"
 run = "uv run --project python dotfiles-setup p2996-hash"

--- a/python/src/dotfiles_setup/image_lock.py
+++ b/python/src/dotfiles_setup/image_lock.py
@@ -1,0 +1,328 @@
+# Copyright (c) 2026 Raymond Manaloto
+"""Regenerate the image lockfiles locally, with CI's recipe as a callable (#650).
+
+``.devcontainer/mise-system.lock`` and ``.devcontainer/mise-runtime.lock`` had
+no local task: the only thing that knew how to rebuild them was CI's
+``.github/actions/lock-refresh/action.yml``, so a session that bumped the shared
+fragment had to hand-transcribe the recipe from a workflow file. On 2026-08-08
+that cost ~15 turns and produced a near-committed corruption — a regen run on
+macOS dropped ``mise-system.lock``'s ``linux-x64`` occurrences 131 -> 64 and
+``mise-runtime.lock``'s 35 -> 12, while the tool count never moved (49 and 22),
+so the collect step returned ``rc=0`` on it (#648, fixed in
+:func:`dotfiles_setup.lock_refresh.collect_system_lock`).
+
+Three gotchas, each of which cost a cycle to learn, are encoded here rather than
+left to be rediscovered:
+
+1. **macOS cannot do this at all.** mise on darwin cannot write the linux conda
+   checksums (jdx/mise#7700), so a regen there silently truncates. This module
+   refuses on a non-linux-x64 host unless it can route itself into the amd64
+   devcontainer, which is what produced a faithful result.
+2. **Lock every platform the committed lock CARRIES, not just ``linux-x64``.**
+   CI passes ``--platform linux-x64`` alone and gets away with it only because
+   the committed lock is seeded in as a starting point: the ``macos-x64``
+   entries survive untouched. Bump a tool and its entries are *replaced*, so the
+   ``macos-x64`` one is lost and ``lock-check`` fails with ``tool uv: lost
+   platform(s) ['macos-x64']``. Measured on the committed files —
+   ``mise-system.lock`` carries six platforms (46 ``linux-x64`` and **29
+   ``macos-x64``** tool entries), ``mise-runtime.lock`` two (11 and **9**).
+   :func:`lock_platforms` derives the set from the file instead of naming it.
+3. **Verify coverage before writing.** Delegated, not re-implemented:
+   :func:`dotfiles_setup.lock_refresh.collect_system_lock` now runs
+   :func:`dotfiles_setup.lock_integrity.regressions` against the git-committed
+   bytes, so a truncated regen raises instead of landing.
+
+Everything is a parameter with this repo's case as its default — the platform
+set, the pass count, the stage directory, the installer fetch, and the container
+routing — so the same functions serve another lock, another image, or a test.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import platform
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from dotfiles_setup.lock_integrity import conda_platforms, tool_platforms
+from dotfiles_setup.lock_refresh import (
+    RUNTIME_ENV,
+    collect_system_lock,
+    stage_system_lock_dir,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+#: The committed lock whose platform coverage defines what a regen must produce.
+SYSTEM_LOCK = ".devcontainer/mise-system.lock"
+
+#: Where the pinned mise binary is installed inside the stage directory.
+PINNED_MISE_DIRNAME = "mise-pinned"
+
+MISE_INSTALLER_URL = "https://mise.run"
+
+#: `mise lock` resolves through GitHub, and anonymous quota exhausts mid-run;
+#: each pass fills what the previous could not. CI uses five and converges.
+DEFAULT_PASSES = 5
+
+#: The only host that can write a faithful image lock (gotcha 1).
+REQUIRED_OS = "Linux"
+REQUIRED_MACHINE = frozenset({"x86_64", "amd64"})
+
+
+class ImageLockError(RuntimeError):
+    """A precondition failed, or a step of the recipe did."""
+
+
+def lock_platforms(lock_text: str) -> tuple[str, ...]:
+    """Every platform the committed lock carries, tool entries and conda alike.
+
+    Derived rather than declared (gotcha 2). A hard-coded ``linux-x64`` is
+    correct only while no tool is bumped, which is the one condition under
+    which anyone runs this.
+    """
+    covered: set[str] = set(conda_platforms(lock_text))
+    for platforms in tool_platforms(lock_text).values():
+        covered |= platforms
+    return tuple(sorted(covered))
+
+
+def host_can_lock(
+    system: str | None = None, machine: str | None = None
+) -> tuple[bool, str]:
+    """Can this host write a faithful image lock? Returns the verdict + reason."""
+    system = system or platform.system()
+    machine = (machine or platform.machine()).lower()
+    if system != REQUIRED_OS:
+        return False, (
+            f"host OS is {system}, not {REQUIRED_OS} — mise cannot write the "
+            f"linux conda checksums off linux (jdx/mise#7700), and the tool "
+            f"count does not move, so the truncation is silent"
+        )
+    if machine not in REQUIRED_MACHINE:
+        return False, (
+            f"host machine is {machine}, not one of {sorted(REQUIRED_MACHINE)} "
+            f"— the image is linux/amd64"
+        )
+    return True, f"{system}/{machine}"
+
+
+def npm_available(which: Callable[[str], str | None] = shutil.which) -> bool:
+    """Is ``npm`` runnable?
+
+    mise's npm backend **execs** node/npm while resolving an ``npm:`` version
+    and ENOENT-fails without them. ``bun`` on PATH does not satisfy it despite
+    ``npm.package_manager = bun``, which is why this asks for ``npm`` by name.
+    """
+    return which("npm") is not None
+
+
+def fetch_installer(url: str = MISE_INSTALLER_URL) -> bytes:
+    """The mise install script, via ``curl`` exactly as the CI recipe does.
+
+    Separate from its use so a test never reaches the network. The scheme is
+    asserted rather than assumed: the bytes are piped to ``sh``, so an
+    ``http://`` or ``file://`` override would be a code-execution primitive
+    rather than a convenience.
+    """
+    if not url.startswith("https://"):
+        msg = f"refusing to fetch the mise installer over a non-https URL: {url}"
+        raise ImageLockError(msg)
+    result = subprocess.run(["curl", "-fsSL", url], capture_output=True, check=False)
+    if result.returncode != 0:
+        msg = (
+            f"fetching {url} failed (rc={result.returncode}): "
+            f"{result.stderr.decode(errors='replace').strip()}"
+        )
+        raise ImageLockError(msg)
+    return result.stdout
+
+
+def install_pinned_mise(
+    stage_dir: Path,
+    version: str,
+    *,
+    fetch: Callable[[str], bytes] = fetch_installer,
+    url: str = MISE_INSTALLER_URL,
+) -> Path:
+    """Install the image's exact mise version into ``stage_dir``.
+
+    The pin is not optional: lock formats are **not** cross-version compatible,
+    so a lock written by a different mise is one the image's
+    ``mise install --locked`` rejects. Same installer and same ``ARG
+    MISE_VERSION`` the Dockerfile uses.
+    """
+    install_path = stage_dir / PINNED_MISE_DIRNAME
+    env = {
+        **os.environ,
+        "MISE_VERSION": f"v{version}",
+        "MISE_INSTALL_PATH": str(install_path),
+    }
+    result = subprocess.run(
+        ["sh"], input=fetch(url), env=env, capture_output=True, check=False
+    )
+    if result.returncode != 0:
+        msg = (
+            f"installing pinned mise v{version} failed (rc={result.returncode}): "
+            f"{result.stderr.decode(errors='replace').strip()}"
+        )
+        raise ImageLockError(msg)
+    if not install_path.exists():
+        msg = f"pinned mise installer reported success but {install_path} is absent"
+        raise ImageLockError(msg)
+    return install_path
+
+
+def lock_command(
+    mise_bin: Path, stage_dir: Path, platforms: tuple[str, ...]
+) -> list[str]:
+    """The ``mise lock`` argv for one convergence pass."""
+    argv = [str(mise_bin), "lock"]
+    for name in platforms:
+        argv += ["--platform", name]
+    return [*argv, "-C", str(stage_dir)]
+
+
+def run_lock_passes(
+    mise_bin: Path,
+    stage_dir: Path,
+    platforms: tuple[str, ...],
+    *,
+    passes: int = DEFAULT_PASSES,
+    run: Callable[..., subprocess.CompletedProcess[bytes]] = subprocess.run,
+) -> None:
+    """Run the convergence loop; the LAST pass must succeed.
+
+    Earlier passes are allowed to fail — that is what the loop is for, since
+    exhausted GitHub quota is the expected mid-run failure. A final failure is
+    real: ``mise lock`` has hard-errored on an unresolvable tool since
+    2026.6.13, so a genuinely broken tool fails loud here rather than producing
+    a quietly short lock.
+    """
+    argv = lock_command(mise_bin, stage_dir, platforms)
+    child_env = {
+        **os.environ,
+        # Both tiers in one pass: mise writes mise.lock (base) and
+        # mise.runtime.lock (runtime tier) under this env (#160 T9).
+        "MISE_ENV": RUNTIME_ENV,
+        "MISE_TRUSTED_CONFIG_PATHS": str(stage_dir),
+    }
+    last: subprocess.CompletedProcess[bytes] | None = None
+    for attempt in range(1, passes + 1):
+        last = run(argv, env=child_env, check=False)
+        if last.returncode == 0:
+            logger.info("mise lock converged on pass %d/%d", attempt, passes)
+            return
+        logger.warning(
+            "mise lock pass %d/%d exited %d — retrying (rate limits are the "
+            "expected cause)",
+            attempt,
+            passes,
+            last.returncode,
+        )
+    rc = last.returncode if last is not None else -1
+    msg = f"mise lock did not converge in {passes} pass(es); last rc={rc}"
+    raise ImageLockError(msg)
+
+
+def container_command(repo_root: Path, extra: tuple[str, ...] = ()) -> list[str]:
+    """Re-invoke this task inside the amd64 devcontainer.
+
+    ``devcontainer exec`` and not raw ``docker exec`` (``do-not.md`` #3), and
+    the inner call passes ``--no-container`` so the recursion terminates. The
+    workspace is bind-mounted, so the inner run's writes land on the host tree.
+    """
+    return [
+        "devcontainer",
+        "exec",
+        "--workspace-folder",
+        str(repo_root),
+        "mise",
+        "exec",
+        "--",
+        "uv",
+        "run",
+        "--project",
+        "python",
+        "dotfiles-setup",
+        "image-lock",
+        "--no-container",
+        *extra,
+    ]
+
+
+def image_lock_main(
+    repo_root: Path,
+    *,
+    platforms: tuple[str, ...] = (),
+    stage: Path | None = None,
+    container: bool | None = None,
+    passes: int = DEFAULT_PASSES,
+) -> int:
+    """Stage, install pinned mise, converge, then collect with coverage verified.
+
+    ``container`` is tri-state on purpose: ``None`` routes into the devcontainer
+    only when the host cannot do the job itself, ``True`` always routes, and
+    ``False`` never does (and therefore fails loudly on a host that cannot).
+    """
+    capable, reason = host_can_lock()
+    if container is True or (container is None and not capable):
+        logger.info("routing into the devcontainer: %s", reason)
+        extra = tuple(arg for name in platforms for arg in ("--platform", name))
+        result = subprocess.run(container_command(repo_root, extra), check=False)
+        return result.returncode
+    if not capable:
+        logger.error(
+            "refusing to regenerate the image locks here: %s. Re-run without "
+            "--no-container to route into the amd64 devcontainer, or run this "
+            "on a linux/amd64 host. A regen on the wrong host truncates the "
+            "lock SILENTLY — the tool count does not move (#648, #650).",
+            reason,
+        )
+        return 1
+    if not npm_available():
+        logger.error(
+            "npm is not on PATH. mise's npm backend EXECS node/npm while "
+            "resolving an `npm:` version and ENOENT-fails without them; bun "
+            "does NOT satisfy it despite npm.package_manager = bun."
+        )
+        return 1
+
+    if not platforms:
+        platforms = lock_platforms((repo_root / SYSTEM_LOCK).read_text())
+        logger.info(
+            "locking the %d platform(s) the committed lock carries: %s",
+            len(platforms),
+            ", ".join(platforms),
+        )
+
+    owned_stage = stage is None
+    stage_dir = (
+        Path(tempfile.mkdtemp(prefix="dotfiles-image-lock-")) if owned_stage else stage
+    )
+    try:
+        version = stage_system_lock_dir(repo_root, stage_dir)
+        mise_bin = install_pinned_mise(stage_dir, version)
+        run_lock_passes(mise_bin, stage_dir, platforms, passes=passes)
+        collect_system_lock(repo_root, stage_dir)
+    except ImageLockError, ValueError, OSError:
+        logger.exception("image-lock failed")
+        return 1
+    finally:
+        if owned_stage:
+            shutil.rmtree(stage_dir, ignore_errors=True)
+    logger.info(
+        "image-lock OK: %s and the runtime lock regenerated with mise v%s "
+        "across %d platform(s), coverage verified against HEAD",
+        SYSTEM_LOCK,
+        version,
+        len(platforms),
+    )
+    return 0

--- a/python/src/dotfiles_setup/lock_refresh.py
+++ b/python/src/dotfiles_setup/lock_refresh.py
@@ -43,6 +43,8 @@ import shutil
 import tomllib
 from typing import TYPE_CHECKING
 
+from dotfiles_setup.lock_integrity import committed_text, regressions
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -144,26 +146,62 @@ def _merge_shared_tools(system_text: str, shared_text: str) -> str:
 def collect_system_lock(repo_root: Path, stage_dir: Path) -> None:
     """Copy the regenerated stage lock back to `.devcontainer/mise-system.lock`.
 
-    Validates before writing: the stage lock must parse as TOML and cover
-    every tool of the merged config — a truncated or partial lock (rate
-    limits, interrupted run) must never overwrite the committed one.
+    Validates before writing, on **two** axes — a truncated or partial lock
+    (rate limits, an interrupted run, the wrong host OS) must never overwrite
+    the committed one:
+
+    1. **tool coverage** — every tool of the merged config is locked;
+    2. **platform coverage** — no tool present in both the committed lock and
+       the candidate lost a platform, and no conda platform family vanished.
+
+    Axis 2 is #648, and axis 1 alone is why it was needed: a regen run on macOS
+    dropped ``mise-system.lock``'s ``linux-x64`` occurrences 131 -> 64 and
+    ``mise-runtime.lock``'s 35 -> 12 while the **tool count never moved** (49
+    and 22, unchanged), so a tool-only predicate returned rc=0 on a near-51%
+    coverage loss. The correct predicate already existed in
+    :mod:`dotfiles_setup.lock_integrity`; it simply was not being called here.
 
     Raises:
-        ValueError: when the stage lock is missing tools from the config.
+        ValueError: when the stage lock is missing tools from the config, or
+            lost platform coverage relative to the committed lock.
     """
     _collect_one(
         stage_dir / "mise.lock",
         repo_root / _SYSTEM_LOCK,
         merged_system_config_tools(repo_root),
+        coverage_baseline(repo_root, _SYSTEM_LOCK),
     )
     _collect_one(
         stage_dir / f"mise.{RUNTIME_ENV}.lock",
         repo_root / _RUNTIME_LOCK,
         runtime_config_tools(repo_root),
+        coverage_baseline(repo_root, _RUNTIME_LOCK),
     )
 
 
-def _collect_one(stage_lock: Path, dest: Path, config_tools: set[str]) -> None:
+def coverage_baseline(repo_root: Path, rel_path: str) -> str | None:
+    """The bytes to measure a candidate lock's coverage against.
+
+    ``HEAD`` first, on purpose: a run that already overwrote the working-tree
+    lock would otherwise be compared against its own damage and certified
+    clean. The on-disk file is the fallback rather than "no check at all",
+    because an untracked lock or a non-git checkout must not silently disable
+    the guard — a weaker baseline still catches the 51% truncation this exists
+    for, whereas ``None`` catches nothing.
+    """
+    from_git = committed_text(repo_root, rel_path)
+    if from_git is not None:
+        return from_git
+    path = repo_root / rel_path
+    return path.read_text() if path.exists() else None
+
+
+def _collect_one(
+    stage_lock: Path,
+    dest: Path,
+    config_tools: set[str],
+    committed: str | None,
+) -> None:
     stage_text = stage_lock.read_text()
     locked_tools = set(tomllib.loads(stage_text).get("tools", {}))
     missing = config_tools - locked_tools
@@ -173,7 +211,26 @@ def _collect_one(stage_lock: Path, dest: Path, config_tools: set[str]) -> None:
             f"(refusing to collect): {sorted(missing)}"
         )
         raise ValueError(msg)
-    dest.write_text(strip_provenance(stage_text))
+    # What is about to be written, not what the stage holds: the committed file
+    # is provenance-stripped, so comparing raw stage text would measure the
+    # stripping rather than the coverage.
+    candidate = strip_provenance(stage_text)
+    # ``committed`` is the git-tracked bytes, never the working tree — a regen
+    # that already overwrote the file would otherwise be compared against its
+    # own damage and certified clean.
+    lost = regressions(committed, candidate) if committed is not None else []
+    if lost:
+        detail = "; ".join(lost)
+        msg = (
+            f"stage lock {stage_lock.name} LOST platform coverage relative to "
+            f"the committed {dest.name} (refusing to collect): {detail}. The "
+            f"usual cause is regenerating on macOS — mise cannot write the "
+            f"linux conda entries there (jdx/mise#7700), and the tool count "
+            f"does not move, so this is invisible to a tool-only check (#648). "
+            f"Regenerate on linux/amd64."
+        )
+        raise ValueError(msg)
+    dest.write_text(candidate)
 
 
 def strip_provenance(lock_text: str) -> str:

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 from kb_setup import evals
 
+from dotfiles_setup import image_lock
 from dotfiles_setup.ai import AIOrchestrator
 from dotfiles_setup.apt_pins import apt_pins_main
 from dotfiles_setup.apt_repo import LLVM_DEV, RepoQuery, apt_repo_main
@@ -57,6 +58,7 @@ from dotfiles_setup.hook_guard import pretooluse_main
 from dotfiles_setup.hook_selfcheck import hook_selfcheck_main
 from dotfiles_setup.image import ImageCommand
 from dotfiles_setup.image import main as image_main
+from dotfiles_setup.image_lock import image_lock_main
 from dotfiles_setup.lint import (
     DEFAULT_TIMEOUT_SECONDS,
     TIMEOUT_ENV_VAR,
@@ -266,6 +268,51 @@ def _add_honesty_subcommands(subparsers: _SubParsers) -> None:
         "--verbose",
         action="store_true",
         help="Print a PASS line per clean check instead of staying silent",
+    )
+    image_lock_parser = subparsers.add_parser(
+        "image-lock",
+        help="Regenerate .devcontainer/mise-system.lock + mise-runtime.lock "
+        "locally, with CI's recipe as a callable (#650): stage the merged "
+        "config, install the image's PINNED mise, converge, then collect with "
+        "platform coverage verified against HEAD. Routes into the amd64 "
+        "devcontainer on a host that cannot write linux conda checksums",
+    )
+    image_lock_parser.add_argument(
+        "--platform",
+        action="append",
+        default=[],
+        dest="platforms",
+        help="Platform to lock; repeatable. Defaults to every platform the "
+        "committed lock already carries — a linux-x64-only pass drops a "
+        "bumped tool's macos-x64 entry",
+    )
+    image_lock_parser.add_argument(
+        "--stage",
+        type=Path,
+        help="Stage directory to reuse (default: a fresh temp dir, removed "
+        "afterwards). Reuse one to resume a rate-limited run",
+    )
+    image_lock_parser.add_argument(
+        "--passes",
+        type=int,
+        default=image_lock.DEFAULT_PASSES,
+        help="Convergence passes; each fills what the previous could not "
+        "resolve under GitHub rate limits",
+    )
+    container = image_lock_parser.add_mutually_exclusive_group()
+    container.add_argument(
+        "--container",
+        dest="container",
+        action="store_true",
+        default=None,
+        help="Always route into the devcontainer (default: only when this "
+        "host cannot write a faithful lock)",
+    )
+    container.add_argument(
+        "--no-container",
+        dest="container",
+        action="store_false",
+        help="Never route; fail loudly on a host that cannot do the job",
     )
     drift_parser = subparsers.add_parser(
         "path-drift",
@@ -1613,6 +1660,15 @@ def _build_command_handlers(
         ),
         "bash-budget": lambda: sys.exit(bash_budget_main(project_root)),
         "renovate-validate": lambda: sys.exit(renovate_validate_main(project_root)),
+        "image-lock": lambda: sys.exit(
+            image_lock_main(
+                project_root,
+                platforms=tuple(args.platforms),
+                stage=args.stage,
+                container=args.container,
+                passes=args.passes,
+            )
+        ),
         "path-drift": lambda: sys.exit(
             path_drift_main(
                 ambient_path=args.ambient_path,

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -1926,3 +1926,24 @@ per_path_tokens = { ".claude/settings.json" = ['DOTFILES_AMBIENT_PATH=\"$PATH\" 
 tokens = [
     "def resolve_ambient_path(",
 ]
+
+[[suite]]
+name = "workflow.image-lock-three-layer-stack"
+description = "#650: the image-lock recipe must exist ONCE, as a skill -> mise task -> python library stack, and its coverage check must be wired. Until this landed, the only thing that knew how to regenerate `.devcontainer/mise-system.lock` and `mise-runtime.lock` was CI's `.github/actions/lock-refresh/action.yml`, so a session bumping the shared fragment hand-transcribed the recipe out of a workflow file — ~15 turns on 2026-08-08, ending in a near-committed corruption. ⚠️ **The failure mode is SILENT TRUNCATION with an UNCHANGED TOOL COUNT, which is why the layer count is not the point of this contract — the coverage predicate is.** A regen on darwin dropped `mise-system.lock`'s `linux-x64` occurrences 131 -> 64 and `mise-runtime.lock`'s 35 -> 12 while `[[tools.*]]` stayed at 49 and 22, so `lock-collect`'s tool-only predicate returned rc=0 on a near-51% coverage loss (#648). The correct predicate already existed in `lock_integrity.regressions` and simply was not called; `lock_refresh._collect_one` now calls it, which is why `lost = regressions(committed, candidate)` is bound as a token — deleting exactly that line is the realistic regression, and mutation-testing confirmed it fails precisely `test_collect_refuses_a_lock_that_lost_platform_coverage` and nothing else. `coverage_baseline` is bound alongside it because WHICH baseline is load-bearing: it prefers `git show HEAD:` bytes over the working tree, so a run that already overwrote the lock is not graded against its own damage, and it falls back to the on-disk file rather than to `None` — a `None` baseline would silently disable the guard on an untracked lock, which is the same shape of hole one layer up. The comparison runs on provenance-STRIPPED text so it measures coverage rather than the stripping. Three gotchas are encoded in the library rather than left to be rediscovered, and each has a refusal: darwin cannot write linux conda checksums (jdx/mise#7700) so `host_can_lock` gates on OS **and** machine and the task routes into the amd64 devcontainer by default; `lock_platforms` DERIVES the platform set from the committed lock instead of hard-coding `linux-x64`, because CI's linux-only pass gets away with it only while the committed lock is the seed — the moment a tool is bumped its `macos-x64` entry is replaced and lost (measured: the committed system lock carries six platforms and 29 `macos-x64` tool entries, the runtime lock 9), and `test_the_real_committed_lock_still_carries_a_non_linux_platform` fails loudly if that ever stops being true rather than letting the precaution rot into dead code; and the npm precondition checks `npm` BY NAME because mise's npm backend execs it and bun does not satisfy it despite `npm.package_manager = bun`. Every seam is a parameter with this repo's case as the default (platforms, passes, stage dir, installer fetch, subprocess runner, host facts), per the build mandate — a library that hard-codes this repo cannot serve the next caller. Asserts the chain: the skill names the module it delegates to, mise.toml's task shells out to the CLI, main.py registers and dispatches the subcommand, the module carries its three gate functions, lock_refresh carries the coverage call site and its baseline chooser, and both test files carry the guard that fails when the wiring is removed."
+category = "workflow"
+check_type = "static"
+handler = "require_tokens"
+paths_required = true
+paths = [
+    ".claude/skills/lock-image/SKILL.md",
+    "mise.toml",
+    "python/src/dotfiles_setup/main.py",
+    "python/src/dotfiles_setup/image_lock.py",
+    "python/src/dotfiles_setup/lock_refresh.py",
+    "tests/test_image_lock.py",
+    "tests/test_lock_refresh.py",
+]
+per_path_tokens = { ".claude/skills/lock-image/SKILL.md" = ["name: lock-image", "python/src/dotfiles_setup/image_lock.py"], "mise.toml" = ["[tasks.lock-image]", "dotfiles-setup image-lock'"], "python/src/dotfiles_setup/main.py" = ['"image-lock",', '"image-lock": lambda'], "python/src/dotfiles_setup/image_lock.py" = ["def image_lock_main(", "def lock_platforms(", "def host_can_lock("], "python/src/dotfiles_setup/lock_refresh.py" = ["lost = regressions(committed, candidate)", "def coverage_baseline("], "tests/test_image_lock.py" = ["def test_the_mise_task_calls_the_cli_rather_than_reimplementing_the_recipe("], "tests/test_lock_refresh.py" = ["def test_collect_refuses_a_lock_that_lost_platform_coverage("] }
+tokens = [
+    "def lock_platforms(",
+]

--- a/tests/test_image_lock.py
+++ b/tests/test_image_lock.py
@@ -1,0 +1,341 @@
+# Copyright (c) 2026 Raymond Manaloto
+"""Tests for the local image-lock task (dotfiles_setup.image_lock).
+
+This module encodes a recipe whose failure mode is **silent truncation**, so
+the tests that matter are the ones pinning the three refusals: a host that
+cannot write linux conda checksums, a missing ``npm``, and a convergence loop
+that ran out of passes. Each is a case where doing the work anyway produces a
+plausible-looking lock that is wrong.
+
+The platform derivation is checked against the **real committed lock** as well
+as a fixture — the fixture proves the parse, the real file proves the parse is
+pointed at something whose shape has not moved (`macos-x64` entries that a
+``--platform linux-x64`` pass would drop are the whole reason this exists).
+
+Nothing here reaches the network or spawns mise: the installer fetch, the
+subprocess runner and the host facts are all injected parameters.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
+
+from dotfiles_setup import image_lock
+
+REPO_ROOT = Path(__file__).parent.parent
+
+_TWO_PLATFORM_LOCK = (
+    '[[tools.hk]]\nversion = "1.0"\n\n'
+    '[tools.hk."platforms.linux-x64"]\nchecksum = "sha256:a"\n\n'
+    '[tools.hk."platforms.macos-x64"]\nchecksum = "sha256:b"\n\n'
+    '[conda-packages.linux-x64.git]\nurl = "https://example.invalid/g"\n'
+)
+
+
+def _completed(rc: int) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.CompletedProcess([], rc, b"", b"")
+
+
+class _Recorder:
+    """A stand-in for ``subprocess.run`` that remembers what it was handed.
+
+    One typed object rather than a fake per test: the assertions here are all
+    "what argv / what env did the code build", so recording is the whole job.
+    """
+
+    def __init__(self, codes: list[int] | None = None) -> None:
+        self.codes = list(codes or [0])
+        self.argvs: list[list[str]] = []
+        self.envs: list[dict[str, str]] = []
+
+    def __call__(
+        self, argv: list[str], **kwargs: object
+    ) -> subprocess.CompletedProcess[bytes]:
+        self.argvs.append(argv)
+        env = kwargs.get("env")
+        if isinstance(env, dict):
+            self.envs.append(env)
+        rc = self.codes.pop(0) if len(self.codes) > 1 else self.codes[0]
+        return _completed(rc)
+
+
+# --------------------------------------------------------------------------- #
+# Platform derivation — gotcha 2
+# --------------------------------------------------------------------------- #
+
+
+def test_platforms_union_tool_entries_and_the_conda_section() -> None:
+    assert image_lock.lock_platforms(_TWO_PLATFORM_LOCK) == (
+        "linux-x64",
+        "macos-x64",
+    )
+
+
+def test_the_real_committed_lock_still_carries_a_non_linux_platform() -> None:
+    """Pin that the derived platform set still includes a non-linux platform.
+
+    If it did not, a ``--platform linux-x64`` pass would be safe and this
+    module's central precaution would be dead code. Measured 2026-08-08: six
+    platforms, 29 macos-x64 tool entries.
+    """
+    derived = image_lock.lock_platforms(
+        (REPO_ROOT / image_lock.SYSTEM_LOCK).read_text()
+    )
+    assert "linux-x64" in derived
+    assert any(name.startswith("macos-") for name in derived), (
+        "the committed image lock no longer carries a macOS platform — "
+        "re-check whether deriving the platform set is still load-bearing"
+    )
+
+
+def test_an_empty_lock_derives_no_platforms_rather_than_guessing() -> None:
+    assert image_lock.lock_platforms("") == ()
+
+
+# --------------------------------------------------------------------------- #
+# Host capability — gotcha 1
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("system", "machine", "capable"),
+    [
+        ("Linux", "x86_64", True),
+        ("Linux", "amd64", True),
+        ("Linux", "aarch64", False),
+        ("Darwin", "arm64", False),
+        ("Darwin", "x86_64", False),
+        ("Windows", "AMD64", False),
+    ],
+)
+def test_host_capability_covers_both_axes(
+    *, system: str, machine: str, capable: bool
+) -> None:
+    """OS and machine are separate refusals; an arm64 Linux is not the image."""
+    verdict, reason = image_lock.host_can_lock(system, machine)
+    assert verdict is capable
+    assert reason
+
+
+def test_the_darwin_refusal_names_the_upstream_defect() -> None:
+    _, reason = image_lock.host_can_lock("Darwin", "arm64")
+    assert "jdx/mise#7700" in reason
+
+
+def test_npm_is_checked_by_name_not_by_a_package_manager() -> None:
+    """The bun binary does NOT satisfy mise's npm backend, which execs npm."""
+    assert image_lock.npm_available(
+        lambda name: "/usr/bin/npm" if name == "npm" else None
+    )
+    assert not image_lock.npm_available(
+        lambda name: "/usr/bin/bun" if name == "bun" else None
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The lock command and its convergence loop
+# --------------------------------------------------------------------------- #
+
+
+def test_every_platform_becomes_its_own_flag() -> None:
+    argv = image_lock.lock_command(
+        Path("/s/mise-pinned"), Path("/s"), ("linux-x64", "macos-x64")
+    )
+    assert argv == [
+        "/s/mise-pinned",
+        "lock",
+        "--platform",
+        "linux-x64",
+        "--platform",
+        "macos-x64",
+        "-C",
+        "/s",
+    ]
+
+
+def test_a_later_pass_may_rescue_an_earlier_failure() -> None:
+    """The loop exists because GitHub quota exhausts mid-run, not for flakiness."""
+    recorder = _Recorder([1, 1, 0])
+    image_lock.run_lock_passes(
+        Path("/s/mise-pinned"), Path("/s"), ("linux-x64",), passes=5, run=recorder
+    )
+    assert len(recorder.argvs) == 3
+
+
+def test_exhausting_every_pass_raises_rather_than_collecting() -> None:
+    with pytest.raises(image_lock.ImageLockError, match="did not converge"):
+        image_lock.run_lock_passes(
+            Path("/s/mise-pinned"),
+            Path("/s"),
+            ("linux-x64",),
+            passes=2,
+            run=lambda *_a, **_k: _completed(1),
+        )
+
+
+def test_both_tiers_are_locked_in_one_pass() -> None:
+    """Pin MISE_ENV=runtime, which is what makes mise write mise.runtime.lock.
+
+    Both tiers come from one pass (#160 T9). Dropping it is a realistic
+    tidy-up, and the result is a runtime lock that is never regenerated at
+    all — invisible in the system lock's diff.
+    """
+    recorder = _Recorder()
+    image_lock.run_lock_passes(
+        Path("/s/mise-pinned"), Path("/s"), ("linux-x64",), run=recorder
+    )
+    assert recorder.envs[0]["MISE_ENV"] == "runtime"
+    assert recorder.envs[0]["MISE_TRUSTED_CONFIG_PATHS"] == "/s"
+
+
+# --------------------------------------------------------------------------- #
+# Installing the pinned mise
+# --------------------------------------------------------------------------- #
+
+
+def test_the_installer_fetch_refuses_a_non_https_url() -> None:
+    """Its output is piped to `sh`, so the scheme is a security boundary."""
+    with pytest.raises(image_lock.ImageLockError, match="non-https"):
+        image_lock.fetch_installer("http://example.invalid/install.sh")
+    with pytest.raises(image_lock.ImageLockError, match="non-https"):
+        image_lock.fetch_installer("file:///tmp/install.sh")
+
+
+def test_a_failed_install_raises_with_the_installer_stderr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        image_lock.subprocess,
+        "run",
+        lambda *_a, **_k: subprocess.CompletedProcess([], 1, b"", b"no network"),
+    )
+    with pytest.raises(image_lock.ImageLockError, match="no network"):
+        image_lock.install_pinned_mise(
+            tmp_path, "2026.7.0", fetch=lambda _u: b"#!/bin/sh\n"
+        )
+
+
+def test_an_installer_that_exits_zero_without_writing_the_binary_still_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """rc=0 is not evidence the binary exists — check the artifact, not the code."""
+    monkeypatch.setattr(image_lock.subprocess, "run", lambda *_a, **_k: _completed(0))
+    with pytest.raises(image_lock.ImageLockError, match="is absent"):
+        image_lock.install_pinned_mise(
+            tmp_path, "2026.7.0", fetch=lambda _u: b"#!/bin/sh\n"
+        )
+
+
+def test_the_pinned_version_is_passed_to_the_installer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pin that the Dockerfile's MISE_VERSION reaches the installer.
+
+    Lock formats are not cross-version compatible, so an unpinned install
+    produces a lock the image's ``mise install --locked`` rejects.
+    """
+    recorder = _Recorder()
+
+    def writing_run(
+        argv: list[str], **kwargs: object
+    ) -> subprocess.CompletedProcess[bytes]:
+        result = recorder(argv, **kwargs)
+        Path(recorder.envs[-1]["MISE_INSTALL_PATH"]).write_text("#!/bin/sh\n")
+        return result
+
+    monkeypatch.setattr(image_lock.subprocess, "run", writing_run)
+    binary = image_lock.install_pinned_mise(
+        tmp_path, "2026.7.0", fetch=lambda _u: b"#!/bin/sh\n"
+    )
+    assert recorder.envs[-1]["MISE_VERSION"] == "v2026.7.0"
+    assert binary == tmp_path / image_lock.PINNED_MISE_DIRNAME
+
+
+# --------------------------------------------------------------------------- #
+# Container routing
+# --------------------------------------------------------------------------- #
+
+
+def test_the_inner_call_cannot_recurse() -> None:
+    """Pin the flag that terminates the recursion.
+
+    Without ``--no-container`` the inner run re-evaluates the host; on a
+    misconfigured container that finds it incapable and routes again, forever.
+    """
+    argv = image_lock.container_command(Path("/repo"))
+    assert argv[:4] == ["devcontainer", "exec", "--workspace-folder", "/repo"]
+    assert "--no-container" in argv
+    assert "docker" not in argv
+
+
+def test_platform_flags_are_passed_through_to_the_inner_call() -> None:
+    argv = image_lock.container_command(Path("/repo"), ("--platform", "linux-x64"))
+    assert argv[-2:] == ["--platform", "linux-x64"]
+
+
+def test_an_incapable_host_routes_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(image_lock, "host_can_lock", lambda: (False, "Darwin"))
+    seen: list[list[str]] = []
+    monkeypatch.setattr(
+        image_lock.subprocess,
+        "run",
+        lambda argv, **_k: (seen.append(argv), _completed(0))[1],
+    )
+    assert image_lock.image_lock_main(REPO_ROOT) == 0
+    assert seen
+    assert seen[0][0] == "devcontainer"
+
+
+def test_an_incapable_host_with_no_container_refuses_instead_of_truncating(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The refusal is the feature: doing it anyway yields a lock that LOOKS fine."""
+    monkeypatch.setattr(image_lock, "host_can_lock", lambda: (False, "Darwin/arm64"))
+    called: list[str] = []
+    monkeypatch.setattr(
+        image_lock.subprocess,
+        "run",
+        lambda *_a, **_k: (called.append("ran"), _completed(0))[1],
+    )
+    assert image_lock.image_lock_main(REPO_ROOT, container=False) == 1
+    assert not called, "nothing may be executed once the host is refused"
+
+
+def test_a_capable_host_without_npm_refuses(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(image_lock, "host_can_lock", lambda: (True, "Linux/x86_64"))
+    monkeypatch.setattr(image_lock, "npm_available", lambda: False)
+    assert image_lock.image_lock_main(REPO_ROOT, container=False) == 1
+
+
+def test_container_true_routes_even_from_a_capable_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(image_lock, "host_can_lock", lambda: (True, "Linux/x86_64"))
+    seen: list[list[str]] = []
+    monkeypatch.setattr(
+        image_lock.subprocess,
+        "run",
+        lambda argv, **_k: (seen.append(argv), _completed(0))[1],
+    )
+    assert image_lock.image_lock_main(REPO_ROOT, container=True) == 0
+    assert seen[0][0] == "devcontainer"
+
+
+# --------------------------------------------------------------------------- #
+# The wiring the fixtures cannot see
+# --------------------------------------------------------------------------- #
+
+
+def test_the_mise_task_calls_the_cli_rather_than_reimplementing_the_recipe() -> None:
+    """The recipe living in TWO places is the defect #650 was filed about."""
+    mise_toml = (REPO_ROOT / "mise.toml").read_text()
+    assert "[tasks.lock-image]" in mise_toml
+    assert "dotfiles-setup image-lock" in mise_toml

--- a/tests/test_lock_refresh.py
+++ b/tests/test_lock_refresh.py
@@ -13,6 +13,7 @@ import pytest
 from dotfiles_setup.lock_refresh import (
     _merge_shared_tools,
     collect_system_lock,
+    coverage_baseline,
     merged_system_config_tools,
     pinned_mise_version,
     stage_system_lock_dir,
@@ -149,3 +150,107 @@ def test_collect_strips_provenance(tmp_path: Path) -> None:
 def test_merged_system_config_tools_unions_both(tmp_path: Path) -> None:
     repo = _mini_repo(tmp_path)
     assert merged_system_config_tools(repo) == {"conda:git", "hk"}
+
+
+# --------------------------------------------------------------------------- #
+# #648 — platform coverage, the axis a tool-only predicate cannot see
+# --------------------------------------------------------------------------- #
+
+# A tool with entries on both platforms, plus the conda section where the
+# macOS-regen damage actually lands. Shaped like the real lock, not minimal:
+# the failure being guarded is "same tools, fewer platforms", so a fixture with
+# one platform could not exhibit it at all (arm the FIXTURE, not just the probe).
+_COVERED = (
+    '[[tools."conda:git"]]\nversion = "2.0"\n\n'
+    '[tools."conda:git"."platforms.linux-x64"]\nchecksum = "sha256:a"\n\n'
+    '[tools."conda:git"."platforms.macos-x64"]\nchecksum = "sha256:b"\n\n'
+    '[[tools.hk]]\nversion = "1.46.0"\n\n'
+    '[tools.hk."platforms.linux-x64"]\nchecksum = "sha256:c"\n\n'
+    '[conda-packages.linux-x64.git]\nurl = "https://example.invalid/g"\n'
+)
+# The 2026-08-08 damage in miniature: every tool still present (so the tool
+# check passes), every linux entry gone.
+_DARWIN_TRUNCATED = (
+    '[[tools."conda:git"]]\nversion = "2.0"\n\n'
+    '[tools."conda:git"."platforms.macos-x64"]\nchecksum = "sha256:b"\n\n'
+    '[[tools.hk]]\nversion = "1.46.0"\n'
+)
+
+
+def _covered_repo(tmp_path: Path) -> Path:
+    repo = _mini_repo(tmp_path)
+    (repo / ".devcontainer" / "mise-system.lock").write_text(_COVERED)
+    return repo
+
+
+def test_collect_refuses_a_lock_that_lost_platform_coverage(tmp_path: Path) -> None:
+    """#648: the tool count does not move, so only the platform axis sees it."""
+    repo = _covered_repo(tmp_path)
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    stage_system_lock_dir(repo, stage)
+    (stage / "mise.lock").write_text(_DARWIN_TRUNCATED)
+    # Control arm for the claim above: the tool-only predicate is SATISFIED by
+    # this input, so a passing tool check is not what makes the test green.
+    assert merged_system_config_tools(repo) <= set(
+        tomllib.loads(_DARWIN_TRUNCATED)["tools"]
+    )
+    with pytest.raises(ValueError, match="LOST platform coverage"):
+        collect_system_lock(repo, stage)
+    assert (repo / ".devcontainer" / "mise-system.lock").read_text() == _COVERED
+
+
+def test_collect_accepts_a_regen_that_kept_coverage(tmp_path: Path) -> None:
+    """The pass arm: same platforms, bumped version, is a legitimate regen."""
+    repo = _covered_repo(tmp_path)
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    stage_system_lock_dir(repo, stage)
+    bumped = _COVERED.replace('version = "2.0"', 'version = "2.1"')
+    (stage / "mise.lock").write_text(bumped)
+    collect_system_lock(repo, stage)
+    assert (repo / ".devcontainer" / "mise-system.lock").read_text() == bumped
+
+
+def test_collect_measures_coverage_after_stripping_provenance(tmp_path: Path) -> None:
+    """Compare like with like, or the check measures the stripping instead.
+
+    The committed lock is provenance-stripped; the stage lock is not. Feeding
+    the raw stage text to the coverage predicate would be a different string
+    on every run for reasons that have nothing to do with coverage.
+    """
+    repo = _covered_repo(tmp_path)
+    stage = tmp_path / "stage"
+    stage.mkdir()
+    stage_system_lock_dir(repo, stage)
+    with_provenance = _COVERED.replace(
+        '[tools.hk."platforms.linux-x64"]\nchecksum = "sha256:c"\n',
+        '[tools.hk."platforms.linux-x64"]\nchecksum = "sha256:c"\n'
+        'provenance = "github-attestations"\n',
+    )
+    (stage / "mise.lock").write_text(with_provenance)
+    collect_system_lock(repo, stage)
+    written = (repo / ".devcontainer" / "mise-system.lock").read_text()
+    assert "provenance" not in written
+
+
+def test_coverage_baseline_prefers_head_over_the_working_tree(tmp_path: Path) -> None:
+    """A run that already overwrote the file must not be graded on its own damage.
+
+    Without the HEAD preference the baseline IS the truncated file, so the
+    comparison is truncated-vs-truncated and reports no loss.
+    """
+    repo = _covered_repo(tmp_path)
+    # Not a git repo, so `git show HEAD:` fails and the fallback is the file.
+    assert coverage_baseline(repo, ".devcontainer/mise-system.lock") == _COVERED
+    (repo / ".devcontainer" / "mise-system.lock").write_text(_DARWIN_TRUNCATED)
+    assert (
+        coverage_baseline(repo, ".devcontainer/mise-system.lock") == _DARWIN_TRUNCATED
+    )
+
+
+def test_coverage_baseline_is_none_only_when_there_is_nothing_to_compare(
+    tmp_path: Path,
+) -> None:
+    repo = _mini_repo(tmp_path)
+    assert coverage_baseline(repo, ".devcontainer/does-not-exist.lock") is None


### PR DESCRIPTION
The recipe for regenerating .devcontainer/mise-system.lock and
mise-runtime.lock lived in exactly one place — CI's lock-refresh composite
action — so a session that bumped the shared fragment hand-transcribed it
out of a workflow file. On 2026-08-08 that cost ~15 turns and produced a
near-committed corruption.

#648 is why the corruption nearly landed, and it is fixed here first
because the new task depends on it. `_collect_one` validated TOOL coverage
only; the darwin-regen damage leaves the tool count untouched (49 and 22,
unchanged) while dropping mise-system.lock's linux-x64 occurrences 131 ->
64 and mise-runtime.lock's 35 -> 12. So a near-51% coverage loss returned
rc=0. The correct predicate already existed in lock_integrity.regressions
and simply was not called. It is now, against `git show HEAD:` bytes — a
run that already overwrote the file must not be graded on its own damage —
falling back to the on-disk file rather than to None, since a None
baseline would silently disable the guard.

The new stack is skill -> mise task -> library, every seam a parameter
with this repo's case as the default:

- `.claude/skills/lock-image/SKILL.md` carries only judgement — which
  artifact you are touching, and the three ways a regen looks fine and is
  not.
- `mise run lock-image` is a thin caller.
- `dotfiles_setup.image_lock` holds the recipe, and encodes the gotchas as
  refusals rather than as comments: `host_can_lock` gates on OS AND
  machine (darwin cannot write linux conda checksums, jdx/mise#7700) and
  the task routes into the amd64 devcontainer by default; `lock_platforms`
  DERIVES the platform set from the committed lock, because CI's
  linux-x64-only pass survives only while that lock is the seed — bump a
  tool and its macos-x64 entry is replaced and lost; and npm is checked by
  name, since mise's npm backend execs it and bun does not satisfy it.

Not exercised end-to-end: the happy path has never run. The live arm here
is the refusal — on this arm64 Mac the task declines with the upstream
defect named and leaves both lockfiles untouched.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016SGa1MC4TUELrVHv5ER5BT

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/657"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788773453&installation_model_id=429246&pr_number=657&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F657&signature=0daf829462c00bf048171eccd9c965a0aa179f84ce9ee694ecf32c80fe843ae7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an `image-lock` command and `mise run lock-image` task to regenerate development-container image lockfiles.
  - Supports platform selection, configurable lock-generation passes, reusable staging directories, and optional container-based execution.
  - Automatically checks host capabilities and required tooling before starting.

- **Bug Fixes**
  - Prevents lock collection when regenerated files lose platform coverage.
  - Preserves existing committed locks when validation fails.

- **Documentation**
  - Added guidance for regenerating, validating, and interpreting image lockfiles across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->