### PR TITLE
docs(triage): the labels ARE in use — replace the "not yet adopted" claim with measured counts

### DIFF
--- a/docs/triage-labels.md
+++ b/docs/triage-labels.md
@@ -34,16 +34,46 @@ is this*, and is unaffected:
 **Both axes coexist on one issue** — `enhancement` + `ready-for-agent` is the normal shape, not a
 conflict. Nothing here changes how `enhancement`/`bug`/`dependencies` are used.
 
-## Honest note on adoption
+## Adoption — measured 2026-08-08, not asserted
 
-These labels exist but are **not yet in use** — no issue carries one today. `/triage` is
-`disable-model-invocation: true`, so only a human typing `/mattpocock-skills:triage` drives it. This
-file records the vocabulary so the skill works when reached for; it does not assert a practice we
-have.
+The labels **are** in use, but coverage is thin. Counted over all open issues at
+`gh issue list --state open --limit 500` (an explicit limit that exceeds the population — the
+default view is a display bound, and reading it at ~40 rows once flipped this very conclusion):
 
-The one wiring in place: `refresh.yml`'s tool-currency issue is labelled `needs-triage` on creation,
-so bot-filed issues enter the flow rather than sitting unlabelled (25 of the last 60 issues have no
-label at all).
+| | before the session | after |
+|---|---|---|
+| open issues | 135 | **134** |
+| carrying a **state** role | **15** | **15** |
+| carrying a **category** role (`bug` / `enhancement`) | 40 | 40 |
+| **no labels at all** | 39 | **37** |
+
+The delta reconciles exactly: `#421` closed as already-implemented and `#193` labelled
+`dependencies`, both of which were previously unlabelled. Nothing else moved.
+
+State-role spread: `needs-triage` 5, `ready-for-agent` 5, `ready-for-human` 4, `needs-info` 1,
+`wontfix` 0.
+
+⚠️ **`wayfinder:*` labels are NOT state roles** (12 `task`, 11 `grilling`, 8 `research`,
+4 `prototype`, 2 `map`). An issue can carry three of them and still be untriaged — do not read them
+as triage coverage.
+
+`/triage` is `disable-model-invocation: true`, so only a human typing `/mattpocock-skills:triage`
+drives it; coverage grows only when someone sits down and runs it.
+
+The one automatic wiring: `refresh.yml`'s tool-currency issue is labelled `needs-triage` on
+creation, so bot-filed issues enter the flow rather than sitting unlabelled.
+
+### Bot-filed issues get a category label, not triage
+
+A permanent bot artifact is not a request and should not sit in the untriaged bucket. Precedent:
+`#184` (tool-currency report, `app/github-actions`) carries `dependencies`; `#193` (Renovate's
+Dependency Dashboard, `app/renovate`) was unlabelled until triage on 2026-08-08 gave it the same
+label. Label them and leave them open — do **not** close them, Renovate needs its dashboard.
+
+> **Superseded 2026-08-08.** This section previously read *"These labels exist but are **not yet in
+> use** — no issue carries one today"* and cited *"25 of the last 60 issues have no label at all"*.
+> The first claim was false by the time it was read; the second used a different denominator (last
+> 60 issues) than the table above (all open issues), so the two numbers are not comparable.
 
 ## See also
 


### PR DESCRIPTION
`docs/triage-labels.md` asserted "these labels exist but are **not yet in
use** — no issue carries one today". Fifteen open issues carry a state role,
and did before the claim was last read.

Replaces it with counts measured at `--limit 500` (the default view is a
display bound — reading it at ~40 rows once flipped this exact conclusion),
a before/after column reconciling this triage session's two edits, and an
explicit warning that `wayfinder:*` labels are not state roles and must not
be read as triage coverage.

Also records the bot-issue convention the repo already follows by precedent
but had never written down: a permanent bot artifact gets a category label
so it leaves the untriaged bucket, and stays open.

Found by `/mattpocock-skills:triage`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MCFymQ3miUyFFWvQ6fouQm

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788806214&installation_model_id=429246&pr_number=665&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F665&signature=2bbc6a4e204e3f56fdd124d3fa38af97927a4f87e1fd464ac803c53ea4c86db8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated triage guidance with measured label adoption data from open issues as of August 8, 2026.
  * Clarified label coverage, state-role distribution, and reconciliation of issue changes.
  * Documented that `wayfinder:*` labels are not triage roles.
  * Added guidance for categorizing bot-filed issues and keeping them open.
  * Retained documentation of automatic `needs-triage` labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->