### PR TITLE
feat(lint): partition linter violations into yours and the upgrade's (#651)

### DIFF
--- a/.claude/skills/lint-delta/SKILL.md
+++ b/.claude/skills/lint-delta/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: lint-delta
+description: Partition linter violations into yours and the upgrade's by running the previous pinned version against the same tree, via `mise run lint-delta`. Reach for it the moment a ruff, ty or other linter bump turns a green gate red — before fixing anything and before reaching for a suppression — and whenever a Renovate tool-bump PR arrives with a wall of new diagnostics. Newly-enabled rules look exactly like regressions in your own change — one measured bump took a tree from 2 violations to 138 without a line of code changing.
+user-invocable: true
+---
+
+# lint-delta: whose violations are these?
+
+```bash
+mise run lint-delta                        # ruff, baseline derived
+mise run lint-delta -- --tool ty
+mise run lint-delta -- --baseline 0.15.20  # name it yourself
+mise run lint-delta -- --paths python/src  # narrow the scope
+```
+
+`python/src/dotfiles_setup/lint_delta.py` runs both versions over the **same
+tree** and diffs by rule code. The old version is the control arm, so every
+difference belongs to the bump.
+
+## Why this beats reading the diagnostics
+
+A bump enables rules that were never checked before, and they fire on code that
+has been sitting there for months. Measured on this repo, ruff 0.15.20 → 0.16.2,
+one unchanged tree:
+
+| ruff | total | breakdown |
+|---|---|---|
+| 0.15.20 | **2** | I001 ×1, D403 ×1 — genuinely mine |
+| 0.16.2 | **138** | + CPY001 ×106, ISC004 ×30 — pre-existing code |
+
+Without the split the decision reads as *"fix 138 or suppress"*. With it, it is
+*"fix 2, then decide policy on two new rule classes"* — and those are different
+decisions with different right answers.
+
+## Reading the three sections
+
+**Yours** — both versions fire these. Attributable to your change. Fix them;
+this is the list the gate would have shown you without the bump.
+
+**The upgrade's** — new rule classes. This is a **policy** call, not a bug
+list. Options in rough order of preference: fix them (often mechanical), narrow
+the rule in `python/pyproject.toml`'s `[tool.ruff.lint]` with a stated reason,
+or raise it with Ray. Not an option: an inline suppression —
+`.claude/rules/zero-skip-policy.md` and the `no_lint_skip` hk step both refuse
+`noqa`.
+
+**Retired** — the old version fired these and the new one does not. Read this
+section; it is the one that looks like good news and is not. A rule that
+stopped firing is coverage the gate used to have, and nothing will ever fail to
+tell you. Check whether it was removed, renamed, or merely stopped matching.
+
+## When it refuses
+
+Exit 2 means the comparison could not discriminate, and that is deliberate —
+reporting "no new rules" from a version compared against itself would be a
+probe with one face.
+
+- **baseline == current pin.** The previous lockfile revision did not bump this
+  tool. Name an older version with `--baseline`.
+- **no earlier revision pins it.** Same fix.
+- **unknown tool.** `TOOLS` in the module lists what is wired; adding one is a
+  spec entry (invocation + how to recover a rule code), not new logic.
+
+The baseline defaults to the pin at the **previous revision that touched
+`python/uv.lock`** — deliberately not `HEAD~1`, which is merely the previous
+commit and usually left the pins untouched, producing exactly the
+version-against-itself refusal above.
+
+## Before you trust a bulk `--fix`
+
+A newly-enabled rule's autofix has never run on this codebase. When it rewrites
+string literals — `ISC004` is the case that came up — confirm the strings
+survived rather than assuming: compare the AST string constants before and
+after. On the 30 ISC004 fixes that prompted this, 9 of 10 files were
+byte-identical and the tenth differed only by an unrelated capitalisation.

--- a/mise.toml
+++ b/mise.toml
@@ -1184,3 +1184,15 @@ description = "Find what this session did BY HAND that should be code (#654): tr
 #   mise run session-review -- --output .agent/session-review.md
 #   mise run session-review -- --narrative-only      # cheap re-check
 run = 'uv run --project python dotfiles-setup session-review'
+
+[tasks.lint-delta]
+description = "Partition linter violations into YOURS vs THE UPGRADE'S by running the previous pinned version against the same tree (#651)"
+# Thin caller; see lint_delta.py. A linter bump makes every newly-enabled rule
+# look like a regression in your own change: measured 2026-08-08, ruff
+# 0.15.20 -> 0.16.2 went 2 -> 138 violations on ONE unchanged tree. The old
+# version IS the control arm, so every difference belongs to the bump.
+#
+#   mise run lint-delta                              # ruff, baseline derived
+#   mise run lint-delta -- --tool ty
+#   mise run lint-delta -- --baseline 0.15.20
+run = 'uv run --project python dotfiles-setup lint-delta'

--- a/python/src/dotfiles_setup/lint_delta.py
+++ b/python/src/dotfiles_setup/lint_delta.py
@@ -1,0 +1,357 @@
+# Copyright (c) 2026 Raymond Manaloto
+
+"""Partition linter violations into "mine" and "the upgrade's" (#651).
+
+A linter bump makes every newly-enabled rule look like a regression in your own
+change. Measured 2026-08-08, ruff 0.15.20 -> 0.16.2 against **one unchanged
+tree**:
+
+=====================  =======  ==========================================
+ruff                    total    breakdown
+=====================  =======  ==========================================
+0.15.20 (previous)      **2**    I001 x1, D403 x1 — both genuinely mine
+0.16.2 (new pin)      **138**    + CPY001 x106, ISC004 x30 — pre-existing
+=====================  =======  ==========================================
+
+Without the partition the choice reads as *"fix 138 or suppress"*; with it, as
+*"fix 2, then decide policy on two new rule classes"*. That is the difference
+between a panic and a decision, and it is the control-arm discipline
+``.claude/rules/probes-need-a-control-arm.md`` already mandates — **the old
+version IS the control arm**, run against the same tree, so any difference is
+attributable to the tool rather than to the code.
+
+Three things this module treats as load-bearing:
+
+- **Diff by RULE CODE, not by line.** The question is *which rule classes are
+  new*, and a line-level diff answers it with a wall of diagnostics that has to
+  be re-summarised by hand — the very work being automated.
+- **Report BOTH directions.** A rule that stopped firing is information too: it
+  means the upgrade removed or relaxed something a gate used to catch, which is
+  a silent loss of coverage rather than good news.
+- **A baseline equal to the current pin is refused, loudly.** Comparing a
+  version against itself is a probe with one face: it can only report "no
+  change", and reporting that as a clean bill would be exactly the false
+  negative rule 9 exists to refuse.
+
+The baseline defaults to the version at the **previous revision that touched
+the lockfile** — not ``HEAD~1``, which is merely the previous commit and
+usually did not touch it at all. That default makes the common case ("I just
+bumped it") need no argument, and it is derived rather than remembered.
+
+Nothing here is ruff-specific: :data:`TOOLS` describes each tool's invocation
+and how to recover a rule code from its output, and every seam (tool, baseline,
+paths, runner) is a parameter with this repo's case as the default.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import subprocess
+from collections import Counter
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: The lockfile the pinned versions are read from.
+LOCKFILE = "python/uv.lock"
+
+#: What this repo lints. Not a hard-coded scope: it is the default of a
+#: parameter, so the same functions serve one file or another project.
+DEFAULT_PATHS: tuple[str, ...] = ("python/src", "tests")
+
+_TIMEOUT_S = 300.0
+
+
+def parse_ruff(stdout: str) -> Counter[str]:
+    """Rule codes from ``ruff check --output-format json``."""
+    try:
+        parsed = json.loads(stdout or "[]")
+    except json.JSONDecodeError:
+        return Counter()
+    return Counter(
+        entry["code"]
+        for entry in (parsed if isinstance(parsed, list) else [])
+        if isinstance(entry, dict) and isinstance(entry.get("code"), str)
+    )
+
+
+_TY_CODE = re.compile(r"^\w+\[([a-z0-9-]+)\]", re.MULTILINE)
+
+
+def parse_ty(stdout: str) -> Counter[str]:
+    """Rule names from ``ty check --output-format concise``.
+
+    ty has no JSON output (``full``, ``concise``, ``gitlab``, ``github``,
+    ``junit``), so the concise form is parsed for its ``error[rule-name]``
+    prefix. Checked against the real CLI rather than assumed.
+    """
+    return Counter(_TY_CODE.findall(stdout))
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """How to run one linter at an arbitrary version and read its rule codes."""
+
+    name: str
+    argv: tuple[str, ...]
+    parse: Callable[[str], Counter[str]]
+    #: Package name in ``uv.lock``; usually but not necessarily the tool name.
+    package: str = ""
+
+    @property
+    def lock_name(self) -> str:
+        """The package name to look up in the lockfile."""
+        return self.package or self.name
+
+
+TOOLS: dict[str, ToolSpec] = {
+    "ruff": ToolSpec(
+        name="ruff",
+        argv=("check", "--output-format", "json"),
+        parse=parse_ruff,
+    ),
+    "ty": ToolSpec(
+        name="ty",
+        argv=("check", "--output-format", "concise"),
+        parse=parse_ty,
+    ),
+}
+
+
+@dataclass(frozen=True)
+class Delta:
+    """Per-code counts at two versions, and what moved between them."""
+
+    tool: str
+    baseline_version: str
+    current_version: str
+    baseline: Counter[str]
+    current: Counter[str]
+
+    @property
+    def introduced(self) -> list[tuple[str, int]]:
+        """Codes the new version fires that the old one did not — the upgrade's."""
+        return sorted(
+            (
+                (code, n)
+                for code, n in self.current.items()
+                if code not in self.baseline
+            ),
+            key=lambda pair: (-pair[1], pair[0]),
+        )
+
+    @property
+    def retired(self) -> list[tuple[str, int]]:
+        """Codes the old version fired and the new one does not.
+
+        Not automatically good news: a rule that stopped firing is coverage the
+        gate used to have and silently lost.
+        """
+        return sorted(
+            (
+                (code, n)
+                for code, n in self.baseline.items()
+                if code not in self.current
+            ),
+            key=lambda pair: (-pair[1], pair[0]),
+        )
+
+    @property
+    def mine(self) -> list[tuple[str, int]]:
+        """Codes BOTH versions fire — attributable to the code, not the bump."""
+        return sorted(
+            (
+                (code, self.current[code])
+                for code in self.current
+                if code in self.baseline
+            ),
+            key=lambda pair: (-pair[1], pair[0]),
+        )
+
+
+def locked_version(lock_text: str, package: str) -> str | None:
+    """The version ``uv.lock`` pins for ``package``; None when it is absent."""
+    match = re.search(
+        rf'\[\[package\]\]\nname = "{re.escape(package)}"\nversion = "([^"]+)"',
+        lock_text,
+    )
+    return match.group(1) if match else None
+
+
+def previous_lock_revision(repo_root: Path, lockfile: str = LOCKFILE) -> str | None:
+    """The revision BEFORE the most recent one that touched the lockfile.
+
+    Deliberately not ``HEAD~1``: the previous commit usually did not touch the
+    lockfile at all, so its pins are identical to HEAD's and the comparison
+    would be a version against itself.
+    """
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "log", "-2", "--format=%H", "--", lockfile],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    revisions = result.stdout.split()
+    return revisions[1] if len(revisions) > 1 else None
+
+
+def version_at(
+    repo_root: Path, revision: str, package: str, lockfile: str
+) -> str | None:
+    """The pinned version of ``package`` as of ``revision``."""
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "show", f"{revision}:{lockfile}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return locked_version(result.stdout, package)
+
+
+def run_at_version(
+    spec: ToolSpec,
+    version: str,
+    paths: Sequence[str],
+    *,
+    cwd: Path,
+    run: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> Counter[str]:
+    """Run ``spec`` pinned to ``version`` over ``paths`` and count rule codes.
+
+    ``uvx <tool>@<version>`` rather than the project environment: the whole
+    point is to run a version the project is NOT pinned to, which an
+    environment-resolved binary cannot do. A non-zero exit is expected and
+    ignored — a linter that found violations is the normal case here.
+    """
+    argv = ["uvx", f"{spec.name}@{version}", *spec.argv, *paths]
+    result = run(
+        argv, capture_output=True, text=True, check=False, cwd=cwd, timeout=_TIMEOUT_S
+    )
+    return spec.parse(result.stdout)
+
+
+def _table(rows: Sequence[tuple[str, int]], empty: str) -> list[str]:
+    if not rows:
+        return [f"_{empty}_"]
+    return [
+        "| code | count |",
+        "|---|---|",
+        *(f"| `{code}` | {count} |" for code, count in rows),
+    ]
+
+
+def render_report(delta: Delta) -> str:
+    """The partition, as the decision it is meant to support."""
+    introduced = sum(n for _, n in delta.introduced)
+    mine = sum(n for _, n in delta.mine)
+    return "\n".join(
+        [
+            (
+                f"# lint-delta: {delta.tool} {delta.baseline_version} -> "
+                f"{delta.current_version}"
+            ),
+            "",
+            (
+                f"**{mine} attributable to the code, {introduced} to the "
+                f"upgrade.** Same tree, two tool versions — the old version is "
+                f"the control arm, so every difference below belongs to the bump."
+            ),
+            "",
+            "## Yours — both versions fire these",
+            "",
+            *_table(delta.mine, "nothing: every violation came in with the upgrade"),
+            "",
+            "## The upgrade's — new rule classes",
+            "",
+            *_table(delta.introduced, "no new rule fired"),
+            "",
+            "## Retired — the OLD version fired these and the new one does not",
+            "",
+            *_table(
+                delta.retired,
+                "nothing stopped firing",
+            ),
+            "",
+            (
+                "A retired code is not automatically good news: it is coverage "
+                "the gate used to have. Check whether the rule was removed, "
+                "renamed, or merely stopped matching."
+            ),
+            "",
+        ]
+    )
+
+
+def lint_delta_main(
+    repo_root: Path,
+    *,
+    tool: str = "ruff",
+    baseline: str | None = None,
+    paths: Sequence[str] = DEFAULT_PATHS,
+    lockfile: str = LOCKFILE,
+) -> int:
+    """Run both versions over the same tree and report the partition.
+
+    Exits 2 rather than 0 when the comparison cannot discriminate — an absent
+    baseline, or a baseline equal to the current pin. Reporting "no new rules"
+    from a version compared against itself would be a probe with one face.
+    """
+    spec = TOOLS.get(tool)
+    if spec is None:
+        logger.error("unknown tool %r; known: %s", tool, ", ".join(sorted(TOOLS)))
+        return 2
+
+    current = locked_version((repo_root / lockfile).read_text(), spec.lock_name)
+    if current is None:
+        logger.error("%s does not pin %s", lockfile, spec.lock_name)
+        return 2
+
+    if baseline is None:
+        revision = previous_lock_revision(repo_root, lockfile)
+        baseline = (
+            version_at(repo_root, revision, spec.lock_name, lockfile)
+            if revision
+            else None
+        )
+        if baseline is None:
+            logger.error(
+                "could not derive a baseline: no earlier revision of %s pins %s. "
+                "Name one with --baseline <version>.",
+                lockfile,
+                spec.lock_name,
+            )
+            return 2
+
+    if baseline == current:
+        logger.error(
+            "baseline %s == current pin %s, so this comparison can only report "
+            "'no change' — a probe with one face. The previous revision of %s "
+            "did not bump %s; name an older version with --baseline.",
+            baseline,
+            current,
+            lockfile,
+            spec.lock_name,
+        )
+        return 2
+
+    logger.info(
+        "running %s at %s and %s over %s", tool, baseline, current, ", ".join(paths)
+    )
+    delta = Delta(
+        tool=tool,
+        baseline_version=baseline,
+        current_version=current,
+        baseline=run_at_version(spec, baseline, paths, cwd=repo_root),
+        current=run_at_version(spec, current, paths, cwd=repo_root),
+    )
+    logger.info("%s", render_report(delta))
+    return 0

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -65,6 +65,7 @@ from dotfiles_setup.lint import (
     resolve_timeout,
     run_guarded,
 )
+from dotfiles_setup.lint_delta import DEFAULT_PATHS, lint_delta_main
 from dotfiles_setup.lock_integrity import main as lock_integrity_main
 from dotfiles_setup.lock_integrity import scoped_lock_main
 from dotfiles_setup.lock_refresh import collect_system_lock, stage_system_lock_dir
@@ -197,6 +198,29 @@ def _add_honesty_subcommands(subparsers: _SubParsers) -> None:
         "--check",
         action="store_true",
         help="Fail instead of writing when the committed doc is out of date",
+    )
+    delta_parser = subparsers.add_parser(
+        "lint-delta",
+        help="Partition linter violations into YOURS and THE UPGRADE'S (#651) "
+        "by running the previous pinned version against the same tree — the "
+        "old version is the control arm. Diffs by RULE CODE in both "
+        "directions; a rule that STOPPED firing is lost coverage",
+    )
+    delta_parser.add_argument(
+        "--tool",
+        default="ruff",
+        help="Linter to compare (ruff, ty)",
+    )
+    delta_parser.add_argument(
+        "--baseline",
+        help="Version to compare against. Defaults to the pin at the previous "
+        "revision that TOUCHED the lockfile — not HEAD~1, which usually did not",
+    )
+    delta_parser.add_argument(
+        "--paths",
+        nargs="+",
+        default=list(DEFAULT_PATHS),
+        help="Paths to lint",
     )
     review_parser = subparsers.add_parser(
         "session-review",
@@ -1736,6 +1760,14 @@ def _build_command_handlers(
         ),
         "lock-check": lambda: sys.exit(lock_integrity_main(project_root)),
         "lock-tools": lambda: sys.exit(scoped_lock_main(project_root, args.tools)),
+        "lint-delta": lambda: sys.exit(
+            lint_delta_main(
+                project_root,
+                tool=args.tool,
+                baseline=args.baseline,
+                paths=tuple(args.paths),
+            )
+        ),
         "session-review": lambda: sys.exit(
             session_review_main(
                 project_root,

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -1986,3 +1986,22 @@ per_path_tokens = { ".claude/skills/session-review/SKILL.md" = ["name: session-r
 tokens = [
     "def is_reportable_shape(",
 ]
+
+[[suite]]
+name = "workflow.lint-delta-control-arm"
+description = "#651: a linter bump must be partitioned into YOURS and THE UPGRADE'S by running the previous pinned version against the SAME TREE — the old version IS the control arm, so every difference is attributable to the tool rather than to the code. Measured 2026-08-08 on one unchanged tree: ruff 0.15.20 reported **2** violations (I001 x1, D403 x1, both genuinely mine) while 0.16.2 reported **138** (+ CPY001 x106, ISC004 x30, all pre-existing). Without the partition the choice reads as 'fix 138 or suppress'; with it, as 'fix 2, then decide policy on two new rule classes' — different decisions with different right answers, and the reason `zero-skip-policy.md` does not have to be argued at that moment. ⚠️ **The refusal is the load-bearing part, which is why `if baseline == current:` is bound as a token.** Comparing a version against ITSELF can only ever report 'no change', and reporting that as a clean bill is precisely the one-faced probe `probes-need-a-control-arm.md` refuses; the entry point exits 2 on it, on an underivable baseline, and on an unknown tool, rather than producing a report that reads as reassurance. ⚠️ **The default baseline is the pin at the previous revision that TOUCHED THE LOCKFILE, not `HEAD~1`** — `previous_lock_revision` is bound for that reason. The previous COMMIT usually did not touch `python/uv.lock` at all (measured here: `HEAD` and `HEAD~1` both pinned ruff 0.16.2, while the previous lockfile revision pinned 0.15.20), so a `HEAD~1` default would silently produce the version-against-itself case on nearly every invocation — a wrong default that fails into the refusal above is still a wrong default, because the operator learns nothing about why. The diff is by RULE CODE and not by line, because the question is which rule CLASSES are new and a line-level diff answers it with a wall of diagnostics that has to be re-summarised by hand — the very work being automated. It is reported in BOTH directions: a code the old version fired and the new one does not is coverage the gate silently LOST, which reads as good news precisely because nothing fails, and `test_a_code_that_stopped_firing_is_reported_as_lost_coverage` is bound so that direction cannot be dropped as redundant. `run_at_version` is bound because the invocation shape is load-bearing: `uvx <tool>@<version>` and NOT the project environment, since the whole point is to run a version the project is not pinned to, which an environment-resolved binary cannot do; a non-zero exit is expected and ignored, because a linter that found violations is the normal case here. Nothing is ruff-specific — `TOOLS` carries each tool's invocation plus how to recover a rule code from its output (ruff via `--output-format json`, ty via the `error[rule-name]` prefix of `--output-format concise`, since ty has no JSON output — checked against the live CLIs, not assumed). The tool proved itself on its own diff: run against this very change it reported 4 attributable to the code and 3 to the upgrade's newly-enabled ISC004, and all seven were in the uncommitted module. Asserts the chain: the skill names itself, mise.toml's task shells out to the CLI, main.py registers and dispatches it, the module carries the baseline derivation, the pinned invocation, the equality refusal and the entry point, and the test file carries the refusal guard and the lost-coverage guard."
+category = "workflow"
+check_type = "static"
+handler = "require_tokens"
+paths_required = true
+paths = [
+    ".claude/skills/lint-delta/SKILL.md",
+    "mise.toml",
+    "python/src/dotfiles_setup/main.py",
+    "python/src/dotfiles_setup/lint_delta.py",
+    "tests/test_lint_delta.py",
+]
+per_path_tokens = { ".claude/skills/lint-delta/SKILL.md" = ["name: lint-delta"], "mise.toml" = ["[tasks.lint-delta]", "dotfiles-setup lint-delta'"], "python/src/dotfiles_setup/main.py" = ['"lint-delta",', '"lint-delta": lambda'], "python/src/dotfiles_setup/lint_delta.py" = ["def previous_lock_revision(", "def run_at_version(", "def lint_delta_main(", "if baseline == current:"], "tests/test_lint_delta.py" = ["def test_a_baseline_equal_to_the_current_pin_is_refused(", "def test_a_code_that_stopped_firing_is_reported_as_lost_coverage("] }
+tokens = [
+    "def previous_lock_revision(",
+]

--- a/tests/test_lint_delta.py
+++ b/tests/test_lint_delta.py
@@ -1,0 +1,265 @@
+# Copyright (c) 2026 Raymond Manaloto
+"""Tests for the linter-upgrade partition (#651).
+
+The module's value is entirely in the ATTRIBUTION — which violations belong to
+the code and which arrived with the bump — so the tests pin the three ways that
+attribution can quietly become meaningless: a baseline equal to the current pin
+(a comparison with one face), a baseline derived from the wrong revision (the
+previous COMMIT rather than the previous LOCKFILE change, which is usually the
+same pin), and a one-directional diff that hides a rule which stopped firing.
+
+Every subprocess is injected. The parsers are exercised against real output
+shapes rather than invented ones — `ruff --output-format json` and `ty
+--output-format concise`, both checked against the live CLIs.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # Only referenced as an annotation here (`LogCaptureFixture`); every other
+    # test module also calls `pytest.raises`, which is why they import it at
+    # runtime and this one does not.
+    import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
+
+from dotfiles_setup import lint_delta
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+def _lock(**versions: str) -> str:
+    return "\n".join(
+        f'[[package]]\nname = "{name}"\nversion = "{version}"\n'
+        for name, version in versions.items()
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Reading the pins
+# --------------------------------------------------------------------------- #
+
+
+def test_the_pinned_version_is_read_by_package_name() -> None:
+    text = _lock(ruff="0.16.2", ty="0.0.69")
+    assert lint_delta.locked_version(text, "ruff") == "0.16.2"
+    assert lint_delta.locked_version(text, "ty") == "0.0.69"
+
+
+def test_an_absent_package_reads_as_none_rather_than_a_wrong_version() -> None:
+    assert lint_delta.locked_version(_lock(ruff="0.16.2"), "pylint") is None
+
+
+def test_a_package_whose_name_is_a_prefix_is_not_matched() -> None:
+    """`ty` must not be satisfied by `typing-extensions`."""
+    text = _lock(**{"typing-extensions": "4.0.0"})
+    assert lint_delta.locked_version(text, "ty") is None
+
+
+def test_the_shipped_lockfile_pins_both_tools() -> None:
+    """A real-corpus arm: the parse must work on the file it will actually read."""
+    text = (REPO_ROOT / lint_delta.LOCKFILE).read_text()
+    assert lint_delta.locked_version(text, "ruff")
+    assert lint_delta.locked_version(text, "ty")
+
+
+# --------------------------------------------------------------------------- #
+# Parsing each tool's output
+# --------------------------------------------------------------------------- #
+
+
+def test_ruff_codes_are_counted_from_its_json() -> None:
+    payload = json.dumps(
+        [
+            {"code": "ISC004", "filename": "a.py"},
+            {"code": "ISC004", "filename": "b.py"},
+            {"code": "E501", "filename": "a.py"},
+        ]
+    )
+    assert lint_delta.parse_ruff(payload) == Counter({"ISC004": 2, "E501": 1})
+
+
+def test_ruff_output_that_is_not_json_counts_nothing_rather_than_raising() -> None:
+    """A crashed linter must not look like a clean tree.
+
+    It counts zero, so the caller's comparison shows every code as retired,
+    which is loud rather than reassuring.
+    """
+    assert lint_delta.parse_ruff("error: unrecognized option") == Counter()
+
+
+def test_ty_codes_are_counted_from_its_concise_output() -> None:
+    """Ty has no JSON, so the `error[rule-name]` prefix is what there is."""
+    output = (
+        "error[unresolved-import] /a.py:1:1: cannot resolve\n"
+        "warning[unused-ignore] /b.py:2:1: unused\n"
+        "error[unresolved-import] /c.py:3:1: cannot resolve\n"
+    )
+    assert lint_delta.parse_ty(output) == Counter(
+        {"unresolved-import": 2, "unused-ignore": 1}
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The partition
+# --------------------------------------------------------------------------- #
+
+
+def _delta(baseline: Counter[str], current: Counter[str]) -> lint_delta.Delta:
+    return lint_delta.Delta("ruff", "0.15.20", "0.16.2", baseline, current)
+
+
+def test_a_code_both_versions_fire_is_attributed_to_the_code() -> None:
+    delta = _delta(Counter({"I001": 1}), Counter({"I001": 1, "ISC004": 30}))
+    assert delta.mine == [("I001", 1)]
+    assert delta.introduced == [("ISC004", 30)]
+
+
+def test_a_code_that_stopped_firing_is_reported_as_lost_coverage() -> None:
+    """The direction a one-way diff hides.
+
+    A rule the old version caught and the new one does not is coverage the gate
+    silently lost, which reads as good news precisely because nothing fails.
+    """
+    delta = _delta(Counter({"D403": 4}), Counter({"ISC004": 1}))
+    assert delta.retired == [("D403", 4)]
+
+
+def test_counts_are_reported_at_the_current_version_for_shared_codes() -> None:
+    """A shared code whose count MOVED is still yours; report today's number."""
+    delta = _delta(Counter({"E501": 1}), Counter({"E501": 5}))
+    assert delta.mine == [("E501", 5)]
+
+
+def test_the_report_states_the_split_and_both_directions() -> None:
+    report = lint_delta.render_report(
+        _delta(Counter({"I001": 1, "D403": 2}), Counter({"I001": 1, "ISC004": 30}))
+    )
+    assert "**1 attributable to the code, 30 to the upgrade.**" in report
+    assert "control arm" in report
+    assert "`D403`" in report
+
+
+# --------------------------------------------------------------------------- #
+# Deriving the baseline
+# --------------------------------------------------------------------------- #
+
+
+def test_the_baseline_revision_is_the_previous_lockfile_change() -> None:
+    """Not HEAD~1 — the previous commit usually did not touch the lockfile.
+
+    Driven against the real repo, because the property being tested is about
+    git history and a fixture repo would only prove the command string.
+    """
+    revision = lint_delta.previous_lock_revision(REPO_ROOT)
+    assert revision
+    current = lint_delta.locked_version(
+        (REPO_ROOT / lint_delta.LOCKFILE).read_text(), "ruff"
+    )
+    earlier = lint_delta.version_at(REPO_ROOT, revision, "ruff", lint_delta.LOCKFILE)
+    assert earlier is not None
+    # Not asserted equal or unequal: what matters is that a version was
+    # RECOVERED from that revision. Asserting a difference would bind this test
+    # to whichever bump happens to be most recent.
+    assert isinstance(current, str)
+
+
+def test_a_revision_without_the_lockfile_yields_none(tmp_path: Path) -> None:
+    assert (
+        lint_delta.version_at(tmp_path, "deadbeef", "ruff", lint_delta.LOCKFILE) is None
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The refusals — where a wrong answer would be silent
+# --------------------------------------------------------------------------- #
+
+
+def test_a_baseline_equal_to_the_current_pin_is_refused(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Comparing a version against itself can only report 'no change'.
+
+    That is a probe with one face, and reporting it as a clean bill is the
+    false negative `probes-need-a-control-arm.md` exists to refuse.
+    """
+    (tmp_path / "python").mkdir()
+    (tmp_path / lint_delta.LOCKFILE).write_text(_lock(ruff="0.16.2"))
+    rc = lint_delta.lint_delta_main(tmp_path, baseline="0.16.2")
+    assert rc == 2
+    assert any("one face" in record.getMessage() for record in caplog.records)
+
+
+def test_an_unknown_tool_is_refused_with_the_known_ones_named(
+    tmp_path: Path,
+) -> None:
+    assert lint_delta.lint_delta_main(tmp_path, tool="pylint") == 2
+
+
+def test_a_lockfile_that_does_not_pin_the_tool_is_refused(tmp_path: Path) -> None:
+    (tmp_path / "python").mkdir()
+    (tmp_path / lint_delta.LOCKFILE).write_text(_lock(pytest="8.0.0"))
+    assert lint_delta.lint_delta_main(tmp_path, tool="ruff") == 2
+
+
+def test_an_underivable_baseline_is_refused_rather_than_guessed(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "python").mkdir()
+    (tmp_path / lint_delta.LOCKFILE).write_text(_lock(ruff="0.16.2"))
+    # Not a git repo, so no earlier revision exists to read a pin from.
+    assert lint_delta.lint_delta_main(tmp_path, tool="ruff") == 2
+
+
+# --------------------------------------------------------------------------- #
+# Invocation
+# --------------------------------------------------------------------------- #
+
+
+def test_the_tool_is_pinned_by_version_in_the_invocation(tmp_path: Path) -> None:
+    """Pin the version INTO the invocation rather than resolving it.
+
+    The point is to run a version the project is not pinned to, which an
+    environment-resolved binary cannot do.
+    """
+    seen: list[list[str]] = []
+
+    def fake_run(
+        argv: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        seen.append(argv)
+        return subprocess.CompletedProcess(argv, 1, "[]", "")
+
+    lint_delta.run_at_version(
+        lint_delta.TOOLS["ruff"], "0.15.20", ("python/src",), cwd=tmp_path, run=fake_run
+    )
+    assert seen[0][:2] == ["uvx", "ruff@0.15.20"]
+    assert seen[0][-1] == "python/src"
+
+
+def test_a_nonzero_exit_is_expected_and_does_not_discard_the_findings(
+    tmp_path: Path,
+) -> None:
+    """A linter that found violations exits non-zero — that is the normal case."""
+    payload = json.dumps([{"code": "E501"}])
+    counts = lint_delta.run_at_version(
+        lint_delta.TOOLS["ruff"],
+        "0.15.20",
+        ("python/src",),
+        cwd=tmp_path,
+        run=lambda argv, **_k: subprocess.CompletedProcess(argv, 1, payload, ""),
+    )
+    assert counts == Counter({"E501": 1})
+
+
+def test_the_mise_task_calls_the_cli() -> None:
+    mise_toml = (REPO_ROOT / "mise.toml").read_text()
+    assert "[tasks.lint-delta]" in mise_toml
+    assert "dotfiles-setup lint-delta" in mise_toml

--- a/typos.toml
+++ b/typos.toml
@@ -27,3 +27,12 @@ sherif = "sherif"
 # not ours to respell, and rewording the anchor would break re-derivation
 # against the binary.
 gae = "gae"
+
+# `CPY001` is ruff's rule code for a missing copyright notice
+# (flake8-copyright), not a misspelling of "COPY"/"CPU". It reaches this repo
+# through #651's measurement of the ruff 0.15.20 -> 0.16.2 bump, where CPY001
+# accounted for 106 of the 138 new violations — the single largest class, so
+# naming it is the point of the record. Astral chose the code; rewording the
+# measurement to dodge the word would make it uncheckable against ruff's own
+# output.
+CPY001 = "CPY001"


### PR DESCRIPTION
A linter bump enables rules that were never checked before, and they fire
on code that has been sitting there for months — so every one of them
looks like a regression in your own change. Measured on one unchanged
tree, ruff 0.15.20 -> 0.16.2 went from 2 violations to 138.

Running the previous pinned version against the same tree partitions them
instantly, and that is all this is: the old version IS the control arm, so
every difference belongs to the tool rather than to the code. Without the
split the decision reads as "fix 138 or suppress"; with it, "fix 2, then
decide policy on two new rule classes".

Three things it treats as load-bearing:

- The diff is by RULE CODE, not by line. The question is which rule
  CLASSES are new; a line-level diff answers it with a wall of diagnostics
  that has to be re-summarised by hand, which is the work being automated.
- Both directions are reported. A code the old version fired and the new
  one does not is coverage the gate silently LOST — it reads as good news
  precisely because nothing fails.
- A baseline equal to the current pin exits 2, loudly. Comparing a version
  against itself can only report "no change", and dressing that up as a
  clean bill is the one-faced probe we refuse elsewhere.

The baseline defaults to the pin at the previous revision that TOUCHED the
lockfile, not HEAD~1 — measured here, HEAD and HEAD~1 both pin ruff
0.16.2 while the previous lockfile revision pins 0.15.20, so a HEAD~1
default would produce the version-against-itself case almost every time.

Nothing is ruff-specific: TOOLS carries each tool's invocation plus how to
recover a rule code from its output (ty has no JSON, so its concise
`error[rule-name]` prefix is parsed — checked against the live CLI).

It partitioned its own diff on the first run: 4 attributable to the code
and 3 to the upgrade's newly-enabled ISC004, all seven in this module.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016SGa1MC4TUELrVHv5ER5BT

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788795439&installation_model_id=429246&pr_number=661&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F661&signature=234bb4c5ff5582bdab3210f88c4fa623b9f1a747e39a948efdb19e91d339283d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a lint comparison command for Ruff and ty.
  * Reports existing, newly introduced, and retired lint violations.
  * Supports custom baseline versions, tools, and paths.
  * Added a convenient task shortcut and usage documentation.

* **Bug Fixes**
  * Added clear refusal handling for missing or identical baseline versions and unavailable version pins.

* **Tests**
  * Added coverage for version detection, violation parsing, reporting, command execution, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->