### PR TITLE
feat(codec): one module owning msgspec's encode and decode hooks (#675)

### DIFF
--- a/docs/research/kb/reports/agents/code-review-675-codec-hooks.md
+++ b/docs/research/kb/reports/agents/code-review-675-codec-hooks.md
@@ -1,0 +1,171 @@
+# `/code-review high` — #675 msgspec codec centralisation
+
+**Agent:** `code-review` fork (general-purpose), 2026-08-10, 40 tool uses / 163k tokens / 9m19s.
+**Scope:** `git diff HEAD` — 8 files, uncommitted working tree on `feat/675-codec-hooks`.
+**Verdict:** 7 findings, **all real**. Three were re-verified independently by the
+parent session before any fix was written (F1, F2, F6 — transcripts in the
+session log); the other four are inspection-evident.
+
+> Persisted per `.claude/rules/agent-report-persistence.md`. ⚠️ The background
+> task's output file is the raw **JSONL transcript** (338 KB), not the report —
+> the 2026-08-10c handoff §5.63 records the last time that was copied verbatim
+> and shipped as "the report". This file is the report text plus the brief.
+
+## The brief it was given
+
+```
+`minimal prompt → single careful diff pass → ≤15 findings`
+
+You are reviewing a pull request for real bugs. Run `git diff @{upstream}...HEAD` (or `git diff main...HEAD` / `git diff HEAD~1`
+if there's no upstream) to get the unified diff under review. If there are
+uncommitted changes, or the range diff is empty, also run `git diff HEAD` and
+include the working-tree changes in scope — the review often runs before the
+commit. If a PR number, branch name, or file path was passed as an argument,
+review that target instead. Treat this diff as the review scope.
+
+Review the diff as a careful senior engineer would: read every hunk, open the surrounding files for context as needed (Read, Grep, git log/blame/show), and hunt for correctness issues — wrong or inverted conditions, off-by-one, null/undefined dereference, missing `await`, dropped error handling, removed guards or validations, broken callers of changed functions, races. Prefer real failure modes over style; every finding needs a concrete scenario in which the code misbehaves.
+
+When you are done, submit at most 15 findings via the ReportFindings tool, filling its fields as defined — for each: the file path and start line, a severity, and a comment that states the issue and the concrete scenario in which the code misbehaves. Quality over quantity: include everything you genuinely believe is a real issue, and nothing you don't.
+
+After the tool call, also restate the findings in your final reply — one line each, `file:line — summary` — so they stay visible in sessions that do not render tool output.
+
+```
+
+## Findings, verbatim
+
+Scope note from the agent: the branch range vs `origin/main` was empty (all
+changes uncommitted), so it reviewed `git diff HEAD`. It verified the tree was
+green **first**, so every finding is something the gates do not catch:
+`pytest tests/test_codec.py` → 27 passed; `ruff check python/src tests plugins`
+→ clean; `verify run --suite workflow.codec-hook-centralisation` → PASSED;
+`token-audit` → rc=0; `md-budget` → rc=0.
+
+It also control-armed the TID251 ban across **9 evasion shapes** (attribute
+access, `from msgspec.json import encode`, `import msgspec.json as mj`,
+`from msgspec import json as mj`, aliased function import, `Encoder()` instance,
+`msgpack.Decoder`) — all FLAGGED — with `class S(msgspec.Struct)` NOT flagged.
+And it cross-checked the 14-entry ban list by `inspect.signature` against the
+docstring scan the test uses: identical sets, no drift.
+
+### F1 — `codec.py:182` · `_lookup` walks `__mro__`, which parametrized generics lack
+
+A `msgspec.Struct` field annotated `Box[int]` (a documented msgspec custom
+generic) raises `AttributeError: __mro__` at decode **even when `Box` is
+registered** — so a registered generic can never be decoded — and an
+unregistered one raises the same bare `AttributeError` instead of the promised
+`UnsupportedTypeError`, defeating AC3's "fail loudly, name the offender".
+`list[int]` passes only because `types.GenericAlias` proxies `__mro__`;
+`typing._GenericAlias` does not.
+
+**Fix:** resolve `typing.get_origin(candidate) or candidate` before the MRO walk.
+
+### F2 — `codec.py:141` · `register()` is a silent no-op for natively-supported types
+
+`codec.register(decimal.Decimal, encode=float, decode=Decimal)` then
+`codec.encode(Decimal("1.50"))` → `b'"1.50"'` — still a JSON string; `float` is
+never called, because msgspec never invokes `enc_hook` for a type it handles
+itself. Same for `datetime`. A caller who registers a conversion to get numeric
+decimals or epoch timestamps gets no error, no effect, and a wire form that
+silently isn't what they asked for — the exact "silently degrading" outcome the
+module's acceptance criterion forbids, sitting on its own extension seam.
+
+### F3 — `tests/test_codec.py:232` · `_ruff()` discards `returncode`
+
+The negative assertions read only `proc.stdout`. A failing ruff invocation
+returns rc=1 with stdout containing no `TID251`, so
+`assert "TID251" not in proc.stdout` is satisfied for free.
+`test_declaring_a_model_is_not_caught_by_the_ban` has **no positive arm**, so a
+broken venv, a missing ruff, or any `uv run` failure makes it green while
+proving nothing — a check that can only pass.
+
+**Fix:** `assert proc.returncode in (0, 1)` inside `_ruff`.
+
+### F4 — `tests/test_codec.py:400` · probe modules written into the live tracked package
+
+`_codec_allowance_probe.py` is a verbatim copy of `codec.py`, written into
+`python/src/dotfiles_setup/`. `finally` covers a normal exception but not a
+SIGKILL, a harness timeout kill, or an OOM between the write and the unlink. A
+leftover then (a) fails `mise run lint` with TID251, (b) fails
+`test_no_module_outside_the_codec_calls_msgspec_directly` on the next run with a
+misleading message, and (c) is one careless `git add` from being committed into
+the shipped package. Same shape at lines 335 and 357.
+
+### F5 — `tests/test_codec.py:433` · the tree sweep matches the bare substring `"msgspec"`
+
+A module that merely **documents** the ban fails it — and `python/AGENTS.md` in
+this same diff tells every author "`msgspec` … Never call it directly", making
+that comment likely. The failure message then says "route them through
+dotfiles_setup.codec" for a file that has no msgspec call. It is the mirror of
+the trap the diff itself calls out at lines 375-393.
+
+**Fix:** match an import (`^\s*(import msgspec|from msgspec)`).
+
+### F6 — `codec.py:138` · the seeded decoder is asymmetric for non-native path flavours
+
+`_DECODERS = {PurePath: Path}` is the "half-registered type" that `register()`'s
+own docstring says the API exists to prevent.
+`codec.encode(PureWindowsPath("C:/x"))` succeeds via `str`, but decoding into a
+`PureWindowsPath`-annotated field raises
+`msgspec.ValidationError: Expected PureWindowsPath, got PosixPath`, because the
+decoder unconditionally constructs `Path`. Write succeeds, read fails in another
+process. (`PurePosixPath` has the same problem on a Windows host.)
+
+**Fix:** key the decoder on the target type rather than hard-coding `Path`.
+
+### F7 — `tests/test_codec.py:174` · `_hook_taking_apis()`'s module list is hand-written
+
+It claims to be "derived at runtime … so a new entry point in a future msgspec
+makes the coverage test fail instead of quietly widening the hole", but its
+module list (`msgspec`, `.json`, `.msgpack`, `.yaml`, `.toml`) is transcribed. A
+new hook-taking submodule — the shape most likely to add a format — is invisible
+to the scan, and the `len(discovered) >= 10` control arm cannot see it either.
+
+**Fix:** `pkgutil.iter_modules(msgspec.__path__)` (currently reports `inspect`,
+`json`, `msgpack`, `structs`, `toml`, `yaml`).
+
+## Not findings (checked and cleared by the agent)
+
+- The TID251 ban resolves through every aliasing shape constructible (9/9), and
+  `msgspec.Struct` stays free — both arms discriminate.
+- The 14-entry ban list is complete for msgspec 0.21.1: docstring-scan and
+  signature-scan agree exactly.
+- `codec.py`'s per-file TID251 allowance is live under the real hk invocation
+  (`uv run --project python ruff check <file>` from the repo root resolves
+  `python/pyproject.toml` per-file, so the relative glob does not re-anchor).
+  The `ruff.toml` header's re-anchoring warning does not bite here.
+- `uv.lock` pins `msgspec 0.21.1` with cp314 wheels for both
+  `manylinux_x86_64` and `macosx_arm64` — no sdist build in the amd64 image.
+- msgspec **does** validate the `dec_hook` return type
+  (`Expected PureWindowsPath, got PosixPath`), so a wrong-typed hook result is
+  not silent — which is why F6 is a loud failure rather than corruption.
+- `python/AGENTS.md` at 112 lines / 5,699 B is inside budget; `md-budget` rc=0.
+
+## Parent-session independent re-verification
+
+Run before any fix was written, because an agent's report is not evidence until
+a second route agrees:
+
+| Finding | Probe | Result |
+|---|---|---|
+| F2 | `register(Decimal, encode=float, …)` then `encode(Decimal("1.50"))` | `b'"1.50"'` — hook never called ✅ confirmed |
+| F6 | `encode(PureWindowsPath("C:/x"))` then decode into `PureWindowsPath` | `ValidationError: Expected PureWindowsPath, got PosixPath` ✅ confirmed |
+| F1 | unregistered `Box[int]` (plain generic, not a Struct) | `AttributeError: __mro__` — not even a codec error ✅ confirmed |
+| F1 | **registered** `Box[int]` | `AttributeError: __mro__` — registered type undecodable ✅ confirmed |
+| F1 | `hasattr(list[int], '__mro__')` vs `hasattr(Box[int], '__mro__')` | `True` vs `False` — explains why `list[int]` survived every test ✅ |
+
+⚠️ The agent's own F1 example (`Box[int]` as a `msgspec.Struct` field) decodes
+**fine** in isolation, because msgspec handles a Struct natively and never
+reaches the hook. The finding is correct; its illustration needed replacing with
+a plain (non-Struct) generic to reach `dec_hook` at all. Worth recording: a
+finding can be right while its repro is not, and taking the repro on trust would
+have produced a "cannot reproduce" dismissal of a real defect.
+
+## GitHub repos touched
+
+- [jcrist/msgspec](https://github.com/jcrist/msgspec) — the library under
+  centralisation; its hook contract, native type support and `inspect` surface
+  were read and probed at 0.21.1.
+- [astral-sh/ruff](https://github.com/astral-sh/ruff) — TID251 `banned-api`
+  resolution semantics (attribute access, aliased imports, per-file-ignores).
+- [ray-manaloto/dotfiles](https://github.com/ray-manaloto/dotfiles) — the repo
+  under review.

--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -82,10 +82,31 @@ substring matches false-positive on prefixed ENV vars (e.g.,
 `CARGO_HOME=` matches `MISE_CARGO_HOME=`); prefer leading-space anchors
 or `regex_forbid` handlers. See `feedback_forbid_tokens_substring_fragile`.
 
+## Serialization: route every call through `codec` (#675)
+
+`msgspec` is the project's model system (#669). **Never call it directly** —
+use `dotfiles_setup.codec.encode` / `.decode`. Machine-enforced by ruff
+**TID251**, whose ban list covers all **14** msgspec entry points that accept a
+conversion hook (enumerated from the library, not hand-written: `Encoder`/
+`Decoder`, `convert` and `to_builtins` are the ones a from-memory list misses).
+`codec.py` carries the only per-file allowance.
+
+The reason is that msgspec's hooks are **per-call keyword arguments**, not a
+global registration — so a direct call works fine while carrying its own copy of
+the conversion table, and the copies drift. `pathlib.Path` is unsupported in
+**both** directions, and the decode half is the quiet one: it raises only
+because the annotation says `Path`, so a field annotated `str` accepts the value
+and hands you a string that behaves like a path until something calls `.parent`.
+
+Teach it a new type with `codec.register(T, encode=…, decode=…)` — both
+directions, because a half-registration encodes cleanly and loses the type at
+read time in another process. Never add a branch to the hook itself.
+
 ## Dependencies
 
-Key packages: `pydantic` (config), `python-debian` (deb822 parsing for
-`apt_repo`; Ubuntu ships the same code as `python3-debian`), `pytest`
+Key packages: `msgspec` (models + serialization — via `codec` only, above),
+`pydantic` (config; leaving the tree in #683), `python-debian` (deb822 parsing
+for `apt_repo`; Ubuntu ships the same code as `python3-debian`), `pytest`
 (testing). Full lockfile at `uv.lock`.
 
 <!-- MANUAL: Any manually added notes below this line are preserved on regeneration -->

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     # datasource bumps this the same way it bumps CLANG_P2996_REF. Dependency
     # direction is dotfiles → KB only; the KB never learns about its consumers.
     "kb-setup @ git+https://github.com/ray-manaloto/knowledge-base@46a3e7d8cbde4b7c591598d54175ae654c96f584",
+    "msgspec>=0.21.1",
 ]
 
 [project.scripts]
@@ -79,6 +80,45 @@ ignore = [
 "src/dotfiles_setup/config.py" = ["S108"]
 # S101 (assert in tests): standard pytest practice — assert is the test mechanism.
 "../tests/*.py" = ["S101"]
+# TID251: `codec.py` is the ONE module allowed to call msgspec's hook-taking
+# entry points — it is what every other caller is redirected to (#675). Without
+# this allowance the ban would make the module it exists to protect unwritable.
+"src/dotfiles_setup/codec.py" = ["TID251"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+# Every msgspec entry point that accepts a conversion hook (#675 AC4).
+#
+# ENUMERATED, not hand-listed: the set was read out of msgspec 0.21.1 by
+# scanning every public callable in `msgspec`, `.json`, `.msgpack`, `.yaml` and
+# `.toml` for `enc_hook`/`dec_hook` in its signature docs. That found FOURTEEN;
+# the four anyone would write from memory (`json.encode/decode`,
+# `msgpack.encode/decode`) are under a third of them. The `Encoder`/`Decoder`
+# classes matter as much as the functions — they take the same hooks and are the
+# form a performance-minded caller reaches for — and `convert`/`to_builtins` are
+# the ones that would slip past entirely.
+#
+# Ruff resolves attribute access AND aliased imports, both verified against this
+# config before it was committed: `msgspec.json.encode(1)` and
+# `from msgspec.json import encode` are each flagged, while `msgspec.Struct`
+# passes. That last one is the control arm — the ban is specific, so declaring a
+# model stays free.
+"msgspec.convert".msg = "route through dotfiles_setup.codec — msgspec's hooks are per-call, so a direct call carries its own conversion table and drifts (#675)"
+"msgspec.to_builtins".msg = "route through dotfiles_setup.codec (#675)"
+"msgspec.json.encode".msg = "use dotfiles_setup.codec.encode (#675)"
+"msgspec.json.decode".msg = "use dotfiles_setup.codec.decode (#675)"
+"msgspec.json.Encoder".msg = "use dotfiles_setup.codec.encode (#675)"
+"msgspec.json.Decoder".msg = "use dotfiles_setup.codec.decode (#675)"
+"msgspec.msgpack.encode".msg = "use dotfiles_setup.codec.encode(fmt=Format.MSGPACK) (#675)"
+"msgspec.msgpack.decode".msg = "use dotfiles_setup.codec.decode(fmt=Format.MSGPACK) (#675)"
+"msgspec.msgpack.Encoder".msg = "use dotfiles_setup.codec.encode(fmt=Format.MSGPACK) (#675)"
+"msgspec.msgpack.Decoder".msg = "use dotfiles_setup.codec.decode(fmt=Format.MSGPACK) (#675)"
+# yaml/toml carry no `Format` yet. The ban is deliberate rather than an
+# oversight: adding a wire format should be a decision recorded in `Format`, not
+# a call site that quietly introduces a third serialization path.
+"msgspec.yaml.encode".msg = "add a codec.Format before introducing a third wire format (#675)"
+"msgspec.yaml.decode".msg = "add a codec.Format before introducing a third wire format (#675)"
+"msgspec.toml.encode".msg = "add a codec.Format before introducing a third wire format (#675)"
+"msgspec.toml.decode".msg = "add a codec.Format before introducing a third wire format (#675)"
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/python/src/dotfiles_setup/codec.py
+++ b/python/src/dotfiles_setup/codec.py
@@ -1,0 +1,384 @@
+# Copyright (c) 2026 Raymond Manaloto
+"""The one module owning msgspec's encode and decode hooks (#675).
+
+msgspec is the project's single model system (#669). It handles the types a
+JSON document is made of, plus a documented set it converts for you —
+``datetime``, ``uuid.UUID``, ``decimal.Decimal`` all encode natively. Anything
+else goes through a **hook**, and msgspec's hooks are ``enc_hook``/``dec_hook``
+keyword arguments to each ``encode``/``decode`` call rather than a global
+registration.
+
+That per-call design is why this module exists **from the outset** rather than
+being extracted later. Every call site that passes msgspec its own hook owns a
+copy of the conversion table, and copies drift; by the time a second type needs
+converting there is no single place to add it. Retrofitting means finding every
+call, which is the situation #669 declined to walk into.
+
+``pathlib.Path`` is the type that forces the issue, and it is unsupported in
+**both** directions. Measured against msgspec 0.21.1, control-armed against the
+three types above (all of which encode unaided, so the probe discriminates)::
+
+    >>> msgspec.json.encode(pathlib.Path("/tmp/x"))
+    TypeError: Encoding objects of type PosixPath is unsupported
+    >>> msgspec.json.decode(b'"/tmp/x"', type=pathlib.Path)
+    ValidationError: Expected `Path`, got `str`
+
+The decode half is the one worth internalising. It raises only because the
+annotation says ``Path``; a field annotated ``str`` accepts the value happily
+and hands the caller a string that behaves like a path right up until something
+calls ``.parent`` on it.
+
+Why a registry rather than an ``isinstance`` chain
+--------------------------------------------------
+
+:func:`register` exists so the *next* unsupported type is a one-line
+declaration instead of an edit to :func:`enc_hook`. A hook that grows a branch
+per type is still "one place" by file count and stops being one by any measure
+that matters — and the branches accumulate in the order people happened to need
+them, which is the shape nobody can review.
+
+The lookup walks the **method resolution order**, not exact identity, because
+``Path()`` never instantiates ``Path``: on this platform it returns
+``PosixPath``, which is what msgspec's own error names. A registry keyed on the
+exact type would therefore miss every real path while passing a test written
+against ``PurePath``.
+
+Failing loudly
+--------------
+
+An unregistered type raises :class:`UnsupportedTypeError`, which subclasses
+``NotImplementedError`` — the exception msgspec's own documentation tells hooks
+to raise — and carries the offending type as an attribute so a caller can branch
+on it without parsing a message.
+
+The alternative worth naming, because it is the tempting one: falling back to
+``str(obj)``. It never fails, since every object has a ``__str__``, so an
+unregistered type would encode as ``"<Foo object at 0x10a>"``, round-trip to
+nothing, and surface as corrupt data a long way from here. That is precisely the
+"silently degrading" this module's acceptance criterion forbids.
+"""
+
+from __future__ import annotations
+
+import enum
+import typing
+from collections.abc import Callable
+from pathlib import PurePath
+from typing import Any
+
+import msgspec
+import msgspec.inspect
+
+__all__ = [
+    "AlreadyNativeError",
+    "Format",
+    "UnsupportedTypeError",
+    "dec_hook",
+    "decode",
+    "enc_hook",
+    "encode",
+    "register",
+    "unregister",
+]
+
+#: Turns an unsupported instance into something msgspec can encode.
+_Encoder = Callable[[Any], Any]
+
+#: Rebuilds an instance from an encoded value. Takes the TARGET TYPE as well as
+#: the value, mirroring msgspec's own ``dec_hook(type, obj)`` — and for the same
+#: reason. The annotation is information the decoder genuinely needs and the
+#: encoder cannot have: encoding sees a concrete instance, while decoding is
+#: told which of a family of types to produce. Seeding ``PurePath -> Path``
+#: instead cost a real defect (review F6): ``PureWindowsPath`` encoded fine and
+#: then failed to decode, because the decoder ignored what it was asked for.
+_Decoder = Callable[[type, Any], Any]
+
+
+class Format(enum.Enum):
+    """The wire formats this project encodes to.
+
+    ``JSON`` is the default and the one #669 chose for records: it is what the
+    devcontainer CLI already emits, it is what the log-scanning gate consumes,
+    and it can be read with ordinary tools during an incident. ``MSGPACK`` is
+    the compact binary form msgspec produces **from the same definitions**, so
+    reaching for it never costs a second model.
+    """
+
+    JSON = "json"
+    MSGPACK = "msgpack"
+
+
+def _unknown_format(fmt: object) -> str:
+    """The message for a format outside :class:`Format`."""
+    supported = ", ".join(f.name for f in Format)
+    return f"unknown format {fmt!r}: expected one of {supported}"
+
+
+class UnsupportedTypeError(NotImplementedError):
+    """A type reached the codec with no registered conversion.
+
+    Subclasses ``NotImplementedError`` because that is what msgspec documents a
+    hook should raise to say "not mine" — so code following msgspec's own docs
+    keeps working — while :attr:`offending_type` gives a caller somewhere to
+    read the answer from other than the message text.
+    """
+
+    def __init__(self, offending_type: type, direction: str) -> None:
+        """Record which type failed, and which way it was travelling.
+
+        Args:
+            offending_type: The type with no registered conversion.
+            direction: ``"encode"`` or ``"decode"`` — the two hooks fail for
+                different reasons and the fix differs, so the message says
+                which one was asked.
+        """
+        self.offending_type = offending_type
+        self.direction = direction
+        super().__init__(
+            f"cannot {direction} {offending_type.__module__}."
+            f"{offending_type.__qualname__}: msgspec has no native support and "
+            f"dotfiles_setup.codec has no registered conversion. Add one with "
+            f"codec.register({offending_type.__qualname__}, encode=..., decode=...) "
+            f"rather than calling msgspec directly"
+        )
+
+
+class AlreadyNativeError(ValueError):
+    """:func:`register` was asked to convert a type msgspec already handles.
+
+    Refused rather than accepted, because accepting it does **nothing**:
+    msgspec only calls a hook for types it cannot handle itself, so a
+    registration for ``Decimal`` or ``datetime`` is never consulted. Measured
+    before this guard existed — ``register(Decimal, encode=float, …)`` followed
+    by ``encode(Decimal("1.50"))`` still produced ``b'"1.50"'``, a JSON string,
+    with ``float`` never called.
+
+    That is the module's own "silently degrading" failure mode occurring on its
+    extension seam: no error, no effect, and a wire form that is not what the
+    caller asked for. Someone registering it wants a different encoding and has
+    to be told they cannot get one this way.
+    """
+
+    def __init__(self, target: type, native: str) -> None:
+        """Name the type and what msgspec already calls it.
+
+        Args:
+            target: The type that was offered for registration.
+            native: msgspec's own name for how it handles that type.
+        """
+        self.target = target
+        self.native = native
+        super().__init__(
+            f"{target.__qualname__} is already handled natively by msgspec "
+            f"({native}), so a registered conversion would never be called — "
+            f"msgspec only invokes a hook for types it cannot encode itself. "
+            f"To change how it is serialized, wrap it in a type msgspec does "
+            f"not know, or annotate the field with msgspec's own controls"
+        )
+
+
+def _native_handling(target: type) -> str | None:
+    """Msgspec's own name for how it handles ``target``, or ``None``.
+
+    ``msgspec.inspect.type_info`` reports ``CustomType`` for anything msgspec
+    has no built-in support for, and a specific class otherwise — verified
+    across ``Decimal``/``datetime``/``UUID``/``int``/``str`` (all specific) and
+    ``Path``/``PurePath``/an unknown class (all ``CustomType``). Asking msgspec
+    beats keeping our own list of what it supports, which would go stale the
+    first time it adds a type.
+    """
+    try:
+        info = msgspec.inspect.type_info(target)
+    except TypeError, NotImplementedError:
+        return None
+    if isinstance(info, msgspec.inspect.CustomType):
+        return None
+    return type(info).__name__
+
+
+#: Registered conversions, keyed by the base type an instance must be an
+#: instance of. Seeded with the one type #675 exists for; every later entry is
+#: a :func:`register` call, which is the whole point of the seam.
+#:
+#: The decoder is ``target(value)``, not ``Path(value)``: the annotation decides
+#: which path flavour to build, so a ``PureWindowsPath`` field decodes to a
+#: ``PureWindowsPath``.
+_ENCODERS: dict[type, _Encoder] = {PurePath: str}
+_DECODERS: dict[type, _Decoder] = {PurePath: lambda target, value: target(value)}
+
+
+def register(
+    target: type,
+    *,
+    encode: _Encoder,
+    decode: _Decoder,
+) -> None:
+    """Teach the codec a type, in both directions at once.
+
+    Both directions are required rather than optional because a half-registered
+    type is the silent-corruption case: it would encode cleanly and decode to
+    whatever primitive it was stored as, so the loss appears at read time in a
+    different process.
+
+    Args:
+        target: The base type to match instances and annotations against.
+            Subclasses resolve through it, so registering ``PurePath`` covers
+            ``PosixPath`` and ``WindowsPath``.
+        encode: Converts an instance to something msgspec can already encode.
+        decode: Rebuilds an instance, given the annotated type and the encoded
+            value — the same shape as msgspec's ``dec_hook``.
+
+    Raises:
+        AlreadyNativeError: msgspec handles ``target`` itself, so the
+            registration would never be consulted.
+    """
+    native = _native_handling(target)
+    if native is not None:
+        raise AlreadyNativeError(target, native)
+    _ENCODERS[target] = encode
+    _DECODERS[target] = decode
+
+
+def unregister(target: type) -> None:
+    """Remove a registration. Chiefly for tests that add a temporary one.
+
+    Args:
+        target: The base type passed to :func:`register`.
+    """
+    _ENCODERS.pop(target, None)
+    _DECODERS.pop(target, None)
+
+
+def _runtime_class(candidate: object) -> type | None:
+    """The class behind ``candidate``, unwrapping a parametrized generic.
+
+    ``dec_hook`` receives the **annotation**, and an annotation is not always a
+    class: ``Box[int]`` is a ``typing._GenericAlias`` with **no ``__mro__``**,
+    so walking one raises ``AttributeError`` before any of this module's own
+    error handling runs (review F1). That defeated the "fail loudly, name the
+    offender" guarantee *and* made a correctly-registered generic impossible to
+    decode.
+
+    ``list[int]`` hid the bug for the whole first draft, because
+    ``types.GenericAlias`` proxies ``__mro__`` to ``list`` while
+    ``typing._GenericAlias`` does not — two spellings of "parametrized
+    generic", only one of which fails.
+    """
+    resolved = typing.get_origin(candidate) or candidate
+    return resolved if isinstance(resolved, type) else None
+
+
+def _lookup[C](table: dict[type, C], candidate: object) -> C | None:
+    """The registered conversion for ``candidate``, walking its MRO.
+
+    Generic in the conversion type rather than returning a union of the two:
+    the encoder takes one argument and the decoder takes two, so a union return
+    is ill-typed at *both* call sites. ty caught that — the union typechecked
+    the table and lost the arity.
+
+    MRO order rather than dict iteration order, so a registration for a
+    subclass wins over one for its base regardless of which was added first —
+    insertion order is not a property anyone should have to reason about.
+    """
+    resolved = _runtime_class(candidate)
+    if resolved is None:
+        return None
+    for base in resolved.__mro__:
+        conversion = table.get(base)
+        if conversion is not None:
+            return conversion
+    return None
+
+
+def enc_hook(obj: object) -> object:
+    """Msgspec's encode hook: convert an unsupported instance to a supported one.
+
+    msgspec calls this only for types it cannot encode itself, so reaching here
+    is already evidence the type needs a registration.
+
+    Args:
+        obj: The instance msgspec could not encode.
+
+    Returns:
+        A value msgspec can encode.
+
+    Raises:
+        UnsupportedTypeError: No conversion is registered for ``obj``'s type.
+    """
+    conversion = _lookup(_ENCODERS, type(obj))
+    if conversion is None:
+        raise UnsupportedTypeError(type(obj), "encode")
+    return conversion(obj)
+
+
+def dec_hook(target: type, obj: object) -> object:
+    """Msgspec's decode hook: rebuild an unsupported type from a supported one.
+
+    msgspec passes the **annotation** it is decoding into, which is the type
+    written in the model — ``Path``, not the ``PosixPath`` it will construct.
+    The conversion is handed that annotation too, so a family of types
+    (``PurePosixPath``, ``PureWindowsPath``) needs one registration rather than
+    one per flavour.
+
+    Args:
+        target: The annotated type to produce.
+        obj: The primitive msgspec decoded from the wire.
+
+    Returns:
+        An instance of ``target``.
+
+    Raises:
+        UnsupportedTypeError: No conversion is registered for ``target``.
+    """
+    conversion = _lookup(_DECODERS, target)
+    if conversion is None:
+        raise UnsupportedTypeError(_runtime_class(target) or type(target), "decode")
+    return conversion(target, obj)
+
+
+def encode(obj: object, *, fmt: Format = Format.JSON) -> bytes:
+    """Encode ``obj``, applying this project's conversions.
+
+    Args:
+        obj: The value to encode.
+        fmt: The wire format. Defaults to JSON, the record form #669 chose.
+
+    Returns:
+        The encoded bytes.
+
+    Raises:
+        UnsupportedTypeError: A value has no registered conversion.
+        ValueError: ``fmt`` is not a :class:`Format`.
+    """
+    match fmt:
+        case Format.JSON:
+            return msgspec.json.encode(obj, enc_hook=enc_hook)
+        case Format.MSGPACK:
+            return msgspec.msgpack.encode(obj, enc_hook=enc_hook)
+        case _:
+            raise ValueError(_unknown_format(fmt))
+
+
+def decode[T](data: bytes, target: type[T], *, fmt: Format = Format.JSON) -> T:
+    """Decode ``data`` into ``target``, applying this project's conversions.
+
+    Args:
+        data: The encoded bytes.
+        target: The type to decode into — msgspec validates against it.
+        fmt: The wire format. Defaults to JSON.
+
+    Returns:
+        An instance of ``target``.
+
+    Raises:
+        UnsupportedTypeError: ``target`` has no registered conversion.
+        ValueError: ``fmt`` is not a :class:`Format`.
+        msgspec.ValidationError: ``data`` does not match ``target``.
+    """
+    match fmt:
+        case Format.JSON:
+            return msgspec.json.decode(data, type=target, dec_hook=dec_hook)
+        case Format.MSGPACK:
+            return msgspec.msgpack.decode(data, type=target, dec_hook=dec_hook)
+        case _:
+            raise ValueError(_unknown_format(fmt))

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -26,6 +26,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "kb-setup" },
+    { name = "msgspec" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-debian" },
@@ -42,6 +43,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "kb-setup", git = "https://github.com/ray-manaloto/knowledge-base?rev=46a3e7d8cbde4b7c591598d54175ae654c96f584" },
+    { name = "msgspec", specifier = ">=0.21.1" },
     { name = "pydantic", specifier = ">=2.13.4" },
     { name = "pydantic-settings", specifier = ">=2.15.0" },
     { name = "python-debian", specifier = ">=1.1.1" },
@@ -68,6 +70,30 @@ wheels = [
 name = "kb-setup"
 version = "0.1.0"
 source = { git = "https://github.com/ray-manaloto/knowledge-base?rev=46a3e7d8cbde4b7c591598d54175ae654c96f584#46a3e7d8cbde4b7c591598d54175ae654c96f584" }
+
+[[package]]
+name = "msgspec"
+version = "0.21.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/60/f79b9b013a16fa3a58350c9295ddc6789f2e335f36ea61ed10a21b215364/msgspec-0.21.1.tar.gz", hash = "sha256:2313508e394b0d208f8f56892ca9b2799e2561329de9763b19619595a6c0f72c", size = 319193, upload-time = "2026-04-12T21:44:50.394Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/ad/86954e987d1d6a5c579e2c2e7832b65e0fff194179fdac4f581536086024/msgspec-0.21.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fab48eb45fdbfbdb2c0edfec00ffc53b6b6085beefc6b50b61e01659f9f8757f", size = 196261, upload-time = "2026-04-12T21:44:27.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a1/c5e46c3e42b866199365e35d11dddfd1fbd8bba4fdb3c52f965b1607ce94/msgspec-0.21.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3cb779ea0c35bc807ff941d415875c1f69ca0be91a2e907ab99a171811d86a9a", size = 188729, upload-time = "2026-04-12T21:44:28.99Z" },
+    { url = "https://files.pythonhosted.org/packages/85/7d/1e29a319d678d6cb962ae5bdf32a6858ebdf38f73bc654c0e9c742a0c2c8/msgspec-0.21.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:68604db36b3b4dd9bf160e436e12798a4738848144cea1aca1cb984011eb160f", size = 219866, upload-time = "2026-04-12T21:44:31.104Z" },
+    { url = "https://files.pythonhosted.org/packages/25/1f/cca084ca2572810fff12ea9dbdcbe39eac048f40daf4a9077b49fcbe8cee/msgspec-0.21.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d6b9dc50948eaf65df54d2fd0ff66e6d8c32f116037209ee861810eb9b676cb", size = 224993, upload-time = "2026-04-12T21:44:32.649Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/d2120fc9d419a89a3a7c13e5b7078798c4b392a96a02a6e2b3ce43a8766c/msgspec-0.21.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:52c5e21930942302394429c5a582ce7e6b62c7f983b3760834c2ce107e0dd6df", size = 223535, upload-time = "2026-04-12T21:44:33.839Z" },
+    { url = "https://files.pythonhosted.org/packages/75/17/42418b66a3ad972a89bab73dd78b79cc6282bb488a25e73c853cee7443b9/msgspec-0.21.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:abbb39d65681fa24ed394e01af3d59d869068324f900c61d06062b7fb9980f2f", size = 227222, upload-time = "2026-04-12T21:44:35.093Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/33/265c894268cca88ff67b144ca2b4c522fc8b9a6f1966a3640c70516e78e1/msgspec-0.21.1-cp314-cp314-win_amd64.whl", hash = "sha256:5666b1b560b97b6ec2eb3fca8a502298ebac56e13bbca1f88523538ce83d01ea", size = 193810, upload-time = "2026-04-12T21:44:36.612Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8f/a6d35f25bf1fc63c492fdd88fdce01ba0875ead48c2b91f90f33653b4131/msgspec-0.21.1-cp314-cp314-win_arm64.whl", hash = "sha256:d8b8578e4c83b14ceea4cef0d0b747e31d9330fe4b03b2b2ad4063866a178f93", size = 179125, upload-time = "2026-04-12T21:44:38.198Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/39/74839641e64b99d87da55af0fc472854d42b46e2183b9e2a67fe1bb2a512/msgspec-0.21.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:15f523d51c00ebad412213bfe9f06f0a50ec2b93e0c19e824a2d267cabb48ea2", size = 200171, upload-time = "2026-04-12T21:44:39.414Z" },
+    { url = "https://files.pythonhosted.org/packages/70/9b/ce0cca6d2d87fcd4b6ff97600790494e64f26a2c55d61507cd2755c16193/msgspec-0.21.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e47390360583ba3d5c6cb44cf0a9f61b0a06a899d3c2c00627cedebb2e2884b", size = 192879, upload-time = "2026-04-12T21:44:40.882Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/08/673a7bb05e5702dc787ddd3011195b509f9867927970da59052211929987/msgspec-0.21.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f60800e6299b798142dc40b0644da77ceac5ea0568be58228417eae14135c847", size = 226281, upload-time = "2026-04-12T21:44:42.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/45/86508cf57283e9070b3c447e3ab25b792a7a0855a3ea4e0c6d111ac34c97/msgspec-0.21.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5f8e9dfcd98419cf7568808470c4317a3fb30bef0e3715b568730a2b272a20d7", size = 229863, upload-time = "2026-04-12T21:44:43.442Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/62/e7c9367cd08d590559faacd711edbae36840342843e669440363f33c7d36/msgspec-0.21.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:92d89dfad13bd1ea640dc3e37e724ed380da1030b272bdf5ecafb983c3ad7c75", size = 230445, upload-time = "2026-04-12T21:44:44.806Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b4/c0f54632103846b658a10930025f4de41c8724b5e4805a5f3b395586cb7e/msgspec-0.21.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0d03867786e5d7ba25d666df4b11320c27170f4aeafcb8e3a8b0a50a4fb742ca", size = 231822, upload-time = "2026-04-12T21:44:46.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/1d/0d85cc79d0ccf5508e9c846cc66552a6a16bf92abd1dbd8362617f7b35cd/msgspec-0.21.1-cp314-cp314t-win_amd64.whl", hash = "sha256:740fbf1c9d59992ca3537d6fbe9ebbf9eaf726a65fbf31448e0ecbc710697a63", size = 206650, upload-time = "2026-04-12T21:44:47.601Z" },
+    { url = "https://files.pythonhosted.org/packages/90/91/56c5d560f20e6c20e9e4f55bd0e458f7f162aa689ee350346c04c48eac0b/msgspec-0.21.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0d2cc73df6058d811a126ac3a8ad63a4dfa210c82f9cf5a004802eaf4712de90", size = 183149, upload-time = "2026-04-12T21:44:48.833Z" },
+]
 
 [[package]]
 name = "packaging"

--- a/python/verification/suites.toml
+++ b/python/verification/suites.toml
@@ -2049,3 +2049,20 @@ per_path_tokens = { ".claude/skills/reap/SKILL.md" = ["name: reap"], "mise.toml"
 tokens = [
     "def ancestor_pids(",
 ]
+
+[[suite]]
+name = "workflow.codec-hook-centralisation"
+description = "#675: msgspec's conversion hooks live in ONE module and every call routes through it. The chain pinned here is pyproject's ban list -> the codec module -> the tests that arm both directions. Why a contract on top of the tests: msgspec's hooks are PER-CALL keyword arguments, not a global registration, so nothing about the library forces centralisation — a new call site that passes its own enc_hook works perfectly, and the second copy of the conversion table is the defect. The ban is enforced by ruff TID251 (banned-api), which resolves attribute access AND aliased imports; both arms were verified against this config before it landed, along with a control arm that `msgspec.Struct` still passes so declaring a model stays free. The ban list was ENUMERATED from the installed msgspec rather than hand-written: fourteen public entry points accept a hook, and the four anyone writes from memory (json/msgpack x encode/decode) are under a third of them — `Encoder`/`Decoder`, `convert` and `to_builtins` are the ones that would have slipped past. Two traps are pinned in the module itself. The registry walks the MRO because `Path()` instantiates `PosixPath`, so exact-type keying misses every real path while passing a test written against `PurePath`. The three review fixes are pinned as tokens because each was a silent defect that a green suite shipped: the MRO walk is reached through `typing.get_origin`, because a parametrized generic annotation has no `__mro__` and raised a bare `AttributeError` before any of this module's own error handling ran (and `list[int]` hid it, since `types.GenericAlias` proxies `__mro__` while `typing._GenericAlias` does not); `register()` REFUSES a type msgspec already handles, because msgspec never calls a hook for one and the registration would sit unreachable — measured, `register(Decimal, encode=float, ...)` then encoding gave back the same JSON string with `float` never called; and the seeded path decoder builds `target(value)` rather than `Path(value)`, so a `PureWindowsPath` field decodes to a `PureWindowsPath` instead of encoding fine and failing to read back. And the encode hook RAISES on an unregistered type rather than falling back to `str(obj)` — that fallback never fails, since every object has a `__str__`, so it would encode `<Foo object at 0x10a>` as valid JSON and surface as corrupt data far from here."
+category = "workflow"
+check_type = "static"
+handler = "require_tokens"
+paths_required = true
+paths = [
+    "python/pyproject.toml",
+    "python/src/dotfiles_setup/codec.py",
+    "tests/test_codec.py",
+]
+per_path_tokens = { "python/pyproject.toml" = ['[tool.ruff.lint.flake8-tidy-imports.banned-api]', '"msgspec.convert".msg'], "python/src/dotfiles_setup/codec.py" = ['def enc_hook(', 'def dec_hook(', 'raise UnsupportedTypeError(type(obj), "encode")', 'resolved = typing.get_origin(candidate) or candidate', 'raise AlreadyNativeError(target, native)', '_DECODERS: dict[type, _Decoder] = {PurePath: lambda target, value: target(value)}'], "tests/test_codec.py" = ['def test_the_ban_covers_every_hook_taking_entry_point_msgspec_offers(', 'def test_the_codec_module_itself_is_allowed_to_call_msgspec(', 'def test_no_module_outside_the_codec_calls_msgspec_directly(', 'def test_msgspec_really_cannot_do_this_unaided('] }
+tokens = [
+    "def enc_hook(",
+]

--- a/ruff.toml
+++ b/ruff.toml
@@ -15,6 +15,18 @@ extend = "python/pyproject.toml"
 # repo root, so "../tests/*.py" points outside the tree and silently stops
 # matching — the exact "dead config" fragility this file's header warns about.
 "tests/**/*.py" = ["D103", "PLR2004", "S101"]
+# TID251 (#675): the codec's own tests must reach msgspec DIRECTLY, because two
+# of them are the control arms for the whole module — they assert that msgspec
+# unaided fails on a `Path` in both directions, which is the premise `codec.py`
+# rests on and cannot be demonstrated through `codec.py`.
+#
+# It lives HERE and not in python/pyproject.toml's per-file-ignores for the
+# reason this file's header states: with a root table declared, an extended
+# "../tests/…" glob re-anchors to the repo root and silently stops matching.
+# Measured while writing #675 — the entry sat in the pyproject for four probe
+# rounds doing nothing, and S101 stayed clean throughout because THIS line was
+# the one suppressing it. A dead ignore looks exactly like a working one.
+"tests/test_codec.py" = ["D103", "PLR2004", "S101", "TID251"]
 # The plugins are standalone CLI helper scripts where print IS the user
 # interface, so T201 (print) is expected rather than a defect.
 "plugins/**/*.py" = ["T201"]

--- a/tests/TEST-INDEX.md
+++ b/tests/TEST-INDEX.md
@@ -25,6 +25,7 @@ derive instead.
 |------|-----------|---------|
 | `test_audit.py` | pytest | `dotfiles-setup audit` command output structure and exit codes |
 | `test_bootstrap.py` | pytest | Bootstrap tool availability (`mise`, `chezmoi`, `uv`, `pixi`, python) |
+| `test_codec.py` | pytest | The one module owning msgspec's encode/decode hooks (`dotfiles_setup.codec`, #675). Round-trips a `Path` bare, inside a `Struct` and nested in containers, across both `Format`s; pins the WIRE FORM (a plain string, not a `{"__path__": …}` wrapper a round-trip test cannot distinguish); and arms the premise — msgspec unaided fails on `Path` in BOTH directions, so the module is not decoration. AC3's silent-degradation arm is explicit: an unregistered type must raise rather than fall back to `str(obj)`, which never fails and would encode `<Foo object at 0x…>` as valid JSON. AC4 is gated twice, for different failure modes: ruff TID251 driven END TO END (a file that must be flagged, plus a control that `msgspec.Struct` is not), and a tree sweep that a disabled rule leaves green. The ban list is bound to msgspec's OWN surface — 14 hook-taking entry points enumerated at runtime, so a new one in a future release fails the test instead of widening the hole |
 | `test_config.py` | pytest | Pydantic `DotfilesConfig` and container-path constants |
 | `test_devcontainer_names.py` | pytest | #677 arch-scoped container/home-volume/SSH-port names, the derived port, and the pre-#677 home-volume migration plan |
 | `test_ghcr.py` | pytest | GHCR prerequisite validation and token scope parsing |

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -1,0 +1,753 @@
+# Copyright (c) 2026 Raymond Manaloto
+"""The one module owning msgspec's encode and decode hooks (#675).
+
+msgspec's conversion hooks are **per-call** — `enc_hook`/`dec_hook` are keyword
+arguments to `encode`/`decode`, not global registrations. So a codebase that
+calls msgspec directly grows one copy of the hook per call site, and they drift.
+#669 chose to centralise from the outset for exactly that reason.
+
+What makes the centralisation load-bearing rather than tidy: `pathlib.Path` is
+unsupported in **both** directions. Measured against msgspec 0.21.1, control-armed
+against three types it does support (datetime, uuid, decimal, all of which encode
+natively):
+
+    >>> msgspec.json.encode(pathlib.Path("/tmp/x"))
+    TypeError: Encoding objects of type PosixPath is unsupported
+    >>> msgspec.json.decode(b'"/tmp/x"', type=pathlib.Path)
+    ValidationError: Expected `Path`, got `str`
+
+The second one is the dangerous half. Encoding *raises*, so a missing hook is
+found immediately; decoding raises only because the annotation is `Path`, and a
+field annotated `str` would accept the value and hand the caller a string that
+behaves like a path until something calls `.parent` on it.
+"""
+
+from __future__ import annotations
+
+import datetime
+import decimal
+import importlib
+import inspect
+import pathlib
+import pkgutil
+import re
+import subprocess
+import sys
+import tomllib
+import uuid
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING
+
+import msgspec
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
+
+from dotfiles_setup import codec
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+REPO_ROOT = Path(__file__).parent.parent
+
+#: A real msgspec IMPORT, not the bare word. The tree sweep below used to match
+#: the substring "msgspec" anywhere in a file, so a module that merely
+#: DOCUMENTED the ban would be reported as violating it — and `python/AGENTS.md`
+#: now instructs every author to write exactly that sentence (review F5). It is
+#: the same trap this file calls out for a docstring satisfying a wiring check,
+#: met from the other side.
+_IMPORTS_MSGSPEC_RE = re.compile(r"^\s*(?:import msgspec|from msgspec)", re.MULTILINE)
+
+
+class _Sample(msgspec.Struct):
+    """A generated-model stand-in: the shape #680 will emit."""
+
+    workspace: Path
+    label: str
+
+
+# --------------------------------------------------------------------------- #
+# AC2 — round-tripping a filesystem path works in both directions
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("fmt", list(codec.Format))
+def test_a_path_round_trips_through_both_formats(fmt: codec.Format) -> None:
+    """The headline acceptance criterion, on every format the module offers.
+
+    Parametrised over `Format` rather than spelled twice, so adding msgpack's
+    successor cannot ship with only the JSON half covered.
+    """
+    original = Path("/workspaces/dotfiles/.devcontainer")
+
+    restored = codec.decode(codec.encode(original, fmt=fmt), Path, fmt=fmt)
+
+    assert restored == original
+    assert isinstance(restored, pathlib.PurePath)
+
+
+def test_a_path_inside_a_struct_round_trips() -> None:
+    """A path is almost never the top-level value — it is a field.
+
+    The top-level case can pass while a nested one fails, because msgspec walks
+    into a Struct with different machinery than it uses for a bare value.
+    """
+    original = _Sample(workspace=Path("/workspaces/dotfiles"), label="dev")
+
+    restored = codec.decode(codec.encode(original), _Sample)
+
+    assert restored == original
+    assert isinstance(restored.workspace, pathlib.PurePath)
+
+
+def test_paths_nested_in_containers_round_trip() -> None:
+    """Containers are a separate walk again — a list of paths, and a dict of them."""
+    original = {"roots": [Path("/a"), Path("/b")]}
+
+    restored = codec.decode(codec.encode(original), dict[str, list[Path]])
+
+    assert restored == original
+
+
+def test_encoding_a_path_produces_the_plain_string_a_reader_expects() -> None:
+    """#669 wants records readable "with ordinary tools during an incident".
+
+    Pinning the WIRE FORM, not just the round-trip: a hook that encoded a path
+    as `{"__path__": "/a"}` would round-trip perfectly and be unreadable to
+    `jq`, and no round-trip test can tell the difference.
+    """
+    assert codec.encode(Path("/workspaces/dotfiles")) == b'"/workspaces/dotfiles"'
+
+
+def test_the_hooks_are_what_msgspec_itself_would_call() -> None:
+    """Control arm for the whole module: bypass it and the SAME hooks work.
+
+    If `encode`/`decode` did the conversion themselves rather than through the
+    hooks, every test above would pass while the hooks — the thing #675 exists
+    to provide, and what a generated model's own call would use — were dead.
+    """
+    raw = msgspec.json.encode(Path("/a/b"), enc_hook=codec.enc_hook)
+    restored = msgspec.json.decode(raw, type=Path, dec_hook=codec.dec_hook)
+
+    assert raw == b'"/a/b"'
+    assert restored == Path("/a/b")
+
+
+def test_msgspec_really_cannot_do_this_unaided() -> None:
+    """The premise, armed. Without it every test above could be vacuous.
+
+    If a future msgspec supports paths natively, this fails and the module's
+    justification should be re-read rather than the test deleted.
+    """
+    with pytest.raises(TypeError, match="unsupported"):
+        msgspec.json.encode(Path("/a"))
+
+    with pytest.raises(msgspec.ValidationError):
+        msgspec.json.decode(b'"/a"', type=Path)
+
+
+# --------------------------------------------------------------------------- #
+# AC3 — an unsupported type fails loudly rather than silently degrading
+# --------------------------------------------------------------------------- #
+
+
+class _Unregistered:
+    """A type the codec was never taught — the realistic future mistake."""
+
+
+def test_encoding_an_unregistered_type_raises_and_names_it() -> None:
+    """Failing "loudly" means naming the offender, not just failing.
+
+    A bare "unsupported type" sends the reader back to a stack trace to find out
+    which of a struct's twenty fields it was.
+    """
+    with pytest.raises(codec.UnsupportedTypeError) as excinfo:
+        codec.encode(_Unregistered())
+
+    assert excinfo.value.offending_type is _Unregistered
+    assert "_Unregistered" in str(excinfo.value)
+
+
+def test_decoding_into_an_unregistered_type_raises_and_names_it() -> None:
+    """The decode direction needs its own arm — it is a different hook.
+
+    Covering only encode is the "both arms, one axis" trap: the two hooks share
+    a module and nothing else.
+    """
+    with pytest.raises(codec.UnsupportedTypeError) as excinfo:
+        codec.decode(b'"x"', _Unregistered)
+
+    assert excinfo.value.offending_type is _Unregistered
+
+
+def test_the_unsupported_error_is_what_msgspec_asks_hooks_to_raise() -> None:
+    """Msgspec documents `NotImplementedError` as the hook's "I can't" signal.
+
+    Subclassing it keeps a caller who catches the documented exception working,
+    while `UnsupportedTypeError` gives one who wants the offending type a place to
+    read it from. Raising something unrelated would be a silent behaviour change
+    for anyone following msgspec's own docs.
+    """
+    assert issubclass(codec.UnsupportedTypeError, NotImplementedError)
+
+
+def test_an_unregistered_type_never_degrades_to_its_repr() -> None:
+    """The specific silent failure AC3 forbids.
+
+    `str(obj)` is the tempting fallback and it always "works" — every object has
+    one. It would encode `<_Unregistered object at 0x…>` as a happy JSON string,
+    round-trip nothing, and surface as corrupt data far from here.
+    """
+    with pytest.raises(codec.UnsupportedTypeError):
+        codec.encode({"field": _Unregistered()})
+
+
+# --------------------------------------------------------------------------- #
+# The registry — extensible by parameter, not by editing the hook
+# --------------------------------------------------------------------------- #
+
+
+def test_a_registered_type_round_trips_without_touching_the_hooks() -> None:
+    """The next unsupported type must be a registration, not a hook edit.
+
+    Otherwise the module becomes a growing `if isinstance(...)` chain and the
+    "one place" property degrades into "one long function".
+    """
+    codec.register(
+        _Unregistered,
+        encode=lambda _: "sentinel",
+        decode=lambda _target, _value: _Unregistered(),
+    )
+    try:
+        assert codec.encode(_Unregistered()) == b'"sentinel"'
+        assert isinstance(codec.decode(b'"sentinel"', _Unregistered), _Unregistered)
+    finally:
+        codec.unregister(_Unregistered)
+
+    with pytest.raises(codec.UnsupportedTypeError):
+        codec.encode(_Unregistered())
+
+
+def test_a_path_subclass_resolves_through_its_base() -> None:
+    """`Path()` instantiates `PosixPath`/`WindowsPath`, never `Path` itself.
+
+    A registry keyed on exact type would therefore miss every real path — the
+    encode hook receives `PosixPath`. Measured: msgspec's own error says
+    "objects of type PosixPath".
+    """
+    assert codec.encode(PurePosixPath("/a/b")) == b'"/a/b"'
+
+
+# --------------------------------------------------------------------------- #
+# AC4 — every codec call in the project routes through this module
+# --------------------------------------------------------------------------- #
+
+
+def _run_ruff(argv: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run ruff's TID251 check, refusing to return a non-answer.
+
+    The `returncode` assertion is the point (review F3). Every negative arm here
+    reads `"TID251" not in proc.stdout`, and a ruff that never ran — broken
+    venv, missing binary, bad config path — produces empty stdout and satisfies
+    that for free. rc 0 means clean and rc 1 means findings; anything else is
+    the tool failing, and a gate must not read that as "no violations".
+    """
+    proc = subprocess.run(
+        [
+            *("uv", "run", "--project", "python"),
+            *("ruff", "check", "--no-cache", "--select", "TID251"),
+            *argv,
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+
+    assert proc.returncode in (0, 1), (
+        f"ruff did not run (rc={proc.returncode}); its verdict cannot be read. "
+        f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    )
+    return proc
+
+
+def _ruff(target: Path) -> subprocess.CompletedProcess[str]:
+    """Check a file INSIDE the repo, exactly as the hk gate invokes ruff.
+
+    No `--config`: ruff resolves config per-file by walking up, which is what
+    makes `python/pyproject.toml`'s relative `per-file-ignores` globs land. An
+    explicit `--config` re-anchors them to the invocation directory and the
+    codec's own allowance stops matching — measured while fixing review F3, and
+    the same re-anchoring hazard `ruff.toml`'s header documents.
+    """
+    return _run_ruff([str(target)])
+
+
+def _ruff_external(target: Path) -> subprocess.CompletedProcess[str]:
+    """Check a file OUTSIDE the repo (a `tmp_path` probe).
+
+    Here `--config` is required rather than harmful: ruff walking up from a
+    temp directory finds no config at all, so the banned-api table — which is
+    the whole subject of these probes — would simply not be loaded, and every
+    probe would come back clean for the most uninteresting possible reason.
+    """
+    return _run_ruff(
+        [*("--config", str(REPO_ROOT / "python" / "pyproject.toml")), str(target)]
+    )
+
+
+def _hook_taking_apis() -> set[str]:
+    """Every msgspec entry point that accepts a conversion hook, from msgspec.
+
+    Derived at runtime from the installed library rather than transcribed, so a
+    new entry point in a future msgspec makes the coverage test below fail
+    instead of quietly widening the hole. Enumerating beat hand-listing here by
+    a wide margin: the obvious four (`json`/`msgpack` x `encode`/`decode`) are
+    under a third of what this finds.
+
+    The SUBMODULE list is discovered too (review F7). It was originally
+    transcribed — `msgspec`, `.json`, `.msgpack`, `.yaml`, `.toml` — which
+    defeated the point: a new hook-taking submodule is the shape most likely to
+    add a wire format, and a hand-written list is blind to precisely that. Half
+    a derivation reads exactly like a whole one.
+    """
+    modules = {"msgspec": msgspec}
+    for info in pkgutil.iter_modules(msgspec.__path__):
+        # Private submodules are out of scope: `msgspec._core` re-exports the
+        # same callables under different names (`json_encode`, `MsgpackEncoder`)
+        # and nobody imports them, so banning those paths would add noise
+        # without closing a route anyone can take.
+        if info.name.startswith("_"):
+            continue
+        try:
+            modules[f"msgspec.{info.name}"] = importlib.import_module(
+                f"msgspec.{info.name}"
+            )
+        except ImportError:  # pragma: no cover - an optional extra is absent
+            continue
+    return {
+        f"{mod_name}.{name}"
+        for mod_name, module in modules.items()
+        for name in dir(module)
+        if not name.startswith("_")
+        and any(
+            hook in (inspect.getdoc(getattr(module, name)) or "")
+            for hook in ("enc_hook", "dec_hook")
+        )
+    }
+
+
+def _banned_apis() -> set[str]:
+    """The ban list as ruff will read it."""
+    config = tomllib.loads(
+        (REPO_ROOT / "python" / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    return set(config["tool"]["ruff"]["lint"]["flake8-tidy-imports"]["banned-api"])
+
+
+def test_the_ban_covers_every_hook_taking_entry_point_msgspec_offers() -> None:
+    """Rule 52's question — *which spellings?* — asked of the library itself.
+
+    A hand-written ban list is a snapshot of what its author remembered. This
+    binds it to what msgspec actually exposes, so `Encoder`/`Decoder` (the form
+    a performance-minded caller reaches for) and `convert`/`to_builtins` cannot
+    be the ones nobody thought of.
+    """
+    uncovered = _hook_taking_apis() - _banned_apis()
+
+    assert uncovered == set(), (
+        f"msgspec entry points that take a conversion hook and are NOT banned: "
+        f"{sorted(uncovered)}. Each is a way to bypass the codec with its own "
+        f"hook table — add it to [tool.ruff.lint.flake8-tidy-imports.banned-api]"
+    )
+
+
+def test_the_coverage_check_is_reading_a_real_surface() -> None:
+    """Control arm: `uncovered == set()` is satisfied for free by an empty scan.
+
+    A typo in a module name or a msgspec that moved its API would make the
+    check above vacuously green, which is the failure mode it exists to prevent.
+    """
+    discovered = _hook_taking_apis()
+
+    assert len(discovered) >= 10, f"only found {len(discovered)}: {sorted(discovered)}"
+    assert "msgspec.json.encode" in discovered
+    assert "msgspec.json.Encoder" in discovered
+    assert "msgspec.Struct" not in discovered, (
+        "the scan matched a type that takes no hook — it is over-broad, and "
+        "banning `Struct` would make declaring a model impossible"
+    )
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        "msgspec.json.encode(1)",
+        "msgspec.msgpack.encode(1)",
+        "msgspec.convert(1, int)",
+        "msgspec.to_builtins(1)",
+    ],
+)
+def test_a_direct_msgspec_call_is_rejected_by_the_linter(
+    call: str, tmp_path: Path
+) -> None:
+    """The gate, driven end to end rather than read out of the config.
+
+    Asserting the pyproject key exists would pass whether or not ruff honours
+    it — and TID251's resolution of *attribute* access (as opposed to a plain
+    import) is exactly the part being relied on. So this feeds ruff files that
+    must fail and requires the failure ([[probes-need-a-control-arm]] rule 9).
+
+    Four shapes rather than one: the two obvious formats plus the two entry
+    points a hand-written ban list would have missed.
+    """
+    offender = tmp_path / "offender.py"
+    offender.write_text(
+        f'"""Temporary probe."""\n\nimport msgspec\n\n{call}\n', encoding="utf-8"
+    )
+
+    proc = _ruff_external(offender)
+
+    assert "TID251" in proc.stdout, (
+        f"ruff did not flag `{call}` — the AC4 gate is not armed for it. "
+        f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    )
+
+
+def test_declaring_a_model_is_not_caught_by_the_ban(tmp_path: Path) -> None:
+    """Control arm: a ban broad enough to catch `msgspec.Struct` is unusable.
+
+    Without this, "the linter rejects a msgspec call" is indistinguishable from
+    "the linter rejects the word msgspec", and the gate would be reported as
+    working while making the library unusable.
+    """
+    innocent = tmp_path / "innocent.py"
+    innocent.write_text(
+        '"""Temporary probe."""\n\nimport msgspec\n\n\n'
+        "class S(msgspec.Struct):\n"
+        '    """A model."""\n\n'
+        "    x: int\n",
+        encoding="utf-8",
+    )
+
+    proc = _ruff_external(innocent)
+
+    assert "TID251" not in proc.stdout, (
+        f"declaring a msgspec model trips the ban — it is over-broad: {proc.stdout!r}"
+    )
+
+
+def test_the_codec_module_itself_is_allowed_to_call_msgspec(tmp_path: Path) -> None:
+    """Control arm: a ban with no exemption would make the module unwritable.
+
+    ⚠️ The first version of this test PASSED with the exemption deleted, and the
+    mutation that caught it is why the module dispatches the way it does. The
+    module used to hold `_CODECS = {Format.JSON: msgspec.json}` and call
+    `_codec(fmt).encode(...)` — an attribute on a *runtime value*, which ruff
+    cannot resolve statically. So the banned path never appeared in the file,
+    the per-file allowance was dead configuration, and this test asserted the
+    absence of a violation that could not have occurred.
+
+    Hence the two arms below, and note what the FIRST attempt at arming this
+    got wrong: it asserted the module's *text* contained a banned path, and
+    passed on the indirect version anyway — because this module's own docstring
+    quotes `msgspec.json.encode` as an example. A file's documentation had
+    satisfied a contract about its wiring, which `python/AGENTS.md` records as
+    the way 11 of 33 contract tokens were being met.
+
+    So the arm below asks ruff, not a substring: the same source, at a path the
+    allowance does not cover, MUST be flagged. That fails on indirection,
+    because indirection is precisely what ruff cannot see.
+    """
+    package = REPO_ROOT / "python" / "src" / "dotfiles_setup"
+    source = (package / "codec.py").read_text(encoding="utf-8")
+
+    unexempt = tmp_path / "codec.py"
+    unexempt.write_text(source, encoding="utf-8")
+
+    without_allowance = _ruff_external(unexempt)
+
+    assert "TID251" in without_allowance.stdout, (
+        "the same source at an unexempt path is NOT flagged, so codec.py's "
+        "TID251 allowance is dead config and this test cannot fail. The usual "
+        "cause is indirect dispatch — ruff cannot resolve an attribute on a "
+        "runtime value, which also means any module could evade the ban that "
+        f"way. stdout={without_allowance.stdout!r}"
+    )
+
+    proc = _ruff(package / "codec.py")
+
+    assert "TID251" not in proc.stdout, (
+        f"the codec module is caught by the ban it exists to satisfy, despite "
+        f"its per-file allowance: {proc.stdout!r}"
+    )
+
+
+def test_no_module_outside_the_codec_calls_msgspec_directly() -> None:
+    """AC4 as a standing sweep, so a new call site cannot arrive unnoticed.
+
+    The linter gate above proves the RULE fires; this proves the TREE is clean,
+    and the two fail for different reasons — a disabled rule leaves this green.
+    """
+    package = REPO_ROOT / "python" / "src" / "dotfiles_setup"
+    offenders = [
+        path.relative_to(REPO_ROOT).as_posix()
+        for path in sorted(package.rglob("*.py"))
+        if path.name != "codec.py"
+        and _IMPORTS_MSGSPEC_RE.search(path.read_text(encoding="utf-8"))
+    ]
+
+    assert offenders == [], (
+        f"modules import msgspec outside the codec: {offenders}. Route them "
+        f"through dotfiles_setup.codec so the hooks are applied exactly once"
+    )
+
+
+def test_the_sweep_can_actually_see_a_violation() -> None:
+    """Control arm for the sweep above.
+
+    A "no offenders" assertion is satisfied for free by an empty file list,
+    which is what a wrong root or a typo'd glob produces. Three arms: the scan
+    reaches a real package, its matcher fires on the one module that really
+    imports msgspec, and it does NOT fire on prose that merely names it.
+
+    That third arm is review F5. The matcher used to be the bare substring
+    `"msgspec"`, so a module documenting the ban would be reported as violating
+    it — and `python/AGENTS.md` in this same change tells every author to write
+    that sentence, with a failure message telling them to "route it through the
+    codec" for a file that has no call at all.
+    """
+    package = REPO_ROOT / "python" / "src" / "dotfiles_setup"
+    scanned = [path for path in package.rglob("*.py") if path.name != "codec.py"]
+
+    assert len(scanned) > 20, f"the sweep found only {len(scanned)} modules to scan"
+    assert _IMPORTS_MSGSPEC_RE.search(
+        (package / "codec.py").read_text(encoding="utf-8")
+    ), (
+        "the matcher does not find an import in the one module that has one, "
+        "so its zero-result on every other module proves nothing"
+    )
+    assert not _IMPORTS_MSGSPEC_RE.search(
+        "# never call msgspec directly - use dotfiles_setup.codec\n"
+    ), (
+        "the matcher fires on prose that merely NAMES msgspec, so a module "
+        "documenting the ban would be reported as violating it"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The format seam
+# --------------------------------------------------------------------------- #
+
+
+def test_the_binary_format_comes_from_the_same_definitions() -> None:
+    """#669: a compact binary form "from the same definitions", one call to swap.
+
+    Pinned because the alternative — a second model or a second hook set for
+    msgpack — is exactly the drift this module exists to prevent.
+    """
+    value = _Sample(workspace=Path("/a"), label="x")
+
+    as_json = codec.encode(value, fmt=codec.Format.JSON)
+    as_msgpack = codec.encode(value, fmt=codec.Format.MSGPACK)
+
+    assert as_json != as_msgpack
+    assert codec.decode(as_msgpack, _Sample, fmt=codec.Format.MSGPACK) == value
+
+
+def test_json_is_the_default_format() -> None:
+    """#669 chose newline-delimited JSON as the record form.
+
+    A default that silently changed would leave every un-annotated call site
+    emitting a binary blob into a log meant to be read with `jq`.
+    """
+    assert codec.encode(Path("/a")) == codec.encode(Path("/a"), fmt=codec.Format.JSON)
+
+
+@pytest.mark.parametrize(
+    ("call", "kwargs"),
+    [(codec.encode, {}), (codec.decode, {})],
+)
+def test_an_unknown_format_is_refused(
+    call: Callable[..., object], kwargs: dict[str, object]
+) -> None:
+    """Neither entry point may fall back to a default on a bad format.
+
+    Both are parametrised together because a guard added to one and forgotten
+    on the other is the realistic half-fix.
+    """
+    args = (Path("/a"),) if call is codec.encode else (b'"/a"', Path)
+
+    with pytest.raises(ValueError, match="format"):
+        call(*args, fmt="yaml", **kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# Regression arms for the `/code-review high` findings (F1-F7)
+#
+# Each pins a defect that shipped past a green suite, so the fix cannot be
+# undone silently. They are grouped rather than scattered because what they have
+# in common is the lesson: every one was invisible to tests written from the
+# happy path.
+# --------------------------------------------------------------------------- #
+
+
+class _Boxed[T]:
+    """A plain generic — deliberately NOT a `msgspec.Struct`.
+
+    A Struct is handled natively, so it never reaches `dec_hook` and cannot
+    exercise F1 at all. The review's own illustration used one and decodes fine;
+    reaching the hook needs a type msgspec does not know.
+    """
+
+    def __init__(self, value: object) -> None:
+        self.value = value
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _Boxed) and other.value == self.value
+
+    def __hash__(self) -> int:
+        return hash(self.value)
+
+
+def test_an_unregistered_parametrized_generic_fails_loudly() -> None:
+    """F1: `Box[int]` has no `__mro__`, so the MRO walk raised `AttributeError`.
+
+    Not merely the wrong exception type — AC3 promises the failure NAMES the
+    offending type, and a bare `AttributeError: __mro__` names nothing and does
+    not even come from this module.
+
+    `list[int]` hid this for the whole first draft: `types.GenericAlias` proxies
+    `__mro__` while `typing._GenericAlias` does not, so the covered spelling and
+    the broken one look identical in a test.
+    """
+    with pytest.raises(codec.UnsupportedTypeError) as excinfo:
+        codec.decode(b"1", _Boxed[int])
+
+    assert excinfo.value.offending_type is _Boxed
+
+
+def test_a_registered_parametrized_generic_can_be_decoded() -> None:
+    """F1's sharper half: registration did not help — it could not be reached.
+
+    A caller who did everything right still got `AttributeError`, which makes
+    the extension seam unusable for generics rather than merely undiagnosed.
+    """
+    codec.register(
+        _Boxed,
+        encode=lambda boxed: boxed.value,
+        decode=lambda _target, value: _Boxed(value),
+    )
+    try:
+        assert codec.decode(b"1", _Boxed[int]) == _Boxed(1)
+        assert codec.encode(_Boxed(1)) == b"1"
+    finally:
+        codec.unregister(_Boxed)
+
+
+def test_the_generic_control_arm_distinguishes_the_two_spellings() -> None:
+    """Control arm for F1: prove the two generic spellings really differ.
+
+    Without this, the tests above could be passing because everything has an
+    `__mro__` and there was never a bug to fix.
+    """
+    assert hasattr(list[int], "__mro__"), "types.GenericAlias no longer proxies __mro__"
+    assert not hasattr(_Boxed[int], "__mro__"), (
+        "typing._GenericAlias now has __mro__, so this whole class of defect is "
+        "gone and the unwrapping in _runtime_class is no longer load-bearing"
+    )
+
+
+def test_registering_a_natively_supported_type_is_refused() -> None:
+    """F2: it used to succeed and do nothing.
+
+    msgspec never calls a hook for a type it handles itself, so the conversion
+    sat in the table forever, unreachable. Measured before the guard:
+    `register(Decimal, encode=float, ...)` then `encode(Decimal("1.50"))` still
+    gave `b'"1.50"'` — a JSON string, `float` never called. Silent, ineffective,
+    and on the module's own extension seam.
+    """
+    with pytest.raises(codec.AlreadyNativeError) as excinfo:
+        codec.register(
+            decimal.Decimal,
+            encode=float,
+            decode=lambda _t, value: decimal.Decimal(value),
+        )
+
+    assert excinfo.value.target is decimal.Decimal
+    assert "Decimal" in str(excinfo.value)
+    assert codec.encode(decimal.Decimal("1.50")) == b'"1.50"'
+
+
+@pytest.mark.parametrize("native", [datetime.datetime, uuid.UUID, int, str])
+def test_the_native_refusal_covers_more_than_the_one_type_that_found_it(
+    native: type,
+) -> None:
+    """F2 across the axis, not just its discovering example.
+
+    Fixing only `Decimal` would leave `datetime` — the other type someone
+    plausibly wants re-encoded (as an epoch) — silently no-op.
+    """
+    with pytest.raises(codec.AlreadyNativeError):
+        codec.register(native, encode=str, decode=lambda _t, value: value)
+
+
+def test_a_type_msgspec_does_not_know_is_still_registrable() -> None:
+    """Control arm for F2: a refusal that refused everything would be useless.
+
+    This is the arm that separates "the guard discriminates" from "the guard
+    rejects all registrations", and the tests above cannot tell them apart.
+    """
+    codec.register(
+        _Boxed, encode=lambda boxed: boxed.value, decode=lambda _t, value: _Boxed(value)
+    )
+    codec.unregister(_Boxed)
+
+
+def test_every_path_flavour_round_trips_into_its_own_type() -> None:
+    """F6: the seeded decoder built `Path` regardless of what was asked for.
+
+    So `PureWindowsPath` encoded happily and failed to decode — a write that
+    succeeds and a read that fails in another process, which is exactly the
+    half-registration `register()`'s docstring says the API exists to prevent.
+    The seed had it.
+    """
+    for flavour in (pathlib.PurePosixPath, pathlib.PureWindowsPath):
+        original = flavour("/opt/toolchain/bin")
+
+        restored = codec.decode(codec.encode(original), flavour)
+
+        assert restored == original, f"{flavour.__name__} did not round-trip"
+        assert type(restored) is flavour, (
+            f"{flavour.__name__} decoded to {type(restored).__name__} — the "
+            f"decoder ignored the annotation it was given"
+        )
+
+
+def test_the_ruff_helper_refuses_a_verdict_it_could_not_read() -> None:
+    """F3: every negative arm reads stdout, which a failed ruff leaves empty.
+
+    So "no TID251 in stdout" was satisfied for free by a broken venv, a missing
+    binary or a bad config path — a check that can only pass. Driven through a
+    config path that does not exist, which is the realistic version of that.
+    """
+    with pytest.raises(AssertionError, match="ruff did not run"):
+        _run_ruff(["--config", "/nonexistent/ruff.toml", "tests/test_codec.py"])
+
+
+def test_the_module_scan_finds_msgspec_submodules_it_was_never_told_about() -> None:
+    """F7: the module list was transcribed, defeating the point of deriving it.
+
+    A new hook-taking submodule is the shape most likely to add a wire format,
+    and a hand-written list is blind to exactly that. Asserted against a
+    submodule NOT in the original four, so a regression to the literal list
+    fails here.
+    """
+    discovered = {name.split(".")[1] for name in _hook_taking_apis() if "." in name}
+
+    assert {"json", "msgpack", "toml", "yaml"} <= discovered
+    submodules = {info.name for info in pkgutil.iter_modules(msgspec.__path__)}
+    assert "structs" in submodules, (
+        "msgspec's package layout changed; the discovery this test guards may "
+        "need re-checking"
+    )


### PR DESCRIPTION
msgspec becomes the project's model system (#669), and this is the module every
encode and decode routes through. It lands first, before the generated models
(#680) and the settings loader (#683), because msgspec's conversion hooks are
`enc_hook`/`dec_hook` KEYWORD ARGUMENTS to each call rather than a global
registration — so a direct call works perfectly while carrying its own copy of
the conversion table, and retrofitting a single home once there are twenty call
sites is exactly the situation #669 declined to walk into.

`pathlib.Path` is what forces it, and it is unsupported in BOTH directions.
Measured against msgspec 0.21.1, control-armed against datetime/uuid/decimal
(all of which encode unaided, so the probe discriminates):

    msgspec.json.encode(Path("/tmp/x"))       TypeError: ... PosixPath ...
    msgspec.json.decode(b'"/tmp/x"', Path)    ValidationError: Expected Path

The decode half is the quiet one: it raises only because the annotation says
`Path`, so a field annotated `str` accepts the value and returns a string that
behaves like a path until something calls `.parent`.

The four acceptance criteria, each walked against the running module and not
merely asserted by a test:

- `codec.enc_hook` / `codec.dec_hook`, with `encode`/`decode` over `Format.JSON`
  (the record form #669 chose) and `Format.MSGPACK` from the same definitions.
- A path round-trips bare, as a `Struct` field, and nested in containers, on
  both formats — and the WIRE FORM is pinned to a plain string, because a hook
  emitting `{"__path__": "/a"}` round-trips perfectly and is unreadable to `jq`.
- An unregistered type raises `UnsupportedTypeError(NotImplementedError)`
  carrying `.offending_type`. Explicitly gated against degrading to `str(obj)`,
  the tempting fallback that never fails because every object has a `__str__`.
- AC4 is gated twice, for different failure modes: ruff TID251 driven end to end
  (files that must be flagged, plus a control that `msgspec.Struct` is not), and
  a tree sweep that a disabled rule would leave green.

The ban list was ENUMERATED from the installed library, not written from memory:
FOURTEEN public entry points accept a hook, and the four anyone lists
(json/msgpack x encode/decode) are under a third. The misses would have been
`Encoder`/`Decoder` — the form a performance-minded caller reaches for — and
`convert`/`to_builtins`. A test re-derives the set at runtime, discovering
submodules via `pkgutil`, so a future msgspec adding one fails the gate.

## Two of my own gates survived mutation and were rebuilt

Both are the same family: a gate written from the artifact is blind to the
mechanism.

- "codec.py is exempt from the ban" passed with the exemption DELETED, because
  the module dispatched through a `_CODECS` dict and called `_codec(fmt).encode`
  — an attribute on a runtime value, which ruff cannot resolve. The allowance
  was dead config. Dispatch is now explicit, which also stops modelling an
  evasion pattern for future code.
- The repaired test then still passed on indirection, because it looked for the
  banned string in the file and this module's own DOCSTRING quotes it. It now
  runs ruff against the same source at an unexempt path and requires the flag.

Durable: when a gate protects an EXEMPTION, mutate the exemption away. An
allowance is the one piece of config whose correctness is invisible — nothing
fails when it is unnecessary.

## /code-review high found seven more, all real

Persisted verbatim (with its brief, and re-verified independently before any fix
was written) at `docs/research/kb/reports/agents/code-review-675-codec-hooks.md`.
Every one shipped past a green suite:

- F1 `_lookup` walked `__mro__`, which a parametrized generic annotation lacks:
  `Box[int]` raised a bare `AttributeError` — not even a codec error, defeating
  AC3 — and a REGISTERED generic could never be decoded. `list[int]` hid it for
  the whole first draft because `types.GenericAlias` proxies `__mro__` while
  `typing._GenericAlias` does not. Now resolved through `typing.get_origin`.
- F2 `register()` was a silent no-op for a natively-supported type: msgspec
  never calls a hook for one, so `register(Decimal, encode=float, ...)` then
  encoding still gave `b'"1.50"'` with `float` never called. The module's own
  "silently degrading" failure, on its extension seam. Now refused with
  `AlreadyNativeError`, detected by asking `msgspec.inspect` rather than keeping
  our own list of what msgspec supports.
- F3 the ruff helper discarded `returncode`, so every negative arm was satisfied
  for free by a ruff that never ran.
- F4 probe files were written into the live tracked package; a kill between
  write and unlink would leave a msgspec-calling module in `dotfiles_setup/`.
  They go to `tmp_path` now.
- F5 the tree sweep matched the bare substring `msgspec`, so a module that
  merely DOCUMENTED the ban would fail it — and `python/AGENTS.md` in this same
  change tells every author to write that sentence. Matches an import now.
- F6 the seeded decoder built `Path` regardless of the annotation, so
  `PureWindowsPath` encoded fine and failed to decode: a write that succeeds and
  a read that fails elsewhere, the exact half-registration `register()`'s
  docstring says the API exists to prevent. Decoders now receive the target
  type, mirroring msgspec's own `dec_hook(type, obj)`.
- F7 the "derived at runtime" module list was itself transcribed, so a new
  hook-taking submodule — the shape most likely to add a format — was invisible.

Each fix carries a regression arm; all seven mutation-tested with the control
green after. Two needed a second attempt, recorded because the first attempts
looked fine: F5's revert passes in isolation (nothing in the tree documents
msgspec yet), so the honest mutation ADDS a documenting module and shows the old
matcher false-positives on it; F7's first mutation was a syntax error, which is
a non-result rather than a caught defect.

⚠️ Two of my own edit scripts silently no-opped when their anchors did not match
while printing "applied" — F5 and F7 were absent for a full test round and the
green suite said nothing, because the tests I had added for them were passing
for other reasons. Anchored string replacement must assert its own effect; the
`Edit` tool does this by construction and is what the fixes finally used.

ty also rejected `_lookup`'s union return type: encoder takes one argument and
decoder two, so a union loses the arity at both call sites. Now generic in the
conversion type.

Gates: LINT_RC=0 (ruff, ruff_format, ty, contract_token_uniqueness all clean),
PYTEST_RC=0 (2031 passed, green under both bare `uv run` and `mise exec`),
VERIFY_RC=0 (130 passed / 0 failed / 4 skipped, incl. the new
`workflow.codec-hook-centralisation`), lint-docs `No issues found`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MCFymQ3miUyFFWvQ6fouQm

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ray-manaloto/codesmith/dotfiles/pr/706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788964447&installation_model_id=429246&pr_number=706&repository=ray-manaloto%2Fdotfiles&return_to=https%3A%2F%2Fgithub.com%2Fray-manaloto%2Fdotfiles%2Fpull%2F706&signature=6c337fd91653858b83605e2a2baa56b0dc44e50837e612698373f45e7fa175f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized JSON and MessagePack serialization with automatic `Path` conversion.
  * Added extensible type conversion registration and clear errors for unsupported or native types.
  * Added safeguards requiring serialization operations to use the centralized codec.

* **Bug Fixes**
  * Improved handling of generic types, nested paths, decoder symmetry, and path flavor preservation.

* **Tests**
  * Added comprehensive coverage for codec behavior, format handling, registry safeguards, and serialization policy enforcement.

* **Documentation**
  * Documented codec usage, centralized hook requirements, and supported path conversion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->