### PR TITLE
docs: a third persistence-gate signature, and point `lock` at `lock-image`

### DIFF
--- a/.claude/rules/persistence-gate-retry.md
+++ b/.claude/rules/persistence-gate-retry.md
@@ -44,9 +44,28 @@ Detail: `docs/rules-evidence/persistence-gate-retry.md`.
 |---|---|---|
 | `getaddrinfo ENOTFOUND ghcr.io` | environmental | retry once per heuristic above |
 | `dial tcp: lookup ... no such host` | environmental | retry once per heuristic above |
+| `docker: ... parent snapshot sha256:... does not exist` | environmental (image store) | retry once — `sync` repairs it as a side effect; do NOT reach for a base pull |
 | `FAIL: installed-tool set drifted across stop/up` | real defect | triage `mise-system.toml` ↔ runtime drift |
 | `FAIL: in-volume canary missing` | real defect | home-volume mount regression — investigate volume name / mount opts |
 | `R[123] ... not works` | real defect | the corresponding R-invariant regressed; do NOT retry without diagnosing |
+
+## The image-store signature repairs itself, and that is not luck
+
+Measured 2026-08-08 during a `mise run ship`: `verify-local` died with
+`docker: ... parent snapshot sha256:c8a425d7... does not exist` — a local
+overlay image referencing a layer the store no longer had, with the local
+`:dev` (`3c957a17`) also behind the registry's (`104cdcdc`). Neither DNS
+signature above was present, so the rule's table said nothing.
+
+**Retrying `mise run verify-local` alone returned rc=0 in ~20 minutes.** The
+repair is a side effect of the same failed run: `sync` detects `CONTAINER
+OUTDATED`, runs `dev-rebuild` (rc=0), and the rebuilt overlay no longer
+references the missing snapshot. So the retry-once heuristic covers this class
+too — and the expensive wrong move is inferring a stale base and starting a
+~21.5GB pull, which the earlier `dev-rebuild` had already made unnecessary.
+
+Distinguish it from a REAL base-currency failure: that one surfaces as smoke
+tier-1 identity failing on a config-hash mismatch, not as a missing snapshot.
 
 ## Applies to
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ mise run verify                    # Run structured verification contracts
 mise run pin-actions                         # Verify GHA actions are SHA-pinned
 mise run lint-docs                           # Validate agent documentation (agnix)
 mise run lock -- "<backend/name>"            # Re-lock ONE tool (bare form is destructive, #370)
+mise run lock-image                          # Regenerate the IMAGE locks instead (#650; routes to amd64)
 ```
 
 The devloop is `mise run up` → work inside the container → `mise run down`.


### PR DESCRIPTION
`persistence-gate-retry.md` listed two environmental signatures, both DNS.
A `mise run ship` failed this session on a third — `docker: parent
snapshot sha256:... does not exist`, local image-store corruption, with
the local `:dev` also behind the registry's. The rule's table said
nothing, and the tempting inference (stale base, pull 21.5GB) was wrong:
retrying `verify-local` alone returned rc=0 in ~20 minutes, because
`sync` rebuilds the overlay as a side effect of detecting CONTAINER
OUTDATED. Recorded with the measurement and with how to tell it apart
from a real base-currency failure, which surfaces as a smoke tier-1
config-hash mismatch instead.

AGENTS.md gets one Quick Start line: `lock` and `lock-image` name
different artifacts and are easy to confuse, which is most of why the
lock-image skill exists.

An addition to `.claude/CLAUDE.md`'s doctor section was reverted rather
than shipped — it took agnix to ~1559 tokens against its 1500 limit, and
the fact it stated is already enforced by a test, a contract, and the
check reporting BLIND out loud.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016SGa1MC4TUELrVHv5ER5BT

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788797688&installation_model_id=429246&pr_number=662&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F662&signature=b2a4333024a50326fe1498c7b35d4477bc3dc7b8bcfc9bc9152041b6c843c94d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->