### PR TITLE
feat(image): make an architecture mismatch FAIL the manifest measure (#674)

### DIFF
--- a/docs/specs/devcontainer-gcc162-dual-arch.md
+++ b/docs/specs/devcontainer-gcc162-dual-arch.md
@@ -259,19 +259,38 @@ select amd64, and compare that hash to an **arm64** container. Not a crash — a
 **false pass**. Manifest selection must take the same `platform` parameter.
 
 ✅ **Parameterised by #673**; the recursion now selects `platform_arch(...)`.
-⚠️ **#674 still owns the rest**, and Ray scoped it 2026-08-09 to **two**
-surfaces: (a) the AC2 control arm — a deliberate architecture mismatch must
-FAIL, kept as a test, which does not exist today; and (b) **`sync.py`'s digest
-convergence** — `registry_digest()` (`sync.py:245`) returns `.Manifest.Digest`
-from `imagetools inspect`, which for a manifest list is the **INDEX** digest,
-while `local_digests()` (`sync.py:267`) returns the tag's `RepoDigests`.
-Whether those still compare like-for-like under a multi-arch `:dev` is an
-**open question to probe, not an established defect** — and "they still match"
-is a welcome answer. ⚠️ `sync.py:127`'s "can never converge" is about a
-**buildkit re-export** minting a new local digest; do NOT cite it as multi-arch
-evidence (this spec did, briefly, and it was wrong). AC3's "passes on both
-architectures" is satisfied by **synthetic manifest fixtures** for now, with
-the real two-arch run deferred to #676 and noted when #674 closes.
+✅ **CLOSED by #674**, across the two surfaces Ray scoped on 2026-08-09:
+
+- **(a) the AC2 control arm — built.** The mismatch path did not merely go
+  unverified, it could not fail: an index with no entry for the requested
+  architecture fell through to `_gzip_size_for_image`, which measures the
+  *local* image whatever architecture that is. It now raises, and the
+  local-gzip fallback is narrowed to a genuinely unreadable document. Four
+  FAIL arms are pinned in `tests/test_image_smoke.py` (absent arch, index of
+  attestations only, `windows/amd64` against a `linux/amd64` request, empty
+  index); both mutations — restoring the fall-through, and dropping the `os`
+  check — are caught.
+- **(b) `sync.py` — probed, and NO change was needed.** Measured both arms
+  against a real multi-architecture tag: `imagetools inspect --format '{{json
+  .Manifest.Digest}}'` and, after a `--platform`-scoped pull of *either*
+  architecture, `image inspect --format '{{json .RepoDigests}}'` return the
+  **same index digest**. A `--platform` pull selects which manifest is
+  materialised, not which digest is recorded, so `SyncStatus.stale` compares
+  like-for-like as written. Recorded in `registry_digest`'s docstring so it is
+  not re-opened. ⚠️ `sync.py:127`'s "can never converge" is about a **buildkit
+  re-export** minting a new local digest; do NOT cite it as multi-arch evidence
+  (this spec did, briefly, and it was wrong).
+
+One fact found while doing it contradicts the framing above: `:dev` is
+**already** an OCI index (an `amd64/v2` entry plus an `unknown/unknown`
+attestation entry), so the recursion runs today rather than lying dormant until
+D1. The (a) defect was therefore **reachable** before dual-arch publication, not
+merely prospective — `dotfiles-setup image size-report --platform linux/arm64/v8`
+against the real `:dev` took the fall-through, and now exits 1 naming
+`available: linux/amd64`. It was not *exercised*, because the repo pin resolves
+to amd64 and every caller inherits it. AC3's "passes on both architectures" is
+satisfied by **synthetic manifest fixtures**; the real two-architecture run is
+deferred to #676.
 
 #### The 12+ hard-coded sites (the real risk is PARTIAL threading)
 

--- a/python/src/dotfiles_setup/image.py
+++ b/python/src/dotfiles_setup/image.py
@@ -27,7 +27,7 @@ from dotfiles_setup.platform_target import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Callable, Iterable, Mapping
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -932,8 +932,70 @@ def _repo_without_tag(image_ref: str) -> str:
     return image_ref
 
 
+def _index_platforms(manifests: Iterable[Mapping[str, Any]]) -> list[str]:
+    """Every real platform an index publishes, in index order.
+
+    Buildx writes an ``unknown/unknown`` ``attestation-manifest`` entry beside
+    each real platform (verified against this repo's own ``:dev``), so the
+    entries are filtered rather than listed — an error message that offered
+    ``unknown/unknown`` as an alternative would be worse than none.
+
+    The microarchitecture level is kept when the entry carries one: a platform
+    is a triple, not an arch word (``platform_target``'s module docstring), so
+    an index publishing a levelled triple must not be reported as offering the
+    bare ``os/arch`` — that is exactly the level-dropping this project treats
+    as load-bearing.
+    """
+    seen: list[str] = []
+    for entry in manifests:
+        entry_platform = entry.get("platform", {})
+        os_name = entry_platform.get("os")
+        arch = entry_platform.get("architecture")
+        if os_name in (None, "unknown") or arch in (None, "unknown"):
+            continue
+        variant = entry_platform.get("variant")
+        candidate = f"{os_name}/{arch}/{variant}" if variant else f"{os_name}/{arch}"
+        if candidate not in seen:
+            seen.append(candidate)
+    return seen
+
+
+def _no_such_architecture(
+    image_ref: str, target_arch: str, manifests: Iterable[Mapping[str, Any]]
+) -> ValueError:
+    """The #674 AC2 failure: the index cannot answer for the requested arch."""
+    available = _index_platforms(manifests)
+    offer = ", ".join(available) if available else "none"
+    msg = (
+        f"{image_ref} publishes no linux/{target_arch} manifest "
+        f"(available: {offer}) — refusing to measure a different architecture "
+        f"and report it as {target_arch}"
+    )
+    return ValueError(msg)
+
+
+def _unreadable_selected_manifest(image_ref: str, target_arch: str) -> ValueError:
+    """The sub-manifest for a CHOSEN architecture could not be read.
+
+    Distinct from :func:`_no_such_architecture`: the index did answer, and the
+    architecture was already selected. Falling back to the local image here
+    would report some other architecture's bytes under the label of the one
+    that was asked for — the same false pass #674 closes, one level down.
+    """
+    msg = (
+        f"{image_ref}'s linux/{target_arch} manifest is not a readable "
+        f"manifest document — refusing to fall back to the local image, which "
+        f"may be a different architecture"
+    )
+    return ValueError(msg)
+
+
 def _sum_manifest_layer_sizes(
-    raw: str, image_ref: str, *, platform: str | None = None
+    raw: str,
+    image_ref: str,
+    *,
+    platform: str | None = None,
+    local_fallback_ok: bool = True,
 ) -> int:
     """Sum compressed layer sizes from an OCI/Docker manifest JSON.
 
@@ -945,13 +1007,35 @@ def _sum_manifest_layer_sizes(
     which under a multi-arch manifest would resolve, silently pick that one,
     and compare it against a container of the other: a false pass, not a
     crash).
+
+    An index that carries no entry for ``platform`` **raises** (#674 AC2). It
+    used to fall through to :func:`_gzip_size_for_image`, which measures the
+    *local* image whatever architecture that is — so a request the registry
+    could not satisfy returned a plausible number describing the wrong
+    architecture, and the selection above could never fail. The gzip fallback
+    survives for a genuinely unrecognised document shape, which is a different
+    condition: "I cannot read this" rather than "this does not have what you
+    asked for".
+
+    ``local_fallback_ok`` is what keeps that distinction honest through the
+    recursion. Once an architecture has been *selected*, the local image is no
+    longer an acceptable stand-in for an unreadable sub-manifest — it may be a
+    different architecture, which is the same false pass one level down — so
+    the recursive call clears the flag and an unreadable document raises there.
     """
     target_arch = platform_arch(resolve_platform(platform))
     doc = json.loads(raw)
     layers = doc.get("layers")
     if layers is not None:
         return sum(int(layer.get("size", 0)) for layer in layers)
-    for entry in doc.get("manifests", []):
+    manifests = doc.get("manifests")
+    if manifests is None:
+        # Not a recognized manifest shape. Only the caller that has not yet
+        # committed to an architecture may fall back to the local measure.
+        if not local_fallback_ok:
+            raise _unreadable_selected_manifest(image_ref, target_arch)
+        return _gzip_size_for_image(image_ref)
+    for entry in manifests:
         entry_platform = entry.get("platform", {})
         if (
             entry_platform.get("os") == "linux"
@@ -968,9 +1052,10 @@ def _sum_manifest_layer_sizes(
                     "--raw",
                 ],
             ).stdout
-            return _sum_manifest_layer_sizes(sub, image_ref, platform=platform)
-    # Not a recognized manifest shape — fall back to the local gzip measure.
-    return _gzip_size_for_image(image_ref)
+            return _sum_manifest_layer_sizes(
+                sub, image_ref, platform=platform, local_fallback_ok=False
+            )
+    raise _no_such_architecture(image_ref, target_arch, manifests)
 
 
 def _compressed_size_for_image(image_ref: str, *, platform: str | None = None) -> int:

--- a/python/src/dotfiles_setup/sync.py
+++ b/python/src/dotfiles_setup/sync.py
@@ -243,7 +243,23 @@ def _stream(
 
 
 def registry_digest(image_ref: str) -> str | None:
-    """Manifest digest the registry serves for ``image_ref`` (no pull)."""
+    """Manifest digest the registry serves for ``image_ref`` (no pull).
+
+    Under a multi-architecture tag this is the **index** digest, and #674 asked
+    whether that still compares like-for-like against :func:`local_digests`'s
+    ``RepoDigests``. Measured, both arms, against a real ghcr index built the
+    way ours is — buildx, two architectures, an attestation manifest beside
+    each (``ghcr.io/astral-sh/uv:latest``), and cross-checked on a Docker Hub
+    index (``alpine:3.20``). ``imagetools inspect --format '{{json
+    .Manifest.Digest}}'`` and, after a ``docker pull`` scoped to ONE
+    architecture with ``--platform``, ``image inspect --format '{{json
+    .RepoDigests}}'`` return the **same index digest** — for *either*
+    architecture asked for. A ``--platform`` pull selects which manifest is
+    *materialised*, not which digest is *recorded*, so :attr:`SyncStatus.stale`
+    needs no per-architecture handling and none was added. Do not "fix" this on
+    the strength of the ``can never converge`` comment above — that one is
+    about a buildkit re-export, not about manifest lists.
+    """
     res = _run(
         [
             "docker",

--- a/tests/test_image_smoke.py
+++ b/tests/test_image_smoke.py
@@ -933,6 +933,259 @@ def test_sum_manifest_layer_sizes_single_manifest() -> None:
     )
 
 
+# ------------------------------- #674: architecture selection in an index
+#
+# The fixture is armed: the two architectures carry DIFFERENT layer totals, so
+# "it selected the right entry" is a discriminating result rather than a
+# coincidence (`probes-need-a-control-arm.md` rule 8). It also carries the
+# `unknown/unknown` attestation entry that a real `imagetools inspect --raw` of
+# this repo's `:dev` actually serves — a fixture without one cannot exercise
+# the skip that keeps an attestation from being mistaken for a platform.
+
+_AMD64_LAYER_BYTES = 4096
+_ARM64_LAYER_BYTES = 8192
+_ARCH_LAYER_BYTES = {"amd64": _AMD64_LAYER_BYTES, "arm64": _ARM64_LAYER_BYTES}
+_ARCH_VARIANT = {"amd64": "v2", "arm64": "v8"}
+_ARCH_DIGEST = {"amd64": "sha256:" + "a" * 64, "arm64": "sha256:" + "b" * 64}
+_ATTESTATION_DIGEST = "sha256:" + "c" * 64
+_INDEX_MEDIA_TYPE = "application/vnd.oci.image.index.v1+json"
+
+
+def _index_raw(*arches: str) -> str:
+    """An OCI index shaped like a real buildx one, for the given architectures."""
+    manifests: list[dict[str, object]] = []
+    for arch in arches:
+        manifests.append(
+            {
+                "digest": _ARCH_DIGEST[arch],
+                "platform": {
+                    "os": "linux",
+                    "architecture": arch,
+                    "variant": _ARCH_VARIANT[arch],
+                },
+            }
+        )
+        manifests.append(
+            {
+                "digest": _ATTESTATION_DIGEST,
+                "platform": {"os": "unknown", "architecture": "unknown"},
+                "annotations": {"vnd.docker.reference.type": "attestation-manifest"},
+            }
+        )
+    return json.dumps({"mediaType": _INDEX_MEDIA_TYPE, "manifests": manifests})
+
+
+def _fake_imagetools(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Serve each architecture's sub-manifest by digest; record the refs asked for."""
+    by_digest = {
+        _ARCH_DIGEST[arch]: json.dumps({"layers": [{"size": size}]})
+        for arch, size in _ARCH_LAYER_BYTES.items()
+    }
+    asked: list[str] = []
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        ref = cmd[cmd.index("inspect") + 1]
+        asked.append(ref)
+        _, _, digest = ref.partition("@")
+        return subprocess.CompletedProcess(cmd, 0, stdout=by_digest[digest], stderr="")
+
+    monkeypatch.setattr("dotfiles_setup.image._run", fake_run)
+    return asked
+
+
+def _forbid_gzip_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the local-gzip fallback loud, so a silent fall-through cannot pass."""
+
+    def explode(image_ref: str) -> int:
+        msg = f"gzip fallback must not run for {image_ref}"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr("dotfiles_setup.image._gzip_size_for_image", explode)
+
+
+@pytest.mark.parametrize("arch", ["amd64", "arm64"])
+def test_sum_manifest_layer_sizes_selects_requested_arch(
+    arch: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The index entry matching the REQUESTED architecture is the one summed."""
+    _forbid_gzip_fallback(monkeypatch)
+    asked = _fake_imagetools(monkeypatch)
+
+    total = _sum_manifest_layer_sizes(
+        _index_raw("amd64", "arm64"),
+        "ghcr.io/owner/repo:tag",
+        platform=f"linux/{arch}/{_ARCH_VARIANT[arch]}",
+    )
+
+    assert total == _ARCH_LAYER_BYTES[arch]
+    assert asked == [f"ghcr.io/owner/repo@{_ARCH_DIGEST[arch]}"]
+
+
+def test_sum_manifest_layer_sizes_fails_on_architecture_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#674 AC2 — an index without the requested architecture FAILS, never falls back.
+
+    The control arm. Before this, the loop fell through to the local-gzip
+    measure, so a request for an architecture the registry does not publish
+    returned a number describing whatever the local image happened to be.
+    """
+    _forbid_gzip_fallback(monkeypatch)
+    _fake_imagetools(monkeypatch)
+
+    with pytest.raises(ValueError, match="arm64") as excinfo:
+        _sum_manifest_layer_sizes(
+            _index_raw("amd64"),
+            "ghcr.io/owner/repo:tag",
+            platform="linux/arm64/v8",
+        )
+
+    assert "amd64" in str(excinfo.value)
+
+
+def test_sum_manifest_layer_sizes_never_offers_an_attestation_as_an_alternative(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An `unknown/unknown` attestation entry is not a platform, so it is not offered.
+
+    The assertion is on the OFFER, not merely on the raise. Asserting the raise
+    alone passes whether or not the filter exists — the selection loop already
+    rejects `architecture: unknown` — so it would have been a duplicate of the
+    absent-arch test wearing this test's name (found by review).
+    """
+    _forbid_gzip_fallback(monkeypatch)
+    _fake_imagetools(monkeypatch)
+
+    with pytest.raises(ValueError, match="publishes no") as excinfo:
+        _sum_manifest_layer_sizes(
+            _index_raw("arm64"),
+            "ghcr.io/owner/repo:tag",
+            platform="linux/amd64/v2",
+        )
+
+    message = str(excinfo.value)
+    assert "unknown" not in message
+    assert "available: linux/arm64/v8" in message
+
+
+def test_sum_manifest_layer_sizes_offers_only_attestations_as_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An index of nothing but attestations offers no alternative at all."""
+    _forbid_gzip_fallback(monkeypatch)
+    _fake_imagetools(monkeypatch)
+    attestation_only = json.dumps(
+        {
+            "mediaType": _INDEX_MEDIA_TYPE,
+            "manifests": [
+                {
+                    "digest": _ATTESTATION_DIGEST,
+                    "platform": {"os": "unknown", "architecture": "unknown"},
+                    "annotations": {
+                        "vnd.docker.reference.type": "attestation-manifest"
+                    },
+                }
+            ],
+        }
+    )
+
+    with pytest.raises(ValueError, match="available: none"):
+        _sum_manifest_layer_sizes(
+            attestation_only,
+            "ghcr.io/owner/repo:tag",
+            platform="linux/amd64/v2",
+        )
+
+
+def test_sum_manifest_layer_sizes_rejects_an_unreadable_selected_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A chosen architecture's sub-manifest that cannot be read FAILS, never falls back.
+
+    The AC2 hole one level down (found by review): the index answered and the
+    architecture was already selected, so the local image — possibly a
+    different architecture — is not an acceptable stand-in for it.
+    """
+    _forbid_gzip_fallback(monkeypatch)
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout=json.dumps({"schemaVersion": 1, "fsLayers": []}), stderr=""
+        )
+
+    monkeypatch.setattr("dotfiles_setup.image._run", fake_run)
+
+    with pytest.raises(ValueError, match="not a readable manifest"):
+        _sum_manifest_layer_sizes(
+            _index_raw("amd64"),
+            "ghcr.io/owner/repo:tag",
+            platform="linux/amd64/v2",
+        )
+
+
+def test_sum_manifest_layer_sizes_rejects_matching_arch_on_another_os(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``windows/amd64`` does not satisfy a request for ``linux/amd64``.
+
+    The os and the architecture are separate axes; matching one is not
+    matching the platform, and the message must offer what is really there.
+    """
+    _forbid_gzip_fallback(monkeypatch)
+    _fake_imagetools(monkeypatch)
+    windows_only = json.dumps(
+        {
+            "mediaType": _INDEX_MEDIA_TYPE,
+            "manifests": [
+                {
+                    "digest": _ARCH_DIGEST["amd64"],
+                    "platform": {"os": "windows", "architecture": "amd64"},
+                }
+            ],
+        }
+    )
+
+    with pytest.raises(ValueError, match="windows/amd64"):
+        _sum_manifest_layer_sizes(
+            windows_only, "ghcr.io/owner/repo:tag", platform="linux/amd64/v2"
+        )
+
+
+def test_sum_manifest_layer_sizes_rejects_an_empty_index(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An index publishing nothing is a mismatch, not an unreadable document."""
+    _forbid_gzip_fallback(monkeypatch)
+    _fake_imagetools(monkeypatch)
+
+    with pytest.raises(ValueError, match="available: none"):
+        _sum_manifest_layer_sizes(
+            json.dumps({"mediaType": _INDEX_MEDIA_TYPE, "manifests": []}),
+            "ghcr.io/owner/repo:tag",
+            platform="linux/amd64/v2",
+        )
+
+
+def test_sum_manifest_layer_sizes_unrecognised_shape_still_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A doc that is neither a manifest nor an index keeps the local-gzip fallback.
+
+    The other arm of the mismatch test: the fallback is narrowed, not deleted.
+    """
+    monkeypatch.setattr(
+        "dotfiles_setup.image._gzip_size_for_image", lambda _ref: _LAYERS_TOTAL_BYTES
+    )
+
+    total = _sum_manifest_layer_sizes(
+        json.dumps({"schemaVersion": 2}),
+        "ghcr.io/owner/repo:tag",
+        platform="linux/amd64/v2",
+    )
+
+    assert total == _LAYERS_TOTAL_BYTES
+
+
 # --------------------------------------- tier-1 identity (merge-base aware)
 
 


### PR DESCRIPTION
#673 made the manifest recursion take the requested architecture as a
parameter. It did not give that selection a control arm — and the selection
could not fail: an index carrying no entry for the requested architecture fell
through to `_gzip_size_for_image`, which measures the LOCAL image whatever
architecture it happens to be. A request the registry could not satisfy
therefore returned a plausible number describing the wrong architecture.

Reachable before dual-arch publication, not merely prospective: `:dev` is
already an OCI index (an amd64/v2 entry plus an `unknown/unknown` attestation
entry), so `size-report --platform linux/arm64/v8` against the real image took
exactly that path. It now exits 1 naming `available: linux/amd64/v2`.

- an index without the requested architecture raises, enumerating what it
  really publishes (attestation entries filtered — offering `unknown/unknown`
  as an alternative would be worse than no offer; the microarchitecture level
  is kept, because a platform is a triple, not an arch word)
- the local-gzip fallback is narrowed to a genuinely unreadable document, and
  `local_fallback_ok` keeps that honest through the recursion: once an
  architecture is SELECTED, an unreadable sub-manifest raises rather than
  standing in the local image for it
- six FAIL arms pinned in tests, fixtures armed so they can produce either
  answer (the two architectures carry different layer totals) and shaped like a
  real buildx index

Five mutations verified caught: restoring the fall-through; dropping the
`os == "linux"` check; weakening the attestation filter; dropping the
recursion's fallback guard; dropping the microarchitecture level.

sync.py is DOCSTRING-ONLY — surface (b) was probed and needed no change.
Measured both arms on a real ghcr buildx-attested two-architecture index
(`ghcr.io/astral-sh/uv:latest`) and cross-checked on Docker Hub
(`alpine:3.20`): a `--platform`-scoped pull of EITHER architecture records the
same INDEX digest that `registry_digest()` returns, so `SyncStatus.stale`
already compares like-for-like. Recorded there so it is not re-opened and
"fixed". The `can never converge` comment is about a buildkit re-export, not
about manifest lists.

AC3's "passes on both architectures" is satisfied by synthetic fixtures; the
real two-architecture run is deferred to #676.

Closes #674

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MCFymQ3miUyFFWvQ6fouQm

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788914216&installation_model_id=429246&pr_number=696&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F696&signature=ea4d95ea708e73ca44af2f64302745fcbd3b679c3f840f2fb80603ad6503a608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-architecture image handling by selecting the requested platform variant when calculating image layer sizes.
  * Added clear failures when the requested architecture is missing, mismatched, or unreadable.
  * Excluded attestation-only manifests from platform selection.
  * Restricted gzip fallback to unrecognized image documents, preventing misleading results for recognized indexes.

* **Documentation**
  * Clarified that registry and local image digests remain consistent across pulled platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->