### PR TITLE
feat(reap): a dry-run-by-default reaper that cannot kill its own shell (#653)

### DIFF
--- a/.claude/skills/reap/SKILL.md
+++ b/.claude/skills/reap/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: reap
+description: Clear a pile of wedged processes safely via `mise run reap` — a dry-run-by-default reaper with ancestor-chain protection, an age floor, and TERM-then-KILL escalation. Reach for it whenever a host has accumulated stuck or duplicated processes (hung `git`, `fnox`, shims, orphaned workers), when load, PID or memory pressure needs a bulk cleanup, and above all before hand-rolling a `pkill`, a `ps | grep | awk | xargs kill`, or a throwaway kill script — that improvisation nearly killed a session's own shell and is why this exists. Also use it to measure a pile before deciding anything, since a dry run signals nothing and prints the full plan.
+user-invocable: true
+---
+
+# reap: clear the pile without killing your own shell
+
+```bash
+mise run reap -- --pattern 'fnox export'                      # dry run: plan only
+mise run reap -- --pattern 'shims/git' --min-age 3600         # ignore anything under 1h
+mise run reap -- --pattern 'fnox export --format json' --kill # signals
+mise run reap -- --pattern '.*worker.*' --full-match --kill   # whole argv must match
+```
+
+`--kill` is the only thing that signals anything. Without it you get the plan
+and an exit code, which is what makes this safe to run first and think second.
+
+## Read the plan before you add `--kill`
+
+```
+reap plan: pattern='fnox export' min-age=1m00s scanned=1603 process(es)
+  protected PIDs (self + ancestors + init): 1, 1390, 1439, 51159, 55203, 55206
+  matched and PROTECTED (never signalled): 4
+  matched but TOO YOUNG (< 1m00s): 0
+  TARGETS: 0
+```
+
+Four buckets, and the three non-target ones are the point — a bare target count
+cannot tell a working age floor from a broken one.
+
+- **PROTECTED** — matched your pattern *and* sits on this process's ancestor
+  chain. The run above is the real thing: on a 1,603-process table, `fnox
+  export` matched **four processes, all of them the reaper's own invocation
+  chain** (the zsh wrapper → `uv` → the python entry point). A hand-rolled
+  `pkill -f 'fnox export'` there kills the shell mid-command.
+- **TOO YOUNG** — matched, but younger than `--min-age` (default 300s), so it
+  is plausibly live work. Raise the floor when you are unsure; the pile this
+  tool exists for was over a day old.
+- **TARGETS** — what `--kill` would signal, each printed with its age and state
+  so the list is auditable before it is destructive.
+
+Check the target ages line (`oldest 1d21h, newest 10h19m`). A "newest" close to
+your floor means the pile is still *growing*, and reaping it treats a symptom
+that is about to recur.
+
+## What a reap actually buys you
+
+**PID and memory pressure — not load.** Wedged processes are typically `stat=S`
+at ~0 CPU: sleeping, not burning anything. The 2026-08-08 clear of 2,362
+processes moved the 1-minute average 7.98 → 7.02, and *signalling* them spiked
+it to **137.96** on the spot. Report the pressure you removed; a load number
+read minutes after a bulk kill is measuring the kill.
+
+## Choosing the pattern
+
+The pattern is a regex over each process's **full argv**, so it can name the
+thing precisely — `fnox export --format json`, not `fnox`. That precision is
+the safety property: a substring wide enough to catch the pile is usually wide
+enough to catch something you need. `--full-match` demands the entire argv
+match, for when even a precise substring feels loose.
+
+Confirm the pattern in dry run, then re-run the identical command with `--kill`
+appended. Changing the pattern and adding `--kill` in one step means signalling
+a set nobody has read.
+
+## Escalation, and why it re-checks
+
+`--kill` sends TERM, waits `--grace` seconds (default 5), re-reads the process
+table, and sends KILL only to what is still alive. `--signal KILL` skips
+straight to KILL when you already know TERM is ignored.
+
+The re-read is also the PID-reuse guard: a PID whose command has changed
+between plan and signal is **dropped**, because the kernel recycles PIDs and a
+plan is a snapshot. The final report names the dropped ones and anything that
+survived KILL — a survivor is a real finding (uninterruptible sleep, usually a
+stuck syscall), not a rounding error.
+
+## When the reap is the wrong tool
+
+A recurring pile has a cause, and clearing it hides the evidence. The
+2026-08-08 pile came from knowledge-base#243, still open — so if you are
+reaping the same pattern twice, the second reap should be preceded by capturing
+what spawned it (`ps -o ppid=,lstart=` on a survivor) rather than by a bigger
+`--min-age`.
+
+Exit codes: `0` fine, `1` targets found under `--strict` (dry run) or survivors
+after KILL, `2` the process table could not be read — which is a probe that
+could not see, deliberately distinct from "nothing matched".

--- a/mise.toml
+++ b/mise.toml
@@ -1196,3 +1196,18 @@ description = "Partition linter violations into YOURS vs THE UPGRADE'S by runnin
 #   mise run lint-delta -- --tool ty
 #   mise run lint-delta -- --baseline 0.15.20
 run = 'uv run --project python dotfiles-setup lint-delta'
+
+[tasks.reap]
+description = "Reap wedged processes by pattern and age, ancestor-protected (#653). DRY RUN unless --kill"
+# Thin caller; see reap.py. The 2026-08-08 pile was 1,174 wedged mise/shims/git
+# processes with a stuck `fnox export` child each — 2,362 to clear, oldest
+# 1d10h. Reaping them safely needs ancestor-chain protection (or it kills the
+# shell that ran it), an age floor, exact matching under a pattern you supply
+# rather than a pkill substring, and TERM-then-KILL with a liveness re-check.
+# `--kill` is required to signal anything, like `lock`/`lock-image` refuse
+# their unsafe forms. A reap removes PID and MEMORY pressure, NOT load.
+#
+#   mise run reap -- --pattern 'fnox export'                    # dry run
+#   mise run reap -- --pattern 'shims/git' --min-age 3600
+#   mise run reap -- --pattern 'fnox export' --kill             # signals
+run = 'uv run --project python dotfiles-setup reap'

--- a/python/src/dotfiles_setup/main.py
+++ b/python/src/dotfiles_setup/main.py
@@ -79,6 +79,12 @@ from dotfiles_setup.p2996_refresh import refresh as refresh_p2996_ref
 from dotfiles_setup.parity import run as parity_run
 from dotfiles_setup.path_drift import AMBIENT_PATH_ENV, path_drift_main
 from dotfiles_setup.pr import automerge_main, land_main, ship_main
+from dotfiles_setup.reap import (
+    DEFAULT_GRACE_S,
+    DEFAULT_MIN_AGE_S,
+    ReapRequest,
+    reap_main,
+)
 from dotfiles_setup.renovate import renovate_status_main
 from dotfiles_setup.renovate_dryrun import renovate_dryrun_main
 from dotfiles_setup.renovate_validate import renovate_validate_main
@@ -221,6 +227,56 @@ def _add_honesty_subcommands(subparsers: _SubParsers) -> None:
         nargs="+",
         default=list(DEFAULT_PATHS),
         help="Paths to lint",
+    )
+    reap_parser = subparsers.add_parser(
+        "reap",
+        help="Reap wedged processes by pattern and age (#653). DRY RUN by "
+        "default — `--kill` is required to signal anything. Protects this "
+        "process, its whole ancestor chain and init, so it cannot kill the "
+        "shell that launched it",
+    )
+    reap_parser.add_argument(
+        "--pattern",
+        required=True,
+        help="Regex matched against each process's full argv. Searched by "
+        "default; see --full-match. Never a pkill-style bare substring",
+    )
+    reap_parser.add_argument(
+        "--min-age",
+        type=int,
+        default=DEFAULT_MIN_AGE_S,
+        dest="min_age",
+        help="Age floor in seconds; anything younger is spared as possibly "
+        f"live work (default: {DEFAULT_MIN_AGE_S})",
+    )
+    reap_parser.add_argument(
+        "--kill",
+        action="store_true",
+        help="Actually signal the targets. Without this nothing is signalled",
+    )
+    reap_parser.add_argument(
+        "--full-match",
+        action="store_true",
+        dest="full_match",
+        help="Require the pattern to match the ENTIRE argv, not a substring",
+    )
+    reap_parser.add_argument(
+        "--signal",
+        default="TERM",
+        choices=("TERM", "KILL"),
+        dest="signal_name",
+        help="First signal. TERM escalates to KILL for survivors; KILL does not",
+    )
+    reap_parser.add_argument(
+        "--grace",
+        type=float,
+        default=DEFAULT_GRACE_S,
+        help="Seconds between TERM and the liveness re-check that decides KILL",
+    )
+    reap_parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit 1 when a dry run finds targets (for use in a gate)",
     )
     review_parser = subparsers.add_parser(
         "session-review",
@@ -1766,6 +1822,19 @@ def _build_command_handlers(
                 tool=args.tool,
                 baseline=args.baseline,
                 paths=tuple(args.paths),
+            )
+        ),
+        "reap": lambda: sys.exit(
+            reap_main(
+                ReapRequest(
+                    pattern=args.pattern,
+                    min_age_s=args.min_age,
+                    kill=args.kill,
+                    full_match=args.full_match,
+                    grace_s=args.grace,
+                    signal_name=args.signal_name,
+                    strict=args.strict,
+                )
             )
         ),
         "session-review": lambda: sys.exit(

--- a/python/src/dotfiles_setup/reap.py
+++ b/python/src/dotfiles_setup/reap.py
@@ -1,0 +1,536 @@
+# Copyright (c) 2026 Raymond Manaloto
+"""Reap wedged processes by pattern and age, without killing your own shell.
+
+On 2026-08-08 this host accumulated **1,174** wedged ``mise/shims/git``
+processes, each with a stuck ``fnox export --format json`` child — 2,362 to
+clear, oldest 1d10h (#653; the cause is knowledge-base#243, still open). The
+cleanup was written by hand, under time pressure, in a throwaway script. Four
+pieces of it are destructive to get wrong, and re-deriving them under pressure
+is exactly when they get got wrong:
+
+* **ancestor-chain protection** — walk ``ppid`` from this process to init and
+  exclude that chain, or the reap kills the shell that launched it;
+* **an age floor** — ``etime`` parsed across every ``ps`` format, so anything
+  younger than N seconds (i.e. possibly live work) is spared;
+* **exact matching under a pattern you supply**, never ``pkill`` on a
+  substring;
+* **TERM, then KILL**, re-checking liveness in between.
+
+What this tool does NOT claim
+-----------------------------
+
+**A reap does not fix load.** Those 2,362 processes were ``stat=S`` at 0:00.03
+CPU — sleeping, not burning CPU. The 1-minute average moved 7.98 → 7.02, and
+the 5/15-minute figures were still decaying from the **kill transient**, which
+spiked the 1-minute average to **137.96** the instant they were signalled. What
+a reap definitively removes is **PID and memory pressure**, so that is what
+:func:`format_plan` says. Any wording that implies a load fix is wrong.
+
+Why dry-run is the default
+--------------------------
+
+``--kill`` is required to signal anything (Ray, 2026-08-08b), matching this
+repo's posture for destructive verbs: ``mise run lock`` refuses its bare form,
+``mise run lock-image`` refuses the wrong host. The flag is named for the
+irreversible thing it does rather than a neutral ``--apply``.
+
+Two safety properties beyond the four above
+-------------------------------------------
+
+**PID reuse is checked, not assumed away.** Between the snapshot that selects
+victims and the signal that kills them, the kernel may recycle a PID onto an
+unrelated process. So :func:`reap` re-snapshots immediately before signalling
+and only signals a PID whose **command string still matches** the one selected
+(:func:`confirm_targets`). A PID that changed identity is dropped, not killed.
+
+**An empty snapshot is an error, not an all-clear.** A ``ps`` that failed,
+timed out, or returned nothing it could parse exits non-zero and says it could not
+see — never "nothing matched"
+(``.claude/rules/probes-need-a-control-arm.md`` rule 9).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import signal
+import subprocess
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Sequence
+
+logger = logging.getLogger(__name__)
+
+#: One line per process: pid, ppid, elapsed time, state, full argv. ``args``
+#: last because it is the only field that contains spaces.
+PS_COMMAND: tuple[str, ...] = ("ps", "-eo", "pid=,ppid=,etime=,stat=,args=")
+
+_PS_TIMEOUT_S = 30.0
+_PS_FIELDS = 5
+
+#: ``DD-HH:MM:SS`` is the widest ``ps`` elapsed-time form: days, then three
+#: colon-separated segments. More than that is not a shape ``ps`` produces.
+_MAX_ETIME_SEGMENTS = 3
+
+#: Never signalled, on any host, whatever the pattern says.
+INIT_PID = 1
+
+#: Seconds a process must have been alive before it is eligible. A floor rather
+#: than zero: the pile this tool exists for was over a day old, while anything
+#: seconds-young is plausibly live work — including a child of this very run.
+DEFAULT_MIN_AGE_S = 300
+
+#: Seconds between TERM and the liveness re-check that decides on KILL.
+DEFAULT_GRACE_S = 5.0
+
+
+class ReapError(RuntimeError):
+    """The process table could not be read — distinct from "nothing matched"."""
+
+
+@dataclass(frozen=True)
+class Process:
+    """One row of the process table, as ``ps`` reported it."""
+
+    pid: int
+    ppid: int
+    age_s: int
+    state: str
+    command: str
+
+    def describe(self) -> str:
+        """``12345 (1d10h, S) /path/to/git ...`` — one auditable line."""
+        return f"{self.pid:>7} ({format_age(self.age_s)}, {self.state}) {self.command}"
+
+
+def parse_etime(text: str) -> int | None:
+    """Seconds from any ``ps`` elapsed-time format, or ``None`` if unparsable.
+
+    Four shapes exist across the platforms this repo runs on: ``SS``,
+    ``MM:SS``, ``HH:MM:SS`` and ``DD-HH:MM:SS``. Getting this wrong in the
+    lenient direction is what turns an age floor into no age floor, so an
+    unrecognised shape returns ``None`` and its process is **excluded** rather
+    than assumed old.
+    """
+    raw = text.strip()
+    if not raw:
+        return None
+    days = 0
+    if "-" in raw:
+        day_text, _, raw = raw.partition("-")
+        try:
+            days = int(day_text)
+        except ValueError:
+            return None
+    parts = raw.split(":")
+    if len(parts) > _MAX_ETIME_SEGMENTS:
+        return None
+    try:
+        values = [int(part) for part in parts]
+    except ValueError:
+        return None
+    seconds = 0
+    for value in values:
+        seconds = seconds * 60 + value
+    return days * 86400 + seconds
+
+
+def format_age(seconds: int) -> str:
+    """``1d10h`` / ``2h05m`` / ``45s`` — compact, for a human reading a plan."""
+    days, rest = divmod(seconds, 86400)
+    hours, rest = divmod(rest, 3600)
+    minutes, secs = divmod(rest, 60)
+    if days:
+        return f"{days}d{hours:02d}h"
+    if hours:
+        return f"{hours}h{minutes:02d}m"
+    if minutes:
+        return f"{minutes}m{secs:02d}s"
+    return f"{secs}s"
+
+
+def run_ps(runner: Callable[[Sequence[str]], str] | None = None) -> str:
+    """Raw ``ps`` output, or raise :exc:`ReapError` naming what went wrong."""
+    if runner is not None:
+        return runner(PS_COMMAND)
+    try:
+        result = subprocess.run(
+            PS_COMMAND,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_PS_TIMEOUT_S,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        msg = f"could not run {' '.join(PS_COMMAND)}: {exc}"
+        raise ReapError(msg) from exc
+    if result.returncode != 0:
+        detail = result.stderr.strip()
+        msg = f"{' '.join(PS_COMMAND)} exited {result.returncode}: {detail}"
+        raise ReapError(msg)
+    return result.stdout
+
+
+def parse_processes(output: str) -> tuple[Process, ...]:
+    """Parse ``ps`` output, dropping rows whose age cannot be established.
+
+    Raises :exc:`ReapError` when nothing at all parsed: a process table with
+    zero rows means the probe failed, not that the host has no processes.
+    """
+    processes: list[Process] = []
+    for line in output.splitlines():
+        fields = line.split(maxsplit=_PS_FIELDS - 1)
+        if len(fields) < _PS_FIELDS:
+            continue
+        pid_text, ppid_text, etime_text, state, command = fields
+        age = parse_etime(etime_text)
+        if age is None:
+            logger.debug("unparsable etime %r for pid %s", etime_text, pid_text)
+            continue
+        try:
+            pid, ppid = int(pid_text), int(ppid_text)
+        except ValueError:
+            continue
+        processes.append(
+            Process(pid=pid, ppid=ppid, age_s=age, state=state, command=command)
+        )
+    if not processes:
+        msg = (
+            "the process table parsed to zero rows — the probe could not see, "
+            "which is NOT 'nothing matched'"
+        )
+        raise ReapError(msg)
+    return tuple(processes)
+
+
+def snapshot(
+    runner: Callable[[Sequence[str]], str] | None = None,
+) -> tuple[Process, ...]:
+    """One parsed view of the process table."""
+    return parse_processes(run_ps(runner))
+
+
+def ancestor_pids(processes: Iterable[Process], start_pid: int) -> tuple[int, ...]:
+    """``start_pid`` and every ancestor up to init, cycle-safe.
+
+    A corrupt or racing table can present a ``ppid`` cycle; the ``seen`` set
+    means that hangs nothing. Anything unreachable simply stops the walk, which
+    fails toward protecting *fewer* processes — so :func:`protected_pids`
+    always adds init separately rather than relying on the walk reaching it.
+    """
+    by_pid = {process.pid: process for process in processes}
+    chain: list[int] = []
+    seen: set[int] = set()
+    current = start_pid
+    while current > 0 and current not in seen:
+        seen.add(current)
+        chain.append(current)
+        process = by_pid.get(current)
+        if process is None:
+            break
+        current = process.ppid
+    return tuple(chain)
+
+
+def protected_pids(
+    processes: Iterable[Process],
+    *,
+    self_pid: int | None = None,
+    extra: Iterable[int] = (),
+) -> frozenset[int]:
+    """The set no pattern can ever select: self, its ancestors, init, extras."""
+    pid = os.getpid() if self_pid is None else self_pid
+    return frozenset(ancestor_pids(processes, pid)) | {INIT_PID} | set(extra)
+
+
+@dataclass(frozen=True)
+class Selection:
+    """What a pattern selected, and everything it deliberately did not."""
+
+    targets: tuple[Process, ...] = ()
+    protected: tuple[Process, ...] = ()
+    too_young: tuple[Process, ...] = ()
+    protected_set: frozenset[int] = field(default_factory=frozenset)
+    scanned: int = 0
+
+    @property
+    def oldest(self) -> Process | None:
+        """The longest-lived target, or ``None`` when nothing was selected."""
+        return max(self.targets, key=lambda p: p.age_s) if self.targets else None
+
+    @property
+    def youngest(self) -> Process | None:
+        """The newest target — a value near the age floor means it is growing."""
+        return min(self.targets, key=lambda p: p.age_s) if self.targets else None
+
+
+def select(
+    processes: Iterable[Process],
+    *,
+    pattern: str,
+    min_age_s: int = DEFAULT_MIN_AGE_S,
+    protected: frozenset[int] | None = None,
+    full_match: bool = False,
+) -> Selection:
+    """Partition the table into targets, protected matches, and too-young ones.
+
+    The three non-target buckets are kept rather than discarded because the
+    plan has to be *auditable*: "42 matched, 3 protected, 7 too young" tells
+    you the filters worked, while a bare target count cannot distinguish a
+    working age floor from a broken one.
+    """
+    processes = tuple(processes)
+    protected = frozenset() if protected is None else protected
+    compiled = re.compile(pattern)
+    matcher = compiled.fullmatch if full_match else compiled.search
+    targets: list[Process] = []
+    protected_hits: list[Process] = []
+    young: list[Process] = []
+    for process in processes:
+        if matcher(process.command) is None:
+            continue
+        if process.pid in protected:
+            protected_hits.append(process)
+        elif process.age_s < min_age_s:
+            young.append(process)
+        else:
+            targets.append(process)
+    return Selection(
+        targets=tuple(targets),
+        protected=tuple(protected_hits),
+        too_young=tuple(young),
+        protected_set=protected,
+        scanned=len(processes),
+    )
+
+
+#: Printed with every plan. The issue's own caveat, kept in the tool's mouth so
+#: it cannot be lost when someone quotes the output.
+LOAD_CAVEAT = (
+    "NOTE: a reap removes PID and MEMORY pressure. It does NOT fix load average "
+    "— wedged processes are typically sleeping (stat=S) at ~0 CPU, and "
+    "signalling thousands of them spikes the 1-minute average (measured: 7.98 "
+    "-> 137.96 at the moment of the kill, #653)."
+)
+
+
+def format_plan(selection: Selection, *, pattern: str, min_age_s: int) -> str:
+    """The human-readable plan, including the protected set, before acting."""
+    floor = format_age(min_age_s)
+    protected_pid_list = ", ".join(str(pid) for pid in sorted(selection.protected_set))
+    lines = [
+        (
+            f"reap plan: pattern={pattern!r} min-age={floor} "
+            f"scanned={selection.scanned} process(es)"
+        ),
+        f"  protected PIDs (self + ancestors + init): {protected_pid_list}",
+        f"  matched and PROTECTED (never signalled): {len(selection.protected)}",
+        f"  matched but TOO YOUNG (< {floor}): {len(selection.too_young)}",
+        f"  TARGETS: {len(selection.targets)}",
+    ]
+    oldest, youngest = selection.oldest, selection.youngest
+    if oldest is not None and youngest is not None:
+        lines.append(
+            f"  target ages: oldest {format_age(oldest.age_s)}, "
+            f"newest {format_age(youngest.age_s)}"
+        )
+    lines.extend(f"    {process.describe()}" for process in selection.protected)
+    lines.extend(f"    target {process.describe()}" for process in selection.targets)
+    lines.append(LOAD_CAVEAT)
+    return "\n".join(lines)
+
+
+def confirm_targets(
+    targets: Iterable[Process],
+    current: Iterable[Process],
+    *,
+    protected: frozenset[int],
+) -> tuple[tuple[Process, ...], tuple[Process, ...]]:
+    """Re-verify identity against a fresh table: ``(still_valid, dropped)``.
+
+    A PID alone is not an identity — the kernel recycles them. A target is only
+    signalled when the live table still shows that PID running the **same
+    command**, and never when it has become protected in the meantime.
+    """
+    live = {process.pid: process for process in current}
+    valid: list[Process] = []
+    dropped: list[Process] = []
+    for target in targets:
+        found = live.get(target.pid)
+        if found is None or found.command != target.command or found.pid in protected:
+            dropped.append(target)
+        else:
+            valid.append(target)
+    return tuple(valid), tuple(dropped)
+
+
+@dataclass(frozen=True)
+class ReapResult:
+    """What was actually signalled, and what survived it."""
+
+    signalled: tuple[Process, ...] = ()
+    dropped: tuple[Process, ...] = ()
+    killed: tuple[Process, ...] = ()
+    survivors: tuple[Process, ...] = ()
+
+
+@dataclass(frozen=True)
+class Runtime:
+    """The three effectful seams, bundled so a test substitutes all of them.
+
+    Reading the table, sending a signal and waiting are the only things this
+    module does to the world, so they travel together: a caller that overrides
+    one almost always overrides the rest, and a test that overrides all three
+    drives the destructive path without a single real signal.
+    """
+
+    runner: Callable[[Sequence[str]], str] | None = None
+    killer: Callable[[int, int], None] = os.kill
+    sleeper: Callable[[float], None] = time.sleep
+
+
+@dataclass(frozen=True)
+class Escalation:
+    """The signal ladder: what to send first, what to send to survivors."""
+
+    first: int = signal.SIGTERM
+    second: int | None = signal.SIGKILL
+    grace_s: float = DEFAULT_GRACE_S
+
+    @classmethod
+    def from_name(cls, name: str, *, grace_s: float = DEFAULT_GRACE_S) -> Escalation:
+        """``TERM`` escalates to KILL; ``KILL`` has nothing left to escalate to."""
+        if name.upper() == "KILL":
+            return cls(first=signal.SIGKILL, second=None, grace_s=grace_s)
+        return cls(first=signal.SIGTERM, second=signal.SIGKILL, grace_s=grace_s)
+
+
+def reap(
+    selection: Selection,
+    *,
+    runtime: Runtime | None = None,
+    escalation: Escalation | None = None,
+) -> ReapResult:
+    """TERM the confirmed targets, then KILL whatever is still alive."""
+    runtime = Runtime() if runtime is None else runtime
+    escalation = Escalation() if escalation is None else escalation
+    fresh = snapshot(runtime.runner)
+    targets, dropped = confirm_targets(
+        selection.targets, fresh, protected=selection.protected_set
+    )
+    signalled = _signal_all(targets, escalation.first, runtime.killer)
+    if escalation.second is None or not signalled:
+        return ReapResult(signalled=signalled, dropped=dropped)
+    runtime.sleeper(escalation.grace_s)
+    after = snapshot(runtime.runner)
+    survivors, _ = confirm_targets(signalled, after, protected=selection.protected_set)
+    killed = _signal_all(survivors, escalation.second, runtime.killer)
+    remaining, _ = confirm_targets(
+        killed, snapshot(runtime.runner), protected=selection.protected_set
+    )
+    return ReapResult(
+        signalled=signalled, dropped=dropped, killed=killed, survivors=remaining
+    )
+
+
+def _signal_all(
+    targets: Iterable[Process],
+    sig: int,
+    killer: Callable[[int, int], None],
+) -> tuple[Process, ...]:
+    """Signal each target, tolerating the ones that exited on their own."""
+    sent: list[Process] = []
+    for process in targets:
+        try:
+            killer(process.pid, sig)
+        except (ProcessLookupError, PermissionError) as exc:
+            logger.warning("could not signal %s: %s", process.pid, exc)
+            continue
+        sent.append(process)
+    return tuple(sent)
+
+
+@dataclass(frozen=True)
+class ReapRequest:
+    """What the operator asked for — one object, so the CLI seam stays narrow.
+
+    ``kill`` defaults to false because that is the posture: the plan is free
+    and the signal is not.
+    """
+
+    pattern: str
+    min_age_s: int = DEFAULT_MIN_AGE_S
+    kill: bool = False
+    full_match: bool = False
+    signal_name: str = "TERM"
+    grace_s: float = DEFAULT_GRACE_S
+    strict: bool = False
+
+
+def reap_main(
+    request: ReapRequest,
+    *,
+    runtime: Runtime | None = None,
+    self_pid: int | None = None,
+) -> int:
+    """CLI entry: print the plan; signal only when ``request.kill`` is true.
+
+    Exit codes: ``0`` fine, ``1`` targets found in dry-run under ``strict`` (or
+    survivors after KILL), ``2`` the process table could not be read.
+
+    ``self_pid`` exists because a mutation proved it had to: deleting the
+    ``protected=`` argument from the :func:`select` call below broke **no
+    test** — every protection test drove :func:`select` directly, so the wiring
+    on the path a user actually invokes was unasserted. Injecting the pid makes
+    the CLI path testable, and that mutation now fails
+    (``test_the_cli_path_protects_the_ancestor_chain``).
+    """
+    runtime = Runtime() if runtime is None else runtime
+    try:
+        processes = snapshot(runtime.runner)
+    except ReapError:
+        logger.exception("reap could not run")
+        return 2
+    escalation = Escalation.from_name(request.signal_name, grace_s=request.grace_s)
+    selection = select(
+        processes,
+        pattern=request.pattern,
+        min_age_s=request.min_age_s,
+        protected=protected_pids(processes, self_pid=self_pid),
+        full_match=request.full_match,
+    )
+    logger.info(
+        "%s",
+        format_plan(selection, pattern=request.pattern, min_age_s=request.min_age_s),
+    )
+    if not request.kill:
+        logger.info(
+            "DRY RUN — nothing was signalled. Re-run with `--kill` to signal the "
+            "%d target(s) above.",
+            len(selection.targets),
+        )
+        return 1 if request.strict and selection.targets else 0
+    if not selection.targets:
+        logger.info("nothing to reap.")
+        return 0
+    try:
+        result = reap(selection, runtime=runtime, escalation=escalation)
+    except ReapError:
+        logger.exception("reap aborted before signalling")
+        return 2
+    logger.info(
+        "reaped: %d signalled with %s, %d escalated to KILL, %d dropped as "
+        "changed identity, %d still alive.",
+        len(result.signalled),
+        signal.Signals(escalation.first).name,
+        len(result.killed),
+        len(result.dropped),
+        len(result.survivors),
+    )
+    for process in result.survivors:
+        logger.warning("still alive after KILL: %s", process.describe())
+    return 1 if result.survivors else 0

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -2005,3 +2005,22 @@ per_path_tokens = { ".claude/skills/lint-delta/SKILL.md" = ["name: lint-delta"],
 tokens = [
     "def previous_lock_revision(",
 ]
+
+[[suite]]
+name = "workflow.reap-protects-before-it-signals"
+description = "#653: a bulk reap is destructive, and the parts that make it safe are exactly the parts a hand-rolled `pkill` leaves out. The 2026-08-08 pile was 1,174 wedged `mise/shims/git` processes each carrying a stuck `fnox export --format json` child — 2,362 to clear, oldest 1d10h — and the cleanup was improvised under pressure, which is when the destructive details get got wrong. ⚠️ **Ancestor-chain protection is the load-bearing one, which is why `def ancestor_pids(` and the CLI's own `protected=protected_pids(processes, self_pid=self_pid),` call site are BOTH bound.** They are two different failures: the function can be perfect while the entry point never calls it, and that is not hypothetical — a mutation deleting exactly that argument broke **zero of 42 tests** on first run, because every protection test drove `select()` directly and nothing asserted the path a user actually invokes (`.claude/rules` mutation discipline: mutate the WIRING, not just the function). `tests/test_reap.py` now carries `def test_the_cli_path_protects_the_ancestor_chain(` and the identical mutation fails. The protection is not theoretical: measured live on a 1,603-process table, `--pattern 'fnox export'` matched **four** processes and **all four were the reaper's own invocation chain** (zsh wrapper -> uv -> the python entry), so the equivalent `pkill -f` would have killed the shell mid-command. ⚠️ **`def parse_etime(` is bound because the age floor is only as good as it is** — `ps` reports elapsed time as `SS`, `MM:SS`, `HH:MM:SS` or `DD-HH:MM:SS`, and a parser that is lenient about a shape it does not recognise turns the floor off silently; it returns `None`, and an age it cannot parse EXCLUDES its process rather than assuming it old. ⚠️ **`def confirm_targets(` is bound because a plan is a snapshot and the kernel recycles PIDs**: the module re-reads the table immediately before signalling and drops any PID whose command changed, so a recycled PID is never signalled on the strength of a stale plan. ⚠️ **`if not request.kill:` binds the posture Ray chose (2026-08-08b): DRY RUN by default, `--kill` required**, named for the irreversible thing rather than a neutral `--apply`, matching `lock` refusing its bare form and `lock-image` refusing the wrong host. The plan prints all four buckets (protected / too young / targets / ages) because a bare target count cannot distinguish a working age floor from a broken one, and it carries the issue's own caveat in the tool's mouth — a reap removes PID and MEMORY pressure and does NOT fix load, since the processes are `stat=S` at ~0 CPU and signalling 2,360 of them spiked the 1-minute average 7.98 -> **137.96**. An unreadable process table exits 2 and says it could not see, never folding into 'nothing matched' (`def test_an_empty_process_table_is_an_error_not_an_all_clear(`). Asserts the chain: the skill names itself, mise.toml's task shells out to the CLI, main.py registers and dispatches it, the module carries the ancestor walk, the etime parser, the identity re-check and the dry-run gate, and the test file carries the wiring guard, the blind-probe guard and the PID-reuse guard."
+category = "workflow"
+check_type = "static"
+handler = "require_tokens"
+paths_required = true
+paths = [
+    ".claude/skills/reap/SKILL.md",
+    "mise.toml",
+    "python/src/dotfiles_setup/main.py",
+    "python/src/dotfiles_setup/reap.py",
+    "tests/test_reap.py",
+]
+per_path_tokens = { ".claude/skills/reap/SKILL.md" = ["name: reap"], "mise.toml" = ["[tasks.reap]", "dotfiles-setup reap'"], "python/src/dotfiles_setup/main.py" = ['"reap",', '"reap": lambda'], "python/src/dotfiles_setup/reap.py" = ["def ancestor_pids(", "def parse_etime(", "def confirm_targets(", "protected=protected_pids(processes, self_pid=self_pid),", "if not request.kill:"], "tests/test_reap.py" = ["def test_the_cli_path_protects_the_ancestor_chain(", "def test_an_empty_process_table_is_an_error_not_an_all_clear(", "def test_a_pid_whose_command_changed_is_dropped_rather_than_signalled("] }
+tokens = [
+    "def ancestor_pids(",
+]

--- a/tests/test_reap.py
+++ b/tests/test_reap.py
@@ -1,0 +1,429 @@
+# Copyright (c) 2026 Raymond Manaloto
+"""Tests for the ancestor-protected process reaper (#653).
+
+The module is destructive, so the tests are written around the four ways it
+could destroy the wrong thing rather than around its happy path: an ancestor
+chain that is not excluded (it kills the shell that ran it), an age floor that
+does not hold (it kills live work), a pattern that matches more than it names,
+and a PID that was recycled between the plan and the signal.
+
+Every arm is paired. The protection tests assert both that the protected PID is
+spared AND that an unprotected sibling with the identical command IS selected —
+without the second half, a `select()` that returned nothing at all would pass.
+
+`ps` output is injected as real observed text (macOS `ps -eo
+pid=,ppid=,etime=,stat=,args=`, including the padded columns and the
+`DD-HH:MM:SS` form), and no test signals a real process: `killer` is a
+parameter, so the TERM-then-KILL escalation is driven end to end against a
+recorded call list.
+"""
+
+from __future__ import annotations
+
+import signal
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
+
+from dotfiles_setup import reap
+
+# Real shapes, transcribed from `ps -eo pid=,ppid=,etime=,stat=,args=` on the
+# authoring host — padded PID column, three etime formats, argv with spaces.
+PS_SAMPLE = """\
+    1     0 05-10:54:57 Ss   /sbin/launchd
+  500     1    35:02:11 S    /usr/sbin/distnoted agent
+ 6001   500       02:30 S    /Users/x/.local/share/mise/shims/git rev-parse
+ 6002  6001 01-10:00:00 S    fnox export --format json
+ 6003     1 01-10:00:05 S    fnox export --format json
+ 6004     1          09 S    fnox export --format json
+"""
+
+
+def _table() -> tuple[reap.Process, ...]:
+    return reap.parse_processes(PS_SAMPLE)
+
+
+def _runner(output: str = PS_SAMPLE) -> Callable[[Sequence[str]], str]:
+    def run(_command: Sequence[str]) -> str:
+        return output
+
+    return run
+
+
+# --------------------------------------------------------------------------- #
+# etime parsing — the age floor is only as good as this
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("09", 9),
+        ("02:30", 150),
+        ("35:02:11", 126131),
+        ("01-10:00:00", 122400),
+        ("05-10:54:57", 471297),
+    ],
+)
+def test_every_ps_elapsed_format_parses_to_seconds(text: str, expected: int) -> None:
+    assert reap.parse_etime(text) == expected
+
+
+@pytest.mark.parametrize("text", ["", "  ", "abc", "1:2:3:4", "x-01:00", "01:xx"])
+def test_an_unparsable_age_is_none_so_its_process_is_excluded(text: str) -> None:
+    # None rather than 0 and never a large fallback: an age this module cannot
+    # establish must fail toward SPARING the process, not toward reaping it.
+    assert reap.parse_etime(text) is None
+
+
+def test_a_row_with_an_unparsable_age_is_dropped_from_the_table() -> None:
+    table = reap.parse_processes(PS_SAMPLE + " 7000 1 not-a-time S fnox export\n")
+    assert 7000 not in {process.pid for process in table}
+
+
+# --------------------------------------------------------------------------- #
+# Parsing the table
+# --------------------------------------------------------------------------- #
+
+
+def test_the_full_argv_survives_parsing_including_its_spaces() -> None:
+    by_pid = {process.pid: process for process in _table()}
+    assert by_pid[6002].command == "fnox export --format json"
+    assert by_pid[6001].command.endswith("shims/git rev-parse")
+    assert by_pid[6001].ppid == 500
+
+
+def test_an_empty_process_table_is_an_error_not_an_all_clear() -> None:
+    # A ps that saw nothing is a probe that failed. Folding it into "no targets"
+    # is the shape `probes-need-a-control-arm.md` rule 9 exists to refuse.
+    with pytest.raises(reap.ReapError, match="could not see"):
+        reap.parse_processes("")
+
+
+def test_a_failing_ps_raises_rather_than_returning_an_empty_table() -> None:
+    reason = "no such binary"
+
+    def explode(_command: Sequence[str]) -> str:
+        raise OSError(reason)
+
+    with pytest.raises(OSError, match=reason):
+        reap.run_ps(explode)
+
+
+# --------------------------------------------------------------------------- #
+# Ancestor protection — the destructive one
+# --------------------------------------------------------------------------- #
+
+
+def test_the_whole_ancestor_chain_is_protected_up_to_init() -> None:
+    assert reap.ancestor_pids(_table(), 6002) == (6002, 6001, 500, 1)
+
+
+def test_a_ppid_cycle_terminates_instead_of_hanging() -> None:
+    cyclic = (
+        reap.Process(pid=10, ppid=11, age_s=99, state="S", command="a"),
+        reap.Process(pid=11, ppid=10, age_s=99, state="S", command="b"),
+    )
+    assert set(reap.ancestor_pids(cyclic, 10)) == {10, 11}
+
+
+def test_init_is_protected_even_when_the_walk_never_reaches_it() -> None:
+    orphan = (reap.Process(pid=42, ppid=999, age_s=99, state="S", command="a"),)
+    assert reap.INIT_PID in reap.protected_pids(orphan, self_pid=42)
+
+
+def test_a_protected_process_is_spared_while_its_twin_is_selected() -> None:
+    # Both arms on one axis: 6002 and 6003 run the IDENTICAL command and are the
+    # same age. The only difference is that 6002 is an ancestor of the reaper.
+    table = _table()
+    selection = reap.select(
+        table,
+        pattern="fnox export",
+        min_age_s=60,
+        protected=reap.protected_pids(table, self_pid=6002),
+    )
+    assert {process.pid for process in selection.protected} == {6002}
+    assert {process.pid for process in selection.targets} == {6003}
+
+
+def test_without_the_protected_set_the_reaper_would_select_its_own_ancestor() -> None:
+    # The control arm for the test above: this is what the bug looks like.
+    selection = reap.select(_table(), pattern="fnox export", min_age_s=60)
+    assert 6002 in {process.pid for process in selection.targets}
+
+
+# --------------------------------------------------------------------------- #
+# The age floor
+# --------------------------------------------------------------------------- #
+
+
+def test_a_process_younger_than_the_floor_is_bucketed_not_targeted() -> None:
+    selection = reap.select(_table(), pattern="fnox export", min_age_s=60)
+    assert {process.pid for process in selection.too_young} == {6004}
+    assert 6004 not in {process.pid for process in selection.targets}
+
+
+def test_lowering_the_floor_admits_the_young_process() -> None:
+    selection = reap.select(_table(), pattern="fnox export", min_age_s=5)
+    assert 6004 in {process.pid for process in selection.targets}
+
+
+# --------------------------------------------------------------------------- #
+# Matching
+# --------------------------------------------------------------------------- #
+
+
+def test_the_pattern_matches_against_the_full_argv_not_the_basename() -> None:
+    selection = reap.select(_table(), pattern="--format json", min_age_s=0)
+    assert len(selection.targets) == 3
+
+
+def test_full_match_refuses_a_substring_that_search_would_accept() -> None:
+    search = reap.select(_table(), pattern="fnox export", min_age_s=0)
+    exact = reap.select(_table(), pattern="fnox export", min_age_s=0, full_match=True)
+    assert search.targets
+    assert not exact.targets
+
+
+def test_full_match_accepts_the_complete_command() -> None:
+    exact = reap.select(
+        _table(),
+        pattern=r"fnox export --format json",
+        min_age_s=0,
+        full_match=True,
+    )
+    assert len(exact.targets) == 3
+
+
+# --------------------------------------------------------------------------- #
+# PID reuse between the plan and the signal
+# --------------------------------------------------------------------------- #
+
+
+def test_a_pid_whose_command_changed_is_dropped_rather_than_signalled() -> None:
+    targets = (reap.Process(pid=6003, ppid=1, age_s=999, state="S", command="fnox"),)
+    recycled = (reap.Process(pid=6003, ppid=1, age_s=1, state="S", command="ssh"),)
+    valid, dropped = reap.confirm_targets(targets, recycled, protected=frozenset({1}))
+    assert not valid
+    assert {process.pid for process in dropped} == {6003}
+
+
+def test_an_unchanged_pid_is_confirmed() -> None:
+    targets = (reap.Process(pid=6003, ppid=1, age_s=999, state="S", command="fnox"),)
+    valid, dropped = reap.confirm_targets(targets, targets, protected=frozenset({1}))
+    assert {process.pid for process in valid} == {6003}
+    assert not dropped
+
+
+def test_a_target_that_became_protected_is_dropped() -> None:
+    targets = (reap.Process(pid=6003, ppid=1, age_s=999, state="S", command="fnox"),)
+    valid, _ = reap.confirm_targets(targets, targets, protected=frozenset({6003}))
+    assert not valid
+
+
+# --------------------------------------------------------------------------- #
+# Signalling — TERM, re-check, KILL
+# --------------------------------------------------------------------------- #
+
+
+def _recording_killer(calls: list[tuple[int, int]]) -> Callable[[int, int], None]:
+    def kill(pid: int, sig: int) -> None:
+        calls.append((pid, sig))
+
+    return kill
+
+
+def _runtime(
+    calls: list[tuple[int, int]],
+    *,
+    runner: Callable[[Sequence[str]], str] | None = None,
+    killer: Callable[[int, int], None] | None = None,
+) -> reap.Runtime:
+    """Every effectful seam substituted, so no test signals a real process."""
+    return reap.Runtime(
+        runner=_runner() if runner is None else runner,
+        killer=_recording_killer(calls) if killer is None else killer,
+        sleeper=lambda _s: None,
+    )
+
+
+def test_a_process_that_dies_on_term_is_never_sent_kill() -> None:
+    calls: list[tuple[int, int]] = []
+    # Snapshot 1 confirms the target, snapshot 2 (after the grace wait) is the
+    # liveness re-check — and by then TERM has worked, so 6003 is gone.
+    gone = PS_SAMPLE.replace(" 6003 ", " 9999 ")
+    tables = iter([PS_SAMPLE, gone])
+
+    def runner(_command: Sequence[str]) -> str:
+        return next(tables, gone)
+
+    table = _table()
+    selection = reap.select(
+        table,
+        pattern="fnox export --format json",
+        min_age_s=60,
+        protected=reap.protected_pids(table, self_pid=6002),
+    )
+    result = reap.reap(selection, runtime=_runtime(calls, runner=runner))
+    assert calls == [(6003, signal.SIGTERM)]
+    assert not result.killed
+
+
+def test_a_survivor_of_term_is_escalated_to_kill() -> None:
+    calls: list[tuple[int, int]] = []
+    table = _table()
+    selection = reap.select(
+        table,
+        pattern="fnox export --format json",
+        min_age_s=60,
+        protected=reap.protected_pids(table, self_pid=6002),
+    )
+    result = reap.reap(selection, runtime=_runtime(calls))
+    assert calls == [(6003, signal.SIGTERM), (6003, signal.SIGKILL)]
+    assert {process.pid for process in result.killed} == {6003}
+    # The table never changes in this fixture, so it is still there afterwards —
+    # and the module reports that rather than claiming success.
+    assert {process.pid for process in result.survivors} == {6003}
+
+
+def test_a_process_that_exited_between_plan_and_signal_is_tolerated() -> None:
+    def vanishing(_pid: int, _sig: int) -> None:
+        raise ProcessLookupError
+
+    table = _table()
+    selection = reap.select(
+        table,
+        pattern="fnox export --format json",
+        min_age_s=60,
+        protected=reap.protected_pids(table, self_pid=6002),
+    )
+    result = reap.reap(selection, runtime=_runtime([], killer=vanishing))
+    assert not result.signalled
+
+
+# --------------------------------------------------------------------------- #
+# The CLI contract: dry run by default
+# --------------------------------------------------------------------------- #
+
+
+def test_the_default_run_signals_nothing() -> None:
+    calls: list[tuple[int, int]] = []
+    rc = reap.reap_main(
+        reap.ReapRequest(pattern="fnox export", min_age_s=60),
+        runtime=_runtime(calls),
+    )
+    assert rc == 0
+    assert calls == []
+
+
+def test_kill_is_what_makes_it_signal() -> None:
+    # The other arm of the same axis, so "signals nothing" cannot be passing
+    # because the selection was empty.
+    calls: list[tuple[int, int]] = []
+    reap.reap_main(
+        reap.ReapRequest(pattern="fnox export", min_age_s=60, kill=True),
+        runtime=_runtime(calls),
+    )
+    assert calls
+
+
+def test_the_cli_path_protects_the_ancestor_chain() -> None:
+    # Written because a mutation demanded it: deleting `protected=` from
+    # reap_main's select() call broke NOTHING — every other protection test
+    # drives select() directly, so the wiring on the path a user actually
+    # invokes was unasserted (`.claude/rules` mutation discipline, §5 rule 32).
+    # 6002 and 6003 are the same command and the same age; only 6002 is an
+    # ancestor of the reaper, so exactly one of them may be signalled.
+    calls: list[tuple[int, int]] = []
+    reap.reap_main(
+        reap.ReapRequest(
+            pattern="fnox export --format json",
+            min_age_s=60,
+            kill=True,
+            signal_name="KILL",
+        ),
+        runtime=_runtime(calls),
+        self_pid=6002,
+    )
+    assert {pid for pid, _sig in calls} == {6003}
+
+
+def test_strict_reports_a_dry_run_that_found_targets() -> None:
+    assert (
+        reap.reap_main(
+            reap.ReapRequest(pattern="fnox export", min_age_s=60, strict=True),
+            runtime=_runtime([]),
+        )
+        == 1
+    )
+
+
+def test_an_unreadable_process_table_exits_two_not_zero() -> None:
+    def blind(_command: Sequence[str]) -> str:
+        return ""
+
+    assert (
+        reap.reap_main(
+            reap.ReapRequest(pattern="fnox export"),
+            runtime=_runtime([], runner=blind),
+        )
+        == 2
+    )
+
+
+def test_the_signal_choice_kill_does_not_escalate_twice() -> None:
+    calls: list[tuple[int, int]] = []
+    reap.reap_main(
+        reap.ReapRequest(
+            pattern="fnox export --format json",
+            min_age_s=60,
+            kill=True,
+            signal_name="KILL",
+        ),
+        runtime=_runtime(calls),
+    )
+    assert {sig for _pid, sig in calls} == {signal.SIGKILL}
+
+
+# --------------------------------------------------------------------------- #
+# The plan is the audit trail
+# --------------------------------------------------------------------------- #
+
+
+def test_the_plan_prints_the_protected_set_so_the_exclusion_is_auditable() -> None:
+    table = _table()
+    selection = reap.select(
+        table,
+        pattern="fnox export",
+        min_age_s=60,
+        protected=reap.protected_pids(table, self_pid=6002),
+    )
+    plan = reap.format_plan(selection, pattern="fnox export", min_age_s=60)
+    assert "protected PIDs (self + ancestors + init): 1, 500, 6001, 6002" in plan
+    assert "TARGETS: 1" in plan
+    assert "TOO YOUNG" in plan
+
+
+def test_the_plan_states_the_load_caveat_rather_than_implying_a_load_fix() -> None:
+    # The issue's own caveat, kept in the tool's mouth: a reap removes PID and
+    # memory pressure, and signalling thousands of sleepers SPIKES load.
+    plan = reap.format_plan(reap.Selection(), pattern="x", min_age_s=1)
+    assert "does NOT fix load" in plan
+    assert "PID and MEMORY pressure" in plan
+
+
+@pytest.mark.parametrize(
+    ("seconds", "expected"),
+    [(9, "9s"), (150, "2m30s"), (7200, "2h00m"), (122400, "1d10h")],
+)
+def test_ages_are_formatted_for_a_human_reading_the_plan(
+    seconds: int, expected: str
+) -> None:
+    assert reap.format_age(seconds) == expected


### PR DESCRIPTION
The 2026-08-08 cleanup of 1,174 wedged `mise/shims/git` processes (2,362 with
their stuck `fnox export` children, oldest 1d10h) was improvised under time
pressure, and four parts of it are destructive to get wrong: ancestor-chain
protection, an age floor, exact matching under a supplied pattern rather than a
pkill substring, and TERM-then-KILL with a liveness re-check.

Three layers, per the 2026-08-08 build mandate: `.claude/skills/reap` -> `mise
run reap` -> `dotfiles_setup.reap`. `--kill` is required to signal anything
(Ray, 2026-08-08b), named for the irreversible thing rather than a neutral
`--apply`, matching `lock` refusing its bare form.

Two safety properties beyond the four: a PID whose command changed between plan
and signal is dropped rather than killed (the kernel recycles PIDs), and an
unreadable process table exits 2 saying it could not see, never folding into
"nothing matched".

Ancestor protection is not theoretical. Measured live on a 1,603-process table,
`--pattern 'fnox export'` matched four processes and all four were the reaper's
own invocation chain (zsh wrapper -> uv -> the python entry point), so the
equivalent `pkill -f` would have killed the shell mid-command.

A mutation deleting `protected=` from the CLI's own `select()` call broke ZERO
of 42 tests, because every protection test drove `select()` directly and
nothing asserted the path a user invokes. `self_pid` is a seam for that reason;
`test_the_cli_path_protects_the_ancestor_chain` now fails on the same mutation,
before and after the arg-count refactor.

The plan prints all four buckets and carries the issue's caveat in the tool's
mouth: a reap removes PID and MEMORY pressure and does not fix load — those
processes were `stat=S` at ~0 CPU, and signalling 2,360 of them spiked the
1-minute average 7.98 -> 137.96.

Gates: lint rc=0 (0 failing steps), pytest 1893 passed, verify 127 passed /
0 failed, lint-docs clean.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016SGa1MC4TUELrVHv5ER5BT

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788799349&installation_model_id=429246&pr_number=663&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F663&signature=6830f2544c91d04ccfefbbc9986b80276d7143b8bb3249985852ff49122eb584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `reap` command for safely identifying and cleaning up processes.
  - Defaults to a dry run and requires explicit confirmation before sending signals.
  - Supports age filters, exact command matching, ancestor protection, and TERM/KILL escalation.
  - Reports planned actions, protected processes, survivors, and distinct failure outcomes.

- **Documentation**
  - Added usage guidance, safety recommendations, and troubleshooting information for recurring process buildup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->