### PR TITLE
feat(verify): pre-flight contract tokens before the contract exists (#652)

### DIFF
--- a/.claude/skills/token-check/SKILL.md
+++ b/.claude/skills/token-check/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: token-check
+description: Prove a candidate contract token binds exactly one site BEFORE writing the contract, via `mise run token-check -- <file> "<token>"...`. Use whenever adding or editing a `[[suite]]` in `python/verification/suites.toml`, choosing `per_path_tokens` for a new gate, or reacting to a `contract_token_uniqueness` / `token-audit` finding. Run it while picking the tokens, not after — a token matching more than once can be satisfied by a stand-in, so the contract silently asserts less than it claims, and that is how a deleted registration stayed green.
+user-invocable: true
+---
+
+# token-check: pre-flighting a contract's tokens
+
+```bash
+mise run token-check -- <file> "<token>" ["<token>" ...]
+mise run token-check -- <file> "<token>" --expect 2   # deliberate multiplicity
+```
+
+Same predicate as the `contract_token_uniqueness` gate, asked while the answer
+still costs one edit. The gate can only speak once the contract exists, so its
+finding arrives after the work. `python/src/dotfiles_setup/token_audit.py` holds
+both scopes; the task is a thin caller.
+
+Both arms print. `OK` lines are the point as much as the failures — you are
+about to commit these strings into a gate, so "I checked" has to be visible
+rather than inferred from silence.
+
+## What a good token is
+
+The count is necessary, not sufficient. A token that binds once and is still
+worthless is the common failure, so choose on meaning first and *then* check.
+
+**Bind a call site.** `if changes_apt_pin_inputs(paths):` asserts the function
+is *wired*; `def changes_apt_pin_inputs(` asserts only that it exists. #299
+shipped the definition form, and deleting the entire wiring line left the
+contract green — the token survived in a comment and in a docstring.
+
+**Prefer the line whose deletion is the realistic regression.** Ask what the
+regression would actually look like, then bind that. Renaming a function is
+rare; deleting the line that calls it is not.
+
+**A definition or a bare name can be satisfied by prose.** Comments, docstrings
+and the contract's own description all live in the same file the token is
+counted against.
+
+## Reading the three verdicts
+
+| Verdict | Means | Do |
+|---|---|---|
+| `OK` | binds exactly the expected sites | use it |
+| `AMBIGUOUS` (> expected) | a stand-in can satisfy the contract | lengthen it until it names one site |
+| `MISSING` (0) | wrong path, or wrong spelling | check the path first — it is the more common of the two |
+
+`MISSING` is worth a beat: a token counted against the wrong file reads exactly
+like a token that is absent, and the pre-flight cannot tell them apart. Confirm
+the path is the one the contract will name.
+
+## When multiplicity is right
+
+`--expect N` exists because some bindings legitimately match twice — the
+`AMBIGUITY_ALLOWED` map in `token_audit.py` documents 18, each with a reason
+(one clause computing a hash and a sibling clause re-checking it, for instance;
+both clauses *are* the contract). Reach for it when the second site is part of
+what you are asserting, not to quiet a token you would rather not rewrite.
+
+A token you allow to match twice must also get an `AMBIGUITY_ALLOWED` entry, or
+the whole-suite audit will report it on the next `mise run verify`.
+
+## Then write the contract
+
+The pre-flight checks one axis. Two others are the author's:
+
+- **`per_path_tokens`, not bare `tokens`** — a bare list is a UNION across every
+  named path, so one file carrying the token satisfies the contract for all of
+  them. It is also invisible to the uniqueness audit.
+- **`paths_required = true`** is the default and should stay so; a declared path
+  that no longer exists must fail the suite rather than quietly drop out.
+
+`python/AGENTS.md` § "Verification contracts" carries both in full.

--- a/mise.toml
+++ b/mise.toml
@@ -1018,6 +1018,19 @@ description = "Re-lock the NAMED tool(s), scoped, then assert coverage held"
 # verifies the artifact afterwards instead of trusting the exit code.
 run = 'uv run --project python dotfiles-setup lock-tools'
 
+[tasks.token-check]
+description = "Pre-flight a candidate contract token: does it bind exactly one site in its target file? (#652)"
+# Thin caller; see token_audit.py. Same predicate as the `token-audit` gate in
+# `mise run verify`, asked EARLY — the gate can only speak once the contract
+# exists, so its finding arrives after the work, while this one costs one edit.
+# A token matching more than once can be satisfied by a stand-in, which is how
+# a deleted registration stayed green (#394); a token matching zero times means
+# the path or the spelling is wrong.
+#
+#   mise run token-check -- <file> "<token>" ["<token>" ...]
+#   mise run token-check -- <file> "<token>" --expect 2   # deliberate multiplicity
+run = 'uv run --project python dotfiles-setup token-audit --check'
+
 [tasks.lock-image]
 description = "Regenerate the IMAGE locks (mise-system.lock + mise-runtime.lock) with CI's recipe, coverage-verified; routes into the amd64 devcontainer from macOS"
 # Thin caller; see image_lock.py. Sibling of `lock` above, and the division is

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -82,7 +82,7 @@ from dotfiles_setup.renovate import renovate_status_main
 from dotfiles_setup.renovate_dryrun import renovate_dryrun_main
 from dotfiles_setup.renovate_validate import renovate_validate_main
 from dotfiles_setup.sync import SyncOptions, sync_main
-from dotfiles_setup.token_audit import token_audit_main
+from dotfiles_setup.token_audit import preflight_main, token_audit_main
 from dotfiles_setup.verify import main as verify_main
 from dotfiles_setup.workflow_hooks import workflow_hooks_main
 
@@ -197,12 +197,28 @@ def _add_honesty_subcommands(subparsers: _SubParsers) -> None:
         action="store_true",
         help="Fail instead of writing when the committed doc is out of date",
     )
-    subparsers.add_parser(
+    token_audit_parser = subparsers.add_parser(
         "token-audit",
         help="Contract-token uniqueness: every per_path_tokens entry should "
         "match its target file exactly once, because a token matching twice can "
         "be satisfied by a stand-in (#394). Genuine multiplicity is allowlisted "
         "with a reason in token_audit.py",
+    )
+    token_audit_parser.add_argument(
+        "--check",
+        nargs="+",
+        metavar=("FILE", "TOKEN"),
+        help="PRE-FLIGHT (#652): count each TOKEN in FILE and exit non-zero "
+        "unless each binds exactly once, so a candidate contract token is "
+        "proven before the contract is written rather than after `verify` "
+        "reports it. Same predicate as the whole-suite audit",
+    )
+    token_audit_parser.add_argument(
+        "--expect",
+        type=int,
+        default=1,
+        help="Occurrences each token must have (default 1). Deliberate "
+        "multiplicity exists — say so rather than being told it is wrong",
     )
     subparsers.add_parser(
         "bash-budget",
@@ -1690,7 +1706,16 @@ def _build_command_handlers(
         ),
         "lock-check": lambda: sys.exit(lock_integrity_main(project_root)),
         "lock-tools": lambda: sys.exit(scoped_lock_main(project_root, args.tools)),
-        "token-audit": lambda: sys.exit(token_audit_main(project_root)),
+        "token-audit": lambda: sys.exit(
+            preflight_main(
+                project_root,
+                args.check[0],
+                args.check[1:],
+                expected=args.expect,
+            )
+            if args.check
+            else token_audit_main(project_root)
+        ),
         "env-blob-scan": lambda: sys.exit(
             env_blob_scan_main(project_root, args.paths or None)
         ),

--- a/python/src/dotfiles_setup/token_audit.py
+++ b/python/src/dotfiles_setup/token_audit.py
@@ -68,6 +68,7 @@ from typing import TYPE_CHECKING
 from dotfiles_setup import verify
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -252,19 +253,65 @@ class Ambiguity:
         return f"{self.suite} [{self.path}] {self.token!r} matches {self.count}x"
 
 
+@dataclass(frozen=True)
+class TokenCount:
+    """How many times one token occurs in one file, and whether that binds."""
+
+    path: str
+    token: str
+    count: int
+    expected: int = 1
+
+    @property
+    def ok(self) -> bool:
+        """True when the token binds exactly the intended number of sites."""
+        return self.count == self.expected
+
+    def render(self) -> str:
+        """One line: the verdict, the token, and what it actually matched."""
+        verdict = (
+            "OK  "
+            if self.ok
+            else "AMBIGUOUS"
+            if self.count > self.expected
+            else "MISSING"
+        )
+        return f"{verdict} {self.token!r} matches {self.count}x in {self.path}"
+
+
+def count_tokens(
+    root: Path,
+    rel_path: str,
+    tokens: Sequence[str],
+    *,
+    expected: int = 1,
+) -> list[TokenCount]:
+    """Count each token in one file — the predicate, at its smallest scope.
+
+    Shared deliberately: :func:`find_ambiguous` walks the whole manifest with
+    it and the pre-flight applies it to one candidate token, so both callers
+    ask the *same* question and cannot drift into two answers. A file that does
+    not exist reads as empty, which surfaces as a count of 0 rather than as an
+    exception — "this path is wrong" and "this token is absent" are the same
+    finding to the caller, and both mean the contract would not bind.
+    """
+    target = root / rel_path
+    text = target.read_text() if target.exists() else ""
+    return [
+        TokenCount(rel_path, token, text.count(token), expected) for token in tokens
+    ]
+
+
 def find_ambiguous(root: Path) -> list[Ambiguity]:
     """Every per-path token that matches its target file other than once."""
     suites = verify.load_manifest(root / MANIFEST)
-    found: list[Ambiguity] = []
-    for suite in suites:
-        for raw, tokens in suite.get("per_path_tokens", {}).items():
-            target = root / raw
-            text = target.read_text() if target.exists() else ""
-            for token in tokens:
-                count = text.count(token)
-                if count != 1:
-                    found.append(Ambiguity(suite["name"], raw, token, count))
-    return found
+    return [
+        Ambiguity(suite["name"], raw, counted.token, counted.count)
+        for suite in suites
+        for raw, tokens in suite.get("per_path_tokens", {}).items()
+        for counted in count_tokens(root, raw, tokens)
+        if not counted.ok
+    ]
 
 
 def find_unaudited(root: Path) -> list[str]:
@@ -305,6 +352,54 @@ def find_violations(root: Path) -> list[str]:
         if (suite, path, token) not in seen
     ]
     return sorted(problems)
+
+
+def preflight_main(
+    root: Path,
+    rel_path: str,
+    tokens: Sequence[str],
+    *,
+    expected: int = 1,
+) -> int:
+    """Pre-flight: prove candidate tokens bind BEFORE the contract is written.
+
+    Same predicate as the whole-suite audit, at the moment it is cheap to act
+    on. The audit can only speak once a contract exists, so its finding arrives
+    after the work — this asks the question while the answer still costs one
+    edit. Both arms are reported, not just failures: a run that prints nothing
+    is indistinguishable from a run that never looked, and the point of a
+    pre-flight is the reassurance as much as the alarm.
+
+    ``expected`` is a parameter because deliberate multiplicity exists —
+    ``AMBIGUITY_ALLOWED`` documents 18 such bindings — so a caller that means
+    "this must bind both clauses" can say so rather than being told it is
+    wrong.
+    """
+    counted = count_tokens(root, rel_path, tokens, expected=expected)
+    for entry in counted:
+        log = logger.info if entry.ok else logger.error
+        log("%s", entry.render())
+    bad = [entry for entry in counted if not entry.ok]
+    if not bad:
+        logger.info(
+            "token-check OK: %d token(s) each bind exactly %d site(s) in %s",
+            len(counted),
+            expected,
+            rel_path,
+        )
+        return 0
+    logger.error(
+        "%d of %d token(s) do not bind %d site(s). A token matching MORE than "
+        "once can be satisfied by a stand-in, so the contract asserts less than "
+        "it claims (#394/#397); a token matching ZERO times means the path or "
+        "the spelling is wrong and the contract would fail on arrival. Pick a "
+        "longer, call-site-shaped substring — never a bare definition or a name "
+        "prose can carry.",
+        len(bad),
+        len(counted),
+        expected,
+    )
+    return 1
 
 
 def token_audit_main(root: Path) -> int:

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -1947,3 +1947,22 @@ per_path_tokens = { ".claude/skills/lock-image/SKILL.md" = ["name: lock-image", 
 tokens = [
     "def lock_platforms(",
 ]
+
+[[suite]]
+name = "workflow.token-preflight-shares-one-predicate"
+description = "#652: the contract-token uniqueness predicate must exist ONCE and be reachable EARLY. #397's rule is that a `per_path_tokens` entry matching its file more than once can be satisfied by a stand-in, so the contract asserts less than it claims — measured: registering a second subjectless classifier made `subject_param=None,` match twice, and deleting either registry entry would have left the contract green (#394). `dotfiles-setup token-audit` encodes that predicate but can only speak once the contract EXISTS, surfacing in `mise run verify` after the work is done; the pre-flight asks the same question while the answer still costs one edit. ⚠️ **The property this contract protects is that the two scopes cannot drift apart**, which is why `for counted in count_tokens(root, raw, tokens)` is bound as a token rather than merely `def count_tokens(`: the whole-suite walk was re-inlining `text.count(token)` before this change, and re-inlining it again is exactly how the pre-flight would start giving permission the gate later refuses — the worst outcome, since the pre-flight's entire value is being BELIEVED before the contract is written. `test_the_suite_audit_and_the_preflight_agree_on_the_same_input` drives both scopes over one manifest and requires the same verdict, and is bound here for the same reason. Three design points worth keeping: zero and many are reported with DIFFERENT words (`MISSING` vs `AMBIGUOUS`) because they are different defects — many means the contract under-asserts, zero means the path or spelling is wrong and it would fail on arrival; the PASSING arm is printed too, because a silent success is indistinguishable from a probe that never ran and the caller is about to commit those strings into a gate; and `expected` is a parameter rather than a hard-coded 1, because deliberate multiplicity is real — `AMBIGUITY_ALLOWED` documents 18 bindings where both sites ARE the contract. ⚠️ **The count is necessary, not sufficient, and the skill carries that judgement**: a token binding exactly once can still be worthless if it names a DEFINITION rather than a CALL SITE, since a comment or a docstring in the same file satisfies it — #299 shipped `def changes_apt_pin_inputs(` and deleting the whole wiring line left the contract green. The tool proved itself on its first real use: pre-flighting THIS contract's own tokens rejected `\"--check\",` at 5 matches in main.py, so the token bound here is the unique help-string instead. Asserts the chain: the skill names the task, mise.toml's task shells out to the CLI flag, main.py registers the flag and dispatches to the pre-flight while keeping the whole-suite default, the module carries both scopes plus the shared call site, and the test file carries the agreement guard."
+category = "workflow"
+check_type = "static"
+handler = "require_tokens"
+paths_required = true
+paths = [
+    ".claude/skills/token-check/SKILL.md",
+    "mise.toml",
+    "python/src/dotfiles_setup/main.py",
+    "python/src/dotfiles_setup/token_audit.py",
+    "tests/test_token_preflight.py",
+]
+per_path_tokens = { ".claude/skills/token-check/SKILL.md" = ["name: token-check"], "mise.toml" = ["[tasks.token-check]", "dotfiles-setup token-audit --check'"], "python/src/dotfiles_setup/main.py" = ['help="PRE-FLIGHT (#652)', "else token_audit_main(project_root)", "preflight_main("], "python/src/dotfiles_setup/token_audit.py" = ["def count_tokens(", "def preflight_main(", "for counted in count_tokens(root, raw, tokens)"], "tests/test_token_preflight.py" = ["def test_the_suite_audit_and_the_preflight_agree_on_the_same_input("] }
+tokens = [
+    "def count_tokens(",
+]

--- a/tests/test_token_preflight.py
+++ b/tests/test_token_preflight.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2026 Raymond Manaloto
+"""Tests for the contract-token pre-flight (#652).
+
+The pre-flight and the whole-suite audit are deliberately the SAME predicate at
+different scopes, so the tests that matter most are the ones pinning that they
+cannot drift apart — a pre-flight that says "binds once" while the gate later
+says "matches twice" would be worse than no pre-flight, because it would be
+trusted.
+
+Fixtures are written into ``tmp_path`` rather than pointed at repo files. That
+is not only isolation: the absent-token arm needs a string that is genuinely
+absent, and a literal written into a tracked test file is thereafter present in
+the corpus — the contamination
+``.claude/rules/probes-need-a-control-arm.md`` rule 3 warns about. Building the
+haystack means absence is a property of the fixture, not a hope about the repo.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
+
+from dotfiles_setup import token_audit
+
+REPO_ROOT = Path(__file__).parent.parent
+
+_HAYSTACK = """\
+def wire_it(handler):
+    return handler
+
+REGISTRY = {"a": wire_it, "b": wire_it}
+"""
+
+
+@pytest.fixture
+def haystack(tmp_path: Path) -> Path:
+    (tmp_path / "mod.py").write_text(_HAYSTACK)
+    return tmp_path
+
+
+# --------------------------------------------------------------------------- #
+# The predicate
+# --------------------------------------------------------------------------- #
+
+
+def test_a_token_binding_one_site_is_ok(haystack: Path) -> None:
+    (counted,) = token_audit.count_tokens(haystack, "mod.py", ["def wire_it("])
+    assert (counted.count, counted.ok) == (1, True)
+
+
+def test_a_token_binding_several_sites_is_not_ok(haystack: Path) -> None:
+    """The #394 shape: either registry entry can stand in for the other."""
+    (counted,) = token_audit.count_tokens(haystack, "mod.py", ["wire_it"])
+    assert counted.count == 3
+    assert not counted.ok
+    assert "AMBIGUOUS" in counted.render()
+
+
+def test_an_absent_token_is_reported_as_missing_not_as_ambiguous(
+    haystack: Path,
+) -> None:
+    """Zero and many are different defects and deserve different words.
+
+    Many means the contract asserts less than it claims; zero means the path
+    or the spelling is wrong and it would fail the moment it ran.
+    """
+    (counted,) = token_audit.count_tokens(haystack, "mod.py", ["def unwire_it("])
+    assert counted.count == 0
+    assert not counted.ok
+    assert "MISSING" in counted.render()
+
+
+def test_a_path_that_does_not_exist_counts_zero_rather_than_raising(
+    haystack: Path,
+) -> None:
+    """A wrong path and an absent token are the same finding to the caller."""
+    (counted,) = token_audit.count_tokens(haystack, "nope.py", ["def wire_it("])
+    assert counted.count == 0
+
+
+def test_expected_multiplicity_is_a_parameter(haystack: Path) -> None:
+    """Deliberate multiplicity exists — AMBIGUITY_ALLOWED documents 18 of them."""
+    (counted,) = token_audit.count_tokens(haystack, "mod.py", ["wire_it"], expected=3)
+    assert counted.ok
+
+
+# --------------------------------------------------------------------------- #
+# The pre-flight entry point
+# --------------------------------------------------------------------------- #
+
+
+def test_all_unique_tokens_exit_zero(haystack: Path) -> None:
+    assert (
+        token_audit.preflight_main(haystack, "mod.py", ["def wire_it(", "REGISTRY = {"])
+        == 0
+    )
+
+
+def test_one_bad_token_among_good_ones_exits_one(haystack: Path) -> None:
+    assert (
+        token_audit.preflight_main(haystack, "mod.py", ["def wire_it(", "wire_it"]) == 1
+    )
+
+
+def test_the_passing_arm_is_reported_too(
+    haystack: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A silent success is indistinguishable from a probe that never ran.
+
+    The reassurance is half the point of a pre-flight: the caller is about to
+    commit these tokens into a contract, so "I checked and they bind" has to be
+    visible, not inferred from the absence of an error.
+    """
+    with caplog.at_level(logging.INFO, logger=token_audit.logger.name):
+        token_audit.preflight_main(haystack, "mod.py", ["def wire_it("])
+    assert any("matches 1x" in record.message for record in caplog.records)
+
+
+def test_the_failure_names_the_stand_in_hazard(
+    haystack: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    with caplog.at_level(logging.ERROR, logger=token_audit.logger.name):
+        token_audit.preflight_main(haystack, "mod.py", ["wire_it"])
+    assert any("stand-in" in record.getMessage() for record in caplog.records)
+
+
+# --------------------------------------------------------------------------- #
+# One predicate, two scopes — the property that makes the pre-flight trustworthy
+# --------------------------------------------------------------------------- #
+
+
+def test_the_suite_audit_and_the_preflight_agree_on_the_same_input(
+    tmp_path: Path,
+) -> None:
+    """Drive both scopes over one manifest and require the same verdict.
+
+    If these two ever answered differently, the pre-flight would be giving
+    permission the gate then refuses — the worst outcome, since its whole value
+    is being believed before the contract is written.
+    """
+    manifest = tmp_path / token_audit.MANIFEST
+    manifest.parent.mkdir(parents=True)
+    (tmp_path / "mod.py").write_text(_HAYSTACK)
+    manifest.write_text(
+        "[[suite]]\n"
+        'name = "x.y"\n'
+        'description = "d"\n'
+        'category = "workflow"\n'
+        'check_type = "static"\n'
+        'handler = "require_tokens"\n'
+        'paths = ["mod.py", "other.md"]\n'
+        'per_path_tokens = { "mod.py" = ["wire_it", "def wire_it("] }\n'
+        'tokens = ["wire_it"]\n'
+    )
+    (tmp_path / "other.md").write_text("filler\n")
+
+    ambiguous = {(a.token, a.count) for a in token_audit.find_ambiguous(tmp_path)}
+    preflighted = {
+        (c.token, c.count)
+        for c in token_audit.count_tokens(
+            tmp_path, "mod.py", ["wire_it", "def wire_it("]
+        )
+        if not c.ok
+    }
+    assert ambiguous == preflighted == {("wire_it", 3)}
+
+
+# --------------------------------------------------------------------------- #
+# Wiring
+# --------------------------------------------------------------------------- #
+
+
+def test_the_mise_task_calls_the_cli_flag_rather_than_a_second_implementation() -> None:
+    mise_toml = (REPO_ROOT / "mise.toml").read_text()
+    assert "[tasks.token-check]" in mise_toml
+    assert "dotfiles-setup token-audit --check" in mise_toml
+
+
+def test_the_shipped_manifest_still_passes_the_whole_suite_audit() -> None:
+    """The regression arm for the refactor: same answer on the real corpus."""
+    assert token_audit.find_violations(REPO_ROOT) == []


### PR DESCRIPTION
#397's rule is that a `per_path_tokens` entry matching its file more than
once can be satisfied by a stand-in, so the contract asserts less than it
claims — that is how a deleted registration stayed green (#394).
`dotfiles-setup token-audit` encodes the predicate but can only speak once
the contract exists, so its finding arrives after the work. The loop was:
write the contract, run verify, discover the token matches twice, rewrite.

This exposes the same predicate at the moment the answer costs one edit,
rather than writing new logic:

- `count_tokens()` is the predicate at its smallest scope, and
  `find_ambiguous()` now walks the manifest THROUGH it. That sharing is the
  point: two implementations could drift, and a pre-flight that grants
  permission the gate later refuses is worse than none, because it is
  believed. A test drives both scopes over one manifest and requires the
  same verdict.
- `preflight_main()` reports zero and many with different words — many
  means the contract under-asserts, zero means the path or spelling is
  wrong — and prints the PASSING arm too, since a silent success is
  indistinguishable from a probe that never ran.
- `expected` is a parameter, not a hard-coded 1: AMBIGUITY_ALLOWED
  documents 18 bindings where both sites are the contract.

Reachable as `mise run token-check -- <file> "<token>"...` with a skill
carrying the judgement the count cannot: a token binding exactly once is
still worthless if it names a definition rather than a call site, because
a comment in the same file satisfies it.

It paid for itself on first use. Pre-flighting this change's own contract
rejected `"--check",` at 5 matches in main.py; the token bound is the
unique help-string instead.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016SGa1MC4TUELrVHv5ER5BT

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788787635&installation_model_id=429246&pr_number=658&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F658&signature=faf7ed3d90297a2e51fb8adc378b37288728052049ee78007c22cd193309108f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token preflight checks to validate that specified tokens appear the expected number of times.
  * Added support for intentional repeated matches using an expected count.
  * Added a convenient command for running token checks.

* **Documentation**
  * Documented token selection, result interpretation, multiplicity checks, and contract requirements.

* **Tests**
  * Added coverage for missing, unique, ambiguous, and repeated tokens, including command integration and manifest validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->